### PR TITLE
ci: opt-in steps with build.env rather than pr labels

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -7,7 +7,7 @@ auto-retry: &auto-retry
 steps:
   - label: "build"
     command: "ci/scripts/build.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-build")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build" || build.env("CI_STEPS") =~ /(^|,)build(,|$$)/)
     key: "build"
     plugins:
       - docker-compose#v4.9.0:
@@ -19,7 +19,7 @@ steps:
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-build-other")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-other" || build.env("CI_STEPS") =~ /(^|,)build-other(,|$$)/)
     key: "build-other"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -36,7 +36,7 @@ steps:
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-build-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-simulation" || build.env("CI_STEPS") =~ /(^|,)build-simulation(,|$$)/)
     key: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -48,7 +48,7 @@ steps:
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-docslt")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-docslt" || build.env("CI_STEPS") =~ /(^|,)docslt(,|$$)/)
     key: "docslt"
     plugins:
       - docker-compose#v4.9.0:
@@ -61,7 +61,7 @@ steps:
   - label: "end-to-end test (release)"
     key: "e2e-test-release"
     command: "ci/scripts/cron-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-test")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -77,7 +77,7 @@ steps:
 
   - label: "end-to-end test (parallel) (release)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-parallel-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/)
     depends_on:
       - "build"
       - "docslt"
@@ -98,7 +98,7 @@ steps:
 
   - label: "end-to-end test (parallel, in-memory) (release)"
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-parallel-in-memory-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-in-memory-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-in-memory-tests?(,|$$)/)
     depends_on:
       - "build"
       - "docslt"
@@ -113,7 +113,7 @@ steps:
 
   - label: "end-to-end source test (release)"
     command: "ci/scripts/e2e-source-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-source-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -128,7 +128,7 @@ steps:
 
   - label: "end-to-end sink test (release)"
     command: "ci/scripts/e2e-sink-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-sink-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -144,7 +144,7 @@ steps:
   - label: "fuzz test"
     key: "fuzz-test"
     command: "ci/scripts/cron-fuzz-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-sqlsmith-fuzzing-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-sqlsmith-fuzzing-tests" || build.env("CI_STEPS") =~ /(^|,)sqlsmith-fuzzing-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-simulation"
@@ -162,7 +162,7 @@ steps:
   # This ensures our `main-cron` workflow will be stable.
   - label: "unit test"
     command: "ci/scripts/unit-test.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-unit-test")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test" || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/)
     plugins:
       - ./ci/plugins/swapfile
       - seek-oss/aws-sm#v2.3.1:
@@ -178,7 +178,7 @@ steps:
 
   - label: "unit test (deterministic simulation)"
     command: "MADSIM_TEST_NUM=100 timeout 15m ci/scripts/deterministic-unit-test.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -189,7 +189,7 @@ steps:
 
   - label: "integration test (deterministic simulation) - scale"
     command: "TEST_NUM=60 ci/scripts/deterministic-it-test.sh scale::"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -202,7 +202,7 @@ steps:
 
   - label: "integration test (deterministic simulation) - recovery"
     command: "TEST_NUM=60 ci/scripts/deterministic-it-test.sh recovery::"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -215,7 +215,7 @@ steps:
 
   - label: "integration test (deterministic simulation) - others"
     command: "TEST_NUM=30 ci/scripts/deterministic-it-test.sh backfill_tests:: storage:: sink::"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -228,7 +228,7 @@ steps:
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=64 timeout 55m ci/scripts/deterministic-e2e-test.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -246,7 +246,7 @@ steps:
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=12 KILL_RATE=1.0 timeout 55m ci/scripts/deterministic-recovery-test.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -259,7 +259,7 @@ steps:
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-misc-check")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-misc-check" || build.env("CI_STEPS") =~ /(^|,)misc-check(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -272,7 +272,7 @@ steps:
   - label: "end-to-end iceberg sink test (release)"
     key: "e2e-iceberg-sink-tests"
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -288,7 +288,7 @@ steps:
 
   - label: "end-to-end iceberg sink v2 test (release)"
     command: "ci/scripts/e2e-iceberg-sink-v2-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-v2-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-v2-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-v2-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -304,7 +304,7 @@ steps:
   - label: "e2e java-binding test (release)"
     key: "e2e-java-binding-tests"
     command: "ci/scripts/java-binding-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-java-binding-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-java-binding-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-java-binding-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -321,7 +321,7 @@ steps:
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run.py"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-s3-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -339,7 +339,7 @@ steps:
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s json_file.py"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-s3-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -357,7 +357,7 @@ steps:
 
   - label: "S3 source check on AWS (csv parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run_csv.py"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-s3-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -375,7 +375,7 @@ steps:
 
   - label: "S3_v2 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s 'fs_source_v2.py json'"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-s3-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -393,7 +393,7 @@ steps:
 
   - label: "S3_v2 source check on AWS (csv parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s 'fs_source_v2.py csv_without_header'"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-s3-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -412,7 +412,7 @@ steps:
   - label: "S3 source on OpenDAL fs engine"
     key: "s3-source-test-for-opendal-fs-engine"
     command: "ci/scripts/s3-source-test-for-opendal-fs-engine.sh -p ci-release -s run"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-s3-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -431,7 +431,7 @@ steps:
   - label: "pulsar source check"
     key: "pulsar-source-tests"
     command: "ci/scripts/pulsar-source-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-pulsar-source-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-pulsar-source-tests" || build.env("CI_STEPS") =~ /(^|,)pulsar-source-tests?(,|$$)/)
     depends_on:
       - build
       - build-other
@@ -452,7 +452,7 @@ steps:
 
   - label: "micro benchmark"
     command: "ci/scripts/run-micro-benchmarks.sh"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-micro-benchmarks")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-micro-benchmarks" || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/)
     key: "run-micro-benchmarks"
     plugins:
       - docker-compose#v4.9.0:
@@ -463,7 +463,7 @@ steps:
     retry: *auto-retry
 
   - label: "upload micro-benchmark"
-    if: build.branch == "main" || (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-micro-benchmarks")
+    if: build.branch == "main" || (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-micro-benchmarks" || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/)
     command:
       - "BUILDKITE_BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER ci/scripts/upload-micro-bench-results.sh"
     depends_on: "run-micro-benchmarks"
@@ -485,7 +485,7 @@ steps:
   - label: "Backwards compatibility tests"
     key: "backwards-compat-tests"
     command: "RW_COMMIT=$BUILDKITE_COMMIT ci/scripts/backwards-compat-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-backwards-compat-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-backwards-compat-tests" || build.env("CI_STEPS") =~ /(^|,)backwards?-compat-tests?(,|$$)/)
     depends_on:
       - "build"
     plugins:
@@ -500,7 +500,7 @@ steps:
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"
     command: "ci/scripts/sqlsmith-differential-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-sqlsmith-differential-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-sqlsmith-differential-tests" || build.env("CI_STEPS") =~ /(^|,)sqlsmith-differential-tests?(,|$$)/)
     depends_on:
       - "build"
     plugins:
@@ -514,7 +514,7 @@ steps:
   - label: "Backfill tests"
     key: "backfill-tests"
     command: "ci/scripts/backfill-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-backfill-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-backfill-tests" || build.env("CI_STEPS") =~ /(^|,)backfill-tests?(,|$$)/)
     depends_on:
       - "build"
     plugins:
@@ -528,7 +528,7 @@ steps:
 
   - label: "e2e standalone binary test"
     command: "ci/scripts/e2e-test.sh -p ci-release -m standalone"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-standalone-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-standalone-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-standalone-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -544,7 +544,7 @@ steps:
 
   - label: "end-to-end test for opendal (parallel)"
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-parallel-tests-for-opendal")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-tests-for-opendal" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?-for-opendal(,|$$)/)
     depends_on:
       - "build"
       - "docslt"
@@ -560,7 +560,7 @@ steps:
   - label: "end-to-end clickhouse sink test"
     key: "e2e-clickhouse-sink-tests"
     command: "ci/scripts/e2e-clickhouse-sink-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-clickhouse-sink-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-clickhouse-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-clickhouse-sink-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -576,7 +576,7 @@ steps:
   - label: "end-to-end pulsar sink test"
     key: "e2e-pulsar-sink-tests"
     command: "ci/scripts/e2e-pulsar-sink-test.sh -p ci-release"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-e2e-pulsar-sink-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-pulsar-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-pulsar-sink-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -592,7 +592,7 @@ steps:
   - label: "connector node integration test Java {{matrix.java_version}}"
     key: "connector-node-integration-test"
     command: "ci/scripts/connector-node-integration-test.sh -p ci-release -v {{matrix.java_version}}"
-    if: (!build.pull_request.labels includes "ci/main-cron/skip-ci" || build.pull_request.labels includes "ci/run-connector-node-integration-tests")
+    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-connector-node-integration-tests" || build.env("CI_STEPS") =~ /(^|,)connector-node-integration-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -7,7 +7,10 @@ auto-retry: &auto-retry
 steps:
   - label: "build"
     command: "ci/scripts/build.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build" || build.env("CI_STEPS") =~ /(^|,)build(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-build"
+      || build.env("CI_STEPS") =~ /(^|,)build(,|$$)/
     key: "build"
     plugins:
       - docker-compose#v4.9.0:
@@ -19,7 +22,10 @@ steps:
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-other" || build.env("CI_STEPS") =~ /(^|,)build-other(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-build-other"
+      || build.env("CI_STEPS") =~ /(^|,)build-other(,|$$)/
     key: "build-other"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -36,7 +42,10 @@ steps:
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-simulation" || build.env("CI_STEPS") =~ /(^|,)build-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-build-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)build-simulation(,|$$)/
     key: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -48,7 +57,10 @@ steps:
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-docslt" || build.env("CI_STEPS") =~ /(^|,)docslt(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-docslt"
+      || build.env("CI_STEPS") =~ /(^|,)docslt(,|$$)/
     key: "docslt"
     plugins:
       - docker-compose#v4.9.0:
@@ -61,7 +73,10 @@ steps:
   - label: "end-to-end test (release)"
     key: "e2e-test-release"
     command: "ci/scripts/cron-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-test"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -77,7 +92,10 @@ steps:
 
   - label: "end-to-end test (parallel) (release)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-parallel-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/
     depends_on:
       - "build"
       - "docslt"
@@ -98,7 +116,10 @@ steps:
 
   - label: "end-to-end test (parallel, in-memory) (release)"
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-in-memory-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-in-memory-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-parallel-in-memory-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-in-memory-tests?(,|$$)/
     depends_on:
       - "build"
       - "docslt"
@@ -113,7 +134,10 @@ steps:
 
   - label: "end-to-end source test (release)"
     command: "ci/scripts/e2e-source-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-source-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -128,7 +152,10 @@ steps:
 
   - label: "end-to-end sink test (release)"
     command: "ci/scripts/e2e-sink-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -144,7 +171,10 @@ steps:
   - label: "fuzz test"
     key: "fuzz-test"
     command: "ci/scripts/cron-fuzz-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-sqlsmith-fuzzing-tests" || build.env("CI_STEPS") =~ /(^|,)sqlsmith-fuzzing-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-sqlsmith-fuzzing-tests"
+      || build.env("CI_STEPS") =~ /(^|,)sqlsmith-fuzzing-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-simulation"
@@ -162,7 +192,10 @@ steps:
   # This ensures our `main-cron` workflow will be stable.
   - label: "unit test"
     command: "ci/scripts/unit-test.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test" || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-unit-test"
+      || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/
     plugins:
       - ./ci/plugins/swapfile
       - seek-oss/aws-sm#v2.3.1:
@@ -178,7 +211,10 @@ steps:
 
   - label: "unit test (deterministic simulation)"
     command: "MADSIM_TEST_NUM=100 timeout 15m ci/scripts/deterministic-unit-test.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -189,7 +225,10 @@ steps:
 
   - label: "integration test (deterministic simulation) - scale"
     command: "TEST_NUM=60 ci/scripts/deterministic-it-test.sh scale::"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -202,7 +241,10 @@ steps:
 
   - label: "integration test (deterministic simulation) - recovery"
     command: "TEST_NUM=60 ci/scripts/deterministic-it-test.sh recovery::"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -215,7 +257,10 @@ steps:
 
   - label: "integration test (deterministic simulation) - others"
     command: "TEST_NUM=30 ci/scripts/deterministic-it-test.sh backfill_tests:: storage:: sink::"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -228,7 +273,10 @@ steps:
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=64 timeout 55m ci/scripts/deterministic-e2e-test.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -246,7 +294,10 @@ steps:
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=12 KILL_RATE=1.0 timeout 55m ci/scripts/deterministic-recovery-test.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -259,7 +310,10 @@ steps:
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-misc-check" || build.env("CI_STEPS") =~ /(^|,)misc-check(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-misc-check"
+      || build.env("CI_STEPS") =~ /(^|,)misc-check(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -272,7 +326,10 @@ steps:
   - label: "end-to-end iceberg sink test (release)"
     key: "e2e-iceberg-sink-tests"
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -288,7 +345,10 @@ steps:
 
   - label: "end-to-end iceberg sink v2 test (release)"
     command: "ci/scripts/e2e-iceberg-sink-v2-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-v2-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-v2-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-iceberg-sink-v2-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-v2-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -304,7 +364,10 @@ steps:
   - label: "e2e java-binding test (release)"
     key: "e2e-java-binding-tests"
     command: "ci/scripts/java-binding-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-java-binding-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-java-binding-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-java-binding-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-java-binding-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -321,7 +384,10 @@ steps:
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run.py"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-s3-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -339,7 +405,10 @@ steps:
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s json_file.py"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-s3-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -357,7 +426,10 @@ steps:
 
   - label: "S3 source check on AWS (csv parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run_csv.py"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-s3-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -375,7 +447,10 @@ steps:
 
   - label: "S3_v2 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s 'fs_source_v2.py json'"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-s3-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -393,7 +468,10 @@ steps:
 
   - label: "S3_v2 source check on AWS (csv parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s 'fs_source_v2.py csv_without_header'"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-s3-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -412,7 +490,10 @@ steps:
   - label: "S3 source on OpenDAL fs engine"
     key: "s3-source-test-for-opendal-fs-engine"
     command: "ci/scripts/s3-source-test-for-opendal-fs-engine.sh -p ci-release -s run"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-s3-source-tests" || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-s3-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)s3-source-tests?(,|$$)/
     depends_on: build
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -431,7 +512,10 @@ steps:
   - label: "pulsar source check"
     key: "pulsar-source-tests"
     command: "ci/scripts/pulsar-source-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-pulsar-source-tests" || build.env("CI_STEPS") =~ /(^|,)pulsar-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-pulsar-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)pulsar-source-tests?(,|$$)/
     depends_on:
       - build
       - build-other
@@ -452,7 +536,10 @@ steps:
 
   - label: "micro benchmark"
     command: "ci/scripts/run-micro-benchmarks.sh"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-micro-benchmarks" || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-micro-benchmarks"
+      || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/
     key: "run-micro-benchmarks"
     plugins:
       - docker-compose#v4.9.0:
@@ -463,7 +550,11 @@ steps:
     retry: *auto-retry
 
   - label: "upload micro-benchmark"
-    if: build.branch == "main" || (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-micro-benchmarks" || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/)
+    if: |
+      build.branch == "main"
+      || !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-micro-benchmarks"
+      || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/
     command:
       - "BUILDKITE_BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER ci/scripts/upload-micro-bench-results.sh"
     depends_on: "run-micro-benchmarks"
@@ -485,7 +576,10 @@ steps:
   - label: "Backwards compatibility tests"
     key: "backwards-compat-tests"
     command: "RW_COMMIT=$BUILDKITE_COMMIT ci/scripts/backwards-compat-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-backwards-compat-tests" || build.env("CI_STEPS") =~ /(^|,)backwards?-compat-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-backwards-compat-tests"
+      || build.env("CI_STEPS") =~ /(^|,)backwards?-compat-tests?(,|$$)/
     depends_on:
       - "build"
     plugins:
@@ -500,7 +594,10 @@ steps:
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"
     command: "ci/scripts/sqlsmith-differential-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-sqlsmith-differential-tests" || build.env("CI_STEPS") =~ /(^|,)sqlsmith-differential-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-sqlsmith-differential-tests"
+      || build.env("CI_STEPS") =~ /(^|,)sqlsmith-differential-tests?(,|$$)/
     depends_on:
       - "build"
     plugins:
@@ -514,7 +611,10 @@ steps:
   - label: "Backfill tests"
     key: "backfill-tests"
     command: "ci/scripts/backfill-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-backfill-tests" || build.env("CI_STEPS") =~ /(^|,)backfill-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-backfill-tests"
+      || build.env("CI_STEPS") =~ /(^|,)backfill-tests?(,|$$)/
     depends_on:
       - "build"
     plugins:
@@ -528,7 +628,10 @@ steps:
 
   - label: "e2e standalone binary test"
     command: "ci/scripts/e2e-test.sh -p ci-release -m standalone"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-standalone-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-standalone-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-standalone-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-standalone-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -544,7 +647,10 @@ steps:
 
   - label: "end-to-end test for opendal (parallel)"
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-tests-for-opendal" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?-for-opendal(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-parallel-tests-for-opendal"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?-for-opendal(,|$$)/
     depends_on:
       - "build"
       - "docslt"
@@ -560,7 +666,10 @@ steps:
   - label: "end-to-end clickhouse sink test"
     key: "e2e-clickhouse-sink-tests"
     command: "ci/scripts/e2e-clickhouse-sink-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-clickhouse-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-clickhouse-sink-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-clickhouse-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-clickhouse-sink-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -576,7 +685,10 @@ steps:
   - label: "end-to-end pulsar sink test"
     key: "e2e-pulsar-sink-tests"
     command: "ci/scripts/e2e-pulsar-sink-test.sh -p ci-release"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-pulsar-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-pulsar-sink-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-pulsar-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-pulsar-sink-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -592,7 +704,10 @@ steps:
   - label: "connector node integration test Java {{matrix.java_version}}"
     key: "connector-node-integration-test"
     command: "ci/scripts/connector-node-integration-test.sh -p ci-release -v {{matrix.java_version}}"
-    if: (!(build.pull_request.labels includes "ci/main-cron/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-connector-node-integration-tests" || build.env("CI_STEPS") =~ /(^|,)connector-node-integration-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-connector-node-integration-tests"
+      || build.env("CI_STEPS") =~ /(^|,)connector-node-integration-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -19,7 +19,10 @@ steps:
   - label: "build"
     command: "ci/scripts/build.sh -p ci-dev"
     key: "build"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build" || build.env("CI_STEPS") =~ /(^|,)build(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-build"
+      || build.env("CI_STEPS") =~ /(^|,)build(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -31,7 +34,10 @@ steps:
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
     key: "build-other"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-other" || build.env("CI_STEPS") =~ /(^|,)build-other(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-build-other"
+      || build.env("CI_STEPS") =~ /(^|,)build-other(,|$$)/
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -48,7 +54,10 @@ steps:
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
     key: "build-simulation"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-simulation" || build.env("CI_STEPS") =~ /(^|,)build-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-build-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)build-simulation(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -60,7 +69,10 @@ steps:
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
     key: "docslt"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-docslt" || build.env("CI_STEPS") =~ /(^|,)docslt(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-docslt"
+      || build.env("CI_STEPS") =~ /(^|,)docslt(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -71,7 +83,10 @@ steps:
 
   - label: "end-to-end test"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-test"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -87,7 +102,10 @@ steps:
 
   - label: "end-to-end test (parallel)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-parallel-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/
     depends_on:
       - "build"
       - "docslt"
@@ -130,7 +148,10 @@ steps:
 
   - label: "end-to-end source test"
     command: "ci/scripts/e2e-source-test.sh -p ci-dev"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-source-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-source-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -145,7 +166,10 @@ steps:
 
   - label: "end-to-end sink test"
     command: "ci/scripts/e2e-sink-test.sh -p ci-dev"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-sink-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -271,7 +295,10 @@ steps:
 
   - label: "regress test"
     command: "ci/scripts/regress-test.sh -p ci-dev"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-regress-test" || build.env("CI_STEPS") =~ /(^|,)regress-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-regress-test"
+      || build.env("CI_STEPS") =~ /(^|,)regress-tests?(,|$$)/
     depends_on: "build"
     plugins:
       - docker-compose#v4.9.0:
@@ -287,7 +314,10 @@ steps:
   # This ensures our `main-cron` workflow will be stable.
   - label: "unit test"
     command: "ci/scripts/pr-unit-test.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test" || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-unit-test"
+      || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/
     plugins:
       - ./ci/plugins/swapfile
       - seek-oss/aws-sm#v2.3.1:
@@ -303,7 +333,10 @@ steps:
 
   - label: "check"
     command: "ci/scripts/check.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-check" || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-check"
+      || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
     plugins:
       - gencer/cache#v2.4.10:
           id: cache
@@ -325,7 +358,10 @@ steps:
 
   - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-unit-test.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -337,7 +373,10 @@ steps:
 
   - label: "integration test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -350,7 +389,10 @@ steps:
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=16 ci/scripts/deterministic-e2e-test.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -369,7 +411,10 @@ steps:
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=8 KILL_RATE=0.5 ci/scripts/deterministic-recovery-test.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
+      || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/
     depends_on: "build-simulation"
     plugins:
       # - seek-oss/aws-sm#v2.3.1:
@@ -389,7 +434,10 @@ steps:
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
-    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-misc-check" || build.env("CI_STEPS") =~ /(^|,)misc-check(,|$$)/)
+    if: |
+      !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-misc-check"
+      || build.env("CI_STEPS") =~ /(^|,)misc-check(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -19,7 +19,7 @@ steps:
   - label: "build"
     command: "ci/scripts/build.sh -p ci-dev"
     key: "build"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-build")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build" || build.env("CI_STEPS") =~ /(^|,)build(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -31,7 +31,7 @@ steps:
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
     key: "build-other"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-build-other")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-other" || build.env("CI_STEPS") =~ /(^|,)build-other(,|$$)/)
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -48,7 +48,7 @@ steps:
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
     key: "build-simulation"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-build-simulation")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-build-simulation" || build.env("CI_STEPS") =~ /(^|,)build-simulation(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -60,7 +60,7 @@ steps:
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
     key: "docslt"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-docslt")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-docslt" || build.env("CI_STEPS") =~ /(^|,)docslt(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -71,7 +71,7 @@ steps:
 
   - label: "end-to-end test"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-e2e-test")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -87,7 +87,7 @@ steps:
 
   - label: "end-to-end test (parallel)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-e2e-parallel-tests")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-parallel-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/)
     depends_on:
       - "build"
       - "docslt"
@@ -101,7 +101,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end test for opendal (parallel)"
-    if: build.pull_request.labels includes "ci/run-opendal-tests"
+    if: build.pull_request.labels includes "ci/run-opendal-tests" || build.env("CI_STEPS") =~ /(^|,)opendal-tests?(,|$$)/
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-dev"
     depends_on:
       - "build"
@@ -116,7 +116,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory)"
-    if: build.pull_request.labels includes "ci/run-e2e-parallel-in-memory-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-parallel-in-memory-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-in-memory-tests?(,|$$)/
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-dev"
     depends_on: "build"
     plugins:
@@ -130,7 +130,7 @@ steps:
 
   - label: "end-to-end source test"
     command: "ci/scripts/e2e-source-test.sh -p ci-dev"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-e2e-source-tests")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-source-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -145,7 +145,7 @@ steps:
 
   - label: "end-to-end sink test"
     command: "ci/scripts/e2e-sink-test.sh -p ci-dev"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-e2e-sink-tests")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/)
     depends_on:
       - "build"
       - "build-other"
@@ -160,7 +160,7 @@ steps:
     retry: *auto-retry
 
   - label: "connector node integration test Java {{matrix.java_version}}"
-    if: build.pull_request.labels includes "ci/run-java-connector-node-integration-tests"
+    if: build.pull_request.labels includes "ci/run-java-connector-node-integration-tests" || build.env("CI_STEPS") =~ /(^|,)java-connector-node-integration-tests?(,|$$)/
     command: "ci/scripts/connector-node-integration-test.sh -p ci-dev -v {{matrix.java_version}}"
     depends_on:
       - "build"
@@ -180,7 +180,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end iceberg sink test"
-    if: build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-dev"
     depends_on:
       - "build"
@@ -195,7 +195,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end iceberg sink v2 test"
-    if: build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-iceberg-sink-v2-test.sh -p ci-dev"
     depends_on:
       - "build"
@@ -210,7 +210,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end iceberg cdc test"
-    if: build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-iceberg-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-iceberg-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-iceberg-cdc.sh -p ci-dev"
     depends_on:
       - "build"
@@ -225,7 +225,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end pulsar sink test"
-    if: build.pull_request.labels includes "ci/run-e2e-pulsar-sink-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-pulsar-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-pulsar-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-pulsar-sink-test.sh -p ci-dev"
     depends_on:
       - "build"
@@ -240,7 +240,7 @@ steps:
     retry: *auto-retry
 
   - label: "end-to-end clickhouse sink test"
-    if: build.pull_request.labels includes "ci/run-e2e-clickhouse-sink-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-clickhouse-sink-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-clickhouse-sink-tests?(,|$$)/
     command: "ci/scripts/e2e-clickhouse-sink-test.sh -p ci-dev"
     depends_on:
       - "build"
@@ -255,7 +255,7 @@ steps:
     retry: *auto-retry
 
   - label: "e2e java-binding test"
-    if: build.pull_request.labels includes "ci/run-java-binding-tests"
+    if: build.pull_request.labels includes "ci/run-java-binding-tests" || build.env("CI_STEPS") =~ /(^|,)java-binding-tests?(,|$$)/
     command: "ci/scripts/java-binding-test.sh -p ci-dev"
     depends_on:
       - "build"
@@ -271,7 +271,7 @@ steps:
 
   - label: "regress test"
     command: "ci/scripts/regress-test.sh -p ci-dev"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-regress-test")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-regress-test" || build.env("CI_STEPS") =~ /(^|,)regress-tests?(,|$$)/)
     depends_on: "build"
     plugins:
       - docker-compose#v4.9.0:
@@ -287,7 +287,7 @@ steps:
   # This ensures our `main-cron` workflow will be stable.
   - label: "unit test"
     command: "ci/scripts/pr-unit-test.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-unit-test")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test" || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/)
     plugins:
       - ./ci/plugins/swapfile
       - seek-oss/aws-sm#v2.3.1:
@@ -303,7 +303,7 @@ steps:
 
   - label: "check"
     command: "ci/scripts/check.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-check")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-check" || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/)
     plugins:
       - gencer/cache#v2.4.10:
           id: cache
@@ -325,7 +325,7 @@ steps:
 
   - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-unit-test.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -337,7 +337,7 @@ steps:
 
   - label: "integration test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v4.9.0:
@@ -350,7 +350,7 @@ steps:
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=16 ci/scripts/deterministic-e2e-test.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -369,7 +369,7 @@ steps:
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=8 KILL_RATE=0.5 ci/scripts/deterministic-recovery-test.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation" || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/)
     depends_on: "build-simulation"
     plugins:
       # - seek-oss/aws-sm#v2.3.1:
@@ -389,7 +389,7 @@ steps:
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
-    if: (!build.pull_request.labels includes "ci/skip-ci" || build.pull_request.labels includes "ci/run-misc-check")
+    if: (!(build.pull_request.labels includes "ci/skip-ci" || build.env("CI_STEPS") != null) || build.pull_request.labels includes "ci/run-misc-check" || build.env("CI_STEPS") =~ /(^|,)misc-check(,|$$)/)
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -410,6 +410,7 @@ steps:
       || build.pull_request.labels includes "ci/run-cpu-flamegraph"
       || build.pull_request.labels includes "heap_flamegraph"
       || build.pull_request.labels includes "ci/run-heap-flamegraph"
+      || build.env("CI_STEPS") =~ /(^|,)(cpu-flamegraph|heap-flamegraph)(,|$$)/
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -426,7 +427,7 @@ steps:
   - label: "Generate CPU flamegraph"
     command: "PULL_REQUEST=$BUILDKITE_PULL_REQUEST ci/scripts/gen-flamegraph.sh cpu"
     depends_on: "flamegraph-env-build"
-    if: build.pull_request.labels includes "cpu_flamegraph" || build.pull_request.labels includes "ci/run-cpu-flamegraph"
+    if: build.pull_request.labels includes "cpu_flamegraph" || build.pull_request.labels includes "ci/run-cpu-flamegraph" || build.env("CI_STEPS") =~ /(^|,)cpu-flamegraph(,|$$)/
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -448,7 +449,7 @@ steps:
     command: "PULL_REQUEST=$BUILDKITE_PULL_REQUEST ci/scripts/gen-flamegraph.sh heap"
     depends_on: "flamegraph-env-build"
 
-    if: build.pull_request.labels includes "heap_flamegraph" || build.pull_request.labels includes "ci/run-heap-flamegraph"
+    if: build.pull_request.labels includes "heap_flamegraph" || build.pull_request.labels includes "ci/run-heap-flamegraph" || build.env("CI_STEPS") =~ /(^|,)heap-flamegraph(,|$$)/
 
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -471,7 +472,8 @@ steps:
     command: "RW_COMMIT=$BUILDKITE_COMMIT ci/scripts/backwards-compat-test.sh -p ci-dev"
     if: |
       build.pull_request.labels includes "breaking-change" ||
-        build.pull_request.labels includes "ci/run-backwards-compat-tests"
+        build.pull_request.labels includes "ci/run-backwards-compat-tests" ||
+        build.env("CI_STEPS") =~ /(^|,)backwards?-compat-tests?(,|$$)/
     depends_on:
       - "build"
     plugins:
@@ -485,7 +487,7 @@ steps:
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"
     command: "ci/scripts/sqlsmith-differential-test.sh -p ci-dev"
-    if: build.pull_request.labels includes "ci/run-sqlsmith-differential-tests"
+    if: build.pull_request.labels includes "ci/run-sqlsmith-differential-tests" || build.env("CI_STEPS") =~ /(^|,)sqlsmith-differential-tests?(,|$$)/
     depends_on:
       - "build"
     plugins:
@@ -497,7 +499,7 @@ steps:
 
   - label: "Backfill tests"
     command: "ci/scripts/backfill-test.sh -p ci-dev"
-    if: build.pull_request.labels includes "ci/run-backfill-tests"
+    if: build.pull_request.labels includes "ci/run-backfill-tests" || build.env("CI_STEPS") =~ /(^|,)backfill-tests?(,|$$)/
     depends_on:
       - "build"
     plugins:
@@ -510,7 +512,7 @@ steps:
 
   - label: "e2e standalone binary test"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m standalone"
-    if: build.pull_request.labels includes "ci/run-e2e-standalone-tests"
+    if: build.pull_request.labels includes "ci/run-e2e-standalone-tests" || build.env("CI_STEPS") =~ /(^|,)e2e-standalone-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-other"
@@ -527,7 +529,7 @@ steps:
   # FIXME(kwannoel): Let the github PR labeller label it, if sqlsmith source files has changes.
   - label: "fuzz test"
     command: "ci/scripts/pr-fuzz-test.sh -p ci-dev"
-    if: build.pull_request.labels includes "ci/run-sqlsmith-fuzzing-tests"
+    if: build.pull_request.labels includes "ci/run-sqlsmith-fuzzing-tests" || build.env("CI_STEPS") =~ /(^|,)sqlsmith-fuzzing-tests?(,|$$)/
     depends_on:
       - "build"
       - "build-simulation"
@@ -550,7 +552,7 @@ steps:
   - label: "micro benchmark"
     command: "ci/scripts/run-micro-benchmarks.sh"
     key: "run-micro-benchmarks"
-    if: build.pull_request.labels includes "ci/run-micro-benchmarks"
+    if: build.pull_request.labels includes "ci/run-micro-benchmarks" || build.env("CI_STEPS") =~ /(^|,)micro-benchmarks?(,|$$)/
     plugins:
       - docker-compose#v4.9.0:
           run: rw-build-env
@@ -560,7 +562,7 @@ steps:
     retry: *auto-retry
 
   - label: "upload micro-benchmark"
-    if: build.pull_request.labels includes "ci/run-upload-micro-benchmark"
+    if: build.pull_request.labels includes "ci/run-upload-micro-benchmark" || build.env("CI_STEPS") =~ /(^|,)upload-micro-benchmarks?(,|$$)/
     command:
       - "BUILDKITE_BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER ci/scripts/upload-micro-bench-results.sh"
     depends_on: "run-micro-benchmarks"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Similar to #12870, but without the need to create a PR (e.g. #13457).

Example usage:
https://buildkite.com/risingwavelabs/pull-request#new
`CI_STEPS=build,build-other,docslt,e2e-test`

Notes about regular expression:
Buildkite conditionals ([doc](https://buildkite.com/docs/pipelines/conditionals) [src](https://github.com/buildkite/conditional)) uses golang [regexp](https://pkg.go.dev/regexp) package:
> Metacharacters: `*+?()|`
> The operator precedence, from weakest to strongest binding, is first alternation, then concatenation, and finally the repetition operators.
* `(^|,)` and `(,|$$)` are used to prevent suffix and prefix match respectively. For example `misc-check` shall not match `/check/` and `build-other` shall not match `/build/`. Parentheses are required to evaluate alternation before concatenation.
* `tests?` is used to accept both singular `test` and plural `tests`. Parentheses are not required because repetition already evaluates before concatenation. Similarly we allow `benchmarks?` and `backwards?`, but no other typos are tolerated.
* `/(^|,)(cpu-flamegraph|heap-flamegraph)(,|$$)/` is used to match either `cpu-flamegraph` or `heap-flamegraph`. This is the only example where user do not need to manually specify the dependency step `flamegraph-env-build`. Note the use of one more pair of parentheses to evaluate alternation before concatenation.

Tests runs:
* Without `CI_STEPS`, pipeline `pull-request` shall include the same set of steps before this PR. ([link](https://buildkite.com/risingwavelabs/pull-request/builds/35644))
* Without `CI_STEPS`, pipeline `main-cron` shall include the same set of steps before this PR. ([link](https://buildkite.com/risingwavelabs/main-cron/builds/1161))
* With `CI_STEPS=`, pipeline `pull-request` runs the selected steps.
  * `build,build-other,docslt,e2e-test` ([link](https://buildkite.com/risingwavelabs/pull-request/builds/35636))
  * `cpu-flamegraph` ([link](https://buildkite.com/risingwavelabs/pull-request/builds/35641))
  * `regress-test,build,unit-tests,misc-check` ([link](https://buildkite.com/risingwavelabs/pull-request/builds/35643))
* With `CI_STEPS=`, pipeline `main-cron` runs the selected steps.
  * `build,s3-source-test` ([link](https://buildkite.com/risingwavelabs/main-cron/builds/1162))

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
