### PR TITLE
refactor(rw_catalog): make rw_worker_nodes list all nodes and resource

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -52,6 +52,11 @@ message WorkerNode {
     bool is_serving = 2;
     bool is_unschedulable = 3;
   }
+  message Resource {
+    string rw_version = 1;
+    uint64 total_memory_bytes = 2;
+    uint64 total_cpu_cores = 3;
+  }
   uint32 id = 1;
   WorkerType type = 2;
   HostAddress host = 3;
@@ -62,6 +67,14 @@ message WorkerNode {
 
   // Ranges from 0 to 1023, used to generate the machine ID field in the global unique ID.
   optional uint32 transactional_id = 7;
+  // Resource spec.
+  // It's populated by meta node with the value reported by worker node, when the worker node is added by meta node.
+  // It's not persistent in meta store.
+  optional Resource resource = 8;
+  // Timestamp the worker node is added by meta node, in seconds.
+  // It's populated by meta node, when the worker node is added by meta node.
+  // It's not persistent in meta store.
+  optional uint64 started_at = 9;
 }
 
 message Buffer {

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -262,6 +262,7 @@ message AddWorkerNodeRequest {
   common.HostAddress host = 2;
   reserved 3;
   Property property = 4;
+  common.WorkerNode.Resource resource = 5;
 }
 
 message AddWorkerNodeResponse {
@@ -304,7 +305,7 @@ message UpdateWorkerNodeSchedulabilityResponse {
 }
 
 message ListAllNodesRequest {
-  common.WorkerType worker_type = 1;
+  optional common.WorkerType worker_type = 1;
   // Whether to include nodes still starting
   bool include_starting_nodes = 2;
 }

--- a/src/ctl/src/cmd_impl/await_tree.rs
+++ b/src/ctl/src/cmd_impl/await_tree.rs
@@ -31,7 +31,7 @@ pub async fn dump(context: &CtlContext) -> anyhow::Result<()> {
     let meta_client = context.meta_client().await?;
 
     let compute_nodes = meta_client
-        .list_worker_nodes(WorkerType::ComputeNode)
+        .list_worker_nodes(Some(WorkerType::ComputeNode))
         .await?;
     let clients = ComputeClientPool::default();
 
@@ -43,7 +43,9 @@ pub async fn dump(context: &CtlContext) -> anyhow::Result<()> {
         merge(&mut all, response);
     }
 
-    let compactor_nodes = meta_client.list_worker_nodes(WorkerType::Compactor).await?;
+    let compactor_nodes = meta_client
+        .list_worker_nodes(Some(WorkerType::Compactor))
+        .await?;
 
     for compactor in compactor_nodes {
         let addr: HostAddr = compactor.get_host().unwrap().into();

--- a/src/ctl/src/cmd_impl/meta/serving.rs
+++ b/src/ctl/src/cmd_impl/meta/serving.rs
@@ -25,7 +25,7 @@ pub async fn list_serving_fragment_mappings(context: &CtlContext) -> anyhow::Res
     let meta_client = context.meta_client().await?;
     let mappings = meta_client.list_serving_vnode_mappings().await?;
     let workers = meta_client
-        .list_worker_nodes(WorkerType::ComputeNode)
+        .list_worker_nodes(Some(WorkerType::ComputeNode))
         .await?;
     let mut pu_to_worker: HashMap<ParallelUnitId, &WorkerNode> = HashMap::new();
     for w in &workers {

--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -382,7 +382,7 @@ prepare_sys_catalog! {
     { BuiltinCatalog::Table(&RW_CONNECTIONS), read_rw_connections_info },
     { BuiltinCatalog::Table(&RW_FUNCTIONS), read_rw_functions_info },
     { BuiltinCatalog::Table(&RW_VIEWS), read_rw_views_info },
-    { BuiltinCatalog::Table(&RW_WORKER_NODES), read_rw_worker_nodes_info },
+    { BuiltinCatalog::Table(&RW_WORKER_NODES), read_rw_worker_nodes_info await },
     { BuiltinCatalog::Table(&RW_PARALLEL_UNITS), read_rw_parallel_units_info },
     { BuiltinCatalog::Table(&RW_TABLE_FRAGMENTS), read_rw_table_fragments_info await },
     { BuiltinCatalog::Table(&RW_FRAGMENTS), read_rw_fragment_distributions_info await },

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_worker_nodes.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_worker_nodes.rs
@@ -16,12 +16,11 @@ use itertools::Itertools;
 use risingwave_common::catalog::RW_CATALOG_SCHEMA_NAME;
 use risingwave_common::error::Result;
 use risingwave_common::row::OwnedRow;
-use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::types::{DataType, ScalarImpl, Timestamptz};
 
 use crate::catalog::system_catalog::{BuiltinTable, SysCatalogReaderImpl};
 
 /// `rw_worker_nodes` contains all information about the compute nodes in the cluster.
-/// TODO: Add other type of nodes if necessary in the future.
 pub const RW_WORKER_NODES: BuiltinTable = BuiltinTable {
     name: "rw_worker_nodes",
     schema: RW_CATALOG_SCHEMA_NAME,
@@ -35,23 +34,29 @@ pub const RW_WORKER_NODES: BuiltinTable = BuiltinTable {
         (DataType::Boolean, "is_streaming"),
         (DataType::Boolean, "is_serving"),
         (DataType::Boolean, "is_unschedulable"),
+        (DataType::Varchar, "rw_version"),
+        (DataType::Int64, "total_memory_bytes"),
+        (DataType::Int64, "total_cpu_cores"),
+        (DataType::Timestamptz, "started_at"),
     ],
     pk: &[0],
 };
 
 impl SysCatalogReaderImpl {
-    pub fn read_rw_worker_nodes_info(&self) -> Result<Vec<OwnedRow>> {
-        let workers = self.worker_node_manager.list_worker_nodes();
+    pub async fn read_rw_worker_nodes_info(&self) -> Result<Vec<OwnedRow>> {
+        let workers = self.meta_client.list_all_nodes().await?;
 
         Ok(workers
             .into_iter()
+            .sorted_by_key(|w| w.id)
             .map(|worker| {
-                let host = worker.host.as_ref().unwrap();
-                let property = worker.property.as_ref().unwrap();
+                let host = worker.host.as_ref();
+                let property = worker.property.as_ref();
+                let resource = worker.resource.as_ref();
                 OwnedRow::new(vec![
                     Some(ScalarImpl::Int32(worker.id as i32)),
-                    Some(ScalarImpl::Utf8(host.host.clone().into())),
-                    Some(ScalarImpl::Utf8(host.port.to_string().into())),
+                    host.map(|h| ScalarImpl::Utf8(h.host.clone().into())),
+                    host.map(|h| ScalarImpl::Utf8(h.port.to_string().into())),
                     Some(ScalarImpl::Utf8(
                         worker.get_type().unwrap().as_str_name().into(),
                     )),
@@ -59,9 +64,15 @@ impl SysCatalogReaderImpl {
                         worker.get_state().unwrap().as_str_name().into(),
                     )),
                     Some(ScalarImpl::Int32(worker.parallel_units.len() as i32)),
-                    Some(ScalarImpl::Bool(property.is_streaming)),
-                    Some(ScalarImpl::Bool(property.is_serving)),
-                    Some(ScalarImpl::Bool(property.is_unschedulable)),
+                    property.map(|p| ScalarImpl::Bool(p.is_streaming)),
+                    property.map(|p| ScalarImpl::Bool(p.is_serving)),
+                    property.map(|p| ScalarImpl::Bool(p.is_unschedulable)),
+                    resource.map(|r| ScalarImpl::Utf8(r.rw_version.to_owned().into())),
+                    resource.map(|r| ScalarImpl::Int64(r.total_memory_bytes as _)),
+                    resource.map(|r| ScalarImpl::Int64(r.total_cpu_cores as _)),
+                    worker.started_at.map(|ts| {
+                        ScalarImpl::Timestamptz(Timestamptz::from_secs(ts as i64).unwrap())
+                    }),
                 ])
             })
             .collect_vec())

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -18,6 +18,7 @@ use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::util::epoch::MAX_EPOCH;
 use risingwave_pb::backup_service::MetaSnapshotMetadata;
 use risingwave_pb::catalog::Table;
+use risingwave_pb::common::WorkerNode;
 use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
@@ -96,6 +97,8 @@ pub trait FrontendMetaClient: Send + Sync {
     async fn list_hummock_active_write_limits(&self) -> Result<HashMap<u64, WriteLimit>>;
 
     async fn list_hummock_meta_configs(&self) -> Result<HashMap<String, String>>;
+
+    async fn list_all_nodes(&self) -> Result<Vec<WorkerNode>>;
 }
 
 pub struct FrontendMetaClientImpl(pub MetaClient);
@@ -239,5 +242,9 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn list_hummock_meta_configs(&self) -> Result<HashMap<String, String>> {
         self.0.list_hummock_meta_config().await
+    }
+
+    async fn list_all_nodes(&self) -> Result<Vec<WorkerNode>> {
+        self.0.list_worker_nodes(None).await
     }
 }

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -613,6 +613,7 @@ pub(crate) mod tests {
                 is_streaming: true,
             }),
             transactional_id: Some(0),
+            ..Default::default()
         };
         let worker2 = WorkerNode {
             id: 1,
@@ -629,6 +630,7 @@ pub(crate) mod tests {
                 is_streaming: true,
             }),
             transactional_id: Some(1),
+            ..Default::default()
         };
         let worker3 = WorkerNode {
             id: 2,
@@ -645,6 +647,7 @@ pub(crate) mod tests {
                 is_streaming: true,
             }),
             transactional_id: Some(2),
+            ..Default::default()
         };
         let workers = vec![worker1, worker2, worker3];
         let worker_node_manager = Arc::new(WorkerNodeManager::mock(workers));

--- a/src/frontend/src/scheduler/worker_node_manager.rs
+++ b/src/frontend/src/scheduler/worker_node_manager.rs
@@ -413,6 +413,7 @@ mod tests {
                     is_streaming: true,
                 }),
                 transactional_id: Some(1),
+                ..Default::default()
             },
             WorkerNode {
                 id: 2,
@@ -426,6 +427,7 @@ mod tests {
                     is_streaming: false,
                 }),
                 transactional_id: Some(2),
+                ..Default::default()
             },
         ];
         worker_nodes

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -36,6 +36,7 @@ use risingwave_pb::catalog::table::OptionalAssociatedSourceId;
 use risingwave_pb::catalog::{
     PbComment, PbDatabase, PbFunction, PbIndex, PbSchema, PbSink, PbSource, PbTable, PbView, Table,
 };
+use risingwave_pb::common::WorkerNode;
 use risingwave_pb::ddl_service::alter_owner_request::Object;
 use risingwave_pb::ddl_service::{create_connection_request, DdlProgress, PbTableJobType};
 use risingwave_pb::hummock::write_limits::WriteLimit;
@@ -893,6 +894,10 @@ impl FrontendMetaClient for MockFrontendMetaClient {
     }
 
     async fn list_hummock_meta_configs(&self) -> RpcResult<HashMap<String, String>> {
+        unimplemented!()
+    }
+
+    async fn list_all_nodes(&self) -> RpcResult<Vec<WorkerNode>> {
         unimplemented!()
     }
 }

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -234,7 +234,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
             });
 
         let add_info = AddressInfo {
-            advertise_addr: opts.advertise_addr,
+            advertise_addr: opts.advertise_addr.to_owned(),
             listen_addr,
             prometheus_addr,
             dashboard_addr,
@@ -300,6 +300,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
                     .meta
                     .compaction_task_max_heartbeat_interval_secs,
                 compaction_config: Some(config.meta.compaction_config),
+                advertise_addr: opts.advertise_addr,
             },
             config.system.into_init_system_params(),
         )

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -48,9 +48,10 @@ impl ClusterService for ClusterServiceImpl {
         let property = req
             .property
             .ok_or_else(|| MetaError::invalid_parameter("worker node property is not provided"))?;
+        let resource = req.resource.unwrap_or_default();
         let result = self
             .cluster_manager
-            .add_worker_node(worker_type, host, property)
+            .add_worker_node(worker_type, host, property, resource)
             .await;
         match result {
             Ok(worker_node) => Ok(Response::new(AddWorkerNodeResponse {
@@ -116,7 +117,7 @@ impl ClusterService for ClusterServiceImpl {
         request: Request<ListAllNodesRequest>,
     ) -> Result<Response<ListAllNodesResponse>, Status> {
         let req = request.into_inner();
-        let worker_type = req.get_worker_type()?;
+        let worker_type = req.worker_type.map(|wt| wt.try_into().unwrap());
         let worker_states = if req.include_starting_nodes {
             None
         } else {

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -113,7 +113,7 @@ impl NotificationServiceImpl {
 
     async fn get_worker_node_snapshot(&self) -> (Vec<WorkerNode>, NotificationVersion) {
         let cluster_guard = self.cluster_manager.get_cluster_core_guard().await;
-        let nodes = cluster_guard.list_worker_node(WorkerType::ComputeNode, Some(Running));
+        let nodes = cluster_guard.list_worker_node(Some(WorkerType::ComputeNode), Some(Running));
         let notification_version = self.env.notification_manager().current_version().await;
         (nodes, notification_version)
     }

--- a/src/meta/service/src/scale_service.rs
+++ b/src/meta/service/src/scale_service.rs
@@ -88,7 +88,7 @@ impl ScaleService for ScaleServiceImpl {
 
         let worker_nodes = self
             .cluster_manager
-            .list_worker_node(WorkerType::ComputeNode, None)
+            .list_worker_node(Some(WorkerType::ComputeNode), None)
             .await;
 
         let actor_splits = self

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -209,7 +209,7 @@ pub async fn collect_global_gc_watermark(
     let workers = [
         cluster_manager.list_active_streaming_compute_nodes().await,
         cluster_manager
-            .list_worker_node(WorkerType::Compactor, Some(Running))
+            .list_worker_node(Some(WorkerType::Compactor), Some(Running))
             .await,
     ]
     .concat();
@@ -237,11 +237,11 @@ pub async fn collect_global_gc_watermark(
                 };
                 match init_version_id.as_ref() {
                     None => {
-                        init_version_id = Some(worker_info.info_version_id());
+                        init_version_id = Some(worker_info.info_version_id);
                     }
                     Some(init_version_id) => {
-                        if worker_info.info_version_id() >= *init_version_id + 2 {
-                            return worker_info.hummock_gc_watermark();
+                        if worker_info.info_version_id >= *init_version_id + 2 {
+                            return worker_info.hummock_gc_watermark;
                         }
                     }
                 }

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -382,6 +382,7 @@ async fn test_release_context_resource() {
                 is_serving: true,
                 is_unschedulable: false,
             },
+            Default::default(),
         )
         .await
         .unwrap();
@@ -469,6 +470,7 @@ async fn test_hummock_manager_basic() {
                 is_serving: true,
                 is_unschedulable: false,
             },
+            Default::default(),
         )
         .await
         .unwrap();

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -217,6 +217,7 @@ impl HummockMetaClient for MockHummockMetaClient {
                     port: 0,
                 },
                 Default::default(),
+                Default::default(),
             )
             .await
             .unwrap();

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -346,6 +346,7 @@ pub async fn setup_compute_env_with_metric(
                 is_serving: true,
                 is_unschedulable: false,
             },
+            Default::default(),
         )
         .await
         .unwrap();

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -15,11 +15,16 @@
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
+use std::iter;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
 use risingwave_common::hash::ParallelUnitId;
+use risingwave_common::util::addr::HostAddr;
+use risingwave_common::util::resource_util::cpu::total_cpu_available;
+use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
+use risingwave_common::RW_VERSION;
 use risingwave_pb::common::worker_node::{Property, State};
 use risingwave_pb::common::{HostAddress, ParallelUnit, WorkerNode, WorkerType};
 use risingwave_pb::meta::add_worker_node_request::Property as AddNodeProperty;
@@ -32,7 +37,7 @@ use tokio::task::JoinHandle;
 
 use crate::manager::{IdCategory, LocalNotification, MetaSrvEnv};
 use crate::model::{MetadataModel, ValTransaction, VarTransaction, Worker, INVALID_EXPIRE_AT};
-use crate::storage::{MetaStore, MetaStoreRef, Transaction};
+use crate::storage::{MetaStore, Transaction};
 use crate::{MetaError, MetaResult};
 
 pub type WorkerId = u32;
@@ -71,7 +76,7 @@ pub struct ClusterManager {
 
 impl ClusterManager {
     pub async fn new(env: MetaSrvEnv, max_heartbeat_interval: Duration) -> MetaResult<Self> {
-        let core = ClusterManagerCore::new(env.meta_store_ref()).await?;
+        let core = ClusterManagerCore::new(env.clone()).await?;
 
         Ok(Self {
             env,
@@ -99,12 +104,15 @@ impl ClusterManager {
         r#type: WorkerType,
         host_address: HostAddress,
         property: AddNodeProperty,
+        resource: risingwave_pb::common::worker_node::Resource,
     ) -> MetaResult<WorkerNode> {
         let worker_node_parallelism = property.worker_node_parallelism as usize;
         let mut property = self.parse_property(r#type, property);
         let mut core = self.core.write().await;
 
         if let Some(worker) = core.get_worker_by_host_mut(host_address.clone()) {
+            worker.update_resource(Some(resource));
+            worker.update_started_at(timestamp_now_sec());
             if let Some(property) = &mut property {
                 property.is_unschedulable = worker
                     .worker_node
@@ -118,7 +126,7 @@ impl ClusterManager {
             if current_parallelism == worker_node_parallelism
                 && worker.worker_node.property == property
             {
-                worker.update_ttl(self.max_heartbeat_interval);
+                worker.update_expire_at(self.max_heartbeat_interval);
                 return Ok(worker.to_protobuf());
             }
 
@@ -162,7 +170,7 @@ impl ClusterManager {
                 new_worker.worker_node.property = property;
             }
 
-            new_worker.update_ttl(self.max_heartbeat_interval);
+            new_worker.update_expire_at(self.max_heartbeat_interval);
             new_worker.insert(self.env.meta_store()).await?;
             *worker = new_worker;
             return Ok(worker.to_protobuf());
@@ -202,9 +210,14 @@ impl ClusterManager {
             parallel_units,
             property,
             transactional_id,
+            // resource doesn't need persist
+            resource: None,
+            started_at: None,
         };
 
-        let worker = Worker::from_protobuf(worker_node.clone());
+        let mut worker = Worker::from_protobuf(worker_node.clone());
+        worker.update_started_at(timestamp_now_sec());
+        worker.update_resource(Some(resource));
         // Persist worker node.
         worker.insert(self.env.meta_store()).await?;
         // Update core.
@@ -318,7 +331,7 @@ impl ClusterManager {
         let mut core = self.core.write().await;
         for worker in core.workers.values_mut() {
             if worker.worker_id() == worker_id {
-                worker.update_ttl(self.max_heartbeat_interval);
+                worker.update_expire_at(self.max_heartbeat_interval);
                 worker.update_info(info);
                 return Ok(());
             }
@@ -353,19 +366,16 @@ impl ClusterManager {
                     // 1. Initialize new workers' TTL.
                     for worker in workers
                         .values_mut()
-                        .filter(|worker| worker.expire_at() == INVALID_EXPIRE_AT)
+                        .filter(|worker| worker.expire_at == INVALID_EXPIRE_AT)
                     {
-                        worker.update_ttl(cluster_manager.max_heartbeat_interval);
+                        worker.update_expire_at(cluster_manager.max_heartbeat_interval);
                     }
                     // 2. Collect expired workers.
-                    let now = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .expect("Clock may have gone backwards")
-                        .as_secs();
+                    let now = timestamp_now_sec();
                     (
                         workers
                             .values()
-                            .filter(|worker| worker.expire_at() < now)
+                            .filter(|worker| worker.expire_at < now)
                             .map(|worker| (worker.worker_id(), worker.key().unwrap()))
                             .collect_vec(),
                         now,
@@ -413,11 +423,11 @@ impl ClusterManager {
 
     /// Get live nodes with the specified type and state.
     /// # Arguments
-    /// * `worker_type` `WorkerType` of the nodes
+    /// * `worker_type` `WorkerType` of the nodes if it is not None.
     /// * `worker_state` Filter by this state if it is not None.
     pub async fn list_worker_node(
         &self,
-        worker_type: WorkerType,
+        worker_type: Option<WorkerType>,
         worker_state: Option<State>,
     ) -> Vec<WorkerNode> {
         let core = self.core.read().await;
@@ -504,19 +514,22 @@ pub struct StreamingClusterInfo {
 }
 
 pub struct ClusterManagerCore {
+    env: MetaSrvEnv,
     /// Record for workers in the cluster.
     workers: HashMap<WorkerKey, Worker>,
-
     /// Record for tracking available machine ids, one is available.
     available_transactional_ids: VecDeque<u32>,
+    /// Used as timestamp when meta node starts in sec.
+    started_at: u64,
 }
 
 impl ClusterManagerCore {
     pub const MAX_WORKER_REUSABLE_ID_BITS: usize = 10;
     pub const MAX_WORKER_REUSABLE_ID_COUNT: usize = 1 << Self::MAX_WORKER_REUSABLE_ID_BITS;
 
-    async fn new(meta_store: MetaStoreRef) -> MetaResult<Self> {
-        let mut workers = Worker::list(&meta_store).await?;
+    async fn new(env: MetaSrvEnv) -> MetaResult<Self> {
+        let meta_store = env.meta_store();
+        let mut workers = Worker::list(meta_store).await?;
 
         let used_transactional_ids: HashSet<_> = workers
             .iter()
@@ -569,11 +582,13 @@ impl ClusterManagerCore {
         }
 
         Ok(Self {
+            env,
             workers: workers
                 .into_iter()
                 .map(|w| (WorkerKey(w.key().unwrap()), w))
                 .collect(),
             available_transactional_ids,
+            started_at: timestamp_now_sec(),
         })
     }
 
@@ -623,24 +638,34 @@ impl ClusterManagerCore {
 
     pub fn list_worker_node(
         &self,
-        worker_type: WorkerType,
+        worker_type: Option<WorkerType>,
         worker_state: Option<State>,
     ) -> Vec<WorkerNode> {
         let worker_state = worker_state.map(|worker_state| worker_state as i32);
-
         self.workers
             .values()
-            .map(|worker| worker.to_protobuf())
-            .filter(|w| w.r#type == worker_type as i32)
+            .map(|worker| WorkerNode {
+                resource: worker.resource.to_owned(),
+                started_at: worker.started_at,
+                ..worker.to_protobuf()
+            })
+            .chain(iter::once(meta_node_info(
+                &self.env.opts.advertise_addr,
+                Some(self.started_at),
+            )))
+            .filter(|w| match worker_type {
+                None => true,
+                Some(worker_type) => w.r#type == worker_type as i32,
+            })
             .filter(|w| match worker_state {
                 None => true,
                 Some(state) => state == w.state,
             })
-            .collect_vec()
+            .collect()
     }
 
     pub fn list_streaming_worker_node(&self, worker_state: Option<State>) -> Vec<WorkerNode> {
-        self.list_worker_node(WorkerType::ComputeNode, worker_state)
+        self.list_worker_node(Some(WorkerType::ComputeNode), worker_state)
             .into_iter()
             .filter(|w| w.property.as_ref().map_or(false, |p| p.is_streaming))
             .collect()
@@ -648,7 +673,7 @@ impl ClusterManagerCore {
 
     // List all parallel units on running nodes
     pub fn list_serving_worker_node(&self, worker_state: Option<State>) -> Vec<WorkerNode> {
-        self.list_worker_node(WorkerType::ComputeNode, worker_state)
+        self.list_worker_node(Some(WorkerType::ComputeNode), worker_state)
             .into_iter()
             .filter(|w| w.property.as_ref().map_or(false, |p| p.is_serving))
             .collect()
@@ -721,6 +746,34 @@ impl ClusterManagerCore {
     }
 }
 
+fn timestamp_now_sec() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("Clock may have gone backwards")
+        .as_secs()
+}
+
+fn meta_node_info(host: &str, started_at: Option<u64>) -> WorkerNode {
+    WorkerNode {
+        id: META_NODE_ID,
+        r#type: WorkerType::Meta as _,
+        host: HostAddr::try_from(host)
+            .as_ref()
+            .map(HostAddr::to_protobuf)
+            .ok(),
+        state: State::Running as _,
+        parallel_units: vec![],
+        property: None,
+        transactional_id: None,
+        resource: Some(risingwave_pb::common::worker_node::Resource {
+            rw_version: RW_VERSION.to_string(),
+            total_memory_bytes: system_memory_available_bytes() as _,
+            total_cpu_cores: total_cpu_available() as _,
+        }),
+        started_at,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -750,6 +803,7 @@ mod tests {
                         is_serving: true,
                         is_unschedulable: false,
                     },
+                    Default::default(),
                 )
                 .await
                 .unwrap();
@@ -790,6 +844,7 @@ mod tests {
                     is_serving: true,
                     is_unschedulable: false,
                 },
+                Default::default(),
             )
             .await
             .unwrap();
@@ -811,6 +866,7 @@ mod tests {
                     is_serving: true,
                     is_unschedulable: false,
                 },
+                Default::default(),
             )
             .await
             .unwrap();
@@ -852,6 +908,7 @@ mod tests {
                     is_serving: true,
                     is_unschedulable: false,
                 },
+                Default::default(),
             )
             .await
             .unwrap();
@@ -904,13 +961,14 @@ mod tests {
                     is_serving: true,
                     is_unschedulable: false,
                 },
+                Default::default(),
             )
             .await
             .unwrap();
         // Two live nodes
         assert_eq!(
             cluster_manager
-                .list_worker_node(WorkerType::ComputeNode, None)
+                .list_worker_node(Some(WorkerType::ComputeNode), None)
                 .await
                 .len(),
             2
@@ -937,7 +995,7 @@ mod tests {
         // started.
         assert_eq!(
             cluster_manager
-                .list_worker_node(WorkerType::ComputeNode, None)
+                .list_worker_node(Some(WorkerType::ComputeNode), None)
                 .await
                 .len(),
             2
@@ -950,7 +1008,7 @@ mod tests {
         // One live node left.
         assert_eq!(
             cluster_manager
-                .list_worker_node(WorkerType::ComputeNode, None)
+                .list_worker_node(Some(WorkerType::ComputeNode), None)
                 .await
                 .len(),
             1

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -169,6 +169,7 @@ pub struct MetaOpts {
 
     pub compaction_task_max_heartbeat_interval_secs: u64,
     pub compaction_config: Option<CompactionConfig>,
+    pub advertise_addr: String,
 }
 
 impl MetaOpts {
@@ -209,6 +210,7 @@ impl MetaOpts {
             partition_vnode_count: 32,
             compaction_task_max_heartbeat_interval_secs: 0,
             compaction_config: None,
+            advertise_addr: "".to_string(),
         }
     }
 }

--- a/src/meta/src/model/cluster.rs
+++ b/src/meta/src/model/cluster.rs
@@ -17,6 +17,7 @@ use std::ops::{Add, Deref};
 use std::time::{Duration, SystemTime};
 
 use risingwave_hummock_sdk::HummockSstableObjectId;
+use risingwave_pb::common::worker_node::Resource;
 use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType};
 use risingwave_pb::meta::heartbeat_request::extra_info::Info;
 use uuid::Uuid;
@@ -37,14 +38,16 @@ pub struct Worker {
     // Volatile values updated by meta node as follows.
     //
     // Unix timestamp that the worker will expire at.
-    expire_at: u64,
+    pub expire_at: u64,
+    pub started_at: Option<u64>,
 
     // Volatile values updated by worker as follows:
     //
     // Monotonic increasing id since meta node bootstrap.
-    info_version_id: u64,
+    pub info_version_id: u64,
     // GC watermark.
-    hummock_gc_watermark: Option<HummockSstableObjectId>,
+    pub hummock_gc_watermark: Option<HummockSstableObjectId>,
+    pub resource: Option<Resource>,
 }
 
 impl MetadataModel for Worker {
@@ -63,8 +66,10 @@ impl MetadataModel for Worker {
         Self {
             worker_node: prost,
             expire_at: INVALID_EXPIRE_AT,
+            started_at: None,
             info_version_id: 0,
-            hummock_gc_watermark: Default::default(),
+            hummock_gc_watermark: None,
+            resource: None,
         }
     }
 
@@ -86,13 +91,9 @@ impl Worker {
         self.worker_node.r#type()
     }
 
-    pub fn expire_at(&self) -> u64 {
-        self.expire_at
-    }
-
-    pub fn update_ttl(&mut self, ttl: Duration) {
+    pub fn update_expire_at(&mut self, ttl: Duration) {
         let expire_at = cmp::max(
-            self.expire_at(),
+            self.expire_at,
             SystemTime::now()
                 .add(ttl)
                 .duration_since(SystemTime::UNIX_EPOCH)
@@ -100,6 +101,10 @@ impl Worker {
                 .as_secs(),
         );
         self.expire_at = expire_at;
+    }
+
+    pub fn update_started_at(&mut self, started_at: u64) {
+        self.started_at = Some(started_at);
     }
 
     pub fn update_info(&mut self, info: Vec<Info>) {
@@ -113,12 +118,8 @@ impl Worker {
         }
     }
 
-    pub fn hummock_gc_watermark(&self) -> Option<HummockSstableObjectId> {
-        self.hummock_gc_watermark
-    }
-
-    pub fn info_version_id(&self) -> u64 {
-        self.info_version_id
+    pub fn update_resource(&mut self, resource: Option<Resource>) {
+        self.resource = resource;
     }
 }
 

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -768,7 +768,7 @@ pub fn start_fragment_info_monitor(
             meta_metrics.actor_info.reset();
             meta_metrics.table_info.reset();
             let workers: HashMap<u32, String> = cluster_manager
-                .list_worker_node(WorkerType::ComputeNode, None)
+                .list_worker_node(Some(WorkerType::ComputeNode), None)
                 .await
                 .into_iter()
                 .map(|worker_node| match worker_node.host {

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -899,6 +899,7 @@ mod tests {
                         is_serving: true,
                         is_unschedulable: false,
                     },
+                    Default::default(),
                 )
                 .await?;
             cluster_manager.activate_worker_node(host).await?;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -32,6 +32,9 @@ use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::telemetry::report::TelemetryInfoFetcher;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
+use risingwave_common::util::resource_util::cpu::total_cpu_available;
+use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
+use risingwave_common::RW_VERSION;
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockEpoch, HummockSstableObjectId, HummockVersionId, LocalSstableInfo,
@@ -245,6 +248,11 @@ impl MetaClient {
                     worker_type: worker_type as i32,
                     host: Some(addr.to_protobuf()),
                     property: Some(property.clone()),
+                    resource: Some(risingwave_pb::common::worker_node::Resource {
+                        rw_version: RW_VERSION.to_string(),
+                        total_memory_bytes: system_memory_available_bytes() as _,
+                        total_cpu_cores: total_cpu_available() as _,
+                    }),
                 })
                 .await?;
             if let Some(status) = &add_worker_resp.status
@@ -663,9 +671,12 @@ impl MetaClient {
         Ok(resp)
     }
 
-    pub async fn list_worker_nodes(&self, worker_type: WorkerType) -> Result<Vec<WorkerNode>> {
+    pub async fn list_worker_nodes(
+        &self,
+        worker_type: Option<WorkerType>,
+    ) -> Result<Vec<WorkerNode>> {
         let request = ListAllNodesRequest {
-            worker_type: worker_type as _,
+            worker_type: worker_type.map(Into::into),
             include_starting_nodes: true,
         };
         let resp = self.inner.list_all_nodes(request).await?;
@@ -1724,7 +1735,6 @@ macro_rules! for_all_meta_rpc {
             ,{ cluster_client, activate_worker_node, ActivateWorkerNodeRequest, ActivateWorkerNodeResponse }
             ,{ cluster_client, delete_worker_node, DeleteWorkerNodeRequest, DeleteWorkerNodeResponse }
             ,{ cluster_client, update_worker_node_schedulability, UpdateWorkerNodeSchedulabilityRequest, UpdateWorkerNodeSchedulabilityResponse }
-            //(not used) ,{ cluster_client, list_all_nodes, ListAllNodesRequest, ListAllNodesResponse }
             ,{ cluster_client, list_all_nodes, ListAllNodesRequest, ListAllNodesResponse }
             ,{ heartbeat_client, heartbeat, HeartbeatRequest, HeartbeatResponse }
             ,{ stream_client, flush, FlushRequest, FlushResponse }

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -249,6 +249,7 @@ pub(crate) mod tests {
                 WorkerType::ComputeNode,
                 HostAddress::default(),
                 Property::default(),
+                Default::default(),
             )
             .await
             .unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR extends rw_catalog.rw_worker_nodes by
- including all types of nodes, i.e. meta node/compactor node/compute node/frontend node. Before it only includes compute nodes.
- adding more columns: 
  - `rw_version/total memory bytes/total cpu cores`, which is reported by worker node when it starts.
  - `started_at`, which is populated by meta node when a worker node starts.
  - These info are not persisted in meta store. They'll be updated whenever worker node restarts.

```
dev=> select * from rw_worker_nodes;
 id |   host    | port |           type           |  state  | parallelism | is_streaming | is_serving | is_unschedulable | rw_version  | total_memory_bytes | total_cpu_cores |        started_at         
----+-----------+------+--------------------------+---------+-------------+--------------+------------+------------------+-------------+--------------------+-----------------+---------------------------
  0 | 127.0.0.1 | 5690 | WORKER_TYPE_META         | RUNNING |           0 |              |            |                  | 1.3.0-alpha |        34359738368 |              10 | 2023-11-17 04:05:28+00:00
  1 | 127.0.0.1 | 5688 | WORKER_TYPE_COMPUTE_NODE | RUNNING |           4 | t            | t          | f                | 1.3.0-alpha |        34359738368 |              10 | 2023-11-17 04:05:32+00:00
  2 | 127.0.0.1 | 4566 | WORKER_TYPE_FRONTEND     | RUNNING |           0 |              |            |                  | 1.3.0-alpha |        34359738368 |              10 | 2023-11-17 04:06:27+00:00
(3 rows)

```

part of #12826

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

System catalog
- Add columns rw_version, total_memory_bytes, total_cpu_cores and started_at in system table rw_worker_nodes. Also include nodes of all kinds in it, e.g. meta node/compute node/frontend node/compactor node. 

</details>
