### PR TITLE
fix: incorrect auto dump threshold

### DIFF
--- a/src/common/heap_profiling/src/profiler.rs
+++ b/src/common/heap_profiling/src/profiler.rs
@@ -36,6 +36,10 @@ pub struct HeapProfiler {
 }
 
 impl HeapProfiler {
+    /// # Arguments
+    ///
+    /// `total_memory` must be the total available memory for the process.
+    /// It will be compared with jemalloc's allocated memory.
     pub fn new(total_memory: usize, config: HeapProfilingConfig) -> Self {
         let threshold_auto_dump_heap_profile =
             (total_memory as f64 * config.threshold_auto as f64) as usize;

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -524,8 +524,7 @@ pub struct StorageConfig {
     pub compactor_max_task_multiplier: f32,
 
     /// The percentage of memory available when compactor is deployed separately.
-    /// total_memory_available_bytes = system_memory_available_bytes *
-    /// compactor_memory_available_proportion
+    /// non_reserved_memory_bytes = system_memory_available_bytes * compactor_memory_available_proportion
     #[serde(default = "default::storage::compactor_memory_available_proportion")]
     pub compactor_memory_available_proportion: f64,
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -148,15 +148,6 @@ pub async fn compute_node_serve(
         reserved_memory_bytes,
     );
 
-    // NOTE: Due to some limits, we use `compute_memory_bytes + storage_memory_bytes` as
-    // `total_compute_memory_bytes` for memory control. This is just a workaround for some
-    // memory control issues and should be modified as soon as we figure out a better solution.
-    //
-    // Related issues:
-    // - https://github.com/risingwavelabs/risingwave/issues/8696
-    // - https://github.com/risingwavelabs/risingwave/issues/8822
-    let total_memory_bytes = compute_memory_bytes + storage_memory_bytes;
-
     let storage_opts = Arc::new(StorageOpts::from((
         &config,
         &system_params,
@@ -285,7 +276,18 @@ pub async fn compute_node_serve(
     let batch_mgr_clone = batch_mgr.clone();
     let stream_mgr_clone = stream_mgr.clone();
 
-    let memory_mgr = GlobalMemoryManager::new(streaming_metrics.clone(), total_memory_bytes);
+    // NOTE: Due to some limits, we use `compute_memory_bytes + storage_memory_bytes` as
+    // `total_compute_memory_bytes` for memory control. This is just a workaround for some
+    // memory control issues and should be modified as soon as we figure out a better solution.
+    //
+    // Related issues:
+    // - https://github.com/risingwavelabs/risingwave/issues/8696
+    // - https://github.com/risingwavelabs/risingwave/issues/8822
+    let memory_mgr = GlobalMemoryManager::new(
+        streaming_metrics.clone(),
+        compute_memory_bytes + storage_memory_bytes,
+    );
+
     // Run a background memory manager
     tokio::spawn(memory_mgr.clone().run(
         batch_mgr_clone,
@@ -294,7 +296,10 @@ pub async fn compute_node_serve(
         system_params_manager.watch_params(),
     ));
 
-    let heap_profiler = HeapProfiler::new(total_memory_bytes, config.server.heap_profiling.clone());
+    let heap_profiler = HeapProfiler::new(
+        opts.total_memory_bytes,
+        config.server.heap_profiling.clone(),
+    );
     // Run a background heap profiler
     heap_profiler.start();
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

On compute nodes and compactor nodes, incorrect `total_memory` is used in auto heap dump.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
