### PR TITLE
feat: support `convert_from`/`convert_to` function that only support UTF8 encoding

### DIFF
--- a/e2e_test/batch/functions/encdec.slt.part
+++ b/e2e_test/batch/functions/encdec.slt.part
@@ -45,6 +45,7 @@ SELECT decode('6a6f616e6e61', 'hex');
 \x6a6f616e6e61
 
 # convert
+# convert_from
 query T
 SELECT convert_from('\xc3b1', 'UTF8');
 ----
@@ -85,3 +86,29 @@ query T
 SELECT convert_from('\x6a6f616e6e61', 'uTF-8');
 ----
 joanna
+
+# convert_to
+query T
+SELECT convert_to('some_text', 'UTF8');
+----
+\x736f6d655f74657874
+
+query T
+SELECT convert_to('柠檬', 'UTF8');
+----
+\xe69fa0e6aaac
+
+query T
+SELECT convert_to('🍋', 'UTF8');
+----
+\xf09f8d8b
+
+query T
+SELECT convert_from(convert_to('good', 'UTF8'), 'UTF8');
+----
+good
+
+query T
+SELECT convert_from(convert_to('wow🐮', 'UTF8'), 'UTF8');
+----
+wow🐮

--- a/e2e_test/batch/functions/encdec.slt.part
+++ b/e2e_test/batch/functions/encdec.slt.part
@@ -1,0 +1,87 @@
+# Text/Binary String Conversion Functions
+
+# encode/decode
+# escape
+query T
+SELECT encode('\xc3b1', 'escape');
+----
+\303\261
+
+query T
+SELECT decode('\303\261', 'escape');
+----
+\xc3b1
+
+query T
+SELECT encode('\xe78e8be58695e6adbbe4ba86e788b6e4bab2', 'escape');
+----
+\347\216\213\345\206\225\346\255\273\344\272\206\347\210\266\344\272\262
+
+query T
+SELECT decode('王冕死了父亲', 'escape');
+----
+\xe78e8be58695e6adbbe4ba86e788b6e4bab2
+
+# base64
+query T
+SELECT encode('123\000\001', 'base64');
+----
+MTIzAAE=
+
+query T
+SELECT decode('MTIzAAE=', 'base64');
+----
+\x3132330001
+
+# hex
+query T
+SELECT encode('joanna', 'hex');
+----
+6a6f616e6e61
+
+query T
+SELECT decode('6a6f616e6e61', 'hex');
+----
+\x6a6f616e6e61
+
+# convert
+query T
+SELECT convert_from('\xc3b1', 'UTF8');
+----
+ñ
+
+query T
+SELECT convert_from('\xe78e8be58695e6adbbe4ba86e788b6e4bab2', 'UTF8');
+----
+王冕死了父亲
+
+query T
+SELECT convert_from('\x6a6f616e6e61', 'UTF8');
+----
+joanna
+
+# UTF[-]8, case-insensitive
+query T
+SELECT convert_from('\x6a6f616e6e61', 'UTF-8');
+----
+joanna
+
+query T
+SELECT convert_from('\x6a6f616e6e61', 'utf8');
+----
+joanna
+
+query T
+SELECT convert_from('\x6a6f616e6e61', 'utf-8');
+----
+joanna
+
+query T
+SELECT convert_from('\x6a6f616e6e61', 'UtF8');
+----
+joanna
+
+query T
+SELECT convert_from('\x6a6f616e6e61', 'uTF-8');
+----
+joanna

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -178,6 +178,7 @@ message ExprNode {
     PGWIRE_SEND = 320;
     PGWIRE_RECV = 321;
     CONVERT_FROM = 322;
+    CONVERT_TO = 323;
 
     // Unary operators
     NEG = 401;

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -177,6 +177,7 @@ message ExprNode {
     FORMAT = 319;
     PGWIRE_SEND = 320;
     PGWIRE_RECV = 321;
+    CONVERT_FROM = 322;
 
     // Unary operators
     NEG = 401;

--- a/src/expr/impl/src/scalar/encdec.rs
+++ b/src/expr/impl/src/scalar/encdec.rs
@@ -77,11 +77,9 @@ pub fn decode(data: &str, format: &str) -> Result<Box<[u8]>> {
 pub fn convert_from(data: &[u8], src_encoding: &str, writer: &mut impl Write) -> Result<()> {
     match src_encoding.to_uppercase().as_str() {
         "UTF8" | "UTF-8" => {
-            let text = String::from_utf8(data.to_vec()).map_err(|e| {
-                ExprError::InvalidParam {
-                    name: "data",
-                    reason: e.to_string().into(),
-                }
+            let text = String::from_utf8(data.to_vec()).map_err(|e| ExprError::InvalidParam {
+                name: "data",
+                reason: e.to_string().into(),
             })?;
             writer.write_str(&text).unwrap();
             Ok(())

--- a/src/expr/impl/src/scalar/encdec.rs
+++ b/src/expr/impl/src/scalar/encdec.rs
@@ -74,13 +74,13 @@ pub fn decode(data: &str, format: &str) -> Result<Box<[u8]>> {
 }
 
 enum CharacterSet {
-    UTF8,
+    Utf8,
 }
 
 impl CharacterSet {
-    fn conversion(encoding: &str) -> Result<Self> {
+    fn recognize(encoding: &str) -> Result<Self> {
         match encoding.to_uppercase().as_str() {
-            "UTF8" | "UTF-8" => Ok(Self::UTF8),
+            "UTF8" | "UTF-8" => Ok(Self::Utf8),
             _ => Err(ExprError::InvalidParam {
                 name: "encoding",
                 reason: format!("unrecognized encoding: \"{}\"", encoding).into(),
@@ -91,8 +91,8 @@ impl CharacterSet {
 
 #[function("convert_from(bytea, varchar) -> varchar")]
 pub fn convert_from(data: &[u8], src_encoding: &str, writer: &mut impl Write) -> Result<()> {
-    match CharacterSet::conversion(src_encoding)? {
-        CharacterSet::UTF8 => {
+    match CharacterSet::recognize(src_encoding)? {
+        CharacterSet::Utf8 => {
             let text = String::from_utf8(data.to_vec()).map_err(|e| ExprError::InvalidParam {
                 name: "data",
                 reason: e.to_string().into(),
@@ -105,8 +105,8 @@ pub fn convert_from(data: &[u8], src_encoding: &str, writer: &mut impl Write) ->
 
 #[function("convert_to(varchar, varchar) -> bytea")]
 pub fn convert_to(string: &str, dest_encoding: &str) -> Result<Box<[u8]>> {
-    match CharacterSet::conversion(dest_encoding)? {
-        CharacterSet::UTF8 => Ok(string.as_bytes().into()),
+    match CharacterSet::recognize(dest_encoding)? {
+        CharacterSet::Utf8 => Ok(string.as_bytes().into()),
     }
 }
 

--- a/src/expr/impl/src/scalar/encdec.rs
+++ b/src/expr/impl/src/scalar/encdec.rs
@@ -73,10 +73,26 @@ pub fn decode(data: &str, format: &str) -> Result<Box<[u8]>> {
     }
 }
 
+enum CharacterSet {
+    UTF8,
+}
+
+impl CharacterSet {
+    fn conversion(encoding: &str) -> Result<Self> {
+        match encoding.to_uppercase().as_str() {
+            "UTF8" | "UTF-8" => Ok(Self::UTF8),
+            _ => Err(ExprError::InvalidParam {
+                name: "encoding",
+                reason: format!("unrecognized encoding: \"{}\"", encoding).into(),
+            }),
+        }
+    }
+}
+
 #[function("convert_from(bytea, varchar) -> varchar")]
 pub fn convert_from(data: &[u8], src_encoding: &str, writer: &mut impl Write) -> Result<()> {
-    match src_encoding.to_uppercase().as_str() {
-        "UTF8" | "UTF-8" => {
+    match CharacterSet::conversion(src_encoding)? {
+        CharacterSet::UTF8 => {
             let text = String::from_utf8(data.to_vec()).map_err(|e| ExprError::InvalidParam {
                 name: "data",
                 reason: e.to_string().into(),
@@ -84,10 +100,13 @@ pub fn convert_from(data: &[u8], src_encoding: &str, writer: &mut impl Write) ->
             writer.write_str(&text).unwrap();
             Ok(())
         }
-        _ => Err(ExprError::InvalidParam {
-            name: "src_encoding",
-            reason: format!("unrecognized encoding: \"{}\"", src_encoding).into(),
-        }),
+    }
+}
+
+#[function("convert_to(varchar, varchar) -> bytea")]
+pub fn convert_to(string: &str, dest_encoding: &str) -> Result<Box<[u8]>> {
+    match CharacterSet::conversion(dest_encoding)? {
+        CharacterSet::UTF8 => Ok(string.as_bytes().into()),
     }
 }
 

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -803,6 +803,7 @@ impl Binder {
                 ("string_to_array", raw_call(ExprType::StringToArray)),
                 ("encode", raw_call(ExprType::Encode)),
                 ("decode", raw_call(ExprType::Decode)),
+                ("convert_from", raw_call(ExprType::ConvertFrom)),
                 ("sha1", raw_call(ExprType::Sha1)),
                 ("sha224", raw_call(ExprType::Sha224)),
                 ("sha256", raw_call(ExprType::Sha256)),

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -804,6 +804,7 @@ impl Binder {
                 ("encode", raw_call(ExprType::Encode)),
                 ("decode", raw_call(ExprType::Decode)),
                 ("convert_from", raw_call(ExprType::ConvertFrom)),
+                ("convert_to", raw_call(ExprType::ConvertTo)),
                 ("sha1", raw_call(ExprType::Sha1)),
                 ("sha224", raw_call(ExprType::Sha224)),
                 ("sha256", raw_call(ExprType::Sha256)),

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -222,7 +222,8 @@ impl ExprVisitor for ImpureAnalyzer {
             | expr_node::Type::ArrayTransform
             | expr_node::Type::Greatest
             | expr_node::Type::Least
-            | expr_node::Type::ConvertFrom =>
+            | expr_node::Type::ConvertFrom
+            | expr_node::Type::ConvertTo =>
             // expression output is deterministic(same result for the same input)
             {
                 let x = func_call

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -221,7 +221,8 @@ impl ExprVisitor for ImpureAnalyzer {
             | expr_node::Type::PgwireRecv
             | expr_node::Type::ArrayTransform
             | expr_node::Type::Greatest
-            | expr_node::Type::Least =>
+            | expr_node::Type::Least
+            | expr_node::Type::ConvertFrom =>
             // expression output is deterministic(same result for the same input)
             {
                 let x = func_call


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

resolve #13306.

Support text conversion function `convert_from` and `convert_to`. But only encoding `UTF8` is supported.

RisingWave uses UTF8 encoding to store text, so all that is done here is just type conversion.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
