### PR TITLE
feat: Add compression capabilities for StreamNode in PbTableFragments.

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -111,7 +111,7 @@ message TableFragments {
   // When we use RENDER_TEMPLATE, template compression is enabled during the conversion between PbTableFragments and model::TableFragments.
   // This avoids pointless repetition in each PbActor’s StreamNode within PbFragment.
   // When RENDER_TEMPLATE is activated, the stream_node_template in PbFragment should not be empty.
-  // Also, the nodes in the original actors field will be disregarded (if template compression is enabled, an irrelevant NoOp should be placed here) and rendered when converted to model::TableFragments.
+  // Also, the nodes in the original actors field will be disregarded and rendered when converted to model::TableFragments.
   GraphRenderType graph_render_type = 7;
 }
 

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -91,8 +91,8 @@ message TableFragments {
     // and modified when creating the mv-on-mv
     repeated uint32 upstream_fragment_ids = 7;
 
-    // Template from RENDER_TEMPLATE
-    optional stream_plan.StreamNode stream_node_template = 8;
+    // A template used to store each StreamNode within an Actor for TableFragments that have compression enabled.
+    stream_plan.StreamNode stream_node_template = 8;
   }
 
   uint32 table_id = 1;

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -91,6 +91,7 @@ message TableFragments {
     // and modified when creating the mv-on-mv
     repeated uint32 upstream_fragment_ids = 7;
 
+    // Template from RENDER_TEMPLATE
     optional stream_plan.StreamNode stream_node_template = 8;
   }
 
@@ -100,19 +101,18 @@ message TableFragments {
   map<uint32, ActorStatus> actor_status = 4;
   map<uint32, source.ConnectorSplits> actor_splits = 5;
 
-  message ActorIds {
-    repeated uint32 actor_ids = 1;
-  }
-
-  map<uint32, ActorIds> actor_upstream_actors = 7;
-
-  enum CompressionType {
-    COMPRESSION_UNSPECIFIED = 0;
-    COMPRESSION_NONE = 1;
-    COMPRESSION_TEMPLATE = 2;
-  }
-
   stream_plan.StreamEnvironment env = 6;
+
+  enum GraphRenderType {
+    RENDER_UNSPECIFIED = 0;
+    RENDER_TEMPLATE = 1;
+  }
+
+  // When we use RENDER_TEMPLATE, template compression is enabled during the conversion between PbTableFragments and model::TableFragments.
+  // This avoids pointless repetition in each PbActor’s StreamNode within PbFragment.
+  // When RENDER_TEMPLATE is activated, the stream_node_template in PbFragment should not be empty.
+  // Also, the nodes in the original actors field will be disregarded (if template compression is enabled, an irrelevant NoOp should be placed here) and rendered when converted to model::TableFragments.
+  GraphRenderType graph_render_type = 7;
 }
 
 /// Parallel unit mapping with fragment id, used for notification.

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -90,12 +90,27 @@ message TableFragments {
     // so we pre-generate and store it here, this member will only be initialized when creating the Fragment
     // and modified when creating the mv-on-mv
     repeated uint32 upstream_fragment_ids = 7;
+
+    optional stream_plan.StreamNode stream_node_template = 8;
   }
+
   uint32 table_id = 1;
   State state = 2;
   map<uint32, Fragment> fragments = 3;
   map<uint32, ActorStatus> actor_status = 4;
   map<uint32, source.ConnectorSplits> actor_splits = 5;
+
+  message ActorIds {
+    repeated uint32 actor_ids = 1;
+  }
+
+  map<uint32, ActorIds> actor_upstream_actors = 7;
+
+  enum CompressionType {
+    COMPRESSION_UNSPECIFIED = 0;
+    COMPRESSION_NONE = 1;
+    COMPRESSION_TEMPLATE = 2;
+  }
 
   stream_plan.StreamEnvironment env = 6;
 }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -810,6 +810,14 @@ message StreamActor {
   common.Buffer vnode_bitmap = 8;
   // The SQL definition of this materialized view. Used for debugging only.
   string mview_definition = 9;
+
+  message ActorIds {
+    repeated uint32 actor_ids = 1;
+  }
+
+  // The upstream actors of this actor, grouped by fragment id.
+  // Content will only be present when using RENDER_TEMPLATE.
+  map<uint32, ActorIds> upstream_actors_by_fragment = 10;
 }
 
 enum FragmentTypeFlag {

--- a/src/common/src/util/mod.rs
+++ b/src/common/src/util/mod.rs
@@ -45,3 +45,4 @@ pub use future_utils::{
 };
 #[macro_use]
 pub mod match_util;
+pub mod table_fragments_util;

--- a/src/common/src/util/table_fragments_util.rs
+++ b/src/common/src/util/table_fragments_util.rs
@@ -26,7 +26,7 @@ impl PbTableFragments {
     // We decompress `PbTableFragments` using the `stream_node_template` of the `PbFragment`,
     // by re-rendering the template, then repopulating the upstream actor ids and upstream fragment id
     // contained in the `MergeNode` by `upstream_actors_by_fragment` in actor.
-    pub fn ensure_uncompressed(&mut self) {
+    pub fn uncompress(&mut self) {
         assert_eq!(
             self.graph_render_type,
             GraphRenderType::RenderTemplate as i32
@@ -76,7 +76,7 @@ impl PbTableFragments {
     // storing their templates in the `stream_node_template` in the `PbFragment`.
     // We have also made special modifications to `MergeNode`s, extracting their upstream fragment id and upstream actor ids.
     // This way, we can save some memory when conducting RPC and storage.
-    pub fn ensure_compressed(&mut self) {
+    pub fn compress(&mut self) {
         assert_eq!(
             self.graph_render_type,
             GraphRenderType::RenderUnspecified as i32

--- a/src/common/src/util/table_fragments_util.rs
+++ b/src/common/src/util/table_fragments_util.rs
@@ -33,7 +33,7 @@ pub fn uncompress_table_fragments(table_fragments: &mut PbTableFragments) {
     for fragment in table_fragments.fragments.values_mut() {
         assert!(
             fragment.stream_node_template.is_some(),
-            "fragment.stream_node_template should be Some() when render type is RenderTemplate"
+            "fragment.stream_node_template should not be None when render type is RenderTemplate"
         );
 
         for actor in &mut fragment.actors {
@@ -57,18 +57,12 @@ pub fn uncompress_table_fragments(table_fragments: &mut PbTableFragments) {
             );
 
             actor.nodes = pb_nodes;
-
-            assert!(
-                !actor.upstream_actors_by_fragment.is_empty(),
-                "actor.upstream_actors_by_fragment should not be empty when render type is RenderTemplate"
-            );
-
             actor.upstream_actors_by_fragment.clear();
         }
 
         assert!(
             fragment.stream_node_template.is_some(),
-            "fragment.stream_node_template should be Some() when render type is RenderTemplate"
+            "fragment.stream_node_template should not be None when render type is RenderTemplate"
         );
         fragment.stream_node_template = None;
     }
@@ -134,7 +128,7 @@ pub fn compress_table_fragments(table_fragments: &mut PbTableFragments) {
 
             assert!(
                 actor.nodes.is_some(),
-                "actor.nodes should be Some() when render type is unspecified"
+                "actor.nodes should not be None when render type is unspecified"
             );
 
             actor.nodes = None;

--- a/src/common/src/util/table_fragments_util.rs
+++ b/src/common/src/util/table_fragments_util.rs
@@ -21,132 +21,135 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 
 use crate::util::stream_graph_visitor::visit_stream_node;
 
-// We decompress `PbTableFragments` using the `stream_node_template` of the `PbFragment`,
-// by re-rendering the template, then repopulating the upstream actor ids and upstream fragment id
-// contained in the `MergeNode` by `upstream_actors_by_fragment` in actor.
-pub fn uncompress_table_fragments(table_fragments: &mut PbTableFragments) {
-    assert_eq!(
-        table_fragments.graph_render_type,
-        GraphRenderType::RenderTemplate as i32
-    );
-
-    for fragment in table_fragments.fragments.values_mut() {
-        assert!(
-            fragment.stream_node_template.is_some(),
-            "fragment.stream_node_template should not be None when render type is RenderTemplate"
+#[easy_ext::ext(TableFragmentsRenderCompression)]
+impl PbTableFragments {
+    // We decompress `PbTableFragments` using the `stream_node_template` of the `PbFragment`,
+    // by re-rendering the template, then repopulating the upstream actor ids and upstream fragment id
+    // contained in the `MergeNode` by `upstream_actors_by_fragment` in actor.
+    pub fn ensure_uncompressed(&mut self) {
+        assert_eq!(
+            self.graph_render_type,
+            GraphRenderType::RenderTemplate as i32
         );
 
-        for actor in &mut fragment.actors {
-            let pb_nodes = {
-                let mut nodes = fragment.stream_node_template.clone().unwrap();
+        for fragment in self.fragments.values_mut() {
+            assert!(
+                fragment.stream_node_template.is_some(),
+                "fragment.stream_node_template should not be None when render type is RenderTemplate"
+            );
 
-                visit_stream_node(&mut nodes, |body| {
-                    if let NodeBody::Merge(m) = body
-                        && let Some(PbActorIds{  actor_ids: upstream_actor_ids }) = actor.upstream_actors_by_fragment.get(&(m.upstream_fragment_id as _))
-                    {
-                        m.upstream_actor_id = upstream_actor_ids.iter().map(|id| *id as _).collect();
+            for actor in &mut fragment.actors {
+                let pb_nodes = {
+                    let mut nodes = fragment.stream_node_template.clone().unwrap();
+
+                    visit_stream_node(&mut nodes, |body| {
+                        if let NodeBody::Merge(m) = body
+                            && let Some(PbActorIds{  actor_ids: upstream_actor_ids }) = actor.upstream_actors_by_fragment.get(&(m.upstream_fragment_id as _))
+                        {
+                            m.upstream_actor_id = upstream_actor_ids.iter().map(|id| *id as _).collect();
+                        }
+                    });
+
+                    Some(nodes)
+                };
+
+                assert!(
+                    actor.nodes.is_none(),
+                    "actor.nodes should be None when render type is RenderTemplate"
+                );
+
+                actor.nodes = pb_nodes;
+                actor.upstream_actors_by_fragment.clear();
+            }
+
+            assert!(
+                fragment.stream_node_template.is_some(),
+                "fragment.stream_node_template should not be None when render type is RenderTemplate"
+            );
+            fragment.stream_node_template = None;
+        }
+
+        self.graph_render_type = GraphRenderType::RenderUnspecified as i32;
+    }
+
+    // We compressed the repetitive `node_body` of `PbStreamNode` in actors in Fragment in TableFragments,
+    // storing their templates in the `stream_node_template` in the `PbFragment`.
+    // We have also made special modifications to `MergeNode`s, extracting their upstream fragment id and upstream actor ids.
+    // This way, we can save some memory when conducting RPC and storage.
+    pub fn ensure_compressed(&mut self) {
+        assert_eq!(
+            self.graph_render_type,
+            GraphRenderType::RenderUnspecified as i32
+        );
+
+        for fragment in self.fragments.values_mut() {
+            assert!(
+                fragment.stream_node_template.is_none(),
+                "fragment.stream_node_template should be None when render type is unspecific"
+            );
+
+            let stream_node = {
+                let actor_template = fragment
+                    .actors
+                    .first()
+                    .cloned()
+                    .expect("fragment has no actor");
+
+                let mut stream_node = actor_template.nodes.unwrap();
+                visit_stream_node(&mut stream_node, |body| {
+                    if let NodeBody::Merge(m) = body {
+                        m.upstream_actor_id = vec![];
                     }
                 });
 
-                Some(nodes)
+                stream_node
             };
 
-            assert!(
-                actor.nodes.is_none(),
-                "actor.nodes should be None when render type is RenderTemplate"
-            );
+            for actor in &mut fragment.actors {
+                let Some(node) = actor.nodes.as_mut() else {
+                    continue;
+                };
 
-            actor.nodes = pb_nodes;
-            actor.upstream_actors_by_fragment.clear();
+                let mut upstream_actors_by_fragment = HashMap::new();
+                visit_stream_node(node, |body| {
+                    if let NodeBody::Merge(m) = body {
+                        let upstream_actor_ids = std::mem::take(&mut m.upstream_actor_id);
+                        assert!(
+                            upstream_actors_by_fragment
+                                .insert(
+                                    m.upstream_fragment_id,
+                                    PbActorIds {
+                                        actor_ids: upstream_actor_ids
+                                    }
+                                )
+                                .is_none(),
+                            "There should only be one link between two fragments"
+                        );
+                    }
+                });
+
+                assert!(
+                    actor.nodes.is_some(),
+                    "actor.nodes should not be None when render type is unspecified"
+                );
+
+                actor.nodes = None;
+
+                assert!(
+                    actor.upstream_actors_by_fragment.is_empty(),
+                    "actor.upstream_actors_by_fragment should be empty when render type is unspecified"
+                );
+
+                actor.upstream_actors_by_fragment = upstream_actors_by_fragment;
+            }
+
+            assert!(
+                fragment.stream_node_template.is_none(),
+                "fragment.stream_node_template should be None when render type is unspecified"
+            );
+            fragment.stream_node_template = Some(stream_node);
         }
 
-        assert!(
-            fragment.stream_node_template.is_some(),
-            "fragment.stream_node_template should not be None when render type is RenderTemplate"
-        );
-        fragment.stream_node_template = None;
+        self.graph_render_type = GraphRenderType::RenderTemplate as _;
     }
-
-    table_fragments.graph_render_type = GraphRenderType::RenderUnspecified as i32;
-}
-
-// We compressed the repetitive `node_body` of `PbStreamNode` in actors in Fragment in TableFragments,
-// storing their templates in the `stream_node_template` in the `PbFragment`.
-// We have also made special modifications to `MergeNode`s, extracting their upstream fragment id and upstream actor ids.
-// This way, we can save some memory when conducting RPC and storage.
-pub fn compress_table_fragments(table_fragments: &mut PbTableFragments) {
-    assert_eq!(
-        table_fragments.graph_render_type,
-        GraphRenderType::RenderUnspecified as i32
-    );
-
-    for fragment in table_fragments.fragments.values_mut() {
-        assert!(
-            fragment.stream_node_template.is_none(),
-            "fragment.stream_node_template should be None when render type is unspecific"
-        );
-
-        let stream_node = {
-            let actor_template = fragment
-                .actors
-                .first()
-                .cloned()
-                .expect("fragment has no actor");
-
-            let mut stream_node = actor_template.nodes.unwrap();
-            visit_stream_node(&mut stream_node, |body| {
-                if let NodeBody::Merge(m) = body {
-                    m.upstream_actor_id = vec![];
-                }
-            });
-
-            stream_node
-        };
-
-        for actor in &mut fragment.actors {
-            let Some(node) = actor.nodes.as_mut() else {
-                continue;
-            };
-
-            let mut upstream_actors_by_fragment = HashMap::new();
-            visit_stream_node(node, |body| {
-                if let NodeBody::Merge(m) = body {
-                    let upstream_actor_ids = std::mem::take(&mut m.upstream_actor_id);
-                    assert!(
-                        upstream_actors_by_fragment
-                            .insert(
-                                m.upstream_fragment_id,
-                                PbActorIds {
-                                    actor_ids: upstream_actor_ids
-                                }
-                            )
-                            .is_none(),
-                        "There should only be one link between two fragments"
-                    );
-                }
-            });
-
-            assert!(
-                actor.nodes.is_some(),
-                "actor.nodes should not be None when render type is unspecified"
-            );
-
-            actor.nodes = None;
-
-            assert!(
-                actor.upstream_actors_by_fragment.is_empty(),
-                "actor.upstream_actors_by_fragment should be empty when render type is unspecified"
-            );
-
-            actor.upstream_actors_by_fragment = upstream_actors_by_fragment;
-        }
-
-        assert!(
-            fragment.stream_node_template.is_none(),
-            "fragment.stream_node_template should be None when render type is unspecified"
-        );
-        fragment.stream_node_template = Some(stream_node);
-    }
-
-    table_fragments.graph_render_type = GraphRenderType::RenderTemplate as _;
 }

--- a/src/common/src/util/table_fragments_util.rs
+++ b/src/common/src/util/table_fragments_util.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use risingwave_pb::meta::table_fragments::GraphRenderType;
+use risingwave_pb::meta::PbTableFragments;
+use risingwave_pb::stream_plan::stream_actor::PbActorIds;
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+
+use crate::util::stream_graph_visitor::visit_stream_node;
+
+pub fn downgrade_table_fragments(table_fragments: &mut PbTableFragments) {
+    assert_eq!(
+        table_fragments.graph_render_type,
+        GraphRenderType::RenderTemplate as i32
+    );
+
+    for fragment in table_fragments.fragments.values_mut() {
+        assert!(fragment.stream_node_template.is_some());
+
+        for actor in &mut fragment.actors {
+            let pb_nodes = {
+                let mut nodes = fragment.stream_node_template.clone().unwrap();
+
+                visit_stream_node(&mut nodes, |body| {
+                    if let NodeBody::Merge(m) = body
+                        && let Some(PbActorIds{  actor_ids: upstream_actor_ids }) = actor.upstream_actors_by_fragment.get(&(m.upstream_fragment_id as _))
+                    {
+                        m.upstream_actor_id = upstream_actor_ids.iter().map(|id| *id as _).collect();
+                    }
+                });
+
+                Some(nodes)
+            };
+
+            actor.nodes = pb_nodes;
+            actor.upstream_actors_by_fragment.clear();
+        }
+
+        fragment.stream_node_template = None;
+    }
+
+    table_fragments.graph_render_type = GraphRenderType::RenderUnspecified as i32;
+}
+
+pub fn upgrade_table_fragments(table_fragments: &mut PbTableFragments) {
+    for fragment in table_fragments.fragments.values_mut() {
+        let stream_node = {
+            let actor_template = fragment
+                .actors
+                .first()
+                .cloned()
+                .expect("fragment has no actor");
+
+            let mut stream_node = actor_template.nodes.unwrap();
+            visit_stream_node(&mut stream_node, |body| {
+                if let NodeBody::Merge(m) = body {
+                    m.upstream_actor_id = vec![];
+                }
+            });
+
+            stream_node
+        };
+
+        for actor in &mut fragment.actors {
+            let Some(node) = actor.nodes.as_mut() else {
+                continue;
+            };
+
+            let mut upstream_actors_by_fragment = HashMap::new();
+            visit_stream_node(node, |body| {
+                if let NodeBody::Merge(m) = body {
+                    let upstream_actor_ids = std::mem::take(&mut m.upstream_actor_id);
+                    assert!(
+                        upstream_actors_by_fragment
+                            .insert(
+                                m.upstream_fragment_id,
+                                PbActorIds {
+                                    actor_ids: upstream_actor_ids
+                                }
+                            )
+                            .is_none(),
+                        "There should only be one link between two fragments"
+                    );
+                }
+            });
+
+            actor.upstream_actors_by_fragment = upstream_actors_by_fragment;
+
+            // todo: can we directly set as none?
+            // actor.nodes = Some(StreamNode {
+            //     node_body: Some(NodeBody::NoOp(PbNoOpNode {})),
+            //     ..Default::default()
+            // });
+            actor.nodes = None;
+        }
+
+        fragment.stream_node_template = Some(stream_node);
+    }
+
+    table_fragments.graph_render_type = GraphRenderType::RenderTemplate as _;
+}

--- a/src/meta/src/controller/catalog.rs
+++ b/src/meta/src/controller/catalog.rs
@@ -355,6 +355,7 @@ impl CatalogController {
         _table_fragments: &PbTableFragments,
         _internal_tables: Vec<PbTable>,
     ) -> MetaResult<()> {
+        // note: If we use PbTableFragments here, we need to determine whether decompression is needed through the ‘graph_render_type’.
         todo!()
     }
 

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -84,7 +84,7 @@ impl CatalogController {
         let mut table_fragments = table_fragments;
 
         if table_fragments.graph_render_type == GraphRenderType::RenderTemplate as i32 {
-            table_fragments.ensure_uncompressed()
+            table_fragments.uncompress()
         }
 
         let PbTableFragments {

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -19,7 +19,7 @@ use anyhow::Context;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node;
-use risingwave_common::util::table_fragments_util::downgrade_table_fragments;
+use risingwave_common::util::table_fragments_util::uncompress_table_fragments;
 use risingwave_meta_model_v2::actor::ActorStatus;
 use risingwave_meta_model_v2::prelude::{Actor, ActorDispatcher, Fragment, StreamingJob};
 use risingwave_meta_model_v2::{
@@ -84,7 +84,7 @@ impl CatalogController {
         let mut table_fragments = table_fragments;
 
         if table_fragments.graph_render_type == GraphRenderType::RenderTemplate as i32 {
-            downgrade_table_fragments(&mut table_fragments);
+            uncompress_table_fragments(&mut table_fragments);
         }
 
         let PbTableFragments {

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -19,7 +19,7 @@ use anyhow::Context;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node;
-use risingwave_common::util::table_fragments_util::uncompress_table_fragments;
+use risingwave_common::util::table_fragments_util::TableFragmentsRenderCompression;
 use risingwave_meta_model_v2::actor::ActorStatus;
 use risingwave_meta_model_v2::prelude::{Actor, ActorDispatcher, Fragment, StreamingJob};
 use risingwave_meta_model_v2::{
@@ -84,7 +84,7 @@ impl CatalogController {
         let mut table_fragments = table_fragments;
 
         if table_fragments.graph_render_type == GraphRenderType::RenderTemplate as i32 {
-            uncompress_table_fragments(&mut table_fragments);
+            table_fragments.ensure_uncompressed()
         }
 
         let PbTableFragments {

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -206,7 +206,7 @@ pub(super) mod handlers {
             if table_fragments.get_graph_render_type().unwrap_or_default()
                 == GraphRenderType::RenderTemplate
             {
-                table_fragments.ensure_uncompressed();
+                table_fragments.uncompress();
             }
         }
 

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -57,7 +57,7 @@ pub(super) mod handlers {
     use axum::Json;
     use itertools::Itertools;
     use risingwave_common::bail;
-    use risingwave_common::util::table_fragments_util::downgrade_table_fragments;
+    use risingwave_common::util::table_fragments_util::uncompress_table_fragments;
     use risingwave_common_heap_profiling::COLLAPSED_SUFFIX;
     use risingwave_pb::catalog::table::TableType;
     use risingwave_pb::catalog::{Sink, Source, Table, View};
@@ -206,7 +206,7 @@ pub(super) mod handlers {
             if table_fragments.get_graph_render_type().unwrap_or_default()
                 == GraphRenderType::RenderTemplate
             {
-                downgrade_table_fragments(table_fragments);
+                uncompress_table_fragments(table_fragments);
             }
         }
 

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -57,7 +57,7 @@ pub(super) mod handlers {
     use axum::Json;
     use itertools::Itertools;
     use risingwave_common::bail;
-    use risingwave_common::util::table_fragments_util::uncompress_table_fragments;
+    use risingwave_common::util::table_fragments_util::TableFragmentsRenderCompression;
     use risingwave_common_heap_profiling::COLLAPSED_SUFFIX;
     use risingwave_pb::catalog::table::TableType;
     use risingwave_pb::catalog::{Sink, Source, Table, View};
@@ -206,7 +206,7 @@ pub(super) mod handlers {
             if table_fragments.get_graph_render_type().unwrap_or_default()
                 == GraphRenderType::RenderTemplate
             {
-                uncompress_table_fragments(table_fragments);
+                table_fragments.ensure_uncompressed();
             }
         }
 

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -18,13 +18,14 @@ use std::ops::AddAssign;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::ParallelUnitId;
-use risingwave_common::util::stream_graph_visitor::visit_stream_node;
+use risingwave_common::util::table_fragments_util::{
+    downgrade_table_fragments, upgrade_table_fragments,
+};
 use risingwave_connector::source::SplitImpl;
 use risingwave_pb::common::{ParallelUnit, ParallelUnitMapping};
 use risingwave_pb::meta::table_fragments::actor_status::ActorState;
 use risingwave_pb::meta::table_fragments::{ActorStatus, Fragment, GraphRenderType, State};
 use risingwave_pb::meta::PbTableFragments;
-use risingwave_pb::stream_plan::stream_actor::PbActorIds;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
     FragmentTypeFlag, PbStreamEnvironment, StreamActor, StreamNode, StreamSource,
@@ -136,98 +137,6 @@ impl MetadataModel for TableFragments {
     fn key(&self) -> MetadataModelResult<Self::KeyType> {
         Ok(self.table_id.table_id())
     }
-}
-
-pub fn downgrade_table_fragments(table_fragments: &mut PbTableFragments) {
-    assert_eq!(
-        table_fragments.graph_render_type,
-        GraphRenderType::RenderTemplate as i32
-    );
-
-    for fragment in table_fragments.fragments.values_mut() {
-        assert!(fragment.stream_node_template.is_some());
-
-        for actor in &mut fragment.actors {
-            let pb_nodes = {
-                let mut nodes = fragment.stream_node_template.clone().unwrap();
-
-                visit_stream_node(&mut nodes, |body| {
-                    if let NodeBody::Merge(m) = body
-                        && let Some(PbActorIds{  actor_ids: upstream_actor_ids }) = actor.upstream_actors_by_fragment.get(&(m.upstream_fragment_id as _))
-                    {
-                        m.upstream_actor_id = upstream_actor_ids.iter().map(|id| *id as _).collect();
-                    }
-                });
-
-                Some(nodes)
-            };
-
-            actor.nodes = pb_nodes;
-            actor.upstream_actors_by_fragment.clear();
-        }
-
-        fragment.stream_node_template = None;
-    }
-
-    table_fragments.graph_render_type = GraphRenderType::RenderUnspecified as _;
-}
-
-pub fn upgrade_table_fragments(table_fragments: &mut PbTableFragments) {
-    for fragment in table_fragments.fragments.values_mut() {
-        let stream_node = {
-            let actor_template = fragment
-                .actors
-                .first()
-                .cloned()
-                .expect("fragment has no actor");
-
-            let mut stream_node = actor_template.nodes.unwrap();
-            visit_stream_node(&mut stream_node, |body| {
-                if let NodeBody::Merge(m) = body {
-                    m.upstream_actor_id = vec![];
-                }
-            });
-
-            stream_node
-        };
-
-        for actor in &mut fragment.actors {
-            let Some(node) = actor.nodes.as_mut() else {
-                continue;
-            };
-
-            let mut upstream_actors_by_fragment = HashMap::new();
-            visit_stream_node(node, |body| {
-                if let NodeBody::Merge(m) = body {
-                    let upstream_actor_ids = std::mem::take(&mut m.upstream_actor_id);
-                    assert!(
-                        upstream_actors_by_fragment
-                            .insert(
-                                m.upstream_fragment_id,
-                                PbActorIds {
-                                    actor_ids: upstream_actor_ids
-                                }
-                            )
-                            .is_none(),
-                        "There should only be one link between two fragments"
-                    );
-                }
-            });
-
-            actor.upstream_actors_by_fragment = upstream_actors_by_fragment;
-
-            // todo: can we directly set as none?
-            // actor.nodes = Some(StreamNode {
-            //     node_body: Some(NodeBody::NoOp(PbNoOpNode {})),
-            //     ..Default::default()
-            // });
-            actor.nodes = None;
-        }
-
-        fragment.stream_node_template = Some(stream_node);
-    }
-
-    table_fragments.graph_render_type = GraphRenderType::RenderTemplate as _;
 }
 
 impl TableFragments {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::ParallelUnitId;
 use risingwave_common::util::table_fragments_util::{
-    downgrade_table_fragments, upgrade_table_fragments,
+    compress_table_fragments, uncompress_table_fragments,
 };
 use risingwave_connector::source::SplitImpl;
 use risingwave_pb::common::{ParallelUnit, ParallelUnitMapping};
@@ -107,7 +107,7 @@ impl MetadataModel for TableFragments {
             ..Default::default()
         };
 
-        upgrade_table_fragments(&mut table_fragments);
+        compress_table_fragments(&mut table_fragments);
 
         table_fragments
     }
@@ -121,7 +121,7 @@ impl MetadataModel for TableFragments {
             .get_graph_render_type()
             .unwrap_or(GraphRenderType::RenderUnspecified)
         {
-            downgrade_table_fragments(&mut prost);
+            uncompress_table_fragments(&mut prost);
         }
 
         Self {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -18,11 +18,13 @@ use std::ops::AddAssign;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::ParallelUnitId;
+use risingwave_common::util::stream_graph_visitor::visit_stream_node;
 use risingwave_connector::source::SplitImpl;
 use risingwave_pb::common::{ParallelUnit, ParallelUnitMapping};
 use risingwave_pb::meta::table_fragments::actor_status::ActorState;
-use risingwave_pb::meta::table_fragments::{ActorStatus, Fragment, State};
+use risingwave_pb::meta::table_fragments::{ActorStatus, Fragment, GraphRenderType, State};
 use risingwave_pb::meta::PbTableFragments;
+use risingwave_pb::stream_plan::stream_actor::PbActorIds;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
     FragmentTypeFlag, PbStreamEnvironment, StreamActor, StreamNode, StreamSource,
@@ -94,18 +96,33 @@ impl MetadataModel for TableFragments {
     }
 
     fn to_protobuf(&self) -> Self::PbType {
-        Self::PbType {
+        let mut table_fragments = PbTableFragments {
             table_id: self.table_id.table_id(),
             state: self.state as _,
             fragments: self.fragments.clone().into_iter().collect(),
             actor_status: self.actor_status.clone().into_iter().collect(),
             actor_splits: build_actor_connector_splits(&self.actor_splits),
             env: Some(self.env.to_protobuf()),
-        }
+            ..Default::default()
+        };
+
+        upgrade_table_fragments(&mut table_fragments);
+
+        table_fragments
     }
 
     fn from_protobuf(prost: Self::PbType) -> Self {
+        let mut prost = prost;
+
         let env = StreamEnvironment::from_protobuf(prost.get_env().unwrap());
+
+        if let GraphRenderType::RenderTemplate = prost
+            .get_graph_render_type()
+            .unwrap_or(GraphRenderType::RenderUnspecified)
+        {
+            downgrade_table_fragments(&mut prost);
+        }
+
         Self {
             table_id: TableId::new(prost.table_id),
             state: prost.state(),
@@ -119,6 +136,98 @@ impl MetadataModel for TableFragments {
     fn key(&self) -> MetadataModelResult<Self::KeyType> {
         Ok(self.table_id.table_id())
     }
+}
+
+pub fn downgrade_table_fragments(table_fragments: &mut PbTableFragments) {
+    assert_eq!(
+        table_fragments.graph_render_type,
+        GraphRenderType::RenderTemplate as i32
+    );
+
+    for fragment in table_fragments.fragments.values_mut() {
+        assert!(fragment.stream_node_template.is_some());
+
+        for actor in &mut fragment.actors {
+            let pb_nodes = {
+                let mut nodes = fragment.stream_node_template.clone().unwrap();
+
+                visit_stream_node(&mut nodes, |body| {
+                    if let NodeBody::Merge(m) = body
+                        && let Some(PbActorIds{  actor_ids: upstream_actor_ids }) = actor.upstream_actors_by_fragment.get(&(m.upstream_fragment_id as _))
+                    {
+                        m.upstream_actor_id = upstream_actor_ids.iter().map(|id| *id as _).collect();
+                    }
+                });
+
+                Some(nodes)
+            };
+
+            actor.nodes = pb_nodes;
+            actor.upstream_actors_by_fragment.clear();
+        }
+
+        fragment.stream_node_template = None;
+    }
+
+    table_fragments.graph_render_type = GraphRenderType::RenderUnspecified as _;
+}
+
+pub fn upgrade_table_fragments(table_fragments: &mut PbTableFragments) {
+    for fragment in table_fragments.fragments.values_mut() {
+        let stream_node = {
+            let actor_template = fragment
+                .actors
+                .first()
+                .cloned()
+                .expect("fragment has no actor");
+
+            let mut stream_node = actor_template.nodes.unwrap();
+            visit_stream_node(&mut stream_node, |body| {
+                if let NodeBody::Merge(m) = body {
+                    m.upstream_actor_id = vec![];
+                }
+            });
+
+            stream_node
+        };
+
+        for actor in &mut fragment.actors {
+            let Some(node) = actor.nodes.as_mut() else {
+                continue;
+            };
+
+            let mut upstream_actors_by_fragment = HashMap::new();
+            visit_stream_node(node, |body| {
+                if let NodeBody::Merge(m) = body {
+                    let upstream_actor_ids = std::mem::take(&mut m.upstream_actor_id);
+                    assert!(
+                        upstream_actors_by_fragment
+                            .insert(
+                                m.upstream_fragment_id,
+                                PbActorIds {
+                                    actor_ids: upstream_actor_ids
+                                }
+                            )
+                            .is_none(),
+                        "There should only be one link between two fragments"
+                    );
+                }
+            });
+
+            actor.upstream_actors_by_fragment = upstream_actors_by_fragment;
+
+            // todo: can we directly set as none?
+            // actor.nodes = Some(StreamNode {
+            //     node_body: Some(NodeBody::NoOp(PbNoOpNode {})),
+            //     ..Default::default()
+            // });
+            actor.nodes = None;
+        }
+
+        fragment.stream_node_template = Some(stream_node);
+    }
+
+    table_fragments.graph_render_type = GraphRenderType::RenderTemplate as _;
 }
 
 impl TableFragments {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -105,7 +105,7 @@ impl MetadataModel for TableFragments {
             ..Default::default()
         };
 
-        table_fragments.ensure_compressed();
+        table_fragments.compress();
 
         table_fragments
     }
@@ -119,7 +119,7 @@ impl MetadataModel for TableFragments {
             .get_graph_render_type()
             .unwrap_or(GraphRenderType::RenderUnspecified)
         {
-            prost.ensure_uncompressed();
+            prost.uncompress();
         }
 
         Self {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -18,9 +18,7 @@ use std::ops::AddAssign;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::ParallelUnitId;
-use risingwave_common::util::table_fragments_util::{
-    compress_table_fragments, uncompress_table_fragments,
-};
+use risingwave_common::util::table_fragments_util::TableFragmentsRenderCompression;
 use risingwave_connector::source::SplitImpl;
 use risingwave_pb::common::{ParallelUnit, ParallelUnitMapping};
 use risingwave_pb::meta::table_fragments::actor_status::ActorState;
@@ -107,7 +105,7 @@ impl MetadataModel for TableFragments {
             ..Default::default()
         };
 
-        compress_table_fragments(&mut table_fragments);
+        table_fragments.ensure_compressed();
 
         table_fragments
     }
@@ -121,7 +119,7 @@ impl MetadataModel for TableFragments {
             .get_graph_render_type()
             .unwrap_or(GraphRenderType::RenderUnspecified)
         {
-            uncompress_table_fragments(&mut prost);
+            prost.ensure_uncompressed();
         }
 
         Self {

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -24,7 +24,6 @@ use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::epoch::Epoch;
-use risingwave_common::util::table_fragments_util::TableFragmentsRenderCompression;
 use risingwave_connector::dispatch_source_prop;
 use risingwave_connector::source::{
     ConnectorProperties, SourceEnumeratorContext, SourceProperties, SplitEnumerator,
@@ -53,7 +52,7 @@ use crate::manager::{
     SchemaId, SinkId, SourceId, StreamingClusterInfo, StreamingJob, TableId, UserId, ViewId,
     IGNORED_NOTIFICATION_VERSION,
 };
-use crate::model::{MetadataModel, StreamEnvironment, TableFragments};
+use crate::model::{StreamEnvironment, TableFragments};
 use crate::rpc::cloud_provider::AwsEc2Client;
 use crate::stream::{
     validate_sink, ActorGraphBuildResult, ActorGraphBuilder, CompleteStreamFragmentGraph,
@@ -598,13 +597,6 @@ impl DdlController {
     ) -> MetaResult<NotificationVersion> {
         let job_id = stream_job.id();
         tracing::debug!(id = job_id, "creating stream job");
-
-        // todo remove me when everything is done
-        let mut pb_table_fragments = table_fragments.to_protobuf();
-        pb_table_fragments.ensure_uncompressed();
-        pb_table_fragments.ensure_compressed();
-        let table_fragments = TableFragments::from_protobuf(pb_table_fragments);
-
         let result = self
             .stream_manager
             .create_streaming_job(table_fragments, ctx)

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -24,9 +24,7 @@ use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::epoch::Epoch;
-use risingwave_common::util::table_fragments_util::{
-    compress_table_fragments, uncompress_table_fragments,
-};
+use risingwave_common::util::table_fragments_util::TableFragmentsRenderCompression;
 use risingwave_connector::dispatch_source_prop;
 use risingwave_connector::source::{
     ConnectorProperties, SourceEnumeratorContext, SourceProperties, SplitEnumerator,
@@ -603,8 +601,8 @@ impl DdlController {
 
         // todo remove me when everything is done
         let mut pb_table_fragments = table_fragments.to_protobuf();
-        uncompress_table_fragments(&mut pb_table_fragments);
-        compress_table_fragments(&mut pb_table_fragments);
+        pb_table_fragments.ensure_uncompressed();
+        pb_table_fragments.ensure_compressed();
         let table_fragments = TableFragments::from_protobuf(pb_table_fragments);
 
         let result = self

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -24,6 +24,9 @@ use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::epoch::Epoch;
+use risingwave_common::util::table_fragments_util::{
+    compress_table_fragments, uncompress_table_fragments,
+};
 use risingwave_connector::dispatch_source_prop;
 use risingwave_connector::source::{
     ConnectorProperties, SourceEnumeratorContext, SourceProperties, SplitEnumerator,
@@ -52,7 +55,7 @@ use crate::manager::{
     SchemaId, SinkId, SourceId, StreamingClusterInfo, StreamingJob, TableId, UserId, ViewId,
     IGNORED_NOTIFICATION_VERSION,
 };
-use crate::model::{StreamEnvironment, TableFragments};
+use crate::model::{MetadataModel, StreamEnvironment, TableFragments};
 use crate::rpc::cloud_provider::AwsEc2Client;
 use crate::stream::{
     validate_sink, ActorGraphBuildResult, ActorGraphBuilder, CompleteStreamFragmentGraph,
@@ -597,6 +600,13 @@ impl DdlController {
     ) -> MetaResult<NotificationVersion> {
         let job_id = stream_job.id();
         tracing::debug!(id = job_id, "creating stream job");
+
+        // todo remove me when everything is done
+        let mut pb_table_fragments = table_fragments.to_protobuf();
+        uncompress_table_fragments(&mut pb_table_fragments);
+        compress_table_fragments(&mut pb_table_fragments);
+        let table_fragments = TableFragments::from_protobuf(pb_table_fragments);
+
         let result = self
             .stream_manager
             .create_streaming_job(table_fragments, ctx)

--- a/src/meta/src/stream/stream_graph/actor.rs
+++ b/src/meta/src/stream/stream_graph/actor.rs
@@ -281,6 +281,7 @@ impl ActorBuilder {
             upstream_actor_id,
             vnode_bitmap: self.vnode_bitmap.map(|b| b.to_protobuf()),
             mview_definition,
+            upstream_actors_by_fragment: Default::default(),
         })
     }
 }

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -836,6 +836,7 @@ impl CompleteStreamFragmentGraph {
             vnode_mapping: Some(distribution.into_mapping().to_protobuf()),
             state_table_ids,
             upstream_fragment_ids,
+            stream_node_template: None,
         }
     }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -850,7 +850,7 @@ impl MetaClient {
 
         for table_fragments in &mut resp.table_fragments {
             if table_fragments.graph_render_type == GraphRenderType::RenderTemplate as i32 {
-                table_fragments.ensure_uncompressed()
+                table_fragments.uncompress()
             }
         }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -34,7 +34,7 @@ use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::resource_util::cpu::total_cpu_available;
 use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
-use risingwave_common::util::table_fragments_util::downgrade_table_fragments;
+use risingwave_common::util::table_fragments_util::uncompress_table_fragments;
 use risingwave_common::RW_VERSION;
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::{
@@ -850,7 +850,7 @@ impl MetaClient {
 
         for table_fragments in &mut resp.table_fragments {
             if table_fragments.graph_render_type == GraphRenderType::RenderTemplate as i32 {
-                downgrade_table_fragments(table_fragments);
+                uncompress_table_fragments(table_fragments);
             }
         }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -34,7 +34,7 @@ use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::resource_util::cpu::total_cpu_available;
 use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
-use risingwave_common::util::table_fragments_util::uncompress_table_fragments;
+use risingwave_common::util::table_fragments_util::TableFragmentsRenderCompression;
 use risingwave_common::RW_VERSION;
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::{
@@ -850,7 +850,7 @@ impl MetaClient {
 
         for table_fragments in &mut resp.table_fragments {
             if table_fragments.graph_render_type == GraphRenderType::RenderTemplate as i32 {
-                uncompress_table_fragments(table_fragments);
+                table_fragments.ensure_uncompressed()
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR attempts to compress duplicate node bodies in PbTableFragments::fragment::actor::nodes. The aim is to possibly reduce the RPC and meta storage to avoid ‘request limit’ errors.

before
<img width="571" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/1997790/f3f31743-77e1-490d-b812-8c6e93528c27">

after
<img width="572" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/1997790/bb2b69c4-1429-4b58-8150-80939bdc0a08">



## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


