### PR TITLE
fix(integration_tests): use `timestamptz` for BigQuery, Cassandra and Redis

### DIFF
--- a/integration_tests/big-query-sink/README.md
+++ b/integration_tests/big-query-sink/README.md
@@ -16,7 +16,7 @@ The cluster contains a RisingWave cluster and its necessary dependencies, a data
 CREATE table '${project_id}'.'${dataset_id}'.'${table_id}'(
     user_id int,
     target_id string,
-    event_timestamp datetime
+    event_timestamp timestamp
 );
 ```
 

--- a/integration_tests/big-query-sink/append-only-sql/create_source.sql
+++ b/integration_tests/big-query-sink/append-only-sql/create_source.sql
@@ -2,7 +2,7 @@ CREATE table user_behaviors (
     user_id int,
     target_id VARCHAR,
     target_type VARCHAR,
-    event_timestamp TIMESTAMP,
+    event_timestamp TIMESTAMPTZ,
     behavior_type VARCHAR,
     parent_target_type VARCHAR,
     parent_target_id VARCHAR,

--- a/integration_tests/cassandra-and-scylladb-sink/create_source.sql
+++ b/integration_tests/cassandra-and-scylladb-sink/create_source.sql
@@ -2,7 +2,7 @@ CREATE table user_behaviors (
     user_id int,
     target_id VARCHAR,
     target_type VARCHAR,
-    event_timestamp TIMESTAMP,
+    event_timestamp TIMESTAMPTZ,
     behavior_type VARCHAR,
     parent_target_type VARCHAR,
     parent_target_id VARCHAR,

--- a/integration_tests/redis-sink/create_source.sql
+++ b/integration_tests/redis-sink/create_source.sql
@@ -2,7 +2,7 @@ CREATE table user_behaviors (
     user_id INT,
     target_id VARCHAR,
     target_type VARCHAR,
-    event_timestamp TIMESTAMP,
+    event_timestamp TIMESTAMPTZ,
     behavior_type VARCHAR,
     parent_target_type VARCHAR,
     parent_target_id VARCHAR,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#datetime_type
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
> To represent an absolute point in time, use a timestamp.
> To represent a Gregorian date and time as they might appear on a watch, use a datetime value.

https://cassandra.apache.org/doc/stable/cassandra/cql/types.html#timestamps
https://opensource.docs.scylladb.com/stable/cql/types.html#working-with-timestamps
> it is recommended that the time zone always be specified for timestamps when feasible

The following sinks will be handled in a followup:
* MySQL, TiDB, Doris, StarRocks
* ClickHouse ([doc](https://clickhouse.com/docs/en/sql-reference/data-types/datetime))
* ElasticSearch ([doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html))

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
