### PR TITLE
feat(meta): record barrier latency in event table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8110,6 +8110,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "strum",
  "sync-point",
  "thiserror",
  "thiserror-ext",

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -584,6 +584,13 @@ message EventLog {
     string definition = 3;
     string error = 4;
   }
+  message EventBarrierComplete {
+    uint64 prev_epoch = 1;
+    uint64 cur_epoch = 2;
+    double duration_sec = 3;
+    string command = 4;
+    string barrier_kind = 5;
+  }
   // Event logs identifier, which should be populated by event log service.
   optional string unique_id = 1;
   // Processing time, which should be populated by event log service.
@@ -592,6 +599,7 @@ message EventLog {
     EventCreateStreamJobFail create_stream_job_fail = 3;
     EventDirtyStreamJobClear dirty_stream_job_clear = 4;
     EventMetaNodeStart meta_node_start = 5;
+    EventBarrierComplete barrier_complete = 6;
   }
 }
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_event_logs.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_event_logs.rs
@@ -42,11 +42,12 @@ impl SysCatalogReaderImpl {
             .await?
             .into_iter()
             .sorted_by(|a, b| a.timestamp.cmp(&b.timestamp))
-            .map(|e| {
-                let ts = Timestamptz::from_millis(e.timestamp.unwrap() as i64).unwrap();
+            .map(|mut e| {
+                let id = e.unique_id.take().unwrap().into();
+                let ts = Timestamptz::from_millis(e.timestamp.take().unwrap() as i64).unwrap();
                 let event_type = event_type(e.event.as_ref().unwrap());
                 OwnedRow::new(vec![
-                    Some(ScalarImpl::Utf8(e.unique_id.to_owned().unwrap().into())),
+                    Some(ScalarImpl::Utf8(id)),
                     Some(ScalarImpl::Timestamptz(ts)),
                     Some(ScalarImpl::Utf8(event_type.into())),
                     Some(ScalarImpl::Jsonb(json!(e).into())),
@@ -62,6 +63,7 @@ fn event_type(e: &Event) -> String {
         Event::CreateStreamJobFail(_) => "CREATE_STREAM_JOB_FAIL",
         Event::DirtyStreamJobClear(_) => "DIRTY_STREAM_JOB_CLEAR",
         Event::MetaNodeStart(_) => "META_NODE_START",
+        Event::BarrierComplete(_) => "BARRIER_COMPLETE",
     }
     .into()
 }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -65,6 +65,7 @@ sea-orm = { version = "0.12.0", features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+strum = { version = "0.25", features = ["derive"] }
 sync-point = { path = "../utils/sync-point" }
 thiserror = "1"
 thiserror-ext = { workspace = true }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -76,7 +76,7 @@ pub struct Reschedule {
 /// [`Command`] is the action of [`crate::barrier::GlobalBarrierManager`]. For different commands,
 /// we'll build different barriers to send, and may do different stuffs after the barrier is
 /// collected.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, strum::Display)]
 pub enum Command {
     /// `Plain` command generates a barrier with the mutation it carries.
     ///

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -1110,8 +1110,23 @@ impl GlobalBarrierManager {
                     self.scheduled_barriers.force_checkpoint_in_next_barrier();
                 }
 
-                node.timer.take().unwrap().observe_duration();
+                let duration_sec = node.timer.take().unwrap().stop_and_record();
                 node.wait_commit_timer.take().unwrap().observe_duration();
+
+                {
+                    // Record barrier latency in event log.
+                    use risingwave_pb::meta::event_log;
+                    let event = event_log::EventBarrierComplete {
+                        prev_epoch: node.command_ctx.prev_epoch.value().0,
+                        cur_epoch: node.command_ctx.curr_epoch.value().0,
+                        duration_sec,
+                        command: node.command_ctx.command.to_string(),
+                        barrier_kind: node.command_ctx.kind.as_str_name().to_string(),
+                    };
+                    self.env
+                        .event_log_manager_ref()
+                        .add_event_logs(vec![event_log::Event::BarrierComplete(event)]);
+                }
 
                 Ok(())
             }

--- a/src/meta/src/manager/event_log.rs
+++ b/src/meta/src/manager/event_log.rs
@@ -167,6 +167,7 @@ impl From<&EventLog> for ChannelId {
             Event::CreateStreamJobFail(_) => 1,
             Event::DirtyStreamJobClear(_) => 2,
             Event::MetaNodeStart(_) => 3,
+            Event::BarrierComplete(_) => 4,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

part of #12826

Failed barrier doesn't write a event log.
Event log table only records latest 10 events for each type by default. We can customize it on demand.

```
dev=> select * from rw_catalog.rw_event_logs where event_type='BARRIER_COMPLETE';
              unique_id               |           timestamp           |    event_type    |                                                                                       info                                                                                       
--------------------------------------+-------------------------------+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 4be656b2-33c2-4e8d-970d-a4934ab51bd7 | 2023-11-24 03:43:31.623+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_BARRIER", "command": "Plain", "curEpoch": "5476333100859392", "durationSec": 0.000279333, "prevEpoch": "5476333035257856"}}
 4846bd92-34d1-4304-ae6d-47912abe90b7 | 2023-11-24 03:43:32.623+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_CHECKPOINT", "command": "Plain", "curEpoch": "5476333166395392", "durationSec": 0.000699541, "prevEpoch": "5476333100859392"}}
 db589497-764b-45eb-ab0c-d5ea03ab4cde | 2023-11-24 03:43:33.622+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_BARRIER", "command": "Plain", "curEpoch": "5476333231865856", "durationSec": 0.000150208, "prevEpoch": "5476333166395392"}}
 fac9942d-45de-42bd-b64d-a64ea088e105 | 2023-11-24 03:43:34.625+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_CHECKPOINT", "command": "Plain", "curEpoch": "5476333297598464", "durationSec": 0.00072525, "prevEpoch": "5476333231865856"}}
 a399701a-c8d9-4495-9712-20cf6271c12e | 2023-11-24 03:43:35.624+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_BARRIER", "command": "Plain", "curEpoch": "5476333363068928", "durationSec": 0.000285166, "prevEpoch": "5476333297598464"}}
 59adb71b-5219-4e04-a483-54cc73125120 | 2023-11-24 03:43:36.624+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_CHECKPOINT", "command": "Plain", "curEpoch": "5476333428604928", "durationSec": 0.00072925, "prevEpoch": "5476333363068928"}}
 bbcf96ca-37b9-414d-9825-88240a8b6768 | 2023-11-24 03:43:37.623+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_BARRIER", "command": "Plain", "curEpoch": "5476333494075392", "durationSec": 0.000203709, "prevEpoch": "5476333428604928"}}
 c90ec544-30bf-459d-b110-f1481c0c4a22 | 2023-11-24 03:43:38.623+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_CHECKPOINT", "command": "Plain", "curEpoch": "5476333559676928", "durationSec": 0.000251042, "prevEpoch": "5476333494075392"}}
 f1f65fc3-360f-4c44-a69b-9757ca996122 | 2023-11-24 03:43:39.625+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_BARRIER", "command": "Plain", "curEpoch": "5476333625278464", "durationSec": 0.000460625, "prevEpoch": "5476333559676928"}}
 9f8715ac-46fd-4034-808e-168dda20e0c7 | 2023-11-24 03:43:40.623+00:00 | BARRIER_COMPLETE | {"barrierComplete": {"barrierKind": "BARRIER_KIND_CHECKPOINT", "command": "Plain", "curEpoch": "5476333690748928", "durationSec": 0.000439125, "prevEpoch": "5476333625278464"}}
(10 rows)

```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
