### PR TITLE
fix(memory): increase reserved mem to 30%

### DIFF
--- a/src/compute/src/memory/config.rs
+++ b/src/compute/src/memory/config.rs
@@ -21,7 +21,7 @@ pub const MIN_COMPUTE_MEMORY_MB: usize = 512;
 /// overhead, network buffer, etc.) in megabytes.
 pub const MIN_SYSTEM_RESERVED_MEMORY_MB: usize = 512;
 
-const SYSTEM_RESERVED_MEMORY_PROPORTION: f64 = 0.2;
+const SYSTEM_RESERVED_MEMORY_PROPORTION: f64 = 0.3;
 
 const STORAGE_MEMORY_PROPORTION: f64 = 0.3;
 
@@ -157,14 +157,14 @@ mod tests {
     #[test]
     fn test_reserve_memory_bytes() {
         // at least 512 MB
-        let (reserved, non_reserved) = reserve_memory_bytes(2 << 30);
+        let (reserved, non_reserved) = reserve_memory_bytes(1 << 30);
         assert_eq!(reserved, 512 << 20);
         assert_eq!(non_reserved, 1536 << 20);
 
         // reserve based on proportion
         let (reserved, non_reserved) = reserve_memory_bytes(10 << 30);
-        assert_eq!(reserved, 2 << 30);
-        assert_eq!(non_reserved, 8 << 30);
+        assert_eq!(reserved, 3 << 30);
+        assert_eq!(non_reserved, 7 << 30);
     }
 
     #[test]

--- a/src/compute/src/memory/config.rs
+++ b/src/compute/src/memory/config.rs
@@ -157,9 +157,9 @@ mod tests {
     #[test]
     fn test_reserve_memory_bytes() {
         // at least 512 MB
-        let (reserved, non_reserved) = reserve_memory_bytes(1 << 30);
+        let (reserved, non_reserved) = reserve_memory_bytes(1536 << 20);
         assert_eq!(reserved, 512 << 20);
-        assert_eq!(non_reserved, 1536 << 20);
+        assert_eq!(non_reserved, 1024 << 20);
 
         // reserve based on proportion
         let (reserved, non_reserved) = reserve_memory_bytes(10 << 30);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The `reserved_memory` is designed for the difference between actual usage (`jemalloc_allocated`) and process usage (`process_resident_memory`).

https://github.com/risingwavelabs/risingwave/blob/b640bc99952d4541a6f43213f57883f2798d76b6/src/compute/src/memory/config.rs#L40-L42

As being observed in #13610,

> - jemalloc_allocated_bytes: 8.59 GB
> - jemalloc_active_bytes: 9.93 GB
> - Node memory (RSS): 12.3 GB

The ratio is `8.59/12.3 = 0.698 ≈ 0.7`.

Passed longevity test: https://buildkite.com/risingwave-test/longevity-test/builds/818 (Previously this would OOM for 2 times)


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
