### PR TITLE
fix: duplicate keys of AwsAuth in props and options

### DIFF
--- a/src/batch/src/executor/source.rs
+++ b/src/batch/src/executor/source.rs
@@ -66,7 +66,7 @@ impl BoxedExecutorBuilder for SourceExecutor {
         let config = ConnectorProperties::extract(source_props).map_err(BatchError::connector)?;
 
         let info = source_node.get_info().unwrap();
-        let parser_config = SpecificParserConfig::new(info, &source_node.properties)?;
+        let parser_config = SpecificParserConfig::new(info, &source_node.properties, None)?;
 
         let columns: Vec<_> = source_node
             .columns

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -196,7 +196,7 @@ impl AvroParserConfig {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::env;
     use std::fs::OpenOptions;
     use std::io::Write;
@@ -299,7 +299,8 @@ mod test {
             row_encode: PbEncodeType::Avro.into(),
             ..Default::default()
         };
-        let parser_config = SpecificParserConfig::new(&info, &HashMap::new())?;
+        let parser_config =
+            SpecificParserConfig::new(&info, &HashMap::new(), Some(&mut BTreeMap::new()))?;
         AvroParserConfig::new(parser_config.encoding_config).await
     }
 

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -140,6 +140,7 @@ impl DebeziumAvroParserConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::io::Read;
     use std::path::PathBuf;
 
@@ -304,7 +305,7 @@ mod tests {
             row_encode: PbEncodeType::Avro.into(),
             ..Default::default()
         };
-        let parser_config = SpecificParserConfig::new(&info, &props)?;
+        let parser_config = SpecificParserConfig::new(&info, &props, Some(&mut BTreeMap::new()))?;
         let config = DebeziumAvroParserConfig::new(parser_config.clone().encoding_config).await?;
         let columns = config
             .map_to_columns()?

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -576,7 +576,7 @@ pub(crate) fn resolve_pb_header(payload: &[u8]) -> Result<&[u8]> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::path::PathBuf;
 
     use prost::Message;
@@ -621,7 +621,8 @@ mod test {
             row_encode: PbEncodeType::Protobuf.into(),
             ..Default::default()
         };
-        let parser_config = SpecificParserConfig::new(&info, &HashMap::new())?;
+        let parser_config =
+            SpecificParserConfig::new(&info, &HashMap::new(), Some(&mut BTreeMap::new()))?;
         let conf = ProtobufParserConfig::new(parser_config.encoding_config).await?;
         let value = DynamicMessage::decode(conf.message_descriptor, PRE_GEN_PROTO_DATA).unwrap();
 
@@ -666,7 +667,8 @@ mod test {
             row_encode: PbEncodeType::Protobuf.into(),
             ..Default::default()
         };
-        let parser_config = SpecificParserConfig::new(&info, &HashMap::new())?;
+        let parser_config =
+            SpecificParserConfig::new(&info, &HashMap::new(), Some(&mut BTreeMap::new()))?;
         let conf = ProtobufParserConfig::new(parser_config.encoding_config).await?;
         let columns = conf.map_to_columns().unwrap();
 
@@ -715,7 +717,8 @@ mod test {
             row_encode: PbEncodeType::Protobuf.into(),
             ..Default::default()
         };
-        let parser_config = SpecificParserConfig::new(&info, &HashMap::new()).unwrap();
+        let parser_config =
+            SpecificParserConfig::new(&info, &HashMap::new(), Some(&mut BTreeMap::new())).unwrap();
         let conf = ProtobufParserConfig::new(parser_config.encoding_config)
             .await
             .unwrap();
@@ -743,7 +746,8 @@ mod test {
             row_encode: PbEncodeType::Protobuf.into(),
             ..Default::default()
         };
-        let parser_config = SpecificParserConfig::new(&info, &HashMap::new()).unwrap();
+        let parser_config =
+            SpecificParserConfig::new(&info, &HashMap::new(), Some(&mut BTreeMap::new())).unwrap();
 
         ProtobufParserConfig::new(parser_config.encoding_config)
             .await

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -119,8 +119,9 @@ fn json_schema_infer_use_schema_registry(schema_config: &Option<(AstString, bool
 async fn extract_avro_table_schema(
     info: &StreamSourceInfo,
     with_properties: &HashMap<String, String>,
+    row_options: &mut BTreeMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
-    let parser_config = SpecificParserConfig::new(info, with_properties)?;
+    let parser_config = SpecificParserConfig::new(info, with_properties, Some(row_options))?;
     let conf = AvroParserConfig::new(parser_config.encoding_config).await?;
     let vec_column_desc = conf.map_to_columns()?;
     Ok(vec_column_desc
@@ -136,8 +137,9 @@ async fn extract_avro_table_schema(
 async fn extract_upsert_avro_table_pk_columns(
     info: &StreamSourceInfo,
     with_properties: &HashMap<String, String>,
+    row_options: &mut BTreeMap<String, String>,
 ) -> Result<Option<Vec<String>>> {
-    let parser_config = SpecificParserConfig::new(info, with_properties)?;
+    let parser_config = SpecificParserConfig::new(info, with_properties, Some(row_options))?;
     let conf = AvroParserConfig::new(parser_config.encoding_config).await?;
     let vec_column_desc = conf.map_to_columns()?;
 
@@ -166,8 +168,9 @@ async fn extract_upsert_avro_table_pk_columns(
 async fn extract_debezium_avro_table_pk_columns(
     info: &StreamSourceInfo,
     with_properties: &HashMap<String, String>,
+    row_options: &mut BTreeMap<String, String>,
 ) -> Result<Vec<String>> {
-    let parser_config = SpecificParserConfig::new(info, with_properties)?;
+    let parser_config = SpecificParserConfig::new(info, with_properties, Some(row_options))?;
     let conf = DebeziumAvroParserConfig::new(parser_config.encoding_config).await?;
     Ok(conf.extract_pks()?.drain(..).map(|c| c.name).collect())
 }
@@ -176,8 +179,9 @@ async fn extract_debezium_avro_table_pk_columns(
 async fn extract_debezium_avro_table_schema(
     info: &StreamSourceInfo,
     with_properties: &HashMap<String, String>,
+    row_options: &mut BTreeMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
-    let parser_config = SpecificParserConfig::new(info, with_properties)?;
+    let parser_config = SpecificParserConfig::new(info, with_properties, Some(row_options))?;
     let conf = DebeziumAvroParserConfig::new(parser_config.encoding_config).await?;
     let vec_column_desc = conf.map_to_columns()?;
     let column_catalog = vec_column_desc
@@ -193,7 +197,8 @@ async fn extract_debezium_avro_table_schema(
 /// Map a protobuf schema to a relational schema.
 async fn extract_protobuf_table_schema(
     schema: &ProtobufSchema,
-    with_properties: HashMap<String, String>,
+    with_properties: &HashMap<String, String>,
+    row_options: &mut BTreeMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
     let info = StreamSourceInfo {
         proto_message_name: schema.message_name.0.clone(),
@@ -203,7 +208,7 @@ async fn extract_protobuf_table_schema(
         row_encode: EncodeType::Protobuf.into(),
         ..Default::default()
     };
-    let parser_config = SpecificParserConfig::new(&info, &with_properties)?;
+    let parser_config = SpecificParserConfig::new(&info, with_properties, Some(row_options))?;
     let conf = ProtobufParserConfig::new(parser_config.encoding_config).await?;
 
     let column_descs = conf.map_to_columns()?;
@@ -338,7 +343,7 @@ pub(crate) async fn bind_columns_from_source(
 
             (
                 Some(
-                    extract_protobuf_table_schema(&protobuf_schema, with_properties.clone())
+                    extract_protobuf_table_schema(&protobuf_schema, with_properties, &mut options)
                         .await?,
                 ),
                 StreamSourceInfo {
@@ -396,7 +401,10 @@ pub(crate) async fn bind_columns_from_source(
                 ..Default::default()
             };
             (
-                Some(extract_avro_table_schema(&stream_source_info, with_properties).await?),
+                Some(
+                    extract_avro_table_schema(&stream_source_info, with_properties, &mut options)
+                        .await?,
+                ),
                 stream_source_info,
             )
         }
@@ -470,7 +478,9 @@ pub(crate) async fn bind_columns_from_source(
                 name_strategy,
                 ..Default::default()
             };
-            let columns = extract_avro_table_schema(&stream_source_info, with_properties).await?;
+            let columns =
+                extract_avro_table_schema(&stream_source_info, with_properties, &mut options)
+                    .await?;
 
             (Some(columns), stream_source_info)
         }
@@ -516,8 +526,12 @@ pub(crate) async fn bind_columns_from_source(
                 ..Default::default()
             };
 
-            let full_columns =
-                extract_debezium_avro_table_schema(&stream_source_info, with_properties).await?;
+            let full_columns = extract_debezium_avro_table_schema(
+                &stream_source_info,
+                with_properties,
+                &mut options,
+            )
+            .await?;
 
             (Some(full_columns), stream_source_info)
         }
@@ -712,6 +726,7 @@ pub(crate) async fn bind_source_pk(
             }
         }
         (Format::Upsert, Encode::Avro) => {
+            let mut options = WithOptions::try_from(source_schema.row_options())?;
             if sql_defined_pk {
                 if sql_defined_pk_names.len() != 1 {
                     return Err(RwError::from(ProtocolError(
@@ -719,8 +734,12 @@ pub(crate) async fn bind_source_pk(
                     )));
                 }
                 sql_defined_pk_names
-            } else if let Some(extracted_pk_names) =
-                extract_upsert_avro_table_pk_columns(source_info, with_properties).await?
+            } else if let Some(extracted_pk_names) = extract_upsert_avro_table_pk_columns(
+                source_info,
+                with_properties,
+                options.inner_mut(),
+            )
+            .await?
             {
                 extracted_pk_names
             } else {
@@ -743,8 +762,13 @@ pub(crate) async fn bind_source_pk(
             if sql_defined_pk {
                 sql_defined_pk_names
             } else {
-                let pk_names =
-                    extract_debezium_avro_table_pk_columns(source_info, with_properties).await?;
+                let mut options = WithOptions::try_from(source_schema.row_options())?;
+                let pk_names = extract_debezium_avro_table_pk_columns(
+                    source_info,
+                    with_properties,
+                    options.inner_mut(),
+                )
+                .await?;
                 // extract pk(s) from schema registry
                 for pk_name in &pk_names {
                     columns

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -102,7 +102,7 @@ impl SourceDescBuilder {
     pub fn build(mut self) -> Result<SourceDesc> {
         let columns = self.column_catalogs_to_source_column_descs();
 
-        let psrser_config = SpecificParserConfig::new(&self.source_info, &self.properties)?;
+        let psrser_config = SpecificParserConfig::new(&self.source_info, &self.properties, None)?;
 
         let is_new_fs_source = ConnectorProperties::is_new_fs_connector_hash_map(&self.properties);
         if is_new_fs_source {
@@ -130,7 +130,7 @@ impl SourceDescBuilder {
     }
 
     pub fn build_fs_source_desc(&self) -> Result<FsSourceDesc> {
-        let parser_config = SpecificParserConfig::new(&self.source_info, &self.properties)?;
+        let parser_config = SpecificParserConfig::new(&self.source_info, &self.properties, None)?;
 
         match (
             &parser_config.protocol_config,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Related to #13367.

The current implementation stores (FORMAT ENCODE) options along with (WITH) properties, and when there are duplicated keys for authentication of AWS in both options and properties they cannot be distinguished. An example is as follows:
```sql
CREATE {TABLE | SOURCE} [IF NOT EXISTS] source_name
WITH (
   connector='kinesis',
   stream='kafka',
   aws.region='user_test_topic',
   endpoint='172.10.1.1:9090,172.10.1.2:9090',
   aws.credentials.access_key_id = 'your_access_key',
   aws.credentials.secret_access_key = 'your_secret_key'
) FORMAT PLAIN ENCODE PROTOBUF (
    message = 'demo_message',
    schema.location = 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.proto'
    aws.credentials.access_key_id = 'your_access_key',
    aws.credentials.secret_access_key = 'your_secret_key'
);
```
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
