### PR TITLE
feat: introduce rebalance for fixed-parallelism fragments

### DIFF
--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -66,6 +66,7 @@ pub struct TableFragments {
     /// The environment associated with this stream plan and its fragments
     pub env: StreamEnvironment,
 
+    /// The parallelism assigned to this table fragments
     pub assigned_parallelism: TableFragmentsParallelism,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As described in the title, we determine the ‘assigned_parallelism’ field of the table fragments that the fragment belongs to when generating a stable resize plan, so as to generate a rebalance plan. Since the rebalance process uses the earliest parallel units of each worker, we can organize the available parallel units for redistribution each time to achieve a stable rebalance solution (though more testing is still required).

we will continue to keep the default behavior as adaptive.

Regarding scheduling, we are currently using a simple algorithm based on consistent hashing. We are using the number of parallel units in a worker as the weight (to support future ensembles). By using the consistent hash ring, we assign the target number of parallelisms. Because the consistent hash strategy cannot guarantee n workers with the same weight have the same number of parallelisms (which completely depends on the hash algorithm), we use a soft limit to restrict the maximum number of parallelisms allocated on a worker. Therefore, this algorithm has some limitations and may not be stable enough in certain circumstances.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
