### PR TITLE
feat: risectl debug dump support catalog

### DIFF
--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -87,6 +87,15 @@ enum DebugCommonKind {
     User,
     Table,
     MetaMember,
+    SourceCatalog,
+    SinkCatalog,
+    IndexCatalog,
+    FunctionCatalog,
+    ViewCatalog,
+    ConnectionCatalog,
+    DatabaseCatalog,
+    SchemaCatalog,
+    TableCatalog,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add catalog support to ‘risectl debug dump’.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
