### PR TITLE
feat(meta): try to record panic info from worker nodes

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -601,6 +601,12 @@ message EventLog {
     uint64 cur_epoch = 2;
     string error = 3;
   }
+  message EventWorkerNodePanic {
+    uint32 worker_id = 1;
+    common.WorkerType worker_type = 2;
+    common.HostAddress host_addr = 3;
+    string panic_info = 4;
+  }
   // Event logs identifier, which should be populated by event log service.
   optional string unique_id = 1;
   // Processing time, which should be populated by event log service.
@@ -612,6 +618,7 @@ message EventLog {
     EventBarrierComplete barrier_complete = 6;
     EventInjectBarrierFail inject_barrier_fail = 7;
     EventCollectBarrierFail collect_barrier_fail = 8;
+    EventLog.EventWorkerNodePanic worker_node_panic = 9;
   }
 }
 
@@ -621,6 +628,16 @@ message ListEventLogResponse {
   repeated EventLog event_logs = 1;
 }
 
+message AddEventLogRequest {
+  // A subset of EventLog.event that can be added by non meta node.
+  oneof event {
+    EventLog.EventWorkerNodePanic worker_node_panic = 1;
+  }
+}
+
+message AddEventLogResponse {}
+
 service EventLogService {
   rpc ListEventLog(ListEventLogRequest) returns (ListEventLogResponse);
+  rpc AddEventLog(AddEventLogRequest) returns (AddEventLogResponse);
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_event_logs.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_event_logs.rs
@@ -66,6 +66,7 @@ fn event_type(e: &Event) -> String {
         Event::BarrierComplete(_) => "BARRIER_COMPLETE",
         Event::InjectBarrierFail(_) => "INJECT_BARRIER_FAIL",
         Event::CollectBarrierFail(_) => "COLLECT_BARRIER_FAIL",
+        Event::WorkerNodePanic(_) => "WORKER_NODE_PANIC",
     }
     .into()
 }

--- a/src/meta/service/src/event_log_service.rs
+++ b/src/meta/service/src/event_log_service.rs
@@ -14,7 +14,9 @@
 
 use risingwave_meta::manager::event_log::EventLogMangerRef;
 use risingwave_pb::meta::event_log_service_server::EventLogService;
-use risingwave_pb::meta::{ListEventLogRequest, ListEventLogResponse};
+use risingwave_pb::meta::{
+    AddEventLogRequest, AddEventLogResponse, ListEventLogRequest, ListEventLogResponse,
+};
 use tonic::{Request, Response, Status};
 
 pub struct EventLogServiceImpl {
@@ -35,5 +37,21 @@ impl EventLogService for EventLogServiceImpl {
     ) -> Result<Response<ListEventLogResponse>, Status> {
         let event_logs = self.event_log_manager.list_event_logs();
         Ok(Response::new(ListEventLogResponse { event_logs }))
+    }
+
+    async fn add_event_log(
+        &self,
+        request: Request<AddEventLogRequest>,
+    ) -> Result<Response<AddEventLogResponse>, Status> {
+        let Some(event) = request.into_inner().event else {
+            return Ok(Response::new(AddEventLogResponse {}));
+        };
+        let e = match event {
+            risingwave_pb::meta::add_event_log_request::Event::WorkerNodePanic(e) => {
+                risingwave_pb::meta::event_log::Event::WorkerNodePanic(e)
+            }
+        };
+        self.event_log_manager.add_event_logs(vec![e]);
+        Ok(Response::new(AddEventLogResponse {}))
     }
 }

--- a/src/meta/src/manager/event_log.rs
+++ b/src/meta/src/manager/event_log.rs
@@ -170,6 +170,7 @@ impl From<&EventLog> for ChannelId {
             Event::BarrierComplete(_) => 4,
             Event::InjectBarrierFail(_) => 5,
             Event::CollectBarrierFail(_) => 6,
+            Event::WorkerNodePanic(_) => 7,
         }
     }
 }

--- a/src/rpc_client/src/lib.rs
+++ b/src/rpc_client/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(let_chains)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(error_generic_member_access)]
+#![feature(panic_update_hook)]
 
 use std::any::type_name;
 use std::fmt::{Debug, Formatter};

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1219,6 +1219,10 @@ impl MetaClient {
         panic_info: impl Display,
         timeout_millis: Option<u64>,
     ) {
+        if cfg!(madsim) {
+            // madsim doesn't support block_on.
+            return;
+        }
         let event = event_log::EventWorkerNodePanic {
             worker_id: self.worker_id,
             worker_type: self.worker_type.into(),

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1213,16 +1213,21 @@ impl MetaClient {
         Ok(resp.task_progress)
     }
 
-    /// If `timeout_millis` is None, default is used.
+    #[cfg(madsim)]
     pub fn try_add_panic_event_blocking(
         &self,
         panic_info: impl Display,
         timeout_millis: Option<u64>,
     ) {
-        if cfg!(madsim) {
-            // madsim doesn't support block_on.
-            return;
-        }
+    }
+
+    /// If `timeout_millis` is None, default is used.
+    #[cfg(not(madsim))]
+    pub fn try_add_panic_event_blocking(
+        &self,
+        panic_info: impl Display,
+        timeout_millis: Option<u64>,
+    ) {
         let event = event_log::EventWorkerNodePanic {
             worker_id: self.worker_id,
             worker_type: self.worker_type.into(),

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1236,7 +1236,7 @@ impl MetaClient {
         };
         let grpc_meta_client = self.inner.clone();
         let _ = thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
+            let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR records panic from worker nodes in system event table. It updates the panic hook when the meta RPC client is created, and sends panic info to meta node via RPC on panic.

```
dev=> select * from rw_event_logs where event_type='WORKER_NODE_PANIC';
              unique_id               |           timestamp           |    event_type     |                                                                                                                                 info                                                                                                                                  
--------------------------------------+-------------------------------+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 10ec9bfe-f656-475a-a640-63cb4c077122 | 2023-12-04 05:29:34.951+00:00 | WORKER_NODE_PANIC | {"workerNodePanic": {"hostAddr": {"host": "127.0.0.1", "port": 5688}, "panicInfo": "panicked at /risingwave/src/stream/src/executor/actor.rs:171:13:\nintentional panic actor 4", "workerId": 1, "workerType": "WORKER_TYPE_COMPUTE_NODE"}}
(1 row)

```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
