### PR TITLE
chore(risedev): split some tasks from `check` to `check-fast`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1223,7 +1223,7 @@ script = """
 scripts/check/check-trailing-spaces.sh --fix
 """
 
-[tasks.check]
+[tasks.check-fast]
 category = "RiseDev - Check"
 dependencies = [
   "warn-on-missing-tools",
@@ -1232,9 +1232,12 @@ dependencies = [
   "check-fmt",
   "check-trailing-spaces",
   "check-typos",
-  "check-clippy",
-  "check-java",
 ]
+description = "Perform part of the pre-CI checks that are fast to run"
+
+[tasks.check]
+category = "RiseDev - Check"
+dependencies = ["check-fast", "check-clippy", "check-java"]
 script = """
 #!/usr/bin/env bash
 
@@ -1250,11 +1253,7 @@ alias = "check"
 category = "RiseDev - Check"
 dependencies = [
   "warn-on-missing-tools",
-  "check-hakari",
-  "check-dep-sort",
-  "check-fmt",
-  "check-trailing-spaces",
-  "check-typos",
+  "check-fast",
   "check-clippy-fix",
   "check-java-fix",
 ]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
as title

The main motivation is that check-trailing-spaces (and hakari) often breaks, and I don't want to run clippy as it's slow.

Maybe we can also add `check-fast` to pre-commit hook, and/or CI auto fix (like hakari-fix)

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
