### PR TITLE
fix(udf): avoid panic on invalid output and fix decimal output scale lost

### DIFF
--- a/e2e_test/udf/test.py
+++ b/e2e_test/udf/test.py
@@ -84,6 +84,11 @@ def hex_to_dec(hex: Optional[str]) -> Optional[Decimal]:
     return dec
 
 
+@udf(input_types=["FLOAT8"], result_type="DECIMAL")
+def float_to_decimal(f: float) -> Decimal:
+    return Decimal(f)
+
+
 @udf(input_types=["DECIMAL", "DECIMAL"], result_type="DECIMAL")
 def decimal_add(a: Decimal, b: Decimal) -> Decimal:
     return a + b
@@ -217,6 +222,7 @@ if __name__ == "__main__":
     server.add_function(split)
     server.add_function(extract_tcp_info)
     server.add_function(hex_to_dec)
+    server.add_function(float_to_decimal)
     server.add_function(decimal_add)
     server.add_function(array_access)
     server.add_function(jsonb_access)

--- a/e2e_test/udf/udf.slt
+++ b/e2e_test/udf/udf.slt
@@ -353,6 +353,9 @@ statement ok
 drop function split;
 
 statement ok
+drop function float_to_decimal;
+
+statement ok
 drop function hex_to_dec;
 
 statement ok

--- a/e2e_test/udf/udf.slt
+++ b/e2e_test/udf/udf.slt
@@ -40,6 +40,9 @@ statement ok
 create function split(varchar) returns table (word varchar, length int) as split using link 'http://localhost:8815';
 
 statement ok
+create function float_to_decimal(float8) returns decimal as float_to_decimal using link 'http://localhost:8815';
+
+statement ok
 create function hex_to_dec(varchar) returns decimal as hex_to_dec using link 'http://localhost:8815';
 
 statement ok
@@ -77,6 +80,7 @@ show functions
 array_access character varying[], integer character varying (empty) http://localhost:8815
 decimal_add numeric, numeric numeric (empty) http://localhost:8815
 extract_tcp_info bytea struct<src_ip character varying, dst_ip character varying, src_port smallint, dst_port smallint> (empty) http://localhost:8815
+float_to_decimal double precision numeric (empty) http://localhost:8815
 gcd integer, integer integer (empty) http://localhost:8815
 gcd integer, integer, integer integer (empty) http://localhost:8815
 hex_to_dec character varying numeric (empty) http://localhost:8815
@@ -109,6 +113,11 @@ query I
 select hex_to_dec('000000000000000000000000000000000000000000c0f6346334241a61f90a36');
 ----
 233276425899864771438119478
+
+query I
+select float_to_decimal('-1e-10'::float8);
+----
+-0.0000000001000000000000000036
 
 query R
 select decimal_add(1.11, 2.22);

--- a/java/udf-example/pom.xml
+++ b/java/udf-example/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.risingwave</groupId>
       <artifactId>risingwave-udf</artifactId>
-      <version>0.1.2-SNAPSHOT</version>
+      <version>0.1.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/java/udf-example/src/main/java/com/example/UdfExample.java
+++ b/java/udf-example/src/main/java/com/example/UdfExample.java
@@ -35,6 +35,7 @@ public class UdfExample {
     public static void main(String[] args) throws IOException {
         try (var server = new UdfServer("0.0.0.0", 8815)) {
             server.addFunction("int_42", new Int42());
+            server.addFunction("float_to_decimal", new FloatToDecimal());
             server.addFunction("sleep", new Sleep());
             server.addFunction("gcd", new Gcd());
             server.addFunction("gcd3", new Gcd3());
@@ -61,6 +62,12 @@ public class UdfExample {
     public static class Int42 implements ScalarFunction {
         public int eval() {
             return 42;
+        }
+    }
+
+    public static class FloatToDecimal implements ScalarFunction {
+        public BigDecimal eval(Double f) {
+            return new BigDecimal(f);
         }
     }
 

--- a/java/udf/CHANGELOG.md
+++ b/java/udf/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2023-12-06
+
+### Fixed
+
+- Fix decimal type output.
+
 ## [0.1.2] - 2023-12-04
 
 ### Fixed

--- a/java/udf/pom.xml
+++ b/java/udf/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.risingwave</groupId>
   <artifactId>risingwave-udf</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.2-SNAPSHOT</version>
+  <version>0.1.3-SNAPSHOT</version>
 
   <parent>
     <artifactId>risingwave-java-root</artifactId>

--- a/java/udf/src/main/java/com/risingwave/functions/TypeUtils.java
+++ b/java/udf/src/main/java/com/risingwave/functions/TypeUtils.java
@@ -245,7 +245,8 @@ class TypeUtils {
             vector.allocateNew(values.length);
             for (int i = 0; i < values.length; i++) {
                 if (values[i] != null) {
-                    vector.set(i, ((BigDecimal) values[i]).toString().getBytes());
+                    // use `toPlainString` to avoid scientific notation
+                    vector.set(i, ((BigDecimal) values[i]).toPlainString().getBytes());
                 }
             }
         } else if (fieldVector instanceof DateDayVector) {

--- a/src/expr/core/src/expr/expr_udf.rs
+++ b/src/expr/core/src/expr/expr_udf.rs
@@ -144,8 +144,7 @@ impl UdfExpression {
             );
         }
 
-        let data_chunk =
-            DataChunk::try_from(&output).expect("failed to convert UDF output to DataChunk");
+        let data_chunk = DataChunk::try_from(&output)?;
         let output = data_chunk.uncompact(vis.clone());
 
         let Some(array) = output.columns().first() else {

--- a/src/udf/python/CHANGELOG.md
+++ b/src/udf/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-12-06
+
+### Fixed
+
+- Fix decimal type output.
+
 ## [0.1.0] - 2023-12-01
 
 ### Fixed

--- a/src/udf/python/pyproject.toml
+++ b/src/udf/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "risingwave"
-version = "0.1.0"
+version = "0.1.1"
 authors = [{ name = "RisingWave Labs" }]
 description = "RisingWave Python API"
 readme = "README.md"

--- a/src/udf/python/risingwave/udf.py
+++ b/src/udf/python/risingwave/udf.py
@@ -120,7 +120,14 @@ def _process_func(type: pa.DataType, output: bool) -> Callable:
 
     if type.equals(UNCONSTRAINED_DECIMAL):
         if output:
-            return lambda v: str(v).encode("utf-8")
+
+            def decimal_to_str(v):
+                if not isinstance(v, Decimal):
+                    raise ValueError(f"Expected Decimal, got {v}")
+                # use `f` format to avoid scientific notation, e.g. `1e10`
+                return format(v, "f").encode("utf-8")
+
+            return decimal_to_str
         else:
             return lambda v: Decimal(v.decode("utf-8"))
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR fixed the panic:
```
failed to convert UDF output to DataChunk: FromArrow("invalid decimal: \"-5.10043e-05\"")
```

First of all, as mentioned in #9002, compute nodes must not panic on errors caused by UDF servers. cc @KveinAxel 

Next, after #11839, decimal values are stored as strings in the arrow array. However, the panic message indicates that a float number with scientific notation `-5.10043e-05` was written by Python, and it couldn't be parsed by rust decimal. It turned out that user defined a function returning `NUMERIC`, but the actual return value is a `float` rather than `Decimal`. Even it returns a `Decimal`, its string form may still contains scientific notation and has a long precision number.

```python
>>> from decimal import Decimal
>>> str(Decimal(1e-10))
'1.0000000000000000364321973154977415791655470655996396089904010295867919921875E-10'
```

When parsed by RisingWave, the tailing numbers and exponent will be truncated, resulting in wrong results.

```sql
dev=> select decimal();
            decimal             
--------------------------------
 1.0000000000000000364321973155
```

So, this PR:
1. check the return value for Python functions that return `DECIMAL` and reject values other than `Decimal` type. (this problem doesn't exist in Java because it's strong typed)
2. format printing decimals in Python and Java to avoid scientific notation

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)
