### PR TITLE
feat(meta): show recovery cause when request is rejected

### DIFF
--- a/src/meta/service/src/scale_service.rs
+++ b/src/meta/service/src/scale_service.rs
@@ -126,11 +126,7 @@ impl ScaleService for ScaleServiceImpl {
         &self,
         request: Request<RescheduleRequest>,
     ) -> Result<Response<RescheduleResponse>, Status> {
-        if !self.barrier_manager.is_running().await {
-            return Err(Status::unavailable(
-                "Rescheduling is unavailable for now. Likely the cluster is starting or recovering.",
-            ));
-        }
+        self.barrier_manager.check_status_running().await?;
 
         let RescheduleRequest {
             reschedules,
@@ -190,13 +186,9 @@ impl ScaleService for ScaleServiceImpl {
         &self,
         request: Request<GetReschedulePlanRequest>,
     ) -> Result<Response<GetReschedulePlanResponse>, Status> {
-        let req = request.into_inner();
+        self.barrier_manager.check_status_running().await?;
 
-        if !self.barrier_manager.is_running().await {
-            return Err(Status::unavailable(
-                "Rescheduling is unavailable for now. Likely the cluster is starting or recovering.",
-            ));
-        }
+        let req = request.into_inner();
 
         let _reschedule_job_lock = self.stream_manager.reschedule_lock.read().await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When a DDL request is sent to the meta service which is under failure recovery, the failure cause will be included in the error message as well. Thanks to the progress made on #11443, all we need to do is to correctly return the error in meta.

```
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: gRPC request to meta service failed: Internal error
  2: The cluster is recovering
  3: gRPC request to stream service failed: Internal error
  4: Actor 4 exited unexpectedly
  5: Executor error
  6: Chunk operation error
  7: Division by zero
```

It's worth noting that after #12999, the message will rarely be seen by users as `DROP` is not rejected. But I guess it's still a good-to-have.

Also I don't find a way to test it in CI, as we cannot manually trigger a failure recovery now (or we have to depend on some unresolved bugs 😄, like the examples above). Perhaps we can introduce a debug-only statement to manually trigger one.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
