### PR TITLE
fix: use EpochWithGap::new_max_epoch if the provided epoch is max epoch

### DIFF
--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -116,8 +116,11 @@ impl Epoch {
 
 pub const EPOCH_AVAILABLE_BITS: u64 = 16;
 pub const MAX_SPILL_TIMES: u16 = ((1 << EPOCH_AVAILABLE_BITS) - 1) as u16;
-pub const EPOCH_MASK: u64 = (1 << EPOCH_AVAILABLE_BITS) - 1;
-pub const MAX_EPOCH: u64 = u64::MAX & !EPOCH_MASK;
+// Low EPOCH_AVAILABLE_BITS bits set to 1
+pub const EPOCH_SPILL_TIME_MASK: u64 = (1 << EPOCH_AVAILABLE_BITS) - 1;
+// High (64-EPOCH_AVAILABLE_BITS) bits set to 1
+pub const EPOCH_MASK: u64 = !EPOCH_SPILL_TIME_MASK;
+pub const MAX_EPOCH: u64 = u64::MAX & EPOCH_MASK;
 
 pub fn is_max_epoch(epoch: u64) -> bool {
     // Since we have write `MAX_EPOCH` as max epoch to sstable in some previous version,

--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -119,7 +119,7 @@ pub const MAX_SPILL_TIMES: u16 = ((1 << EPOCH_AVAILABLE_BITS) - 1) as u16;
 // Low EPOCH_AVAILABLE_BITS bits set to 1
 pub const EPOCH_SPILL_TIME_MASK: u64 = (1 << EPOCH_AVAILABLE_BITS) - 1;
 // High (64-EPOCH_AVAILABLE_BITS) bits set to 1
-pub const EPOCH_MASK: u64 = !EPOCH_SPILL_TIME_MASK;
+const EPOCH_MASK: u64 = !EPOCH_SPILL_TIME_MASK;
 pub const MAX_EPOCH: u64 = u64::MAX & EPOCH_MASK;
 
 pub fn is_max_epoch(epoch: u64) -> bool {

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -26,7 +26,7 @@ mod key_cmp;
 use std::cmp::Ordering;
 
 pub use key_cmp::*;
-use risingwave_common::util::epoch::EPOCH_MASK;
+use risingwave_common::util::epoch::EPOCH_SPILL_TIME_MASK;
 use risingwave_pb::common::{batch_query_epoch, BatchQueryEpoch};
 use risingwave_pb::hummock::SstableInfo;
 
@@ -284,11 +284,12 @@ impl EpochWithGap {
         //  So for compatibility, we must skip checking it for u64::MAX. See bug description in https://github.com/risingwavelabs/risingwave/issues/13717
         #[cfg(not(feature = "enable_test_epoch"))]
         {
-            debug_assert!(
-                ((epoch & EPOCH_MASK) == 0) || risingwave_common::util::epoch::is_max_epoch(epoch)
-            );
-            let epoch_with_gap = epoch + spill_offset as u64;
-            EpochWithGap(epoch_with_gap)
+            if risingwave_common::util::epoch::is_max_epoch(epoch) {
+                EpochWithGap::new_max_epoch()
+            } else {
+                debug_assert!((epoch & EPOCH_SPILL_TIME_MASK) == 0);
+                EpochWithGap(epoch + spill_offset)
+            }
         }
         #[cfg(feature = "enable_test_epoch")]
         {
@@ -322,7 +323,7 @@ impl EpochWithGap {
     pub fn pure_epoch(&self) -> HummockEpoch {
         #[cfg(not(feature = "enable_test_epoch"))]
         {
-            self.0 & !EPOCH_MASK
+            self.0 & !EPOCH_SPILL_TIME_MASK
         }
         #[cfg(feature = "enable_test_epoch")]
         {
@@ -331,6 +332,6 @@ impl EpochWithGap {
     }
 
     pub fn offset(&self) -> u64 {
-        self.0 & EPOCH_MASK
+        self.0 & EPOCH_SPILL_TIME_MASK
     }
 }

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -288,7 +288,7 @@ impl EpochWithGap {
                 EpochWithGap::new_max_epoch()
             } else {
                 debug_assert!((epoch & EPOCH_SPILL_TIME_MASK) == 0);
-                EpochWithGap(epoch + spill_offset)
+                EpochWithGap(epoch + spill_offset as u64)
             }
         }
         #[cfg(feature = "enable_test_epoch")]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

#13696 fixes the max epoch bug for range tombstone but introduces a overflow panic when the provided epoch is u64::MAX. For example, the HummockEpoch::MAX epoch [here](https://github.com/risingwavelabs/risingwave/blob/798c36f5bccfe981db4c14a85f6e54dd77db856f/src/stream/src/common/log_store_impl/kv_log_store/reader.rs#L133) will be later used to [create EpochWithGap with MAX_SPILL_TIMES](https://github.com/risingwavelabs/risingwave/blob/798c36f5bccfe981db4c14a85f6e54dd77db856f/src/storage/src/hummock/iterator/forward_user.rs#L187), which will cause a u64 overflow. This panic will be 100% triggered for sinks with log store enabled.

This PR fixes the issue by treating epochs in [MAX_EPOCH, u64::MAX] as the maximum EpochWithGap(u64::MAX).

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
