### PR TITLE
refactor(storage): refactor sstable encode function receiver

### DIFF
--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -510,6 +510,8 @@ impl<T: AsRef<[u8]>> UserKey<T> {
     }
 
     /// Encode in to a buffer.
+    ///
+    /// length prefixed requires 4B more than its `encoded_len()`
     pub fn encode_length_prefixed(&self, mut buf: impl BufMut) {
         buf.put_u32(self.table_id.table_id());
         buf.put_u32(self.table_key.as_ref().len() as u32);

--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -510,7 +510,7 @@ impl<T: AsRef<[u8]>> UserKey<T> {
     }
 
     /// Encode in to a buffer.
-    pub fn encode_length_prefixed(&self, buf: &mut impl BufMut) {
+    pub fn encode_length_prefixed(&self, mut buf: impl BufMut) {
         buf.put_u32(self.table_id.table_id());
         buf.put_u32(self.table_key.as_ref().len() as u32);
         buf.put_slice(self.table_key.as_ref());

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -390,7 +390,6 @@ impl SstableMeta {
     /// | file offset of this meta block (8B) |
     /// | checksum (8B) | version (4B) | magic (4B) |
     /// ```
-    #[expect(clippy::uninit_vec)]
     pub fn encode_to_bytes(&self) -> Vec<u8> {
         let encoded_size = self.encoded_size();
         let mut buf = Vec::with_capacity(encoded_size);

--- a/src/storage/src/hummock/sstable/utils.rs
+++ b/src/storage/src/hummock/sstable/utils.rs
@@ -71,7 +71,7 @@ pub fn xxhash64_verify(data: &[u8], checksum: u64) -> HummockResult<()> {
 
 use bytes::{Buf, BufMut};
 
-pub fn put_length_prefixed_slice(buf: &mut Vec<u8>, slice: &[u8]) {
+pub fn put_length_prefixed_slice(mut buf: impl BufMut, slice: &[u8]) {
     let len = checked_into_u32(slice.len())
         .unwrap_or_else(|_| panic!("WARN overflow can't convert slice {} into u32", slice.len()));
     buf.put_u32_le(len);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

### Motivation:

Currently, the encoder function of `Sstable` only receives `&Vec<u8>`. It has met most cases before, but we still have cases that requires it can be directly encoded to an existing buffer to avoid buffer copy. For example, file cache requires `Key` and `Value` to implement `fn write(&self, buf: &mut [u8])` to encode data directly into the preallocated buffer. With the current buffer, it can only be encoded to a `Vec<u8>` then copied to the buffer.

### Why `impl ButMut + AsRef<u8>`?

`ButMut` provides interfaces like `put_xxx` which are very useful for serialization. But for `ButMut` is designed for both block and stream, it does not provide either the method to get the buffer length or access to the written buffer. (It doesn't assume the buffer is continuous.) So we can't calculate checksum based on the written buffer even when its underlying buffer is continuous while calculating checksum part by part cannot fully utilize the power of **simd**. So we need `AsRef<u8>` for that.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
