### PR TITLE
chore: disable failpoint test in simulation integration test

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -965,7 +965,6 @@ set -e
 
 cargo nextest run \
   --config "target.'cfg(all())'.rustflags = ['--cfg=madsim']" \
-  --features fail/failpoints \
   -p risingwave_simulation \
   "$@"
 """
@@ -981,7 +980,6 @@ set -e
 
 cargo nextest archive \
   --config "target.'cfg(all())'.rustflags = ['--cfg=madsim']" \
-  --features fail/failpoints \
   -p risingwave_simulation \
   --archive-file simulation-it-test.tar.zst \
   "$@"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -63,8 +63,6 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
-    # FIXME: decrease this when we found what's causing the build to be slow.
-    timeout_in_minutes: 20
     retry: *auto-retry
 
   - label: "docslt"

--- a/src/tests/simulation/tests/integration_tests/recovery/event_log.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/event_log.rs
@@ -128,6 +128,7 @@ async fn test_create_fail(
 
 /// Tests event log can record info of stream job creation failure, for CREATE TABLE/MV/INDEX/SINK.
 #[tokio::test]
+#[ignore]
 async fn failpoint_limited_test_create_stream_job_fail() -> Result<()> {
     let mut cluster = Cluster::start(cluster_config()).await.unwrap();
     let mut session = cluster.start_session();
@@ -224,6 +225,7 @@ async fn failpoint_limited_test_create_stream_job_fail() -> Result<()> {
 /// Theoretically errors either reported by compute nodes, or chosen by meta node, may not be the root cause.
 /// But during my tests with MADSIM_TEST_SEED from 1..1000, this test always succeeded.
 #[tokio::test]
+#[ignore]
 async fn failpoint_limited_test_collect_barrier_failure() -> Result<()> {
     let mut cluster = Cluster::start(cluster_config()).await.unwrap();
     let mut session = cluster.start_session();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The ignored tests are not critical but hurt CI performance.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
