### PR TITLE
refactor(over window): reduce repeated calculation of projection from state key to table sub-pk

### DIFF
--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -730,7 +730,7 @@ impl<'a> RowConverter<'a> {
             self.order_key_order_types,
         )?
         .chain(key.pk.as_inner())
-        .project(&self.state_key_to_table_sub_pk_proj)
+        .project(self.state_key_to_table_sub_pk_proj)
         .into_owned_row())
     }
 

--- a/src/stream/src/executor/over_window/over_partition.rs
+++ b/src/stream/src/executor/over_window/over_partition.rs
@@ -15,23 +15,21 @@
 //! Types and functions that store or manipulate state/cache inside one single over window
 //! partition.
 
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::marker::PhantomData;
 use std::ops::{Bound, RangeInclusive};
 
 use futures_async_stream::for_await;
 use risingwave_common::array::stream_record::Record;
-use risingwave_common::row::{OwnedRow, Row, RowExt};
+use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::session_config::OverWindowCachePolicy as CachePolicy;
-use risingwave_common::types::DataType;
-use risingwave_common::util::memcmp_encoding;
-use risingwave_common::util::sort_util::OrderType;
 use risingwave_expr::window_function::{FrameBounds, StateKey, WindowFuncCall};
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::StateStore;
 
 use super::delta_btree_map::Change;
 use super::estimated_btree_map::EstimatedBTreeMap;
+use super::general::RowConverter;
 use super::sentinel::KeyWithSentinel;
 use crate::executor::over_window::delta_btree_map::DeltaBTreeMap;
 use crate::executor::test_utils::prelude::StateTable;
@@ -233,11 +231,7 @@ pub(super) struct OverPartition<'a, S: StateStore> {
     cache_policy: CachePolicy,
 
     calls: &'a [WindowFuncCall],
-    order_key_data_types: &'a [DataType],
-    order_key_order_types: &'a [OrderType],
-    order_key_indices: &'a [usize],
-    input_pk_indices: &'a [usize],
-    state_key_to_table_sub_pk_proj: Vec<usize>,
+    row_conv: RowConverter<'a>,
 
     stats: OverPartitionStats,
 
@@ -253,37 +247,15 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         cache: &'a mut PartitionCache,
         cache_policy: CachePolicy,
         calls: &'a [WindowFuncCall],
-        partition_key_indices: &'a [usize],
-        order_key_data_types: &'a [DataType],
-        order_key_order_types: &'a [OrderType],
-        order_key_indices: &'a [usize],
-        input_pk_indices: &'a [usize],
+        row_conv: RowConverter<'a>,
     ) -> Self {
-        // TODO(rc): move the calculation to executor?
-        let mut projection = Vec::with_capacity(order_key_indices.len() + input_pk_indices.len());
-        let mut col_dedup: HashSet<usize> = partition_key_indices.iter().copied().collect();
-        for (proj_idx, key_idx) in order_key_indices
-            .iter()
-            .chain(input_pk_indices.iter())
-            .enumerate()
-        {
-            if col_dedup.insert(*key_idx) {
-                projection.push(proj_idx);
-            }
-        }
-        projection.shrink_to_fit();
-
         Self {
             this_partition_key,
             range_cache: cache,
             cache_policy,
 
             calls,
-            order_key_data_types,
-            order_key_order_types,
-            order_key_indices,
-            input_pk_indices,
-            state_key_to_table_sub_pk_proj: projection,
+            row_conv: row_conv,
 
             stats: Default::default(),
 
@@ -481,7 +453,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         #[for_await]
         for row in table_iter {
             let row: OwnedRow = row?.into_owned_row();
-            new_cache.insert(self.row_to_state_key(&row)?.into(), row);
+            new_cache.insert(self.row_conv.row_to_state_key(&row)?.into(), row);
         }
         *self.range_cache = new_cache;
 
@@ -522,8 +494,8 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         if self.cache_real_len() == 0 {
             // no normal entry in the cache, just load the given range
             let table_sub_range = (
-                Bound::Included(self.state_key_to_table_sub_pk(range.start())?),
-                Bound::Included(self.state_key_to_table_sub_pk(range.end())?),
+                Bound::Included(self.row_conv.state_key_to_table_sub_pk(range.start())?),
+                Bound::Included(self.row_conv.state_key_to_table_sub_pk(range.end())?),
             );
             tracing::debug!(
                 partition=?self.this_partition_key,
@@ -542,8 +514,11 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         if self.cache_left_is_sentinel() && *range.start() < cache_real_first_key {
             // extend leftward only if there's smallest sentinel
             let table_sub_range = (
-                Bound::Included(self.state_key_to_table_sub_pk(range.start())?),
-                Bound::Excluded(self.state_key_to_table_sub_pk(cache_real_first_key)?),
+                Bound::Included(self.row_conv.state_key_to_table_sub_pk(range.start())?),
+                Bound::Excluded(
+                    self.row_conv
+                        .state_key_to_table_sub_pk(cache_real_first_key)?,
+                ),
             );
             tracing::trace!(
                 partition=?self.this_partition_key,
@@ -558,8 +533,11 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         if self.cache_right_is_sentinel() && *range.end() > cache_real_last_key {
             // extend rightward only if there's largest sentinel
             let table_sub_range = (
-                Bound::Excluded(self.state_key_to_table_sub_pk(cache_real_last_key)?),
-                Bound::Included(self.state_key_to_table_sub_pk(range.end())?),
+                Bound::Excluded(
+                    self.row_conv
+                        .state_key_to_table_sub_pk(cache_real_last_key)?,
+                ),
+                Bound::Included(self.row_conv.state_key_to_table_sub_pk(range.end())?),
             );
             tracing::trace!(
                 partition=?self.this_partition_key,
@@ -595,7 +573,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         #[for_await]
         for row in stream {
             let row: OwnedRow = row?.into_owned_row();
-            let key = self.row_to_state_key(&row)?;
+            let key = self.row_conv.row_to_state_key(&row)?;
             self.range_cache.insert(CacheKey::from(key), row);
         }
 
@@ -656,7 +634,10 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         {
             let sub_range = (
                 Bound::<OwnedRow>::Unbounded,
-                Bound::Excluded(self.state_key_to_table_sub_pk(range_to_exclusive)?),
+                Bound::Excluded(
+                    self.row_conv
+                        .state_key_to_table_sub_pk(range_to_exclusive)?,
+                ),
             );
             let stream = table
                 .iter_with_prefix(
@@ -682,7 +663,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
 
         let n_extended = to_extend.len();
         for row in to_extend {
-            let key = self.row_to_state_key(&row)?;
+            let key = self.row_conv.row_to_state_key(&row)?;
             self.range_cache.insert(CacheKey::from(key), row);
         }
         if n_extended < MAGIC_BATCH_SIZE && self.cache_real_len() > 0 {
@@ -746,7 +727,10 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         let mut n_extended = 0usize;
         {
             let sub_range = (
-                Bound::Excluded(self.state_key_to_table_sub_pk(range_from_exclusive)?),
+                Bound::Excluded(
+                    self.row_conv
+                        .state_key_to_table_sub_pk(range_from_exclusive)?,
+                ),
                 Bound::<OwnedRow>::Unbounded,
             );
             let stream = table
@@ -761,7 +745,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             for row in stream {
                 let row: OwnedRow = row?.into_owned_row();
 
-                let key = self.row_to_state_key(&row)?;
+                let key = self.row_conv.row_to_state_key(&row)?;
                 self.range_cache.insert(CacheKey::from(key), row);
 
                 n_extended += 1;
@@ -777,31 +761,6 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         }
 
         Ok(())
-    }
-
-    /// Convert [`StateKey`] to sub pk (pk without partition key) as [`OwnedRow`].
-    fn state_key_to_table_sub_pk(&self, key: &StateKey) -> StreamExecutorResult<OwnedRow> {
-        Ok(memcmp_encoding::decode_row(
-            &key.order_key,
-            self.order_key_data_types,
-            self.order_key_order_types,
-        )?
-        .chain(key.pk.as_inner())
-        .project(&self.state_key_to_table_sub_pk_proj)
-        .into_owned_row())
-    }
-
-    fn row_to_state_key(&self, full_row: impl Row + Copy) -> StreamExecutorResult<StateKey> {
-        Ok(StateKey {
-            order_key: memcmp_encoding::encode_row(
-                full_row.project(self.order_key_indices),
-                self.order_key_order_types,
-            )?,
-            pk: full_row
-                .project(self.input_pk_indices)
-                .into_owned_row()
-                .into(),
-        })
     }
 }
 

--- a/src/stream/src/executor/over_window/over_partition.rs
+++ b/src/stream/src/executor/over_window/over_partition.rs
@@ -255,7 +255,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             cache_policy,
 
             calls,
-            row_conv: row_conv,
+            row_conv,
 
             stats: Default::default(),
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously we calculate the projection from `StateKey` (over window cache key type) to state table sub pk (used to do prefixed table scanning) for each over window partition, which can cost unnecessary CPU time. This PR moves the calculation to executor `new`, so that each `OverWindowExecutor` instance only need to calculate the projection once.

Some explanation for the words:

- `StateKey`: Over window range cache key type, containing order key and input pk.
- State table sub-PK: State table PK = PK prefix (partition key) + sub-PK (order key + input pk).
- Input/output row: Input schema is the prefix of output schema.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
