### PR TITLE
feat(ordered-set agg): allow constant expression and NULL as direct argument

### DIFF
--- a/e2e_test/batch/aggregate/ordered_set_agg.slt.part
+++ b/e2e_test/batch/aggregate/ordered_set_agg.slt.part
@@ -27,7 +27,15 @@ from (values(1::float8),(3),(5),(7)) t(a);
 query RR
 select
   percentile_cont(0.25) within group (order by a),
-  percentile_disc(0.5) within group (order by a)
+  percentile_disc(0.2 + 0.3) within group (order by a)
 from (values(1::float8),(3),(5),(7)) t(a);
 ----
 2.5 3
+
+query RR
+select
+  percentile_cont(NULL) within group (order by a),
+  percentile_cont(0.3 + NULL) within group (order by a)
+from (values(1::float8),(3),(5),(7)) t(a);
+----
+NULL NULL

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -881,6 +881,31 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    create table t (x int, y int);
+    select percentile_cont(null) within group (order by y) from t;
+  expected_outputs:
+  - batch_plan
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.2 + 0.3) within group (order by y) from t;
+  expected_outputs:
+  - batch_plan
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.2 + null) within group (order by y) from t;
+  expected_outputs:
+  - batch_plan
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.8 + 0.8) within group (order by y) from t;
+  expected_outputs:
+  - binder_error
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.2 + x) within group (order by y) from t group by x;
+  expected_outputs:
+  - binder_error
+- sql: |
     create table t (x int, y varchar);
     select percentile_disc(1) within group (order by y desc) from t;
   expected_outputs:

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1526,8 +1526,8 @@
     Failed to bind expression: percentile_cont(x)
 
     Caused by:
-      Feature is not yet implemented: non-constant direct arguments for ordered-set aggregation is not supported now
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
+      Feature is not yet implemented: variable as direct argument of ordered-set aggregate
+    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/14079
 - sql: |
     create table t (x int, y int);
     select percentile_cont('abc') within group (order by y) from t;
@@ -1535,7 +1535,8 @@
     Failed to bind expression: percentile_cont('abc')
 
     Caused by:
-      Invalid input syntax: direct arg in `percentile_cont` must be castable to float64
+      Feature is not yet implemented: variable as direct argument of ordered-set aggregate
+    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/14079
 - sql: |
     create table t (x int, y int);
     select percentile_cont(1.3) within group (order by y) from t;
@@ -1568,6 +1569,47 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchProject { exprs: [t.y::Float64 as $expr1, t.y] }
         └─BatchScan { table: t, columns: [t.y], distribution: SomeShard }
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(null) within group (order by y) from t;
+  batch_plan: |-
+    BatchSimpleAgg { aggs: [percentile_cont($expr1 order_by(t.y ASC))] }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.y::Float64 as $expr1, t.y] }
+        └─BatchScan { table: t, columns: [t.y], distribution: SomeShard }
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.2 + 0.3) within group (order by y) from t;
+  batch_plan: |-
+    BatchSimpleAgg { aggs: [percentile_cont($expr1 order_by(t.y ASC))] }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.y::Float64 as $expr1, t.y] }
+        └─BatchScan { table: t, columns: [t.y], distribution: SomeShard }
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.2 + null) within group (order by y) from t;
+  batch_plan: |-
+    BatchSimpleAgg { aggs: [percentile_cont($expr1 order_by(t.y ASC))] }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.y::Float64 as $expr1, t.y] }
+        └─BatchScan { table: t, columns: [t.y], distribution: SomeShard }
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.8 + 0.8) within group (order by y) from t;
+  binder_error: |
+    Failed to bind expression: percentile_cont(0.8 + 0.8)
+
+    Caused by:
+      Invalid input syntax: direct arg in `percentile_cont` must between 0.0 and 1.0
+- sql: |
+    create table t (x int, y int);
+    select percentile_cont(0.2 + x) within group (order by y) from t group by x;
+  binder_error: |
+    Failed to bind expression: percentile_cont(0.2 + x)
+
+    Caused by:
+      Feature is not yet implemented: variable as direct argument of ordered-set aggregate
+    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/14079
 - sql: |
     create table t (x int, y varchar);
     select percentile_disc(1) within group (order by y desc) from t;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

> Docs for background info:
> - https://docs.risingwave.com/docs/current/sql-function-aggregate/#ordered-set-aggregate-functions
> - https://www.postgresql.org/docs/current/xaggr.html#XAGGR-ORDERED-SET-AGGREGATES
> - https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE

Previously we don't support `NULL` and expression as direct arguments of ordered-set aggregate function. E.g.

```sql
create table t (a int);
select percentile_cont(null) within group (order by a) from t;
select percentile_cont(0.1 + 0.2) within group (order by a) from t;
```

This PR supports this syntax.

Variables in the direct argument expression still not supported, tracked in https://github.com/risingwavelabs/risingwave/issues/14079.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
