### PR TITLE
feat(meta): optimize the complexity of MinOverlappingPicker

### DIFF
--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -159,20 +159,6 @@ impl CompactStatus {
             return false;
         }
 
-        const MAX_TRIVIAL_MOVE_FILE_SIZE: u64 = 256 * 1024 * 1024; // 256MB.
-
-        // do not trivial move a large file because it may cause large write amplification in next compact.
-        if !task.gc_delete_keys
-            && task.input_ssts.iter().any(|input| {
-                input
-                    .table_infos
-                    .iter()
-                    .any(|sst| sst.file_size > MAX_TRIVIAL_MOVE_FILE_SIZE && input.level_idx > 0)
-            })
-        {
-            return false;
-        }
-
         if task.input_ssts.len() == 1 {
             return task.input_ssts[0].level_idx == 0
                 && can_concat(&task.input_ssts[0].table_infos);

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -159,6 +159,20 @@ impl CompactStatus {
             return false;
         }
 
+        const MAX_TRIVIAL_MOVE_FILE_SIZE: u64 = 256 * 1024 * 1024; // 256MB.
+
+        // do not trivial move a large file because it may cause large write amplification in next compact.
+        if !task.gc_delete_keys
+            && task.input_ssts.iter().any(|input| {
+                input
+                    .table_infos
+                    .iter()
+                    .any(|sst| sst.file_size > MAX_TRIVIAL_MOVE_FILE_SIZE && input.level_idx > 0)
+            })
+        {
+            return false;
+        }
+
         if task.input_ssts.len() == 1 {
             return task.input_ssts[0].level_idx == 0
                 && can_concat(&task.input_ssts[0].table_infos);

--- a/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
@@ -20,10 +20,7 @@ use risingwave_hummock_sdk::prost_key_range::KeyRangeExt;
 use risingwave_pb::hummock::hummock_version::Levels;
 use risingwave_pb::hummock::{InputLevel, Level, LevelType, SstableInfo};
 
-use super::{
-    CompactionInput, CompactionPicker, LocalPickerStatistic,
-    MAX_COMPACT_LEVEL_COUNT,
-};
+use super::{CompactionInput, CompactionPicker, LocalPickerStatistic, MAX_COMPACT_LEVEL_COUNT};
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::level_handler::LevelHandler;
 
@@ -96,8 +93,7 @@ impl MinOverlappingPicker {
                 }
                 select_file_size += select_tables[*idx].file_size;
                 if range.end > target_level_overlap_range.end {
-                    for other in &target_tables[target_level_overlap_range.end..range.end]
-                    {
+                    for other in &target_tables[target_level_overlap_range.end..range.end] {
                         total_file_size += other.file_size;
                     }
                     target_level_overlap_range.end = range.end;

--- a/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
@@ -88,9 +88,11 @@ impl MinOverlappingPicker {
             for other in &target_tables[target_level_overlap_range.clone()] {
                 total_file_size += other.file_size;
             }
-            let left_idx = select_file_ranges[left].0;
+            let start_idx = select_file_ranges[left].0;
+            let mut end_idx = start_idx + 1;
             for (idx, range) in select_file_ranges.iter().skip(left) {
                 if select_file_size > self.max_select_bytes
+                    || *idx > end_idx
                     || range.start >= target_level_overlap_range.end
                 {
                     break;
@@ -107,11 +109,12 @@ impl MinOverlappingPicker {
                 } else {
                     total_file_size * 100 / select_file_size
                 };
+                end_idx = idx + 1;
                 if score < min_score
                     || (score == min_score && select_file_size < min_score_select_file_size)
                 {
                     min_score = score;
-                    min_score_select_range = left_idx..(*idx + 1);
+                    min_score_select_range = start_idx..end_idx;
                     min_score_target_range = target_level_overlap_range.clone();
                     min_score_select_file_size = select_file_size;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## Background

Although https://github.com/risingwavelabs/risingwave/pull/14036 has optimize the performance of pick trivial move task of MinOverlappingPicker, it is still not enough. Because the PR above only assume that most of files could trivial moved to next level, we do not need to calculate scores for all possible task. But when there are really a large data in hummock, and most of them can not be compacted to next level by trivial-move, hummock will cost a long time to pick one task, and meta-node would hold the mutex for a long time, too.

## Solution

In original algorithm, we iterator all possible interval for select-level, and we check whether overlapping files in target level are pending compact for every task. We can see that, there will be many files in target level which are checked many times. The time complexity of MinOverlappingPicker is O(N^2*k), where k represent the overlap size of next level, and N is the number of files in select level.

In new algorithm, we only calculate the overlapping range for every independent file rather than calculate it for all interval. Because we can get the overlapping result of interval by merge the result of each file. So the time complexity of MinOverlappingPicker is O(MAX(N^2, N * M)), where N represents the number of files in select level and M represents the number of files in target level.

The strategy does not change so that all result of unit-test will not change at all. 


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
