### PR TITLE
feat(sink): support format encode syntax for sink into table

### DIFF
--- a/e2e_test/sink/sink_into_table.slt
+++ b/e2e_test/sink/sink_into_table.slt
@@ -55,7 +55,7 @@ statement error Only append-only sinks can sink to a table without primary keys.
 create sink s1 into t_row_id_as_primary_key as select v1, v2 from t_s1;
 
 statement ok
-create sink s1 into t_row_id_as_primary_key as select v1, v2 from t_s1 with (type = 'append-only', force_append_only = 'true');
+create sink s1 into t_row_id_as_primary_key as select v1, v2 from t_s1 FORMAT PLAIN ENCODE NATIVE(force_append_only='true');
 
 statement ok
 flush;
@@ -154,7 +154,7 @@ statement error Only append-only sinks can sink to a table without primary keys.
 create sink s2 into t_append_only as select v1, v2 from t_s2;
 
 statement ok
-create sink s2 into t_append_only as select v1, v2 from t_s2 with (type = 'append-only', force_append_only = 'true');
+create sink s2 into t_append_only as select v1, v2 from t_s2 FORMAT PLAIN ENCODE NATIVE(force_append_only='true');
 
 statement ok
 flush;

--- a/src/connector/src/sink/catalog/mod.rs
+++ b/src/connector/src/sink/catalog/mod.rs
@@ -133,6 +133,7 @@ pub enum SinkEncode {
     Protobuf,
     Avro,
     Template,
+    Native,
 }
 
 impl SinkFormatDesc {
@@ -179,6 +180,7 @@ impl SinkFormatDesc {
             SinkEncode::Protobuf => E::Protobuf,
             SinkEncode::Avro => E::Avro,
             SinkEncode::Template => E::Template,
+            SinkEncode::Native => E::Native,
         };
         let options = self
             .options
@@ -216,7 +218,8 @@ impl TryFrom<PbSinkFormatDesc> for SinkFormatDesc {
             E::Protobuf => SinkEncode::Protobuf,
             E::Template => SinkEncode::Template,
             E::Avro => SinkEncode::Avro,
-            e @ (E::Unspecified | E::Native | E::Csv | E::Bytes) => {
+            E::Native => SinkEncode::Native,
+            e @ (E::Unspecified | E::Csv | E::Bytes) => {
                 return Err(SinkError::Config(anyhow!(
                     "sink encode unsupported: {}",
                     e.as_str_name()

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -150,6 +150,7 @@ impl SinkFormatterImpl {
                             AppendOnlyFormatter::new(Some(key_encoder), val_encoder),
                         ))
                     }
+                    SinkEncode::Native => err_unsupported(),
                 }
             }
             SinkFormat::Debezium => {
@@ -251,6 +252,7 @@ impl SinkFormatterImpl {
                         Ok(SinkFormatterImpl::UpsertAvro(formatter))
                     }
                     SinkEncode::Protobuf => err_unsupported(),
+                    SinkEncode::Native => err_unsupported(),
                 }
             }
         }

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -245,7 +245,7 @@ pub fn gen_sink_plan(
             || sink_catalog.sink_type == SinkType::ForceAppendOnly)
         {
             return Err(RwError::from(ErrorCode::BindError(
-                "Only append-only sinks can sink to a table without primary keys.".to_string(),
+                "Only append-only sinks can sink to a table without primary keys. Please try to add \"FORMAT PLAIN ENCODE NATIVE\"".to_string(),
             )));
         }
 
@@ -581,7 +581,8 @@ fn bind_sink_format_desc(value: ConnectorSchema) -> Result<SinkFormatDesc> {
         E::Protobuf => SinkEncode::Protobuf,
         E::Avro => SinkEncode::Avro,
         E::Template => SinkEncode::Template,
-        e @ (E::Native | E::Csv | E::Bytes) => {
+        E::Native => SinkEncode::Native,
+        e @ (E::Csv | E::Bytes) => {
             return Err(ErrorCode::BindError(format!("sink encode unsupported: {e}")).into());
         }
     };
@@ -625,6 +626,10 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
                 RedisSink::SINK_NAME => hashmap!(
                     Format::Plain => vec![Encode::Json,Encode::Template],
                     Format::Upsert => vec![Encode::Json,Encode::Template],
+                ),
+                "table" => hashmap!(
+                    Format::Plain => vec![Encode::Native],
+                    Format::Upsert => vec![Encode::Native],
                 ),
         ))
     });

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -645,10 +645,7 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
     });
 
 pub fn allow_old_sink_type_syntax(connector: &str) -> bool {
-    match connector {
-        "table" => false,
-        _ => true,
-    }
+    !matches!(connector, "table")
 }
 
 pub fn validate_compatibility(connector: &str, format_desc: &ConnectorSchema) -> Result<()> {

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -599,6 +599,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::SET,
     Keyword::RETURNING,
     Keyword::EMIT,
+    Keyword::FORMAT,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?


Current behaviors
```
dev=> create sink s into t as select * from tt;
ERROR:  Failed to run the query

Caused by:
  Bind error: Only append-only sinks can sink to a table without primary keys. Please try to add "FORMAT PLAIN ENCODE NATIVE"

dev=> create sink s into t as select * from tt with (type='append-only');
ERROR:  Failed to run the query

Caused by:
  Bind error: connector table does not support `type = '...'`, please use syntax `FORMAT ... ENCODE ...` instead.

dev=> create sink ss into t as select max(v) from tt FORMAT PLAIN ENCODE NATIVE;
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: Sink error
  2: The sink cannot be append-only. Please add "force_append_only='true'" in FORMAT ENCODE options to force the sink to be append-only. Notice that this will cause the sink executor to drop any UPDATE or DELETE message.

dev=> create sink ss into t as select max(v) from tt FORMAT PLAIN ENCODE NATIVE (force_append_only='true');
CREATE_SINK
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
