### PR TITLE
refactor(error): migrate function errors to anyhow

### DIFF
--- a/e2e_test/batch/aggregate/sum.slt.part
+++ b/e2e_test/batch/aggregate/sum.slt.part
@@ -77,7 +77,7 @@ select sum(d) from t;
 statement ok
 insert into t values (9000000000000000000000000000);
 
-statement error Numeric out of range
+statement error numeric out of range
 select sum(d) from t;
 
 statement ok

--- a/e2e_test/batch/basic/func.slt.part
+++ b/e2e_test/batch/basic/func.slt.part
@@ -643,7 +643,7 @@ select regexp_count('foobarbaz', 'b..', 'i');
 query error invalid regular expression option: "a"
 select regexp_count('foobarbaz', 'b..', 3, 'a');
 
-query error regexp_count() does not support the "global" option
+query error regexp_count\(\) does not support the "global" option
 select regexp_count('foobar', 'b..', 1, 'g');
 
 query T

--- a/e2e_test/batch/basic/func.slt.part
+++ b/e2e_test/batch/basic/func.slt.part
@@ -528,10 +528,10 @@ select regexp_replace('abc123', 'abc', 'prefix\&suffix');
 ----
 prefixabcsuffix123
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "g"
 select regexp_replace('foobarbaz', 'b..', 'X', 1, 'g');
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "g"
 select regexp_replace('foobarbaz', 'b..', 'X', 'g', 1);
 
 # With Unicode
@@ -634,16 +634,16 @@ select regexp_count('foobarbaz', 'b..', 3);
 ----
 2
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "g"
 select regexp_count('foobarbaz', 'b..', 'g');
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "i"
 select regexp_count('foobarbaz', 'b..', 'i');
 
 query error invalid regular expression option: "a"
 select regexp_count('foobarbaz', 'b..', 3, 'a');
 
-query error does not support the global option
+query error regexp_count() does not support the "global" option
 select regexp_count('foobar', 'b..', 1, 'g');
 
 query T

--- a/e2e_test/batch/basic/make_timestamptz.slt.part
+++ b/e2e_test/batch/basic/make_timestamptz.slt.part
@@ -11,16 +11,16 @@ SELECT make_timestamptz(-1973, 07, 15, 08, 15, 55.33);
 ----
 -1973-07-15 08:15:55.330+00:00
 
-query error Invalid parameter sec: invalid sec
+query error invalid sec
 SELECT make_timestamptz(1973, 07, 15, 08, 15, -55.33);
 
-query error Invalid parameter hour, min, sec: invalid time
+query error invalid time
 SELECT make_timestamptz(1973, 07, 15, 08, -15, 55.33);
 
-query error Invalid parameter year, month, day: invalid date
+query error invalid date
 SELECT make_timestamptz(1973, -07, 15, 08, 15, 55.33);
 
-query error Invalid parameter year, month, day: invalid date
+query error invalid date
 SELECT make_timestamptz(1973, 06, 31, 08, 15, 55.33);
 
 statement ok
@@ -45,7 +45,7 @@ select * from ttz;
 statement ok
 drop table ttz;
 
-query error Invalid parameter time_zone: 'Nehwon/Lankhmar' is not a valid timezone
+query error 'Nehwon/Lankhmar' is not a valid timezone
 SELECT make_timestamptz(1910, 12, 24, 0, 0, 0, 'Nehwon/Lankhmar');
 
 query TT

--- a/e2e_test/batch/basic/query.slt.part
+++ b/e2e_test/batch/basic/query.slt.part
@@ -30,7 +30,7 @@ select count(*) from t3;
 ----
 1
 
-statement error Division by zero
+statement error division by zero
 select v1/0 from t3;
 
 

--- a/e2e_test/batch/functions/array_max.slt.part
+++ b/e2e_test/batch/functions/array_max.slt.part
@@ -28,10 +28,10 @@ select array_max(array['2c😅🤔😅️c2', '114🥵514', '30🤣🥳03', '5�
 ----
 5🥵💩💩🥵5
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "a"
 select array_max(array['a', 'b', 'c', 114514]);
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "a"
 select array_max(array[114514, 'a', 'b', 'c']);
 
 # i32::MIN & i32::MIN - 1 & i32::MAX

--- a/e2e_test/batch/functions/array_min.slt.part
+++ b/e2e_test/batch/functions/array_min.slt.part
@@ -28,10 +28,10 @@ select array_min(array['901😅🤔😅️109', '114🥵514', '3🤣🥳3', '5�
 ----
 114🥵514
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "a"
 select array_min(array['a', 'b', 'c', 114514]);
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "a"
 select array_min(array[114514, 'a', 'b', 'c']);
 
 # i32::MIN & i32::MIN - 1 & i32::MAX

--- a/e2e_test/batch/functions/array_sort.slt.part
+++ b/e2e_test/batch/functions/array_sort.slt.part
@@ -33,5 +33,5 @@ select array_sort(array[3, 2, NULL, 1, NULL]);
 ----
 {1,2,3,NULL,NULL}
 
-query error invalid digit found in string
+query error invalid input syntax for type integer: "a"
 select array_sort(array[3, 2, 1, 'a']);

--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -43,14 +43,13 @@ select pow(100000, 0);
 ----
 1
 
-statement error underflow
+statement error numeric out of range: underflow
 select pow(100000, -200000000000000);
 
-statement error Numeric out of range
+statement error numeric out of range: overflow
 select pow(100000, 200000000000000);
 
-
-statement error Numeric out of range
+statement error numeric out of range: overflow
 select pow(-100000, 200000000000001);
 
 query R
@@ -98,14 +97,14 @@ select 100000 ^ 0;
 ----
 1
 
-statement error underflow
+statement error numeric out of range: underflow
 select 100000 ^ -200000000000000;
 
-statement error Numeric out of range
+statement error numeric out of range: overflow
 select 100000 ^ 200000000000000;
 
 
-statement error Numeric out of range
+statement error numeric out of range: overflow
 select -100000 ^ 200000000000001;
 
 query RRRR
@@ -231,10 +230,10 @@ select exp(2::smallint)
 ----
 7.38905609893065
 
-statement error Numeric out of range: overflow
+statement error numeric out of range: overflow
 select exp(10000000);
 
-statement error Numeric out of range: underflow
+statement error numeric out of range: underflow
 select exp(-10000000);
 
 query TRR

--- a/e2e_test/batch/functions/to_char.slt.part
+++ b/e2e_test/batch/functions/to_char.slt.part
@@ -113,7 +113,8 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Invalid parameter pattern: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
+  2: in function "to_char"
+  3: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
 
 
 query error
@@ -123,7 +124,8 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Invalid parameter pattern: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
+  2: in function "to_char"
+  3: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
 
 
 query error
@@ -133,7 +135,8 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Invalid parameter pattern: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
+  2: in function "to_char"
+  3: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
 
 
 query error
@@ -143,7 +146,8 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Invalid parameter pattern: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
+  2: in function "to_char"
+  3: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
 
 
 query error
@@ -153,4 +157,5 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Invalid parameter pattern: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.
+  2: in function "to_char"
+  3: invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.

--- a/e2e_test/batch/issue_7324.slt
+++ b/e2e_test/batch/issue_7324.slt
@@ -21,7 +21,7 @@ INSERT INTO INT2_TBL(f1) VALUES ('32767');
 statement ok
 INSERT INTO INT2_TBL(f1) VALUES ('-32767');
 
-statement error Numeric out of range
+statement error numeric out of range
 SELECT i.f1, i.f1 * smallint '2' AS x FROM INT2_TBL i;
 
 statement ok

--- a/e2e_test/error_ui/extended/main.slt
+++ b/e2e_test/error_ui/extended/main.slt
@@ -1,7 +1,7 @@
 query error
 selet 1;
 ----
-db error: ERROR: Failed to prepare the statement
+db error: ERROR: Failed to run the query
 
 Caused by:
   sql parser error: Expected an SQL statement, found: selet at line:1, column:6
@@ -11,8 +11,9 @@ Near "selet"
 query error
 select 1/0;
 ----
-db error: ERROR: Failed to execute the statement
+db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Division by zero
+  2: in function "divide"
+  3: division by zero

--- a/e2e_test/error_ui/extended/main.slt
+++ b/e2e_test/error_ui/extended/main.slt
@@ -1,7 +1,7 @@
 query error
 selet 1;
 ----
-db error: ERROR: Failed to run the query
+db error: ERROR: Failed to prepare the statement
 
 Caused by:
   sql parser error: Expected an SQL statement, found: selet at line:1, column:6
@@ -11,7 +11,7 @@ Near "selet"
 query error
 select 1/0;
 ----
-db error: ERROR: Failed to run the query
+db error: ERROR: Failed to execute the statement
 
 Caused by these errors (recent errors listed first):
   1: Expr error

--- a/e2e_test/error_ui/simple/main.slt
+++ b/e2e_test/error_ui/simple/main.slt
@@ -47,7 +47,8 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Division by zero
+  2: in function "divide"
+  3: division by zero
 
 
 query error
@@ -57,7 +58,8 @@ db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
   1: Expr error
-  2: Division by zero
+  2: in function "divide"
+  3: division by zero
 
 
 statement error

--- a/e2e_test/source/basic/ddl.slt
+++ b/e2e_test/source/basic/ddl.slt
@@ -17,7 +17,7 @@ create source invalid_startup_mode (
   properties.bootstrap.server = 'message_queue:29092'
 ) FORMAT PLAIN ENCODE JSON;
 
-statement error invalid input syntax for type integer: "abc"
+statement error invalid digit found in string
 create source invalid_startup_timestamp (
   column1 varchar
 ) with (

--- a/e2e_test/source/basic/ddl.slt
+++ b/e2e_test/source/basic/ddl.slt
@@ -17,8 +17,7 @@ create source invalid_startup_mode (
   properties.bootstrap.server = 'message_queue:29092'
 ) FORMAT PLAIN ENCODE JSON;
 
-# TODO: Better to refine the error message.
-statement error invalid digit found in string
+statement error invalid input syntax for type integer: "abc"
 create source invalid_startup_timestamp (
   column1 varchar
 ) with (

--- a/e2e_test/source/basic/old_row_format_syntax/ddl.slt
+++ b/e2e_test/source/basic/old_row_format_syntax/ddl.slt
@@ -17,7 +17,7 @@ create source invalid_startup_mode (
   properties.bootstrap.server = 'message_queue:29092'
 ) ROW FORMAT JSON;
 
-statement error invalid input syntax for type integer: "abc"
+statement error invalid digit found in string
 create source invalid_startup_timestamp (
   column1 varchar
 ) with (

--- a/e2e_test/source/basic/old_row_format_syntax/ddl.slt
+++ b/e2e_test/source/basic/old_row_format_syntax/ddl.slt
@@ -17,8 +17,7 @@ create source invalid_startup_mode (
   properties.bootstrap.server = 'message_queue:29092'
 ) ROW FORMAT JSON;
 
-# TODO: Better to refine the error message.
-statement error invalid digit found in string
+statement error invalid input syntax for type integer: "abc"
 create source invalid_startup_timestamp (
   column1 varchar
 ) with (

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -14,6 +14,7 @@
 
 use std::num::NonZeroUsize;
 
+use anyhow::anyhow;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::DataChunk;
@@ -158,13 +159,12 @@ impl HopWindowExecutor {
         let units = window_size
             .exact_div(&window_slide)
             .and_then(|x| NonZeroUsize::new(usize::try_from(x).ok()?))
-            .ok_or_else(|| ExprError::InvalidParam {
-                name: "window",
-                reason: format!(
+            .ok_or_else(|| {
+                ExprError::from(anyhow!(
                     "window_size {} cannot be divided by window_slide {}",
-                    window_size, window_slide
-                )
-                .into(),
+                    window_size,
+                    window_slide
+                ))
             })?
             .get();
 

--- a/src/expr/core/src/expr/expr_literal.rs
+++ b/src/expr/core/src/expr/expr_literal.rs
@@ -78,7 +78,7 @@ impl Build for LiteralExpression {
             prost_value,
             &DataType::from(prost.get_return_type().unwrap()),
         )
-        .map_err(|e| ExprError::Internal(e.into()))?;
+        .map_err(|e| ExprError::Anyhow(e.into()))?;
         Ok(Self {
             return_type: ret_type,
             literal: value,

--- a/src/expr/impl/benches/expr.rs
+++ b/src/expr/impl/benches/expr.rs
@@ -562,7 +562,7 @@ fn bench_raw(c: &mut Criterion) {
                 overflow |= (c ^ a) & (c ^ b) < 0;
             }
             if overflow {
-                bail!("numeric overflow");
+                bail!("numeric out of range: overflow");
             }
             c.set_bitmap(a.null_bitmap() & b.null_bitmap());
             Ok(c)

--- a/src/expr/impl/benches/expr.rs
+++ b/src/expr/impl/benches/expr.rs
@@ -21,6 +21,7 @@
 
 risingwave_expr_impl::enable!();
 
+use anyhow::bail;
 use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion};
 use risingwave_common::array::*;
@@ -29,7 +30,6 @@ use risingwave_common::types::*;
 use risingwave_expr::aggregate::{build_append_only, AggArgs, AggCall, AggKind};
 use risingwave_expr::expr::*;
 use risingwave_expr::sig::FUNCTION_REGISTRY;
-use risingwave_expr::ExprError;
 use risingwave_pb::expr::expr_node::PbType;
 use thiserror_ext::AsReport;
 
@@ -562,7 +562,7 @@ fn bench_raw(c: &mut Criterion) {
                 overflow |= (c ^ a) & (c ^ b) < 0;
             }
             if overflow {
-                return Err(ExprError::NumericOverflow);
+                bail!("numeric overflow");
             }
             c.set_bitmap(a.null_bitmap() & b.null_bitmap());
             Ok(c)

--- a/src/expr/impl/src/aggregate/general.rs
+++ b/src/expr/impl/src/aggregate/general.rs
@@ -14,8 +14,9 @@
 
 use std::convert::From;
 
+use anyhow::{Context, Result};
 use num_traits::{CheckedAdd, CheckedSub};
-use risingwave_expr::{aggregate, ExprError, Result};
+use risingwave_expr::aggregate;
 
 #[aggregate("sum(int2) -> int8")]
 #[aggregate("sum(int4) -> int8")]
@@ -32,14 +33,11 @@ where
     S: Default + From<T> + CheckedAdd<Output = S> + CheckedSub<Output = S>,
 {
     if retract {
-        state
-            .checked_sub(&S::from(input))
-            .ok_or_else(|| ExprError::NumericOutOfRange)
+        state.checked_sub(&S::from(input))
     } else {
-        state
-            .checked_add(&S::from(input))
-            .ok_or_else(|| ExprError::NumericOutOfRange)
+        state.checked_add(&S::from(input))
     }
+    .context("numeric out of range")
 }
 
 #[aggregate("avg(int2) -> decimal", rewritten)]

--- a/src/expr/impl/src/aggregate/jsonb_agg.rs
+++ b/src/expr/impl/src/aggregate/jsonb_agg.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Context as _, Result};
 use risingwave_common::estimate_size::EstimateSize;
 use risingwave_common::types::{Datum, JsonbVal};
+use risingwave_expr::aggregate;
 use risingwave_expr::aggregate::AggStateDyn;
 use risingwave_expr::expr::Context;
-use risingwave_expr::{aggregate, ExprError, Result};
 
 use crate::scalar::ToJsonb;
 
@@ -43,7 +44,7 @@ fn jsonb_object_agg(
     value: Option<impl ToJsonb>,
     ctx: &Context,
 ) -> Result<()> {
-    let key = key.ok_or(ExprError::FieldNameNull)?;
+    let key = key.context("field name must not be null")?;
     state.0.add_string(key);
     value.add_to(&ctx.arg_types[1], &mut state.0)?;
     Ok(())

--- a/src/expr/impl/src/scalar/arithmetic_op.rs
+++ b/src/expr/impl/src/scalar/arithmetic_op.rs
@@ -174,10 +174,10 @@ pub fn pow_f64(l: F64, r: F64) -> Result<F64> {
     }
     let res = l.powf(r);
     if res.is_infinite() && l.is_finite() && r.is_finite() {
-        return Err(anyhow!("numeric overflow"));
+        return Err(anyhow!("numeric out of range: overflow"));
     }
     if res.is_zero() && l.is_finite() && r.is_finite() && !l.is_zero() {
-        return Err(anyhow!("numeric underflow"));
+        return Err(anyhow!("numeric out of range: underflow"));
     }
     Ok(res)
 }
@@ -189,7 +189,7 @@ pub fn pow_decimal(l: Decimal, r: Decimal) -> Result<Decimal> {
     l.checked_powd(&r).map_err(|e| match e {
         PowError::ZeroNegative => err_pow_zero_negative(),
         PowError::NegativeFract => err_pow_negative_fract(),
-        PowError::Overflow => anyhow!("numeric overflow"),
+        PowError::Overflow => anyhow!("numeric out of range: overflow"),
     })
 }
 

--- a/src/expr/impl/src/scalar/array_sum.rs
+++ b/src/expr/impl/src/scalar/array_sum.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Context as _, Result};
 use risingwave_common::array::{ArrayError, ListRef};
 use risingwave_common::types::{CheckedAdd, Decimal, ScalarRefImpl};
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 #[function("array_sum(int2[]) -> int8")]
 fn array_sum_int2(list: ListRef<'_>) -> Result<Option<i64>> {
@@ -54,9 +55,7 @@ where
     let mut sum = T::default();
     for e in list.iter().flatten() {
         let v: S = e.try_into()?;
-        sum = sum
-            .checked_add(v.into())
-            .ok_or_else(|| ExprError::NumericOutOfRange)?;
+        sum = sum.checked_add(v.into()).context("numeric out of range")?;
     }
     Ok(Some(sum))
 }

--- a/src/expr/impl/src/scalar/cardinality.rs
+++ b/src/expr/impl/src/scalar/cardinality.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{anyhow, Result};
 use risingwave_common::array::ListRef;
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 /// Returns the total number of elements in the array.
 ///
@@ -64,5 +65,5 @@ fn cardinality<T: TryFrom<usize>>(array: ListRef<'_>) -> Result<T> {
         .flatten()
         .len()
         .try_into()
-        .map_err(|_| ExprError::NumericOverflow)
+        .map_err(|_| anyhow!("array length overflow"))
 }

--- a/src/expr/impl/src/scalar/cast.rs
+++ b/src/expr/impl/src/scalar/cast.rs
@@ -41,10 +41,12 @@ pub fn str_parse<T>(elem: &str, ctx: &Context) -> Result<T>
 where
     T: FromStr,
 {
-    elem.trim()
-        .parse()
-        .ok()
-        .with_context(|| format!("failed to parse {}", ctx.return_type))
+    elem.trim().parse().ok().with_context(|| {
+        format!(
+            "invalid input syntax for type {}: \"{}\"",
+            ctx.return_type, elem
+        )
+    })
 }
 
 // TODO: introduce `FromBinary` and support all types

--- a/src/expr/impl/src/scalar/date_trunc.rs
+++ b/src/expr/impl/src/scalar/date_trunc.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{anyhow, bail, Result};
 use risingwave_common::types::{Interval, Timestamp, Timestamptz};
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 use super::timestamptz::timestamp_at_time_zone;
 
@@ -94,10 +95,9 @@ pub fn date_trunc_interval(field: &str, interval: Interval) -> Result<Interval> 
         MINUTE => interval.truncate_minute(),
         HOUR => interval.truncate_hour(),
         DAY => interval.truncate_day(),
-        WEEK => return Err(ExprError::UnsupportedFunction(
+        WEEK => bail!(
             "interval units \"week\" not supported because months usually have fractional weeks"
-                .into(),
-        )),
+        ),
         MONTH => interval.truncate_month(),
         QUARTER => interval.truncate_quarter(),
         YEAR => interval.truncate_year(),
@@ -109,9 +109,7 @@ pub fn date_trunc_interval(field: &str, interval: Interval) -> Result<Interval> 
 }
 
 #[inline]
-fn invalid_field_error(field: &str) -> ExprError {
-    ExprError::InvalidParam {
-        name: "field",
-        reason: format!("invalid field {field:?}. must be one of: microseconds, milliseconds, second, minute, hour, day, week, month, quarter, year, decade, century, millennium").into(),
-    }
+#[track_caller]
+fn invalid_field_error(field: &str) -> anyhow::Error {
+    anyhow!("invalid field {field:?}. must be one of: microseconds, milliseconds, second, minute, hour, day, week, month, quarter, year, decade, century, millennium")
 }

--- a/src/expr/impl/src/scalar/exp.rs
+++ b/src/expr/impl/src/scalar/exp.rs
@@ -40,9 +40,9 @@ pub fn exp_f64(input: F64) -> Result<F64> {
         // means that the operation had an overflow or an underflow, and the appropriate
         // error should be returned.
         if res.is_infinite() {
-            bail!("numeric overflow")
+            bail!("numeric out of range: overflow")
         } else if res.is_zero() {
-            bail!("numeric underflow")
+            bail!("numeric out of range: underflow")
         } else {
             Ok(res)
         }
@@ -67,7 +67,9 @@ pub fn log10_f64(input: F64) -> Result<F64> {
 
 #[function("exp(decimal) -> decimal")]
 pub fn exp_decimal(input: Decimal) -> Result<Decimal> {
-    input.checked_exp().context("numeric overflow")
+    input
+        .checked_exp()
+        .context("numeric out of range: overflow")
 }
 
 #[function("ln(decimal) -> decimal")]
@@ -95,13 +97,13 @@ mod tests {
     #[test]
     fn underflow() {
         let res = exp_f64((-1000.0).into()).unwrap_err();
-        assert!(res.to_string().contains("numeric underflow"));
+        assert!(res.to_string().contains("numeric out of range: underflow"));
     }
 
     #[test]
     fn overflow() {
         let res = exp_f64(1000.0.into()).unwrap_err();
-        assert!(res.to_string().contains("numeric overflow"));
+        assert!(res.to_string().contains("numeric out of range: overflow"));
     }
 
     #[test]

--- a/src/expr/impl/src/scalar/format.rs
+++ b/src/expr/impl/src/scalar/format.rs
@@ -33,7 +33,7 @@ fn format(formatter: &Formatter, row: impl Row, writer: &mut impl Write) -> Resu
         match node {
             FormatterNode::Literal(literal) => writer.write_str(literal).unwrap(),
             FormatterNode::Specifier(sp) => {
-                let arg = args.next().context("too few arguments")?;
+                let arg = args.next().context("too few arguments for format()")?;
                 match sp.ty {
                     SpecifierType::SimpleString => {
                         if let Some(scalar) = arg {

--- a/src/expr/impl/src/scalar/jsonb_info.rs
+++ b/src/expr/impl/src/scalar/jsonb_info.rs
@@ -14,8 +14,9 @@
 
 use std::fmt::Write;
 
+use anyhow::{anyhow, Result};
 use risingwave_common::types::JsonbRef;
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 #[function("jsonb_typeof(jsonb) -> varchar")]
 pub fn jsonb_typeof(v: JsonbRef<'_>, writer: &mut impl Write) {
@@ -24,12 +25,7 @@ pub fn jsonb_typeof(v: JsonbRef<'_>, writer: &mut impl Write) {
 
 #[function("jsonb_array_length(jsonb) -> int4")]
 pub fn jsonb_array_length(v: JsonbRef<'_>) -> Result<i32> {
-    v.array_len()
-        .map(|n| n as i32)
-        .map_err(|e| ExprError::InvalidParam {
-            name: "",
-            reason: e.into(),
-        })
+    Ok(v.array_len().map_err(|e| anyhow!("{e}"))? as i32)
 }
 
 #[function("is_json(varchar) -> boolean")]

--- a/src/expr/impl/src/scalar/jsonb_path.rs
+++ b/src/expr/impl/src/scalar/jsonb_path.rs
@@ -12,28 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{bail, Result};
 use jsonbb::ValueRef;
 use risingwave_common::types::{JsonbRef, JsonbVal};
-use risingwave_expr::{function, ExprError, Result};
-use sql_json_path::{EvalError, JsonPath, ParseError};
-use thiserror_ext::AsReport;
+use risingwave_expr::function;
+use sql_json_path::JsonPath;
 
 #[function(
     "jsonb_path_exists(jsonb, varchar) -> boolean",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_exists2(target: JsonbRef<'_>, path: &JsonPath) -> Result<bool> {
-    path.exists::<ValueRef<'_>>(target.into())
-        .map_err(eval_error)
+    Ok(path.exists::<ValueRef<'_>>(target.into())?)
 }
 
 #[function(
     "jsonb_path_exists(jsonb, varchar, jsonb) -> boolean",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_exists3(target: JsonbRef<'_>, vars: JsonbRef<'_>, path: &JsonPath) -> Result<bool> {
-    path.exists_with_vars::<ValueRef<'_>>(target.into(), vars.into())
-        .map_err(eval_error)
+    Ok(path.exists_with_vars::<ValueRef<'_>>(target.into(), vars.into())?)
 }
 
 /// Checks whether the JSON path returns any item for the specified JSON value.
@@ -52,7 +50,7 @@ fn jsonb_path_exists3(target: JsonbRef<'_>, vars: JsonbRef<'_>, path: &JsonPath)
 /// ```
 #[function(
     "jsonb_path_exists(jsonb, varchar, jsonb, boolean) -> boolean",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_exists4(
     target: JsonbRef<'_>,
@@ -69,40 +67,30 @@ fn jsonb_path_exists4(
 
 #[function(
     "jsonb_path_match(jsonb, varchar) -> boolean",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_match2(target: JsonbRef<'_>, path: &JsonPath) -> Result<Option<bool>> {
-    let matched = path
-        .query::<ValueRef<'_>>(target.into())
-        .map_err(eval_error)?;
+    let matched = path.query::<ValueRef<'_>>(target.into())?;
 
     if matched.len() != 1 || !matched[0].as_ref().is_boolean() && !matched[0].as_ref().is_null() {
-        return Err(ExprError::InvalidParam {
-            name: "jsonb_path_match",
-            reason: "single boolean result is expected".into(),
-        });
+        bail!("single boolean result is expected");
     }
     Ok(matched[0].as_ref().as_bool())
 }
 
 #[function(
     "jsonb_path_match(jsonb, varchar, jsonb) -> boolean",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_match3(
     target: JsonbRef<'_>,
     vars: JsonbRef<'_>,
     path: &JsonPath,
 ) -> Result<Option<bool>> {
-    let matched = path
-        .query_with_vars::<ValueRef<'_>>(target.into(), vars.into())
-        .map_err(eval_error)?;
+    let matched = path.query_with_vars::<ValueRef<'_>>(target.into(), vars.into())?;
 
     if matched.len() != 1 || !matched[0].as_ref().is_boolean() && !matched[0].as_ref().is_null() {
-        return Err(ExprError::InvalidParam {
-            name: "jsonb_path_match",
-            reason: "single boolean result is expected".into(),
-        });
+        bail!("single boolean result is expected");
     }
     Ok(matched[0].as_ref().as_bool())
 }
@@ -122,7 +110,7 @@ fn jsonb_path_match3(
 /// ```
 #[function(
     "jsonb_path_match(jsonb, varchar, jsonb, boolean) -> boolean",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_match4(
     target: JsonbRef<'_>,
@@ -139,30 +127,26 @@ fn jsonb_path_match4(
 
 #[function(
     "jsonb_path_query(jsonb, varchar) -> setof jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query2<'a>(
     target: JsonbRef<'a>,
     path: &JsonPath,
 ) -> Result<impl Iterator<Item = JsonbVal> + 'a> {
-    let matched = path
-        .query::<ValueRef<'_>>(target.into())
-        .map_err(eval_error)?;
+    let matched = path.query::<ValueRef<'_>>(target.into())?;
     Ok(matched.into_iter().map(|json| json.into_owned().into()))
 }
 
 #[function(
     "jsonb_path_query(jsonb, varchar, jsonb) -> setof jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query3<'a>(
     target: JsonbRef<'a>,
     vars: JsonbRef<'a>,
     path: &JsonPath,
 ) -> Result<impl Iterator<Item = JsonbVal> + 'a> {
-    let matched = path
-        .query_with_vars::<ValueRef<'_>>(target.into(), vars.into())
-        .map_err(eval_error)?;
+    let matched = path.query_with_vars::<ValueRef<'_>>(target.into(), vars.into())?;
     Ok(matched.into_iter().map(|json| json.into_owned().into()))
 }
 
@@ -181,7 +165,7 @@ fn jsonb_path_query3<'a>(
 /// ```
 #[function(
     "jsonb_path_query(jsonb, varchar, jsonb, boolean) -> setof jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query4<'a>(
     target: JsonbRef<'a>,
@@ -198,28 +182,24 @@ fn jsonb_path_query4<'a>(
 
 #[function(
     "jsonb_path_query_array(jsonb, varchar) -> jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query_array2(target: JsonbRef<'_>, path: &JsonPath) -> Result<JsonbVal> {
-    let matched = path
-        .query::<ValueRef<'_>>(target.into())
-        .map_err(eval_error)?;
+    let matched = path.query::<ValueRef<'_>>(target.into())?;
     let array = jsonbb::Value::array(matched.iter().map(|json| json.as_ref()));
     Ok(array.into())
 }
 
 #[function(
     "jsonb_path_query_array(jsonb, varchar, jsonb) -> jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query_array3(
     target: JsonbRef<'_>,
     vars: JsonbRef<'_>,
     path: &JsonPath,
 ) -> Result<JsonbVal> {
-    let matched = path
-        .query_with_vars::<ValueRef<'_>>(target.into(), vars.into())
-        .map_err(eval_error)?;
+    let matched = path.query_with_vars::<ValueRef<'_>>(target.into(), vars.into())?;
     let array = jsonbb::Value::array(matched.iter().map(|json| json.as_ref()));
     Ok(array.into())
 }
@@ -237,7 +217,7 @@ fn jsonb_path_query_array3(
 /// ```
 #[function(
     "jsonb_path_query_array(jsonb, varchar, jsonb, boolean) -> jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query_array4(
     target: JsonbRef<'_>,
@@ -254,12 +234,10 @@ fn jsonb_path_query_array4(
 
 #[function(
     "jsonb_path_query_first(jsonb, varchar) -> jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query_first2(target: JsonbRef<'_>, path: &JsonPath) -> Result<Option<JsonbVal>> {
-    let matched = path
-        .query_first::<ValueRef<'_>>(target.into())
-        .map_err(eval_error)?;
+    let matched = path.query_first::<ValueRef<'_>>(target.into())?;
     Ok(matched
         .into_iter()
         .next()
@@ -268,16 +246,14 @@ fn jsonb_path_query_first2(target: JsonbRef<'_>, path: &JsonPath) -> Result<Opti
 
 #[function(
     "jsonb_path_query_first(jsonb, varchar, jsonb) -> jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query_first3(
     target: JsonbRef<'_>,
     vars: JsonbRef<'_>,
     path: &JsonPath,
 ) -> Result<Option<JsonbVal>> {
-    let matched = path
-        .query_first_with_vars::<ValueRef<'_>>(target.into(), vars.into())
-        .map_err(eval_error)?;
+    let matched = path.query_first_with_vars::<ValueRef<'_>>(target.into(), vars.into())?;
     Ok(matched
         .into_iter()
         .next()
@@ -298,7 +274,7 @@ fn jsonb_path_query_first3(
 /// ```
 #[function(
     "jsonb_path_query_first(jsonb, varchar, jsonb, boolean) -> jsonb",
-    prebuild = "JsonPath::new($1).map_err(parse_error)?"
+    prebuild = "JsonPath::new($1).map_err(anyhow::Error::from)?"
 )]
 fn jsonb_path_query_first4(
     target: JsonbRef<'_>,
@@ -310,16 +286,5 @@ fn jsonb_path_query_first4(
         Ok(x) => Ok(x),
         Err(_) if silent => Ok(None),
         Err(e) => Err(e),
-    }
-}
-
-fn parse_error(e: ParseError) -> ExprError {
-    ExprError::Parse(e.to_report_string().into())
-}
-
-fn eval_error(e: EvalError) -> ExprError {
-    ExprError::InvalidParam {
-        name: "jsonpath",
-        reason: e.to_report_string().into(),
     }
 }

--- a/src/expr/impl/src/scalar/make_timestamptz.rs
+++ b/src/expr/impl/src/scalar/make_timestamptz.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{bail, Context as _, Result};
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use risingwave_common::types::{FloatExt, Timestamp, Timestamptz, F64};
 use risingwave_expr::expr_context::TIME_ZONE;
-use risingwave_expr::{capture_context, function, ExprError, Result};
+use risingwave_expr::{capture_context, function};
 
 use crate::scalar::timestamptz::timestamp_at_time_zone;
 
@@ -57,25 +58,14 @@ fn make_timestamptz_impl(
     sec: F64,
 ) -> Result<Timestamptz> {
     if !sec.is_finite() || sec.0.is_sign_negative() {
-        return Err(ExprError::InvalidParam {
-            name: "sec",
-            reason: "invalid sec".into(),
-        });
+        bail!("invalid sec");
     }
     let sec_u32 = sec.0.trunc() as u32;
     let microsecond_u32 = ((sec.0 - sec.0.trunc()) * 1_000_000.0).round_ties_even() as u32;
     let naive_date_time = NaiveDateTime::new(
-        NaiveDate::from_ymd_opt(year, month as u32, day as u32).ok_or_else(|| {
-            ExprError::InvalidParam {
-                name: "year, month, day",
-                reason: "invalid date".into(),
-            }
-        })?,
+        NaiveDate::from_ymd_opt(year, month as u32, day as u32).context("invalid date")?,
         NaiveTime::from_hms_micro_opt(hour as u32, min as u32, sec_u32, microsecond_u32)
-            .ok_or_else(|| ExprError::InvalidParam {
-                name: "hour, min, sec",
-                reason: "invalid time".into(),
-            })?,
+            .context("invalid time")?,
     );
 
     timestamp_at_time_zone(Timestamp(naive_date_time), time_zone)

--- a/src/expr/impl/src/scalar/proctime.rs
+++ b/src/expr/impl/src/scalar/proctime.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Context as _, Result};
 use risingwave_common::types::Timestamptz;
 use risingwave_common::util::epoch;
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 /// Get the processing time in Timestamptz scalar from the task-local epoch.
 #[function("proctime() -> timestamptz", volatile)]
 fn proctime() -> Result<Timestamptz> {
-    let epoch = epoch::task_local::curr_epoch().ok_or(ExprError::Context("EPOCH"))?;
+    let epoch = epoch::task_local::curr_epoch().context("no context: EPOCH")?;
     Ok(epoch.as_timestamptz())
 }
 

--- a/src/expr/impl/src/scalar/regexp.rs
+++ b/src/expr/impl/src/scalar/regexp.rs
@@ -55,7 +55,7 @@ impl RegexpContext {
 
     pub fn from_pattern_flags_for_count(pattern: &str, flags: &str) -> Result<Self> {
         if flags.contains('g') {
-            bail!("regexp_count() does not support the global option");
+            bail!("regexp_count() does not support the \"global\" option");
         }
         Self::new(pattern, flags, "")
     }

--- a/src/expr/impl/src/scalar/round.rs
+++ b/src/expr/impl/src/scalar/round.rs
@@ -21,7 +21,7 @@ pub fn round_digits(input: Decimal, digits: i32) -> Result<Decimal> {
     if digits < 0 {
         input
             .round_left_ties_away(digits.unsigned_abs())
-            .context("numeric overflow")
+            .context("numeric out of range: overflow")
     } else {
         // rust_decimal can only handle up to 28 digits of scale
         Ok(input.round_dp_ties_away((digits as u32).min(Decimal::MAX_PRECISION.into())))

--- a/src/expr/impl/src/scalar/round.rs
+++ b/src/expr/impl/src/scalar/round.rs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Context as _, Result};
 use risingwave_common::types::{Decimal, F64};
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 #[function("round_digit(decimal, int4) -> decimal")]
 pub fn round_digits(input: Decimal, digits: i32) -> Result<Decimal> {
     if digits < 0 {
         input
             .round_left_ties_away(digits.unsigned_abs())
-            .ok_or(ExprError::NumericOverflow)
+            .context("numeric overflow")
     } else {
         // rust_decimal can only handle up to 28 digits of scale
         Ok(input.round_dp_ties_away((digits as u32).min(Decimal::MAX_PRECISION.into())))

--- a/src/expr/impl/src/scalar/split_part.rs
+++ b/src/expr/impl/src/scalar/split_part.rs
@@ -14,7 +14,8 @@
 
 use std::fmt::Write;
 
-use risingwave_expr::{function, ExprError, Result};
+use anyhow::{ensure, Result};
+use risingwave_expr::function;
 
 #[function("split_part(varchar, varchar, int4) -> varchar")]
 pub fn split_part(
@@ -23,12 +24,7 @@ pub fn split_part(
     nth_expr: i32,
     writer: &mut impl Write,
 ) -> Result<()> {
-    if nth_expr == 0 {
-        return Err(ExprError::InvalidParam {
-            name: "data",
-            reason: "can't be zero".into(),
-        });
-    };
+    ensure!(nth_expr != 0, "field position must not be zero");
 
     let mut split = string_expr.split(delimiter_expr);
     let nth_val = if string_expr.is_empty() {

--- a/src/expr/impl/src/scalar/substr.rs
+++ b/src/expr/impl/src/scalar/substr.rs
@@ -14,7 +14,8 @@
 
 use std::fmt::Write;
 
-use risingwave_expr::{function, ExprError, Result};
+use anyhow::{bail, Result};
+use risingwave_expr::function;
 
 #[function("substr(varchar, int4) -> varchar")]
 pub fn substr_start(s: &str, start: i32, writer: &mut impl Write) -> Result<()> {
@@ -37,10 +38,7 @@ pub fn substr_start_bytea(s: &[u8], start: i32) -> Box<[u8]> {
 
 fn convert_args(start: i32, count: i32) -> Result<(usize, usize)> {
     if count < 0 {
-        return Err(ExprError::InvalidParam {
-            name: "length",
-            reason: "negative substring length not allowed".into(),
-        });
+        bail!("negative substring length not allowed");
     }
 
     let skip = start.saturating_sub(1).max(0) as usize;

--- a/src/expr/impl/src/scalar/to_char.rs
+++ b/src/expr/impl/src/scalar/to_char.rs
@@ -16,10 +16,11 @@ use std::fmt::{Debug, Write};
 use std::sync::LazyLock;
 
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
+use anyhow::{anyhow, Result};
 use chrono::format::{Item, StrftimeItems};
 use chrono::{Datelike, NaiveDate};
 use risingwave_common::types::{Interval, Timestamp, Timestamptz};
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 use super::timestamptz::time_zone_err;
 use crate::scalar::arithmetic_op::timestamp_interval_add;
@@ -27,11 +28,8 @@ use crate::scalar::arithmetic_op::timestamp_interval_add;
 type Pattern<'a> = Vec<chrono::format::Item<'a>>;
 
 #[inline(always)]
-fn invalid_pattern_err() -> ExprError {
-    ExprError::InvalidParam {
-        name: "pattern",
-        reason: "invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.".into(),
-    }
+fn invalid_pattern_err() -> anyhow::Error {
+    anyhow!("invalid format specification for an interval value, HINT: Intervals are not tied to specific calendar dates.")
 }
 
 self_cell::self_cell! {

--- a/src/expr/impl/src/scalar/to_jsonb.rs
+++ b/src/expr/impl/src/scalar/to_jsonb.rs
@@ -14,6 +14,7 @@
 
 use std::fmt::Debug;
 
+use anyhow::{Context as _, Result};
 use jsonbb::Builder;
 use risingwave_common::types::{
     DataType, Date, Decimal, Int256Ref, Interval, JsonbRef, JsonbVal, ListRef, ScalarRefImpl,
@@ -21,7 +22,7 @@ use risingwave_common::types::{
 };
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_expr::expr::Context;
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 #[function("to_jsonb(*) -> jsonb")]
 fn to_jsonb(input: Option<impl ToJsonb>, ctx: &Context) -> Result<JsonbVal> {
@@ -138,7 +139,7 @@ impl ToJsonb for Decimal {
     fn add_to(self, t: &DataType, builder: &mut Builder) -> Result<()> {
         let res: F64 = self
             .try_into()
-            .map_err(|_| ExprError::CastOutOfRange("IEEE 754 double"))?;
+            .context("numeric our of range. must be IEEE 754 double")?;
         res.add_to(t, builder)?;
         Ok(())
     }

--- a/src/expr/impl/src/scalar/to_timestamp.rs
+++ b/src/expr/impl/src/scalar/to_timestamp.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Result;
 use chrono::format::Parsed;
 use risingwave_common::types::{Date, Timestamp, Timestamptz};
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 use super::timestamptz::{timestamp_at_time_zone, timestamptz_at_time_zone};
 use super::to_char::ChronoPattern;

--- a/src/expr/impl/src/scalar/trim_array.rs
+++ b/src/expr/impl/src/scalar/trim_array.rs
@@ -52,10 +52,10 @@ use risingwave_expr::function;
 /// ----
 /// NULL
 ///
-/// statement error
+/// query error number of elements to trim must be between 0 and 6
 /// select trim_array(array[1,2,3,4,5,null], 7);
 ///
-/// statement error
+/// query error number of elements to trim must be between 0 and 6
 /// select trim_array(array[1,2,3,4,5,null], -1);
 ///
 /// statement error
@@ -74,7 +74,7 @@ use risingwave_expr::function;
 fn trim_array(array: ListRef<'_>, n: i32) -> Result<ListValue> {
     let values = array.iter();
     ensure!(
-        (0..array.len() as i32).contains(&n),
+        (0..=array.len() as i32).contains(&n),
         "number of elements to trim must be between 0 and {}",
         array.len()
     );

--- a/src/expr/impl/src/scalar/tumble.rs
+++ b/src/expr/impl/src/scalar/tumble.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Context as _, Result};
 use num_traits::Zero;
 use risingwave_common::types::{Date, Interval, Timestamp, Timestamptz};
-use risingwave_expr::{function, ExprError, Result};
+use risingwave_expr::function;
 
 #[inline(always)]
 fn interval_to_micro_second(t: Interval) -> Result<i64> {
@@ -28,7 +29,7 @@ fn interval_to_micro_second(t: Interval) -> Result<i64> {
             )
     };
 
-    checked_interval_to_micro_second().ok_or(ExprError::NumericOutOfRange)
+    checked_interval_to_micro_second().context("numeric out of range")
 }
 
 #[function("tumble_start(date, interval) -> timestamp")]
@@ -94,17 +95,17 @@ fn get_window_start_with_offset(
     // Inspired by https://issues.apache.org/jira/browse/FLINK-26334
     let remainder = timestamp_micro_second
         .checked_sub(offset_micro_second)
-        .ok_or(ExprError::NumericOutOfRange)?
+        .context("numeric out of range")?
         .checked_rem(window_size_micro_second)
-        .ok_or(ExprError::DivisionByZero)?;
+        .context("division by zero")?;
     if remainder < 0 {
         timestamp_micro_second
             .checked_sub(remainder + window_size_micro_second)
-            .ok_or(ExprError::NumericOutOfRange)
+            .context("numeric out of range")
     } else {
         timestamp_micro_second
             .checked_sub(remainder)
-            .ok_or(ExprError::NumericOutOfRange)
+            .context("numeric out of range")
     }
 }
 

--- a/src/expr/macro/src/context.rs
+++ b/src/expr/macro/src/context.rs
@@ -81,7 +81,7 @@ impl DefineContextField {
                     static LOCAL_KEY: #ty;
                 }
 
-                #vis fn try_with<F, R>(f: F) -> Result<R, risingwave_expr::ExprError>
+                #vis fn try_with<F, R>(f: F) -> std::result::Result<R, risingwave_expr::ExprError>
                 where
                     F: FnOnce(&#ty) -> R
                 {
@@ -203,7 +203,7 @@ pub(super) fn generate_captured_function(
             scoped = quote_spanned! { context.span()=>
                 // TODO: Can we add an assertion here that `&<<#context::Type> as Deref>::Target` is same as `#arg.ty`?
                 #context::try_with(|#name| {
-                    #scoped
+                    #scoped.map_err(Into::into)
                 }).flatten()
             }
         }

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -118,7 +118,7 @@ impl FunctionAttr {
             let name = format_ident!("{}", user_fn.name);
             quote! { #name }
         } else if self.rewritten {
-            quote! { |_, _| Err(ExprError::UnsupportedFunction(#name.into())) }
+            quote! { |_, _| Err(risingwave_expr::ExprError::UnsupportedFunction(#name.into())) }
         } else {
             self.generate_build_scalar_function(user_fn, true)?
         };
@@ -551,7 +551,7 @@ impl FunctionAttr {
             let name = format_ident!("{}", user_fn.as_fn().name);
             quote! { #name }
         } else if self.rewritten {
-            quote! { |_| Err(ExprError::UnsupportedFunction(#name.into())) }
+            quote! { |_| Err(risingwave_expr::ExprError::UnsupportedFunction(#name.into())) }
         } else {
             self.generate_agg_build_fn(user_fn)?
         };
@@ -898,7 +898,7 @@ impl FunctionAttr {
             let name = format_ident!("{}", user_fn.name);
             quote! { #name }
         } else if self.rewritten {
-            quote! { |_, _| Err(ExprError::UnsupportedFunction(#name.into())) }
+            quote! { |_, _| Err(risingwave_expr::ExprError::UnsupportedFunction(#name.into())) }
         } else {
             self.generate_build_table_function(user_fn)?
         };

--- a/src/frontend/planner_test/tests/testdata/output/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/expr.yaml
@@ -592,8 +592,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      division by zero
+    Caused by these errors (recent errors listed first):
+      1: in function "divide"
+      2: division by zero
 - sql: |
     select * from abs(-1);
   batch_plan: 'BatchValues { rows: [[1:Int32]] }'

--- a/src/frontend/planner_test/tests/testdata/output/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/expr.yaml
@@ -593,7 +593,7 @@
     Expr error
 
     Caused by:
-      Division by zero
+      division by zero
 - sql: |
     select * from abs(-1);
   batch_plan: 'BatchValues { rows: [[1:Int32]] }'

--- a/src/frontend/planner_test/tests/testdata/output/format.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/format.yaml
@@ -21,8 +21,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      too few arguments for format()
+    Caused by these errors (recent errors listed first):
+      1: in function "format"
+      2: too few arguments for format()
 - sql: |
     SELECT format('Testing %s, %s, %s, %', 'one', 'two', 'three');
   batch_error: |

--- a/src/frontend/planner_test/tests/testdata/output/format.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/format.yaml
@@ -29,14 +29,14 @@
     Expr error
 
     Caused by:
-      Parse error: unterminated format() type specifier
+      unterminated format() type specifier
 - sql: |
     SELECT format('Testing %s, %f, %d, %', 'one', 'two', 'three');
   batch_error: |
     Expr error
 
     Caused by:
-      Parse error: unrecognized format() type specifier "f"
+      unrecognized format() type specifier "f"
 - sql: |
     SELECT format();
   binder_error: |

--- a/src/frontend/planner_test/tests/testdata/output/range_scan.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/range_scan.yaml
@@ -35,8 +35,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      division by zero
+    Caused by these errors (recent errors listed first):
+      1: in function "divide"
+      2: division by zero
 - before:
   - create_table_and_mv
   sql: |
@@ -44,8 +45,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      numeric out of range
+    Caused by these errors (recent errors listed first):
+      1: in function "add"
+      2: numeric out of range
 - before:
   - create_table_and_mv
   sql: |
@@ -53,8 +55,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      invalid input syntax for type bigint: "a"
+    Caused by these errors (recent errors listed first):
+      1: in function "cast"
+      2: invalid input syntax for type bigint: "a"
 - before:
   - create_table_and_mv
   sql: |
@@ -62,8 +65,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      invalid input syntax for type bigint: "a"
+    Caused by these errors (recent errors listed first):
+      1: in function "cast"
+      2: invalid input syntax for type bigint: "a"
 - before:
   - create_table_and_mv
   sql: |
@@ -148,8 +152,9 @@
   batch_error: |
     Expr error
 
-    Caused by:
-      invalid input syntax for type bigint: "43.0"
+    Caused by these errors (recent errors listed first):
+      1: in function "cast"
+      2: invalid input syntax for type bigint: "43.0"
 - before:
   - create_table_and_mv
   sql: |

--- a/src/frontend/planner_test/tests/testdata/output/range_scan.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/range_scan.yaml
@@ -36,7 +36,7 @@
     Expr error
 
     Caused by:
-      Division by zero
+      division by zero
 - before:
   - create_table_and_mv
   sql: |
@@ -45,7 +45,7 @@
     Expr error
 
     Caused by:
-      Numeric out of range
+      numeric out of range
 - before:
   - create_table_and_mv
   sql: |
@@ -54,7 +54,7 @@
     Expr error
 
     Caused by:
-      Parse error: bigint invalid digit found in string
+      invalid input syntax for type bigint: "a"
 - before:
   - create_table_and_mv
   sql: |
@@ -63,7 +63,7 @@
     Expr error
 
     Caused by:
-      Parse error: bigint invalid digit found in string
+      invalid input syntax for type bigint: "a"
 - before:
   - create_table_and_mv
   sql: |
@@ -149,7 +149,7 @@
     Expr error
 
     Caused by:
-      Parse error: bigint invalid digit found in string
+      invalid input syntax for type bigint: "43.0"
 - before:
   - create_table_and_mv
   sql: |

--- a/src/frontend/src/expr/function_impl/cast_regclass.rs
+++ b/src/frontend/src/expr/function_impl/cast_regclass.rs
@@ -17,7 +17,6 @@ use risingwave_expr::{capture_context, function, ExprError};
 use risingwave_sqlparser::parser::{Parser, ParserError};
 use risingwave_sqlparser::tokenizer::{Token, Tokenizer};
 use thiserror::Error;
-use thiserror_ext::AsReport;
 
 use super::context::{AUTH_CONTEXT, CATALOG_READER, DB_NAME, SEARCH_PATH};
 use crate::catalog::root_catalog::SchemaPath;
@@ -34,13 +33,7 @@ enum ResolveRegclassError {
 
 impl From<ResolveRegclassError> for ExprError {
     fn from(e: ResolveRegclassError) -> Self {
-        match e {
-            ResolveRegclassError::Parser(e) => ExprError::Parse(e.to_report_string().into()),
-            ResolveRegclassError::Catalog(e) => ExprError::InvalidParam {
-                name: "name",
-                reason: e.to_report_string().into(),
-            },
-        }
+        ExprError::Anyhow(e.into())
     }
 }
 

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -29,7 +29,6 @@ use risingwave_common::types::{DataType, DefaultOrd, ToOwnedDatum};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_expr::expr::NonStrictExpression;
-use risingwave_expr::ExprError;
 use risingwave_storage::StateStore;
 use tokio::time::Instant;
 
@@ -925,9 +924,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 match eval_result {
                     Ok(value) => input_watermark.val = value.unwrap(),
                     Err(err) => {
-                        if !matches!(err, ExprError::NumericOutOfRange) {
-                            self.ctx.on_compute_error(err, &self.info.identity);
-                        }
+                        self.ctx.on_compute_error(err, &self.info.identity);
                         continue;
                     }
                 }

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -14,6 +14,7 @@
 
 use std::num::NonZeroUsize;
 
+use anyhow::anyhow;
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
@@ -103,13 +104,10 @@ impl HopWindowExecutor {
         let units = window_size
             .exact_div(&window_slide)
             .and_then(|x| NonZeroUsize::new(usize::try_from(x).ok()?))
-            .ok_or_else(|| ExprError::InvalidParam {
-                name: "window",
-                reason: format!(
-                    "window_size {} cannot be divided by window_slide {}",
-                    window_size, window_slide
-                )
-                .into(),
+            .ok_or_else(|| {
+                ExprError::from(anyhow!(
+                    "window_size {window_size} cannot be divided by window_slide {window_slide}",
+                ))
             })?
             .get();
 

--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 //! Provides validation logic for expected errors.
-use risingwave_expr::ExprError;
 
 /// Ignore errors related to `0`.
 fn is_zero_err(db_error: &str) -> bool {
-    db_error.contains(&ExprError::DivisionByZero.to_string()) || db_error.contains("can't be zero")
+    db_error.contains("division by zero") || db_error.contains("can't be zero")
 }
 
 /// `Casting to u32 out of range` occurs when we have functions
@@ -26,8 +25,7 @@ fn is_zero_err(db_error: &str) -> bool {
 // NOTE: If this error occurs too often, perhaps it is better to
 // wrap call sites with `abs(rhs)`, e.g. 222 << abs(-1);
 fn is_numeric_out_of_range_err(db_error: &str) -> bool {
-    db_error.contains(&ExprError::NumericOutOfRange.to_string())
-        || db_error.contains("Casting to u32 out of range")
+    db_error.contains("numeric out of range") || db_error.contains("Casting to u32 out of range")
 }
 
 fn is_parse_err(db_error: &str) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

SQL functions now return `anyhow` error. Making it easy for implementors to construct errors using `anyhow!`, `bail!` and `.context()`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)
