### PR TITLE
feat(storage): compare deserialized row value in sanity check

### DIFF
--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -1381,7 +1381,7 @@ async fn test_replicated_local_hummock_storage() {
     let mut local_hummock_storage = hummock_storage
         .new_local(NewLocalOptions::new_replicated(
             TEST_TABLE_ID,
-            OpConsistentLevel::Inconsistent,
+            OpConsistencyLevel::Inconsistent,
             TableOption {
                 retention_seconds: None,
             },

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -1381,7 +1381,7 @@ async fn test_replicated_local_hummock_storage() {
     let mut local_hummock_storage = hummock_storage
         .new_local(NewLocalOptions::new_replicated(
             TEST_TABLE_ID,
-            false,
+            OpConsistentLevel::Inconsistent,
             TableOption {
                 retention_seconds: None,
             },

--- a/src/storage/hummock_trace/src/opts.rs
+++ b/src/storage/hummock_trace/src/opts.rs
@@ -136,7 +136,7 @@ impl From<TracedTableOption> for TableOption {
 }
 
 #[derive(Encode, Decode, PartialEq, Eq, Debug, Clone, Copy, Hash)]
-pub enum TracedOpConsistentLevel {
+pub enum TracedOpConsistencyLevel {
     Inconsistent,
     ConsistentOldValue,
 }
@@ -144,7 +144,7 @@ pub enum TracedOpConsistentLevel {
 #[derive(Encode, Decode, PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub struct TracedNewLocalOptions {
     pub table_id: TracedTableId,
-    pub op_consistent_level: TracedOpConsistentLevel,
+    pub op_consistency_level: TracedOpConsistencyLevel,
     pub table_option: TracedTableOption,
     pub is_replicated: bool,
 }
@@ -154,7 +154,7 @@ impl TracedNewLocalOptions {
     pub(crate) fn for_test(table_id: u32) -> Self {
         Self {
             table_id: TracedTableId { table_id },
-            op_consistent_level: TracedOpConsistentLevel::Inconsistent,
+            op_consistency_level: TracedOpConsistencyLevel::Inconsistent,
             table_option: TracedTableOption {
                 retention_seconds: None,
             },

--- a/src/storage/hummock_trace/src/opts.rs
+++ b/src/storage/hummock_trace/src/opts.rs
@@ -136,9 +136,15 @@ impl From<TracedTableOption> for TableOption {
 }
 
 #[derive(Encode, Decode, PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub enum TracedOpConsistentLevel {
+    Inconsistent,
+    ConsistentOldValue,
+}
+
+#[derive(Encode, Decode, PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub struct TracedNewLocalOptions {
     pub table_id: TracedTableId,
-    pub is_consistent_op: bool,
+    pub op_consistent_level: TracedOpConsistentLevel,
     pub table_option: TracedTableOption,
     pub is_replicated: bool,
 }
@@ -148,7 +154,7 @@ impl TracedNewLocalOptions {
     pub(crate) fn for_test(table_id: u32) -> Self {
         Self {
             table_id: TracedTableId { table_id },
-            is_consistent_op: true,
+            op_consistent_level: TracedOpConsistentLevel::Inconsistent,
             table_option: TracedTableOption {
                 retention_seconds: None,
             },

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -58,7 +58,7 @@ pub struct LocalHummockStorage {
     epoch: Option<u64>,
 
     table_id: TableId,
-    is_consistent_op: bool,
+    op_consistent_level: OpConsistentLevel,
     table_option: TableOption,
 
     instance_guard: LocalInstanceGuard,
@@ -300,43 +300,46 @@ impl LocalStateStore for LocalHummockStorage {
                 // a workaround you may call disable the check by initializing the
                 // state store with `is_consistent_op=false`.
                 KeyOp::Insert(value) => {
-                    if ENABLE_SANITY_CHECK && self.is_consistent_op {
+                    if ENABLE_SANITY_CHECK {
                         do_insert_sanity_check(
-                            key.clone(),
-                            value.clone(),
+                            &key,
+                            &value,
                             self,
                             self.epoch(),
                             self.table_id,
                             self.table_option,
+                            &self.op_consistent_level,
                         )
                         .await?;
                     }
                     kv_pairs.push((key, StorageValue::new_put(value)));
                 }
                 KeyOp::Delete(old_value) => {
-                    if ENABLE_SANITY_CHECK && self.is_consistent_op {
+                    if ENABLE_SANITY_CHECK {
                         do_delete_sanity_check(
-                            key.clone(),
-                            old_value,
+                            &key,
+                            &old_value,
                             self,
                             self.epoch(),
                             self.table_id,
                             self.table_option,
+                            &self.op_consistent_level,
                         )
                         .await?;
                     }
                     kv_pairs.push((key, StorageValue::new_delete()));
                 }
                 KeyOp::Update((old_value, new_value)) => {
-                    if ENABLE_SANITY_CHECK && self.is_consistent_op {
+                    if ENABLE_SANITY_CHECK {
                         do_update_sanity_check(
-                            key.clone(),
-                            old_value,
-                            new_value.clone(),
+                            &key,
+                            &old_value,
+                            &new_value,
                             self,
                             self.epoch(),
                             self.table_id,
                             self.table_option,
+                            &self.op_consistent_level,
                         )
                         .await?;
                     }
@@ -519,11 +522,11 @@ impl LocalHummockStorage {
     ) -> Self {
         let stats = hummock_version_reader.stats().clone();
         Self {
-            mem_table: MemTable::new(option.is_consistent_op),
+            mem_table: MemTable::new(option.op_consistent_level.clone()),
             spill_offset: 0,
             epoch: None,
             table_id: option.table_id,
-            is_consistent_op: option.is_consistent_op,
+            op_consistent_level: option.op_consistent_level,
             table_option: option.table_option,
             is_replicated: option.is_replicated,
             instance_guard,

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -58,7 +58,7 @@ pub struct LocalHummockStorage {
     epoch: Option<u64>,
 
     table_id: TableId,
-    op_consistent_level: OpConsistentLevel,
+    op_consistency_level: OpConsistencyLevel,
     table_option: TableOption,
 
     instance_guard: LocalInstanceGuard,
@@ -308,7 +308,7 @@ impl LocalStateStore for LocalHummockStorage {
                             self.epoch(),
                             self.table_id,
                             self.table_option,
-                            &self.op_consistent_level,
+                            &self.op_consistency_level,
                         )
                         .await?;
                     }
@@ -323,7 +323,7 @@ impl LocalStateStore for LocalHummockStorage {
                             self.epoch(),
                             self.table_id,
                             self.table_option,
-                            &self.op_consistent_level,
+                            &self.op_consistency_level,
                         )
                         .await?;
                     }
@@ -339,7 +339,7 @@ impl LocalStateStore for LocalHummockStorage {
                             self.epoch(),
                             self.table_id,
                             self.table_option,
-                            &self.op_consistent_level,
+                            &self.op_consistency_level,
                         )
                         .await?;
                     }
@@ -522,11 +522,11 @@ impl LocalHummockStorage {
     ) -> Self {
         let stats = hummock_version_reader.stats().clone();
         Self {
-            mem_table: MemTable::new(option.op_consistent_level.clone()),
+            mem_table: MemTable::new(option.op_consistency_level.clone()),
             spill_offset: 0,
             epoch: None,
             table_id: option.table_id,
-            op_consistent_level: option.op_consistent_level,
+            op_consistency_level: option.op_consistency_level,
             table_option: option.table_option,
             is_replicated: option.is_replicated,
             instance_guard,

--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -35,7 +35,7 @@ use super::{HummockError, HummockResult};
 use crate::error::StorageResult;
 use crate::hummock::CachePolicy;
 use crate::mem_table::{KeyOp, MemTableError};
-use crate::store::{ReadOptions, StateStoreRead};
+use crate::store::{OpConsistentLevel, ReadOptions, StateStoreRead};
 
 pub fn range_overlap<R, B>(
     search_key_range: &R,
@@ -372,13 +372,17 @@ pub(crate) const ENABLE_SANITY_CHECK: bool = cfg!(debug_assertions);
 
 /// Make sure the key to insert should not exist in storage.
 pub(crate) async fn do_insert_sanity_check(
-    key: TableKey<Bytes>,
-    value: Bytes,
+    key: &TableKey<Bytes>,
+    value: &Bytes,
     inner: &impl StateStoreRead,
     epoch: u64,
     table_id: TableId,
     table_option: TableOption,
+    op_consistent_level: &OpConsistentLevel,
 ) -> StorageResult<()> {
+    if let OpConsistentLevel::Inconsistent = op_consistent_level {
+        return Ok(());
+    }
     let read_options = ReadOptions {
         retention_seconds: table_option.retention_seconds,
         table_id,
@@ -389,9 +393,9 @@ pub(crate) async fn do_insert_sanity_check(
 
     if let Some(stored_value) = stored_value {
         return Err(Box::new(MemTableError::InconsistentOperation {
-            key,
+            key: key.clone(),
             prev: KeyOp::Insert(stored_value),
-            new: KeyOp::Insert(value),
+            new: KeyOp::Insert(value.clone()),
         })
         .into());
     }
@@ -400,13 +404,17 @@ pub(crate) async fn do_insert_sanity_check(
 
 /// Make sure that the key to delete should exist in storage and the value should be matched.
 pub(crate) async fn do_delete_sanity_check(
-    key: TableKey<Bytes>,
-    old_value: Bytes,
+    key: &TableKey<Bytes>,
+    old_value: &Bytes,
     inner: &impl StateStoreRead,
     epoch: u64,
     table_id: TableId,
     table_option: TableOption,
+    op_consistent_level: &OpConsistentLevel,
 ) -> StorageResult<()> {
+    let OpConsistentLevel::ConsistentOldValue(old_value_checker) = op_consistent_level else {
+        return Ok(());
+    };
     let read_options = ReadOptions {
         retention_seconds: table_option.retention_seconds,
         table_id,
@@ -415,17 +423,17 @@ pub(crate) async fn do_delete_sanity_check(
     };
     match inner.get(key.clone(), epoch, read_options).await? {
         None => Err(Box::new(MemTableError::InconsistentOperation {
-            key,
+            key: key.clone(),
             prev: KeyOp::Delete(Bytes::default()),
-            new: KeyOp::Delete(old_value),
+            new: KeyOp::Delete(old_value.clone()),
         })
         .into()),
         Some(stored_value) => {
-            if stored_value != old_value {
+            if !old_value_checker(&stored_value, old_value) {
                 Err(Box::new(MemTableError::InconsistentOperation {
-                    key,
+                    key: key.clone(),
                     prev: KeyOp::Insert(stored_value),
-                    new: KeyOp::Delete(old_value),
+                    new: KeyOp::Delete(old_value.clone()),
                 })
                 .into())
             } else {
@@ -437,14 +445,18 @@ pub(crate) async fn do_delete_sanity_check(
 
 /// Make sure that the key to update should exist in storage and the value should be matched
 pub(crate) async fn do_update_sanity_check(
-    key: TableKey<Bytes>,
-    old_value: Bytes,
-    new_value: Bytes,
+    key: &TableKey<Bytes>,
+    old_value: &Bytes,
+    new_value: &Bytes,
     inner: &impl StateStoreRead,
     epoch: u64,
     table_id: TableId,
     table_option: TableOption,
+    op_consistent_level: &OpConsistentLevel,
 ) -> StorageResult<()> {
+    let OpConsistentLevel::ConsistentOldValue(old_value_checker) = op_consistent_level else {
+        return Ok(());
+    };
     let read_options = ReadOptions {
         retention_seconds: table_option.retention_seconds,
         table_id,
@@ -454,17 +466,17 @@ pub(crate) async fn do_update_sanity_check(
 
     match inner.get(key.clone(), epoch, read_options).await? {
         None => Err(Box::new(MemTableError::InconsistentOperation {
-            key,
+            key: key.clone(),
             prev: KeyOp::Delete(Bytes::default()),
-            new: KeyOp::Update((old_value, new_value)),
+            new: KeyOp::Update((old_value.clone(), new_value.clone())),
         })
         .into()),
         Some(stored_value) => {
-            if stored_value != old_value {
+            if !old_value_checker(&stored_value, old_value) {
                 Err(Box::new(MemTableError::InconsistentOperation {
-                    key,
+                    key: key.clone(),
                     prev: KeyOp::Insert(stored_value),
-                    new: KeyOp::Update((old_value, new_value)),
+                    new: KeyOp::Update((old_value.clone(), new_value.clone())),
                 })
                 .into())
             } else {

--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -35,7 +35,7 @@ use super::{HummockError, HummockResult};
 use crate::error::StorageResult;
 use crate::hummock::CachePolicy;
 use crate::mem_table::{KeyOp, MemTableError};
-use crate::store::{OpConsistentLevel, ReadOptions, StateStoreRead};
+use crate::store::{OpConsistencyLevel, ReadOptions, StateStoreRead};
 
 pub fn range_overlap<R, B>(
     search_key_range: &R,
@@ -378,9 +378,9 @@ pub(crate) async fn do_insert_sanity_check(
     epoch: u64,
     table_id: TableId,
     table_option: TableOption,
-    op_consistent_level: &OpConsistentLevel,
+    op_consistency_level: &OpConsistencyLevel,
 ) -> StorageResult<()> {
-    if let OpConsistentLevel::Inconsistent = op_consistent_level {
+    if let OpConsistencyLevel::Inconsistent = op_consistency_level {
         return Ok(());
     }
     let read_options = ReadOptions {
@@ -410,9 +410,9 @@ pub(crate) async fn do_delete_sanity_check(
     epoch: u64,
     table_id: TableId,
     table_option: TableOption,
-    op_consistent_level: &OpConsistentLevel,
+    op_consistency_level: &OpConsistencyLevel,
 ) -> StorageResult<()> {
-    let OpConsistentLevel::ConsistentOldValue(old_value_checker) = op_consistent_level else {
+    let OpConsistencyLevel::ConsistentOldValue(old_value_checker) = op_consistency_level else {
         return Ok(());
     };
     let read_options = ReadOptions {
@@ -452,9 +452,9 @@ pub(crate) async fn do_update_sanity_check(
     epoch: u64,
     table_id: TableId,
     table_option: TableOption,
-    op_consistent_level: &OpConsistentLevel,
+    op_consistency_level: &OpConsistencyLevel,
 ) -> StorageResult<()> {
-    let OpConsistentLevel::ConsistentOldValue(old_value_checker) = op_consistent_level else {
+    let OpConsistencyLevel::ConsistentOldValue(old_value_checker) = op_consistency_level else {
         return Ok(());
     };
     let read_options = ReadOptions {

--- a/src/storage/src/mem_table.rs
+++ b/src/storage/src/mem_table.rs
@@ -268,7 +268,7 @@ impl MemTable {
                         Ok(())
                     }
                     KeyOp::Update((origin_old_value, original_new_value)) => {
-                        if ENABLE_SANITY_CHECK && value_checker(original_new_value, &old_value) {
+                        if ENABLE_SANITY_CHECK && !value_checker(original_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
                                 key: e.key().clone(),
                                 prev: e.get().clone(),

--- a/src/storage/src/mem_table.rs
+++ b/src/storage/src/mem_table.rs
@@ -54,7 +54,7 @@ pub enum KeyOp {
 #[derive(Clone)]
 pub struct MemTable {
     pub(crate) buffer: MemTableStore,
-    pub(crate) is_consistent_op: bool,
+    pub(crate) op_consistent_level: OpConsistentLevel,
     pub(crate) kv_size: KvSize,
 }
 
@@ -107,17 +107,17 @@ impl RustIteratorBuilder for MemTableIteratorBuilder {
 pub type MemTableHummockIterator<'a> = FromRustIterator<'a, MemTableIteratorBuilder>;
 
 impl MemTable {
-    pub fn new(is_consistent_op: bool) -> Self {
+    pub fn new(op_consistent_level: OpConsistentLevel) -> Self {
         Self {
             buffer: BTreeMap::new(),
-            is_consistent_op,
+            op_consistent_level,
             kv_size: KvSize::new(),
         }
     }
 
     pub fn drain(&mut self) -> Self {
         self.kv_size.set(0);
-        std::mem::replace(self, Self::new(self.is_consistent_op))
+        std::mem::replace(self, Self::new(self.op_consistent_level.clone()))
     }
 
     pub fn is_dirty(&self) -> bool {
@@ -126,7 +126,7 @@ impl MemTable {
 
     /// write methods
     pub fn insert(&mut self, pk: TableKey<Bytes>, value: Bytes) -> Result<()> {
-        if !self.is_consistent_op {
+        if let OpConsistentLevel::Inconsistent = &self.op_consistent_level {
             let key_len = std::mem::size_of::<Bytes>() + pk.len();
             let insert_value = KeyOp::Insert(value);
             self.kv_size.add(&pk, &insert_value);
@@ -134,7 +134,7 @@ impl MemTable {
             self.sub_origin_size(origin_value, key_len);
 
             return Ok(());
-        }
+        };
         let entry = self.buffer.entry(pk);
         match entry {
             Entry::Vacant(e) => {
@@ -169,13 +169,13 @@ impl MemTable {
 
     pub fn delete(&mut self, pk: TableKey<Bytes>, old_value: Bytes) -> Result<()> {
         let key_len = std::mem::size_of::<Bytes>() + pk.len();
-        if !self.is_consistent_op {
+        let OpConsistentLevel::ConsistentOldValue(value_checker) = &self.op_consistent_level else {
             let delete_value = KeyOp::Delete(old_value);
             self.kv_size.add(&pk, &delete_value);
             let origin_value = self.buffer.insert(pk, delete_value);
             self.sub_origin_size(origin_value, key_len);
             return Ok(());
-        }
+        };
         let entry = self.buffer.entry(pk);
         match entry {
             Entry::Vacant(e) => {
@@ -189,7 +189,7 @@ impl MemTable {
                 self.kv_size.sub_val(origin_value);
                 match origin_value {
                     KeyOp::Insert(original_value) => {
-                        if ENABLE_SANITY_CHECK && original_value != &old_value {
+                        if ENABLE_SANITY_CHECK && !value_checker(original_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
@@ -233,7 +233,7 @@ impl MemTable {
         old_value: Bytes,
         new_value: Bytes,
     ) -> Result<()> {
-        if !self.is_consistent_op {
+        let OpConsistentLevel::ConsistentOldValue(value_checker) = &self.op_consistent_level else {
             let key_len = std::mem::size_of::<Bytes>() + pk.len();
 
             let update_value = KeyOp::Update((old_value, new_value));
@@ -241,7 +241,7 @@ impl MemTable {
             let origin_value = self.buffer.insert(pk, update_value);
             self.sub_origin_size(origin_value, key_len);
             return Ok(());
-        }
+        };
         let entry = self.buffer.entry(pk);
         match entry {
             Entry::Vacant(e) => {
@@ -255,7 +255,7 @@ impl MemTable {
                 self.kv_size.sub_val(origin_value);
                 match origin_value {
                     KeyOp::Insert(original_new_value) => {
-                        if ENABLE_SANITY_CHECK && original_new_value != &old_value {
+                        if ENABLE_SANITY_CHECK && !value_checker(original_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
@@ -268,7 +268,7 @@ impl MemTable {
                         Ok(())
                     }
                     KeyOp::Update((origin_old_value, original_new_value)) => {
-                        if ENABLE_SANITY_CHECK && original_new_value != &old_value {
+                        if ENABLE_SANITY_CHECK && value_checker(original_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
@@ -426,7 +426,7 @@ pub struct MemtableLocalStateStore<S: StateStoreWrite + StateStoreRead> {
     epoch: Option<u64>,
 
     table_id: TableId,
-    is_consistent_op: bool,
+    op_consistent_level: OpConsistentLevel,
     table_option: TableOption,
 }
 
@@ -434,10 +434,10 @@ impl<S: StateStoreWrite + StateStoreRead> MemtableLocalStateStore<S> {
     pub fn new(inner: S, option: NewLocalOptions) -> Self {
         Self {
             inner,
-            mem_table: MemTable::new(option.is_consistent_op),
+            mem_table: MemTable::new(option.op_consistent_level.clone()),
             epoch: None,
             table_id: option.table_id,
-            is_consistent_op: option.is_consistent_op,
+            op_consistent_level: option.op_consistent_level,
             table_option: option.table_option,
         }
     }
@@ -524,45 +524,48 @@ impl<S: StateStoreWrite + StateStoreRead> LocalStateStore for MemtableLocalState
             match key_op {
                 // Currently, some executors do not strictly comply with these semantics. As
                 // a workaround you may call disable the check by initializing the
-                // state store with `is_consistent_op=false`.
+                // state store with `op_consistent_level=Inconsistent`.
                 KeyOp::Insert(value) => {
-                    if ENABLE_SANITY_CHECK && self.is_consistent_op {
+                    if ENABLE_SANITY_CHECK {
                         do_insert_sanity_check(
-                            key.clone(),
-                            value.clone(),
+                            &key,
+                            &value,
                             &self.inner,
                             self.epoch(),
                             self.table_id,
                             self.table_option,
+                            &self.op_consistent_level,
                         )
                         .await?;
                     }
                     kv_pairs.push((key, StorageValue::new_put(value)));
                 }
                 KeyOp::Delete(old_value) => {
-                    if ENABLE_SANITY_CHECK && self.is_consistent_op {
+                    if ENABLE_SANITY_CHECK {
                         do_delete_sanity_check(
-                            key.clone(),
-                            old_value,
+                            &key,
+                            &old_value,
                             &self.inner,
                             self.epoch(),
                             self.table_id,
                             self.table_option,
+                            &self.op_consistent_level,
                         )
                         .await?;
                     }
                     kv_pairs.push((key, StorageValue::new_delete()));
                 }
                 KeyOp::Update((old_value, new_value)) => {
-                    if ENABLE_SANITY_CHECK && self.is_consistent_op {
+                    if ENABLE_SANITY_CHECK {
                         do_update_sanity_check(
-                            key.clone(),
-                            old_value,
-                            new_value.clone(),
+                            &key,
+                            &old_value,
+                            &new_value,
                             &self.inner,
                             self.epoch(),
                             self.table_id,
                             self.table_option,
+                            &self.op_consistent_level,
                         )
                         .await?;
                     }
@@ -633,10 +636,13 @@ mod tests {
     use crate::hummock::iterator::HummockIterator;
     use crate::hummock::value::HummockValue;
     use crate::mem_table::{KeyOp, MemTable, MemTableHummockIterator};
+    use crate::store::{OpConsistentLevel, CHECK_BYTES_EQUAL};
 
     #[tokio::test]
     async fn test_mem_table_memory_size() {
-        let mut mem_table = MemTable::new(true);
+        let mut mem_table = MemTable::new(OpConsistentLevel::ConsistentOldValue(
+            CHECK_BYTES_EQUAL.clone(),
+        ));
         assert_eq!(mem_table.kv_size.size(), 0);
 
         mem_table
@@ -746,7 +752,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mem_table_memory_size_not_consistent_op() {
-        let mut mem_table = MemTable::new(false);
+        let mut mem_table = MemTable::new(OpConsistentLevel::Inconsistent);
         assert_eq!(mem_table.kv_size.size(), 0);
 
         mem_table
@@ -829,7 +835,9 @@ mod tests {
         let mut test_data = ordered_test_data.clone();
 
         test_data.shuffle(&mut rng);
-        let mut mem_table = MemTable::new(true);
+        let mut mem_table = MemTable::new(OpConsistentLevel::ConsistentOldValue(
+            CHECK_BYTES_EQUAL.clone(),
+        ));
         for (key, op) in test_data {
             match op {
                 KeyOp::Insert(value) => {

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -20,7 +20,7 @@ use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntCounter};
 use risingwave_connector::sink::log_store::LogStoreFactory;
 use risingwave_connector::sink::{SinkParam, SinkWriterParam};
 use risingwave_pb::catalog::Table;
-use risingwave_storage::store::{NewLocalOptions, OpConsistentLevel};
+use risingwave_storage::store::{NewLocalOptions, OpConsistencyLevel};
 use risingwave_storage::StateStore;
 use tokio::sync::watch;
 
@@ -237,7 +237,7 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
                 table_id: TableId {
                     table_id: self.table_catalog.id,
                 },
-                op_consistent_level: OpConsistentLevel::Inconsistent,
+                op_consistency_level: OpConsistencyLevel::Inconsistent,
                 table_option: TableOption {
                     retention_seconds: None,
                 },

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -20,7 +20,7 @@ use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntCounter};
 use risingwave_connector::sink::log_store::LogStoreFactory;
 use risingwave_connector::sink::{SinkParam, SinkWriterParam};
 use risingwave_pb::catalog::Table;
-use risingwave_storage::store::NewLocalOptions;
+use risingwave_storage::store::{NewLocalOptions, OpConsistentLevel};
 use risingwave_storage::StateStore;
 use tokio::sync::watch;
 
@@ -237,7 +237,7 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
                 table_id: TableId {
                     table_id: self.table_catalog.id,
                 },
-                is_consistent_op: false,
+                op_consistent_level: OpConsistentLevel::Inconsistent,
                 table_option: TableOption {
                     retention_seconds: None,
                 },

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -213,6 +213,9 @@ where
 
 fn consistent_old_value_op(row_serde: impl ValueRowSerde) -> OpConsistencyLevel {
     OpConsistencyLevel::ConsistentOldValue(Arc::new(move |first: &Bytes, second: &Bytes| {
+        if first == second {
+            return true;
+        }
         let first = match row_serde.deserialize(first) {
             Ok(rows) => rows,
             Err(e) => {

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -85,16 +85,7 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
     ) -> Self {
         let arrange_key_indices: Vec<usize> = arrange_key.iter().map(|k| k.column_index).collect();
 
-        let state_table = if table_catalog.version.is_some() {
-            // TODO: If we do some `Delete` after schema change, we cannot ensure the encoded value
-            // with the new version of serializer is the same as the old one, even if they can be
-            // decoded into the same value. The table is now performing consistency check on the raw
-            // bytes, so we need to turn off the check here. We may turn it on if we can compare the
-            // decoded row.
-            StateTableInner::from_table_catalog_inconsistent_op(table_catalog, store, vnodes).await
-        } else {
-            StateTableInner::from_table_catalog(table_catalog, store, vnodes).await
-        };
+        let state_table = StateTableInner::from_table_catalog(table_catalog, store, vnodes).await;
 
         let metrics_info =
             MetricsInfo::new(metrics, table_catalog.id, actor_context.id, "Materialize");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously in local state store, for case `is_consistent_op=true`, we compare the serialized bytes of old value, which may fail the sanity check after schema check. In this PR, we change to pass a dynamic old value checker to perform the old value sanity check. In this way, we can create a dynamic old value checker in state table to deserialize the raw value bytes and compare the row value. 

We change the bool `is_consistent_op` in `NewLocalOptions` to an enum `OpConsistentLevel`. 

The state table of materialized executor has `is_consistent_op=true` even after schema check.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
