### PR TITLE
fix(expr): fix `SOME/ALL/ANY` expression

### DIFF
--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -760,8 +760,6 @@ impl DataChunkTestExt for DataChunk {
             {
                 let datum = match val_str {
                     "." => None,
-                    "t" => Some(true.into()),
-                    "f" => Some(false.into()),
                     "(empty)" => Some("".into()),
                     _ => Some(ScalarImpl::from_text(val_str.as_bytes(), ty).unwrap()),
                 };

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -872,7 +872,7 @@ impl ScalarImpl {
         let res = match data_type {
             DataType::Varchar => Self::Utf8(str.to_string().into()),
             DataType::Boolean => {
-                Self::Bool(bool::from_str(str).map_err(|_| FromSqlError::from_text(str))?)
+                Self::Bool(str_to_bool(str).map_err(|_| FromSqlError::from_text(str))?)
             }
             DataType::Int16 => {
                 Self::Int16(i16::from_str(str).map_err(|_| FromSqlError::from_text(str))?)

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -929,6 +929,9 @@ impl ScalarImpl {
                 }
                 let mut builder = elem_type.create_array_builder(0);
                 for s in str[1..str.len() - 1].split(',') {
+                    if s.is_empty() {
+                        continue;
+                    }
                     builder.append(Some(Self::from_text(s.trim().as_bytes(), elem_type)?));
                 }
                 Self::List(ListValue::new(builder.finish()))

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -931,8 +931,11 @@ impl ScalarImpl {
                 for s in str[1..str.len() - 1].split(',') {
                     if s.is_empty() {
                         continue;
+                    } else if s.eq_ignore_ascii_case("null") {
+                        builder.append_null();
+                    } else {
+                        builder.append(Some(Self::from_text(s.trim().as_bytes(), elem_type)?));
                     }
-                    builder.append(Some(Self::from_text(s.trim().as_bytes(), elem_type)?));
                 }
                 Self::List(ListValue::new(builder.finish()))
             }

--- a/src/expr/core/src/expr/expr_some_all.rs
+++ b/src/expr/core/src/expr/expr_some_all.rs
@@ -288,10 +288,14 @@ mod tests {
             build_from_pretty("$1:boolean"),
         );
         let (input, expected) = DataChunk::from_pretty(
-            "B[]   B
-             {}    f
-             {t,f} t
-             {f,t} t",
+            "B[]        B
+             .          .
+             {}         f
+             {NULL}     .
+             {NULL,f}   .
+             {NULL,t}   t
+             {t,f}      t
+             {f,t}      t", // <- regression test for #14214
         )
         .split_column_at(1);
 
@@ -315,10 +319,14 @@ mod tests {
             build_from_pretty("$1:boolean"),
         );
         let (input, expected) = DataChunk::from_pretty(
-            "B[]   B
-             {}    t
-             {f,f} f
-             {t}   t",
+            "B[]        B
+             .          .
+             {}         t
+             {NULL}     .
+             {NULL,t}   .
+             {NULL,f}   f
+             {f,f}      f
+             {t}        t", // <- regression test for #14214
         )
         .split_column_at(1);
 

--- a/src/expr/core/src/expr/expr_some_all.rs
+++ b/src/expr/core/src/expr/expr_some_all.rs
@@ -284,6 +284,7 @@ mod tests {
         );
         let (input, expected) = DataChunk::from_pretty(
             "B[]   B
+             {}    f
              {t,f} t
              {f,t} t",
         )
@@ -310,6 +311,7 @@ mod tests {
         );
         let (input, expected) = DataChunk::from_pretty(
             "B[]   B
+             {}    t
              {f,f} f
              {t}   t",
         )

--- a/src/expr/core/src/expr/expr_some_all.rs
+++ b/src/expr/core/src/expr/expr_some_all.rs
@@ -49,6 +49,8 @@ impl SomeAllExpression {
         }
     }
 
+    // Notice that this function may not exhaust the iterator,
+    // so never pass an iterator created `by_ref`.
     fn resolve_bools(&self, bools: impl Iterator<Item = Option<bool>>) -> Option<bool> {
         match self.expr_type {
             Type::Some => {

--- a/src/expr/core/src/expr/expr_some_all.rs
+++ b/src/expr/core/src/expr/expr_some_all.rs
@@ -160,12 +160,17 @@ impl Expression for SomeAllExpression {
         );
 
         let func_results = self.func.eval(&data_chunk).await?;
-        let mut func_results_iter = func_results.as_bool().iter();
+        let bools = func_results.as_bool();
+        let mut offset = 0;
         Ok(Arc::new(
             num_array
                 .into_iter()
                 .map(|num| match num {
-                    Some(num) => self.resolve_bools(func_results_iter.by_ref().take(num)),
+                    Some(num) => {
+                        let range = offset..offset + num;
+                        offset += num;
+                        self.resolve_bools(range.map(|i| bools.value_at(i)))
+                    }
                     None => None,
                 })
                 .collect::<BoolArray>()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix #14214, which was introduced by #13402.

```diff
 dev=> select a = any(b) from (values (1, array[1,2]), (1, array[2,1])) as t(a, b);
  ?column? 
 ----------
  t
- f
+ t
 (2 rows)

 dev=> select a = all(b) from (values (1, array[2,3]), (1, array[1])) as t(a, b);
  ?column? 
 ----------
  f
- f
+ t
 (2 rows)
```

When short-circuit occurred, the `resolve_bools` function did not consume all items in the input iterator, causing subsequent booleans to be misaligned.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Fixes the correctness of SOME/ALL/ANY expressions. **The fix introduces a breaking change** for versions from v1.5.0 to v1.5.3. It is recommended to drop and recreate any materialized views that contain `SOME/ALL/ANY` expressions.