### PR TITLE
fix(connector): print Java exception stacktrace in log

### DIFF
--- a/java/connector-node/tracing/pom.xml
+++ b/java/connector-node/tracing/pom.xml
@@ -31,6 +31,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/java/connector-node/tracing/src/main/java/com/risingwave/tracing/TracingSlf4jAdapter.java
+++ b/java/connector-node/tracing/src/main/java/com/risingwave/tracing/TracingSlf4jAdapter.java
@@ -19,6 +19,7 @@ package com.risingwave.tracing;
 
 // Import log4j's ParameterizedMessage, so that we can format the messages
 // with the same interpolation as log4j (i.e. "{}" instead of "%s").
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -73,8 +74,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void trace(String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.TRACE, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.TRACE, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -113,8 +115,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void trace(Marker marker, String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.TRACE, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.TRACE, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -153,8 +156,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void debug(String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.DEBUG, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.DEBUG, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -193,8 +197,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void debug(Marker marker, String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.DEBUG, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.DEBUG, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -233,8 +238,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void info(String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.INFO, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.INFO, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -273,8 +279,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void info(Marker marker, String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.INFO, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.INFO, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -313,8 +320,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void warn(String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.WARN, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.WARN, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -353,8 +361,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void warn(Marker marker, String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.WARN, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.WARN, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -393,8 +402,9 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void error(String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.ERROR, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.ERROR, String.format("%s: %s", msg, sStackTrace));
     }
 
     @Override
@@ -433,7 +443,8 @@ public class TracingSlf4jAdapter implements Logger {
 
     @Override
     public void error(Marker marker, String msg, Throwable t) {
+        String sStackTrace = ExceptionUtils.getStackTrace(t);
         TracingSlf4jImpl.event(
-                name, TracingSlf4jImpl.ERROR, String.format("%s: %s", msg, t.toString()));
+                name, TracingSlf4jImpl.ERROR, String.format("%s: %s", msg, sStackTrace));
     }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,6 +75,7 @@
         <commons.cli.version>1.5.0</commons.cli.version>
         <commons.io.version>2.11.0</commons.io.version>
         <commons.text.version>1.10.0</commons.text.version>
+        <commons.lang3.version>3.12.0</commons.lang3.version>
         <debezium.version>2.4.2.Final</debezium.version>
         <jackson.version>2.13.5</jackson.version>
         <spark_sql.version>3.3.1</spark_sql.version>
@@ -121,6 +122,11 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons.io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons.lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Output after fix:
```
2023-12-29T14:29:15.488752+08:00 ERROR risingwave_connector_node: Internal error on source validation: org.postgresql.util.PSQLException: The connection attempt failed.
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:331)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:49)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:247)
	at org.postgresql.Driver.makeConnection(Driver.java:434)
	at org.postgresql.Driver.connect(Driver.java:291)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:677)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:228)
	at com.risingwave.connector.source.common.PostgresValidator.<init>(PostgresValidator.java:65)
	at com.risingwave.connector.source.SourceValidateHandler.validateSource(SourceValidateHandler.java:96)
	at com.risingwave.connector.source.JniSourceValidateHandler.validate(JniSourceValidateHandler.java:38)
Caused by: java.net.SocketException: Connection reset
	at java.base/java.net.SocketInputStream.read(SocketInputStream.java:186)
	at java.base/java.net.SocketInputStream.read(SocketInputStream.java:140)
	at org.postgresql.core.VisibleBufferedInputStream.readMore(VisibleBufferedInputStream.java:161)
	at org.postgresql.core.VisibleBufferedInputStream.ensureBytes(VisibleBufferedInputStream.java:128)
	at org.postgresql.core.VisibleBufferedInputStream.ensureBytes(VisibleBufferedInputStream.java:113)
	at org.postgresql.core.VisibleBufferedInputStream.read(VisibleBufferedInputStream.java:73)
	at org.postgresql.core.PGStream.receiveChar(PGStream.java:453)
	at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:553)
	at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:168)
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:235)
	... 9 more
 thread="Thread-1" class="com.risingwave.connector.source.JniSourceValidateHandler"
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
