### PR TITLE
fix(over window): fix over window range cache shortcut return

### DIFF
--- a/e2e_test/streaming/over_window/main.slt
+++ b/e2e_test/streaming/over_window/main.slt
@@ -5,22 +5,20 @@ set rw_streaming_over_window_cache_policy = full;
 
 include ./generated/main.slt.part
 
-# TODO(rc): The following tests are temporarily commented out because of recovery test failure.
+statement ok
+set rw_streaming_over_window_cache_policy = recent;
 
-#statement ok
-#set rw_streaming_over_window_cache_policy = recent;
-#
-#include ./generated/main.slt.part
-#
-#statement ok
-#set rw_streaming_over_window_cache_policy = recent_first_n;
-#
-#include ./generated/main.slt.part
-#
-#statement ok
-#set rw_streaming_over_window_cache_policy = recent_last_n;
-#
-#include ./generated/main.slt.part
+include ./generated/main.slt.part
+
+statement ok
+set rw_streaming_over_window_cache_policy = recent_first_n;
+
+include ./generated/main.slt.part
+
+statement ok
+set rw_streaming_over_window_cache_policy = recent_last_n;
+
+include ./generated/main.slt.part
 
 statement ok
 set rw_streaming_over_window_cache_policy = default;

--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -657,6 +657,7 @@ impl<S: StateStore> OverWindowExecutor<S> {
                             this.state_table.update_vnode_bitmap(vnode_bitmap);
                         if cache_may_stale {
                             vars.cached_partitions.clear();
+                            vars.recently_accessed_ranges.clear();
                         }
                     }
 

--- a/src/stream/src/executor/over_window/over_partition.rs
+++ b/src/stream/src/executor/over_window/over_partition.rs
@@ -506,10 +506,9 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
                 .await;
         }
 
-        // get the first and last keys again, now we are guaranteed to have at least a normal key
-        let cache_real_first_key = self.cache_real_first_key().unwrap();
-        let cache_real_last_key = self.cache_real_last_key().unwrap();
-
+        let cache_real_first_key = self
+            .cache_real_first_key()
+            .expect("cache real len is not 0");
         if self.cache_left_is_sentinel() && *range.start() < cache_real_first_key {
             // extend leftward only if there's smallest sentinel
             let table_sub_range = (
@@ -524,11 +523,11 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
                 table_sub_range=?table_sub_range,
                 "loading the left half of given range"
             );
-            return self
-                .extend_cache_by_range_inner(table, table_sub_range)
-                .await;
+            self.extend_cache_by_range_inner(table, table_sub_range)
+                .await?;
         }
 
+        let cache_real_last_key = self.cache_real_last_key().expect("cache real len is not 0");
         if self.cache_right_is_sentinel() && *range.end() > cache_real_last_key {
             // extend rightward only if there's largest sentinel
             let table_sub_range = (
@@ -543,9 +542,8 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
                 table_sub_range=?table_sub_range,
                 "loading the right half of given range"
             );
-            return self
-                .extend_cache_by_range_inner(table, table_sub_range)
-                .await;
+            self.extend_cache_by_range_inner(table, table_sub_range)
+                .await?;
         }
 
         // TODO(rc): Uncomment the following to enable prefetching rows before the start of the


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously the `extend_cache_by_range(self, table, range: RangeInclusive<&StateKey>)` method wrongly shortcut returned after loading the left half of `range`, pseudo-code like below:

```rust
if left_extendable && range.start < first_key_in_cache {
  return extend_cache_by_range_inner(Range(Include(range.start), Exclude(first_key_in_cache)));
}

if right_extendable && range.end > last_key_in_cache {
  return extend_cache_by_range_inner(Range(Exclude(last_key_in_cache), Include(range.end)));
}
```

But it actually should be:

```rust
if left_extendable && range.start < first_key_in_cache {
  extend_cache_by_range_inner(Range(Include(range.start), Exclude(first_key_in_cache)));
}

if right_extendable && range.end > last_key_in_cache {
  extend_cache_by_range_inner(Range(Exclude(last_key_in_cache), Include(range.end)));
}
```

This PR correct it and re-enable e2e tests for range cache.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
