### PR TITLE
test: update `similar-to-escape` to test explicitly disable escape

### DIFF
--- a/e2e_test/batch/functions/similar_to_escape.slt.part
+++ b/e2e_test/batch/functions/similar_to_escape.slt.part
@@ -68,11 +68,21 @@ select 'foobar' similar to '%#"o_b#"%' escape '\';
 ----
 f
 
-# fallback to default escape string
+# disable escape
 query B
-select 'foobar' similar to '%#"o_b#"%' escape '';
+select 'foo\bar' similar to 'foo\%bar' escape '';
+----
+t
+
+query B
+select 'foo\bar' similar to 'foo\%bar' escape '\';
 ----
 f
+
+query B
+select 'foo%bar' similar to 'foo\%bar' escape '\';
+----
+t
 
 query B
 select 'foobar' similar to '%#"o_b#"%' escape '#';

--- a/src/expr/impl/src/scalar/similar_to_escape.rs
+++ b/src/expr/impl/src/scalar/similar_to_escape.rs
@@ -18,7 +18,7 @@ use risingwave_expr::{function, ExprError, Result};
 
 // escape `similar-to` pattern to POSIX regex pattern
 // Adapted from:
-// https://github.com/postgres/postgres/blob/REL_16_STABLE/src/backend/utils/adt/regexp.c#L768
+// https://github.com/postgres/postgres/blob/db4f21e4a34b1d5a3f7123e28e77f575d1a971ea/src/backend/utils/adt/regexp.c#L768
 fn similar_escape_internal(
     pat: &str,
     esc_text: Option<char>,
@@ -58,7 +58,7 @@ fn similar_escape_internal(
 
                 afterescape = false;
             }
-            c if esc_text.is_some() && c == esc_text.unwrap() => {
+            c if esc_text.is_some_and(|t| t == c) => {
                 afterescape = true;
             }
             c if incharclass => {
@@ -220,5 +220,29 @@ mod tests {
         let mut writer = String::new();
         let res = similar_to_escape_with_escape_text(pat, "💅💅", &mut writer);
         assert!(res.is_err())
+    }
+
+    #[test]
+    fn test_escape_with_escape_disabled() {
+        let cases = vec![
+            ("", "^(?:)$"),
+            ("_bcd%", "^(?:.bcd.*)$"),
+            ("bcd%", "^(?:bcd.*)$"),
+            (r#"_bcd\%"#, r#"^(?:.bcd\\.*)$"#),
+            ("bcd[]ee", "^(?:bcd[]ee)$"),
+            (r#"bcd[]ee"""#, r#"^(?:bcd[]ee"")$"#),
+            (r#"bcd[]"ee""#, r#"^(?:bcd[]"ee")$"#),
+            ("bcd[pp]ee", "^(?:bcd[pp]ee)$"),
+            ("bcd[pp_%.]ee", "^(?:bcd[pp_%.]ee)$"),
+            ("bcd[pp_%.]ee_%.", r#"^(?:bcd[pp_%.]ee..*\.)$"#),
+            ("bcd[pp_%.](ee_%.)", r#"^(?:bcd[pp_%.](?:ee..*\.))$"#),
+            (r#"%\"o_b\"%"#, r#"^(?:.*\\"o.b\\".*)$"#),
+        ];
+
+        for (pat, escaped) in cases {
+            let mut writer = String::new();
+            similar_to_escape_with_escape_text(pat, "", &mut writer).ok();
+            assert_eq!(writer, escaped);
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

No functional changes.
Correct previous erroneous tests comment and update some tests to more obviously demonstrate the functionality of disabling escape (by `ESCAPE ''`).

ref: https://www.postgresql.org/docs/16/functions-matching.html#FUNCTIONS-SIMILARTO-REGEXP
> As with `LIKE`, a backslash disables the special meaning of any of these metacharacters. A different escape character can be specified with `ESCAPE`, or the escape capability can be disabled by writing `ESCAPE ''`.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
