### PR TITLE
feat(over window): window function `RANGE` frame support - backend part

### DIFF
--- a/e2e_test/over_window/generated/batch/basic/cross_check.slt.part
+++ b/e2e_test/over_window/generated/batch/basic/cross_check.slt.part
@@ -23,6 +23,16 @@ from v_a natural join v_c;
 
 query i
 select
+    id, out1, out10, out11
+from v_a_d
+except
+select
+    id, out1, out10, out11
+from v_a natural join v_d;
+----
+
+query i
+select
     id, out3, out4, out7, out8, out9
 from v_b_c
 except
@@ -33,10 +43,40 @@ from v_b natural join v_c;
 
 query i
 select
+    id, out3, out4, out10, out11
+from v_b_d
+except
+select
+    id, out3, out4, out10, out11
+from v_b natural join v_d;
+----
+
+query i
+select
+    id, out7, out8, out9, out10, out11
+from v_c_d
+except
+select
+    id, out7, out8, out9, out10, out11
+from v_c natural join v_d;
+----
+
+query i
+select
     id, out1, out2, out3, out4, out5, out6, out7, out8, out9
 from v_a_b_c
 except
 select
     id, out1, out2, out3, out4, out5, out6, out7, out8, out9
 from v_a natural join v_b natural join v_c;
+----
+
+query i
+select
+    id, out1, out2, out3, out4, out5, out6, out7, out8, out9, out10, out11
+from v_a_b_c_d
+except
+select
+    id, out1, out2, out3, out4, out5, out6, out7, out8, out9, out10, out11
+from v_a natural join v_b natural join v_c natural join v_d;
 ----

--- a/e2e_test/over_window/generated/batch/basic/mod.slt.part
+++ b/e2e_test/over_window/generated/batch/basic/mod.slt.part
@@ -35,6 +35,14 @@ select * from v_c order by id;
 100003  100  208  2  723  807  723  NULL  NULL  NULL  NULL
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2124
+100002	100	200	2	700	806	1	2124
+100003	100	208	2	723	807	1	2124
+100004	103	200	2	702	808	2	702
+
 include ./cross_check.slt.part
 
 statement ok
@@ -71,6 +79,16 @@ select * from v_c order by id;
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 100005  100  200  3  717  810  717   700   700  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2124
+100002	100	200	2	700	806	1	2841
+100003	100	208	2	723	807	1	2841
+100004	103	200	2	702	808	2	702
+100005	100	200	3	717	810	1	2140
+100006	105	204	5	703	828	5	703
 
 include ./cross_check.slt.part
 
@@ -113,6 +131,16 @@ select * from v_c order by id;
 100005  100  200  1  717  810  717   723   701   806   806
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
 
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2940
+100002	100	200	2	799	806	1	2940
+100003	100	200	2	723	807	1	2940
+100004	103	200	2	702	808	2	702
+100005	100	200	1	717	810	1	2940
+100006	105	204	5	703	828	5	703
+
 include ./cross_check.slt.part
 
 statement ok
@@ -138,6 +166,13 @@ select * from v_c order by id;
 100001  100  200  1  701  805  701  NULL  NULL   810  NULL
 100005  100  200  1  717  810  717   701   701  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	1418
+100005	100	200	1	717	810	1	1418
+100006	105	204	5	703	828	5	703
 
 include ./cross_check.slt.part
 

--- a/e2e_test/over_window/generated/batch/basic/setup.slt.part
+++ b/e2e_test/over_window/generated/batch/basic/setup.slt.part
@@ -40,6 +40,15 @@ select
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
 from t;
 
+# range frame
+statement ok
+create view v_d as
+select
+    *
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
 statement ok
 create view v_a_b as
 select
@@ -60,6 +69,15 @@ select
 from t;
 
 statement ok
+create view v_a_d as
+select
+    *
+    , first_value(v1) over (partition by p1, p2 order by time, id rows 3 preceding) as out1
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
+statement ok
 create view v_b_c as
 select
     *
@@ -68,6 +86,27 @@ select
     , lag(v1) over (partition by p1, p2 order by time, id) as out7
     , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+from t;
+
+statement ok
+create view v_b_d as
+select
+    *
+    , sum(v1) over (partition by p1, p2 order by time, id rows between unbounded preceding and current row) as out3
+    , min(v1) over (partition by p1, p2 order by time, id rows between current row and unbounded following) as out4
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
+statement ok
+create view v_c_d as
+select
+    *
+    , lag(v1) over (partition by p1, p2 order by time, id) as out7
+    , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
+    , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
 from t;
 
 statement ok
@@ -83,4 +122,21 @@ select
     , lag(v1) over (partition by p1, p2 order by time, id) as out7
     , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+from t;
+
+statement ok
+create view v_a_b_c_d as
+select
+    *
+    , first_value(v1) over (partition by p1, p2 order by time, id rows 3 preceding) as out1
+    , avg(v1) over (partition by p1) as out2
+    , sum(v1) over (partition by p1, p2 order by time, id rows between unbounded preceding and current row) as out3
+    , min(v1) over (partition by p1, p2 order by time, id rows between current row and unbounded following) as out4
+    , lag(v1, 0) over (partition by p1 order by id) as out5
+    , lag(v1, 1) over (partition by p1, p2 order by id) as out6
+    , lag(v1) over (partition by p1, p2 order by time, id) as out7
+    , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
+    , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
 from t;

--- a/e2e_test/over_window/generated/batch/basic/teardown.slt.part
+++ b/e2e_test/over_window/generated/batch/basic/teardown.slt.part
@@ -10,16 +10,31 @@ statement ok
 drop view v_c;
 
 statement ok
-drop view v_a_b;
+drop view v_d;
 
 statement ok
-drop view v_b_c;
+drop view v_a_b;
 
 statement ok
 drop view v_a_c;
 
 statement ok
+drop view v_a_d;
+
+statement ok
+drop view v_b_c;
+
+statement ok
+drop view v_b_d;
+
+statement ok
+drop view v_c_d;
+
+statement ok
 drop view v_a_b_c;
+
+statement ok
+drop view v_a_b_c_d;
 
 statement ok
 drop table t;

--- a/e2e_test/over_window/generated/streaming/basic/cross_check.slt.part
+++ b/e2e_test/over_window/generated/streaming/basic/cross_check.slt.part
@@ -23,6 +23,16 @@ from v_a natural join v_c;
 
 query i
 select
+    id, out1, out10, out11
+from v_a_d
+except
+select
+    id, out1, out10, out11
+from v_a natural join v_d;
+----
+
+query i
+select
     id, out3, out4, out7, out8, out9
 from v_b_c
 except
@@ -33,10 +43,40 @@ from v_b natural join v_c;
 
 query i
 select
+    id, out3, out4, out10, out11
+from v_b_d
+except
+select
+    id, out3, out4, out10, out11
+from v_b natural join v_d;
+----
+
+query i
+select
+    id, out7, out8, out9, out10, out11
+from v_c_d
+except
+select
+    id, out7, out8, out9, out10, out11
+from v_c natural join v_d;
+----
+
+query i
+select
     id, out1, out2, out3, out4, out5, out6, out7, out8, out9
 from v_a_b_c
 except
 select
     id, out1, out2, out3, out4, out5, out6, out7, out8, out9
 from v_a natural join v_b natural join v_c;
+----
+
+query i
+select
+    id, out1, out2, out3, out4, out5, out6, out7, out8, out9, out10, out11
+from v_a_b_c_d
+except
+select
+    id, out1, out2, out3, out4, out5, out6, out7, out8, out9, out10, out11
+from v_a natural join v_b natural join v_c natural join v_d;
 ----

--- a/e2e_test/over_window/generated/streaming/basic/mod.slt.part
+++ b/e2e_test/over_window/generated/streaming/basic/mod.slt.part
@@ -35,6 +35,14 @@ select * from v_c order by id;
 100003  100  208  2  723  807  723  NULL  NULL  NULL  NULL
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2124
+100002	100	200	2	700	806	1	2124
+100003	100	208	2	723	807	1	2124
+100004	103	200	2	702	808	2	702
+
 include ./cross_check.slt.part
 
 statement ok
@@ -71,6 +79,16 @@ select * from v_c order by id;
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 100005  100  200  3  717  810  717   700   700  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2124
+100002	100	200	2	700	806	1	2841
+100003	100	208	2	723	807	1	2841
+100004	103	200	2	702	808	2	702
+100005	100	200	3	717	810	1	2140
+100006	105	204	5	703	828	5	703
 
 include ./cross_check.slt.part
 
@@ -113,6 +131,16 @@ select * from v_c order by id;
 100005  100  200  1  717  810  717   723   701   806   806
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
 
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2940
+100002	100	200	2	799	806	1	2940
+100003	100	200	2	723	807	1	2940
+100004	103	200	2	702	808	2	702
+100005	100	200	1	717	810	1	2940
+100006	105	204	5	703	828	5	703
+
 include ./cross_check.slt.part
 
 statement ok
@@ -138,6 +166,13 @@ select * from v_c order by id;
 100001  100  200  1  701  805  701  NULL  NULL   810  NULL
 100005  100  200  1  717  810  717   701   701  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	1418
+100005	100	200	1	717	810	1	1418
+100006	105	204	5	703	828	5	703
 
 include ./cross_check.slt.part
 

--- a/e2e_test/over_window/generated/streaming/basic/setup.slt.part
+++ b/e2e_test/over_window/generated/streaming/basic/setup.slt.part
@@ -40,6 +40,15 @@ select
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
 from t;
 
+# range frame
+statement ok
+create materialized view v_d as
+select
+    *
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
 statement ok
 create materialized view v_a_b as
 select
@@ -60,6 +69,15 @@ select
 from t;
 
 statement ok
+create materialized view v_a_d as
+select
+    *
+    , first_value(v1) over (partition by p1, p2 order by time, id rows 3 preceding) as out1
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
+statement ok
 create materialized view v_b_c as
 select
     *
@@ -68,6 +86,27 @@ select
     , lag(v1) over (partition by p1, p2 order by time, id) as out7
     , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+from t;
+
+statement ok
+create materialized view v_b_d as
+select
+    *
+    , sum(v1) over (partition by p1, p2 order by time, id rows between unbounded preceding and current row) as out3
+    , min(v1) over (partition by p1, p2 order by time, id rows between current row and unbounded following) as out4
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
+statement ok
+create materialized view v_c_d as
+select
+    *
+    , lag(v1) over (partition by p1, p2 order by time, id) as out7
+    , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
+    , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
 from t;
 
 statement ok
@@ -83,4 +122,21 @@ select
     , lag(v1) over (partition by p1, p2 order by time, id) as out7
     , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+from t;
+
+statement ok
+create materialized view v_a_b_c_d as
+select
+    *
+    , first_value(v1) over (partition by p1, p2 order by time, id rows 3 preceding) as out1
+    , avg(v1) over (partition by p1) as out2
+    , sum(v1) over (partition by p1, p2 order by time, id rows between unbounded preceding and current row) as out3
+    , min(v1) over (partition by p1, p2 order by time, id rows between current row and unbounded following) as out4
+    , lag(v1, 0) over (partition by p1 order by id) as out5
+    , lag(v1, 1) over (partition by p1, p2 order by id) as out6
+    , lag(v1) over (partition by p1, p2 order by time, id) as out7
+    , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
+    , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
 from t;

--- a/e2e_test/over_window/generated/streaming/basic/teardown.slt.part
+++ b/e2e_test/over_window/generated/streaming/basic/teardown.slt.part
@@ -10,16 +10,31 @@ statement ok
 drop materialized view v_c;
 
 statement ok
-drop materialized view v_a_b;
+drop materialized view v_d;
 
 statement ok
-drop materialized view v_b_c;
+drop materialized view v_a_b;
 
 statement ok
 drop materialized view v_a_c;
 
 statement ok
+drop materialized view v_a_d;
+
+statement ok
+drop materialized view v_b_c;
+
+statement ok
+drop materialized view v_b_d;
+
+statement ok
+drop materialized view v_c_d;
+
+statement ok
 drop materialized view v_a_b_c;
+
+statement ok
+drop materialized view v_a_b_c_d;
 
 statement ok
 drop table t;

--- a/e2e_test/over_window/templates/basic/cross_check.slt.part
+++ b/e2e_test/over_window/templates/basic/cross_check.slt.part
@@ -21,6 +21,16 @@ from v_a natural join v_c;
 
 query i
 select
+    id, out1, out10, out11
+from v_a_d
+except
+select
+    id, out1, out10, out11
+from v_a natural join v_d;
+----
+
+query i
+select
     id, out3, out4, out7, out8, out9
 from v_b_c
 except
@@ -31,10 +41,40 @@ from v_b natural join v_c;
 
 query i
 select
+    id, out3, out4, out10, out11
+from v_b_d
+except
+select
+    id, out3, out4, out10, out11
+from v_b natural join v_d;
+----
+
+query i
+select
+    id, out7, out8, out9, out10, out11
+from v_c_d
+except
+select
+    id, out7, out8, out9, out10, out11
+from v_c natural join v_d;
+----
+
+query i
+select
     id, out1, out2, out3, out4, out5, out6, out7, out8, out9
 from v_a_b_c
 except
 select
     id, out1, out2, out3, out4, out5, out6, out7, out8, out9
 from v_a natural join v_b natural join v_c;
+----
+
+query i
+select
+    id, out1, out2, out3, out4, out5, out6, out7, out8, out9, out10, out11
+from v_a_b_c_d
+except
+select
+    id, out1, out2, out3, out4, out5, out6, out7, out8, out9, out10, out11
+from v_a natural join v_b natural join v_c natural join v_d;
 ----

--- a/e2e_test/over_window/templates/basic/mod.slt.part
+++ b/e2e_test/over_window/templates/basic/mod.slt.part
@@ -33,6 +33,14 @@ select * from v_c order by id;
 100003  100  208  2  723  807  723  NULL  NULL  NULL  NULL
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2124
+100002	100	200	2	700	806	1	2124
+100003	100	208	2	723	807	1	2124
+100004	103	200	2	702	808	2	702
+
 include ./cross_check.slt.part
 
 statement ok
@@ -69,6 +77,16 @@ select * from v_c order by id;
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 100005  100  200  3  717  810  717   700   700  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2124
+100002	100	200	2	700	806	1	2841
+100003	100	208	2	723	807	1	2841
+100004	103	200	2	702	808	2	702
+100005	100	200	3	717	810	1	2140
+100006	105	204	5	703	828	5	703
 
 include ./cross_check.slt.part
 
@@ -111,6 +129,16 @@ select * from v_c order by id;
 100005  100  200  1  717  810  717   723   701   806   806
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
 
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	2940
+100002	100	200	2	799	806	1	2940
+100003	100	200	2	723	807	1	2940
+100004	103	200	2	702	808	2	702
+100005	100	200	1	717	810	1	2940
+100006	105	204	5	703	828	5	703
+
 include ./cross_check.slt.part
 
 statement ok
@@ -136,6 +164,13 @@ select * from v_c order by id;
 100001  100  200  1  701  805  701  NULL  NULL   810  NULL
 100005  100  200  1  717  810  717   701   701  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query iiiiiiii
+select * from v_d order by id;
+----
+100001	100	200	1	701	805	1	1418
+100005	100	200	1	717	810	1	1418
+100006	105	204	5	703	828	5	703
 
 include ./cross_check.slt.part
 

--- a/e2e_test/over_window/templates/basic/setup.slt.part
+++ b/e2e_test/over_window/templates/basic/setup.slt.part
@@ -38,6 +38,15 @@ select
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
 from t;
 
+# range frame
+statement ok
+create $view_type v_d as
+select
+    *
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
 statement ok
 create $view_type v_a_b as
 select
@@ -58,6 +67,15 @@ select
 from t;
 
 statement ok
+create $view_type v_a_d as
+select
+    *
+    , first_value(v1) over (partition by p1, p2 order by time, id rows 3 preceding) as out1
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
+statement ok
 create $view_type v_b_c as
 select
     *
@@ -66,6 +84,27 @@ select
     , lag(v1) over (partition by p1, p2 order by time, id) as out7
     , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+from t;
+
+statement ok
+create $view_type v_b_d as
+select
+    *
+    , sum(v1) over (partition by p1, p2 order by time, id rows between unbounded preceding and current row) as out3
+    , min(v1) over (partition by p1, p2 order by time, id rows between current row and unbounded following) as out4
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
+from t;
+
+statement ok
+create $view_type v_c_d as
+select
+    *
+    , lag(v1) over (partition by p1, p2 order by time, id) as out7
+    , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
+    , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
 from t;
 
 statement ok
@@ -81,4 +120,21 @@ select
     , lag(v1) over (partition by p1, p2 order by time, id) as out7
     , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+from t;
+
+statement ok
+create $view_type v_a_b_c_d as
+select
+    *
+    , first_value(v1) over (partition by p1, p2 order by time, id rows 3 preceding) as out1
+    , avg(v1) over (partition by p1) as out2
+    , sum(v1) over (partition by p1, p2 order by time, id rows between unbounded preceding and current row) as out3
+    , min(v1) over (partition by p1, p2 order by time, id rows between current row and unbounded following) as out4
+    , lag(v1, 0) over (partition by p1 order by id) as out5
+    , lag(v1, 1) over (partition by p1, p2 order by id) as out6
+    , lag(v1) over (partition by p1, p2 order by time, id) as out7
+    , lead(v2, 1) over (partition by p1, p2 order by time, id) as out8
+    , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
+    , last_value(time) over (partition by p1 order by time desc range between current row and 2 following) as out10
+    , sum(v1) over (partition by p1 order by time range between 1 preceding and 1 following) as out11
 from t;

--- a/e2e_test/over_window/templates/basic/teardown.slt.part
+++ b/e2e_test/over_window/templates/basic/teardown.slt.part
@@ -8,16 +8,31 @@ statement ok
 drop $view_type v_c;
 
 statement ok
-drop $view_type v_a_b;
+drop $view_type v_d;
 
 statement ok
-drop $view_type v_b_c;
+drop $view_type v_a_b;
 
 statement ok
 drop $view_type v_a_c;
 
 statement ok
+drop $view_type v_a_d;
+
+statement ok
+drop $view_type v_b_c;
+
+statement ok
+drop $view_type v_b_d;
+
+statement ok
+drop $view_type v_c_d;
+
+statement ok
 drop $view_type v_a_b_c;
+
+statement ok
+drop $view_type v_a_b_c_d;
 
 statement ok
 drop table t;

--- a/src/batch/src/executor/sort_over_window.rs
+++ b/src/batch/src/executor/sort_over_window.rs
@@ -16,7 +16,6 @@ use futures_async_stream::try_stream;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::row::{OwnedRow, Row, RowExt};
-use risingwave_common::types::DataType;
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::memcmp_encoding::{self, MemcmpEncoded};
@@ -45,7 +44,6 @@ struct ExecutorInner {
     calls: Vec<WindowFuncCall>,
     partition_key_indices: Vec<usize>,
     order_key_indices: Vec<usize>,
-    order_key_data_types: Vec<DataType>,
     order_key_order_types: Vec<OrderType>,
     chunk_size: usize,
 }
@@ -73,7 +71,7 @@ impl BoxedExecutorBuilder for SortOverWindowExecutor {
             .iter()
             .map(|i| *i as usize)
             .collect();
-        let (order_key_indices, order_key_order_types): (Vec<_>, Vec<_>) = node
+        let (order_key_indices, order_key_order_types) = node
             .get_order_by()
             .iter()
             .map(ColumnOrder::from_protobuf)
@@ -85,11 +83,6 @@ impl BoxedExecutorBuilder for SortOverWindowExecutor {
             schema.fields.push(Field::unnamed(call.return_type.clone()));
         });
 
-        let order_key_data_types = order_key_indices
-            .iter()
-            .map(|i| schema[*i].data_type())
-            .collect();
-
         Ok(Box::new(Self {
             child,
             schema,
@@ -100,7 +93,6 @@ impl BoxedExecutorBuilder for SortOverWindowExecutor {
                 calls,
                 partition_key_indices,
                 order_key_indices,
-                order_key_data_types,
                 order_key_order_types,
                 chunk_size: source.context.get_config().developer.chunk_size,
             },

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -600,6 +600,27 @@ pub trait ToOwnedDatum {
     fn to_owned_datum(self) -> Datum;
 }
 
+impl ToOwnedDatum for Datum {
+    #[inline(always)]
+    fn to_owned_datum(self) -> Datum {
+        self
+    }
+}
+
+impl ToOwnedDatum for &Datum {
+    #[inline(always)]
+    fn to_owned_datum(self) -> Datum {
+        self.clone()
+    }
+}
+
+impl ToOwnedDatum for Option<&ScalarImpl> {
+    #[inline(always)]
+    fn to_owned_datum(self) -> Datum {
+        self.cloned()
+    }
+}
+
 impl ToOwnedDatum for DatumRef<'_> {
     #[inline(always)]
     fn to_owned_datum(self) -> Datum {

--- a/src/common/src/types/sentinel.rs
+++ b/src/common/src/types/sentinel.rs
@@ -54,6 +54,21 @@ impl<T> Sentinelled<T> {
             (Normal(a), Normal(b)) => cmp_fn(a, b),
         }
     }
+
+    pub fn map<U>(self, map_fn: impl FnOnce(T) -> U) -> Sentinelled<U> {
+        use Sentinelled::*;
+        match self {
+            Smallest => Smallest,
+            Normal(inner) => Normal(map_fn(inner)),
+            Largest => Largest,
+        }
+    }
+}
+
+impl<T> From<T> for Sentinelled<T> {
+    fn from(inner: T) -> Self {
+        Self::Normal(inner)
+    }
 }
 
 impl<T> PartialOrd for Sentinelled<T>

--- a/src/expr/core/src/window_function/call.rs
+++ b/src/expr/core/src/window_function/call.rs
@@ -468,7 +468,7 @@ impl RangeFrameBounds {
     }
 }
 
-#[derive(Display, Debug, Clone, Copy, Eq, PartialEq, Hash, EnumAsInner)]
+#[derive(Display, Debug, Clone, Eq, PartialEq, Hash, EnumAsInner)]
 #[display(style = "TITLE CASE")]
 pub enum FrameBound<T> {
     UnboundedPreceding,
@@ -532,7 +532,7 @@ impl<T> FrameBound<T> {
 
 impl<T> FrameBound<T>
 where
-    FrameBound<T>: Copy,
+    T: Copy,
 {
     fn reverse(self) -> FrameBound<T> {
         match self {

--- a/src/expr/core/src/window_function/call.rs
+++ b/src/expr/core/src/window_function/call.rs
@@ -19,9 +19,13 @@ use std::sync::Arc;
 use anyhow::Context;
 use educe::Educe;
 use enum_as_inner::EnumAsInner;
+use futures_util::FutureExt;
 use parse_display::Display;
-use risingwave_common::types::{DataType, Datum, IsNegative, ScalarImpl, ScalarRefImpl, ToText};
-use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::row::OwnedRow;
+use risingwave_common::types::{
+    DataType, Datum, IsNegative, ScalarImpl, ScalarRefImpl, Sentinelled, ToOwnedDatum, ToText,
+};
+use risingwave_common::util::sort_util::{Direction, OrderType};
 use risingwave_common::util::value_encoding::{DatumFromProtoExt, DatumToProtoExt};
 use risingwave_common::{bail, must_match};
 use risingwave_pb::expr::window_frame::{
@@ -34,7 +38,8 @@ use FrameBound::{CurrentRow, Following, Preceding, UnboundedFollowing, Unbounded
 use super::WindowFuncKind;
 use crate::aggregate::AggArgs;
 use crate::expr::{
-    build_func, BoxedExpression, ExpressionBoxExt, InputRefExpression, LiteralExpression,
+    build_func, BoxedExpression, Expression, ExpressionBoxExt, InputRefExpression,
+    LiteralExpression,
 };
 use crate::Result;
 
@@ -296,11 +301,9 @@ pub struct RangeFrameOffset {
     /// The original offset value.
     offset: ScalarImpl,
     /// Built expression for `$0 + offset`.
-    #[expect(dead_code)]
     #[educe(PartialEq(ignore), Hash(ignore))]
     add_expr: Option<Arc<BoxedExpression>>,
     /// Built expression for `$0 - offset`.
-    #[expect(dead_code)]
     #[educe(PartialEq(ignore), Hash(ignore))]
     sub_expr: Option<Arc<BoxedExpression>>,
 }
@@ -379,7 +382,93 @@ impl FrameBoundsImpl for RangeFrameBounds {
     }
 }
 
-#[derive(Display, Debug, Clone, Eq, PartialEq, Hash, EnumAsInner)]
+impl RangeFrameBounds {
+    /// Get the frame start for a given order column value.
+    ///
+    /// ## Examples
+    ///
+    /// For the following frames:
+    ///
+    /// ```sql
+    /// ORDER BY x ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    /// ORDER BY x DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    /// ```
+    ///
+    /// For any CURRENT ROW with any order value, the frame start is always the first-most row, which is
+    /// represented by [`Sentinelled::Smallest`].
+    ///
+    /// For the following frame:
+    ///
+    /// ```sql
+    /// ORDER BY x ASC RANGE BETWEEN 10 PRECEDING AND CURRENT ROW
+    /// ```
+    ///
+    /// For CURRENT ROW with order value `100`, the frame start is the **FIRST** row with order value `90`.
+    ///
+    /// For the following frame:
+    ///
+    /// ```sql
+    /// ORDER BY x DESC RANGE BETWEEN 10 PRECEDING AND CURRENT ROW
+    /// ```
+    ///
+    /// For CURRENT ROW with order value `100`, the frame start is the **FIRST** row with order value `110`.
+    pub fn frame_start_of(&self, order_value: impl ToOwnedDatum) -> Sentinelled<Datum> {
+        self.start.for_calc().bound_of(order_value, self.order_type)
+    }
+
+    /// Get the frame end for a given order column value. It's very similar to `frame_start_of`, just with
+    /// everything on the other direction.
+    pub fn frame_end_of(&self, order_value: impl ToOwnedDatum) -> Sentinelled<Datum> {
+        self.end.for_calc().bound_of(order_value, self.order_type)
+    }
+
+    /// Get the order value of the CURRENT ROW of the first frame that includes the given order value.
+    ///
+    /// ## Examples
+    ///
+    /// For the following frames:
+    ///
+    /// ```sql
+    /// ORDER BY x ASC RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+    /// ORDER BY x DESC RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+    /// ```
+    ///
+    /// For any given order value, the first CURRENT ROW is always the first-most row, which is
+    /// represented by [`Sentinelled::Smallest`].
+    ///
+    /// For the following frame:
+    ///
+    /// ```sql
+    /// ORDER BY x ASC RANGE BETWEEN CURRENT ROW AND 10 FOLLOWING
+    /// ```
+    ///
+    /// For a given order value `100`, the first CURRENT ROW should have order value `90`.
+    ///
+    /// For the following frame:
+    ///
+    /// ```sql
+    /// ORDER BY x DESC RANGE BETWEEN CURRENT ROW AND 10 FOLLOWING
+    /// ```
+    ///
+    /// For a given order value `100`, the first CURRENT ROW should have order value `110`.
+    pub fn first_curr_of(&self, order_value: impl ToOwnedDatum) -> Sentinelled<Datum> {
+        self.end
+            .for_calc()
+            .reverse()
+            .bound_of(order_value, self.order_type)
+    }
+
+    /// Get the order value of the CURRENT ROW of the last frame that includes the given order value.
+    /// It's very similar to `first_curr_of`, just with everything on the other direction.
+    pub fn last_curr_of(&self, order_value: impl ToOwnedDatum) -> Sentinelled<Datum> {
+        self.start
+            .for_calc()
+            .reverse()
+            .bound_of(order_value, self.order_type)
+    }
+}
+
+#[derive(Display, Debug, Clone, Copy, Eq, PartialEq, Hash, EnumAsInner)]
 #[display(style = "TITLE CASE")]
 pub enum FrameBound<T> {
     UnboundedPreceding,
@@ -437,6 +526,21 @@ impl<T> FrameBound<T> {
             CurrentRow => CurrentRow,
             Following(offset) => Following(f(offset)),
             UnboundedFollowing => UnboundedFollowing,
+        }
+    }
+}
+
+impl<T> FrameBound<T>
+where
+    FrameBound<T>: Copy,
+{
+    fn reverse(self) -> FrameBound<T> {
+        match self {
+            UnboundedPreceding => UnboundedFollowing,
+            Preceding(offset) => Following(offset),
+            CurrentRow => CurrentRow,
+            Following(offset) => Preceding(offset),
+            UnboundedFollowing => UnboundedPreceding,
         }
     }
 }
@@ -570,6 +674,58 @@ impl RangeFrameBound {
             Following(offset) => Following(offset.as_scalar_ref_impl().to_text()),
             UnboundedFollowing => UnboundedFollowing,
         }
+    }
+
+    fn for_calc(&self) -> FrameBound<RangeFrameOffsetRef<'_>> {
+        match self {
+            UnboundedPreceding => UnboundedPreceding,
+            Preceding(offset) => Preceding(RangeFrameOffsetRef {
+                add_expr: offset.add_expr.as_ref().unwrap().as_ref(),
+                sub_expr: offset.sub_expr.as_ref().unwrap().as_ref(),
+            }),
+            CurrentRow => CurrentRow,
+            Following(offset) => Following(RangeFrameOffsetRef {
+                add_expr: offset.add_expr.as_ref().unwrap().as_ref(),
+                sub_expr: offset.sub_expr.as_ref().unwrap().as_ref(),
+            }),
+            UnboundedFollowing => UnboundedFollowing,
+        }
+    }
+}
+
+#[derive(Debug, Educe)]
+#[educe(Clone, Copy)]
+pub struct RangeFrameOffsetRef<'a> {
+    /// Built expression for `$0 + offset`.
+    add_expr: &'a dyn Expression,
+    /// Built expression for `$0 - offset`.
+    sub_expr: &'a dyn Expression,
+}
+
+impl FrameBound<RangeFrameOffsetRef<'_>> {
+    fn bound_of(self, order_value: impl ToOwnedDatum, order_type: OrderType) -> Sentinelled<Datum> {
+        let expr = match (self, order_type.direction()) {
+            (UnboundedPreceding, _) => return Sentinelled::Smallest,
+            (UnboundedFollowing, _) => return Sentinelled::Largest,
+            (CurrentRow, _) => return Sentinelled::Normal(order_value.to_owned_datum()),
+            (Preceding(offset), Direction::Ascending)
+            | (Following(offset), Direction::Descending) => {
+                // should SUBTRACT the offset
+                offset.sub_expr
+            }
+            (Following(offset), Direction::Ascending)
+            | (Preceding(offset), Direction::Descending) => {
+                // should ADD the offset
+                offset.add_expr
+            }
+        };
+        let row = OwnedRow::new(vec![order_value.to_owned_datum()]);
+        Sentinelled::Normal(
+            expr.eval_row(&row)
+                .now_or_never()
+                .expect("frame bound calculation should finish immediately")
+                .expect("just simple calculation, should succeed"), // TODO(rc): handle overflow
+        )
     }
 }
 

--- a/src/expr/core/src/window_function/state/aggregate.rs
+++ b/src/expr/core/src/window_function/state/aggregate.rs
@@ -22,7 +22,7 @@ use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::{bail, must_match};
 use smallvec::SmallVec;
 
-use super::buffer::{RowsWindow, WindowBuffer, WindowImpl};
+use super::buffer::{RangeWindow, RowsWindow, WindowBuffer, WindowImpl};
 use super::{BoxedWindowState, StateEvictHint, StateKey, StatePos, WindowState};
 use crate::aggregate::{
     AggArgs, AggCall, AggregateFunction, AggregateState as AggImplState, BoxedAggregateFunction,
@@ -90,9 +90,17 @@ pub(super) fn new(call: &WindowFuncCall) -> Result<BoxedWindowState> {
             ),
             buffer_heap_size: KvSize::new(),
         }) as BoxedWindowState,
-        FrameBounds::Range(_) => {
-            todo!("`RANGE` frame should be temporarily banned in `LogicalOverWindow`")
-        }
+        FrameBounds::Range(frame_bounds) => Box::new(AggregateState {
+            agg_func,
+            agg_impl,
+            arg_data_types,
+            buffer: WindowBuffer::<RangeWindow<StateValue>>::new(
+                RangeWindow::new(frame_bounds.clone()),
+                call.frame.exclusion,
+                enable_delta,
+            ),
+            buffer_heap_size: KvSize::new(),
+        }) as BoxedWindowState,
     };
     Ok(this)
 }

--- a/src/expr/core/src/window_function/state/buffer.rs
+++ b/src/expr/core/src/window_function/state/buffer.rs
@@ -397,7 +397,6 @@ impl<V: Clone> WindowImpl for RangeWindow<V> {
             self.frame_bounds.order_type,
         )
         .expect("no reason to fail here because we just encoded it in memory");
-        println!("[rc] curr_order_value = {:?}", curr_order_value);
 
         match self.frame_bounds.frame_start_of(&curr_order_value) {
             Sentinelled::Smallest => {
@@ -433,19 +432,6 @@ impl<V: Clone> WindowImpl for RangeWindow<V> {
             }
             Sentinelled::Smallest => unreachable!("frame end never be UNBOUNDED PRECEDING"),
         }
-
-        println!(
-            "[rc] buffer: {:?}",
-            buffer_ref
-                .buffer
-                .iter()
-                .map(|elem| &elem.key)
-                .collect::<Vec<_>>()
-        );
-        println!(
-            "[rc] left = {}, right excl = {}, curr = {}",
-            buffer_ref.left_idx, buffer_ref.right_excl_idx, buffer_ref.curr_idx
-        );
     }
 }
 

--- a/src/expr/core/src/window_function/state/buffer.rs
+++ b/src/expr/core/src/window_function/state/buffer.rs
@@ -336,6 +336,7 @@ impl<K: Ord, V: Clone> WindowImpl for RowsWindow<K, V> {
     }
 }
 
+/// The sliding window implementation for `RANGE` frames.
 pub(super) struct RangeWindow<V: Clone> {
     frame_bounds: RangeFrameBounds,
     _phantom: std::marker::PhantomData<V>,

--- a/src/expr/core/src/window_function/state/buffer.rs
+++ b/src/expr/core/src/window_function/state/buffer.rs
@@ -17,10 +17,13 @@ use std::ops::Range;
 
 use educe::Educe;
 use risingwave_common::array::Op;
+use risingwave_common::types::Sentinelled;
+use risingwave_common::util::memcmp_encoding;
 
 use super::range_utils::range_except;
+use super::StateKey;
 use crate::window_function::state::range_utils::range_diff;
-use crate::window_function::{FrameExclusion, RowsFrameBounds};
+use crate::window_function::{FrameExclusion, RangeFrameBounds, RowsFrameBounds};
 
 /// A common sliding window buffer.
 pub(super) struct WindowBuffer<W: WindowImpl> {
@@ -330,6 +333,119 @@ impl<K: Ord, V: Clone> WindowImpl for RowsWindow<K, V> {
             // unbounded end
             *buffer_ref.right_excl_idx = buffer_ref.buffer.len();
         }
+    }
+}
+
+pub(super) struct RangeWindow<V: Clone> {
+    frame_bounds: RangeFrameBounds,
+    _phantom: std::marker::PhantomData<V>,
+}
+
+impl<V: Clone> RangeWindow<V> {
+    pub fn new(frame_bounds: RangeFrameBounds) -> Self {
+        Self {
+            frame_bounds,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<V: Clone> WindowImpl for RangeWindow<V> {
+    type Key = StateKey;
+    type Value = V;
+
+    fn preceding_saturated(&self, buffer_ref: BufferRef<'_, Self::Key, Self::Value>) -> bool {
+        buffer_ref.curr_idx < buffer_ref.buffer.len() && {
+            // XXX(rc): It seems that preceding saturation is not important, may remove later.
+            true
+        }
+    }
+
+    fn following_saturated(&self, buffer_ref: BufferRef<'_, Self::Key, Self::Value>) -> bool {
+        buffer_ref.curr_idx < buffer_ref.buffer.len()
+            && {
+                // Left OK? (note that `left_idx` can be greater than `right_idx`)
+                // The following line checks whether the left value is the last one in the buffer.
+                // Here we adopt a conservative approach, which means we assume the next future value
+                // is likely to be the same as the last value in the current window, in which case
+                // we can't say the current window is saturated.
+                buffer_ref.left_idx < buffer_ref.buffer.len() /* non-zero */ - 1
+            }
+            && {
+                // Right OK? Ditto.
+                buffer_ref.right_excl_idx < buffer_ref.buffer.len()
+            }
+    }
+
+    fn recalculate_left_right(&self, buffer_ref: BufferRefMut<'_, Self::Key, Self::Value>) {
+        if buffer_ref.buffer.is_empty() {
+            *buffer_ref.left_idx = 0;
+            *buffer_ref.right_excl_idx = 0;
+        }
+
+        let Some(entry) = buffer_ref.buffer.get(*buffer_ref.curr_idx) else {
+            // If the current index has been moved to a future position, we can't touch anything
+            // because the next coming key may equal to the previous one which means the left and
+            // right indices will be the same.
+            return;
+        };
+        let curr_key = &entry.key;
+
+        let curr_order_value = memcmp_encoding::decode_value(
+            &self.frame_bounds.order_data_type,
+            &curr_key.order_key,
+            self.frame_bounds.order_type,
+        )
+        .expect("no reason to fail here because we just encoded it in memory");
+        println!("[rc] curr_order_value = {:?}", curr_order_value);
+
+        match self.frame_bounds.frame_start_of(&curr_order_value) {
+            Sentinelled::Smallest => {
+                // unbounded frame start
+                assert_eq!(
+                    *buffer_ref.left_idx, 0,
+                    "for unbounded start, left index should always be 0"
+                );
+            }
+            Sentinelled::Normal(value) => {
+                // bounded, find the start position
+                let value_enc = memcmp_encoding::encode_value(value, self.frame_bounds.order_type)
+                    .expect("no reason to fail here");
+                *buffer_ref.left_idx = buffer_ref
+                    .buffer
+                    .partition_point(|elem| elem.key.order_key < value_enc);
+            }
+            Sentinelled::Largest => unreachable!("frame start never be UNBOUNDED FOLLOWING"),
+        }
+
+        match self.frame_bounds.frame_end_of(curr_order_value) {
+            Sentinelled::Largest => {
+                // unbounded frame end
+                *buffer_ref.right_excl_idx = buffer_ref.buffer.len();
+            }
+            Sentinelled::Normal(value) => {
+                // bounded, find the end position
+                let value_enc = memcmp_encoding::encode_value(value, self.frame_bounds.order_type)
+                    .expect("no reason to fail here");
+                *buffer_ref.right_excl_idx = buffer_ref
+                    .buffer
+                    .partition_point(|elem| elem.key.order_key <= value_enc);
+            }
+            Sentinelled::Smallest => unreachable!("frame end never be UNBOUNDED PRECEDING"),
+        }
+
+        println!(
+            "[rc] buffer: {:?}",
+            buffer_ref
+                .buffer
+                .iter()
+                .map(|elem| &elem.key)
+                .collect::<Vec<_>>()
+        );
+        println!(
+            "[rc] left = {}, right excl = {}, curr = {}",
+            buffer_ref.left_idx, buffer_ref.right_excl_idx, buffer_ref.curr_idx
+        );
     }
 }
 

--- a/src/expr/core/src/window_function/state/mod.rs
+++ b/src/expr/core/src/window_function/state/mod.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 use itertools::Itertools;
 use risingwave_common::estimate_size::EstimateSize;
 use risingwave_common::row::OwnedRow;
-use risingwave_common::types::{Datum, DefaultOrdered, Sentinelled};
+use risingwave_common::types::{Datum, DefaultOrdered};
 use risingwave_common::util::memcmp_encoding::MemcmpEncoded;
 use smallvec::SmallVec;
 
@@ -34,12 +34,6 @@ mod rank;
 pub struct StateKey {
     pub order_key: MemcmpEncoded,
     pub pk: DefaultOrdered<OwnedRow>,
-}
-
-impl From<StateKey> for Sentinelled<StateKey> {
-    fn from(key: StateKey) -> Self {
-        Self::Normal(key)
-    }
 }
 
 #[derive(Debug)]

--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -135,16 +135,16 @@
     select x, y, max(x) over(PARTITION BY y ORDER BY x RANGE 100 PRECEDING) from t;
   expected_outputs:
     - logical_plan
-    - stream_error
-    - batch_error
+    - stream_plan
+    - batch_plan
 - id: aggregate with over clause, range frame definition with between
   sql: |
     create table t(x int, y int);
     select x, y, max(x) over(PARTITION BY y ORDER BY x RANGE BETWEEN 100 PRECEDING and UNBOUNDED FOLLOWING) from t;
   expected_outputs:
     - logical_plan
-    - stream_error
-    - batch_error
+    - stream_plan
+    - batch_plan
 - id: aggregate with over clause, unbounded range, with ORDER BY
   sql: |
     create table t(x int, y int);
@@ -556,20 +556,20 @@
 - sql: |
     create table t (i int, bi bigint, d decimal, f float, da date, t time, ts timestamp, tstz timestamptz, itv interval);
     select
-        count(*) over (partition by 1::int order by i range 1 preceding),
-        count(*) over (partition by 1::int order by bi range 1 preceding),
-        count(*) over (partition by 1::int order by d range 1.5 preceding),
-        count(*) over (partition by 1::int order by f range 1.5 preceding),
-        -- count(*) over (partition by 1::int order by da range '1 day' preceding), -- `date` not supported yet
-        -- count(*) over (partition by 1::int order by t range '1 min' preceding), -- `time` not supported yet
-        count(*) over (partition by 1::int order by ts range '1 day 1 hour' preceding),
-        count(*) over (partition by 1::int order by tstz range '1 min' preceding)
+        count(*) over (partition by 1::int order by i range 1 preceding) as col1,
+        count(*) over (partition by 1::int order by bi range 1 preceding) as col2,
+        count(*) over (partition by 1::int order by d range 1.5 preceding) as col3,
+        count(*) over (partition by 1::int order by f range 1.5 preceding) as col4,
+        -- count(*) over (partition by 1::int order by da range '1 day' preceding) as col5, -- `date` not supported yet
+        -- count(*) over (partition by 1::int order by t range '1 min' preceding) as col6, -- `time` not supported yet
+        count(*) over (partition by 1::int order by ts range '1 day 1 hour' preceding) as col7,
+        count(*) over (partition by 1::int order by tstz range '1 min' preceding) as col8
     from t;
   expected_outputs:
     - logical_plan
     - optimized_logical_plan_for_stream
-    - stream_error
-    - batch_error
+    - stream_plan
+    - batch_plan
 - sql: |
     create table t (i int, bi bigint, d decimal, f float, da date, t time, ts timestamp, tstz timestamptz, itv interval);
     select

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -264,12 +264,17 @@
     └─LogicalOverWindow { window_functions: [max(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC RANGE BETWEEN 100 PRECEDING AND CURRENT ROW)] }
       └─LogicalProject { exprs: [t.x, t.y, t._row_id] }
         └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
-  batch_error: |-
-    Feature is not yet implemented: Window function with `RANGE` frame is not supported yet
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
-  stream_error: |-
-    Feature is not yet implemented: Window function with `RANGE` frame is not supported yet
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchOverWindow { window_functions: [max(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC RANGE BETWEEN 100 PRECEDING AND CURRENT ROW)] }
+      └─BatchExchange { order: [t.y ASC, t.x ASC], dist: HashShard(t.y) }
+        └─BatchSort { order: [t.y ASC, t.x ASC] }
+          └─BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, t._row_id(hidden), max], stream_key: [t._row_id, y], pk_columns: [t._row_id, y], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [max(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC RANGE BETWEEN 100 PRECEDING AND CURRENT ROW)] }
+      └─StreamExchange { dist: HashShard(t.y) }
+        └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - id: aggregate with over clause, range frame definition with between
   sql: |
     create table t(x int, y int);
@@ -279,12 +284,17 @@
     └─LogicalOverWindow { window_functions: [max(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC RANGE BETWEEN 100 PRECEDING AND UNBOUNDED FOLLOWING)] }
       └─LogicalProject { exprs: [t.x, t.y, t._row_id] }
         └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
-  batch_error: |-
-    Feature is not yet implemented: Window function with `RANGE` frame is not supported yet
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
-  stream_error: |-
-    Feature is not yet implemented: Window function with `RANGE` frame is not supported yet
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchOverWindow { window_functions: [max(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC RANGE BETWEEN 100 PRECEDING AND UNBOUNDED FOLLOWING)] }
+      └─BatchExchange { order: [t.y ASC, t.x ASC], dist: HashShard(t.y) }
+        └─BatchSort { order: [t.y ASC, t.x ASC] }
+          └─BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, t._row_id(hidden), max], stream_key: [t._row_id, y], pk_columns: [t._row_id, y], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [max(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC RANGE BETWEEN 100 PRECEDING AND UNBOUNDED FOLLOWING)] }
+      └─StreamExchange { dist: HashShard(t.y) }
+        └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - id: aggregate with over clause, unbounded range, with ORDER BY
   sql: |
     create table t(x int, y int);
@@ -1128,14 +1138,14 @@
 - sql: |
     create table t (i int, bi bigint, d decimal, f float, da date, t time, ts timestamp, tstz timestamptz, itv interval);
     select
-        count(*) over (partition by 1::int order by i range 1 preceding),
-        count(*) over (partition by 1::int order by bi range 1 preceding),
-        count(*) over (partition by 1::int order by d range 1.5 preceding),
-        count(*) over (partition by 1::int order by f range 1.5 preceding),
-        -- count(*) over (partition by 1::int order by da range '1 day' preceding), -- `date` not supported yet
-        -- count(*) over (partition by 1::int order by t range '1 min' preceding), -- `time` not supported yet
-        count(*) over (partition by 1::int order by ts range '1 day 1 hour' preceding),
-        count(*) over (partition by 1::int order by tstz range '1 min' preceding)
+        count(*) over (partition by 1::int order by i range 1 preceding) as col1,
+        count(*) over (partition by 1::int order by bi range 1 preceding) as col2,
+        count(*) over (partition by 1::int order by d range 1.5 preceding) as col3,
+        count(*) over (partition by 1::int order by f range 1.5 preceding) as col4,
+        -- count(*) over (partition by 1::int order by da range '1 day' preceding) as col5, -- `date` not supported yet
+        -- count(*) over (partition by 1::int order by t range '1 min' preceding) as col6, -- `time` not supported yet
+        count(*) over (partition by 1::int order by ts range '1 day 1 hour' preceding) as col7,
+        count(*) over (partition by 1::int order by tstz range '1 min' preceding) as col8
     from t;
   logical_plan: |-
     LogicalProject { exprs: [count, count, count, count, count, count] }
@@ -1157,12 +1167,46 @@
                         └─LogicalOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.i ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)] }
                           └─LogicalProject { exprs: [t.i, t.bi, t.d, t.f, t.ts, t.tstz, 1:Int32] }
                             └─LogicalScan { table: t, columns: [t.i, t.bi, t.d, t.f, t.ts, t.tstz] }
-  batch_error: |-
-    Feature is not yet implemented: Window function with `RANGE` frame is not supported yet
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
-  stream_error: |-
-    Feature is not yet implemented: Window function with `RANGE` frame is not supported yet
-    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [count, count, count, count, count, count] }
+      └─BatchOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.tstz ASC RANGE BETWEEN 00:01:00 PRECEDING AND CURRENT ROW)] }
+        └─BatchSort { order: [1:Int32 ASC, t.tstz ASC] }
+          └─BatchProject { exprs: [t.tstz, 1:Int32, count, count, count, count, count] }
+            └─BatchOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.ts ASC RANGE BETWEEN 1 day 01:00:00 PRECEDING AND CURRENT ROW)] }
+              └─BatchSort { order: [1:Int32 ASC, t.ts ASC] }
+                └─BatchProject { exprs: [t.ts, t.tstz, 1:Int32, count, count, count, count] }
+                  └─BatchOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.f ASC RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW)] }
+                    └─BatchSort { order: [1:Int32 ASC, t.f ASC] }
+                      └─BatchProject { exprs: [t.f, t.ts, t.tstz, 1:Int32, count, count, count] }
+                        └─BatchOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.d ASC RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW)] }
+                          └─BatchSort { order: [1:Int32 ASC, t.d ASC] }
+                            └─BatchProject { exprs: [t.d, t.f, t.ts, t.tstz, 1:Int32, count, count] }
+                              └─BatchOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.bi ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)] }
+                                └─BatchSort { order: [1:Int32 ASC, t.bi ASC] }
+                                  └─BatchProject { exprs: [t.bi, t.d, t.f, t.ts, t.tstz, 1:Int32, count] }
+                                    └─BatchOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.i ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)] }
+                                      └─BatchExchange { order: [1:Int32 ASC, t.i ASC], dist: HashShard(1:Int32) }
+                                        └─BatchSort { order: [1:Int32 ASC, t.i ASC] }
+                                          └─BatchProject { exprs: [t.i, t.bi, t.d, t.f, t.ts, t.tstz, 1:Int32] }
+                                            └─BatchScan { table: t, columns: [t.i, t.bi, t.d, t.f, t.ts, t.tstz], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [col1, col2, col3, col4, col7, col8, t._row_id(hidden), 1:Int32(hidden)], stream_key: [t._row_id, 1:Int32], pk_columns: [t._row_id, 1:Int32], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [count, count, count, count, count, count, t._row_id, 1:Int32] }
+      └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.tstz ASC RANGE BETWEEN 00:01:00 PRECEDING AND CURRENT ROW)] }
+        └─StreamProject { exprs: [t.tstz, 1:Int32, count, count, count, count, count, t._row_id] }
+          └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.ts ASC RANGE BETWEEN 1 day 01:00:00 PRECEDING AND CURRENT ROW)] }
+            └─StreamProject { exprs: [t.ts, t.tstz, 1:Int32, count, count, count, count, t._row_id] }
+              └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.f ASC RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW)] }
+                └─StreamProject { exprs: [t.f, t.ts, t.tstz, 1:Int32, count, count, count, t._row_id] }
+                  └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.d ASC RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW)] }
+                    └─StreamProject { exprs: [t.d, t.f, t.ts, t.tstz, 1:Int32, count, count, t._row_id] }
+                      └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.bi ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)] }
+                        └─StreamProject { exprs: [t.bi, t.d, t.f, t.ts, t.tstz, 1:Int32, count, t._row_id] }
+                          └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY 1:Int32 ORDER BY t.i ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)] }
+                            └─StreamExchange { dist: HashShard(1:Int32) }
+                              └─StreamProject { exprs: [t.i, t.bi, t.d, t.f, t.ts, t.tstz, 1:Int32, t._row_id] }
+                                └─StreamTableScan { table: t, columns: [t.i, t.bi, t.d, t.f, t.ts, t.tstz, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (i int, bi bigint, d decimal, f float, da date, t time, ts timestamp, tstz timestamptz, itv interval);
     select

--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -718,14 +718,6 @@ impl ToBatch for LogicalOverWindow {
             "must apply OverWindowSplitRule before generating physical plan"
         );
 
-        if self
-            .window_functions()
-            .iter()
-            .any(|wf| wf.frame.bounds.is_range())
-        {
-            bail_not_implemented!("Window function with `RANGE` frame is not supported yet");
-        }
-
         // TODO(rc): Let's not introduce too many cases at once. Later we may decide to support
         // empty PARTITION BY by simply removing the following check.
         let partition_key_indices = self.window_functions()[0]
@@ -754,14 +746,6 @@ impl ToStream for LogicalOverWindow {
             self.core.funcs_have_same_partition_and_order(),
             "must apply OverWindowSplitRule before generating physical plan"
         );
-
-        if self
-            .window_functions()
-            .iter()
-            .any(|wf| wf.frame.bounds.is_range())
-        {
-            bail_not_implemented!("Window function with `RANGE` frame is not supported yet");
-        }
 
         let stream_input = self.core.input.to_stream(ctx)?;
 

--- a/src/stream/src/executor/over_window/frame_finder.rs
+++ b/src/stream/src/executor/over_window/frame_finder.rs
@@ -18,8 +18,12 @@
 use std::ops::Bound;
 
 use delta_btree_map::DeltaBTreeMap;
+use itertools::Itertools;
 use risingwave_common::row::OwnedRow;
-use risingwave_expr::window_function::{FrameBound, RowsFrameBounds};
+use risingwave_common::types::{Datum, Sentinelled, ToDatumRef};
+use risingwave_common::util::memcmp_encoding;
+use risingwave_common::util::sort_util::cmp_datum;
+use risingwave_expr::window_function::{FrameBound, RangeFrameBounds, RowsFrameBounds, StateKey};
 
 use super::over_partition::CacheKey;
 
@@ -141,6 +145,73 @@ pub(super) fn find_frame_end_for_rows_frame<'cache>(
     curr_key: &'cache CacheKey,
 ) -> &'cache CacheKey {
     find_boundary_for_rows_frame::<false /* RIGHT */>(frame_bounds, part_with_delta, curr_key)
+}
+
+/// Given the first and last key in delta, calculate the order values of the first
+/// and the last frames logically affected by some `RANGE` frames.
+pub(super) fn calc_logical_curr_for_range_frames(
+    range_frames: &[&RangeFrameBounds],
+    delta_first_key: &StateKey,
+    delta_last_key: &StateKey,
+) -> Option<(Sentinelled<Datum>, Sentinelled<Datum>)> {
+    calc_logical_ord_for_range_frames(
+        range_frames,
+        delta_first_key,
+        delta_last_key,
+        |bounds, v| bounds.first_curr_of(v),
+        |bounds, v| bounds.last_curr_of(v),
+    )
+}
+
+/// Given the curr keys of the first and the last affected frames, calculate the order
+/// values of the logical start row of the first frame and the logical end row of the
+/// last frame.
+pub(super) fn calc_logical_boundary_for_range_frames(
+    range_frames: &[&RangeFrameBounds],
+    first_curr_key: &StateKey,
+    last_curr_key: &StateKey,
+) -> Option<(Sentinelled<Datum>, Sentinelled<Datum>)> {
+    calc_logical_ord_for_range_frames(
+        range_frames,
+        first_curr_key,
+        last_curr_key,
+        |bounds, v| bounds.frame_start_of(v),
+        |bounds, v| bounds.frame_end_of(v),
+    )
+}
+
+/// Given a left logical order value (e.g. first curr order value, first delta order value),
+/// find the most closed cache key in `part_with_delta`. Ideally this function returns
+/// the smallest key that is larger than or equal to the given logical order (using `lower_bound`).
+pub(super) fn find_left_for_range_frames<'cache>(
+    range_frames: &[&RangeFrameBounds],
+    part_with_delta: DeltaBTreeMap<'cache, CacheKey, OwnedRow>,
+    logical_order_value: impl ToDatumRef,
+    cache_key_pk_len: usize, // this is dirty but we have no better choice
+) -> &'cache CacheKey {
+    find_for_range_frames::<true>(
+        range_frames,
+        part_with_delta,
+        logical_order_value,
+        cache_key_pk_len,
+    )
+}
+
+/// Given a right logical order value (e.g. last curr order value, last delta order value),
+/// find the most closed cache key in `part_with_delta`. Ideally this function returns
+/// the largest key that is smaller than or equal to the given logical order (using `lower_bound`).
+pub(super) fn find_right_for_range_frames<'cache>(
+    range_frames: &[&RangeFrameBounds],
+    part_with_delta: DeltaBTreeMap<'cache, CacheKey, OwnedRow>,
+    logical_order_value: impl ToDatumRef,
+    cache_key_pk_len: usize, // this is dirty but we have no better choice
+) -> &'cache CacheKey {
+    find_for_range_frames::<false>(
+        range_frames,
+        part_with_delta,
+        logical_order_value,
+        cache_key_pk_len,
+    )
 }
 
 // -------------------------- ↑ PUBLIC INTERFACE ↑ --------------------------
@@ -308,6 +379,143 @@ fn find_boundary_for_rows_frame<'cache, const LEFT: bool>(
             }
         })
         .unwrap()
+}
+
+/// Given a pair of left and right state keys, calculate the leftmost (smallest) and rightmost
+/// (largest) order values after the two given `offset_fn`s are applied, for all range frames.
+///
+/// A more vivid description may be: Given a pair of left and right keys, this function pushes
+/// the keys leftward and rightward respectively according to the given `offset_fn`s.
+///
+/// This is not very understandable but we have to extract the code to a function to avoid
+/// repeating. Check [`calc_logical_curr_for_range_frames`] and [`calc_logical_boundary_for_range_frames`]
+/// if you cannot understand the purpose of this function.
+fn calc_logical_ord_for_range_frames(
+    range_frames: &[&RangeFrameBounds],
+    left_key: &StateKey,
+    right_key: &StateKey,
+    left_offset_fn: impl Fn(&RangeFrameBounds, &Datum) -> Sentinelled<Datum>,
+    right_offset_fn: impl Fn(&RangeFrameBounds, &Datum) -> Sentinelled<Datum>,
+) -> Option<(Sentinelled<Datum>, Sentinelled<Datum>)> {
+    if range_frames.is_empty() {
+        return None;
+    }
+
+    let (data_type, order_type) = range_frames
+        .iter()
+        .map(|bounds| (&bounds.order_data_type, bounds.order_type))
+        .all_equal_value()
+        .unwrap();
+
+    let datum_cmp = |a: &Datum, b: &Datum| cmp_datum(a, b, order_type);
+
+    let left_given_ord = memcmp_encoding::decode_value(data_type, &left_key.order_key, order_type)
+        .expect("no reason to fail because we just encoded it in memory");
+    let right_given_ord =
+        memcmp_encoding::decode_value(data_type, &right_key.order_key, order_type)
+            .expect("no reason to fail because we just encoded it in memory");
+
+    let logical_left_offset_ord = {
+        let mut order_value = None;
+        for bounds in range_frames {
+            let new_order_value = left_offset_fn(bounds, &left_given_ord);
+            order_value = match (order_value, new_order_value) {
+                (None, any_new) => Some(any_new),
+                (Some(old), new) => Some(std::cmp::min_by(old, new, |x, y| x.cmp_by(y, datum_cmp))),
+            };
+            if !order_value.as_ref().unwrap().is_normal() {
+                // already unbounded
+                assert!(
+                    order_value.as_ref().unwrap().is_smallest(),
+                    "left order value should never be `Largest`"
+                );
+                break;
+            }
+        }
+        order_value.expect("# of range frames > 0")
+    };
+
+    let logical_right_offset_ord = {
+        let mut order_value = None;
+        for bounds in range_frames {
+            let new_order_value = right_offset_fn(bounds, &right_given_ord);
+            order_value = match (order_value, new_order_value) {
+                (None, any_new) => Some(any_new),
+                (Some(old), new) => Some(std::cmp::max_by(old, new, |x, y| x.cmp_by(y, datum_cmp))),
+            };
+            if !order_value.as_ref().unwrap().is_normal() {
+                // already unbounded
+                assert!(
+                    order_value.as_ref().unwrap().is_largest(),
+                    "right order value should never be `Smallest`"
+                );
+                break;
+            }
+        }
+        order_value.expect("# of range frames > 0")
+    };
+
+    Some((logical_left_offset_ord, logical_right_offset_ord))
+}
+
+fn find_for_range_frames<'cache, const LEFT: bool>(
+    range_frames: &[&RangeFrameBounds],
+    part_with_delta: DeltaBTreeMap<'cache, CacheKey, OwnedRow>,
+    logical_order_value: impl ToDatumRef,
+    cache_key_pk_len: usize,
+) -> &'cache CacheKey {
+    debug_assert!(
+        part_with_delta.first_key().is_some(),
+        "must have something in the range cache after applying delta"
+    );
+
+    let order_type = range_frames
+        .iter()
+        .map(|bounds| bounds.order_type)
+        .all_equal_value()
+        .unwrap();
+
+    let search_key = Sentinelled::Normal(StateKey {
+        order_key: memcmp_encoding::encode_value(logical_order_value, order_type)
+            .expect("the data type is simple, should succeed"),
+        pk: if LEFT {
+            OwnedRow::empty() // empty row is minimal
+        } else {
+            OwnedRow::new(vec![None; cache_key_pk_len]) // all-NULL row is maximal in default order
+        }
+        .into(),
+    });
+
+    if LEFT {
+        let cursor = part_with_delta.lower_bound(Bound::Included(&search_key));
+        if let Some((prev_key, _)) = cursor.peek_prev()
+            && prev_key.is_smallest()
+        {
+            // If the found lower bound of search key is right behind a smallest sentinel,
+            // we don't know if there's any other rows with the same order key in the state
+            // table but not in cache. We should conservatively return the sentinel key as
+            // the curr key.
+            prev_key
+        } else {
+            // If cursor is in ghost position, it simply means that the search key is larger
+            // than any existing key. Returning the last key in this case does no harm. Especially,
+            // if the last key is largest sentinel, the caller should extend the cache rightward
+            // to get possible entries with the same order value into the cache.
+            cursor.key().or_else(|| part_with_delta.last_key()).unwrap()
+        }
+    } else {
+        let cursor = part_with_delta.upper_bound(Bound::Included(&search_key));
+        if let Some((next_key, _)) = cursor.peek_next()
+            && next_key.is_largest()
+        {
+            next_key
+        } else {
+            cursor
+                .key()
+                .or_else(|| part_with_delta.first_key())
+                .unwrap()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -171,7 +171,9 @@ impl<S: StateStore> OverWindowExecutor<S> {
             .calls
             .iter()
             .any(|call| call.frame.bounds.is_unbounded());
-        let cache_policy = if has_unbounded_frame {
+        // TODO(rc): only support full cache for `RANGE` frame for now, for the sake of simplicity
+        let has_range_frame = args.calls.iter().any(|call| call.frame.bounds.is_range());
+        let cache_policy = if has_unbounded_frame || has_range_frame {
             // For unbounded frames, we finally need all entries of the partition in the cache,
             // so for simplicity we just use full cache policy for these cases.
             CachePolicy::Full
@@ -182,7 +184,7 @@ impl<S: StateStore> OverWindowExecutor<S> {
         let order_key_data_types = args
             .order_key_indices
             .iter()
-            .map(|i| input_schema.fields()[*i].data_type.clone())
+            .map(|i| input_schema[*i].data_type())
             .collect();
 
         let state_key_to_table_sub_pk_proj = RowConverter::calc_state_key_to_table_sub_pk_proj(

--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -171,9 +171,7 @@ impl<S: StateStore> OverWindowExecutor<S> {
             .calls
             .iter()
             .any(|call| call.frame.bounds.is_unbounded());
-        // TODO(rc): only support full cache for `RANGE` frame for now, for the sake of simplicity
-        let has_range_frame = args.calls.iter().any(|call| call.frame.bounds.is_range());
-        let cache_policy = if has_unbounded_frame || has_range_frame {
+        let cache_policy = if has_unbounded_frame {
             // For unbounded frames, we finally need all entries of the partition in the cache,
             // so for simplicity we just use full cache policy for these cases.
             CachePolicy::Full

--- a/src/stream/src/executor/over_window/over_partition.rs
+++ b/src/stream/src/executor/over_window/over_partition.rs
@@ -26,8 +26,10 @@ use risingwave_common::array::stream_record::Record;
 use risingwave_common::estimate_size::collections::EstimatedBTreeMap;
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::session_config::OverWindowCachePolicy as CachePolicy;
-use risingwave_common::types::Sentinelled;
-use risingwave_expr::window_function::{RowsFrameBounds, StateKey, WindowFuncCall};
+use risingwave_common::types::{Datum, Sentinelled};
+use risingwave_expr::window_function::{
+    RangeFrameBounds, RowsFrameBounds, StateKey, WindowFuncCall,
+};
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::StateStore;
 
@@ -268,6 +270,7 @@ pub(super) struct OverPartition<'a, S: StateStore> {
     /// The `ROWS` frame that is the union of all `ROWS` frames of all window functions in this
     /// over window executor.
     super_rows_frame_bounds: RowsFrameBounds,
+    range_frames: Vec<&'a RangeFrameBounds>,
     start_is_unbounded: bool,
     end_is_unbounded: bool,
     row_conv: RowConverter<'a>,
@@ -294,6 +297,10 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             .collect::<Vec<_>>();
         // TODO(rc): maybe should avoid repeated merging
         let super_rows_frame_bounds = merge_rows_frames(&rows_frames);
+        let range_frames = calls
+            .iter()
+            .filter_map(|call| call.frame.bounds.as_range())
+            .collect::<Vec<_>>();
 
         let start_is_unbounded = calls
             .iter()
@@ -308,6 +315,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             cache_policy,
 
             super_rows_frame_bounds,
+            range_frames,
             start_is_unbounded,
             end_is_unbounded,
             row_conv,
@@ -423,10 +431,16 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
         let delta_first = delta.first_key_value().unwrap().0.as_normal_expect();
         let delta_last = delta.last_key_value().unwrap().0.as_normal_expect();
 
+        let range_frame_logical_curr =
+            calc_logical_curr_for_range_frames(&self.range_frames, delta_first, delta_last);
+
         if self.cache_policy.is_full() {
             // ensure everything is in the cache
             self.extend_cache_to_boundary(table).await?;
         } else {
+            // TODO(rc): later we should extend cache using `self.super_rows_frame_bounds` and
+            // `range_frame_logical_curr` as hints.
+
             // ensure the cache covers all delta (if possible)
             self.extend_cache_by_range(table, delta_first..=delta_last)
                 .await?;
@@ -445,7 +459,8 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             let part_with_delta = DeltaBTreeMap::new(cache_inner, delta);
 
             self.stats.lookup_count += 1;
-            let res = self.find_affected_ranges_readonly(part_with_delta);
+            let res = self
+                .find_affected_ranges_readonly(part_with_delta, range_frame_logical_curr.as_ref());
 
             let (need_extend_leftward, need_extend_rightward) = match res {
                 Ok(ranges) => return Ok((part_with_delta, ranges)),
@@ -479,6 +494,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
     fn find_affected_ranges_readonly<'cache>(
         &'_ self,
         part_with_delta: DeltaBTreeMap<'cache, CacheKey, OwnedRow>,
+        range_frame_logical_curr: Option<&(Sentinelled<Datum>, Sentinelled<Datum>)>,
     ) -> std::result::Result<Vec<AffectedRange<'cache>>, (bool, bool)> {
         if part_with_delta.first_key().is_none() {
             // nothing is left after applying the delta, meaning all entries are deleted
@@ -487,6 +503,7 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
 
         let delta_first_key = part_with_delta.delta().first_key_value().unwrap().0;
         let delta_last_key = part_with_delta.delta().last_key_value().unwrap().0;
+        let cache_key_pk_len = delta_first_key.as_normal_expect().pk.len();
 
         if part_with_delta.snapshot().is_empty() {
             // all existing keys are inserted in the delta
@@ -506,22 +523,48 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             // to the first key is always affected.
             first_key
         } else {
-            find_first_curr_for_rows_frame(
+            let mut key = find_first_curr_for_rows_frame(
                 &self.super_rows_frame_bounds,
                 part_with_delta,
                 delta_first_key,
-            )
+            );
+
+            if let Some((logical_first_curr, _)) = range_frame_logical_curr {
+                let logical_curr = logical_first_curr.as_normal_expect(); // otherwise should go `end_is_unbounded` branch
+                let new_key = find_left_for_range_frames(
+                    &self.range_frames,
+                    part_with_delta,
+                    logical_curr,
+                    cache_key_pk_len,
+                );
+                key = std::cmp::min(key, new_key);
+            }
+
+            key
         };
 
         let last_curr_key = if self.start_is_unbounded || delta_last_key == last_key {
             // similar to `first_curr_key`
             last_key
         } else {
-            find_last_curr_for_rows_frame(
+            let mut key = find_last_curr_for_rows_frame(
                 &self.super_rows_frame_bounds,
                 part_with_delta,
                 delta_last_key,
-            )
+            );
+
+            if let Some((_, logical_last_curr)) = range_frame_logical_curr {
+                let logical_curr = logical_last_curr.as_normal_expect(); // otherwise should go `start_is_unbounded` branch
+                let new_key = find_right_for_range_frames(
+                    &self.range_frames,
+                    part_with_delta,
+                    logical_curr,
+                    cache_key_pk_len,
+                );
+                key = std::cmp::max(key, new_key);
+            }
+
+            key
         };
 
         {
@@ -553,16 +596,35 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             return Ok(vec![]);
         }
 
+        let range_frame_logical_boundary = calc_logical_boundary_for_range_frames(
+            &self.range_frames,
+            first_curr_key.as_normal_expect(),
+            last_curr_key.as_normal_expect(),
+        );
+
         let first_frame_start = if self.start_is_unbounded || first_curr_key == first_key {
             // If the frame start is unbounded, or, the first curr key is the first key, then the first key
             // always need to be included in the affected range.
             first_key
         } else {
-            find_frame_start_for_rows_frame(
+            let mut key = find_frame_start_for_rows_frame(
                 &self.super_rows_frame_bounds,
                 part_with_delta,
                 first_curr_key,
-            )
+            );
+
+            if let Some((logical_first_start, _)) = range_frame_logical_boundary.as_ref() {
+                let logical_boundary = logical_first_start.as_normal_expect(); // otherwise should go `end_is_unbounded` branch
+                let new_key = find_left_for_range_frames(
+                    &self.range_frames,
+                    part_with_delta,
+                    logical_boundary,
+                    cache_key_pk_len,
+                );
+                key = std::cmp::min(key, new_key);
+            }
+
+            key
         };
         assert!(first_frame_start <= first_curr_key);
 
@@ -570,11 +632,24 @@ impl<'a, S: StateStore> OverPartition<'a, S> {
             // similar to `first_frame_start`
             last_key
         } else {
-            find_frame_end_for_rows_frame(
+            let mut key = find_frame_end_for_rows_frame(
                 &self.super_rows_frame_bounds,
                 part_with_delta,
                 last_curr_key,
-            )
+            );
+
+            if let Some((_, logical_last_end)) = range_frame_logical_boundary.as_ref() {
+                let logical_boundary = logical_last_end.as_normal_expect(); // otherwise should go `end_is_unbounded` branch
+                let new_key = find_right_for_range_frames(
+                    &self.range_frames,
+                    part_with_delta,
+                    logical_boundary,
+                    cache_key_pk_len,
+                );
+                key = std::cmp::max(key, new_key);
+            }
+
+            key
         };
         assert!(last_frame_end >= last_curr_key);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR implements the real `RANGE` frame support in backend executors. Resolves #11109.

The basic idea to support `RANGE` frame in `find_affected_ranges` is to:

1. Calculate the logical order column values of the first and last *current row/key* for a given set of delta;
2. Try to find the cache keys that are closest to the logical order values calculated in step 1;
3. Compare with the first/last *current key* of `ROWS` frames, choose the minimum/maximum one as the final first/last *current key*;
4. Calculate the logical order column values of the first frame start and last frame end, similar to step 1;
5. Try to find the closest cache keys, similar to step 2;
6. Compare with the first/last frame start/end of `ROWS` frames, choose the minimum/maximum one, similar to step 3.

The basic idea to support `RANGE` frame in `WindowBuffer` is to:

1. Calculate the logical order column values of the frame start and frame end for a given *current key*;
2. Try to find the closest ones in the buffer.

118x out of 17xx lines of addition are tests, reviewers plz don't panic.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

- Support `RANGE` frames in window function calls.

</details>
