### PR TITLE
refactor: local barrier manager use prev epoch to track barrier state

### DIFF
--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -297,11 +297,20 @@ impl LocalBarrierWorker {
     fn notify_failure(&mut self, actor_id: ActorId, err: StreamError) {
         let err = err.into_unexpected_exit(actor_id);
         if let Some(prev_err) = self.failure_actors.insert(actor_id, err.clone()) {
-            warn!(?actor_id, prev_err = %prev_err.as_report(), "actor error overwritten");
+            warn!(
+                actor_id,
+                prev_err = %prev_err.as_report(),
+                "actor error overwritten"
+            );
         }
         for (fail_epoch, notifier) in self.state.notifiers_await_on_actor(actor_id) {
             if notifier.send(Err(err.clone())).is_err() {
-                warn!(?fail_epoch, ?actor_id, err = ?err.as_report(), "fail to notify actor failure");
+                warn!(
+                    fail_epoch,
+                    actor_id,
+                    err = %err.as_report(),
+                    "fail to notify actor failure"
+                );
             }
         }
     }

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -14,17 +14,19 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::once;
+use std::ops::Sub;
+use std::sync::Arc;
 
+use prometheus::HistogramTimer;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_service::barrier_complete_response::CreateMviewProgress;
 use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
-use thiserror_ext::AsReport;
 use tokio::sync::oneshot;
 
 use super::progress::BackfillState;
 use super::CollectResult;
-use crate::error::{IntoUnexpectedExit, StreamError, StreamResult};
-use crate::executor::monitor::GLOBAL_STREAMING_METRICS;
+use crate::error::StreamResult;
+use crate::executor::monitor::StreamingMetrics;
 use crate::executor::Barrier;
 use crate::task::ActorId;
 
@@ -45,50 +47,59 @@ enum ManagedBarrierStateInner {
 
         /// Notify that the collection is finished.
         collect_notifier: Option<oneshot::Sender<StreamResult<CollectResult>>>,
+
+        barrier_inflight_latency: HistogramTimer,
     },
 }
 
 #[derive(Debug)]
 pub(super) struct BarrierState {
-    prev_epoch: u64,
+    curr_epoch: u64,
     inner: ManagedBarrierStateInner,
     kind: BarrierKind,
 }
 
-#[derive(Debug)]
 pub(super) struct ManagedBarrierState {
     /// Record barrier state for each epoch of concurrent checkpoints.
     ///
-    /// The key is curr_epoch, and the first value is prev_epoch
+    /// The key is prev_epoch, and the first value is curr_epoch
     epoch_barrier_state_map: BTreeMap<u64, BarrierState>,
 
     /// Record the progress updates of creating mviews for each epoch of concurrent checkpoints.
     pub(super) create_mview_progress: HashMap<u64, HashMap<ActorId, BackfillState>>,
 
-    /// Record all unexpected exited actors.
-    failure_actors: HashMap<ActorId, StreamError>,
+    pub(super) state_store: StateStoreImpl,
 
-    state_store: StateStoreImpl,
+    pub(super) streaming_metrics: Arc<StreamingMetrics>,
 }
 
 impl ManagedBarrierState {
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self::new(
+            StateStoreImpl::for_test(),
+            Arc::new(StreamingMetrics::unused()),
+        )
+    }
+
     /// Create a barrier manager state. This will be called only once.
-    pub(super) fn new(state_store: StateStoreImpl) -> Self {
+    pub(super) fn new(
+        state_store: StateStoreImpl,
+        streaming_metrics: Arc<StreamingMetrics>,
+    ) -> Self {
         Self {
             epoch_barrier_state_map: BTreeMap::default(),
             create_mview_progress: Default::default(),
-            failure_actors: Default::default(),
             state_store,
+            streaming_metrics,
         }
     }
 
     /// Notify if we have collected barriers from all actor ids. The state must be `Issued`.
-    fn may_notify(&mut self, curr_epoch: u64) {
+    fn may_notify(&mut self, prev_epoch: u64) {
         // Report if there's progress on the earliest in-flight barrier.
-        if self.epoch_barrier_state_map.keys().next() == Some(&curr_epoch) {
-            if let Some(metrics) = GLOBAL_STREAMING_METRICS.get() {
-                metrics.barrier_manager_progress.inc();
-            }
+        if self.epoch_barrier_state_map.keys().next() == Some(&prev_epoch) {
+            self.streaming_metrics.barrier_manager_progress.inc();
         }
 
         while let Some(entry) = self.epoch_barrier_state_map.first_entry() {
@@ -103,10 +114,23 @@ impl ManagedBarrierState {
                 break;
             }
 
-            let (epoch, barrier_state) = entry.remove_entry();
+            let (prev_epoch, barrier_state) = entry.remove_entry();
+
+            let collect_notifier = match barrier_state.inner {
+                ManagedBarrierStateInner::Issued {
+                    collect_notifier,
+                    barrier_inflight_latency: timer,
+                    ..
+                } => {
+                    timer.observe_duration();
+                    collect_notifier
+                }
+                _ => unreachable!(),
+            };
+
             let create_mview_progress = self
                 .create_mview_progress
-                .remove(&epoch)
+                .remove(&barrier_state.curr_epoch)
                 .unwrap_or_default()
                 .into_iter()
                 .map(|(actor, state)| CreateMviewProgress {
@@ -114,7 +138,7 @@ impl ManagedBarrierState {
                     done: matches!(state, BackfillState::Done(_)),
                     consumed_epoch: match state {
                         BackfillState::ConsumingUpstream(consumed_epoch, _) => consumed_epoch,
-                        BackfillState::Done(_) => epoch,
+                        BackfillState::Done(_) => barrier_state.curr_epoch,
                     },
                     consumed_rows: match state {
                         BackfillState::ConsumingUpstream(_, consumed_rows) => consumed_rows,
@@ -127,77 +151,76 @@ impl ManagedBarrierState {
             match kind {
                 BarrierKind::Unspecified => unreachable!(),
                 BarrierKind::Initial => tracing::info!(
-                    epoch = barrier_state.prev_epoch,
+                    epoch = prev_epoch,
                     "ignore sealing data for the first barrier"
                 ),
                 BarrierKind::Barrier | BarrierKind::Checkpoint => {
                     dispatch_state_store!(&self.state_store, state_store, {
-                        state_store.seal_epoch(barrier_state.prev_epoch, kind.is_checkpoint());
+                        state_store.seal_epoch(prev_epoch, kind.is_checkpoint());
                     });
                 }
             }
 
-            match barrier_state.inner {
-                ManagedBarrierStateInner::Issued {
-                    collect_notifier, ..
-                } => {
-                    // Notify about barrier finishing.
-                    let result = CollectResult {
-                        create_mview_progress,
-                        kind,
-                    };
-                    if collect_notifier.unwrap().send(Ok(result)).is_err() {
-                        warn!("failed to notify barrier collection with epoch {}", epoch)
-                    }
+            if let Some(notifier) = collect_notifier {
+                // Notify about barrier finishing.
+                let result = CollectResult {
+                    create_mview_progress,
+                    kind,
+                };
+
+                if notifier.send(Ok(result)).is_err() {
+                    warn!(
+                        "failed to notify barrier collection with epoch {}",
+                        prev_epoch
+                    )
                 }
-                _ => unreachable!(),
             }
         }
     }
 
-    /// Clear and reset all states.
-    pub(crate) fn clear_all_states(&mut self) {
-        tracing::debug!("clear all states in local barrier manager");
-
-        *self = Self::new(self.state_store.clone());
-    }
-
-    /// Notify unexpected actor exit with given `actor_id`.
-    pub(crate) fn notify_failure(&mut self, actor_id: ActorId, err: StreamError) {
-        // Attach the actor id to the error.
-        let err = err.into_unexpected_exit(actor_id);
-
-        for barrier_state in self.epoch_barrier_state_map.values_mut() {
-            #[allow(clippy::single_match)]
-            match barrier_state.inner {
-                ManagedBarrierStateInner::Issued {
-                    ref remaining_actors,
-                    ref mut collect_notifier,
-                } => {
-                    if remaining_actors.contains(&actor_id)
-                        && let Some(collect_notifier) = collect_notifier.take()
-                        && collect_notifier.send(Err(err.clone())).is_err()
-                    {
-                        warn!(error = %err.as_report(), actor_id, "failed to notify actor exiting");
+    /// Returns an iterator on the notifiers of epochs that is awaiting on `actor_id`.
+    /// This is used on notifying actor failure. On actor failure, the
+    /// barrier manager can call this method to iterate on notifiers of epochs that
+    /// waits on the failed actor and then notify failure on the result
+    /// sender of the epoch.
+    pub(crate) fn notifiers_await_on_actor(
+        &mut self,
+        actor_id: ActorId,
+    ) -> impl Iterator<Item = (u64, oneshot::Sender<StreamResult<CollectResult>>)> + '_ {
+        self.epoch_barrier_state_map
+            .iter_mut()
+            .filter_map(move |(prev_epoch, barrier_state)| {
+                #[allow(clippy::single_match)]
+                match &mut barrier_state.inner {
+                    ManagedBarrierStateInner::Issued {
+                        ref remaining_actors,
+                        ref mut collect_notifier,
+                        ..
+                    } => {
+                        if remaining_actors.contains(&actor_id) {
+                            collect_notifier
+                                .take()
+                                .map(|notifier| (*prev_epoch, notifier))
+                        } else {
+                            None
+                        }
                     }
+                    _ => None,
                 }
-                _ => {}
-            }
-        }
-        self.failure_actors.insert(actor_id, err);
+            })
     }
 
     /// Collect a `barrier` from the actor with `actor_id`.
     pub(super) fn collect(&mut self, actor_id: ActorId, barrier: &Barrier) {
         tracing::debug!(
             target: "events::stream::barrier::manager::collect",
-            epoch = barrier.epoch.curr, actor_id, state = ?self,
+            epoch = ?barrier.epoch, actor_id, state = ?self.epoch_barrier_state_map,
             "collect_barrier",
         );
 
-        match self.epoch_barrier_state_map.get_mut(&barrier.epoch.curr) {
+        match self.epoch_barrier_state_map.get_mut(&barrier.epoch.prev) {
             Some(&mut BarrierState {
-                prev_epoch,
+                curr_epoch,
                 inner:
                     ManagedBarrierStateInner::Stashed {
                         ref mut collected_actors,
@@ -206,10 +229,10 @@ impl ManagedBarrierState {
             }) => {
                 let new = collected_actors.insert(actor_id);
                 assert!(new);
-                assert_eq!(prev_epoch, barrier.epoch.prev);
+                assert_eq!(curr_epoch, barrier.epoch.curr);
             }
             Some(&mut BarrierState {
-                prev_epoch,
+                curr_epoch,
                 inner:
                     ManagedBarrierStateInner::Issued {
                         ref mut remaining_actors,
@@ -223,14 +246,14 @@ impl ManagedBarrierState {
                     "the actor doesn't exist. actor_id: {:?}, curr_epoch: {:?}",
                     actor_id, barrier.epoch.curr
                 );
-                assert_eq!(prev_epoch, barrier.epoch.prev);
-                self.may_notify(barrier.epoch.curr);
+                assert_eq!(curr_epoch, barrier.epoch.curr);
+                self.may_notify(barrier.epoch.prev);
             }
             None => {
                 self.epoch_barrier_state_map.insert(
-                    barrier.epoch.curr,
+                    barrier.epoch.prev,
                     BarrierState {
-                        prev_epoch: barrier.epoch.prev,
+                        curr_epoch: barrier.epoch.curr,
                         inner: ManagedBarrierStateInner::Stashed {
                             collected_actors: once(actor_id).collect(),
                         },
@@ -246,10 +269,14 @@ impl ManagedBarrierState {
     pub(super) fn transform_to_issued(
         &mut self,
         barrier: &Barrier,
-        actor_ids_to_collect: impl IntoIterator<Item = ActorId>,
+        actor_ids_to_collect: HashSet<ActorId>,
         collect_notifier: oneshot::Sender<StreamResult<CollectResult>>,
-    ) -> StreamResult<()> {
-        let inner = match self.epoch_barrier_state_map.get_mut(&barrier.epoch.curr) {
+    ) {
+        let timer = self
+            .streaming_metrics
+            .barrier_inflight_latency
+            .start_timer();
+        let inner = match self.epoch_barrier_state_map.get_mut(&barrier.epoch.prev) {
             Some(&mut BarrierState {
                 inner:
                     ManagedBarrierStateInner::Stashed {
@@ -257,18 +284,16 @@ impl ManagedBarrierState {
                     },
                 ..
             }) => {
-                let remaining_actors: HashSet<ActorId> = actor_ids_to_collect
-                    .into_iter()
-                    .filter(|a| !collected_actors.remove(a))
-                    .collect();
-                for (actor_id, err) in &self.failure_actors {
-                    if remaining_actors.contains(actor_id) {
-                        return Err(err.clone());
-                    }
-                }
-                assert!(collected_actors.is_empty());
+                assert!(
+                    actor_ids_to_collect.is_superset(collected_actors),
+                    "to_collect: {:?}, collected: {:?}",
+                    actor_ids_to_collect,
+                    collected_actors
+                );
+                let remaining_actors: HashSet<ActorId> = actor_ids_to_collect.sub(collected_actors);
                 ManagedBarrierStateInner::Issued {
                     remaining_actors,
+                    barrier_inflight_latency: timer,
                     collect_notifier: Some(collect_notifier),
                 }
             }
@@ -281,33 +306,21 @@ impl ManagedBarrierState {
                     barrier.epoch
                 );
             }
-            None => {
-                let remaining_actors: HashSet<ActorId> = actor_ids_to_collect.into_iter().collect();
-                // The failure actors could exit before the barrier is issued, while their
-                // up-downstream actors could be stuck somehow. Return error directly to trigger the
-                // recovery.
-                for (actor_id, err) in &self.failure_actors {
-                    if remaining_actors.contains(actor_id) {
-                        return Err(err.clone());
-                    }
-                }
-                ManagedBarrierStateInner::Issued {
-                    remaining_actors,
-                    collect_notifier: Some(collect_notifier),
-                }
-            }
+            None => ManagedBarrierStateInner::Issued {
+                remaining_actors: actor_ids_to_collect,
+                barrier_inflight_latency: timer,
+                collect_notifier: Some(collect_notifier),
+            },
         };
         self.epoch_barrier_state_map.insert(
-            barrier.epoch.curr,
+            barrier.epoch.prev,
             BarrierState {
-                prev_epoch: barrier.epoch.prev,
+                curr_epoch: barrier.epoch.curr,
                 inner,
                 kind: barrier.kind,
             },
         );
-        self.may_notify(barrier.epoch.curr);
-
-        Ok(())
+        self.may_notify(barrier.epoch.prev);
     }
 }
 
@@ -315,7 +328,6 @@ impl ManagedBarrierState {
 mod tests {
     use std::collections::HashSet;
 
-    use risingwave_storage::StateStoreImpl;
     use tokio::sync::oneshot;
 
     use crate::executor::Barrier;
@@ -323,7 +335,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_managed_state_add_actor() {
-        let mut managed_barrier_state = ManagedBarrierState::new(StateStoreImpl::for_test());
+        let mut managed_barrier_state = ManagedBarrierState::for_test();
         let barrier1 = Barrier::new_test_barrier(1);
         let barrier2 = Barrier::new_test_barrier(2);
         let barrier3 = Barrier::new_test_barrier(3);
@@ -333,15 +345,9 @@ mod tests {
         let actor_ids_to_collect1 = HashSet::from([1, 2]);
         let actor_ids_to_collect2 = HashSet::from([1, 2]);
         let actor_ids_to_collect3 = HashSet::from([1, 2, 3]);
-        managed_barrier_state
-            .transform_to_issued(&barrier1, actor_ids_to_collect1, tx1)
-            .unwrap();
-        managed_barrier_state
-            .transform_to_issued(&barrier2, actor_ids_to_collect2, tx2)
-            .unwrap();
-        managed_barrier_state
-            .transform_to_issued(&barrier3, actor_ids_to_collect3, tx3)
-            .unwrap();
+        managed_barrier_state.transform_to_issued(&barrier1, actor_ids_to_collect1, tx1);
+        managed_barrier_state.transform_to_issued(&barrier2, actor_ids_to_collect2, tx2);
+        managed_barrier_state.transform_to_issued(&barrier3, actor_ids_to_collect3, tx3);
         managed_barrier_state.collect(1, &barrier1);
         managed_barrier_state.collect(2, &barrier1);
         assert_eq!(
@@ -350,7 +356,7 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &2
+            &1
         );
         managed_barrier_state.collect(1, &barrier2);
         managed_barrier_state.collect(1, &barrier3);
@@ -361,7 +367,7 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &3
+            &2
         );
         managed_barrier_state.collect(2, &barrier3);
         managed_barrier_state.collect(3, &barrier3);
@@ -370,7 +376,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_managed_state_stop_actor() {
-        let mut managed_barrier_state = ManagedBarrierState::new(StateStoreImpl::for_test());
+        let mut managed_barrier_state = ManagedBarrierState::for_test();
         let barrier1 = Barrier::new_test_barrier(1);
         let barrier2 = Barrier::new_test_barrier(2);
         let barrier3 = Barrier::new_test_barrier(3);
@@ -380,15 +386,9 @@ mod tests {
         let actor_ids_to_collect1 = HashSet::from([1, 2, 3, 4]);
         let actor_ids_to_collect2 = HashSet::from([1, 2, 3]);
         let actor_ids_to_collect3 = HashSet::from([1, 2]);
-        managed_barrier_state
-            .transform_to_issued(&barrier1, actor_ids_to_collect1, tx1)
-            .unwrap();
-        managed_barrier_state
-            .transform_to_issued(&barrier2, actor_ids_to_collect2, tx2)
-            .unwrap();
-        managed_barrier_state
-            .transform_to_issued(&barrier3, actor_ids_to_collect3, tx3)
-            .unwrap();
+        managed_barrier_state.transform_to_issued(&barrier1, actor_ids_to_collect1, tx1);
+        managed_barrier_state.transform_to_issued(&barrier2, actor_ids_to_collect2, tx2);
+        managed_barrier_state.transform_to_issued(&barrier3, actor_ids_to_collect3, tx3);
 
         managed_barrier_state.collect(1, &barrier1);
         managed_barrier_state.collect(1, &barrier2);
@@ -402,7 +402,7 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &1
+            &0
         );
         managed_barrier_state.collect(3, &barrier1);
         managed_barrier_state.collect(3, &barrier2);
@@ -412,7 +412,7 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &1
+            &0
         );
         managed_barrier_state.collect(4, &barrier1);
         assert!(managed_barrier_state.epoch_barrier_state_map.is_empty());
@@ -420,7 +420,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_managed_state_issued_after_collect() {
-        let mut managed_barrier_state = ManagedBarrierState::new(StateStoreImpl::for_test());
+        let mut managed_barrier_state = ManagedBarrierState::for_test();
         let barrier1 = Barrier::new_test_barrier(1);
         let barrier2 = Barrier::new_test_barrier(2);
         let barrier3 = Barrier::new_test_barrier(3);
@@ -438,7 +438,7 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &3
+            &2
         );
         managed_barrier_state.collect(1, &barrier2);
         assert_eq!(
@@ -447,7 +447,7 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &2
+            &1
         );
         managed_barrier_state.collect(1, &barrier1);
         assert_eq!(
@@ -456,14 +456,22 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &1
+            &0
         );
         managed_barrier_state.collect(2, &barrier1);
         managed_barrier_state.collect(2, &barrier2);
         managed_barrier_state.collect(2, &barrier3);
-        managed_barrier_state
-            .transform_to_issued(&barrier1, actor_ids_to_collect1, tx1)
-            .unwrap();
+        managed_barrier_state.transform_to_issued(&barrier1, actor_ids_to_collect1, tx1);
+        assert_eq!(
+            managed_barrier_state
+                .epoch_barrier_state_map
+                .first_key_value()
+                .unwrap()
+                .0,
+            &1
+        );
+        managed_barrier_state.transform_to_issued(&barrier2, actor_ids_to_collect2, tx2);
+        managed_barrier_state.collect(3, &barrier2);
         assert_eq!(
             managed_barrier_state
                 .epoch_barrier_state_map
@@ -472,18 +480,6 @@ mod tests {
                 .0,
             &2
         );
-        managed_barrier_state
-            .transform_to_issued(&barrier2, actor_ids_to_collect2, tx2)
-            .unwrap();
-        managed_barrier_state.collect(3, &barrier2);
-        assert_eq!(
-            managed_barrier_state
-                .epoch_barrier_state_map
-                .first_key_value()
-                .unwrap()
-                .0,
-            &3
-        );
         managed_barrier_state.collect(3, &barrier3);
         assert_eq!(
             managed_barrier_state
@@ -491,11 +487,9 @@ mod tests {
                 .first_key_value()
                 .unwrap()
                 .0,
-            &3
+            &2
         );
-        managed_barrier_state
-            .transform_to_issued(&barrier3, actor_ids_to_collect3, tx3)
-            .unwrap();
+        managed_barrier_state.transform_to_issued(&barrier3, actor_ids_to_collect3, tx3);
         assert!(managed_barrier_state.epoch_barrier_state_map.is_empty());
     }
 }

--- a/src/stream/src/task/barrier_manager/tests.rs
+++ b/src/stream/src/task/barrier_manager/tests.rs
@@ -39,8 +39,10 @@ async fn test_managed_barrier_collection() -> StreamResult<()> {
         .collect_vec();
 
     // Send a barrier to all actors
-    let epoch = 114514;
-    let barrier = Barrier::new_test_barrier(epoch);
+    let curr_epoch = 114514;
+    let barrier = Barrier::new_test_barrier(curr_epoch);
+    let epoch = barrier.epoch.prev;
+
     manager
         .send_barrier(barrier.clone(), actor_ids.clone(), actor_ids)
         .await
@@ -51,7 +53,7 @@ async fn test_managed_barrier_collection() -> StreamResult<()> {
         .iter_mut()
         .map(|(actor_id, rx)| {
             let barrier = rx.try_recv().unwrap();
-            assert_eq!(barrier.epoch.curr, epoch);
+            assert_eq!(barrier.epoch.prev, epoch);
             (*actor_id, barrier)
         })
         .collect_vec();
@@ -99,8 +101,9 @@ async fn test_managed_barrier_collection_before_send_request() -> StreamResult<(
         .collect_vec();
 
     // Prepare the barrier
-    let epoch = 114514;
-    let barrier = Barrier::new_test_barrier(epoch);
+    let curr_epoch = 114514;
+    let barrier = Barrier::new_test_barrier(curr_epoch);
+    let epoch = barrier.epoch.prev;
 
     // Collect a barrier before sending
     manager.collect(extra_actor_id, &barrier);
@@ -117,7 +120,7 @@ async fn test_managed_barrier_collection_before_send_request() -> StreamResult<(
         .iter_mut()
         .map(|(actor_id, rx)| {
             let barrier = rx.try_recv().unwrap();
-            assert_eq!(barrier.epoch.curr, epoch);
+            assert_eq!(barrier.epoch.prev, epoch);
             (*actor_id, barrier)
         })
         .collect_vec();

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -270,7 +270,6 @@ impl LocalStreamManager {
             .expect("no rx for local mode")
             .await
             .context("failed to collect barrier")??;
-        complete_receiver.barrier_inflight_timer.observe_duration();
         Ok(result)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Split from https://github.com/risingwavelabs/risingwave/pull/14377 as suggested in https://github.com/risingwavelabs/risingwave/pull/14377#issuecomment-1878369468

Refactor includes the following changes:
- use `prev_epoch` as the key of barrier state map. Previously we use `curr_epoch`.
- observe barrier inflight latency when barrier has been collected from all actors. Previously we observe the latency in the collect_barrier rpc handler when we get notified on collecting barriers from all actors.
- maintain failure actor in local barrier worker instead of the managed state.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
