### PR TITLE
fix(planner): preserve order in array-construction subquery

### DIFF
--- a/e2e_test/batch/subquery/array_construct.slt.part
+++ b/e2e_test/batch/subquery/array_construct.slt.part
@@ -1,0 +1,31 @@
+query T
+select array(select unnest || ordinality from unnest(array['c', 'a', 'b']) with ordinality order by ordinality asc);
+----
+{c1,a2,b3}
+
+query T
+select array(select unnest || ordinality from unnest(array['c', 'a', 'b']) with ordinality order by ordinality desc);
+----
+{b3,a2,c1}
+
+query T
+select array(select unnest || ordinality from unnest(array['c', 'a', 'b']) with ordinality order by unnest asc);
+----
+{a2,b3,c1}
+
+query T
+select array(select unnest || ordinality from unnest(array['c', 'a', 'b']) with ordinality order by unnest desc);
+----
+{c1,b3,a2}
+
+# Test order by a non-output column, and output column is not 0th of source table.
+query T
+select array(select ordinality from unnest(array['c', 'a', 'b']) with ordinality order by unnest desc);
+----
+{1,3,2}
+
+# Test order by a non-output column, and order column is not 0th of source table.
+query T
+select array(select unnest from unnest(array['c', 'a', 'b']) with ordinality order by ordinality desc);
+----
+{b,a,c}

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -589,7 +589,8 @@ impl TestCase {
         let mut logical_plan = match planner.plan(bound) {
             Ok(logical_plan) => {
                 if self.expected_outputs.contains(&TestType::LogicalPlan) {
-                    ret.logical_plan = Some(explain_plan(&logical_plan.clone().into_subplan()));
+                    ret.logical_plan =
+                        Some(explain_plan(&logical_plan.clone().into_unordered_subplan()));
                 }
                 logical_plan
             }

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -158,7 +158,7 @@ impl PlanRoot {
     /// Transform the [`PlanRoot`] back to a [`PlanRef`] suitable to be used as a subplan, for
     /// example as insert source or subquery. This ignores Order but retains post-Order pruning
     /// (`out_fields`).
-    pub fn into_subplan(self) -> PlanRef {
+    pub fn into_unordered_subplan(self) -> PlanRef {
         if self.out_fields.count_ones(..) == self.out_fields.len() {
             return self.plan;
         }
@@ -859,7 +859,7 @@ mod tests {
             out_fields,
             out_names,
         );
-        let subplan = root.into_subplan();
+        let subplan = root.into_unordered_subplan();
         assert_eq!(
             subplan.schema(),
             &Schema::new(vec![Field::with_name(DataType::Int32, "v1")])

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -45,6 +45,7 @@ pub use logical_optimization::*;
 pub use optimizer_context::*;
 use plan_expr_rewriter::ConstEvalRewriter;
 use property::Order;
+use risingwave_common::bail;
 use risingwave_common::catalog::{
     ColumnCatalog, ColumnDesc, ColumnId, ConflictBehavior, Field, Schema, TableId,
 };
@@ -150,11 +151,6 @@ impl PlanRoot {
         }
     }
 
-    /// Get out fields of the plan root.
-    pub fn out_fields(&self) -> &FixedBitSet {
-        &self.out_fields
-    }
-
     /// Transform the [`PlanRoot`] back to a [`PlanRef`] suitable to be used as a subplan, for
     /// example as insert source or subquery. This ignores Order but retains post-Order pruning
     /// (`out_fields`).
@@ -163,6 +159,38 @@ impl PlanRoot {
             return self.plan;
         }
         LogicalProject::with_out_fields(self.plan, &self.out_fields).into()
+    }
+
+    /// Transform the [`PlanRoot`] wrapped in an array-construction subquery to a [`PlanRef`]
+    /// supported by `ARRAY_AGG`. Similar to the unordered version, this abstracts away internal
+    /// `self.plan` which is further modified by `self.required_order` then `self.out_fields`.
+    pub fn into_array_agg(self) -> Result<PlanRef> {
+        use generic::Agg;
+        use plan_node::PlanAggCall;
+        use risingwave_common::types::DataType;
+        use risingwave_expr::aggregate::AggKind;
+
+        use crate::expr::InputRef;
+        use crate::utils::{Condition, IndexSet};
+
+        let Ok(select_idx) = self.out_fields.ones().exactly_one() else {
+            bail!("subquery must return only one column");
+        };
+        let input_column_type = self.plan.schema().fields()[select_idx].data_type();
+        Ok(Agg::new(
+            vec![PlanAggCall {
+                agg_kind: AggKind::ArrayAgg,
+                return_type: DataType::List(input_column_type.clone().into()),
+                inputs: vec![InputRef::new(select_idx, input_column_type)],
+                distinct: false,
+                order_by: self.required_order.column_orders,
+                filter: Condition::true_cond(),
+                direct_args: vec![],
+            }],
+            IndexSet::empty(),
+            self.plan,
+        )
+        .into())
     }
 
     /// Apply logical optimization to the plan for stream.

--- a/src/frontend/src/planner/insert.rs
+++ b/src/frontend/src/planner/insert.rs
@@ -23,7 +23,7 @@ use crate::planner::Planner;
 
 impl Planner {
     pub(super) fn plan_insert(&mut self, insert: BoundInsert) -> Result<PlanRoot> {
-        let mut input = self.plan_query(insert.source)?.into_subplan();
+        let mut input = self.plan_query(insert.source)?.into_unordered_subplan();
         if !insert.cast_exprs.is_empty() {
             input = LogicalProject::create(input, insert.cast_exprs);
         }

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -42,7 +42,7 @@ impl Planner {
             Relation::BaseTable(t) => self.plan_base_table(&t),
             Relation::SystemTable(st) => self.plan_sys_table(*st),
             // TODO: order is ignored in the subquery
-            Relation::Subquery(q) => Ok(self.plan_query(q.query)?.into_subplan()),
+            Relation::Subquery(q) => Ok(self.plan_query(q.query)?.into_unordered_subplan()),
             Relation::Join(join) => self.plan_join(*join),
             Relation::Apply(join) => self.plan_apply(*join),
             Relation::WindowTableFunction(tf) => self.plan_window_table_function(*tf),

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -316,7 +316,7 @@ impl Planner {
         let correlated_indices =
             subquery.collect_correlated_indices_by_depth_and_assign_id(0, correlated_id);
         let output_column_type = subquery.query.data_types()[0].clone();
-        let right_plan = self.plan_query(subquery.query)?.into_subplan();
+        let right_plan = self.plan_query(subquery.query)?.into_unordered_subplan();
         let on = match subquery.kind {
             SubqueryKind::Existential => ExprImpl::literal_bool(true),
             SubqueryKind::In(left_expr) => {
@@ -391,7 +391,7 @@ impl Planner {
             .zip_eq_fast(rewriter.correlated_indices_collection)
             .zip_eq_fast(rewriter.correlated_ids)
         {
-            let mut right = self.plan_query(subquery.query)?.into_subplan();
+            let mut right = self.plan_query(subquery.query)?.into_unordered_subplan();
 
             match subquery.kind {
                 SubqueryKind::Scalar => {}

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -15,13 +15,12 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
+use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::ColumnOrder;
-use risingwave_common::{bail, bail_not_implemented};
-use risingwave_expr::aggregate::AggKind;
 use risingwave_expr::ExprError;
 use risingwave_pb::plan_common::JoinType;
 
@@ -219,30 +218,6 @@ impl Planner {
         Ok(LogicalProject::create(count_star.into(), vec![ge.into()]))
     }
 
-    /// Helper to create an `ARRAY_AGG` operator with the given `input`.
-    /// It is represented by `ARRAY_AGG($0) -> input`
-    fn create_array_agg(&self, input: PlanRef) -> Result<PlanRef> {
-        let fields = input.schema().fields();
-        if fields.len() != 1 {
-            bail!("subquery must return only one column");
-        }
-        let input_column_type = fields[0].data_type();
-        Ok(Agg::new(
-            vec![PlanAggCall {
-                agg_kind: AggKind::ArrayAgg,
-                return_type: DataType::List(input.schema().fields()[0].data_type().into()),
-                inputs: vec![InputRef::new(0, input_column_type)],
-                distinct: false,
-                order_by: vec![],
-                filter: Condition::true_cond(),
-                direct_args: vec![],
-            }],
-            IndexSet::empty(),
-            input,
-        )
-        .into())
-    }
-
     /// For `(NOT) EXISTS subquery` or `(NOT) IN subquery`, we can plan it as
     /// `LeftSemi/LeftAnti` [`LogicalApply`]
     /// For other subqueries, we plan it as `LeftOuter` [`LogicalApply`] using
@@ -391,18 +366,16 @@ impl Planner {
             .zip_eq_fast(rewriter.correlated_indices_collection)
             .zip_eq_fast(rewriter.correlated_ids)
         {
-            let mut right = self.plan_query(subquery.query)?.into_unordered_subplan();
+            let subroot = self.plan_query(subquery.query)?;
 
-            match subquery.kind {
-                SubqueryKind::Scalar => {}
+            let right = match subquery.kind {
+                SubqueryKind::Scalar => subroot.into_unordered_subplan(),
                 SubqueryKind::Existential => {
-                    right = self.create_exists(right)?;
+                    self.create_exists(subroot.into_unordered_subplan())?
                 }
-                SubqueryKind::Array => {
-                    right = self.create_array_agg(right)?;
-                }
+                SubqueryKind::Array => subroot.into_array_agg()?,
                 _ => bail_not_implemented!(issue = 1343, "{:?}", subquery.kind),
-            }
+            };
 
             root = Self::create_apply(
                 correlated_id,

--- a/src/frontend/src/planner/set_expr.rs
+++ b/src/frontend/src/planner/set_expr.rs
@@ -30,7 +30,7 @@ impl Planner {
         match set_expr {
             BoundSetExpr::Select(s) => self.plan_select(*s, extra_order_exprs, order),
             BoundSetExpr::Values(v) => self.plan_values(*v),
-            BoundSetExpr::Query(q) => Ok(self.plan_query(*q)?.into_subplan()),
+            BoundSetExpr::Query(q) => Ok(self.plan_query(*q)?.into_unordered_subplan()),
             BoundSetExpr::SetOperation {
                 op,
                 all,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #14153. In most cases, the output order of a subquery has no impact of the outer query except for `array(...)` construction.
* Rename `into_subplan` to `into_unordered_subplan` for clarity.
* Handle `order` properly in the latter case by leveraging `order by` of `PlanAggCall`

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
