### PR TITLE
chore(type): merge `ScalarImpl::from_text` and `from_literal`

### DIFF
--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -761,7 +761,7 @@ impl DataChunkTestExt for DataChunk {
                 let datum = match val_str {
                     "." => None,
                     "(empty)" => Some("".into()),
-                    _ => Some(ScalarImpl::from_text(val_str.as_bytes(), ty).unwrap()),
+                    _ => Some(ScalarImpl::from_text(val_str, ty).unwrap()),
                 };
                 builder.append(datum);
             }

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -768,8 +768,7 @@ impl ListValue {
                     }
                 };
                 Ok(Some(
-                    ScalarImpl::from_literal(&s, self.data_type)
-                        .map_err(|e| e.to_report_string())?,
+                    ScalarImpl::from_text(&s, self.data_type).map_err(|e| e.to_report_string())?,
                 ))
             }
 
@@ -797,7 +796,7 @@ impl ListValue {
                         _ => {}
                     }
                 };
-                ScalarImpl::from_literal(&s, self.data_type).map_err(|e| e.to_report_string())
+                ScalarImpl::from_text(&s, self.data_type).map_err(|e| e.to_report_string())
             }
 
             /// Unescape a string.

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -338,6 +338,24 @@ impl StructValue {
     }
 
     /// Construct an array from literal string.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use risingwave_common::types::{StructValue, StructType, DataType, ScalarImpl};
+    ///
+    /// let ty = DataType::Struct(StructType::unnamed(vec![
+    ///     DataType::Int32,
+    ///     DataType::Float64,
+    /// ]));
+    /// let s = StructValue::from_str("(1, 2.0)", &ty).unwrap();
+    /// assert_eq!(s.fields()[0], Some(ScalarImpl::Int32(1)));
+    /// assert_eq!(s.fields()[1], Some(ScalarImpl::Float64(2.0.into())));
+    ///
+    /// let s = StructValue::from_str("(,)", &ty).unwrap();
+    /// assert_eq!(s.fields()[0], None);
+    /// assert_eq!(s.fields()[1], None);
+    /// ```
     pub fn from_str(s: &str, data_type: &DataType) -> Result<Self, BoxedError> {
         // FIXME(runji): this is a trivial implementation which does not support nested struct.
         let DataType::Struct(ty) = data_type else {

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -25,11 +25,13 @@ use risingwave_pb::data::{PbArray, PbArrayType, StructArrayData};
 use super::{Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayResult, DataChunk};
 use crate::array::ArrayRef;
 use crate::buffer::{Bitmap, BitmapBuilder};
+use crate::error::BoxedError;
 use crate::estimate_size::EstimateSize;
 use crate::types::{
-    hash_datum, DataType, Datum, DatumRef, DefaultOrd, Scalar, StructType, ToDatumRef, ToText,
+    hash_datum, DataType, Datum, DatumRef, DefaultOrd, Scalar, ScalarImpl, StructType, ToDatumRef,
+    ToText,
 };
-use crate::util::iter_util::ZipEqFast;
+use crate::util::iter_util::{ZipEqDebug, ZipEqFast};
 use crate::util::memcmp_encoding;
 use crate::util::value_encoding::estimate_serialize_datum_size;
 
@@ -333,6 +335,29 @@ impl StructValue {
             .map(|field| memcmp_encoding::deserialize_datum_in_composite(field, deserializer))
             .try_collect()
             .map(Self::new)
+    }
+
+    /// Construct an array from literal string.
+    pub fn from_str(s: &str, data_type: &DataType) -> Result<Self, BoxedError> {
+        // FIXME(runji): this is a trivial implementation which does not support nested struct.
+        let DataType::Struct(ty) = data_type else {
+            return Err(format!("Expect struct type, got {:?}", data_type).into());
+        };
+        if !s.starts_with('(') {
+            return Err("Missing left parenthesis".into());
+        }
+        if !s.ends_with(')') {
+            return Err("Missing right parenthesis".into());
+        }
+        let mut fields = Vec::with_capacity(s.len());
+        for (s, ty) in s[1..s.len() - 1].split(',').zip_eq_debug(ty.types()) {
+            let datum = match s.trim() {
+                "" => None,
+                s => Some(ScalarImpl::from_text(s, ty)?),
+            };
+            fields.push(datum);
+        }
+        Ok(StructValue::new(fields))
     }
 }
 

--- a/src/expr/core/src/expr/build.rs
+++ b/src/expr/core/src/expr/build.rs
@@ -288,9 +288,7 @@ impl<Iter: Iterator<Item = Token>> Parser<Iter> {
                 let ty = self.parse_type();
                 let value = match value.as_str() {
                     "null" | "NULL" => None,
-                    _ => Some(
-                        ScalarImpl::from_text(value.as_bytes(), &ty).expect_str("value", &value),
-                    ),
+                    _ => Some(ScalarImpl::from_text(&value, &ty).expect_str("value", &value)),
                 };
                 LiteralExpression::new(ty, value).boxed()
             }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -135,7 +135,7 @@ impl FunctionCall {
             let datum = literal
                 .get_data()
                 .as_ref()
-                .map(|scalar| ScalarImpl::from_literal(scalar.as_utf8(), &target))
+                .map(|scalar| ScalarImpl::from_text(scalar.as_utf8(), &target))
                 .transpose();
             if let Ok(datum) = datum {
                 *child = Literal::new(datum, target).into();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. These two methods do something similar. We merge them to remove duplicate code.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)
