### PR TITLE
feat(dashboard): improvements on the relation dep graph

### DIFF
--- a/dashboard/components/CatalogModal.tsx
+++ b/dashboard/components/CatalogModal.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react"
+
+import Link from "next/link"
+import { parseAsInteger, useQueryState } from "nuqs"
+import {
+  Relation,
+  relationIsStreamingJob,
+  relationTypeTitleCase,
+} from "../pages/api/streaming"
+import { ReactJson } from "./Relations"
+
+export function useCatalogModal(relationList: Relation[] | undefined) {
+  const [modalId, setModalId] = useQueryState("modalId", parseAsInteger)
+  const modalData = relationList?.find((r) => r.id === modalId)
+
+  return [modalData, setModalId] as const
+}
+
+export function CatalogModal({
+  modalData,
+  onClose,
+}: {
+  modalData: Relation | undefined
+  onClose: () => void
+}) {
+  return (
+    <Modal isOpen={modalData !== undefined} onClose={onClose} size="3xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          Catalog of {modalData && relationTypeTitleCase(modalData)}{" "}
+          {modalData?.id} - {modalData?.name}
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {modalData && (
+            <ReactJson
+              src={modalData}
+              collapsed={1}
+              name={null}
+              displayDataTypes={false}
+            />
+          )}
+        </ModalBody>
+
+        <ModalFooter>
+          {modalData && relationIsStreamingJob(modalData) && (
+            <Button colorScheme="blue" mr={3}>
+              <Link href={`/fragment_graph/?id=${modalData.id}`}>
+                View Fragments
+              </Link>
+            </Button>
+          )}
+          <Button mr={3} onClick={onClose}>
+            Close
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/dashboard/components/FragmentGraph.tsx
+++ b/dashboard/components/FragmentGraph.tsx
@@ -21,8 +21,8 @@ import {
   FragmentBox,
   FragmentBoxPosition,
   Position,
-  generateBoxEdges,
-  layout,
+  generateFragmentEdges,
+  layoutFragment,
 } from "../lib/layout"
 import { PlanNodeDatum } from "../pages/fragment_graph"
 import { StreamNode } from "../proto/gen/stream_plan"
@@ -142,7 +142,7 @@ export default function FragmentGraph({
       includedFragmentIds.add(fragmentId)
     }
 
-    const fragmentLayout = layout(
+    const fragmentLayout = layoutFragment(
       fragmentDependencyDag.map(({ width: _1, height: _2, id, ...data }) => {
         const { width, height } = layoutFragmentResult.get(id)!
         return { width, height, id, ...data }
@@ -167,7 +167,7 @@ export default function FragmentGraph({
       svgHeight = Math.max(svgHeight, y + height + 50)
       svgWidth = Math.max(svgWidth, x + width)
     })
-    const edges = generateBoxEdges(fragmentLayout)
+    const edges = generateFragmentEdges(fragmentLayout)
 
     return {
       layoutResult,

--- a/dashboard/components/FragmentGraph.tsx
+++ b/dashboard/components/FragmentGraph.tsx
@@ -22,7 +22,7 @@ import {
   FragmentBoxPosition,
   Position,
   generateFragmentEdges,
-  layoutFragment,
+  layoutItem,
 } from "../lib/layout"
 import { PlanNodeDatum } from "../pages/fragment_graph"
 import { StreamNode } from "../proto/gen/stream_plan"
@@ -142,7 +142,7 @@ export default function FragmentGraph({
       includedFragmentIds.add(fragmentId)
     }
 
-    const fragmentLayout = layoutFragment(
+    const fragmentLayout = layoutItem(
       fragmentDependencyDag.map(({ width: _1, height: _2, id, ...data }) => {
         const { width, height } = layoutFragmentResult.get(id)!
         return { width, height, id, ...data }

--- a/dashboard/components/FragmentGraph.tsx
+++ b/dashboard/components/FragmentGraph.tsx
@@ -17,6 +17,7 @@ import { cloneDeep } from "lodash"
 import { Fragment, useCallback, useEffect, useRef, useState } from "react"
 import {
   Edge,
+  Enter,
   FragmentBox,
   FragmentBoxPosition,
   Position,
@@ -35,10 +36,6 @@ type FragmentLayout = {
   height: number
   actorIds: string[]
 } & Position
-
-type Enter<Type> = Type extends d3.Selection<any, infer B, infer C, infer D>
-  ? d3.Selection<d3.EnterElement, B, C, D>
-  : never
 
 function treeLayoutFlip<Datum>(
   root: d3.HierarchyNode<Datum>,

--- a/dashboard/components/RelationDependencyGraph.tsx
+++ b/dashboard/components/RelationDependencyGraph.tsx
@@ -19,15 +19,15 @@ import { theme } from "@chakra-ui/react"
 import * as d3 from "d3"
 import { useCallback, useEffect, useRef } from "react"
 import {
-  FragmentPoint,
-  FragmentPointPosition,
   Position,
-  flipLayoutPoint,
-  generatePointEdges,
+  RelationPoint,
+  RelationPointPosition,
+  flipLayoutRelation,
+  generateRelationEdges,
 } from "../lib/layout"
 
 function boundBox(
-  fragmentPosition: FragmentPointPosition[],
+  relationPosition: RelationPointPosition[],
   nodeRadius: number
 ): {
   width: number
@@ -35,7 +35,7 @@ function boundBox(
 } {
   let width = 0
   let height = 0
-  for (const { x, y } of fragmentPosition) {
+  for (const { x, y } of relationPosition) {
     width = Math.max(width, x + nodeRadius)
     height = Math.max(height, y + nodeRadius)
   }
@@ -51,13 +51,13 @@ export default function RelationDependencyGraph({
   nodes,
   selectedId,
 }: {
-  nodes: FragmentPoint[]
+  nodes: RelationPoint[]
   selectedId?: string
 }) {
   const svgRef = useRef<any>()
 
   const layoutMapCallback = useCallback(() => {
-    const layoutMap = flipLayoutPoint(
+    const layoutMap = flipLayoutRelation(
       nodes,
       layerMargin,
       rowMargin,
@@ -68,9 +68,9 @@ export default function RelationDependencyGraph({
           x: x + layoutMargin,
           y: y + layoutMargin,
           ...data,
-        } as FragmentPointPosition)
+        } as RelationPointPosition)
     )
-    const links = generatePointEdges(layoutMap)
+    const links = generateRelationEdges(layoutMap)
     const { width, height } = boundBox(layoutMap, nodeRadius)
     return {
       layoutMap,

--- a/dashboard/components/RelationDependencyGraph.tsx
+++ b/dashboard/components/RelationDependencyGraph.tsx
@@ -19,6 +19,7 @@ import { theme } from "@chakra-ui/react"
 import * as d3 from "d3"
 import { useCallback, useEffect, useRef } from "react"
 import {
+  Enter,
   Position,
   RelationPoint,
   RelationPointPosition,
@@ -54,7 +55,7 @@ export default function RelationDependencyGraph({
   nodes: RelationPoint[]
   selectedId?: string
 }) {
-  const svgRef = useRef<any>()
+  const svgRef = useRef<SVGSVGElement>(null)
 
   const layoutMapCallback = useCallback(() => {
     const layoutMap = flipLayoutRelation(
@@ -96,29 +97,30 @@ export default function RelationDependencyGraph({
 
     const edgeSelection = svgSelection
       .select(".edges")
-      .selectAll(".edge")
+      .selectAll<SVGPathElement, null>(".edge")
       .data(links)
+    type EdgeSelection = typeof edgeSelection
 
     const isSelected = (id: string) => id === selectedId
 
-    const applyEdge = (sel: any) =>
+    const applyEdge = (sel: EdgeSelection) =>
       sel
-        .attr("d", ({ points }: any) => line(points))
+        .attr("d", ({ points }) => line(points))
         .attr("fill", "none")
         .attr("stroke-width", 1)
-        .attr("stroke-width", (d: any) =>
+        .attr("stroke-width", (d) =>
           isSelected(d.source) || isSelected(d.target) ? 2 : 1
         )
-        .attr("opacity", (d: any) =>
+        .attr("opacity", (d) =>
           isSelected(d.source) || isSelected(d.target) ? 1 : 0.5
         )
-        .attr("stroke", (d: any) =>
+        .attr("stroke", (d) =>
           isSelected(d.source) || isSelected(d.target)
             ? theme.colors.blue["500"]
             : theme.colors.gray["300"]
         )
 
-    const createEdge = (sel: any) =>
+    const createEdge = (sel: Enter<EdgeSelection>) =>
       sel.append("path").attr("class", "edge").call(applyEdge)
     edgeSelection.exit().remove()
     edgeSelection.enter().call(createEdge)
@@ -157,11 +159,13 @@ export default function RelationDependencyGraph({
       return g
     }
 
-    const createNode = (sel: any) =>
+    const createNode = (sel: Enter<NodeSelection>) =>
       sel.append("g").attr("class", "node").call(applyNode)
 
     const g = svgSelection.select(".boxes")
-    const nodeSelection = g.selectAll(".node").data(layoutMap)
+    const nodeSelection = g
+      .selectAll<SVGGElement, null>(".node")
+      .data(layoutMap)
     type NodeSelection = typeof nodeSelection
 
     nodeSelection.enter().call(createNode)

--- a/dashboard/components/RelationDependencyGraph.tsx
+++ b/dashboard/components/RelationDependencyGraph.tsx
@@ -191,7 +191,7 @@ export default function RelationDependencyGraph({
         .attr("font-size", 16)
         .attr("font-weight", "bold")
 
-      // Relation link
+      // Relation modal
       g.style("cursor", "pointer").on("click", (_, { relation, id }) => {
         setSelectedId(id)
         setModalId(relation.id)

--- a/dashboard/components/RelationDependencyGraph.tsx
+++ b/dashboard/components/RelationDependencyGraph.tsx
@@ -32,7 +32,7 @@ import {
   relationType,
   relationTypeTitleCase,
 } from "../pages/api/streaming"
-import { CatalogModal, useCatalogModal } from "./Relations"
+import { CatalogModal, useCatalogModal } from "./CatalogModal"
 
 function boundBox(
   relationPosition: RelationPointPosition[],

--- a/dashboard/components/RelationDependencyGraph.tsx
+++ b/dashboard/components/RelationDependencyGraph.tsx
@@ -30,6 +30,7 @@ import {
   Relation,
   relationIsStreamingJob,
   relationType,
+  relationTypeTitleCase,
 } from "../pages/api/streaming"
 import { CatalogModal, useCatalogModal } from "./Relations"
 
@@ -190,6 +191,17 @@ export default function RelationDependencyGraph({
         .attr("dy", nodeRadius * 0.5)
         .attr("font-size", 16)
         .attr("font-weight", "bold")
+
+      // Relation type tooltip
+      let typeTooltip = g.select<SVGTitleElement>("title")
+      if (typeTooltip.empty()) {
+        typeTooltip = g.append<SVGTitleElement>("title")
+      }
+
+      typeTooltip.text(
+        ({ relation }) =>
+          `${relation.name} (${relationTypeTitleCase(relation)})`
+      )
 
       // Relation modal
       g.style("cursor", "pointer").on("click", (_, { relation, id }) => {

--- a/dashboard/components/Relations.tsx
+++ b/dashboard/components/Relations.tsx
@@ -18,13 +18,6 @@
 import {
   Box,
   Button,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   Table,
   TableContainer,
   Tbody,
@@ -37,24 +30,19 @@ import loadable from "@loadable/component"
 import Head from "next/head"
 
 import Link from "next/link"
-import { parseAsInteger, useQueryState } from "nuqs"
 import { Fragment } from "react"
 import Title from "../components/Title"
 import extractColumnInfo from "../lib/extractInfo"
 import useFetch from "../pages/api/fetch"
-import {
-  Relation,
-  StreamingJob,
-  relationIsStreamingJob,
-  relationTypeTitleCase,
-} from "../pages/api/streaming"
+import { Relation, StreamingJob } from "../pages/api/streaming"
 import {
   Sink as RwSink,
   Source as RwSource,
   Table as RwTable,
 } from "../proto/gen/catalog"
+import { CatalogModal, useCatalogModal } from "./CatalogModal"
 
-const ReactJson = loadable(() => import("react-json-view"))
+export const ReactJson = loadable(() => import("react-json-view"))
 
 export type Column<R> = {
   name: string
@@ -120,57 +108,6 @@ export const connectorColumnSink: Column<RwSink> = {
 }
 
 export const streamingJobColumns = [dependentsColumn, fragmentsColumn]
-
-export function useCatalogModal(relationList: Relation[] | undefined) {
-  const [modalId, setModalId] = useQueryState("modalId", parseAsInteger)
-  const modalData = relationList?.find((r) => r.id === modalId)
-
-  return [modalData, setModalId] as const
-}
-
-export function CatalogModal({
-  modalData,
-  onClose,
-}: {
-  modalData: Relation | undefined
-  onClose: () => void
-}) {
-  return (
-    <Modal isOpen={modalData !== undefined} onClose={onClose} size="3xl">
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>
-          Catalog of {modalData && relationTypeTitleCase(modalData)}{" "}
-          {modalData?.id} - {modalData?.name}
-        </ModalHeader>
-        <ModalCloseButton />
-        <ModalBody>
-          {modalData && (
-            <ReactJson
-              src={modalData}
-              collapsed={1}
-              name={null}
-              displayDataTypes={false}
-            />
-          )}
-        </ModalBody>
-
-        <ModalFooter>
-          {modalData && relationIsStreamingJob(modalData) && (
-            <Button colorScheme="blue" mr={3}>
-              <Link href={`/fragment_graph/?id=${modalData.id}`}>
-                View Fragments
-              </Link>
-            </Button>
-          )}
-          <Button mr={3} onClick={onClose}>
-            Close
-          </Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  )
-}
 
 export function Relations<R extends Relation>(
   title: string,

--- a/dashboard/components/Relations.tsx
+++ b/dashboard/components/Relations.tsx
@@ -36,7 +36,6 @@ import {
 import loadable from "@loadable/component"
 import Head from "next/head"
 
-import _ from "lodash"
 import Link from "next/link"
 import { parseAsInteger, useQueryState } from "nuqs"
 import { Fragment } from "react"
@@ -47,7 +46,7 @@ import {
   Relation,
   StreamingJob,
   relationIsStreamingJob,
-  relationType,
+  relationTypeTitleCase,
 } from "../pages/api/streaming"
 import {
   Sink as RwSink,
@@ -141,7 +140,7 @@ export function CatalogModal({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
-          Catalog of {modalData && _.lowerCase(relationType(modalData))}{" "}
+          Catalog of {modalData && relationTypeTitleCase(modalData)}{" "}
           {modalData?.id} - {modalData?.name}
         </ModalHeader>
         <ModalCloseButton />

--- a/dashboard/components/Relations.tsx
+++ b/dashboard/components/Relations.tsx
@@ -42,7 +42,11 @@ import { Fragment } from "react"
 import Title from "../components/Title"
 import extractColumnInfo from "../lib/extractInfo"
 import useFetch from "../pages/api/fetch"
-import { Relation, StreamingJob } from "../pages/api/streaming"
+import {
+  Relation,
+  StreamingJob,
+  relationIsStreamingJob,
+} from "../pages/api/streaming"
 import {
   Sink as RwSink,
   Source as RwSource,
@@ -150,7 +154,14 @@ export function Relations<R extends Relation>(
         </ModalBody>
 
         <ModalFooter>
-          <Button colorScheme="blue" mr={3} onClick={() => setModalId(null)}>
+          {modalData && relationIsStreamingJob(modalData) && (
+            <Button colorScheme="blue" mr={3}>
+              <Link href={`/fragment_graph/?id=${modalData.id}`}>
+                View Fragments
+              </Link>
+            </Button>
+          )}
+          <Button mr={3} onClick={() => setModalId(null)}>
             Close
           </Button>
         </ModalFooter>

--- a/dashboard/components/Relations.tsx
+++ b/dashboard/components/Relations.tsx
@@ -36,6 +36,7 @@ import {
 import loadable from "@loadable/component"
 import Head from "next/head"
 
+import _ from "lodash"
 import Link from "next/link"
 import { parseAsInteger, useQueryState } from "nuqs"
 import { Fragment } from "react"
@@ -46,6 +47,7 @@ import {
   Relation,
   StreamingJob,
   relationIsStreamingJob,
+  relationType,
 } from "../pages/api/streaming"
 import {
   Sink as RwSink,
@@ -121,7 +123,7 @@ export const connectorColumnSink: Column<RwSink> = {
 export const streamingJobColumns = [dependentsColumn, fragmentsColumn]
 
 export function useCatalogModal(relationList: Relation[] | undefined) {
-  const [modalId, setModalId] = useQueryState("id", parseAsInteger)
+  const [modalId, setModalId] = useQueryState("modalId", parseAsInteger)
   const modalData = relationList?.find((r) => r.id === modalId)
 
   return [modalData, setModalId] as const
@@ -139,7 +141,8 @@ export function CatalogModal({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
-          Catalog of {modalData?.id} - {modalData?.name}
+          Catalog of {modalData && _.lowerCase(relationType(modalData))}{" "}
+          {modalData?.id} - {modalData?.name}
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody>

--- a/dashboard/components/Relations.tsx
+++ b/dashboard/components/Relations.tsx
@@ -120,22 +120,22 @@ export const connectorColumnSink: Column<RwSink> = {
 
 export const streamingJobColumns = [dependentsColumn, fragmentsColumn]
 
-export function Relations<R extends Relation>(
-  title: string,
-  getRelations: () => Promise<R[]>,
-  extraColumns: Column<R>[]
-) {
-  const { response: relationList } = useFetch(getRelations)
-
+export function useCatalogModal(relationList: Relation[] | undefined) {
   const [modalId, setModalId] = useQueryState("id", parseAsInteger)
   const modalData = relationList?.find((r) => r.id === modalId)
 
-  const catalogModal = (
-    <Modal
-      isOpen={modalData !== undefined}
-      onClose={() => setModalId(null)}
-      size="3xl"
-    >
+  return [modalData, setModalId] as const
+}
+
+export function CatalogModal({
+  modalData,
+  onClose,
+}: {
+  modalData: Relation | undefined
+  onClose: () => void
+}) {
+  return (
+    <Modal isOpen={modalData !== undefined} onClose={onClose} size="3xl">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
@@ -161,12 +161,25 @@ export function Relations<R extends Relation>(
               </Link>
             </Button>
           )}
-          <Button mr={3} onClick={() => setModalId(null)}>
+          <Button mr={3} onClick={onClose}>
             Close
           </Button>
         </ModalFooter>
       </ModalContent>
     </Modal>
+  )
+}
+
+export function Relations<R extends Relation>(
+  title: string,
+  getRelations: () => Promise<R[]>,
+  extraColumns: Column<R>[]
+) {
+  const { response: relationList } = useFetch(getRelations)
+  const [modalData, setModalId] = useCatalogModal(relationList)
+
+  const modal = (
+    <CatalogModal modalData={modalData} onClose={() => setModalId(null)} />
   )
 
   const table = (
@@ -225,7 +238,7 @@ export function Relations<R extends Relation>(
       <Head>
         <title>{title}</title>
       </Head>
-      {catalogModal}
+      {modal}
       {table}
     </Fragment>
   )

--- a/dashboard/lib/layout.ts
+++ b/dashboard/lib/layout.ts
@@ -19,6 +19,15 @@ import { cloneDeep, max } from "lodash"
 import { TableFragments_Fragment } from "../proto/gen/meta"
 import { GraphNode } from "./algo"
 
+export type Enter<Type> = Type extends d3.Selection<
+  any,
+  infer B,
+  infer C,
+  infer D
+>
+  ? d3.Selection<d3.EnterElement, B, C, D>
+  : never
+
 interface DagNode {
   node: GraphNode
   temp: boolean

--- a/dashboard/pages/api/streaming.ts
+++ b/dashboard/pages/api/streaming.ts
@@ -45,6 +45,19 @@ export interface StreamingJob extends Relation {
   dependentRelations: number[]
 }
 
+export function relationType(x: Relation) {
+  if ((x as Table).tableType !== undefined) {
+    return (x as Table).tableType
+  } else if ((x as Sink).sinkFromName !== undefined) {
+    return "SINK"
+  } else if ((x as Source).info !== undefined) {
+    return "SOURCE"
+  } else {
+    return "UNKNOWN"
+  }
+}
+export type RelationType = ReturnType<typeof relationType>
+
 export function relationIsStreamingJob(x: Relation): x is StreamingJob {
   return (x as StreamingJob).dependentRelations !== undefined
 }

--- a/dashboard/pages/api/streaming.ts
+++ b/dashboard/pages/api/streaming.ts
@@ -59,7 +59,8 @@ export function relationType(x: Relation) {
 export type RelationType = ReturnType<typeof relationType>
 
 export function relationIsStreamingJob(x: Relation): x is StreamingJob {
-  return (x as StreamingJob).dependentRelations !== undefined
+  const type = relationType(x)
+  return type !== "UNKNOWN" && type !== "SOURCE" && type !== "INTERNAL"
 }
 
 export async function getStreamingJobs() {

--- a/dashboard/pages/api/streaming.ts
+++ b/dashboard/pages/api/streaming.ts
@@ -58,6 +58,10 @@ export function relationType(x: Relation) {
 }
 export type RelationType = ReturnType<typeof relationType>
 
+export function relationTypeTitleCase(x: Relation) {
+  return _.startCase(_.toLower(relationType(x)))
+}
+
 export function relationIsStreamingJob(x: Relation): x is StreamingJob {
   const type = relationType(x)
   return type !== "UNKNOWN" && type !== "SOURCE" && type !== "INTERNAL"

--- a/dashboard/pages/dependency_graph.tsx
+++ b/dashboard/pages/dependency_graph.tsx
@@ -22,13 +22,13 @@ import { parseAsInteger, useQueryState } from "nuqs"
 import { Fragment, useCallback } from "react"
 import RelationDependencyGraph from "../components/RelationDependencyGraph"
 import Title from "../components/Title"
-import { FragmentPoint } from "../lib/layout"
+import { RelationPoint } from "../lib/layout"
 import useFetch from "./api/fetch"
 import { Relation, getRelations, relationIsStreamingJob } from "./api/streaming"
 
 const SIDEBAR_WIDTH = "200px"
 
-function buildDependencyAsEdges(list: Relation[]): FragmentPoint[] {
+function buildDependencyAsEdges(list: Relation[]): RelationPoint[] {
   const edges = []
   const relationSet = new Set(list.map((r) => r.id))
   for (const r of reverse(sortBy(list, "id"))) {
@@ -47,18 +47,18 @@ function buildDependencyAsEdges(list: Relation[]): FragmentPoint[] {
 }
 
 export default function StreamingGraph() {
-  const { response: streamingJobList } = useFetch(getRelations)
+  const { response: relationList } = useFetch(getRelations)
   const [selectedId, setSelectedId] = useQueryState("id", parseAsInteger)
 
-  const mvDependencyCallback = useCallback(() => {
-    if (streamingJobList) {
-      return buildDependencyAsEdges(streamingJobList)
+  const relationDependencyCallback = useCallback(() => {
+    if (relationList) {
+      return buildDependencyAsEdges(relationList)
     } else {
       return undefined
     }
-  }, [streamingJobList])
+  }, [relationList])
 
-  const mvDependency = mvDependencyCallback()
+  const relationDependency = relationDependencyCallback()
 
   const retVal = (
     <Flex p={3} height="calc(100vh - 20px)" flexDirection="column">
@@ -77,7 +77,7 @@ export default function StreamingGraph() {
           </Text>
           <Box flex={1} overflowY="scroll">
             <VStack width={SIDEBAR_WIDTH} align="start" spacing={1}>
-              {streamingJobList?.map((r) => {
+              {relationList?.map((r) => {
                 const match = selectedId === r.id
                 return (
                   <Button
@@ -105,9 +105,9 @@ export default function StreamingGraph() {
           overflowY="scroll"
         >
           <Text fontWeight="semibold">Graph</Text>
-          {mvDependency && (
+          {relationDependency && (
             <RelationDependencyGraph
-              nodes={mvDependency}
+              nodes={relationDependency}
               selectedId={selectedId?.toString()}
             />
           )}

--- a/dashboard/pages/dependency_graph.tsx
+++ b/dashboard/pages/dependency_graph.tsx
@@ -20,7 +20,9 @@ import { reverse, sortBy } from "lodash"
 import Head from "next/head"
 import { parseAsInteger, useQueryState } from "nuqs"
 import { Fragment, useCallback } from "react"
-import RelationDependencyGraph from "../components/RelationDependencyGraph"
+import RelationDependencyGraph, {
+  nodeRadius,
+} from "../components/RelationDependencyGraph"
 import Title from "../components/Title"
 import { RelationPoint } from "../lib/layout"
 import useFetch from "./api/fetch"
@@ -41,6 +43,9 @@ function buildDependencyAsEdges(list: Relation[]): RelationPoint[] {
             .map((r) => r.toString())
         : [],
       order: r.id,
+      width: nodeRadius * 2,
+      height: nodeRadius * 2,
+      relation: r,
     })
   }
   return edges

--- a/dashboard/pages/dependency_graph.tsx
+++ b/dashboard/pages/dependency_graph.tsx
@@ -109,11 +109,12 @@ export default function StreamingGraph() {
           overflowX="scroll"
           overflowY="scroll"
         >
-          <Text fontWeight="semibold">Graph</Text>
+          <Text fontWeight="semibold">Dependency Graph</Text>
           {relationDependency && (
             <RelationDependencyGraph
               nodes={relationDependency}
               selectedId={selectedId?.toString()}
+              setSelectedId={(id) => setSelectedId(parseInt(id))}
             />
           )}
         </Box>

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -406,7 +406,7 @@ export default function Streaming() {
               <Box flex="1" overflowY="scroll">
                 <FragmentDependencyGraph
                   svgWidth={SIDEBAR_WIDTH}
-                  mvDependency={fragmentDependencyDag}
+                  fragmentDependency={fragmentDependencyDag}
                   onSelectedIdChange={(id) =>
                     setSelectedFragmentId(parseInt(id))
                   }

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -64,7 +64,7 @@ function buildPlanNodeDependency(
 
   const hierarchyActorNode = (node: StreamNode): PlanNodeDatum => {
     return {
-      name: node.nodeBody?.$case.toString() || "unknown",
+      name: node.nodeBody?.$case?.toString() || "unknown",
       children: (node.input || []).map(hierarchyActorNode),
       operatorId: node.operatorId,
       node,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Improve the relation dependency graph. Act as a follow-up of #14446 for inter-job investigations.

- Show relation types in dep graph.
  <img width="481" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/a2b5638a-9e58-46eb-871a-513bfe714eb3">
- Click the relation point to see its catalog.
  <img width="438" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/6d517813-95a0-4eaa-87f5-299c858f7467">
- Navigate to fragment graph from catalog modal.
  <img width="440" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/7340980a-97f7-4b38-8df7-42c9470b52c4">

Also include some necessary refactors:

- Add type annotation for SVG of fragment dep graph and relation dep graph.
- Make layout algorithms generic on items, instead of mocking `RelationPoint` into `FragmentBox`. Correctly rename copy-pasted codes.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
