### PR TITLE
refactor(storage): create storage table from desc

### DIFF
--- a/src/batch/src/executor/join/distributed_lookup_join.rs
+++ b/src/batch/src/executor/join/distributed_lookup_join.rs
@@ -17,7 +17,7 @@ use std::mem::swap;
 
 use futures::pin_mut;
 use itertools::Itertools;
-use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId, TableOption};
+use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
 use risingwave_common::hash::{HashKey, HashKeyDispatcher};
 use risingwave_common::memory::MemoryContext;
 use risingwave_common::row::OwnedRow;
@@ -25,7 +25,6 @@ use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::scan_range::ScanRange;
-use risingwave_common::util::sort_util::OrderType;
 use risingwave_expr::expr::{build_from_prost, BoxedExpression};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::common::BatchQueryEpoch;
@@ -170,67 +169,16 @@ impl BoxedExecutorBuilder for DistributedLookupJoinExecutorBuilder {
 
         let chunk_size = source.context.get_config().developer.chunk_size;
 
-        let table_id = TableId {
-            table_id: table_desc.table_id,
-        };
-        let column_descs = table_desc
-            .columns
-            .iter()
-            .map(ColumnDesc::from)
-            .collect_vec();
         let column_ids = inner_side_column_ids
             .iter()
             .copied()
             .map(ColumnId::from)
             .collect();
 
-        let order_types: Vec<OrderType> = table_desc
-            .pk
-            .iter()
-            .map(|order| OrderType::from_protobuf(order.get_order_type().unwrap()))
-            .collect();
-
-        let pk_indices = table_desc
-            .pk
-            .iter()
-            .map(|k| k.column_index as usize)
-            .collect_vec();
-
-        let dist_key_in_pk_indices = table_desc
-            .dist_key_in_pk_indices
-            .iter()
-            .map(|&k| k as usize)
-            .collect_vec();
         // Lookup Join always contains distribution key, so we don't need vnode bitmap
-        let distribution = Distribution::all_vnodes(dist_key_in_pk_indices);
-        let table_option = TableOption {
-            retention_seconds: if table_desc.retention_seconds > 0 {
-                Some(table_desc.retention_seconds)
-            } else {
-                None
-            },
-        };
-        let value_indices = table_desc
-            .get_value_indices()
-            .iter()
-            .map(|&k| k as usize)
-            .collect_vec();
-        let prefix_hint_len = table_desc.get_read_prefix_len_hint() as usize;
-        let versioned = table_desc.versioned;
+        let vnodes = Some(Distribution::all_vnodes());
         dispatch_state_store!(source.context().state_store(), state_store, {
-            let table = StorageTable::new_partial(
-                state_store,
-                table_id,
-                column_descs,
-                column_ids,
-                order_types,
-                pk_indices,
-                distribution,
-                table_option,
-                value_indices,
-                prefix_hint_len,
-                versioned,
-            );
+            let table = StorageTable::new_partial(state_store, column_ids, vnodes, table_desc);
 
             let inner_side_builder = InnerSideExecutorBuilder::new(
                 outer_side_key_types,

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -20,12 +20,11 @@ use itertools::Itertools;
 use prometheus::Histogram;
 use risingwave_common::array::DataChunk;
 use risingwave_common::buffer::Bitmap;
-use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema, TableId, TableOption};
+use risingwave_common::catalog::{ColumnId, Schema};
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::select_all;
-use risingwave_common::util::sort_util::OrderType;
 use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{scan_range, PbScanRange};
@@ -173,14 +172,6 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
         )?;
 
         let table_desc: &StorageTableDesc = seq_scan_node.get_table_desc()?;
-        let table_id = TableId {
-            table_id: table_desc.table_id,
-        };
-        let column_descs = table_desc
-            .columns
-            .iter()
-            .map(ColumnDesc::from)
-            .collect_vec();
         let column_ids = seq_scan_node
             .column_ids
             .iter()
@@ -188,52 +179,13 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             .map(ColumnId::from)
             .collect();
 
-        let pk_types = table_desc
-            .pk
-            .iter()
-            .map(|order| column_descs[order.column_index as usize].clone().data_type)
-            .collect_vec();
-        let order_types: Vec<OrderType> = table_desc
-            .pk
-            .iter()
-            .map(|order| OrderType::from_protobuf(order.get_order_type().unwrap()))
-            .collect();
-
-        let pk_indices = table_desc
-            .pk
-            .iter()
-            .map(|k| k.column_index as usize)
-            .collect_vec();
-
-        let dist_key_in_pk_indices = table_desc
-            .dist_key_in_pk_indices
-            .iter()
-            .map(|&k| k as usize)
-            .collect_vec();
-        let distribution = match &seq_scan_node.vnode_bitmap {
-            Some(vnodes) => Distribution {
-                vnodes: Bitmap::from(vnodes).into(),
-                dist_key_in_pk_indices,
-            },
+        let vnodes = match &seq_scan_node.vnode_bitmap {
+            Some(vnodes) => Some(Bitmap::from(vnodes).into()),
             // This is possible for dml. vnode_bitmap is not filled by scheduler.
             // Or it's single distribution, e.g., distinct agg. We scan in a single executor.
-            None => Distribution::all_vnodes(dist_key_in_pk_indices),
+            None => Some(Distribution::all_vnodes()),
         };
 
-        let table_option = TableOption {
-            retention_seconds: if table_desc.retention_seconds > 0 {
-                Some(table_desc.retention_seconds)
-            } else {
-                None
-            },
-        };
-        let value_indices = table_desc
-            .get_value_indices()
-            .iter()
-            .map(|&k| k as usize)
-            .collect_vec();
-        let prefix_hint_len = table_desc.get_read_prefix_len_hint() as usize;
-        let versioned = table_desc.versioned;
         let scan_ranges = {
             let scan_ranges = &seq_scan_node.scan_ranges;
             if scan_ranges.is_empty() {
@@ -241,10 +193,21 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             } else {
                 scan_ranges
                     .iter()
-                    .map(|scan_range| ScanRange::new(scan_range.clone(), pk_types.iter().cloned()))
+                    .map(|scan_range| {
+                        let pk_types = table_desc.pk.iter().map(|order| {
+                            DataType::from(
+                                table_desc.columns[order.column_index as usize]
+                                    .column_type
+                                    .as_ref()
+                                    .unwrap(),
+                            )
+                        });
+                        ScanRange::new(scan_range.clone(), pk_types)
+                    })
                     .try_collect()?
             }
         };
+
         let ordered = seq_scan_node.ordered;
 
         let epoch = source.epoch.clone();
@@ -257,19 +220,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
         let metrics = source.context().batch_metrics();
 
         dispatch_state_store!(source.context().state_store(), state_store, {
-            let table = StorageTable::new_partial(
-                state_store,
-                table_id,
-                column_descs,
-                column_ids,
-                order_types,
-                pk_indices,
-                distribution,
-                table_option,
-                value_indices,
-                prefix_hint_len,
-                versioned,
-            );
+            let table = StorageTable::new_partial(state_store, column_ids, vnodes, table_desc);
             Ok(Box::new(RowSeqScanExecutor::new(
                 table,
                 scan_ranges,

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -71,14 +71,18 @@ impl Distribution {
         FALLBACK_VNODES.clone()
     }
 
-    /// Distribution that accesses all vnodes, mainly used for tests.
-    pub fn all_vnodes(dist_key_in_pk_indices: Vec<usize>) -> Self {
+    pub fn all_vnodes() -> Arc<Bitmap> {
         /// A bitmap that all vnodes are set.
         static ALL_VNODES: LazyLock<Arc<Bitmap>> =
             LazyLock::new(|| Bitmap::ones(VirtualNode::COUNT).into());
+        ALL_VNODES.clone()
+    }
+
+    /// Distribution that accesses all vnodes, mainly used for tests.
+    pub fn all(dist_key_in_pk_indices: Vec<usize>) -> Self {
         Self {
             dist_key_in_pk_indices,
-            vnodes: ALL_VNODES.clone(),
+            vnodes: Self::all_vnodes(),
         }
     }
 }

--- a/src/stream/src/common/table/test_storage_table.rs
+++ b/src/stream/src/common/table/test_storage_table.rs
@@ -14,7 +14,7 @@
 
 use futures::pin_mut;
 use itertools::Itertools;
-use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId, TableOption};
+use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::DataType;
 use risingwave_common::util::epoch::EpochPair;
@@ -22,7 +22,7 @@ use risingwave_common::util::sort_util::OrderType;
 use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::{Distribution, TableIter};
+use risingwave_storage::table::TableIter;
 
 use crate::common::table::state_table::StateTable;
 use crate::common::table::test_utils::{gen_prost_table, gen_prost_table_with_value_indices};
@@ -299,18 +299,14 @@ async fn test_row_based_storage_table_point_get_in_batch_mode() {
             .await;
 
     let column_ids_partial = vec![ColumnId::from(1), ColumnId::from(2)];
-    let table = StorageTable::new_partial(
+    let table = StorageTable::for_test_with_partial_columns(
         test_env.storage.clone(),
         TEST_TABLE_ID,
         column_descs.clone(),
         column_ids_partial,
         order_types.clone(),
         pk_indices,
-        Distribution::fallback(),
-        TableOption::default(),
         value_indices,
-        0,
-        false,
     );
     let mut epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
@@ -408,18 +404,14 @@ async fn test_batch_scan_with_value_indices() {
 
     let column_ids_partial = vec![ColumnId::from(1), ColumnId::from(2)];
 
-    let table = StorageTable::new_partial(
+    let table = StorageTable::for_test_with_partial_columns(
         test_env.storage.clone(),
         TEST_TABLE_ID,
         column_descs.clone(),
         column_ids_partial,
         order_types.clone(),
         pk_indices,
-        Distribution::fallback(),
-        TableOption::default(),
         value_indices,
-        0,
-        false,
     );
     let mut epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -383,7 +383,7 @@ mod tests {
             column_descs,
             order_types.to_vec(),
             pk_indices.to_vec(),
-            Distribution::all_vnodes(vec![0]),
+            Distribution::all(vec![0]),
             Some(val_indices.to_vec()),
         )
         .await

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -12,13 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use itertools::Itertools;
-use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId, TableOption};
-use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::catalog::ColumnId;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan::BatchPlanNode;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::Distribution;
 use risingwave_storage::StateStore;
 
 use super::*;
@@ -43,21 +40,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         }
 
         let table_desc: &StorageTableDesc = node.get_table_desc()?;
-        let table_id = TableId {
-            table_id: table_desc.table_id,
-        };
 
-        let order_types = table_desc
-            .pk
-            .iter()
-            .map(|desc| OrderType::from_protobuf(desc.get_order_type().unwrap()))
-            .collect_vec();
-
-        let column_descs = table_desc
-            .columns
-            .iter()
-            .map(ColumnDesc::from)
-            .collect_vec();
         let column_ids = node
             .column_ids
             .iter()
@@ -65,52 +48,11 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             .map(ColumnId::from)
             .collect();
 
-        // Use indices based on full table instead of streaming executor output.
-        let pk_indices = table_desc
-            .pk
-            .iter()
-            .map(|k| k.column_index as usize)
-            .collect_vec();
-
-        let dist_key_in_pk_indices = table_desc
-            .dist_key_in_pk_indices
-            .iter()
-            .map(|&k| k as usize)
-            .collect_vec();
-        let distribution = match params.vnode_bitmap {
-            Some(vnodes) => Distribution {
-                dist_key_in_pk_indices,
-                vnodes: vnodes.into(),
-            },
-            None => Distribution::fallback(),
-        };
-
-        let table_option = TableOption {
-            retention_seconds: if table_desc.retention_seconds > 0 {
-                Some(table_desc.retention_seconds)
-            } else {
-                None
-            },
-        };
-        let value_indices = table_desc
-            .get_value_indices()
-            .iter()
-            .map(|&k| k as usize)
-            .collect_vec();
-        let prefix_hint_len = table_desc.get_read_prefix_len_hint() as usize;
-        let versioned = table_desc.versioned;
         let table = StorageTable::new_partial(
             state_store,
-            table_id,
-            column_descs,
             column_ids,
-            order_types,
-            pk_indices,
-            distribution,
-            table_option,
-            value_indices,
-            prefix_hint_len,
-            versioned,
+            params.vnode_bitmap.map(Into::into),
+            table_desc,
         );
         assert_eq!(table.schema().data_types(), params.info.schema.data_types());
 

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -14,14 +14,12 @@
 
 use std::sync::Arc;
 
-use risingwave_common::catalog::{ColumnDesc, TableId, TableOption};
+use risingwave_common::catalog::ColumnId;
 use risingwave_common::hash::{HashKey, HashKeyDispatcher};
 use risingwave_common::types::DataType;
-use risingwave_common::util::sort_util::OrderType;
 use risingwave_expr::expr::{build_non_strict_from_prost, NonStrictExpression};
 use risingwave_pb::plan_common::{JoinType as JoinTypeProto, StorageTableDesc};
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::Distribution;
 
 use super::*;
 use crate::executor::monitor::StreamingMetrics;
@@ -41,71 +39,17 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
     ) -> StreamResult<BoxedExecutor> {
         let table_desc: &StorageTableDesc = node.get_table_desc()?;
         let table = {
-            let table_id = TableId {
-                table_id: table_desc.table_id,
-            };
-
-            let order_types = table_desc
-                .pk
-                .iter()
-                .map(|desc| OrderType::from_protobuf(desc.get_order_type().unwrap()))
-                .collect_vec();
-
-            let column_descs = table_desc
+            let column_ids = table_desc
                 .columns
                 .iter()
-                .map(ColumnDesc::from)
+                .map(|x| ColumnId::new(x.column_id))
                 .collect_vec();
-            let column_ids = column_descs.iter().map(|x| x.column_id).collect_vec();
-
-            // Use indices based on full table instead of streaming executor output.
-            let pk_indices = table_desc
-                .pk
-                .iter()
-                .map(|k| k.column_index as usize)
-                .collect_vec();
-
-            let dist_key_in_pk_indices = table_desc
-                .dist_key_in_pk_indices
-                .iter()
-                .map(|&k| k as usize)
-                .collect_vec();
-            let distribution = match params.vnode_bitmap.clone() {
-                Some(vnodes) => Distribution {
-                    dist_key_in_pk_indices,
-                    vnodes: vnodes.into(),
-                },
-                None => Distribution::fallback(),
-            };
-
-            let table_option = TableOption {
-                retention_seconds: if table_desc.retention_seconds > 0 {
-                    Some(table_desc.retention_seconds)
-                } else {
-                    None
-                },
-            };
-
-            let value_indices = table_desc
-                .get_value_indices()
-                .iter()
-                .map(|&k| k as usize)
-                .collect_vec();
-
-            let prefix_hint_len = table_desc.get_read_prefix_len_hint() as usize;
 
             StorageTable::new_partial(
                 store,
-                table_id,
-                column_descs,
                 column_ids,
-                order_types,
-                pk_indices,
-                distribution,
-                table_option,
-                value_indices,
-                prefix_hint_len,
-                table_desc.versioned,
+                params.vnode_bitmap.map(Into::into),
+                table_desc,
             )
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In our current call path on `StorageTable::new_partial`, we always have the following duplicate logic that generates some storage table information from `StorageTableDesc` before calling `new_partial`, and then pass all these information to `new_partial`. 

```
let table_id = TableId {
    table_id: table_desc.table_id,
};
let column_descs = table_desc
    .columns
    .iter()
    .map(ColumnDesc::from)
    .collect_vec();
let order_types: Vec<OrderType> = table_desc
    .pk
    .iter()
    .map(|order| OrderType::from_protobuf(order.get_order_type().unwrap()))
    .collect();

let pk_indices = table_desc
    .pk
    .iter()
    .map(|k| k.column_index as usize)
    .collect_vec();

let table_option = TableOption {
    retention_seconds: if table_desc.retention_seconds > 0 {
        Some(table_desc.retention_seconds)
    } else {
        None
    },
};
let value_indices = table_desc
    .get_value_indices()
    .iter()
    .map(|&k| k as usize)
    .collect_vec();
let prefix_hint_len = table_desc.get_read_prefix_len_hint() as usize;
let versioned = table_desc.versioned;
```

In this PR, we extract this duplicate logic to inside the `new_partial`, and instead the `new_partial` will create storage table from `StorageTableDesc` directly. All the current usages of `new_partial` differ only in the input `vnodes` and `output_column_id`. Fortunately, all current usage of `new_partial` is with `StorageTableDesc`, and therefore we can safely remove the usage original usage of `new_partial`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
