### PR TITLE
refactor(frontend): Move some pg wire value into common and make them const

### DIFF
--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -91,6 +91,16 @@ pub const RW_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Placeholder for unknown git sha.
 pub const UNKNOWN_GIT_SHA: &str = "unknown";
 
+// The single source of truth of the pg parameters, The used in ConfigMap and other places.
+// The version of PostgreSQL that Risingwave claims to be.
+pub const PG_VERSION: &str = "9.5.0";
+/// The version of PostgreSQL that Risingwave claims to be.
+pub const SERVER_VERSION_NUM: i32 = 90500;
+/// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time.
+pub const CLIENT_ENCODING: &str = "UTF8";
+/// see <https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STANDARD-CONFORMING-STRINGS>
+pub const STANDARD_CONFORMING_STRINGS: &str = "on";
+
 #[macro_export]
 macro_rules! git_sha {
     ($env:literal) => {
@@ -107,5 +117,8 @@ macro_rules! git_sha {
 pub const GIT_SHA: &str = git_sha!("GIT_SHA");
 
 pub fn current_cluster_version() -> String {
-    format!("PostgreSQL 9.5-RisingWave-{} ({})", RW_VERSION, GIT_SHA)
+    format!(
+        "PostgreSQL {}-RisingWave-{} ({})",
+        PG_VERSION, RW_VERSION, GIT_SHA
+    )
 }

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -96,7 +96,7 @@ pub const UNKNOWN_GIT_SHA: &str = "unknown";
 pub const PG_VERSION: &str = "9.5.0";
 /// The version of PostgreSQL that Risingwave claims to be.
 pub const SERVER_VERSION_NUM: i32 = 90500;
-/// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time. It is also the default value of CLIENT_ENCODING.
+/// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time. It is also the default value of `client_encoding`.
 pub const SERVER_ENCODING: &str = "UTF8";
 /// see <https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STANDARD-CONFORMING-STRINGS>
 pub const STANDARD_CONFORMING_STRINGS: &str = "on";

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -91,7 +91,7 @@ pub const RW_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Placeholder for unknown git sha.
 pub const UNKNOWN_GIT_SHA: &str = "unknown";
 
-// The single source of truth of the pg parameters, The used in ConfigMap and other places.
+// The single source of truth of the pg parameters, Used in ConfigMap and current_cluster_version.
 // The version of PostgreSQL that Risingwave claims to be.
 pub const PG_VERSION: &str = "9.5.0";
 /// The version of PostgreSQL that Risingwave claims to be.

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -96,8 +96,8 @@ pub const UNKNOWN_GIT_SHA: &str = "unknown";
 pub const PG_VERSION: &str = "9.5.0";
 /// The version of PostgreSQL that Risingwave claims to be.
 pub const SERVER_VERSION_NUM: i32 = 90500;
-/// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time.
-pub const CLIENT_ENCODING: &str = "UTF8";
+/// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time. It is also the default value of CLIENT_ENCODING.
+pub const SERVER_ENCODING: &str = "UTF8";
 /// see <https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STANDARD-CONFORMING-STRINGS>
 pub const STANDARD_CONFORMING_STRINGS: &str = "on";
 

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -24,7 +24,7 @@ use chrono_tz::Tz;
 pub use over_window::OverWindowCachePolicy;
 pub use query_mode::QueryMode;
 use risingwave_common::{
-    CLIENT_ENCODING, PG_VERSION, SERVER_VERSION_NUM, STANDARD_CONFORMING_STRINGS,
+    SERVER_ENCODING, PG_VERSION, SERVER_VERSION_NUM, STANDARD_CONFORMING_STRINGS,
 };
 use risingwave_common_proc_macro::SessionConfig;
 pub use search_path::{SearchPath, USER_NAME_WILD_CARD};
@@ -190,7 +190,7 @@ pub struct ConfigMap {
     client_min_messages: String,
 
     /// see <https://www.postgresql.org/docs/15/runtime-config-client.html#GUC-CLIENT-ENCODING>
-    #[parameter(default = CLIENT_ENCODING , check_hook = check_client_encoding)]
+    #[parameter(default = SERVER_ENCODING , check_hook = check_client_encoding)]
     client_encoding: String,
 
     /// Enable decoupling sink and internal streaming graph or not
@@ -237,7 +237,7 @@ pub struct ConfigMap {
     background_ddl: bool,
 
     /// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time.
-    #[parameter(default = CLIENT_ENCODING)]
+    #[parameter(default = SERVER_ENCODING)]
     server_encoding: String,
 
     #[parameter(default = "hex", check_hook = check_bytea_output)]

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -23,9 +23,6 @@ mod visibility_mode;
 use chrono_tz::Tz;
 pub use over_window::OverWindowCachePolicy;
 pub use query_mode::QueryMode;
-use risingwave_common::{
-    SERVER_ENCODING, PG_VERSION, SERVER_VERSION_NUM, STANDARD_CONFORMING_STRINGS,
-};
 use risingwave_common_proc_macro::SessionConfig;
 pub use search_path::{SearchPath, USER_NAME_WILD_CARD};
 use thiserror::Error;
@@ -34,6 +31,7 @@ use self::non_zero64::ConfigNonZeroU64;
 use crate::session_config::sink_decouple::SinkDecouple;
 use crate::session_config::transaction_isolation_level::IsolationLevel;
 pub use crate::session_config::visibility_mode::VisibilityMode;
+use crate::{PG_VERSION, SERVER_ENCODING, SERVER_VERSION_NUM, STANDARD_CONFORMING_STRINGS};
 
 pub const SESSION_CONFIG_LIST_SEP: &str = ", ";
 
@@ -190,7 +188,7 @@ pub struct ConfigMap {
     client_min_messages: String,
 
     /// see <https://www.postgresql.org/docs/15/runtime-config-client.html#GUC-CLIENT-ENCODING>
-    #[parameter(default = SERVER_ENCODING , check_hook = check_client_encoding)]
+    #[parameter(default = SERVER_ENCODING, check_hook = check_client_encoding)]
     client_encoding: String,
 
     /// Enable decoupling sink and internal streaming graph or not

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -23,6 +23,9 @@ mod visibility_mode;
 use chrono_tz::Tz;
 pub use over_window::OverWindowCachePolicy;
 pub use query_mode::QueryMode;
+use risingwave_common::{
+    CLIENT_ENCODING, PG_VERSION, SERVER_VERSION_NUM, STANDARD_CONFORMING_STRINGS,
+};
 use risingwave_common_proc_macro::SessionConfig;
 pub use search_path::{SearchPath, USER_NAME_WILD_CARD};
 use thiserror::Error;
@@ -175,11 +178,11 @@ pub struct ConfigMap {
     batch_parallelism: ConfigNonZeroU64,
 
     /// The version of PostgreSQL that Risingwave claims to be.
-    #[parameter(default = "9.5.0")]
+    #[parameter(default = PG_VERSION)]
     server_version: String,
 
     /// The version of PostgreSQL that Risingwave claims to be.
-    #[parameter(default = 90500)]
+    #[parameter(default = SERVER_VERSION_NUM)]
     server_version_num: i32,
 
     /// see <https://www.postgresql.org/docs/15/runtime-config-client.html#GUC-CLIENT-MIN-MESSAGES>
@@ -187,7 +190,7 @@ pub struct ConfigMap {
     client_min_messages: String,
 
     /// see <https://www.postgresql.org/docs/15/runtime-config-client.html#GUC-CLIENT-ENCODING>
-    #[parameter(default = "UTF8", check_hook = check_client_encoding)]
+    #[parameter(default = CLIENT_ENCODING , check_hook = check_client_encoding)]
     client_encoding: String,
 
     /// Enable decoupling sink and internal streaming graph or not
@@ -217,7 +220,7 @@ pub struct ConfigMap {
     row_security: bool,
 
     /// see <https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STANDARD-CONFORMING-STRINGS>
-    #[parameter(default = "on")]
+    #[parameter(default = STANDARD_CONFORMING_STRINGS)]
     standard_conforming_strings: String,
 
     /// Set streaming rate limit (rows per second) for each parallelism for mv backfilling
@@ -234,7 +237,7 @@ pub struct ConfigMap {
     background_ddl: bool,
 
     /// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time.
-    #[parameter(default = "UTF8")]
+    #[parameter(default = CLIENT_ENCODING)]
     server_encoding: String,
 
     #[parameter(default = "hex", check_hook = check_bytea_output)]

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -28,7 +28,7 @@ use openssl::ssl::{SslAcceptor, SslContext, SslContextRef, SslMethod};
 use risingwave_common::types::DataType;
 use risingwave_common::util::panic::FutureCatchUnwindExt;
 use risingwave_common::util::query_log::*;
-use risingwave_common::{CLIENT_ENCODING, PG_VERSION, STANDARD_CONFORMING_STRINGS};
+use risingwave_common::{SERVER_ENCODING, PG_VERSION, STANDARD_CONFORMING_STRINGS};
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use thiserror_ext::AsReport;
@@ -974,7 +974,7 @@ where
 
     fn write_parameter_status_msg_no_flush(&mut self, status: &ParameterStatus) -> io::Result<()> {
         self.write_no_flush(&BeMessage::ParameterStatus(
-            BeParameterStatusMessage::ClientEncoding(CLIENT_ENCODING),
+            BeParameterStatusMessage::ClientEncoding(SERVER_ENCODING),
         ))?;
         self.write_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::StandardConformingString(STANDARD_CONFORMING_STRINGS),

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -28,6 +28,7 @@ use openssl::ssl::{SslAcceptor, SslContext, SslContextRef, SslMethod};
 use risingwave_common::types::DataType;
 use risingwave_common::util::panic::FutureCatchUnwindExt;
 use risingwave_common::util::query_log::*;
+use risingwave_common::{CLIENT_ENCODING, PG_VERSION, STANDARD_CONFORMING_STRINGS};
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use thiserror_ext::AsReport;
@@ -973,13 +974,13 @@ where
 
     fn write_parameter_status_msg_no_flush(&mut self, status: &ParameterStatus) -> io::Result<()> {
         self.write_no_flush(&BeMessage::ParameterStatus(
-            BeParameterStatusMessage::ClientEncoding("UTF8"),
+            BeParameterStatusMessage::ClientEncoding(CLIENT_ENCODING),
         ))?;
         self.write_no_flush(&BeMessage::ParameterStatus(
-            BeParameterStatusMessage::StandardConformingString("on"),
+            BeParameterStatusMessage::StandardConformingString(STANDARD_CONFORMING_STRINGS),
         ))?;
         self.write_no_flush(&BeMessage::ParameterStatus(
-            BeParameterStatusMessage::ServerVersion("9.5.0"),
+            BeParameterStatusMessage::ServerVersion(PG_VERSION),
         ))?;
         if let Some(application_name) = &status.application_name {
             self.write_no_flush(&BeMessage::ParameterStatus(

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -28,7 +28,7 @@ use openssl::ssl::{SslAcceptor, SslContext, SslContextRef, SslMethod};
 use risingwave_common::types::DataType;
 use risingwave_common::util::panic::FutureCatchUnwindExt;
 use risingwave_common::util::query_log::*;
-use risingwave_common::{SERVER_ENCODING, PG_VERSION, STANDARD_CONFORMING_STRINGS};
+use risingwave_common::{PG_VERSION, SERVER_ENCODING, STANDARD_CONFORMING_STRINGS};
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use thiserror_ext::AsReport;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
In #11265
1. we need to refactor the `current_cluster_version` function which used in `function / streaming job / ddl controller` which should get from the `ConfigMap`. 
2. When setting the pgwire for `ParameterStatus`, we hard code the `server version / client encoding / StandardConformingString / ApplicationName`. 

This PR try to refactor the above two parts. 
1. Firstly move some default value of the `ConfigMap` into common and make they as pub const. Use this const when initialize the `ConfigMap`. 
2. Secondly, in theory,  we should read `ParameterStatus` from the `session_config`. But we use const value to init `session_config`, so we directly use the const for `ParameterStatus`. The same logic for `current_cluster_version`
4. For application name, it is not const value, so I keep the orginal code path without change.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
