### PR TITLE
refactor: unify compute vnode logic

### DIFF
--- a/src/batch/src/executor/join/distributed_lookup_join.rs
+++ b/src/batch/src/executor/join/distributed_lookup_join.rs
@@ -30,7 +30,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::common::BatchQueryEpoch;
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::{Distribution, TableIter};
+use risingwave_storage::table::{TableDistribution, TableIter};
 use risingwave_storage::{dispatch_state_store, StateStore};
 
 use crate::error::Result;
@@ -176,7 +176,7 @@ impl BoxedExecutorBuilder for DistributedLookupJoinExecutorBuilder {
             .collect();
 
         // Lookup Join always contains distribution key, so we don't need vnode bitmap
-        let vnodes = Some(Distribution::all_vnodes());
+        let vnodes = Some(TableDistribution::all_vnodes());
         dispatch_state_store!(source.context().state_store(), state_store, {
             let table = StorageTable::new_partial(state_store, column_ids, vnodes, table_desc);
 

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -32,7 +32,7 @@ use risingwave_pb::common::BatchQueryEpoch;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::{collect_data_chunk, Distribution};
+use risingwave_storage::table::{collect_data_chunk, TableDistribution};
 use risingwave_storage::{dispatch_state_store, StateStore};
 
 use crate::error::{BatchError, Result};
@@ -183,7 +183,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             Some(vnodes) => Some(Bitmap::from(vnodes).into()),
             // This is possible for dml. vnode_bitmap is not filled by scheduler.
             // Or it's single distribution, e.g., distinct agg. We scan in a single executor.
-            None => Some(Distribution::all_vnodes()),
+            None => Some(TableDistribution::all_vnodes()),
         };
 
         let scan_ranges = {

--- a/src/common/src/hash/consistent_hash/vnode.rs
+++ b/src/common/src/hash/consistent_hash/vnode.rs
@@ -18,7 +18,7 @@ use parse_display::Display;
 use crate::array::{Array, ArrayImpl, DataChunk};
 use crate::hash::Crc32HashCode;
 use crate::row::{Row, RowExt};
-use crate::types::{DataType, ScalarRefImpl};
+use crate::types::{DataType, DatumRef, ScalarRefImpl};
 use crate::util::hash_util::Crc32FastBuilder;
 use crate::util::row_id::extract_vnode_id_from_row_id;
 
@@ -85,6 +85,14 @@ impl VirtualNode {
     pub const fn from_scalar(scalar: i16) -> Self {
         debug_assert!((scalar as usize) < Self::COUNT);
         Self(scalar as _)
+    }
+
+    pub const fn vnode_data_type() -> DataType {
+        DataType::Int16
+    }
+
+    pub fn from_datum(datum: DatumRef<'_>) -> Self {
+        Self::from_scalar(datum.expect("should not be none").into_int16())
     }
 
     /// Returns the scalar representation of the virtual node. Used by `VNODE` expression.

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -21,7 +21,7 @@ use risingwave_storage::hummock::HummockStorage;
 use risingwave_storage::monitor::MonitoredStateStore;
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::Distribution;
+use risingwave_storage::table::TableDistribution;
 use risingwave_storage::StateStore;
 use risingwave_stream::common::table::state_table::StateTable;
 
@@ -63,7 +63,7 @@ pub async fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -
             .collect(),
         table.pk().iter().map(|x| x.order_type).collect(),
         table.pk().iter().map(|x| x.column_index).collect(),
-        Distribution::all(table.distribution_key().to_vec()), // scan all vnodes
+        TableDistribution::all(table.distribution_key().to_vec()), // scan all vnodes
         Some(table.value_indices.clone()),
     )
     .await
@@ -78,7 +78,7 @@ pub fn make_storage_table<S: StateStore>(hummock: S, table: &TableCatalog) -> St
     StorageTable::new_partial(
         hummock,
         output_columns_ids,
-        Some(Distribution::all_vnodes()),
+        Some(TableDistribution::all_vnodes()),
         &table.table_desc().to_protobuf(),
     )
 }

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -16,6 +16,7 @@ use itertools::Itertools as _;
 use num_integer::Integer as _;
 use risingwave_common::bail_no_function;
 use risingwave_common::error::{ErrorCode, Result};
+use risingwave_common::hash::VirtualNode;
 use risingwave_common::types::{DataType, StructType};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr::aggregate::AggKind;
@@ -578,7 +579,7 @@ fn infer_type_for_special(
         }
         ExprType::Vnode => {
             ensure_arity!("vnode", 1 <= | inputs |);
-            Ok(Some(DataType::Int16))
+            Ok(Some(VirtualNode::vnode_data_type()))
         }
         ExprType::Greatest | ExprType::Least => {
             ensure_arity!("greatest/least", 1 <= | inputs |);

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -47,7 +47,7 @@ use crate::row_serde::value_serde::{ValueRowSerde, ValueRowSerdeNew};
 use crate::row_serde::{find_columns_by_ids, ColumnMapping};
 use crate::store::{PrefetchOptions, ReadOptions};
 use crate::table::merge_sort::merge_sort;
-use crate::table::{compute_vnode, Distribution, KeyedRow, TableIter};
+use crate::table::{KeyedRow, TableDistribution, TableIter};
 use crate::StateStore;
 
 /// [`StorageTableInner`] is the interface accessing relational data in KV(`StateStore`) with
@@ -89,16 +89,7 @@ pub struct StorageTableInner<S: StateStore, SD: ValueRowSerde> {
     // FIXME: revisit constructions and usages.
     pk_indices: Vec<usize>,
 
-    /// Indices of distribution key for computing vnode.
-    /// Note that the index is based on the primary key columns by `pk_indices`.
-    dist_key_in_pk_indices: Vec<usize>,
-
-    /// Virtual nodes that the table is partitioned into.
-    ///
-    /// Only the rows whose vnode of the primary key is in this set will be visible to the
-    /// executor. For READ_WRITE instances, the table will also check whether the written rows
-    /// confirm to this partition.
-    vnodes: Arc<Bitmap>,
+    distribution: TableDistribution,
 
     /// Used for catalog table_properties
     table_option: TableOption,
@@ -168,20 +159,12 @@ impl<S: StateStore> StorageTableInner<S, EitherSerde> {
             .collect_vec();
         let prefix_hint_len = table_desc.get_read_prefix_len_hint() as usize;
         let versioned = table_desc.versioned;
-        let distribution = match vnodes {
-            None => Distribution::fallback(),
-            Some(vnodes) => {
-                let dist_key_in_pk_indices = table_desc
-                    .dist_key_in_pk_indices
-                    .iter()
-                    .map(|&k| k as usize)
-                    .collect_vec();
-                Distribution {
-                    dist_key_in_pk_indices,
-                    vnodes,
-                }
-            }
-        };
+        let dist_key_in_pk_indices = table_desc
+            .dist_key_in_pk_indices
+            .iter()
+            .map(|&k| k as usize)
+            .collect_vec();
+        let distribution = TableDistribution::new(vnodes, dist_key_in_pk_indices, None);
 
         Self::new_inner(
             store,
@@ -214,7 +197,7 @@ impl<S: StateStore> StorageTableInner<S, EitherSerde> {
             output_column_ids,
             order_types,
             pk_indices,
-            Distribution::fallback(),
+            TableDistribution::singleton(),
             Default::default(),
             value_indices,
             0,
@@ -250,10 +233,7 @@ impl<S: StateStore> StorageTableInner<S, EitherSerde> {
         output_column_ids: Vec<ColumnId>,
         order_types: Vec<OrderType>,
         pk_indices: Vec<usize>,
-        Distribution {
-            dist_key_in_pk_indices,
-            vnodes,
-        }: Distribution,
+        distribution: TableDistribution,
         table_option: TableOption,
         value_indices: Vec<usize>,
         read_prefix_len_hint: usize,
@@ -316,8 +296,7 @@ impl<S: StateStore> StorageTableInner<S, EitherSerde> {
             mapping: Arc::new(mapping),
             row_serde: Arc::new(row_serde),
             pk_indices,
-            dist_key_in_pk_indices,
-            vnodes,
+            distribution,
             table_option,
             read_prefix_len_hint,
         }
@@ -357,20 +336,6 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
 }
 /// Point get
 impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
-    /// Get vnode value with given primary key.
-    fn compute_vnode_by_pk(&self, pk: impl Row) -> VirtualNode {
-        compute_vnode(pk, &self.dist_key_in_pk_indices, &self.vnodes)
-    }
-
-    /// Try getting vnode value with given primary key prefix, used for `vnode_hint` in iterators.
-    /// Return `None` if the provided columns are not enough.
-    fn try_compute_vnode_by_pk_prefix(&self, pk_prefix: impl Row) -> Option<VirtualNode> {
-        self.dist_key_in_pk_indices
-            .iter()
-            .all(|&d| d < pk_prefix.len())
-            .then(|| compute_vnode(pk_prefix, &self.dist_key_in_pk_indices, &self.vnodes))
-    }
-
     /// Get a single row by point get
     pub async fn get_row(
         &self,
@@ -380,8 +345,11 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
         let epoch = wait_epoch.get_epoch();
         let read_backup = matches!(wait_epoch, HummockReadEpoch::Backup(_));
         self.store.try_wait_epoch(wait_epoch).await?;
-        let serialized_pk =
-            serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
+        let serialized_pk = serialize_pk_with_vnode(
+            &pk,
+            &self.pk_serializer,
+            self.distribution.compute_vnode_by_pk(&pk),
+        );
         assert!(pk.len() <= self.pk_indices.len());
 
         let prefix_hint = if self.read_prefix_len_hint != 0 && self.read_prefix_len_hint == pk.len()
@@ -444,8 +412,7 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
     /// Update the vnode bitmap of the storage table, returns the previous vnode bitmap.
     #[must_use = "the executor should decide whether to manipulate the cache based on the previous vnode bitmap"]
     pub fn update_vnode_bitmap(&mut self, new_vnodes: Arc<Bitmap>) -> Arc<Bitmap> {
-        assert_eq!(self.vnodes.len(), new_vnodes.len());
-        std::mem::replace(&mut self.vnodes, new_vnodes)
+        self.distribution.update_vnode_bitmap(new_vnodes)
     }
 }
 
@@ -494,7 +461,7 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
                 // If `vnode_hint` is set, we can only access this single vnode.
                 Some(vnode) => Either::Left(std::iter::once(vnode)),
                 // Otherwise, we need to access all vnodes of this table.
-                None => Either::Right(self.vnodes.iter_vnodes()),
+                None => Either::Right(self.distribution.vnodes().iter_vnodes()),
             };
             vnodes.map(|vnode| prefixed_range_with_vnode(encoded_key_range.clone(), vnode))
         };
@@ -667,7 +634,7 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
             prefix_hint,
             (start_key, end_key),
             epoch,
-            self.try_compute_vnode_by_pk_prefix(pk_prefix),
+            self.distribution.try_compute_vnode_by_pk_prefix(pk_prefix),
             ordered,
             prefetch_options,
         )

--- a/src/stream/src/common/log_store_impl/kv_log_store/serde.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/serde.rs
@@ -205,7 +205,13 @@ impl LogStoreRowSerde {
     fn compute_vnode(&self, row: impl Row) -> VirtualNode {
         match &self.vnodes {
             None => SINGLETON_VNODE,
-            Some(vnodes) => compute_vnode(row, &self.dist_key_indices, vnodes),
+            Some(vnodes) => {
+                if self.dist_key_indices.is_empty() {
+                    SINGLETON_VNODE
+                } else {
+                    compute_vnode(row, &self.dist_key_indices, vnodes)
+                }
+            }
         }
     }
 

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -58,7 +58,7 @@ use risingwave_storage::store::{
     ReadOptions, SealCurrentEpochOptions, StateStoreIterItemStream,
 };
 use risingwave_storage::table::merge_sort::merge_sort;
-use risingwave_storage::table::{compute_chunk_vnode, compute_vnode, Distribution, KeyedRow};
+use risingwave_storage::table::{KeyedRow, TableDistribution};
 use risingwave_storage::StateStore;
 use tracing::{trace, Instrument};
 
@@ -108,30 +108,17 @@ pub struct StateTableInner<
     // FIXME: revisit constructions and usages.
     pk_indices: Vec<usize>,
 
-    /// Indices of distribution key for computing vnode.
-    /// Note that the index is based on the all columns of the table, instead of the output ones.
-    // FIXME: revisit constructions and usages.
-    // dist_key_indices: Vec<usize>,
-
-    /// Indices of distribution key for computing vnode.
-    /// Note that the index is based on the primary key columns by `pk_indices`.
-    dist_key_in_pk_indices: Vec<usize>,
+    /// Distribution of the state table.
+    ///
+    /// It holds vnode bitmap. Only the rows whose vnode of the primary key is in this set will be visible to the
+    /// executor. The table will also check whether the written rows
+    /// conform to this partition.
+    distribution: TableDistribution,
 
     prefix_hint_len: usize,
 
-    /// Virtual nodes that the table is partitioned into.
-    ///
-    /// Only the rows whose vnode of the primary key is in this set will be visible to the
-    /// executor. The table will also check whether the written rows
-    /// conform to this partition.
-    vnodes: Arc<Bitmap>,
-
     /// Used for catalog table_properties
     table_option: TableOption,
-
-    /// An optional column index which is the vnode of each row computed by the table's consistent
-    /// hash distribution.
-    vnode_col_idx_in_pk: Option<usize>,
 
     value_indices: Option<Vec<usize>>,
 
@@ -322,21 +309,20 @@ where
                 .collect()
         };
 
+        let vnode_col_idx_in_pk = table_catalog.vnode_col_index.as_ref().and_then(|idx| {
+            let vnode_col_idx = *idx as usize;
+            pk_indices.iter().position(|&i| vnode_col_idx == i)
+        });
+
+        let distribution =
+            TableDistribution::new(vnodes, dist_key_in_pk_indices, vnode_col_idx_in_pk);
+
         let pk_data_types = pk_indices
             .iter()
             .map(|i| table_columns[*i].data_type.clone())
             .collect();
         let pk_serde = OrderedRowSerde::new(pk_data_types, order_types);
 
-        let vnodes = match vnodes {
-            Some(vnodes) => vnodes,
-
-            None => Distribution::fallback_vnodes(),
-        };
-        let vnode_col_idx_in_pk = table_catalog.vnode_col_index.as_ref().and_then(|idx| {
-            let vnode_col_idx = *idx as usize;
-            pk_indices.iter().position(|&i| vnode_col_idx == i)
-        });
         let input_value_indices = table_catalog
             .value_indices
             .iter()
@@ -428,11 +414,9 @@ where
             pk_serde,
             row_serde,
             pk_indices,
-            dist_key_in_pk_indices,
+            distribution,
             prefix_hint_len,
-            vnodes,
             table_option,
-            vnode_col_idx_in_pk,
             value_indices,
             watermark_buffer_strategy: W::default(),
             state_clean_watermark: None,
@@ -458,7 +442,7 @@ where
             columns,
             order_types,
             pk_indices,
-            Distribution::fallback(),
+            TableDistribution::singleton(),
             None,
         )
         .await
@@ -479,7 +463,7 @@ where
             columns,
             order_types,
             pk_indices,
-            Distribution::fallback(),
+            TableDistribution::singleton(),
             Some(value_indices),
         )
         .await
@@ -499,7 +483,7 @@ where
             columns,
             order_types,
             pk_indices,
-            Distribution::fallback(),
+            TableDistribution::singleton(),
             None,
             false,
         )
@@ -514,7 +498,7 @@ where
         table_columns: Vec<ColumnDesc>,
         order_types: Vec<OrderType>,
         pk_indices: Vec<usize>,
-        distribution: Distribution,
+        distribution: TableDistribution,
         value_indices: Option<Vec<usize>>,
     ) -> Self {
         Self::new_with_distribution_inner(
@@ -536,7 +520,7 @@ where
         table_columns: Vec<ColumnDesc>,
         order_types: Vec<OrderType>,
         pk_indices: Vec<usize>,
-        distribution: Distribution,
+        distribution: TableDistribution,
         value_indices: Option<Vec<usize>>,
     ) -> Self {
         Self::new_with_distribution_inner(
@@ -559,10 +543,7 @@ where
         table_columns: Vec<ColumnDesc>,
         order_types: Vec<OrderType>,
         pk_indices: Vec<usize>,
-        Distribution {
-            dist_key_in_pk_indices,
-            vnodes,
-        }: Distribution,
+        distribution: TableDistribution,
         value_indices: Option<Vec<usize>>,
         is_consistent_op: bool,
     ) -> Self {
@@ -612,11 +593,9 @@ where
             pk_serde,
             row_serde,
             pk_indices,
-            dist_key_in_pk_indices,
+            distribution,
             prefix_hint_len: 0,
-            vnodes,
             table_option: Default::default(),
-            vnode_col_idx_in_pk: None,
             value_indices,
             watermark_buffer_strategy: W::default(),
             state_clean_watermark: None,
@@ -636,17 +615,6 @@ where
         self.table_id.table_id
     }
 
-    /// Returns whether the table is a singleton table.
-    fn is_singleton(&self) -> bool {
-        // If the table has a vnode column, it must be hash-distributed (but act like a singleton
-        // table). So we should return false here. Otherwise, we check the distribution key.
-        if self.vnode_col_idx_in_pk.is_some() {
-            false
-        } else {
-            self.dist_key_in_pk_indices.is_empty()
-        }
-    }
-
     /// get the newest epoch of the state store and panic if the `init_epoch()` has never be called
     pub fn epoch(&self) -> u64 {
         self.local_store.epoch()
@@ -654,25 +622,9 @@ where
 
     /// Get the vnode value with given (prefix of) primary key
     fn compute_prefix_vnode(&self, pk_prefix: impl Row) -> VirtualNode {
-        let prefix_len = pk_prefix.len();
-        if let Some(vnode_col_idx_in_pk) = self.vnode_col_idx_in_pk {
-            let vnode = pk_prefix.datum_at(vnode_col_idx_in_pk).unwrap();
-            VirtualNode::from_scalar(vnode.into_int16())
-        } else {
-            // For streaming, the given prefix must be enough to calculate the vnode
-            assert!(self.dist_key_in_pk_indices.iter().all(|&d| d < prefix_len));
-            compute_vnode(pk_prefix, &self.dist_key_in_pk_indices, &self.vnodes)
-        }
-    }
-
-    /// Get the vnode value of the given row
-    // pub fn compute_vnode(&self, row: impl Row) -> VirtualNode {
-    //     compute_vnode(row, &self.dist_key_indices, &self.vnodes)
-    // }
-
-    /// Get the vnode value of the given row
-    pub fn compute_vnode_by_pk(&self, pk: impl Row) -> VirtualNode {
-        compute_vnode(pk, &self.dist_key_in_pk_indices, &self.vnodes)
+        self.distribution
+            .try_compute_vnode_by_pk_prefix(pk_prefix)
+            .expect("For streaming, the given prefix must be enough to calculate the vnode")
     }
 
     /// NOTE(kwannoel): This is used by backfill.
@@ -696,12 +648,8 @@ where
         &self.pk_serde
     }
 
-    // pub fn dist_key_indices(&self) -> &[usize] {
-    //     &self.dist_key_indices
-    // }
-
     pub fn vnodes(&self) -> &Arc<Bitmap> {
-        &self.vnodes
+        self.distribution.vnodes()
     }
 
     pub fn value_indices(&self) -> &Option<Vec<usize>> {
@@ -710,10 +658,6 @@ where
 
     fn is_dirty(&self) -> bool {
         self.local_store.is_dirty() || self.state_clean_watermark.is_some()
-    }
-
-    pub fn vnode_bitmap(&self) -> &Bitmap {
-        &self.vnodes
     }
 }
 
@@ -773,8 +717,11 @@ where
             debug_assert_eq!(self.prefix_hint_len, pk.len());
         }
 
-        let serialized_pk =
-            serialize_pk_with_vnode(&pk, &self.pk_serde, self.compute_prefix_vnode(&pk));
+        let serialized_pk = serialize_pk_with_vnode(
+            &pk,
+            &self.pk_serde,
+            self.distribution.compute_vnode_by_pk(&pk),
+        );
 
         let prefix_hint = if self.prefix_hint_len != 0 && self.prefix_hint_len == pk.len() {
             Some(serialized_pk.slice(VirtualNode::SIZE..))
@@ -822,15 +769,16 @@ where
             !self.is_dirty(),
             "vnode bitmap should only be updated when state table is clean"
         );
-        if self.is_singleton() {
+        if self.distribution.is_singleton() {
             assert_eq!(
-                new_vnodes, self.vnodes,
+                &new_vnodes,
+                self.vnodes(),
                 "should not update vnode bitmap for singleton table"
             );
         }
-        assert_eq!(self.vnodes.len(), new_vnodes.len());
+        assert_eq!(self.vnodes().len(), new_vnodes.len());
 
-        let cache_may_stale = cache_may_stale(&self.vnodes, &new_vnodes);
+        let cache_may_stale = cache_may_stale(self.vnodes(), &new_vnodes);
 
         if cache_may_stale {
             self.state_clean_watermark = None;
@@ -840,7 +788,7 @@ where
         }
 
         (
-            std::mem::replace(&mut self.vnodes, new_vnodes),
+            self.distribution.update_vnode_bitmap(new_vnodes),
             cache_may_stale,
         )
     }
@@ -920,7 +868,11 @@ where
             self.watermark_cache.insert(&pk);
         }
 
-        let key_bytes = serialize_pk_with_vnode(pk, &self.pk_serde, self.compute_prefix_vnode(pk));
+        let key_bytes = serialize_pk_with_vnode(
+            pk,
+            &self.pk_serde,
+            self.distribution.compute_vnode_by_pk(pk),
+        );
         let value_bytes = self.serialize_value(value);
         self.insert_inner(key_bytes, value_bytes);
     }
@@ -934,7 +886,11 @@ where
             self.watermark_cache.delete(&pk);
         }
 
-        let key_bytes = serialize_pk_with_vnode(pk, &self.pk_serde, self.compute_prefix_vnode(pk));
+        let key_bytes = serialize_pk_with_vnode(
+            pk,
+            &self.pk_serde,
+            self.distribution.compute_vnode_by_pk(pk),
+        );
         let value_bytes = self.serialize_value(old_value);
         self.delete_inner(key_bytes, value_bytes);
     }
@@ -948,8 +904,11 @@ where
             "pk should not change: {old_pk:?} vs {new_pk:?}",
         );
 
-        let new_key_bytes =
-            serialize_pk_with_vnode(new_pk, &self.pk_serde, self.compute_prefix_vnode(new_pk));
+        let new_key_bytes = serialize_pk_with_vnode(
+            new_pk,
+            &self.pk_serde,
+            self.distribution.compute_vnode_by_pk(new_pk),
+        );
         let old_value_bytes = self.serialize_value(old_value);
         let new_value_bytes = self.serialize_value(new_value);
 
@@ -961,8 +920,11 @@ where
     /// `op_consistency_level` should be set to `Inconsistent`.
     pub fn update_without_old_value(&mut self, new_value: impl Row) {
         let new_pk = (&new_value).project(self.pk_indices());
-        let new_key_bytes =
-            serialize_pk_with_vnode(new_pk, &self.pk_serde, self.compute_prefix_vnode(new_pk));
+        let new_key_bytes = serialize_pk_with_vnode(
+            new_pk,
+            &self.pk_serde,
+            self.distribution.compute_vnode_by_pk(new_pk),
+        );
         let new_value_bytes = self.serialize_value(new_value);
 
         self.update_inner(new_key_bytes, None, new_value_bytes);
@@ -992,12 +954,9 @@ where
         };
         let (chunk, op) = chunk.into_parts();
 
-        let vnodes = compute_chunk_vnode(
-            &chunk,
-            &self.dist_key_in_pk_indices,
-            &self.pk_indices,
-            &self.vnodes,
-        );
+        let vnodes = self
+            .distribution
+            .compute_chunk_vnode(&chunk, &self.pk_indices);
 
         let values = if let Some(ref value_indices) = self.value_indices {
             chunk.project(value_indices).serialize_with(&self.row_serde)
@@ -1209,7 +1168,7 @@ where
         // Compute Delete Ranges
         if should_clean_watermark && let Some(watermark_suffix) = watermark_suffix {
             trace!(table_id = %self.table_id, watermark = ?watermark_suffix, vnodes = ?{
-                self.vnodes.iter_vnodes().collect_vec()
+                self.vnodes().iter_vnodes().collect_vec()
             }, "delete range");
             if prefix_serializer
                 .as_ref()
@@ -1222,7 +1181,7 @@ where
                 seal_watermark = Some((
                     WatermarkDirection::Ascending,
                     VnodeWatermark::new(
-                        self.vnodes.clone(),
+                        self.vnodes().clone(),
                         Bytes::copy_from_slice(watermark_suffix.as_ref()),
                     ),
                 ));
@@ -1230,7 +1189,7 @@ where
                 seal_watermark = Some((
                     WatermarkDirection::Descending,
                     VnodeWatermark::new(
-                        self.vnodes.clone(),
+                        self.vnodes().clone(),
                         Bytes::copy_from_slice(watermark_suffix.as_ref()),
                     ),
                 ));
@@ -1414,10 +1373,6 @@ where
         self.iter_kv(memcomparable_range_with_vnode, None, prefetch_options)
             .await
             .map_err(StreamExecutorError::from)
-    }
-
-    pub fn get_vnodes(&self) -> Arc<Bitmap> {
-        self.vnodes.clone()
     }
 
     /// Returns:

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -405,7 +405,7 @@ pub(crate) fn mapping_message(msg: Message, upstream_indices: &[usize]) -> Optio
 pub(crate) async fn get_progress_per_vnode<S: StateStore, const IS_REPLICATED: bool>(
     state_table: &StateTableInner<S, BasicSerde, IS_REPLICATED>,
 ) -> StreamExecutorResult<Vec<(VirtualNode, BackfillStatePerVnode)>> {
-    debug_assert!(!state_table.vnode_bitmap().is_empty());
+    debug_assert!(!state_table.vnodes().is_empty());
     let vnodes = state_table.vnodes().iter_vnodes();
     let mut result = Vec::with_capacity(state_table.vnodes().len());
     let vnode_keys = vnodes.map(|vnode| {

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -453,7 +453,7 @@ impl<S: StateStore, const USE_WATERMARK_CACHE: bool> DynamicFilterExecutor<S, US
                     if last_committed_epoch_row != current_epoch_row {
                         // Only write the RHS value if this actor is in charge of vnode 0 on LHS
                         // Otherwise, we only actively replicate the changes.
-                        if self.left_table.vnode_bitmap().is_set(0) {
+                        if self.left_table.vnodes().is_set(0) {
                             // If both `None`, then this branch is inactive.
                             // Hence, at least one is `Some`, hence at least one update.
                             if let Some(old_row) = last_committed_epoch_row.take() {

--- a/src/stream/src/executor/sort_buffer.rs
+++ b/src/stream/src/executor/sort_buffer.rs
@@ -212,7 +212,7 @@ impl<S: StateStore> SortBuffer<S> {
         );
 
         let streams: Vec<_> =
-            futures::future::try_join_all(buffer_table.vnode_bitmap().iter_vnodes().map(|vnode| {
+            futures::future::try_join_all(buffer_table.vnodes().iter_vnodes().map(|vnode| {
                 buffer_table.iter_with_vnode(
                     vnode,
                     &pk_range,

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -246,8 +246,7 @@ impl<S: StateStore> WatermarkFilterExecutor<S> {
                         last_checkpoint_watermark = current_watermark.clone();
                         // Persist the watermark when checkpoint arrives.
                         if let Some(watermark) = current_watermark.clone() {
-                            let vnodes = table.get_vnodes();
-                            for vnode in vnodes.iter_vnodes() {
+                            for vnode in table.vnodes().clone().iter_vnodes() {
                                 let pk = Some(ScalarImpl::Int16(vnode.to_scalar()));
                                 let row = [pk, Some(watermark.clone())];
                                 // This is an upsert.
@@ -353,7 +352,7 @@ mod tests {
     use risingwave_common::types::Date;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_storage::memory::MemoryStateStore;
-    use risingwave_storage::table::Distribution;
+    use risingwave_storage::table::TableDistribution;
 
     use super::*;
     use crate::executor::test_utils::expr::build_from_pretty;
@@ -383,7 +382,7 @@ mod tests {
             column_descs,
             order_types.to_vec(),
             pk_indices.to_vec(),
-            Distribution::all(vec![0]),
+            TableDistribution::all(vec![0]),
             Some(val_indices.to_vec()),
         )
         .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Currently in our batch `StorageTable` and streaming `StateTable`, we shared a similar logic to compute vnode.
```
if vnode_bitmap.is_none() {
    DEFAULT_VNODE
} else if vnode_col_index.is_some() {
    // get vnode directly from row
} else {
    assert!(dist_key_in_pk_indices is not empty);
    // compute vnode by provided dist key indices
}
```

Code with similar logic appear in both `StorageTable` and `StateTable`. In this PR, we unify this logic to the `risingwave_storage::table::Distribution`. The type is renamed to `TableDistribution` to be distinguished with the optimizer `Distribution`. The `TableDistribution` will be a enum with the following definition
```
pub enum TableDistribution {
    Singleton,
    DistKeyInPkIndices {
        dist_key_in_pk_indices: Vec<usize>,
        vnodes: Arc<Bitmap>,
    },
    VnodeColumnIndex {
        vnode_col_idx_in_pk: usize,
        vnodes: Arc<Bitmap>,
    },
}
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
