### PR TITLE
fix(connector): add additional check in nats list_splits

### DIFF
--- a/src/connector/src/source/nats/enumerator/mod.rs
+++ b/src/connector/src/source/nats/enumerator/mod.rs
@@ -21,10 +21,11 @@ use super::source::{NatsOffset, NatsSplit};
 use super::NatsProperties;
 use crate::source::{SourceEnumeratorContextRef, SplitEnumerator, SplitId};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct NatsSplitEnumerator {
     subject: String,
     split_id: SplitId,
+    client: async_nats::Client,
 }
 
 #[async_trait]
@@ -36,13 +37,23 @@ impl SplitEnumerator for NatsSplitEnumerator {
         properties: Self::Properties,
         _context: SourceEnumeratorContextRef,
     ) -> anyhow::Result<NatsSplitEnumerator> {
+        let client = properties.common.build_client().await?;
         Ok(Self {
             subject: properties.common.subject,
             split_id: Arc::from("0"),
+            client,
         })
     }
 
     async fn list_splits(&mut self) -> anyhow::Result<Vec<NatsSplit>> {
+        // Nats currently does not support list_splits API, if we simple return the default 0 without checking the client status, will result executor crash
+        let state = self.client.connection_state();
+        if state != async_nats::connection::State::Connected {
+            return Err(anyhow::anyhow!(
+                "Nats connection status is not connected, current status is {:?}",
+                state
+            ));
+        }
         // TODO: to simplify the logic, return 1 split for first version
         let nats_split = NatsSplit {
             subject: self.subject.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
In #12942, once a time, there is some connection error in source between rw and nats which result in the compute node crash. The root cause: when source executor call the `list_splits` function, nats didn't provide the API for it, so currently we directly return `0`. But if the connection has error, executor will crash in the following logic. 

So I add a `client` in `NatsSplitEnumerator`, and when call `list_splits`, will check the [connection state](https://docs.rs/async-nats/latest/async_nats/client/struct.Client.html#method.connection_state) first. If return [State::Connected](https://docs.rs/async-nats/latest/async_nats/connection/enum.State.html#), continue, otherwise throw error.


## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
