### PR TITLE
fix: specify distribution key for fs source

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -96,7 +96,7 @@ impl Source {
         (lower_bound, upper_bound)
     }
 
-    pub fn infer_internal_table_catalog() -> TableCatalog {
+    pub fn infer_internal_table_catalog(require_dist_key: bool) -> TableCatalog {
         // note that source's internal table is to store partition_id -> offset mapping and its
         // schema is irrelevant to input schema
         // On the premise of ensuring that the materialized_source data can be cleaned up, keep the
@@ -122,6 +122,13 @@ impl Source {
         builder.add_column(&value);
         builder.add_order_column(ordered_col_idx, OrderType::ascending());
 
-        builder.build(vec![], 1)
+        builder.build(
+            if require_dist_key {
+                vec![ordered_col_idx]
+            } else {
+                vec![]
+            },
+            1,
+        )
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_fs_fetch.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_fs_fetch.rs
@@ -101,6 +101,8 @@ impl StreamNode for StreamFsFetch {
             source_id: source_catalog.id,
             source_name: source_catalog.name.clone(),
             state_table: Some(
+                // `StreamFsSource` will do range scan according to assigned vnodes, so we need to set
+                // the key for distributing data to different vnodes.
                 generic::Source::infer_internal_table_catalog(true)
                     .with_id(state.gen_table_id_wrapped())
                     .to_internal_table_prost(),

--- a/src/frontend/src/optimizer/plan_node/stream_fs_fetch.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_fs_fetch.rs
@@ -101,7 +101,7 @@ impl StreamNode for StreamFsFetch {
             source_id: source_catalog.id,
             source_name: source_catalog.name.clone(),
             state_table: Some(
-                generic::Source::infer_internal_table_catalog()
+                generic::Source::infer_internal_table_catalog(true)
                     .with_id(state.gen_table_id_wrapped())
                     .to_internal_table_prost(),
             ),

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -75,6 +75,8 @@ impl StreamNode for StreamSource {
             source_id: source_catalog.id,
             source_name: source_catalog.name.clone(),
             state_table: Some(
+                // `StreamSource` can write all data to the same vnode
+                // but it is ok because we only do point get on each key rather than range scan.
                 generic::Source::infer_internal_table_catalog(false)
                     .with_id(state.gen_table_id_wrapped())
                     .to_internal_table_prost(),

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -75,7 +75,7 @@ impl StreamNode for StreamSource {
             source_id: source_catalog.id,
             source_name: source_catalog.name.clone(),
             state_table: Some(
-                generic::Source::infer_internal_table_catalog()
+                generic::Source::infer_internal_table_catalog(false)
                     .with_id(state.gen_table_id_wrapped())
                     .to_internal_table_prost(),
             ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

* **bug**: in prev impl, the distribution key is missing and we apply all state changes to vnode0 in the runtime. This behavior leads to only one fs fetch exec will work (not introducing correctness problem but low efficiency). 
  * The root cause is that the fs fetch exec will do range scan on assigned vnodes but all data is written to one vnode. 
* **fix**: set the distribution key in the frontend before writing to catalog. Do NOTHING to existing jobs, preventing data consistency problem. 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
