### PR TITLE
chore: Use force mode with risectl unregister-workers.

### DIFF
--- a/src/ctl/src/cmd_impl/meta/reschedule.rs
+++ b/src/ctl/src/cmd_impl/meta/reschedule.rs
@@ -241,6 +241,7 @@ pub async fn unregister_workers(
     workers: Vec<String>,
     yes: bool,
     ignore_not_found: bool,
+    check_fragment_occupied: bool,
 ) -> Result<()> {
     let meta_client = context.meta_client().await?;
 
@@ -320,7 +321,7 @@ pub async fn unregister_workers(
                 .intersection(&target_worker_ids)
                 .collect();
 
-            if !intersection_worker_ids.is_empty() {
+            if check_fragment_occupied && !intersection_worker_ids.is_empty() {
                 println!(
                     "worker ids {:?} are still occupied by fragment #{}",
                     intersection_worker_ids, fragment_id

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -486,6 +486,10 @@ enum MetaCommands {
         /// The worker not found will be ignored
         #[clap(long, default_value_t = false)]
         ignore_not_found: bool,
+
+        /// Checking whether the fragment is occupied by workers
+        #[clap(long, default_value_t = false)]
+        check_fragment_occupied: bool,
     },
 
     /// Validate source interface for the cloud team
@@ -706,7 +710,17 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             workers,
             yes,
             ignore_not_found,
-        }) => cmd_impl::meta::unregister_workers(context, workers, yes, ignore_not_found).await?,
+            check_fragment_occupied,
+        }) => {
+            cmd_impl::meta::unregister_workers(
+                context,
+                workers,
+                yes,
+                ignore_not_found,
+                check_fragment_occupied,
+            )
+            .await?
+        }
         Commands::Meta(MetaCommands::ValidateSource { props }) => {
             cmd_impl::meta::validate_source(context, props).await?
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add `--check-fragment-occupied` flag to enhance `unregister_workers` function


Implemented a new feature in `unregister_workers` and updated CLI options to improve worker unregistering process.


- Addition of a boolean parameter `check_fragment_occupied` to `unregister_workers` in `reschedule.rs`.
- Modification of `unregister_workers` to include a check for an occupied fragment if `check_fragment_occupied` is `true`.
- Integration of `check_fragment_occupied` as a CLI argument (`--check-fragment-occupied`) with a default value of `false` in `MetaCommands::UnregisterWorkers` within `lib.rs`.
- Update the `start_impl` function call to `unregister_workers` to pass the new CLI argument.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
