### PR TITLE
refactor(common): generate more code on system params with macro

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -861,7 +861,7 @@ macro_rules! define_system_config {
             pub struct SystemConfig {
                 $(
                     #[doc = $doc]
-                    #[serde(default = "default::system::" $field)]
+                    #[serde(default = "default::system::" $field "_opt")]
                     pub $field: Option<$type>,
                 )*
             }

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_default::DefaultFromSerde;
 use serde_json::Value;
 
+use crate::for_all_params;
 use crate::hash::VirtualNode;
 
 /// Use the maximum value for HTTP/2 connection window size to avoid deadlock among multiplexed
@@ -849,64 +850,26 @@ pub struct BatchDeveloperConfig {
     #[serde(default = "default::developer::batch_chunk_size")]
     pub chunk_size: usize,
 }
-/// The section `[system]` in `risingwave.toml`. All these fields are used to initialize the system
-/// parameters persisted in Meta store. Most fields are for testing purpose only and should not be
-/// documented.
-#[derive(Clone, Debug, Serialize, Deserialize, DefaultFromSerde)]
-pub struct SystemConfig {
-    /// The interval of periodic barrier.
-    #[serde(default = "default::system::barrier_interval_ms")]
-    pub barrier_interval_ms: Option<u32>,
 
-    /// There will be a checkpoint for every n barriers
-    #[serde(default = "default::system::checkpoint_frequency")]
-    pub checkpoint_frequency: Option<u64>,
-
-    /// Target size of the Sstable.
-    #[serde(default = "default::system::sstable_size_mb")]
-    pub sstable_size_mb: Option<u32>,
-
-    #[serde(default = "default::system::parallel_compact_size_mb")]
-    pub parallel_compact_size_mb: Option<u32>,
-
-    /// Size of each block in bytes in SST.
-    #[serde(default = "default::system::block_size_kb")]
-    pub block_size_kb: Option<u32>,
-
-    /// False positive probability of bloom filter.
-    #[serde(default = "default::system::bloom_false_positive")]
-    pub bloom_false_positive: Option<f64>,
-
-    #[serde(default = "default::system::state_store")]
-    pub state_store: Option<String>,
-
-    /// Remote directory for storing data and metadata objects.
-    #[serde(default = "default::system::data_directory")]
-    pub data_directory: Option<String>,
-
-    /// Remote storage url for storing snapshots.
-    #[serde(default = "default::system::backup_storage_url")]
-    pub backup_storage_url: Option<String>,
-
-    /// Remote directory for storing snapshots.
-    #[serde(default = "default::system::backup_storage_directory")]
-    pub backup_storage_directory: Option<String>,
-
-    /// Max number of concurrent creating streaming jobs.
-    #[serde(default = "default::system::max_concurrent_creating_streaming_jobs")]
-    pub max_concurrent_creating_streaming_jobs: Option<u32>,
-
-    /// Whether to pause all data sources on next bootstrap.
-    #[serde(default = "default::system::pause_on_next_bootstrap")]
-    pub pause_on_next_bootstrap: Option<bool>,
-
-    #[serde(default = "default::system::wasm_storage_url")]
-    pub wasm_storage_url: Option<String>,
-
-    /// Whether to enable distributed tracing.
-    #[serde(default = "default::system::enable_tracing")]
-    pub enable_tracing: Option<bool>,
+macro_rules! define_system_config {
+    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, $doc:literal, $($rest:tt)* },)*) => {
+        paste::paste!(
+            /// The section `[system]` in `risingwave.toml`. All these fields are used to initialize the system
+            /// parameters persisted in Meta store. Most fields are for testing purpose only and should not be
+            /// documented.
+            #[derive(Clone, Debug, Serialize, Deserialize, DefaultFromSerde)]
+            pub struct SystemConfig {
+                $(
+                    #[doc = $doc]
+                    #[serde(default = "default::system::" $field)]
+                    pub $field: Option<$type>,
+                )*
+            }
+        );
+    };
 }
+
+for_all_params!(define_system_config);
 
 /// The subsections `[storage.object_store]`.
 #[derive(Clone, Debug, Serialize, Deserialize, DefaultFromSerde)]
@@ -946,23 +909,16 @@ pub struct S3ObjectStoreConfig {
 impl SystemConfig {
     #![allow(deprecated)]
     pub fn into_init_system_params(self) -> SystemParams {
-        SystemParams {
-            barrier_interval_ms: self.barrier_interval_ms,
-            checkpoint_frequency: self.checkpoint_frequency,
-            sstable_size_mb: self.sstable_size_mb,
-            parallel_compact_size_mb: self.parallel_compact_size_mb,
-            block_size_kb: self.block_size_kb,
-            bloom_false_positive: self.bloom_false_positive,
-            state_store: self.state_store,
-            data_directory: self.data_directory,
-            backup_storage_url: self.backup_storage_url,
-            backup_storage_directory: self.backup_storage_directory,
-            max_concurrent_creating_streaming_jobs: self.max_concurrent_creating_streaming_jobs,
-            pause_on_next_bootstrap: self.pause_on_next_bootstrap,
-            wasm_storage_url: self.wasm_storage_url,
-            enable_tracing: self.enable_tracing,
-            telemetry_enabled: None, // deprecated
+        macro_rules! fields {
+            ($({ $field:ident, $($rest:tt)* },)*) => {
+                SystemParams {
+                    $($field: self.$field,)*
+                    ..Default::default() // deprecated fields
+                }
+            };
         }
+
+        for_all_params!(fields)
     }
 }
 

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -1360,9 +1360,7 @@ pub mod default {
         }
     }
 
-    pub mod system {
-        pub use crate::system_param::default::*;
-    }
+    pub use crate::system_param::default as system;
 
     pub mod batch {
         pub fn enable_barrier_read() -> bool {

--- a/src/common/src/system_param/common.rs
+++ b/src/common/src/system_param/common.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Mutex;
 
-use super::reader::SystemParamsReader;
+use super::reader::{SystemParamsRead, SystemParamsReader};
 use crate::util::tracing::layer::toggle_otel_layer;
 
 /// Node-independent handler for system parameter changes.

--- a/src/common/src/system_param/mod.rs
+++ b/src/common/src/system_param/mod.rs
@@ -26,6 +26,7 @@ pub mod reader;
 
 use std::fmt::Debug;
 use std::ops::RangeBounds;
+use std::str::FromStr;
 
 use paste::paste;
 use risingwave_pb::meta::PbSystemParams;
@@ -33,6 +34,28 @@ use risingwave_pb::meta::PbSystemParams;
 pub type SystemParamsError = String;
 
 type Result<T> = core::result::Result<T, SystemParamsError>;
+
+/// The trait for the value type of a system parameter.
+pub trait ParamValue: ToString + FromStr {
+    type Borrowed<'a>;
+}
+
+macro_rules! impl_param_value {
+    ($type:ty) => {
+        impl_param_value!($type => $type);
+    };
+    ($type:ty => $borrowed:ty) => {
+        impl ParamValue for $type {
+            type Borrowed<'a> = $borrowed;
+        }
+    };
+}
+
+impl_param_value!(bool);
+impl_param_value!(u32);
+impl_param_value!(u64);
+impl_param_value!(f64);
+impl_param_value!(String => &'a str);
 
 /// Define all system parameters here.
 ///

--- a/src/common/src/system_param/mod.rs
+++ b/src/common/src/system_param/mod.rs
@@ -135,11 +135,16 @@ macro_rules! def_default {
         pub fn $field() -> $type {
             $default.unwrap()
         }
+        paste::paste!(
+            pub static [<$field:upper>]: LazyLock<$type> = LazyLock::new($field);
+        );
     };
 }
 
 /// Default values for all parameters.
 pub mod default {
+    use std::sync::LazyLock;
+
     for_all_params!(def_default_opt);
     for_all_params!(def_default);
 }

--- a/src/common/src/system_param/mod.rs
+++ b/src/common/src/system_param/mod.rs
@@ -44,21 +44,21 @@ type Result<T> = core::result::Result<T, SystemParamsError>;
 macro_rules! for_all_params {
     ($macro:ident) => {
         $macro! {
-            // name                                     type    default value                               mutable
-            { barrier_interval_ms,                      u32,    Some(1000_u32),                             true,   },
-            { checkpoint_frequency,                     u64,    Some(1_u64),                                true,   },
-            { sstable_size_mb,                          u32,    Some(256_u32),                              false,  },
-            { parallel_compact_size_mb,                 u32,    Some(512_u32),                              false,  },
-            { block_size_kb,                            u32,    Some(64_u32),                               false,  },
-            { bloom_false_positive,                     f64,    Some(0.001_f64),                            false,  },
-            { state_store,                              String, None,                                       false,  },
-            { data_directory,                           String, None,                                       false,  },
-            { backup_storage_url,                       String, Some("memory".to_string()),                 true,   },
-            { backup_storage_directory,                 String, Some("backup".to_string()),                 true,   },
-            { max_concurrent_creating_streaming_jobs,   u32,    Some(1_u32),                                true,   },
-            { pause_on_next_bootstrap,                  bool,   Some(false),                                true,   },
-            { wasm_storage_url,                         String, Some("fs://.risingwave/data".to_string()),  false,  },
-            { enable_tracing,                           bool,   Some(false),                                true,   },
+            // name                                     type    default value                               mut?    doc
+            { barrier_interval_ms,                      u32,    Some(1000_u32),                             true,   "The interval of periodic barrier.", },
+            { checkpoint_frequency,                     u64,    Some(1_u64),                                true,   "There will be a checkpoint for every n barriers.", },
+            { sstable_size_mb,                          u32,    Some(256_u32),                              false,  "Target size of the Sstable.", },
+            { parallel_compact_size_mb,                 u32,    Some(512_u32),                              false,  "", },
+            { block_size_kb,                            u32,    Some(64_u32),                               false,  "Size of each block in bytes in SST.", },
+            { bloom_false_positive,                     f64,    Some(0.001_f64),                            false,  "False positive probability of bloom filter.", },
+            { state_store,                              String, None,                                       false,  "", },
+            { data_directory,                           String, None,                                       false,  "Remote directory for storing data and metadata objects.", },
+            { backup_storage_url,                       String, Some("memory".to_string()),                 true,   "Remote storage url for storing snapshots.", },
+            { backup_storage_directory,                 String, Some("backup".to_string()),                 true,   "Remote directory for storing snapshots.", },
+            { max_concurrent_creating_streaming_jobs,   u32,    Some(1_u32),                                true,   "Max number of concurrent creating streaming jobs.", },
+            { pause_on_next_bootstrap,                  bool,   Some(false),                                true,   "Whether to pause all data sources on next bootstrap.", },
+            { wasm_storage_url,                         String, Some("fs://.risingwave/data".to_string()),  false,  "", },
+            { enable_tracing,                           bool,   Some(false),                                true,   "Whether to enable distributed tracing.", },
         }
     };
 }
@@ -188,7 +188,7 @@ macro_rules! impl_system_params_from_kv {
 /// If you want custom rules, please override the default implementation in
 /// `OverrideValidateOnSet` below.
 macro_rules! impl_default_validation_on_set {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, },)*) => {
+    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, $($rest:tt)* },)*) => {
         #[allow(clippy::ptr_arg)]
         trait ValidateOnSet {
             $(
@@ -277,7 +277,7 @@ macro_rules! impl_set_system_param {
 }
 
 macro_rules! impl_is_mutable {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, },)*) => {
+    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, $($rest:tt)* },)*) => {
         pub fn is_mutable(field: &str) -> Result<bool> {
             match field {
                 $(

--- a/src/common/src/system_param/reader.rs
+++ b/src/common/src/system_param/reader.rs
@@ -50,8 +50,10 @@ impl From<PbSystemParams> for SystemParamsReader {
     }
 }
 
-// Unwrap the field if it exists from the initial release.
-// Otherwise, fill it with the backward compatibility logic.
+/// - Unwrap the field if it always exists.
+///   For example, if a parameter is introduced before the initial public release.
+///
+/// - Otherwise, specify the fallback logic when the field is missing.
 impl SystemParamsRead for SystemParamsReader {
     fn barrier_interval_ms(&self) -> u32 {
         self.prost.barrier_interval_ms.unwrap()
@@ -110,7 +112,10 @@ impl SystemParamsRead for SystemParamsReader {
     }
 
     fn wasm_storage_url(&self) -> &str {
-        self.prost.wasm_storage_url.as_ref().unwrap()
+        self.prost
+            .wasm_storage_url
+            .as_ref()
+            .unwrap_or(&default::WASM_STORAGE_URL)
     }
 }
 

--- a/src/common/src/system_param/reader.rs
+++ b/src/common/src/system_param/reader.rs
@@ -28,7 +28,7 @@ macro_rules! define_system_params_read_trait {
         pub trait SystemParamsRead {
             $(
                 #[doc = $doc]
-                fn $field<'a>(&'a self) -> <$type as ParamValue>::Borrowed<'a>;
+                fn $field(&self) -> <$type as ParamValue>::Borrowed<'_>;
             )*
         }
     };
@@ -100,13 +100,13 @@ impl SystemParamsRead for SystemParamsReader {
     fn pause_on_next_bootstrap(&self) -> bool {
         self.prost
             .pause_on_next_bootstrap
-            .unwrap_or_else(|| default::pause_on_next_bootstrap().unwrap())
+            .unwrap_or_else(default::pause_on_next_bootstrap)
     }
 
     fn enable_tracing(&self) -> bool {
         self.prost
             .enable_tracing
-            .unwrap_or_else(|| default::enable_tracing().unwrap())
+            .unwrap_or_else(default::enable_tracing)
     }
 
     fn wasm_storage_url(&self) -> &str {

--- a/src/common/src/system_param/reader.rs
+++ b/src/common/src/system_param/reader.rs
@@ -14,12 +14,31 @@
 
 use risingwave_pb::meta::PbSystemParams;
 
-use super::{default, system_params_to_kv};
+use super::{default, system_params_to_kv, ParamValue};
+use crate::for_all_params;
 
-/// A wrapper for [`risingwave_pb::meta::SystemParams`] for 2 purposes:
-/// - Avoid misuse of deprecated fields by hiding their getters.
-/// - Abstract fallback logic for fields that might not be provided by meta service due to backward
-///   compatibility.
+macro_rules! define_system_params_read_trait {
+    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, $doc:literal, $($rest:tt)* },)*) => {
+        /// The trait delegating reads on [`risingwave_pb::meta::SystemParams`].
+        ///
+        /// For 2 purposes:
+        /// - Avoid misuse of deprecated fields by hiding their getters.
+        /// - Abstract fallback logic for fields that might not be provided by meta service due to backward
+        ///   compatibility.
+        pub trait SystemParamsRead {
+            $(
+                #[doc = $doc]
+                fn $field<'a>(&'a self) -> <$type as ParamValue>::Borrowed<'a>;
+            )*
+        }
+    };
+}
+
+for_all_params!(define_system_params_read_trait);
+
+/// The wrapper delegating reads on [`risingwave_pb::meta::SystemParams`].
+///
+/// See [`SystemParamsRead`] for more details.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SystemParamsReader {
     prost: PbSystemParams,
@@ -31,67 +50,71 @@ impl From<PbSystemParams> for SystemParamsReader {
     }
 }
 
-impl SystemParamsReader {
-    pub fn barrier_interval_ms(&self) -> u32 {
+// Unwrap the field if it exists from the initial release.
+// Otherwise, fill it with the backward compatibility logic.
+impl SystemParamsRead for SystemParamsReader {
+    fn barrier_interval_ms(&self) -> u32 {
         self.prost.barrier_interval_ms.unwrap()
     }
 
-    pub fn checkpoint_frequency(&self) -> u64 {
+    fn checkpoint_frequency(&self) -> u64 {
         self.prost.checkpoint_frequency.unwrap()
     }
 
-    pub fn parallel_compact_size_mb(&self) -> u32 {
+    fn parallel_compact_size_mb(&self) -> u32 {
         self.prost.parallel_compact_size_mb.unwrap()
     }
 
-    pub fn sstable_size_mb(&self) -> u32 {
+    fn sstable_size_mb(&self) -> u32 {
         self.prost.sstable_size_mb.unwrap()
     }
 
-    pub fn block_size_kb(&self) -> u32 {
+    fn block_size_kb(&self) -> u32 {
         self.prost.block_size_kb.unwrap()
     }
 
-    pub fn bloom_false_positive(&self) -> f64 {
+    fn bloom_false_positive(&self) -> f64 {
         self.prost.bloom_false_positive.unwrap()
     }
 
-    pub fn state_store(&self) -> &str {
+    fn state_store(&self) -> &str {
         self.prost.state_store.as_ref().unwrap()
     }
 
-    pub fn data_directory(&self) -> &str {
+    fn data_directory(&self) -> &str {
         self.prost.data_directory.as_ref().unwrap()
     }
 
-    pub fn backup_storage_url(&self) -> &str {
+    fn backup_storage_url(&self) -> &str {
         self.prost.backup_storage_url.as_ref().unwrap()
     }
 
-    pub fn backup_storage_directory(&self) -> &str {
+    fn backup_storage_directory(&self) -> &str {
         self.prost.backup_storage_directory.as_ref().unwrap()
     }
 
-    pub fn max_concurrent_creating_streaming_jobs(&self) -> u32 {
+    fn max_concurrent_creating_streaming_jobs(&self) -> u32 {
         self.prost.max_concurrent_creating_streaming_jobs.unwrap()
     }
 
-    pub fn pause_on_next_bootstrap(&self) -> bool {
+    fn pause_on_next_bootstrap(&self) -> bool {
         self.prost
             .pause_on_next_bootstrap
             .unwrap_or_else(|| default::pause_on_next_bootstrap().unwrap())
     }
 
-    pub fn enable_tracing(&self) -> bool {
+    fn enable_tracing(&self) -> bool {
         self.prost
             .enable_tracing
             .unwrap_or_else(|| default::enable_tracing().unwrap())
     }
 
-    pub fn wasm_storage_url(&self) -> &str {
+    fn wasm_storage_url(&self) -> &str {
         self.prost.wasm_storage_url.as_ref().unwrap()
     }
+}
 
+impl SystemParamsReader {
     pub fn to_kv(&self) -> Vec<(String, String)> {
         system_params_to_kv(&self.prost).unwrap()
     }

--- a/src/compute/src/memory/manager.rs
+++ b/src/compute/src/memory/manager.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use risingwave_common::system_param::local_manager::SystemParamsReaderRef;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_stream::executor::monitor::StreamingMetrics;
 
 use super::controller::LruWatermarkController;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -28,6 +28,7 @@ use risingwave_common::config::{
 };
 use risingwave_common::monitor::connection::{RouterExt, TcpConfig};
 use risingwave_common::system_param::local_manager::LocalSystemParamsManager;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::telemetry::manager::TelemetryManager;
 use risingwave_common::telemetry::telemetry_env_enabled;
 use risingwave_common::util::addr::HostAddr;

--- a/src/frontend/src/handler/alter_system.rs
+++ b/src/frontend/src/handler/alter_system.rs
@@ -14,6 +14,7 @@
 
 use pgwire::pg_response::StatementType;
 use risingwave_common::error::Result;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_sqlparser::ast::{Ident, SetVariableValue};
 
 use super::variable::set_var_to_param_str;

--- a/src/frontend/src/handler/create_function.rs
+++ b/src/frontend/src/handler/create_function.rs
@@ -18,6 +18,7 @@ use bytes::Bytes;
 use itertools::Itertools;
 use pgwire::pg_response::StatementType;
 use risingwave_common::catalog::FunctionId;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::types::DataType;
 use risingwave_expr::expr::get_or_create_wasm_runtime;
 use risingwave_object_store::object::{build_remote_object_store, ObjectStoreConfig};

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -22,6 +22,7 @@ use itertools::Itertools;
 use otlp_embedded::TraceServiceServer;
 use regex::Regex;
 use risingwave_common::monitor::connection::{RouterExt, TcpConfig};
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::telemetry::manager::TelemetryManager;
 use risingwave_common::telemetry::telemetry_env_enabled;
 use risingwave_common_service::metrics_manager::MetricsManager;

--- a/src/meta/src/backup_restore/backup_manager.rs
+++ b/src/meta/src/backup_restore/backup_manager.rs
@@ -22,6 +22,7 @@ use risingwave_backup::storage::{MetaSnapshotStorage, ObjectStoreMetaSnapshotSto
 use risingwave_backup::{MetaBackupJobId, MetaSnapshotId, MetaSnapshotManifest};
 use risingwave_common::bail;
 use risingwave_common::config::ObjectStoreConfig;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_hummock_sdk::HummockSstableObjectId;
 use risingwave_object_store::object::build_remote_object_store;
 use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -24,6 +24,7 @@ use itertools::Itertools;
 use prometheus::HistogramTimer;
 use risingwave_common::bail;
 use risingwave_common::catalog::TableId;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::system_param::PAUSE_ON_NEXT_BOOTSTRAP_KEY;
 use risingwave_common::util::epoch::{Epoch, INVALID_EPOCH};
 use risingwave_hummock_sdk::table_watermark::{

--- a/src/meta/src/controller/system_param.rs
+++ b/src/meta/src/controller/system_param.rs
@@ -51,7 +51,7 @@ pub struct SystemParamsController {
 
 /// Derive system params from db models.
 macro_rules! impl_system_params_from_db {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr },)*) => {
+    ($({ $field:ident, $type:ty, $($rest:tt)* },)*) => {
         /// Try to deserialize deprecated fields as well.
         /// Warn if there are unrecognized fields.
         pub fn system_params_from_db(mut models: Vec<system_parameter::Model>) -> MetaResult<PbSystemParams> {
@@ -79,7 +79,7 @@ macro_rules! impl_system_params_from_db {
 
 /// Derive serialization to db models.
 macro_rules! impl_system_params_to_models {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr },)*) => {
+    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, },)*) => {
         #[allow(clippy::vec_init_then_push)]
         pub fn system_params_to_model(params: &PbSystemParams) -> MetaResult<Vec<system_parameter::ActiveModel>> {
             check_missing_params(params).map_err(|e| anyhow!(e))?;
@@ -106,7 +106,7 @@ macro_rules! impl_system_params_to_models {
 // 4. None, None: A new version of RW cluster is launched for the first time and newly introduced
 // params are not set. The new field is not initialized either, just leave it as `None`.
 macro_rules! impl_merge_params {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr },)*) => {
+    ($({ $field:ident, $($rest:tt)* },)*) => {
         fn merge_params(mut persisted: PbSystemParams, init: PbSystemParams) -> PbSystemParams {
             $(
                 match (persisted.$field.as_ref(), init.$field) {

--- a/src/meta/src/controller/system_param.rs
+++ b/src/meta/src/controller/system_param.rs
@@ -79,7 +79,7 @@ macro_rules! impl_system_params_from_db {
 
 /// Derive serialization to db models.
 macro_rules! impl_system_params_to_models {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, },)*) => {
+    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr, $($rest:tt)* },)*) => {
         #[allow(clippy::vec_init_then_push)]
         pub fn system_params_to_model(params: &PbSystemParams) -> MetaResult<Vec<system_parameter::ActiveModel>> {
             check_missing_params(params).map_err(|e| anyhow!(e))?;

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -31,6 +31,7 @@ use parking_lot::Mutex;
 use risingwave_common::config::default::compaction_config;
 use risingwave_common::config::ObjectStoreConfig;
 use risingwave_common::monitor::rwlock::MonitoredRwLock;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::epoch::{Epoch, INVALID_EPOCH};
 use risingwave_common::util::{pending_on_none, select_all};
 use risingwave_hummock_sdk::compact::{compact_task_to_string, statistics_compact_task};

--- a/src/meta/src/manager/system_param/mod.rs
+++ b/src/meta/src/manager/system_param/mod.rs
@@ -168,7 +168,7 @@ impl SystemParamsManager {
 // 4. None, None: A new version of RW cluster is launched for the first time and newly introduced
 // params are not set. The new field is not initialized either, just leave it as `None`.
 macro_rules! impl_merge_params {
-    ($({ $field:ident, $type:ty, $default:expr, $is_mutable:expr },)*) => {
+    ($({ $field:ident, $($rest:tt)* },)*) => {
         fn merge_params(mut persisted: SystemParams, init: SystemParams) -> SystemParams {
             $(
                 match (persisted.$field.as_ref(), init.$field) {

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -23,6 +23,7 @@ use itertools::Itertools;
 use rand::Rng;
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::{ParallelUnitMapping, VirtualNode};
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_common::util::stream_graph_visitor::{

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -767,6 +767,7 @@ mod tests {
 
     use risingwave_common::catalog::TableId;
     use risingwave_common::hash::ParallelUnitMapping;
+    use risingwave_common::system_param::reader::SystemParamsRead;
     use risingwave_pb::common::{HostAddress, WorkerType};
     use risingwave_pb::meta::add_worker_node_request::Property;
     use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -23,7 +23,7 @@ use risingwave_common::config::{
 };
 use risingwave_common::monitor::connection::{RouterExt, TcpConfig};
 use risingwave_common::system_param::local_manager::LocalSystemParamsManager;
-use risingwave_common::system_param::reader::SystemParamsReader;
+use risingwave_common::system_param::reader::{SystemParamsRead, SystemParamsReader};
 use risingwave_common::telemetry::manager::TelemetryManager;
 use risingwave_common::telemetry::telemetry_env_enabled;
 use risingwave_common::util::addr::HostAddr;

--- a/src/storage/src/hummock/backup_reader.rs
+++ b/src/storage/src/hummock/backup_reader.rs
@@ -27,6 +27,7 @@ use risingwave_backup::storage::{MetaSnapshotStorage, ObjectStoreMetaSnapshotSto
 use risingwave_backup::{meta_snapshot_v1, MetaSnapshotId};
 use risingwave_common::config::ObjectStoreConfig;
 use risingwave_common::system_param::local_manager::SystemParamsReaderRef;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_object_store::object::build_remote_object_store;
 use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
 

--- a/src/storage/src/opts.rs
+++ b/src/storage/src/opts.rs
@@ -15,7 +15,7 @@
 use risingwave_common::config::{
     extract_storage_memory_config, ObjectStoreConfig, RwConfig, StorageMemoryConfig,
 };
-use risingwave_common::system_param::reader::SystemParamsReader;
+use risingwave_common::system_param::reader::{SystemParamsRead, SystemParamsReader};
 use risingwave_common::system_param::system_params_for_test;
 
 #[derive(Clone, Debug)]

--- a/src/stream/src/executor/source/fs_source_executor.rs
+++ b/src/stream/src/executor/source/fs_source_executor.rs
@@ -23,6 +23,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::Schema;
 use risingwave_common::system_param::local_manager::SystemParamsReaderRef;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_connector::source::{
     BoxSourceWithStateStream, ConnectorState, SourceContext, SourceCtrlOpts, SplitId, SplitImpl,
     SplitMetaData, StreamChunkWithState,

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -21,6 +21,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use risingwave_common::metrics::GLOBAL_ERROR_METRICS;
 use risingwave_common::system_param::local_manager::SystemParamsReaderRef;
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_connector::source::{
     BoxSourceWithStateStream, ConnectorState, SourceContext, SourceCtrlOpts, SplitMetaData,
     StreamChunkWithState,

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -30,6 +30,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::config::{
     extract_storage_memory_config, load_config, NoOverride, ObjectStoreConfig, RwConfig,
 };
+use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::TableKey;
 use risingwave_hummock_test::get_notification_client_for_test;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When I was working on #14528, I find a lot of places have to be updated when trying to introduce a new system parameter. This PR is an attempt to improve that.

- Generate `SystemConfig` and initial system params.
- Generate `SystemParamsRead` trait, so developers will be reminded to add a new method on `SystemParamsReader` after introducing a new system param.
- Generate unwrapped default value functions, as suggested by @xxchan in https://github.com/risingwavelabs/risingwave/pull/14528#discussion_r1449908549.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
