### PR TITLE
fix(ci): disable LTO for `ci-release` to resolve build timeout in main-cron

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,7 @@ lto = "thin"
 [profile.ci-release]
 inherits = "release"
 incremental = false
+lto = "off"
 debug = "line-tables-only"
 split-debuginfo = "off"
 debug-assertions = true

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -17,7 +17,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
     retry: *auto-retry
 
   - label: "build other components"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -17,7 +17,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
-    timeout_in_minutes: 40
+    timeout_in_minutes: 20
     retry: *auto-retry
 
   - label: "build other components"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<img width="1091" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/161719ce-b348-4039-81c6-ed934a768578">

30 min is barely enough for the `cargo build` command, but sometimes it timeouts due to the fluctuation and other phases.

https://buildkite.com/risingwavelabs/main-cron/builds/1559#018d1d50-28d4-4f64-8175-e842dd03e634

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
