### PR TITLE
chore(lints): bump toolchain to make it work again

### DIFF
--- a/ci/rust-toolchain
+++ b/ci/rust-toolchain
@@ -1,7 +1,7 @@
 # To update toolchain, do the following:
 # 1. update this file
-# 2. update lints/rust-toolchain, lints/Cargo.toml
-# 3. update ci/build-ci-image.sh and ci/docker-compose.yml to build a new CI image
+# 2. update ci/build-ci-image.sh and ci/docker-compose.yml to build a new CI image
+# 3. (optional) **follow the instructions in lints/README.md** to update the toolchain and dependencies for lints
 
 [toolchain]
 channel = "nightly-2023-12-26"

--- a/lints/Cargo.lock
+++ b/lints/Cargo.lock
@@ -112,15 +112,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clippy_utils"
-version = "0.1.75"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=a585cda701581a16894858dc088eacd5a02fc78b#a585cda701581a16894858dc088eacd5a02fc78b"
+name = "clippy_config"
+version = "0.1.77"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=6fd0258e45105161b7e759a22e7350958e5cb0b1#6fd0258e45105161b7e759a22e7350958e5cb0b1"
 dependencies = [
- "arrayvec",
- "if_chain",
- "itertools 0.10.5",
  "rustc-semver",
  "serde",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "clippy_utils"
+version = "0.1.77"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=6fd0258e45105161b7e759a22e7350958e5cb0b1#6fd0258e45105161b7e759a22e7350958e5cb0b1"
+dependencies = [
+ "arrayvec",
+ "clippy_config",
+ "itertools 0.11.0",
+ "rustc-semver",
 ]
 
 [[package]]
@@ -224,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b9feb84cd2620b4b75119b7e914ac132dbd9e523f9a98821f3b3a7e355053"
+checksum = "71fdb7b800ab13925402f0048ed0911068db2e5ba6168dd93962269d4f39541d"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -245,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ede982d9261f23a19b92ed7dc4ddeefc8328fc21c88e2c79ffd6e071c7972be"
+checksum = "5154dada2bee2a69f75f54eae57479f56f93ca1db80725a1d82cdb5fe231ef73"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -257,15 +266,16 @@ dependencies = [
  "if_chain",
  "is-terminal",
  "log",
+ "once_cell",
  "rust-embed",
  "sedregex",
 ]
 
 [[package]]
 name = "dylint_linting"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7f2f02100bafd2f02c5fcc4ca981adca28397485bf3393ad0a1e8e46ec583b"
+checksum = "d203baeb8770847314632f652e0e62dd7fec6a21102a116472eec0d6931f5dd9"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -273,14 +283,14 @@ dependencies = [
  "rustversion",
  "serde",
  "thiserror",
- "toml",
+ "toml 0.8.8",
 ]
 
 [[package]]
 name = "dylint_testing"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964c9965a990e1ab44a862cb9823772603fe4d82b777b1190fe2d4d62ed8a885"
+checksum = "1208b1f2c40fc2f3c3fa0d5631efbc7a95721d619410dc2da5b0496810d6a941"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -388,11 +398,11 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -480,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -519,15 +529,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.2+1.6.4"
+version = "0.16.1+1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
 dependencies = [
  "cc",
  "libc",
@@ -587,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -624,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
@@ -754,9 +764,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rust-embed"
-version = "8.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40"
+checksum = "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -765,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
+checksum = "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -778,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada"
+checksum = "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665"
 dependencies = [
  "globset",
  "sha2",
@@ -807,15 +817,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -921,15 +931,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.4.1",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1002,6 +1012,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
@@ -1009,7 +1031,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -1019,6 +1041,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]

--- a/lints/Cargo.toml
+++ b/lints/Cargo.toml
@@ -12,12 +12,12 @@ name = "format_error"
 path = "ui/format_error.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "e4c626dd9a17a23270bf8e7158e59cf2b9c04840" } # should match the toolchain version (rustc -vV)
-dylint_linting = "2.5.0"
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "6fd0258e45105161b7e759a22e7350958e5cb0b1" } # should match the toolchain version of lints
+dylint_linting = "2.6.0"
 itertools = "0.12"
 
 [dev-dependencies]
-dylint_testing = "2.5.0"
+dylint_testing = "2.6.0"
 
 # UI test dependencies
 tracing = "0.1"

--- a/lints/Cargo.toml
+++ b/lints/Cargo.toml
@@ -11,8 +11,9 @@ crate-type = ["cdylib"]
 name = "format_error"
 path = "ui/format_error.rs"
 
+# See `README.md` before bumping the version.
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "6fd0258e45105161b7e759a22e7350958e5cb0b1" } # should match the toolchain version of lints
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "6fd0258e45105161b7e759a22e7350958e5cb0b1" }
 dylint_linting = "2.6.0"
 itertools = "0.12"
 

--- a/lints/README.md
+++ b/lints/README.md
@@ -38,3 +38,5 @@ The information below can be helpful in finding the appropriate version to bump 
 - The toolchain used by the latest version of `cargo-dylint`: https://github.com/trailofbits/dylint/blob/master/internal/template/rust-toolchain
 - The toolchain used by the latest version of `clippy`: https://github.com/rust-lang/rust-clippy/blob/master/rust-toolchain
 - The hash of the latest commit in `rust-lang/rust-clippy` repo for the dependency `clippy-utils`.
+
+Run the lints after bumping the toolchain to verify it works.

--- a/lints/README.md
+++ b/lints/README.md
@@ -33,8 +33,8 @@ Duplicate `.vscode/settings.json.example` to `.vscode/settings.json` to enable r
 The version of the toolchain is specified in `rust-toolchain` file under current directory.
 It does not have to be exactly the same as the one used to build RisingWave, but it should be close enough to avoid compile errors.
 
-Information below may be helpful to find a proper version to bump to:
+The information below can be helpful in finding the appropriate version to bump to.
 
-- The toolchain used by the lastest version of `cargo-dylint`: https://github.com/trailofbits/dylint/blob/master/internal/template/rust-toolchain
-- The toolchain used by the lastest version of `clippy`: https://github.com/rust-lang/rust-clippy/blob/master/rust-toolchain
+- The toolchain used by the latest version of `cargo-dylint`: https://github.com/trailofbits/dylint/blob/master/internal/template/rust-toolchain
+- The toolchain used by the latest version of `clippy`: https://github.com/rust-lang/rust-clippy/blob/master/rust-toolchain
 - The hash of the latest commit in `rust-lang/rust-clippy` repo for the dependency `clippy-utils`.

--- a/lints/README.md
+++ b/lints/README.md
@@ -4,9 +4,17 @@ Custom lints for RisingWave to enforce code style and best practices, empowered 
 
 See [cargo dylint](https://github.com/trailofbits/dylint) for more information.
 
+## Install `cargo-dylint`
+
+```bash
+cargo install dylint
+```
+
 ## Run lints
 
 To run all lints, run `cargo dylint --all` in the root of the repository.
+
+If you find there are some compile errors, try updating the `cargo-dylint` binary by installing it again.
 
 ## Add new lints
 
@@ -19,3 +27,14 @@ To test a lint, create a new file in the `ui` directory and add it as an `exampl
 ## VS Code integration
 
 Duplicate `.vscode/settings.json.example` to `.vscode/settings.json` to enable rust-analyzer integration for developing lints.
+
+## Bump toolchain
+
+The version of the toolchain is specified in `rust-toolchain` file under current directory.
+It does not have to be exactly the same as the one used to build RisingWave, but it should be close enough to avoid compile errors.
+
+Information below may be helpful to find a proper version to bump to:
+
+- The toolchain used by the lastest version of `cargo-dylint`: https://github.com/trailofbits/dylint/blob/master/internal/template/rust-toolchain
+- The toolchain used by the lastest version of `clippy`: https://github.com/rust-lang/rust-clippy/blob/master/rust-toolchain
+- The hash of the latest commit in `rust-lang/rust-clippy` repo for the dependency `clippy-utils`.

--- a/lints/rust-toolchain
+++ b/lints/rust-toolchain
@@ -1,3 +1,5 @@
+# See `README.md` before bumping the version.
+
 [toolchain]
 channel = "nightly-2024-01-11"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/lints/rust-toolchain
+++ b/lints/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-12-26"                      # should be identical to the root one
+channel = "nightly-2024-01-11"
 components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolve #14304. The toolchain version for `lints` does not have to match that for RisingWave components. Added comments for reference.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
