### PR TITLE
repro: ci.toml's `meta.compaction_config` can cause arrangement backfill test to fail

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1305,6 +1305,11 @@ command = "target/${BUILD_MODE_DIR}/risedev-dev"
 args = ["${@}"]
 description = "Clean data and start a full RisingWave dev cluster using risedev-dev"
 
+[tasks.ci-kill-no-logs]
+category = "RiseDev - CI"
+dependencies = ["k", "check-logs", "wait-processes-exit"]
+description = "Kill cluster, dump logs and check logs"
+
 [tasks.ci-kill]
 category = "RiseDev - CI"
 dependencies = ["k", "l", "check-logs", "wait-processes-exit"]

--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -24,9 +24,9 @@ COMMON_DIR=$BACKGROUND_DDL_DIR/common
 
 CLUSTER_PROFILE='ci-1cn-1fe-kafka-with-recovery'
 if [[ -n "${BUILDKITE:-}" ]]; then
-  RUNTIME_CLUSTER_PROFILE='ci-3cn-1fe-with-monitoring'
+  RUNTIME_CLUSTER_PROFILE='ci-3cn-1fe-with-minio-rate-limit'
 else
-  RUNTIME_CLUSTER_PROFILE='ci-3cn-1fe'
+  RUNTIME_CLUSTER_PROFILE='ci-3cn-1fe-with-monitoring-and-minio-rate-limit'
 fi
 export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
 
@@ -60,7 +60,7 @@ rename_logs_with_prefix() {
 }
 
 kill_cluster() {
-  cargo make ci-kill
+  cargo make ci-kill-no-logs
   wait
 }
 
@@ -247,18 +247,18 @@ test_backfill_snapshot_runtime() {
 
 main() {
   set -euo pipefail
-  test_snapshot_and_upstream_read
-  test_backfill_tombstone
-  test_replication_with_column_pruning
-  test_sink_backfill_recovery
+#  test_snapshot_and_upstream_read
+#  test_backfill_tombstone
+#  test_replication_with_column_pruning
+#  test_sink_backfill_recovery
 
   # Only if profile is "ci-release", run it.
   if [[ ${profile:-} == "ci-release" ]]; then
     echo "--- Using release profile, running backfill performance tests."
     # Need separate tests, we don't want to backfill concurrently.
     # It's difficult to measure the time taken for each backfill if we do so.
-    test_no_shuffle_backfill_snapshot_and_upstream_runtime
-    test_arrangement_backfill_snapshot_and_upstream_runtime
+#    test_no_shuffle_backfill_snapshot_and_upstream_runtime
+#    test_arrangement_backfill_snapshot_and_upstream_runtime
 
     # Backfill will happen in sequence here.
     test_backfill_snapshot_runtime

--- a/risedev.yml
+++ b/risedev.yml
@@ -565,6 +565,32 @@ profile:
       - use: prometheus
       - use: grafana
 
+  ci-3cn-1fe-with-recovery-monitoring-minio-rate-limit:
+    config-path: src/config/ci-recovery.toml
+    steps:
+      - use: minio
+        api-requests-max: 1
+        api-requests-deadline: 1s
+      - use: etcd
+        unsafe-no-fsync: true
+      - use: meta-node
+      - use: compute-node
+        port: 5687
+        exporter-port: 1222
+        enable-tiered-cache: true
+      - use: compute-node
+        port: 5688
+        exporter-port: 1223
+        enable-tiered-cache: true
+      - use: compute-node
+        port: 5689
+        exporter-port: 1224
+        enable-tiered-cache: true
+      - use: frontend
+      - use: compactor
+      - use: prometheus
+      - use: grafana
+
   ci-3cn-3fe:
     config-path: src/config/ci.toml
     steps:
@@ -908,6 +934,15 @@ template:
 
     # Prometheus nodes used by this MinIO
     provide-prometheus: "prometheus*"
+
+    # Max concurrent api requests.
+    # see: https://github.com/minio/minio/blob/master/docs/throttle/README.md.
+    # '0' means this env var will use the default of minio.
+    api-requests-max: 0
+
+    # Deadline for api requests.
+    # Empty string means this env var will use the default of minio.
+    api-requests-deadline: ""
 
   etcd:
     # Id of this instance

--- a/risedev.yml
+++ b/risedev.yml
@@ -565,11 +565,35 @@ profile:
       - use: prometheus
       - use: grafana
 
-  ci-3cn-1fe-with-recovery-monitoring-minio-rate-limit:
-    config-path: src/config/ci-recovery.toml
+  ci-3cn-1fe-and-minio-rate-limit:
+    config-path: src/config/ci.toml
     steps:
       - use: minio
         api-requests-max: 1
+        api-requests-deadline: 1s
+      - use: etcd
+        unsafe-no-fsync: true
+      - use: meta-node
+      - use: compute-node
+        port: 5687
+        exporter-port: 1222
+        enable-tiered-cache: true
+      - use: compute-node
+        port: 5688
+        exporter-port: 1223
+        enable-tiered-cache: true
+      - use: compute-node
+        port: 5689
+        exporter-port: 1224
+        enable-tiered-cache: true
+      - use: frontend
+      - use: compactor
+
+  ci-3cn-1fe-with-monitoring-and-minio-rate-limit:
+    config-path: src/config/ci.toml
+    steps:
+      - use: minio
+        api-requests-max: 10
         api-requests-deadline: 1s
       - use: etcd
         unsafe-no-fsync: true

--- a/risedev.yml
+++ b/risedev.yml
@@ -593,7 +593,7 @@ profile:
     config-path: src/config/ci.toml
     steps:
       - use: minio
-        api-requests-max: 10
+        api-requests-max: 1
         api-requests-deadline: 1s
       - use: etcd
         unsafe-no-fsync: true

--- a/src/config/ci.toml
+++ b/src/config/ci.toml
@@ -20,3 +20,6 @@ imm_merge_threshold = 2
 barrier_interval_ms = 250
 checkpoint_frequency = 5
 max_concurrent_creating_streaming_jobs = 0
+
+[storage.object_store.s3]
+retry_unknown_service_error = true

--- a/src/config/ci.toml
+++ b/src/config/ci.toml
@@ -1,11 +1,11 @@
 [meta]
 disable_recovery = true
 max_heartbeat_interval_secs = 600
-
-[meta.compaction_config]
-level0_tier_compact_file_number = 6
-level0_overlapping_sub_level_compact_level_count = 3
-level0_max_compact_file_number = 96
+#
+#[meta.compaction_config]
+#level0_tier_compact_file_number = 6
+#level0_overlapping_sub_level_compact_level_count = 3
+#level0_max_compact_file_number = 96
 
 [streaming]
 in_flight_barrier_nums = 10
@@ -21,5 +21,5 @@ barrier_interval_ms = 250
 checkpoint_frequency = 5
 max_concurrent_creating_streaming_jobs = 0
 
-[storage.object_store.s3]
-retry_unknown_service_error = true
+# [storage.object_store.s3]
+# retry_unknown_service_error = true

--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -875,7 +875,7 @@ pub async fn build_remote_object_store(
             panic!("Passing s3-compatible is not supported, please modify the environment variable and pass in s3.");
         }
         minio if minio.starts_with("minio://") => ObjectStoreImpl::S3(
-            S3ObjectStore::with_minio(minio, metrics.clone())
+            S3ObjectStore::with_minio(minio, metrics.clone(), config)
                 .await
                 .monitored(metrics),
         ),

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -140,6 +140,10 @@ pub struct MinioConfig {
     pub hummock_bucket: String,
 
     pub provide_prometheus: Option<Vec<PrometheusConfig>>,
+
+    // For rate limiting minio in a test environment.
+    pub api_requests_max: usize,
+    pub api_requests_deadline: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/risedevtool/src/task/minio_service.rs
+++ b/src/risedevtool/src/task/minio_service.rs
@@ -53,6 +53,14 @@ impl MinioService {
             // https://github.com/risingwavelabs/risingwave/pull/3012
             // https://docs.min.io/minio/baremetal/installation/deploy-minio-single-node-single-drive.html#id3
             .env("MINIO_CI_CD", "1");
+        if config.api_requests_max > 0 {
+            // Rate limit minio
+            cmd.env("MINIO_API_REQUESTS_MAX", config.api_requests_max.to_string());
+        }
+        if config.api_requests_deadline != "" {
+            // Rate limit minio
+            cmd.env("MINIO_API_REQUESTS_DEADLINE", &config.api_requests_deadline);
+        }
 
         let provide_prometheus = config.provide_prometheus.as_ref().unwrap();
         match provide_prometheus.len() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

PR is just for repro. Won't be merged. You can ignore the changes in the files, it's just a hack to get certain things working.

### Reproduce the slowdown error

Some background:

The changes in this branch are from a WIP PR. Some features are required (rate limiting minio), in order to stably reproduce the failing case.

If you check the logs, you should see the following error: `SlowDown`. Originally the suspicion is that this is caused by arrangement backfill's concurrent snapshot reads, since it's processing throughput is much higher (cpu bound processing in the form of merging records across vnodes in `no_shuffle_backfill` is not present in `arrangemnet_backfill`. Meaning it can ingest more records via snapshot read, i.e. increase the requests/sec to s3).

Another factor that was discovered is that when the following configurations were commented out:
```
#[meta.compaction_config]
#level0_tier_compact_file_number = 6
#level0_overlapping_sub_level_compact_level_count = 3
#level0_max_compact_file_number = 96
```

The test will pass rather quickly, compared to if they were left as is (in that case, snapshot read still encounters `SlowDown` when running arrangemnet backfill test case).

To reproduce:
1. `./risedev configure` -> enable release mode. **It will take a while to build after this, 15mins**
2. `profile=ci-release ./ci/scripts/run-backfill-tests.sh`. This step should pass test.
3. uncomment the lines in `ci.toml`:
    ```
    #[meta.compaction_config]
    #level0_tier_compact_file_number = 6
    #level0_overlapping_sub_level_compact_level_count = 3
    #level0_max_compact_file_number = 96
    ```
4. repeat step 2. Now it will fail with slowdown. You can check the CN / meta logs to see the error.


### Reproduce the inconsistent `merged_imm_ids` error

Error:
```

thread 'rw-main' panicked at src/storage/src/hummock/store/version.rs:470:17:
assertion `left == right` failed: merged_imm_ids: [102, 101]
  left: 81
 right: 102
stack backtrace:
   0: rust_begin_unwind
             at /rustc/e4c626dd9a17a23270bf8e7158e59cf2b9c04840/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/e4c626dd9a17a23270bf8e7158e59cf2b9c04840/library/core/src/panicking.rs:72:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/e4c626dd9a17a23270bf8e7158e59cf2b9c04840/library/core/src/panicking.rs:297:5
   4: risingwave_storage::hummock::store::version::HummockReadVersion::add_merged_imm
             at ./src/storage/src/hummock/store/version.rs:470:17
```

Happens after just:
1. creating some table.
2. running dml.

You can reproduce it by:
1. `./risedev configure` -> debug build instead of release.
2. uncomment `meta.compaction_config` in `ci.toml`.
3. run: `profile=ci-release ./ci/scripts/run-backfill-tests.sh`.
4. If can't repro, uncomment the retry config in `ci.toml`

Happy to debug it if any hints can be provided.

Edit: Step 2 is sort of independent it seems. With or without it, we encounter the error.

I suppose the main difference is the `minio` configuration.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
