### PR TITLE
feat: handle streaming control rpc in worker loop

### DIFF
--- a/src/compute/src/rpc/service/config_service.rs
+++ b/src/compute/src/rpc/service/config_service.rs
@@ -23,7 +23,7 @@ use tonic::{Code, Request, Response, Status};
 
 pub struct ConfigServiceImpl {
     batch_mgr: Arc<BatchManager>,
-    stream_mgr: Arc<LocalStreamManager>,
+    stream_mgr: LocalStreamManager,
 }
 
 #[async_trait::async_trait]
@@ -46,7 +46,7 @@ impl ConfigService for ConfigServiceImpl {
 }
 
 impl ConfigServiceImpl {
-    pub fn new(batch_mgr: Arc<BatchManager>, stream_mgr: Arc<LocalStreamManager>) -> Self {
+    pub fn new(batch_mgr: Arc<BatchManager>, stream_mgr: LocalStreamManager) -> Self {
         Self {
             batch_mgr,
             stream_mgr,

--- a/src/compute/src/rpc/service/exchange_service.rs
+++ b/src/compute/src/rpc/service/exchange_service.rs
@@ -38,7 +38,7 @@ const BATCH_EXCHANGE_BUFFER_SIZE: usize = 1024;
 #[derive(Clone)]
 pub struct ExchangeServiceImpl {
     batch_mgr: Arc<BatchManager>,
-    stream_mgr: Arc<LocalStreamManager>,
+    stream_mgr: LocalStreamManager,
     metrics: Arc<ExchangeServiceMetrics>,
 }
 
@@ -128,7 +128,7 @@ impl ExchangeService for ExchangeServiceImpl {
 impl ExchangeServiceImpl {
     pub fn new(
         mgr: Arc<BatchManager>,
-        stream_mgr: Arc<LocalStreamManager>,
+        stream_mgr: LocalStreamManager,
         metrics: Arc<ExchangeServiceMetrics>,
     ) -> Self {
         ExchangeServiceImpl {

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -15,7 +15,6 @@
 use std::ffi::CString;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;
@@ -34,14 +33,14 @@ use tonic::{Code, Request, Response, Status};
 
 #[derive(Clone)]
 pub struct MonitorServiceImpl {
-    stream_mgr: Arc<LocalStreamManager>,
+    stream_mgr: LocalStreamManager,
     grpc_await_tree_reg: Option<AwaitTreeRegistryRef>,
     server_config: ServerConfig,
 }
 
 impl MonitorServiceImpl {
     pub fn new(
-        stream_mgr: Arc<LocalStreamManager>,
+        stream_mgr: LocalStreamManager,
         grpc_await_tree_reg: Option<AwaitTreeRegistryRef>,
         server_config: ServerConfig,
     ) -> Self {

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use await_tree::InstrumentAwait;
 use itertools::Itertools;
 use risingwave_hummock_sdk::table_stats::to_prost_table_stats_map;
@@ -26,16 +24,16 @@ use risingwave_stream::error::StreamError;
 use risingwave_stream::executor::Barrier;
 use risingwave_stream::task::{BarrierCompleteResult, LocalStreamManager, StreamEnvironment};
 use thiserror_ext::AsReport;
-use tonic::{Code, Request, Response, Status};
+use tonic::{Request, Response, Status};
 
 #[derive(Clone)]
 pub struct StreamServiceImpl {
-    mgr: Arc<LocalStreamManager>,
+    mgr: LocalStreamManager,
     env: StreamEnvironment,
 }
 
 impl StreamServiceImpl {
-    pub fn new(mgr: Arc<LocalStreamManager>, env: StreamEnvironment) -> Self {
+    pub fn new(mgr: LocalStreamManager, env: StreamEnvironment) -> Self {
         StreamServiceImpl { mgr, env }
     }
 }
@@ -48,7 +46,7 @@ impl StreamService for StreamServiceImpl {
         request: Request<UpdateActorsRequest>,
     ) -> std::result::Result<Response<UpdateActorsResponse>, Status> {
         let req = request.into_inner();
-        let res = self.mgr.update_actors(&req.actors);
+        let res = self.mgr.update_actors(req.actors).await;
         match res {
             Err(e) => {
                 error!(error = %e.as_report(), "failed to update stream actor");
@@ -66,10 +64,7 @@ impl StreamService for StreamServiceImpl {
         let req = request.into_inner();
 
         let actor_id = req.actor_id;
-        let res = self
-            .mgr
-            .build_actors(actor_id.as_slice(), self.env.clone())
-            .await;
+        let res = self.mgr.build_actors(actor_id).await;
         match res {
             Err(e) => {
                 error!(error = %e.as_report(), "failed to build actors");
@@ -108,7 +103,7 @@ impl StreamService for StreamServiceImpl {
     ) -> std::result::Result<Response<DropActorsResponse>, Status> {
         let req = request.into_inner();
         let actors = req.actor_ids;
-        self.mgr.drop_actors(&actors)?;
+        self.mgr.drop_actors(actors).await?;
         Ok(Response::new(DropActorsResponse {
             request_id: req.request_id,
             status: None,
@@ -121,8 +116,7 @@ impl StreamService for StreamServiceImpl {
         request: Request<ForceStopActorsRequest>,
     ) -> std::result::Result<Response<ForceStopActorsResponse>, Status> {
         let req = request.into_inner();
-        self.mgr.stop_all_actors().await?;
-        self.env.dml_manager_ref().clear();
+        self.mgr.reset().await;
         Ok(Response::new(ForceStopActorsResponse {
             request_id: req.request_id,
             status: None,
@@ -137,28 +131,6 @@ impl StreamService for StreamServiceImpl {
         let req = request.into_inner();
         let barrier =
             Barrier::from_protobuf(req.get_barrier().unwrap()).map_err(StreamError::from)?;
-
-        // The barrier might be outdated and been injected after recovery in some certain extreme
-        // scenarios. So some newly creating actors in the barrier are possibly not rebuilt during
-        // recovery. Check it here and return an error here if some actors are not found to
-        // avoid collection hang. We need some refine in meta side to remove this workaround since
-        // it will cause another round of unnecessary recovery.
-        let actor_ids = self.mgr.all_actor_ids();
-        let missing_actor_ids = req
-            .actor_ids_to_collect
-            .iter()
-            .filter(|id| !actor_ids.contains(id))
-            .collect_vec();
-        if !missing_actor_ids.is_empty() {
-            tracing::warn!(
-                "to collect actors not found, they should be cleaned when recovering: {:?}",
-                missing_actor_ids
-            );
-            return Err(Status::new(
-                Code::InvalidArgument,
-                "to collect actors not found",
-            ));
-        }
 
         self.mgr
             .send_barrier(barrier, req.actor_ids_to_send, req.actor_ids_to_collect)

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -298,17 +298,6 @@ pub async fn compute_node_serve(
     // Run a background heap profiler
     heap_profiler.start();
 
-    let stream_mgr = Arc::new(LocalStreamManager::new(
-        advertise_addr.clone(),
-        state_store.clone(),
-        streaming_metrics.clone(),
-        config.streaming.clone(),
-        await_tree_config.clone(),
-        memory_mgr.get_watermark_epoch(),
-    ));
-
-    let grpc_await_tree_reg = await_tree_config
-        .map(|config| AwaitTreeRegistryRef::new(await_tree::Registry::new(config).into()));
     let dml_mgr = Arc::new(DmlManager::new(
         worker_id,
         config.streaming.developer.dml_channel_initial_permits,
@@ -362,6 +351,16 @@ pub async fn compute_node_serve(
         source_metrics,
         meta_client.clone(),
     );
+
+    let stream_mgr = LocalStreamManager::new(
+        stream_env.clone(),
+        streaming_metrics.clone(),
+        await_tree_config.clone(),
+        memory_mgr.get_watermark_epoch(),
+    );
+
+    let grpc_await_tree_reg = await_tree_config
+        .map(|config| AwaitTreeRegistryRef::new(await_tree::Registry::new(config).into()));
 
     // Generally, one may use `risedev ctl trace` to manually get the trace reports. However, if
     // this is not the case, we can use the following command to get it printed into the logs

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -366,7 +366,6 @@ impl GlobalStreamManager {
         res
     }
 
-    /// First broadcasts the actor info to `WorkerNodes`, and then let them build actors and channels.
     async fn build_actors(
         &self,
         table_fragments: &TableFragments,

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -148,7 +148,11 @@ impl StreamActorManagerState {
             sender,
             join_result
                 .map_err(|join_error| {
-                    anyhow!("failed to join creating actors futures: {:?}", join_error).into()
+                    anyhow!(
+                        "failed to join creating actors futures: {:?}",
+                        join_error.as_report()
+                    )
+                    .into()
                 })
                 .and_then(|result| result),
         )

--- a/src/stream/src/task/barrier_manager/progress.rs
+++ b/src/stream/src/task/barrier_manager/progress.rs
@@ -21,7 +21,7 @@ type ConsumedEpoch = u64;
 type ConsumedRows = u64;
 
 #[derive(Debug, Clone, Copy)]
-pub(super) enum BackfillState {
+pub(crate) enum BackfillState {
     ConsumingUpstream(ConsumedEpoch, ConsumedRows),
     Done(ConsumedRows),
 }

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -247,8 +247,6 @@ impl LocalStreamManager {
             .await?
     }
 
-    /// This function could only be called once during the lifecycle of `LocalStreamManager` for
-    /// now.
     pub async fn build_actors(&self, actors: Vec<ActorId>) -> StreamResult<()> {
         self.local_barrier_manager
             .send_and_await(|result_sender| LocalBarrierEvent::BuildActors {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -37,7 +37,6 @@ use risingwave_storage::monitor::HummockTraceFutureExt;
 use risingwave_storage::{dispatch_state_store, StateStore};
 use rw_futures_util::AttachedFuture;
 use thiserror_ext::AsReport;
-use tokio::spawn;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -13,32 +13,31 @@
 // limitations under the License.
 
 use core::time::Duration;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::Write;
+use std::mem::take;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_recursion::async_recursion;
 use futures::FutureExt;
-use hytra::TrAdder;
 use itertools::Itertools;
 use parking_lot::Mutex;
 use risingwave_common::bail;
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::{Field, Schema};
-use risingwave_common::config::{MetricLevel, StreamingConfig};
-use risingwave_common::util::addr::HostAddr;
-use risingwave_common::util::runtime::BackgroundShutdownRuntime;
+use risingwave_common::config::MetricLevel;
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::stream_plan;
-use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{StreamActor, StreamNode};
 use risingwave_storage::monitor::HummockTraceFutureExt;
-use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
+use risingwave_storage::{dispatch_state_store, StateStore};
+use rw_futures_util::AttachedFuture;
 use thiserror_ext::AsReport;
+use tokio::spawn;
 use tokio::task::JoinHandle;
 
 use super::{unique_executor_id, unique_operator_id, BarrierCompleteResult};
@@ -47,49 +46,28 @@ use crate::executor::monitor::StreamingMetrics;
 use crate::executor::subtask::SubtaskHandle;
 use crate::executor::*;
 use crate::from_proto::create_executor;
-use crate::task::{ActorId, FragmentId, LocalBarrierManager, SharedContext, StreamEnvironment};
+use crate::task::barrier_manager::{LocalBarrierEvent, LocalBarrierWorker};
+use crate::task::{
+    ActorId, FragmentId, LocalBarrierManager, SharedContext, StreamActorManager,
+    StreamActorManagerState, StreamEnvironment,
+};
 
 #[cfg(test)]
-pub static LOCAL_TEST_ADDR: std::sync::LazyLock<HostAddr> =
+pub static LOCAL_TEST_ADDR: std::sync::LazyLock<risingwave_common::util::addr::HostAddr> =
     std::sync::LazyLock::new(|| "127.0.0.1:2333".parse().unwrap());
 
 pub type ActorHandle = JoinHandle<()>;
 
 pub type AtomicU64Ref = Arc<AtomicU64>;
 
-pub struct LocalStreamManagerCore {
-    /// Runtime for the streaming actors.
-    runtime: BackgroundShutdownRuntime,
-
-    /// Each processor runs in a future. Upon receiving a `Terminate` message, they will exit.
-    /// `handles` store join handles of these futures, and therefore we could wait their
-    /// termination.
-    handles: HashMap<ActorId, ActorHandle>,
-
-    /// Stores all actor information, taken after actor built.
-    actors: HashMap<ActorId, stream_plan::StreamActor>,
-
-    /// Stores all actor tokio runtime monitoring tasks.
-    actor_monitor_tasks: HashMap<ActorId, ActorHandle>,
-}
-
 /// `LocalStreamManager` manages all stream executors in this project.
+#[derive(Clone)]
 pub struct LocalStreamManager {
-    core: Mutex<LocalStreamManagerCore>,
+    await_tree_reg: Option<Arc<Mutex<await_tree::Registry<ActorId>>>>,
 
-    state_store: StateStoreImpl,
     context: Arc<SharedContext>,
-    streaming_metrics: Arc<StreamingMetrics>,
-
-    total_mem_val: Arc<TrAdder<i64>>,
-
-    /// Watermark epoch number.
-    watermark_epoch: AtomicU64Ref,
 
     local_barrier_manager: LocalBarrierManager,
-
-    /// Manages the await-trees of all actors.
-    await_tree_reg: Option<Mutex<await_tree::Registry<ActorId>>>,
 }
 
 /// Report expression evaluation errors to the actor context.
@@ -164,27 +142,28 @@ impl Debug for ExecutorParams {
 
 impl LocalStreamManager {
     pub fn new(
-        addr: HostAddr,
-        state_store: StateStoreImpl,
+        env: StreamEnvironment,
         streaming_metrics: Arc<StreamingMetrics>,
-        config: StreamingConfig,
         await_tree_config: Option<await_tree::Config>,
         watermark_epoch: AtomicU64Ref,
     ) -> Self {
-        let local_barrier_manager =
-            LocalBarrierManager::new(state_store.clone(), streaming_metrics.clone());
-        let context = Arc::new(SharedContext::new(addr, &config));
-        let core = LocalStreamManagerCore::new(context.config.actor_runtime_worker_threads_num);
-        Self {
-            state_store,
-            context,
-            total_mem_val: Arc::new(TrAdder::new()),
-            core: Mutex::new(core),
+        let context = Arc::new(SharedContext::new(
+            env.server_address().clone(),
+            env.config(),
+        ));
+        let await_tree_reg =
+            await_tree_config.map(|config| Arc::new(Mutex::new(await_tree::Registry::new(config))));
+        let local_barrier_manager = LocalBarrierManager::new(
+            context.clone(),
+            env,
             streaming_metrics,
+            await_tree_reg.clone(),
             watermark_epoch,
+        );
+        Self {
+            await_tree_reg,
+            context,
             local_barrier_manager,
-            await_tree_reg: await_tree_config
-                .map(|config| Mutex::new(await_tree::Registry::new(config))),
         }
     }
 
@@ -216,11 +195,6 @@ impl LocalStreamManager {
         }
     }
 
-    /// Get all existing actor ids.
-    pub fn all_actor_ids(&self) -> HashSet<ActorId> {
-        self.core.lock().handles.keys().cloned().collect()
-    }
-
     /// Broadcast a barrier to all senders. Save a receiver in barrier manager
     pub async fn send_barrier(
         &self,
@@ -228,19 +202,10 @@ impl LocalStreamManager {
         actor_ids_to_send: impl IntoIterator<Item = ActorId>,
         actor_ids_to_collect: impl IntoIterator<Item = ActorId>,
     ) -> StreamResult<()> {
-        if barrier.kind == BarrierKind::Initial {
-            self.watermark_epoch
-                .store(barrier.epoch.curr, std::sync::atomic::Ordering::SeqCst);
-        }
         self.local_barrier_manager
             .send_barrier(barrier, actor_ids_to_send, actor_ids_to_collect)
             .await?;
         Ok(())
-    }
-
-    /// Reset the state of the barrier manager.
-    pub fn reset_barrier_manager(&self) {
-        self.local_barrier_manager.reset();
     }
 
     /// Use `epoch` to find collect rx. And wait for all actor to be collected before
@@ -251,26 +216,62 @@ impl LocalStreamManager {
             .await
     }
 
-    pub async fn clear_storage_buffer(&self) {
-        dispatch_state_store!(self.state_store.clone(), store, {
-            store.clear_shared_buffer().await.unwrap();
-        });
+    pub fn context(&self) -> &Arc<SharedContext> {
+        &self.context
     }
 
     /// Drop the resources of the given actors.
-    pub fn drop_actors(&self, actors: &[ActorId]) -> StreamResult<()> {
-        self.context.drop_actors(actors);
-        let mut core = self.core.lock();
-        for &id in actors {
-            core.drop_actor(id);
-        }
-        tracing::debug!(actors = ?actors, "drop actors");
-        Ok(())
+    pub async fn drop_actors(&self, actors: Vec<ActorId>) -> StreamResult<()> {
+        self.local_barrier_manager
+            .send_and_await(|result_sender| LocalBarrierEvent::DropActors {
+                actors,
+                result_sender,
+            })
+            .await
     }
 
     /// Force stop all actors on this worker, and then drop their resources.
-    pub async fn stop_all_actors(&self) -> StreamResult<()> {
-        let actor_handles = self.core.lock().drain_actor_handles();
+    pub async fn reset(&self) {
+        self.local_barrier_manager
+            .send_and_await(LocalBarrierEvent::Reset)
+            .await
+            .expect("should receive reset")
+    }
+
+    pub async fn update_actors(&self, actors: Vec<stream_plan::StreamActor>) -> StreamResult<()> {
+        self.local_barrier_manager
+            .send_and_await(|result_sender| LocalBarrierEvent::UpdateActors {
+                actors,
+                result_sender,
+            })
+            .await?
+    }
+
+    /// This function could only be called once during the lifecycle of `LocalStreamManager` for
+    /// now.
+    pub async fn build_actors(&self, actors: Vec<ActorId>) -> StreamResult<()> {
+        self.local_barrier_manager
+            .send_and_await(|result_sender| LocalBarrierEvent::BuildActors {
+                actors,
+                result_sender,
+            })
+            .await?
+    }
+}
+
+impl LocalBarrierWorker {
+    /// Drop the resources of the given actors.
+    pub(super) fn drop_actors(&mut self, actors: &[ActorId]) {
+        self.actor_manager.context.drop_actors(actors);
+        for &id in actors {
+            self.actor_manager_state.drop_actor(id);
+        }
+        tracing::debug!(actors = ?actors, "drop actors");
+    }
+
+    /// Force stop all actors on this worker, and then drop their resources.
+    pub(super) async fn reset(&mut self) {
+        let actor_handles = self.actor_manager_state.drain_actor_handles();
         for (actor_id, handle) in &actor_handles {
             tracing::debug!("force stopping actor {}", actor_id);
             handle.abort();
@@ -280,85 +281,63 @@ impl LocalStreamManager {
             let result = handle.await;
             assert!(result.is_ok() || result.unwrap_err().is_cancelled());
         }
-        self.context.clear_channels();
-        self.context.actor_infos.write().clear();
-        self.core.lock().clear_state();
-        if let Some(m) = self.await_tree_reg.as_ref() {
+        for handle in take(&mut self.actor_manager_state.creating_actors)
+            .into_iter()
+            .map(|attached_future| attached_future.inner)
+        {
+            handle.abort();
+            let result = handle.await;
+            assert!(result.is_ok() || result.err().unwrap().is_cancelled());
+        }
+        self.actor_manager.context.clear_channels();
+        self.actor_manager.context.actor_infos.write().clear();
+        self.actor_manager_state.clear_state();
+        if let Some(m) = self.actor_manager.await_tree_reg.as_ref() {
             m.lock().clear();
         }
-        self.reset_barrier_manager();
-        // Clear shared buffer in storage to release memory
-        self.clear_storage_buffer().await;
-
-        Ok(())
+        dispatch_state_store!(&self.actor_manager.env.state_store(), store, {
+            store.clear_shared_buffer().await.unwrap();
+        });
+        self.reset_state();
+        self.actor_manager.env.dml_manager_ref().clear();
     }
 
-    pub fn update_actors(&self, actors: &[stream_plan::StreamActor]) -> StreamResult<()> {
-        let mut core = self.core.lock();
-        core.update_actors(actors)
+    pub(super) fn update_actors(
+        &mut self,
+        actors: Vec<stream_plan::StreamActor>,
+    ) -> StreamResult<()> {
+        self.actor_manager_state.update_actors(actors)
     }
 
     /// This function could only be called once during the lifecycle of `LocalStreamManager` for
     /// now.
-    pub async fn build_actors(
-        &self,
-        actors: &[ActorId],
-        env: StreamEnvironment,
-    ) -> StreamResult<()> {
+    pub(super) fn start_create_actors(&mut self, actors: &[ActorId]) -> StreamResult<u64> {
         let actors = {
-            let mut core = self.core.lock();
             actors
                 .iter()
                 .map(|actor_id| {
-                    core.actors
+                    self.actor_manager_state
+                        .actors
                         .remove(actor_id)
                         .ok_or_else(|| anyhow!("No such actor with actor id:{}", actor_id))
                 })
                 .try_collect()?
         };
-        let actors = self.create_actors(actors, env).await?;
-        self.core.lock().spawn_actors(
-            actors,
-            &self.streaming_metrics,
-            &self.local_barrier_manager,
-            self.await_tree_reg.as_ref(),
-        );
-        Ok(())
-    }
-
-    pub fn context(&self) -> &Arc<SharedContext> {
-        &self.context
-    }
-
-    pub fn total_mem_usage(&self) -> usize {
-        self.total_mem_val.get() as usize
+        self.actor_manager_state.next_create_actor_future_id += 1;
+        let future_id = self.actor_manager_state.next_create_actor_future_id;
+        let actor_manager = self.actor_manager.clone();
+        let join_handle = spawn(actor_manager.create_actors(actors));
+        self.actor_manager_state
+            .creating_actors
+            .push(AttachedFuture {
+                inner: join_handle,
+                item: future_id,
+            });
+        Ok(future_id)
     }
 }
 
-impl LocalStreamManagerCore {
-    fn new(actor_runtime_worker_threads_num: Option<usize>) -> Self {
-        let runtime = {
-            let mut builder = tokio::runtime::Builder::new_multi_thread();
-            if let Some(worker_threads_num) = actor_runtime_worker_threads_num {
-                builder.worker_threads(worker_threads_num);
-            }
-            builder
-                .thread_name("rw-streaming")
-                .enable_all()
-                .build()
-                .unwrap()
-        };
-
-        Self {
-            runtime: runtime.into(),
-            handles: HashMap::new(),
-            actors: HashMap::new(),
-            actor_monitor_tasks: HashMap::new(),
-        }
-    }
-}
-
-impl LocalStreamManager {
+impl StreamActorManager {
     /// Create dispatchers with downstream information registered before
     fn create_dispatcher(
         &self,
@@ -542,18 +521,17 @@ impl LocalStreamManager {
     }
 
     async fn create_actors(
-        &self,
+        self: Arc<Self>,
         actors: Vec<StreamActor>,
-        env: StreamEnvironment,
     ) -> StreamResult<Vec<Actor<DispatchExecutor>>> {
         let mut ret = Vec::with_capacity(actors.len());
         for actor in actors {
             let actor_id = actor.actor_id;
             let actor_context = ActorContext::create_with_metrics(
                 &actor,
-                self.total_mem_val.clone(),
+                self.env.total_mem_usage(),
                 self.streaming_metrics.clone(),
-                env.config().unique_user_stream_errors,
+                self.env.config().unique_user_stream_errors,
             );
             let vnode_bitmap = actor.vnode_bitmap.as_ref().map(|b| b.into());
             let expr_context = actor.expr_context.clone().unwrap();
@@ -562,7 +540,7 @@ impl LocalStreamManager {
                 .create_nodes(
                     actor.fragment_id,
                     actor.get_nodes()?,
-                    env.clone(),
+                    self.env.clone(),
                     &actor_context,
                     vnode_bitmap,
                 )
@@ -587,14 +565,8 @@ impl LocalStreamManager {
     }
 }
 
-impl LocalStreamManagerCore {
-    fn spawn_actors(
-        &mut self,
-        actors: Vec<Actor<DispatchExecutor>>,
-        streaming_metrics: &Arc<StreamingMetrics>,
-        barrier_manager: &LocalBarrierManager,
-        await_tree_reg: Option<&Mutex<await_tree::Registry<ActorId>>>,
-    ) {
+impl LocalBarrierWorker {
+    pub(super) fn spawn_actors(&mut self, actors: Vec<Actor<DispatchExecutor>>) {
         for actor in actors {
             let monitor = tokio_metrics::TaskMonitor::new();
             let actor_context = actor.actor_context.clone();
@@ -602,7 +574,7 @@ impl LocalStreamManagerCore {
 
             let handle = {
                 let trace_span = format!("Actor {actor_id}: `{}`", actor_context.mview_definition);
-                let barrier_manager = barrier_manager.clone();
+                let barrier_manager = self.actor_manager.local_barrier_manager.clone();
                 let actor = actor.run().map(move |result| {
                     if let Err(err) = result {
                         // TODO: check error type and panic if it's unexpected.
@@ -611,7 +583,7 @@ impl LocalStreamManagerCore {
                         barrier_manager.notify_failure(actor_id, err);
                     }
                 });
-                let traced = match await_tree_reg {
+                let traced = match &self.actor_manager.await_tree_reg {
                     Some(m) => m
                         .lock()
                         .register(actor_id, trace_span)
@@ -641,16 +613,16 @@ impl LocalStreamManagerCore {
                 }
                 #[cfg(not(enable_task_local_alloc))]
                 {
-                    self.runtime.spawn(instrumented)
+                    self.actor_manager.runtime.spawn(instrumented)
                 }
             };
-            self.handles.insert(actor_id, handle);
+            self.actor_manager_state.handles.insert(actor_id, handle);
 
-            if streaming_metrics.level >= MetricLevel::Debug {
+            if self.actor_manager.streaming_metrics.level >= MetricLevel::Debug {
                 tracing::info!("Tokio metrics are enabled because metrics_level >= Debug");
                 let actor_id_str = actor_id.to_string();
-                let metrics = streaming_metrics.clone();
-                let actor_monitor_task = self.runtime.spawn(async move {
+                let metrics = self.actor_manager.streaming_metrics.clone();
+                let actor_monitor_task = self.actor_manager.runtime.spawn(async move {
                     loop {
                         let task_metrics = monitor.cumulative();
                         metrics
@@ -700,28 +672,11 @@ impl LocalStreamManagerCore {
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 });
-                self.actor_monitor_tasks
+                self.actor_manager_state
+                    .actor_monitor_tasks
                     .insert(actor_id, actor_monitor_task);
             }
         }
-    }
-
-    pub fn take_all_handles(&mut self) -> StreamResult<HashMap<ActorId, ActorHandle>> {
-        Ok(std::mem::take(&mut self.handles))
-    }
-
-    pub fn remove_actor_handles(
-        &mut self,
-        actor_ids: &[ActorId],
-    ) -> StreamResult<Vec<ActorHandle>> {
-        actor_ids
-            .iter()
-            .map(|actor_id| {
-                self.handles
-                    .remove(actor_id)
-                    .ok_or_else(|| anyhow!("No such actor with actor id:{}", actor_id).into())
-            })
-            .try_collect()
     }
 }
 
@@ -745,7 +700,7 @@ impl LocalStreamManager {
     }
 }
 
-impl LocalStreamManagerCore {
+impl StreamActorManagerState {
     /// `drop_actor` is invoked by meta node via RPC once the stop barrier arrives at the
     /// sink. All the actors in the actors should stop themselves before this method is invoked.
     fn drop_actor(&mut self, actor_id: ActorId) {
@@ -771,11 +726,12 @@ impl LocalStreamManagerCore {
         self.actor_monitor_tasks.clear();
     }
 
-    fn update_actors(&mut self, actors: &[stream_plan::StreamActor]) -> StreamResult<()> {
+    fn update_actors(&mut self, actors: Vec<stream_plan::StreamActor>) -> StreamResult<()> {
         for actor in actors {
+            let actor_id = actor.get_actor_id();
             self.actors
-                .try_insert(actor.get_actor_id(), actor.clone())
-                .map_err(|_| anyhow!("duplicated actor {}", actor.get_actor_id()))?;
+                .try_insert(actor_id, actor)
+                .map_err(|_| anyhow!("duplicated actor {}", actor_id))?;
         }
 
         Ok(())

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -337,7 +337,10 @@ impl LocalBarrierWorker {
             }
         };
         let actor_manager = self.actor_manager.clone();
-        let join_handle = spawn(actor_manager.create_actors(actors));
+        let join_handle = self
+            .actor_manager
+            .runtime
+            .spawn(actor_manager.create_actors(actors));
         self.actor_manager_state
             .creating_actors
             .push(AttachedFuture::new(join_handle, result_sender));

--- a/src/utils/futures_util/src/misc.rs
+++ b/src/utils/futures_util/src/misc.rs
@@ -78,6 +78,12 @@ pub async fn await_future_with_monitor_error_stream<T, E, F: Future>(
     }
 }
 
+/// Attach an item of type `T` to the future `F`. When the future is polled with ready,
+/// the item will be attached to the output of future as `(F::Output, item)`.
+///
+/// The generated future will be similar to `future.map(|output| (output, item))`. The
+/// only difference is that the `Map` future does not provide method `into_inner` to
+/// get the original inner future.
 pub struct AttachedFuture<F, T> {
     inner: F,
     item: Option<T>,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously we have a `LocalStreamManagerCore` that keeps track of actor states. The `core` is wrapped by `Arc<Mutex<...>>` and shared by grpc handlers. To handle each grpc request, we will have to acquire the lock on `core` to fetch or modify the states.

In this PR, the `LocalStreamManagerCore` is renamed to `StreamActorManagerState` and owned by `LocalBarrierWorker` loop so that we don't need to acquire lock to access it. All streaming control rpc request will be sent to `LocalBarrierWorker` as an event to handle the request. `LocalStreamManager` is renamed to `StreamActorManager` to handle actor creation, and the original `LocalStreamManager` becomes a simple wrapper on local barrier event sender to send grpc request to barrier worker as event.

Previously handling all streaming control rpc except `build_actors` are non-async. Therefore in `LocalBarrierWorker` loop, handling these events can easily be non-blocking. For `build_actors` rpc, since it is async when creating the actors, to handle it in `LocalBarrierWorker` loop, it becomes a two-phase operation. Its async part that creates the actors will be spawned to run concurrently so that it won't block the worker loop. The worker loop will keep polling the join handle to get notified on the completion of creating actors. After actors are created, it will spawn the actors and send the response to the original rpc handler.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
