### PR TITLE
feat(expr): allow partial option arguments in functions

### DIFF
--- a/src/expr/impl/src/scalar/array_positions.rs
+++ b/src/expr/impl/src/scalar/array_positions.rs
@@ -66,10 +66,7 @@ use risingwave_expr::{function, ExprError, Result};
 /// 2
 /// ```
 #[function("array_position(anyarray, any) -> int4")]
-fn array_position(
-    array: Option<ListRef<'_>>,
-    element: Option<ScalarRefImpl<'_>>,
-) -> Result<Option<i32>> {
+fn array_position(array: ListRef<'_>, element: Option<ScalarRefImpl<'_>>) -> Result<Option<i32>> {
     array_position_common(array, element, 0)
 }
 
@@ -98,7 +95,7 @@ fn array_position(
 /// ```
 #[function("array_position(anyarray, any, int4) -> int4")]
 fn array_position_start(
-    array: Option<ListRef<'_>>,
+    array: ListRef<'_>,
     element: Option<ScalarRefImpl<'_>>,
     start: Option<i32>,
 ) -> Result<Option<i32>> {
@@ -115,16 +112,15 @@ fn array_position_start(
 }
 
 fn array_position_common(
-    array: Option<ListRef<'_>>,
+    array: ListRef<'_>,
     element: Option<ScalarRefImpl<'_>>,
     skip: usize,
 ) -> Result<Option<i32>> {
-    let Some(left) = array else { return Ok(None) };
-    if i32::try_from(left.len()).is_err() {
+    if i32::try_from(array.len()).is_err() {
         return Err(ExprError::CastOutOfRange("invalid array length"));
     }
 
-    Ok(left
+    Ok(array
         .iter()
         .skip(skip)
         .position(|item| item == element)

--- a/src/expr/impl/src/scalar/array_remove.rs
+++ b/src/expr/impl/src/scalar/array_remove.rs
@@ -67,10 +67,6 @@ use risingwave_expr::function;
 /// select array_remove(ARRAY[array[1],array[2],array[3],array[2],null], array[true]);
 /// ```
 #[function("array_remove(anyarray, any) -> anyarray")]
-fn array_remove(array: Option<ListRef<'_>>, elem: Option<ScalarRefImpl<'_>>) -> Option<ListValue> {
-    let array = array?;
-    Some(ListValue::from_datum_iter(
-        &array.data_type(),
-        array.iter().filter(|x| x != &elem),
-    ))
+fn array_remove(array: ListRef<'_>, elem: Option<ScalarRefImpl<'_>>) -> ListValue {
+    ListValue::from_datum_iter(&array.data_type(), array.iter().filter(|x| x != &elem))
 }

--- a/src/expr/impl/src/scalar/array_replace.rs
+++ b/src/expr/impl/src/scalar/array_replace.rs
@@ -56,16 +56,15 @@ use risingwave_expr::function;
 /// ```
 #[function("array_replace(anyarray, any, any) -> anyarray")]
 fn array_replace(
-    array: Option<ListRef<'_>>,
+    array: ListRef<'_>,
     elem_from: Option<ScalarRefImpl<'_>>,
     elem_to: Option<ScalarRefImpl<'_>>,
-) -> Option<ListValue> {
-    let array = array?;
-    Some(ListValue::from_datum_iter(
+) -> ListValue {
+    ListValue::from_datum_iter(
         &array.data_type(),
         array.iter().map(|val| match val == elem_from {
             true => elem_to,
             false => val,
         }),
-    ))
+    )
 }

--- a/src/expr/impl/src/scalar/format_type.rs
+++ b/src/expr/impl/src/scalar/format_type.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Write;
+
 use risingwave_common::types::DataType;
 use risingwave_expr::function;
 
 #[function("format_type(int4, int4) -> varchar")]
-pub fn format_type(oid: Option<i32>, _typemod: Option<i32>) -> Option<Box<str>> {
+pub fn format_type(oid: i32, _typemod: Option<i32>, writer: &mut impl Write) {
     // since we don't support type modifier, ignore it.
-    oid.map(|i| {
-        DataType::from_oid(i)
-            .map(|dt| format!("{}", dt).into_boxed_str())
-            .unwrap_or("???".into())
-    })
+    match DataType::from_oid(oid) {
+        Ok(dt) => write!(writer, "{}", dt).unwrap(),
+        Err(_) => write!(writer, "???").unwrap(),
+    }
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/scalar/string_to_array.rs
+++ b/src/expr/impl/src/scalar/string_to_array.rs
@@ -34,25 +34,19 @@ fn string_to_array_inner<'a>(s: &'a str, sep: Option<&'a str>) -> impl Iterator<
 
 // Use cases shown in `e2e_test/batch/functions/string_to_array.slt.part`
 #[function("string_to_array(varchar, varchar) -> varchar[]")]
-pub fn string_to_array2(s: Option<&str>, sep: Option<&str>) -> Option<ListValue> {
-    Some(ListValue::new(
-        string_to_array_inner(s?, sep).collect::<Utf8Array>().into(),
-    ))
+pub fn string_to_array2(s: &str, sep: Option<&str>) -> ListValue {
+    ListValue::new(string_to_array_inner(s, sep).collect::<Utf8Array>().into())
 }
 
 #[function("string_to_array(varchar, varchar, varchar) -> varchar[]")]
-pub fn string_to_array3(
-    s: Option<&str>,
-    sep: Option<&str>,
-    null: Option<&str>,
-) -> Option<ListValue> {
+pub fn string_to_array3(s: &str, sep: Option<&str>, null: Option<&str>) -> ListValue {
     let Some(null) = null else {
         return string_to_array2(s, sep);
     };
-    Some(ListValue::new(
-        string_to_array_inner(s?, sep)
+    ListValue::new(
+        string_to_array_inner(s, sep)
             .map(|x| if x == null { None } else { Some(x) })
             .collect::<Utf8Array>()
             .into(),
-    ))
+    )
 }

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -349,6 +349,7 @@ impl FunctionAttr {
                 }
             };
         } else {
+            #[allow(clippy::disallowed_methods)] // allow zip
             let some_inputs = inputs
                 .iter()
                 .zip(user_fn.args_option.iter())

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -341,10 +341,27 @@ impl FunctionAttr {
         };
         // if user function accepts non-option arguments, we assume the function
         // returns null on null input, so we need to unwrap the inputs before calling.
-        if !user_fn.arg_option {
+        if self.prebuild.is_some() {
             output = quote! {
                 match (#(#inputs,)*) {
                     (#(Some(#inputs),)*) => #output,
+                    _ => None,
+                }
+            };
+        } else {
+            let some_inputs = inputs
+                .iter()
+                .zip(user_fn.args_option.iter())
+                .map(|(input, opt)| {
+                    if *opt {
+                        quote! { #input }
+                    } else {
+                        quote! { Some(#input) }
+                    }
+                });
+            output = quote! {
+                match (#(#inputs,)*) {
+                    (#(#some_inputs,)*) => #output,
                     _ => None,
                 }
             };
@@ -728,7 +745,7 @@ impl FunctionAttr {
             ReturnTypeKind::Result => quote! { Some(#next_state?) },
             ReturnTypeKind::ResultOption => quote! { #next_state? },
         };
-        if !user_fn.accumulate().arg_option {
+        if user_fn.accumulate().args_option.iter().all(|b| !b) {
             match self.args.len() {
                 0 => {
                     next_state = quote! {

--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -522,8 +522,8 @@ struct UserFunctionAttr {
     write: bool,
     /// Whether the last argument type is `retract: bool`.
     retract: bool,
-    /// The argument type are `Option`s.
-    arg_option: bool,
+    /// Whether each argument type is `Option<T>`.
+    args_option: Vec<bool>,
     /// If the first argument type is `&mut T`, then `Some(T)`.
     first_mut_ref_arg: Option<String>,
     /// The return type kind.
@@ -610,7 +610,7 @@ impl UserFunctionAttr {
         !self.async_
             && !self.write
             && !self.context
-            && !self.arg_option
+            && self.args_option.iter().all(|b| !b)
             && self.return_type_kind == ReturnTypeKind::T
     }
 }

--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -187,11 +187,10 @@ mod utils;
 ///
 /// ```ignore
 /// #[function("trim_array(anyarray, int32) -> anyarray")]
-/// fn trim_array(array: Option<ListRef<'_>>, n: Option<i32>) -> ListValue {...}
+/// fn trim_array(array: ListRef<'_>, n: Option<i32>) -> ListValue {...}
 /// ```
 ///
-/// Note that we currently only support all arguments being either `Option` or non-`Option`. Mixed
-/// cases are not supported.
+/// This function will be called when `n` is null, but not when `array` is null.
 ///
 /// ## Return Value
 ///
@@ -278,11 +277,11 @@ mod utils;
 /// }
 /// ```
 ///
-/// The `prebuild` argument can be specified, and its value is a Rust expression used to construct a
-/// new variable from the input arguments of the function. Here `$1`, `$2` represent the second and
-/// third arguments of the function (indexed from 0), and their types are `&str`. In the Rust
-/// function signature, these positions of parameters will be omitted, replaced by an extra new
-/// variable at the end.
+/// The `prebuild` argument can be specified, and its value is a Rust expression `Type::method(...)`
+/// used to construct a new variable of `Type` from the input arguments of the function.
+/// Here `$1`, `$2` represent the second and third arguments of the function (indexed from 0),
+/// and their types are `&str`. In the Rust function signature, these positions of parameters will
+/// be omitted, replaced by an extra new variable at the end.
 ///
 /// This macro generates two versions of the function. If all the input parameters that `prebuild`
 /// depends on are constants, it will precompute them during the build function. Otherwise, it will

--- a/src/expr/macro/src/parse.rs
+++ b/src/expr/macro/src/parse.rs
@@ -124,7 +124,7 @@ impl From<&syn::Signature> for UserFunctionAttr {
             write: sig.inputs.iter().any(arg_is_write),
             context: sig.inputs.iter().any(arg_is_context),
             retract: last_arg_is_retract(sig),
-            arg_option: args_contain_option(sig),
+            args_option: sig.inputs.iter().map(arg_is_option).collect(),
             first_mut_ref_arg: first_mut_ref_arg(sig),
             return_type_kind,
             iterator_item_kind,
@@ -224,23 +224,18 @@ fn last_arg_is_retract(sig: &syn::Signature) -> bool {
     pat.ident.to_string().contains("retract")
 }
 
-/// Check if any argument is `Option`.
-fn args_contain_option(sig: &syn::Signature) -> bool {
-    for arg in &sig.inputs {
-        let syn::FnArg::Typed(arg) = arg else {
-            continue;
-        };
-        let syn::Type::Path(path) = arg.ty.as_ref() else {
-            continue;
-        };
-        let Some(seg) = path.path.segments.last() else {
-            continue;
-        };
-        if seg.ident == "Option" {
-            return true;
-        }
-    }
-    false
+/// Check if the argument is `Option`.
+fn arg_is_option(arg: &syn::FnArg) -> bool {
+    let syn::FnArg::Typed(arg) = arg else {
+        return false;
+    };
+    let syn::Type::Path(path) = arg.ty.as_ref() else {
+        return false;
+    };
+    let Some(seg) = path.path.segments.last() else {
+        return false;
+    };
+    seg.ident == "Option"
 }
 
 /// Returns `T` if the first argument (except `self`) is `&mut T`.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Currently `#[function]` only accepts all arguments as `Option` or none of them as `Option`. This PR breaks this limitation, allowing partial `Option` arguments.

For example:
```rust
#[function("array_remove(anyarray, any) -> anyarray")]
fn array_remove(array: ListRef<'_>, elem: Option<ScalarRefImpl<'_>>) -> ListValue {...}
```

which will be called when `elem` is null, but not when `array` is null.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)
