### PR TITLE
feat(meta): add get back pressure RPC for UI dashboard

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -103,6 +103,13 @@ message WaitEpochCommitResponse {
   common.Status status = 1;
 }
 
+// Back pressure
+message GetBackPressureRequest {
+}
+message GetBackPressureResponse {
+  uint64 back_pressure = 1;
+}
+
 service StreamService {
   rpc UpdateActors(UpdateActorsRequest) returns (UpdateActorsResponse);
   rpc BuildActors(BuildActorsRequest) returns (BuildActorsResponse);
@@ -112,6 +119,7 @@ service StreamService {
   rpc InjectBarrier(InjectBarrierRequest) returns (InjectBarrierResponse);
   rpc BarrierComplete(BarrierCompleteRequest) returns (BarrierCompleteResponse);
   rpc WaitEpochCommit(WaitEpochCommitRequest) returns (WaitEpochCommitResponse);
+  rpc GetBackPressure(GetBackPressureRequest) returns (GetBackPressureResponse);
 }
 
 // TODO: Lifecycle management for actors.

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -104,14 +104,13 @@ message WaitEpochCommitResponse {
 }
 
 // Back pressure
-message GetBackPressureRequest {
-}
+message GetBackPressureRequest {}
 
 message BackPressureInfo {
-    uint32 actor_id = 1;          
-    uint32 fragment_id = 2;   
-    uint32 downstream_fragment_id = 3; 
-    double value = 4;           
+  uint32 actor_id = 1;
+  uint32 fragment_id = 2;
+  uint32 downstream_fragment_id = 3;
+  double value = 4;
 }
 
 message GetBackPressureResponse {

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -106,8 +106,16 @@ message WaitEpochCommitResponse {
 // Back pressure
 message GetBackPressureRequest {
 }
+
+message BackPressureInfo {
+    string actor_id = 1;          
+    string fragment_id = 2;   
+    string downstream_fragment_id = 3; 
+    double value = 4;           
+}
+
 message GetBackPressureResponse {
-  uint64 back_pressure = 1;
+  repeated BackPressureInfo back_pressure_infos = 1;
 }
 
 service StreamService {

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -108,9 +108,9 @@ message GetBackPressureRequest {
 }
 
 message BackPressureInfo {
-    string actor_id = 1;          
-    string fragment_id = 2;   
-    string downstream_fragment_id = 3; 
+    uint32 actor_id = 1;          
+    uint32 fragment_id = 2;   
+    uint32 downstream_fragment_id = 3; 
     double value = 4;           
 }
 

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use await_tree::InstrumentAwait;
 use itertools::Itertools;
+use risingwave_common::config::MetricLevel;
 use risingwave_hummock_sdk::table_stats::to_prost_table_stats_map;
 use risingwave_hummock_sdk::LocalSstableInfo;
 use risingwave_pb::stream_service::barrier_complete_response::GroupedSstableInfo;
@@ -23,6 +24,7 @@ use risingwave_pb::stream_service::stream_service_server::StreamService;
 use risingwave_pb::stream_service::*;
 use risingwave_storage::dispatch_state_store;
 use risingwave_stream::error::StreamError;
+use risingwave_stream::executor::monitor::global_streaming_metrics;
 use risingwave_stream::executor::Barrier;
 use risingwave_stream::task::{BarrierCompleteResult, LocalStreamManager, StreamEnvironment};
 use thiserror_ext::AsReport;
@@ -237,5 +239,16 @@ impl StreamService for StreamServiceImpl {
         });
 
         Ok(Response::new(WaitEpochCommitResponse { status: None }))
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_back_pressure(
+        &self,
+        _request: Request<GetBackPressureRequest>,
+    ) -> Result<Response<GetBackPressureResponse>, Status> {
+        let back_pressure = global_streaming_metrics(MetricLevel::Info);
+        Ok(Response::new(GetBackPressureResponse {
+            back_pressure: 199,
+        }))
     }
 }

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -256,13 +256,14 @@ impl StreamService for StreamServiceImpl {
             let mut back_pressure_info = BackPressureInfo::default();
             for label_pair in label_pairs.get_label() {
                 if label_pair.get_name() == "actor_id" {
-                    back_pressure_info.actor_id = label_pair.get_value().to_string();
+                    back_pressure_info.actor_id = label_pair.get_value().parse::<u32>().unwrap();
                 }
                 if label_pair.get_name() == "fragment_id" {
-                    back_pressure_info.fragment_id = label_pair.get_value().to_string();
+                    back_pressure_info.fragment_id = label_pair.get_value().parse::<u32>().unwrap();
                 }
                 if label_pair.get_name() == "downstream_fragment_id" {
-                    back_pressure_info.downstream_fragment_id = label_pair.get_value().to_string();
+                    back_pressure_info.downstream_fragment_id =
+                        label_pair.get_value().parse::<u32>().unwrap();
                 }
             }
             back_pressure_info.value = label_pairs.get_counter().get_value();

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -269,7 +269,6 @@ impl StreamService for StreamServiceImpl {
             back_pressure_infos.push(back_pressure_info);
         }
 
-
         Ok(Response::new(GetBackPressureResponse {
             back_pressure_infos,
         }))

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -371,7 +371,7 @@ impl ClusterController {
             .get_worker_extra_info_by_id(worker_id)
     }
 
-    pub async fn get_back_pressure_rate(&self) -> MetaResult<GetBackPressureResponse> {
+    pub async fn get_back_pressure(&self) -> MetaResult<GetBackPressureResponse> {
         let nodes = self
             .inner
             .read()

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -36,6 +36,7 @@ use risingwave_pb::meta::add_worker_node_request::Property as AddNodeProperty;
 use risingwave_pb::meta::heartbeat_request;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::update_worker_node_schedulability_request::Schedulability;
+use risingwave_pb::stream_service::BackPressureInfo;
 use sea_orm::prelude::Expr;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
@@ -378,11 +379,11 @@ impl ClusterController {
             .list_active_serving_workers()
             .await
             .unwrap();
+        let mut back_pressures : Vec<BackPressureInfo> = Vec::new();
         for node in nodes {
             let client = self.env.stream_client_pool().get(&node).await.unwrap();
             let request = risingwave_pb::stream_service::GetBackPressureRequest {};
-            let back_pressure = client.get_back_pressure(request).await.unwrap();
-            break;
+            back_pressures.extend(client.get_back_pressure(request).await.unwrap().back_pressure_infos);
         }
 
         Ok(196)

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -369,6 +369,24 @@ impl ClusterController {
             .await
             .get_worker_extra_info_by_id(worker_id)
     }
+
+    pub async fn get_back_pressure_rate(&self) -> MetaResult<u64> {
+        let nodes = self
+            .inner
+            .read()
+            .await
+            .list_active_serving_workers()
+            .await
+            .unwrap();
+        for node in nodes {
+            let client = self.env.stream_client_pool().get(&node).await.unwrap();
+            let request = risingwave_pb::stream_service::GetBackPressureRequest {};
+            let back_pressure = client.get_back_pressure(request).await.unwrap();
+            break;
+        }
+
+        Ok(196)
+    }
 }
 
 #[derive(Default, Clone)]

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -36,7 +36,7 @@ use risingwave_pb::meta::add_worker_node_request::Property as AddNodeProperty;
 use risingwave_pb::meta::heartbeat_request;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::update_worker_node_schedulability_request::Schedulability;
-use risingwave_pb::stream_service::BackPressureInfo;
+use risingwave_pb::stream_service::{BackPressureInfo, GetBackPressureResponse};
 use sea_orm::prelude::Expr;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
@@ -371,7 +371,7 @@ impl ClusterController {
             .get_worker_extra_info_by_id(worker_id)
     }
 
-    pub async fn get_back_pressure_rate(&self) -> MetaResult<u64> {
+    pub async fn get_back_pressure_rate(&self) -> MetaResult<GetBackPressureResponse> {
         let nodes = self
             .inner
             .read()
@@ -379,14 +379,22 @@ impl ClusterController {
             .list_active_serving_workers()
             .await
             .unwrap();
-        let mut back_pressures : Vec<BackPressureInfo> = Vec::new();
+        let mut back_pressure_infos: Vec<BackPressureInfo> = Vec::new();
         for node in nodes {
             let client = self.env.stream_client_pool().get(&node).await.unwrap();
             let request = risingwave_pb::stream_service::GetBackPressureRequest {};
-            back_pressures.extend(client.get_back_pressure(request).await.unwrap().back_pressure_infos);
+            back_pressure_infos.extend(
+                client
+                    .get_back_pressure(request)
+                    .await
+                    .unwrap()
+                    .back_pressure_infos,
+            );
         }
 
-        Ok(196)
+        Ok(GetBackPressureResponse {
+            back_pressure_infos,
+        })
     }
 }
 

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -407,7 +407,7 @@ impl DashboardService {
                 "/metrics/actor/back_pressures",
                 get(prometheus::list_prometheus_actor_back_pressure),
             )
-            .route("/metrics/back_pressures_rate", get(get_back_pressure))
+            .route("/metrics/back_pressures", get(get_back_pressure))
             .route("/monitor/await_tree/:worker_id", get(dump_await_tree))
             .route("/monitor/await_tree/", get(dump_await_tree_all))
             .route("/monitor/dump_heap_profile/:worker_id", get(heap_profile))

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -362,19 +362,17 @@ pub(super) mod handlers {
         Ok(report)
     }
 
-    pub async fn get_back_pressure_rate(
+    pub async fn get_back_pressure(
         // Path(worker_id): Path<WorkerId>,
         Extension(srv): Extension<Service>,
     ) -> Result<Json<GetBackPressureResponse>> {
         let back_pressure_infos = match &srv.metadata_manager {
-            MetadataManager::V1(mgr) => mgr
-                .cluster_manager
-                .get_back_pressure_rate()
-                .await
-                .map_err(err)?,
+            MetadataManager::V1(mgr) => {
+                mgr.cluster_manager.get_back_pressure().await.map_err(err)?
+            }
             MetadataManager::V2(mgr) => mgr
                 .cluster_controller
-                .get_back_pressure_rate()
+                .get_back_pressure()
                 .await
                 .map_err(err)?,
         };
@@ -409,7 +407,7 @@ impl DashboardService {
                 "/metrics/actor/back_pressures",
                 get(prometheus::list_prometheus_actor_back_pressure),
             )
-            .route("/metrics/back_pressures_rate", get(get_back_pressure_rate))
+            .route("/metrics/back_pressures_rate", get(get_back_pressure))
             .route("/monitor/await_tree/:worker_id", get(dump_await_tree))
             .route("/monitor/await_tree/", get(dump_await_tree_all))
             .route("/monitor/dump_heap_profile/:worker_id", get(heap_profile))

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -360,6 +360,17 @@ pub(super) mod handlers {
 
         Ok(report)
     }
+
+    pub async fn get_back_pressure_rate(
+        // Path(worker_id): Path<WorkerId>,
+        Extension(srv): Extension<Service>,
+    ) -> Result<String> {
+        let result = match &srv.metadata_manager {
+            MetadataManager::V1(mgr) => mgr.cluster_manager.get_back_pressure_rate().await,
+            MetadataManager::V2(mgr) => mgr.cluster_controller.get_back_pressure_rate().await,
+        };
+        Ok("198".to_string())
+    }
 }
 
 impl DashboardService {
@@ -388,6 +399,7 @@ impl DashboardService {
                 "/metrics/actor/back_pressures",
                 get(prometheus::list_prometheus_actor_back_pressure),
             )
+            .route("/metrics/back_pressures_rate", get(get_back_pressure_rate))
             .route("/monitor/await_tree/:worker_id", get(dump_await_tree))
             .route("/monitor/await_tree/", get(dump_await_tree_all))
             .route("/monitor/dump_heap_profile/:worker_id", get(heap_profile))

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -492,6 +492,22 @@ impl ClusterManager {
     pub async fn get_worker_by_id(&self, worker_id: WorkerId) -> Option<Worker> {
         self.core.read().await.get_worker_by_id(worker_id)
     }
+
+    pub async fn get_back_pressure_rate(&self) -> MetaResult<u64>  {
+        let mut core = self.core.write().await;
+        for worker in core.workers.values_mut() {
+            let client = self
+                .env
+                .stream_client_pool()
+                .get(&worker.worker_node)
+                .await
+                .unwrap();
+            let request = risingwave_pb::stream_service::GetBackPressureRequest {};
+            let result = client.get_back_pressure(request).await.unwrap();
+            break;
+        }
+        Ok(197)
+    }
 }
 
 /// The cluster info used for scheduling a streaming job.

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -31,6 +31,7 @@ use risingwave_pb::meta::add_worker_node_request::Property as AddNodeProperty;
 use risingwave_pb::meta::heartbeat_request;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::update_worker_node_schedulability_request::Schedulability;
+use risingwave_pb::stream_service::BackPressureInfo;
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot::Sender;
 use tokio::sync::{RwLock, RwLockReadGuard};
@@ -493,9 +494,13 @@ impl ClusterManager {
         self.core.read().await.get_worker_by_id(worker_id)
     }
 
-    pub async fn get_back_pressure_rate(&self) -> MetaResult<u64>  {
+    pub async fn get_back_pressure_rate(&self) -> MetaResult<u64> {
         let mut core = self.core.write().await;
+        let mut back_pressures: Vec<BackPressureInfo> = Vec::new();
         for worker in core.workers.values_mut() {
+            if worker.worker_type() != WorkerType::ComputeNode {
+                continue;
+            }
             let client = self
                 .env
                 .stream_client_pool()
@@ -503,8 +508,13 @@ impl ClusterManager {
                 .await
                 .unwrap();
             let request = risingwave_pb::stream_service::GetBackPressureRequest {};
-            let result = client.get_back_pressure(request).await.unwrap();
-            break;
+            back_pressures.extend(
+                client
+                    .get_back_pressure(request)
+                    .await
+                    .unwrap()
+                    .back_pressure_infos,
+            );
         }
         Ok(197)
     }

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -494,7 +494,7 @@ impl ClusterManager {
         self.core.read().await.get_worker_by_id(worker_id)
     }
 
-    pub async fn get_back_pressure_rate(&self) -> MetaResult<GetBackPressureResponse> {
+    pub async fn get_back_pressure(&self) -> MetaResult<GetBackPressureResponse> {
         let mut core = self.core.write().await;
         let mut back_pressure_infos: Vec<BackPressureInfo> = Vec::new();
         for worker in core.workers.values_mut() {

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -915,6 +915,13 @@ mod tests {
         ) -> std::result::Result<Response<WaitEpochCommitResponse>, Status> {
             Ok(Response::new(WaitEpochCommitResponse::default()))
         }
+
+        async fn get_back_pressure(
+            &self,
+            _request: Request<GetBackPressureRequest>,
+        ) -> std::result::Result<Response<GetBackPressureResponse>, Status> {
+            Ok(Response::new(GetBackPressureResponse::default()))
+        }
     }
 
     struct MockServices {

--- a/src/rpc_client/src/stream_client.rs
+++ b/src/rpc_client/src/stream_client.rs
@@ -72,6 +72,7 @@ macro_rules! for_all_stream_rpc {
             ,{ 0, inject_barrier, InjectBarrierRequest, InjectBarrierResponse }
             ,{ 0, barrier_complete, BarrierCompleteRequest, BarrierCompleteResponse }
             ,{ 0, wait_epoch_commit, WaitEpochCommitRequest, WaitEpochCommitResponse }
+            ,{ 0, get_back_pressure, GetBackPressureRequest, GetBackPressureResponse }
         }
     };
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
In #13830, we want to embedded a back pressure rate metrics for dashbaord UI. In this PR, I add a API to get the back pressure from all compute node to meta node. 

But I still need to implement the calculation steps. The way to calculate the rate:
1. Get the (previous) back pressure metrics 1 in time 1.
2. Get the (current) back pressure metrics 2 in time 2. Do `(metrics 2 - metrics 1)/(time2 - time1)`. 
3. Then make the current back pressure as the previous metrics and repeat step 1 and step 2 every 15 seconds.

In meta node, I didn't find a good way to do this crobjob, also not find a good place to storage the previous metrics in memory. May try to implement the logic in ui frontend or some place in meta in following PR.

Result:
If you deploy and request the `http://127.0.0.1:5691/api/metrics/back_pressures`, will get result:
```
{
    "backPressureInfos": [
        {
            "actorId": "8",
            "fragmentId": "2",
            "downstreamFragmentId": "1",
            "value": 483665.0
        },
        {
            "actorId": "15",
            "fragmentId": "4",
            "downstreamFragmentId": "3",
            "value": 239666.0
        },
        {
            "actorId": "7",
            "fragmentId": "2",
            "downstreamFragmentId": "1",
            "value": 317250.0
        },
        .....
    ]
}
```
## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
