### PR TITLE
fix: extract decimal correctly when bytes len >= 5

### DIFF
--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -444,19 +444,23 @@ mod tests {
         assert_eq!(rust_decimal, rust_decimal::Decimal::try_from(28.1).unwrap());
 
         // 1.1234567891
-        let value = BigInt::from(11234567891 as i64);
+        let value = BigInt::from(11234567891_i64);
         let negative = value.sign() == Sign::Minus;
         let (lo, mid, hi) = extract_decimal(value.to_bytes_be().1).unwrap();
-        let decimal =
-            rust_decimal::Decimal::from_parts(lo, mid, hi, negative, 10);
-        assert_eq!(decimal, rust_decimal::Decimal::try_from(1.1234567891).unwrap());
-
+        let decimal = rust_decimal::Decimal::from_parts(lo, mid, hi, negative, 10);
+        assert_eq!(
+            decimal,
+            rust_decimal::Decimal::try_from(1.1234567891).unwrap()
+        );
 
         // 1.123456789123456789123456789
         let v = vec![3, 161, 77, 58, 146, 180, 49, 220, 100, 4, 95, 21];
         let avro_decimal = AvroDecimal::from(v);
         let rust_decimal = avro_decimal_to_rust_decimal(avro_decimal, 28, 27).unwrap();
-        assert_eq!(rust_decimal, rust_decimal::Decimal::from_str("1.123456789123456789123456789").unwrap());
+        assert_eq!(
+            rust_decimal,
+            rust_decimal::Decimal::from_str("1.123456789123456789123456789").unwrap()
+        );
     }
 
     /// Convert Avro value to datum.For now, support the following [Avro type](https://avro.apache.org/docs/current/spec.html).

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -157,7 +157,7 @@ impl<'a> AvroParseOptions<'a> {
                 }?;
 
                 let negative = value.sign() == Sign::Minus;
-                let (lo, mid, hi) = extract_decimal(value.to_bytes_be().1);
+                let (lo, mid, hi) = extract_decimal(value.to_bytes_be().1)?;
                 let decimal =
                     rust_decimal::Decimal::from_parts(lo, mid, hi, negative, scale as u32);
                 ScalarImpl::Decimal(risingwave_common::types::Decimal::Normalized(decimal))
@@ -331,7 +331,7 @@ pub(crate) fn avro_decimal_to_rust_decimal(
     let negative = !avro_decimal.is_positive();
     let bytes = avro_decimal.to_vec_unsigned();
 
-    let (lo, mid, hi) = extract_decimal(bytes);
+    let (lo, mid, hi) = extract_decimal(bytes)?;
     Ok(rust_decimal::Decimal::from_parts(
         lo,
         mid,
@@ -341,30 +341,41 @@ pub(crate) fn avro_decimal_to_rust_decimal(
     ))
 }
 
-pub(crate) fn extract_decimal(bytes: Vec<u8>) -> (u32, u32, u32) {
+pub(crate) fn extract_decimal(bytes: Vec<u8>) -> anyhow::Result<(u32, u32, u32)> {
+    tracing::info!("decimal bytes: {:?}", bytes);
     match bytes.len() {
         len @ 0..=4 => {
             let mut pad = vec![0; 4 - len];
             pad.extend_from_slice(&bytes);
             let lo = u32::from_be_bytes(pad.try_into().unwrap());
-            (lo, 0, 0)
+            Ok((lo, 0, 0))
         }
         len @ 5..=8 => {
-            let mid = u32::from_be_bytes(bytes[..4].to_owned().try_into().unwrap());
-            let mut pad = vec![0; 8 - len];
-            pad.extend_from_slice(&bytes[4..]);
-            let lo = u32::from_be_bytes(pad.try_into().unwrap());
-            (lo, mid, 0)
+            let zero_len = 8 - len;
+            let mid_end = 4 - zero_len;
+
+            let mut pad = vec![0; zero_len];
+            pad.extend_from_slice(&bytes[..mid_end]);
+            let mid = u32::from_be_bytes(pad.try_into().unwrap());
+
+            let lo = u32::from_be_bytes(bytes[mid_end..].to_owned().try_into().unwrap());
+            Ok((lo, mid, 0))
         }
         len @ 9..=12 => {
-            let hi = u32::from_be_bytes(bytes[..4].to_owned().try_into().unwrap());
-            let mid = u32::from_be_bytes(bytes[4..8].to_owned().try_into().unwrap());
-            let mut pad = vec![0; 12 - len];
-            pad.extend_from_slice(&bytes[8..]);
-            let lo = u32::from_be_bytes(pad.try_into().unwrap());
-            (lo, mid, hi)
+            let zero_len = 12 - len;
+            let hi_end = 4 - zero_len;
+            let mid_end = hi_end + 4;
+
+            let mut pad = vec![0; zero_len];
+            pad.extend_from_slice(&bytes[..hi_end]);
+            let hi = u32::from_be_bytes(pad.try_into().unwrap());
+
+            let mid = u32::from_be_bytes(bytes[hi_end..mid_end].to_owned().try_into().unwrap());
+
+            let lo = u32::from_be_bytes(bytes[mid_end..].to_owned().try_into().unwrap());
+            Ok((lo, mid, hi))
         }
-        _ => unreachable!(),
+        _ => Err(anyhow!("decimal bytes len: {:?} > 12", bytes.len())),
     }
 }
 
@@ -431,6 +442,21 @@ mod tests {
         let avro_decimal = AvroDecimal::from(v);
         let rust_decimal = avro_decimal_to_rust_decimal(avro_decimal, 28, 1).unwrap();
         assert_eq!(rust_decimal, rust_decimal::Decimal::try_from(28.1).unwrap());
+
+        // 1.1234567891
+        let value = BigInt::from(11234567891 as i64);
+        let negative = value.sign() == Sign::Minus;
+        let (lo, mid, hi) = extract_decimal(value.to_bytes_be().1).unwrap();
+        let decimal =
+            rust_decimal::Decimal::from_parts(lo, mid, hi, negative, 10);
+        assert_eq!(decimal, rust_decimal::Decimal::try_from(1.1234567891).unwrap());
+
+
+        // 1.123456789123456789123456789
+        let v = vec![3, 161, 77, 58, 146, 180, 49, 220, 100, 4, 95, 21];
+        let avro_decimal = AvroDecimal::from(v);
+        let rust_decimal = avro_decimal_to_rust_decimal(avro_decimal, 28, 27).unwrap();
+        assert_eq!(rust_decimal, rust_decimal::Decimal::from_str("1.123456789123456789123456789").unwrap());
     }
 
     /// Convert Avro value to datum.For now, support the following [Avro type](https://avro.apache.org/docs/current/spec.html).

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -342,7 +342,6 @@ pub(crate) fn avro_decimal_to_rust_decimal(
 }
 
 pub(crate) fn extract_decimal(bytes: Vec<u8>) -> anyhow::Result<(u32, u32, u32)> {
-    tracing::info!("decimal bytes: {:?}", bytes);
     match bytes.len() {
         len @ 0..=4 => {
             let mut pad = vec![0; 4 - len];
@@ -528,7 +527,7 @@ mod tests {
         assert_eq!(
             resp,
             Some(ScalarImpl::Decimal(Decimal::Normalized(
-                rust_decimal::Decimal::from_str("4.557430887741865791").unwrap()
+                rust_decimal::Decimal::from_str("0.017802464409370431").unwrap()
             )))
         );
     }

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -358,7 +358,7 @@ impl JsonParseOptions {
                     .as_bytes();
                 let decimal = BigInt::from_signed_bytes_be(value);
                 let negative = decimal.sign() == Sign::Minus;
-                let (lo, mid, hi) = extract_decimal(decimal.to_bytes_be().1);
+                let (lo, mid, hi) = extract_decimal(decimal.to_bytes_be().1)?;
                 let decimal =
                     rust_decimal::Decimal::from_parts(lo, mid, hi, negative, scale as u32);
                 ScalarImpl::Decimal(Decimal::Normalized(decimal))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Correctly handle the situation when the length of bytes is greater than 4.
defore:
`1.1234567891` -> `18848476.8633979091`
after:
`1.1234567891` -> `1.1234567891`

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
