### PR TITLE
fix(avro): correct parse `timestamp` data before Epoch

### DIFF
--- a/src/common/src/types/datetime.rs
+++ b/src/common/src/types/datetime.rs
@@ -536,6 +536,12 @@ impl Timestamp {
         self.0.timestamp_nanos_opt().unwrap()
     }
 
+    pub fn with_millis(timestamp_millis: i64) -> Result<Self> {
+        let secs = timestamp_millis.div_euclid(1_000);
+        let nsecs = timestamp_millis.rem_euclid(1_000) * 1_000_000;
+        Self::with_secs_nsecs(secs, nsecs as u32)
+    }
+
     pub fn with_micros(timestamp_micros: i64) -> Result<Self> {
         let secs = timestamp_micros.div_euclid(1_000_000);
         let nsecs = timestamp_micros.rem_euclid(1_000_000) * 1000;

--- a/src/connector/src/parser/avro/util.rs
+++ b/src/connector/src/parser/avro/util.rs
@@ -103,6 +103,8 @@ fn avro_type_mapping(schema: &Schema) -> anyhow::Result<DataType> {
             DataType::Decimal
         }
         Schema::Date => DataType::Date,
+        Schema::LocalTimestampMillis => DataType::Timestamp,
+        Schema::LocalTimestampMicros => DataType::Timestamp,
         Schema::TimestampMillis => DataType::Timestamptz,
         Schema::TimestampMicros => DataType::Timestamptz,
         Schema::Duration => DataType::Interval,

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -434,7 +434,7 @@ pub(crate) fn unix_epoch_days() -> i32 {
 mod tests {
     use apache_avro::Decimal as AvroDecimal;
     use risingwave_common::error::{ErrorCode, RwError};
-    use risingwave_common::types::{Decimal, Timestamp};
+    use risingwave_common::types::{Decimal, Timestamptz};
 
     use super::*;
 
@@ -496,24 +496,24 @@ mod tests {
     }
 
     #[test]
-    fn test_avro_timestamp_micros() {
-        let v1 = Value::TimestampMicros(1620000000000);
-        let v2 = Value::TimestampMillis(1620000000);
+    fn test_avro_timestamptz_micros() {
+        let v1 = Value::TimestampMicros(1620000000000000);
+        let v2 = Value::TimestampMillis(1620000000000);
         let value_schema1 = Schema::TimestampMicros;
         let value_schema2 = Schema::TimestampMillis;
-        let datum1 = from_avro_value(v1, &value_schema1, &DataType::Timestamp).unwrap();
-        let datum2 = from_avro_value(v2, &value_schema2, &DataType::Timestamp).unwrap();
+        let datum1 = from_avro_value(v1, &value_schema1, &DataType::Timestamptz).unwrap();
+        let datum2 = from_avro_value(v2, &value_schema2, &DataType::Timestamptz).unwrap();
         assert_eq!(
             datum1,
-            Some(ScalarImpl::Timestamp(Timestamp::new(
-                "2021-05-03T00:00:00".parse().unwrap()
-            )))
+            Some(ScalarImpl::Timestamptz(
+                Timestamptz::from_str("2021-05-03T00:00:00Z").unwrap()
+            ))
         );
         assert_eq!(
             datum2,
-            Some(ScalarImpl::Timestamp(Timestamp::new(
-                "2021-05-03T00:00:00".parse().unwrap()
-            )))
+            Some(ScalarImpl::Timestamptz(
+                Timestamptz::from_str("2021-05-03T00:00:00Z").unwrap()
+            ))
         );
     }
 

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -197,8 +197,7 @@ impl<'a> AvroParseOptions<'a> {
             (Some(DataType::Timestamptz), Value::TimestampMillis(ms)) => {
                 Timestamptz::from_millis(*ms)
                     .ok_or(AccessError::Other(anyhow!(
-                        "timestamp with milliseconds {:?} * 1000 is out of range",
-                        ms
+                        "timestamptz with milliseconds {ms} * 1000 is out of range",
                     )))?
                     .into()
             }

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -195,7 +195,6 @@ impl<'a> AvroParseOptions<'a> {
 
             // ---- TimestampTz -----
             (Some(DataType::Timestamptz), Value::TimestampMillis(ms)) => {
-                tracing::debug!("timestamp milliseconds {:?}", ms);
                 Timestamptz::from_millis(*ms)
                     .ok_or(AccessError::Other(anyhow!(
                         "timestamp with milliseconds {:?} * 1000 is out of range",

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -194,14 +194,14 @@ impl<'a> AvroParseOptions<'a> {
             }
 
             // ---- TimestampTz -----
-            (Some(DataType::Timestamptz), Value::TimestampMillis(ms)) => {
+            (Some(DataType::Timestamptz) | None, Value::TimestampMillis(ms)) => {
                 Timestamptz::from_millis(*ms)
                     .ok_or(AccessError::Other(anyhow!(
                         "timestamptz with milliseconds {ms} * 1000 is out of range",
                     )))?
                     .into()
             }
-            (Some(DataType::Timestamptz), Value::TimestampMicros(us)) => {
+            (Some(DataType::Timestamptz) | None, Value::TimestampMicros(us)) => {
                 Timestamptz::from_micros(*us).into()
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

before:
insert timestamp before Epoch, will get error:
e.g. `1969-01-01 00:00:00`:
```
WARN   rw-streaming actor{otel.name="Actor 18" actor_id=18 prev_epoch=5850098781323264 curr_epoch=5850098793119744}:executor{otel.name="Source 1200002715 (actor 18)" actor_id=18}:source_parse_chunk{actor_id=18 source_id=1002}: risingwave_connector::parser: failed to parse non-pk column, padding with `NULL` error=Expected type `Some(Timestamptz)` but got `TimestampMillis(-31536000000)` for `` split_id="0" offset="2" column="c_timestamp" suppressed_count=0
```

Note:

While for the ancient `timestamp` data, it is incorrect:
`0001-01-01 00:00:00`(pg) ->  `-62135769600000`(kafka) ->`0000-12-30 00:00:00+00:00`(rw).


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
