### PR TITLE
feat(stream): support row count for arrangement backfill

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -570,7 +570,7 @@ profile:
     steps:
       - use: minio
         api-requests-max: 30
-        api-requests-deadline: 2s
+        api-requests-deadline: 3s
       - use: etcd
         unsafe-no-fsync: true
       - use: meta-node

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -140,7 +140,7 @@ pub struct ConfigMap {
     streaming_enable_bushy_join: bool,
 
     /// Enable arrangement backfill for streaming queries. Defaults to false.
-    #[parameter(default = true)]
+    #[parameter(default = false)]
     streaming_enable_arrangement_backfill: bool,
 
     /// Allow `jsonb` in stream key

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -140,7 +140,7 @@ pub struct ConfigMap {
     streaming_enable_bushy_join: bool,
 
     /// Enable arrangement backfill for streaming queries. Defaults to false.
-    #[parameter(default = false)]
+    #[parameter(default = true)]
     streaming_enable_arrangement_backfill: bool,
 
     /// Allow `jsonb` in stream key

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -185,7 +185,7 @@ where
         let mut snapshot_read_epoch;
 
         // Keep track of rows from the snapshot.
-        let mut total_snapshot_processed_rows: u64 = 0;
+        let mut total_snapshot_processed_rows: u64 = backfill_state.get_snapshot_row_count();
 
         // Arrangement Backfill Algorithm:
         //
@@ -278,9 +278,8 @@ where
                                         // mark.
                                         for chunk in upstream_chunk_buffer.drain(..) {
                                             let chunk_cardinality = chunk.cardinality() as u64;
-                                            cur_barrier_snapshot_processed_rows +=
+                                            cur_barrier_upstream_processed_rows +=
                                                 chunk_cardinality;
-                                            total_snapshot_processed_rows += chunk_cardinality;
                                             yield Message::Chunk(mapping_chunk(
                                                 chunk,
                                                 &self.output_indices,

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -290,6 +290,8 @@ where
                                         break 'backfill_loop;
                                     }
                                     Some((vnode, chunk)) => {
+                                        let chunk_cardinality = chunk.cardinality() as u64;
+
                                         // Raise the current position.
                                         // As snapshot read streams are ordered by pk, so we can
                                         // just use the last row to update `current_pos`.
@@ -298,9 +300,9 @@ where
                                             &chunk,
                                             &pk_in_output_indices,
                                             &mut backfill_state,
+                                            chunk_cardinality,
                                         )?;
 
-                                        let chunk_cardinality = chunk.cardinality() as u64;
                                         cur_barrier_snapshot_processed_rows += chunk_cardinality;
                                         total_snapshot_processed_rows += chunk_cardinality;
                                         let chunk = Message::Chunk(mapping_chunk(
@@ -354,6 +356,7 @@ where
                     })
                 })) {
                     if let Some(chunk) = chunk {
+                        let chunk_cardinality = chunk.cardinality() as u64;
                         // Raise the current position.
                         // As snapshot read streams are ordered by pk, so we can
                         // just use the last row to update `current_pos`.
@@ -362,9 +365,9 @@ where
                             &chunk,
                             &pk_in_output_indices,
                             &mut backfill_state,
+                            chunk_cardinality,
                         )?;
 
-                        let chunk_cardinality = chunk.cardinality() as u64;
                         cur_barrier_snapshot_processed_rows += chunk_cardinality;
                         total_snapshot_processed_rows += chunk_cardinality;
                         yield Message::Chunk(mapping_chunk(chunk, &self.output_indices));

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -585,8 +585,10 @@ where
             let backfill_progress = backfill_state.get_progress(&vnode)?;
             let current_pos = match backfill_progress {
                 BackfillProgressPerVnode::NotStarted => None,
-                BackfillProgressPerVnode::Completed(current_pos)
-                | BackfillProgressPerVnode::InProgress(current_pos) => Some(current_pos.clone()),
+                BackfillProgressPerVnode::Completed { current_pos, .. }
+                | BackfillProgressPerVnode::InProgress { current_pos, .. } => {
+                    Some(current_pos.clone())
+                }
             };
 
             let range_bounds = compute_bounds(upstream_table.pk_indices(), current_pos.clone());

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -259,6 +259,8 @@ metrics_level = "Disabled"
             meta_nodes: 1,
             compactor_nodes: 1,
             compute_node_cores: 1,
+            per_session_queries: vec!["SET STREAMING_ENABLE_ARRANGEMENT_BACKFILL = true;".into()]
+                .into(),
             ..Default::default()
         }
     }

--- a/src/tests/simulation/tests/integration_tests/backfill_tests.rs
+++ b/src/tests/simulation/tests/integration_tests/backfill_tests.rs
@@ -276,7 +276,6 @@ async fn test_arrangement_backfill_progress() -> Result<()> {
     let progress = session
         .run("SELECT progress FROM rw_catalog.rw_ddl_progress")
         .await?;
-    println!("progress: {}", progress);
     let progress = progress.replace('%', "");
     let progress = progress.parse::<f64>().unwrap();
     assert!((prev_progress..prev_progress + 1.5).contains(&progress));

--- a/src/tests/simulation/tests/integration_tests/backfill_tests.rs
+++ b/src/tests/simulation/tests/integration_tests/backfill_tests.rs
@@ -19,6 +19,8 @@ use itertools::Itertools;
 use risingwave_simulation::cluster::{Cluster, Configuration};
 use tokio::time::{sleep, timeout};
 
+use crate::utils::kill_cn_and_wait_recover;
+
 const SET_PARALLELISM: &str = "SET STREAMING_PARALLELISM=1;";
 const ROOT_TABLE_CREATE: &str = "create table t1 (_id int, data jsonb);";
 const INSERT_SEED_SQL: &str =
@@ -47,13 +49,6 @@ select
     order_customer_id
 from p2;
 "#;
-
-async fn kill_cn_and_wait_recover(cluster: &Cluster) {
-    cluster
-        .kill_nodes(["compute-1", "compute-2", "compute-3"], 0)
-        .await;
-    sleep(Duration::from_secs(10)).await;
-}
 
 #[tokio::test]
 async fn test_backfill_with_upstream_and_snapshot_read() -> Result<()> {

--- a/src/tests/simulation/tests/integration_tests/backfill_tests.rs
+++ b/src/tests/simulation/tests/integration_tests/backfill_tests.rs
@@ -263,7 +263,11 @@ async fn test_arrangement_backfill_progress() -> Result<()> {
         .await?;
     let progress = progress.replace('%', "");
     let progress = progress.parse::<f64>().unwrap();
-    assert!((1.0..2.0).contains(&progress));
+    assert!(
+        (1.0..2.0).contains(&progress),
+        "progress not within bounds {}",
+        progress
+    );
 
     // Trigger recovery and test it again.
     kill_cn_and_wait_recover(&cluster).await;
@@ -273,7 +277,11 @@ async fn test_arrangement_backfill_progress() -> Result<()> {
         .await?;
     let progress = progress.replace('%', "");
     let progress = progress.parse::<f64>().unwrap();
-    assert!((prev_progress..prev_progress + 1.5).contains(&progress));
+    assert!(
+        (prev_progress - 0.5..prev_progress + 1.5).contains(&progress),
+        "progress not within bounds {}",
+        progress
+    );
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/backfill_tests.rs
+++ b/src/tests/simulation/tests/integration_tests/backfill_tests.rs
@@ -266,7 +266,6 @@ async fn test_arrangement_backfill_progress() -> Result<()> {
     let progress = session
         .run("SELECT progress FROM rw_catalog.rw_ddl_progress")
         .await?;
-    println!("progress: {}", progress);
     let progress = progress.replace('%', "");
     let progress = progress.parse::<f64>().unwrap();
     assert!((1.0..2.0).contains(&progress));

--- a/src/tests/simulation/tests/integration_tests/main.rs
+++ b/src/tests/simulation/tests/integration_tests/main.rs
@@ -28,3 +28,5 @@ mod scale;
 mod sink;
 mod storage;
 mod throttle;
+
+mod utils;

--- a/src/tests/simulation/tests/integration_tests/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/utils.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use risingwave_simulation::cluster::{Cluster, KillOpts};
+use tokio::time::sleep;
+
+pub(crate) async fn kill_cn_and_wait_recover(cluster: &Cluster) {
+    cluster
+        .kill_nodes(["compute-1", "compute-2", "compute-3"], 0)
+        .await;
+    sleep(Duration::from_secs(10)).await;
+}
+
+pub(crate) async fn kill_cn_and_meta_and_wait_recover(cluster: &Cluster) {
+    cluster
+        .kill_nodes(
+            [
+                "compute-1",
+                "compute-2",
+                "compute-3",
+                "meta-1",
+                "meta-2",
+                "meta-3",
+            ],
+            0,
+        )
+        .await;
+    sleep(Duration::from_secs(10)).await;
+}
+
+pub(crate) async fn kill_random_and_wait_recover(cluster: &Cluster) {
+    // Kill it again
+    for _ in 0..3 {
+        sleep(Duration::from_secs(2)).await;
+        cluster.kill_node(&KillOpts::ALL_FAST).await;
+    }
+    sleep(Duration::from_secs(10)).await;
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Supports recoverable row count for arrangement backfill. We will persist and recover it.

It's to ensure that arrangement backfill remains compatible with background ddl. We must persist the row count so that after recovery, we can recover the estimated progress for the materialized view in `show jobs`.

The meta-side logic is the same as with `NoShuffleBackfill`, after recovery, meta will receive updates from `NoShuffleBackfill` executors to reconstruct the progress bar.

Progress is calculated with: `total_snapshot_row_count / total_upstream_row_count` in meta.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
