### PR TITLE
feat(sql-udf): add type mismatch check at definition time

### DIFF
--- a/e2e_test/udf/sql_udf.slt
+++ b/e2e_test/udf/sql_udf.slt
@@ -81,6 +81,19 @@ create function print_add_two(INT) returns int language sql as 'select print($1 
 statement error failed to conduct semantic check, please see if you are calling non-existence functions
 create function non_exist(INT) returns int language sql as 'select yo(114514)';
 
+# Try to create an anonymous sql udf whose return type mismatches with the sql body definition
+statement error return type mismatch detected
+create function type_mismatch(INT) returns varchar language sql as 'select $1 + 114514 + $1';
+
+# A valid example
+statement ok
+create function type_match(INT) returns varchar language sql as $$select '$1 + 114514 + $1'$$;
+
+query T
+select type_match(114514);
+----
+$1 + 114514 + $1
+
 # Call the defined sql udf
 query I
 select add(1, -1);
@@ -189,7 +202,7 @@ create function add_sub(INT, FLOAT, INT) returns float language sql as $$select 
 
 # Complex types interleaving
 statement ok
-create function add_sub_types(INT, BIGINT, FLOAT, DECIMAL, REAL) returns real language sql as 'select $1 + $2 - $3 + $4 + $5';
+create function add_sub_types(INT, BIGINT, FLOAT, DECIMAL, REAL) returns double language sql as 'select $1 + $2 - $3 + $4 + $5';
 
 statement ok
 create function add_sub_return(INT, FLOAT, INT) returns float language sql return -$1 + $2 - $3;
@@ -289,6 +302,9 @@ drop function print_add_two;
 
 statement ok
 drop function regexp_replace_wrapper;
+
+statement ok
+drop function type_match;
 
 # Drop the mock table
 statement ok

--- a/src/frontend/src/handler/create_sql_function.rs
+++ b/src/frontend/src/handler/create_sql_function.rs
@@ -29,7 +29,7 @@ use thiserror_ext::AsReport;
 use super::*;
 use crate::binder::UdfContext;
 use crate::catalog::CatalogError;
-use crate::expr::{ExprImpl, Literal};
+use crate::expr::{Expr, ExprImpl, Literal};
 use crate::{bind_data_type, Binder};
 
 /// Create a mock `udf_context`, which is used for semantic check
@@ -176,12 +176,27 @@ pub async fn handle_create_sql_function(
             .update_context(create_mock_udf_context(arg_types.clone()));
 
         if let Ok(expr) = UdfContext::extract_udf_expression(ast) {
-            if let Err(e) = binder.bind_expr(expr) {
+            let bind_result = binder.bind_expr(expr);
+
+            if let Err(e) = &bind_result {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
                     "failed to conduct semantic check, please see if you are calling non-existence functions: {}",
                     e.as_report()
                 ))
                 .into());
+            } else {
+                // We can safely unwrap here
+                let e = bind_result.unwrap();
+
+                // Check if the return type mismatches
+                if e.return_type() != return_type {
+                    return Err(ErrorCode::InvalidInputSyntax(format!(
+                        "return type mismatch detected\nexpected: {}\nactual: {}\nplease adjust your function definition accordingly",
+                        return_type,
+                        e.return_type()
+                    ))
+                    .into());
+                }
             }
         } else {
             return Err(ErrorCode::InvalidInputSyntax(

--- a/src/frontend/src/handler/create_sql_function.rs
+++ b/src/frontend/src/handler/create_sql_function.rs
@@ -178,6 +178,7 @@ pub async fn handle_create_sql_function(
         if let Ok(expr) = UdfContext::extract_udf_expression(ast) {
             match binder.bind_expr(expr) {
                 Ok(expr) => {
+                    // Check if the return type mismatches
                     if expr.return_type() != return_type {
                         return Err(ErrorCode::InvalidInputSyntax(format!(
                             "\nreturn type mismatch detected\nexpected: [{}]\nactual: [{}]\nplease adjust your function definition accordingly",

--- a/src/frontend/src/handler/create_sql_function.rs
+++ b/src/frontend/src/handler/create_sql_function.rs
@@ -191,7 +191,7 @@ pub async fn handle_create_sql_function(
                 // Check if the return type mismatches
                 if e.return_type() != return_type {
                     return Err(ErrorCode::InvalidInputSyntax(format!(
-                        "return type mismatch detected\nexpected: {}\nactual: {}\nplease adjust your function definition accordingly",
+                        "return type mismatch detected, expected: [{}] actual: [{}], please adjust your function definition accordingly",
                         return_type,
                         e.return_type()
                     ))

--- a/src/frontend/src/handler/create_sql_function.rs
+++ b/src/frontend/src/handler/create_sql_function.rs
@@ -191,7 +191,7 @@ pub async fn handle_create_sql_function(
                 // Check if the return type mismatches
                 if e.return_type() != return_type {
                     return Err(ErrorCode::InvalidInputSyntax(format!(
-                        "return type mismatch detected, expected: [{}] actual: [{}], please adjust your function definition accordingly",
+                        "\nreturn type mismatch detected\nexpected: [{}]\nactual: [{}]\nplease adjust your function definition accordingly",
                         return_type,
                         e.return_type()
                     ))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled, now the below definition will be rejected at creation time.

```sql
create function type_mismatch(INT) returns varchar language sql as 'select $1 + 114514 + $1';
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [x] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
