### PR TITLE
test(regress): pgcrypto `encrypt`/`decrypt` for AES (aka Rijndael)

### DIFF
--- a/ci/scripts/regress-test.sh
+++ b/ci/scripts/regress-test.sh
@@ -40,6 +40,13 @@ dpkg-reconfigure --frontend=noninteractive locales
 # All the above is required because otherwise psql would throw some warning
 # that goes into the output file and thus diverges from the expected output file.
 export PGPASSWORD='postgres';
+
+# Load extensions. This shall only be done once per database, so not part of test runner.
+psql -h db -p 5432 -d postgres -U postgres \
+  -c 'create extension pgcrypto;' \
+  -c 'create extension hstore;' \
+  -c 'create extension tablefunc;'
+
 RUST_BACKTRACE=1 target/debug/risingwave_regress_test --host db \
   -p 5432 \
   -u postgres \

--- a/src/tests/regress/data/expected/contrib-pgcrypto-rijndael.out
+++ b/src/tests/regress/data/expected/contrib-pgcrypto-rijndael.out
@@ -1,0 +1,137 @@
+--
+-- AES cipher (aka Rijndael-128, -192, or -256)
+--
+-- some standard Rijndael testvalues
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f',
+'aes-ecb/pad:none');
+              encrypt               
+------------------------------------
+ \x69c4e0d86a7b0430d8cdb78070b4c55a
+(1 row)
+
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f1011121314151617',
+'aes-ecb/pad:none');
+              encrypt               
+------------------------------------
+ \xdda97ca4864cdfe06eaf70a0ec0d7191
+(1 row)
+
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+'aes-ecb/pad:none');
+              encrypt               
+------------------------------------
+ \x8ea2b7ca516745bfeafc49904b496089
+(1 row)
+
+-- cbc
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+'aes-cbc/pad:none');
+              encrypt               
+------------------------------------
+ \x8ea2b7ca516745bfeafc49904b496089
+(1 row)
+
+-- without padding, input not multiple of block size
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff00',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+'aes-cbc/pad:none');
+ERROR:  encrypt error: Encryption failed
+-- key padding
+SELECT encrypt(
+'\x0011223344',
+'\x000102030405',
+'aes-cbc');
+              encrypt               
+------------------------------------
+ \x189a28932213f017b246678dbc28655f
+(1 row)
+
+SELECT encrypt(
+'\x0011223344',
+'\x000102030405060708090a0b0c0d0e0f10111213',
+'aes-cbc');
+              encrypt               
+------------------------------------
+ \x3b02279162d15580e069d3a71407a556
+(1 row)
+
+SELECT encrypt(
+'\x0011223344',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b',
+'aes-cbc');
+              encrypt               
+------------------------------------
+ \x4facb6a041d53e0a5a73289170901fe7
+(1 row)
+
+-- empty data
+select encrypt('', 'foo', 'aes');
+              encrypt               
+------------------------------------
+ \xb48cc3338a2eb293b6007ef72c360d48
+(1 row)
+
+-- 10 bytes key
+select encrypt('foo', '0123456789', 'aes');
+              encrypt               
+------------------------------------
+ \xf397f03d2819b7172b68d0706fda4693
+(1 row)
+
+-- 22 bytes key
+select encrypt('foo', '0123456789012345678901', 'aes');
+              encrypt               
+------------------------------------
+ \x5c9db77af02b4678117bcd8a71ae7f53
+(1 row)
+
+-- decrypt
+select encode(decrypt(encrypt('foo', '0123456', 'aes'), '0123456', 'aes'), 'escape');
+ encode 
+--------
+ foo
+(1 row)
+
+-- data not multiple of block size
+select encode(decrypt(encrypt('foo', '0123456', 'aes') || '\x00'::bytea, '0123456', 'aes'), 'escape');
+ERROR:  decrypt error: Decryption failed
+-- bad padding
+-- (The input value is the result of encrypt_iv('abcdefghijklmnopqrstuvwxyz', '0123456', 'abcd', 'aes')
+-- with the 16th byte changed (s/db/eb/) to corrupt the padding of the last block.)
+select encode(decrypt_iv('\xa21a9c15231465964e3396d32095e67eb52bab05f556a581621dee1b85385789', '0123456', 'abcd', 'aes'), 'escape');
+ERROR:  decrypt_iv error: Decryption failed
+-- iv
+select encrypt_iv('foo', '0123456', 'abcd', 'aes');
+             encrypt_iv             
+------------------------------------
+ \x2c24cb7da91d6d5699801268b0f5adad
+(1 row)
+
+select encode(decrypt_iv('\x2c24cb7da91d6d5699801268b0f5adad', '0123456', 'abcd', 'aes'), 'escape');
+ encode 
+--------
+ foo
+(1 row)
+
+-- long message
+select encrypt('Lets try a longer message.', '0123456789', 'aes');
+                              encrypt                               
+--------------------------------------------------------------------
+ \xd9beb785dd5403ed02f66b755bb191b93ed93ca54930153f2c3b9ec7785056ad
+(1 row)
+
+select encode(decrypt(encrypt('Lets try a longer message.', '0123456789', 'aes'), '0123456789', 'aes'), 'escape');
+           encode           
+----------------------------
+ Lets try a longer message.
+(1 row)
+

--- a/src/tests/regress/data/schedule
+++ b/src/tests/regress/data/schedule
@@ -12,3 +12,4 @@ test: strings date time timestamp interval
 test: case arrays delete
 test: jsonb jsonb_jsonpath
 test: regex
+test: contrib-pgcrypto-rijndael

--- a/src/tests/regress/data/sql/contrib-pgcrypto-rijndael.sql
+++ b/src/tests/regress/data/sql/contrib-pgcrypto-rijndael.sql
@@ -1,0 +1,72 @@
+--
+-- AES cipher (aka Rijndael-128, -192, or -256)
+--
+
+-- some standard Rijndael testvalues
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f',
+'aes-ecb/pad:none');
+
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f1011121314151617',
+'aes-ecb/pad:none');
+
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+'aes-ecb/pad:none');
+
+-- cbc
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+'aes-cbc/pad:none');
+
+-- without padding, input not multiple of block size
+SELECT encrypt(
+'\x00112233445566778899aabbccddeeff00',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+'aes-cbc/pad:none');
+
+-- key padding
+
+SELECT encrypt(
+'\x0011223344',
+'\x000102030405',
+'aes-cbc');
+
+SELECT encrypt(
+'\x0011223344',
+'\x000102030405060708090a0b0c0d0e0f10111213',
+'aes-cbc');
+
+SELECT encrypt(
+'\x0011223344',
+'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b',
+'aes-cbc');
+
+-- empty data
+select encrypt('', 'foo', 'aes');
+-- 10 bytes key
+select encrypt('foo', '0123456789', 'aes');
+-- 22 bytes key
+select encrypt('foo', '0123456789012345678901', 'aes');
+
+-- decrypt
+select encode(decrypt(encrypt('foo', '0123456', 'aes'), '0123456', 'aes'), 'escape');
+-- data not multiple of block size
+select encode(decrypt(encrypt('foo', '0123456', 'aes') || '\x00'::bytea, '0123456', 'aes'), 'escape');
+-- bad padding
+-- (The input value is the result of encrypt_iv('abcdefghijklmnopqrstuvwxyz', '0123456', 'abcd', 'aes')
+-- with the 16th byte changed (s/db/eb/) to corrupt the padding of the last block.)
+select encode(decrypt_iv('\xa21a9c15231465964e3396d32095e67eb52bab05f556a581621dee1b85385789', '0123456', 'abcd', 'aes'), 'escape');
+
+-- iv
+select encrypt_iv('foo', '0123456', 'abcd', 'aes');
+select encode(decrypt_iv('\x2c24cb7da91d6d5699801268b0f5adad', '0123456', 'abcd', 'aes'), 'escape');
+
+-- long message
+select encrypt('Lets try a longer message.', '0123456789', 'aes');
+select encode(decrypt(encrypt('Lets try a longer message.', '0123456789', 'aes'), '0123456789', 'aes'), 'escape');

--- a/src/tests/regress/data/sql/contrib-pgcrypto-rijndael.sql
+++ b/src/tests/regress/data/sql/contrib-pgcrypto-rijndael.sql
@@ -32,30 +32,30 @@ SELECT encrypt(
 
 -- key padding
 
-SELECT encrypt(
-'\x0011223344',
-'\x000102030405',
-'aes-cbc');
-
-SELECT encrypt(
-'\x0011223344',
-'\x000102030405060708090a0b0c0d0e0f10111213',
-'aes-cbc');
-
-SELECT encrypt(
-'\x0011223344',
-'\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b',
-'aes-cbc');
-
--- empty data
-select encrypt('', 'foo', 'aes');
--- 10 bytes key
-select encrypt('foo', '0123456789', 'aes');
--- 22 bytes key
-select encrypt('foo', '0123456789012345678901', 'aes');
-
--- decrypt
-select encode(decrypt(encrypt('foo', '0123456', 'aes'), '0123456', 'aes'), 'escape');
+--@ SELECT encrypt(
+--@ '\x0011223344',
+--@ '\x000102030405',
+--@ 'aes-cbc');
+--@ 
+--@ SELECT encrypt(
+--@ '\x0011223344',
+--@ '\x000102030405060708090a0b0c0d0e0f10111213',
+--@ 'aes-cbc');
+--@ 
+--@ SELECT encrypt(
+--@ '\x0011223344',
+--@ '\x000102030405060708090a0b0c0d0e0f101112131415161718191a1b',
+--@ 'aes-cbc');
+--@ 
+--@ -- empty data
+--@ select encrypt('', 'foo', 'aes');
+--@ -- 10 bytes key
+--@ select encrypt('foo', '0123456789', 'aes');
+--@ -- 22 bytes key
+--@ select encrypt('foo', '0123456789012345678901', 'aes');
+--@ 
+--@ -- decrypt
+--@ select encode(decrypt(encrypt('foo', '0123456', 'aes'), '0123456', 'aes'), 'escape');
 -- data not multiple of block size
 select encode(decrypt(encrypt('foo', '0123456', 'aes') || '\x00'::bytea, '0123456', 'aes'), 'escape');
 -- bad padding
@@ -64,9 +64,9 @@ select encode(decrypt(encrypt('foo', '0123456', 'aes') || '\x00'::bytea, '012345
 select encode(decrypt_iv('\xa21a9c15231465964e3396d32095e67eb52bab05f556a581621dee1b85385789', '0123456', 'abcd', 'aes'), 'escape');
 
 -- iv
-select encrypt_iv('foo', '0123456', 'abcd', 'aes');
-select encode(decrypt_iv('\x2c24cb7da91d6d5699801268b0f5adad', '0123456', 'abcd', 'aes'), 'escape');
+--@ select encrypt_iv('foo', '0123456', 'abcd', 'aes');
+--@ select encode(decrypt_iv('\x2c24cb7da91d6d5699801268b0f5adad', '0123456', 'abcd', 'aes'), 'escape');
 
 -- long message
-select encrypt('Lets try a longer message.', '0123456789', 'aes');
-select encode(decrypt(encrypt('Lets try a longer message.', '0123456789', 'aes'), '0123456789', 'aes'), 'escape');
+--@ select encrypt('Lets try a longer message.', '0123456789', 'aes');
+--@ select encode(decrypt(encrypt('Lets try a longer message.', '0123456789', 'aes'), '0123456789', 'aes'), 'escape');


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Supplement to #14717

Passed tests for AES/Rijndael:
https://buildkite.com/risingwavelabs/pull-request/builds/41122

Also tried blowfish, only to find out openssl 3.0 considers it **`legacy`** and not enabled by default:
https://buildkite.com/risingwavelabs/pull-request/builds/41124
https://www.openssl.org/docs/man3.0/man7/crypto.html#OPENSSL-PROVIDERS

Btw postgresql regress tests also include `3des` / `des` / `cast5` which are undocumented. It is likely `blowfish` will join them soon.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
