### PR TITLE
feat(frontend): support tab-completion for `[ALTER SYSTEM] SET`

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -48,3 +48,33 @@ visibility_mode
 query TT
 SELECT * FROM pg_catalog.pg_settings where name='dummy';
 ----
+
+# Tab-completion of `SET` command
+query T
+SELECT name
+FROM
+  (SELECT pg_catalog.lower(name) AS name
+   FROM pg_catalog.pg_settings
+   WHERE context IN ('user',
+                     'superuser')
+   UNION ALL SELECT 'constraints'
+   UNION ALL SELECT 'transaction'
+   UNION ALL SELECT 'session'
+   UNION ALL SELECT 'role'
+   UNION ALL SELECT 'tablespace'
+   UNION ALL SELECT 'all') ss
+WHERE substring(name, 1, 8)='search_p';
+----
+search_path
+
+# Tab-completion of `ALTER SYSTEM SET` command
+query T
+SELECT name
+FROM
+  (SELECT pg_catalog.lower(name) AS name
+   FROM pg_catalog.pg_settings
+   WHERE context != 'internal'
+   UNION ALL SELECT 'all') ss
+WHERE substring(name, 1, 7)='checkpo';
+----
+checkpoint_frequency

--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -1,49 +1,63 @@
 query TT
-SELECT name FROM pg_catalog.pg_settings order by name;
+SELECT context, name FROM pg_catalog.pg_settings ORDER BY (context, name);
 ----
-application_name
-background_ddl
-batch_enable_distributed_dml
-batch_parallelism
-bytea_output
-client_encoding
-client_min_messages
-create_compaction_group_for_mv
-datestyle
-extra_float_digits
-idle_in_transaction_session_timeout
-intervalstyle
-lock_timeout
-max_split_range_gap
-query_epoch
-query_mode
-row_security
-rw_batch_enable_lookup_join
-rw_batch_enable_sort_agg
-rw_enable_join_ordering
-rw_enable_share_plan
-rw_enable_two_phase_agg
-rw_force_split_distinct_agg
-rw_force_two_phase_agg
-rw_implicit_flush
-rw_streaming_allow_jsonb_in_stream_key
-rw_streaming_enable_bushy_join
-rw_streaming_enable_delta_join
-rw_streaming_over_window_cache_policy
-search_path
-server_encoding
-server_version
-server_version_num
-sink_decouple
-standard_conforming_strings
-statement_timeout
-streaming_enable_arrangement_backfill
-streaming_parallelism
-streaming_rate_limit
-synchronize_seqscans
-timezone
-transaction_isolation
-visibility_mode
+internal    block_size_kb
+internal    bloom_false_positive
+internal    data_directory
+internal    parallel_compact_size_mb
+internal    sstable_size_mb
+internal    state_store
+internal    wasm_storage_url
+postmaster  backup_storage_directory
+postmaster  backup_storage_url
+postmaster  barrier_interval_ms
+postmaster  checkpoint_frequency
+postmaster  enable_tracing
+postmaster  max_concurrent_creating_streaming_jobs
+postmaster  pause_on_next_bootstrap
+user        application_name
+user        background_ddl
+user        batch_enable_distributed_dml
+user        batch_parallelism
+user        bytea_output
+user        client_encoding
+user        client_min_messages
+user        create_compaction_group_for_mv
+user        datestyle
+user        extra_float_digits
+user        idle_in_transaction_session_timeout
+user        intervalstyle
+user        lock_timeout
+user        max_split_range_gap
+user        query_epoch
+user        query_mode
+user        row_security
+user        rw_batch_enable_lookup_join
+user        rw_batch_enable_sort_agg
+user        rw_enable_join_ordering
+user        rw_enable_share_plan
+user        rw_enable_two_phase_agg
+user        rw_force_split_distinct_agg
+user        rw_force_two_phase_agg
+user        rw_implicit_flush
+user        rw_streaming_allow_jsonb_in_stream_key
+user        rw_streaming_enable_bushy_join
+user        rw_streaming_enable_delta_join
+user        rw_streaming_over_window_cache_policy
+user        search_path
+user        server_encoding
+user        server_version
+user        server_version_num
+user        sink_decouple
+user        standard_conforming_strings
+user        statement_timeout
+user        streaming_enable_arrangement_backfill
+user        streaming_parallelism
+user        streaming_rate_limit
+user        synchronize_seqscans
+user        timezone
+user        transaction_isolation
+user        visibility_mode
 
 query TT
 SELECT * FROM pg_catalog.pg_settings where name='dummy';

--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -31,6 +31,7 @@ use risingwave_common::catalog::{
 };
 use risingwave_common::error::BoxedError;
 use risingwave_common::session_config::ConfigMap;
+use risingwave_common::system_param::local_manager::SystemParamsReaderRef;
 use risingwave_common::types::DataType;
 use risingwave_pb::meta::list_table_fragment_states_response::TableFragmentState;
 use risingwave_pb::meta::table_parallelism::{PbFixedParallelism, PbParallelism};
@@ -110,6 +111,8 @@ pub struct SysCatalogReaderImpl {
     auth_context: Arc<AuthContext>,
     // Read config.
     config: Arc<RwLock<ConfigMap>>,
+    // Read system params.
+    system_params: SystemParamsReaderRef,
 }
 
 impl SysCatalogReaderImpl {
@@ -120,6 +123,7 @@ impl SysCatalogReaderImpl {
         meta_client: Arc<dyn FrontendMetaClient>,
         auth_context: Arc<AuthContext>,
         config: Arc<RwLock<ConfigMap>>,
+        system_params: SystemParamsReaderRef,
     ) -> Self {
         Self {
             catalog_reader,
@@ -128,6 +132,7 @@ impl SysCatalogReaderImpl {
             meta_client,
             auth_context,
             config,
+            system_params,
         }
     }
 }

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -52,6 +52,7 @@ impl BatchTaskContext for FrontendBatchTaskContext {
             self.session.env().meta_client_ref(),
             self.session.auth_context(),
             self.session.shared_config(),
+            self.session.env().system_params_manager().get_params(),
         ))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Based on #15113 and #15108. Resolve #8850.

----

Note that the session variables is always a subset of system parameters in Postgres' configuration system (Grand Unified Configuration, GUC), which does not hold in RisingWave.

As a result, `psql` will also auto-complete session variables for `ALTER SYSTEM SET` that are false positives. There's no elegant way to fix that as the query for auto-completion is automatically sent by the client. However, this is not a significant issue so we may simply leave it as it is.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Support tab-completion for `SET` and `ALTER SYSTEM SET` commands in `psql` client.
