### PR TITLE
fix(frontend): require primary key for system table

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -63,6 +63,14 @@ query TT
 SELECT * FROM pg_catalog.pg_settings where name='dummy';
 ----
 
+# https://github.com/risingwavelabs/risingwave/issues/15125
+query TT
+SELECT min(name) name, context FROM pg_catalog.pg_settings GROUP BY context;
+----
+application_name            user
+backup_storage_directory    postmaster
+block_size_kb               internal
+
 # Tab-completion of `SET` command
 query T
 SELECT name

--- a/src/common/fields-derive/src/gen/test_empty_pk.rs
+++ b/src/common/fields-derive/src/gen/test_empty_pk.rs
@@ -1,0 +1,29 @@
+impl ::risingwave_common::types::Fields for Data {
+    const PRIMARY_KEY: Option<&'static [usize]> = Some(&[]);
+    fn fields() -> Vec<(&'static str, ::risingwave_common::types::DataType)> {
+        vec![
+            ("v1", < i16 as ::risingwave_common::types::WithDataType >
+            ::default_data_type()), ("v2", < String as
+            ::risingwave_common::types::WithDataType > ::default_data_type())
+        ]
+    }
+    fn into_owned_row(self) -> ::risingwave_common::row::OwnedRow {
+        ::risingwave_common::row::OwnedRow::new(
+            vec![
+                ::risingwave_common::types::ToOwnedDatum::to_owned_datum(self.v1),
+                ::risingwave_common::types::ToOwnedDatum::to_owned_datum(self.v2)
+            ],
+        )
+    }
+}
+impl From<Data> for ::risingwave_common::types::ScalarImpl {
+    fn from(v: Data) -> Self {
+        ::risingwave_common::types::StructValue::new(
+                vec![
+                    ::risingwave_common::types::ToOwnedDatum::to_owned_datum(v.v1),
+                    ::risingwave_common::types::ToOwnedDatum::to_owned_datum(v.v2)
+                ],
+            )
+            .into()
+    }
+}

--- a/src/common/fields-derive/src/gen/test_no_pk.rs
+++ b/src/common/fields-derive/src/gen/test_no_pk.rs
@@ -1,0 +1,29 @@
+impl ::risingwave_common::types::Fields for Data {
+    const PRIMARY_KEY: Option<&'static [usize]> = None;
+    fn fields() -> Vec<(&'static str, ::risingwave_common::types::DataType)> {
+        vec![
+            ("v1", < i16 as ::risingwave_common::types::WithDataType >
+            ::default_data_type()), ("v2", < String as
+            ::risingwave_common::types::WithDataType > ::default_data_type())
+        ]
+    }
+    fn into_owned_row(self) -> ::risingwave_common::row::OwnedRow {
+        ::risingwave_common::row::OwnedRow::new(
+            vec![
+                ::risingwave_common::types::ToOwnedDatum::to_owned_datum(self.v1),
+                ::risingwave_common::types::ToOwnedDatum::to_owned_datum(self.v2)
+            ],
+        )
+    }
+}
+impl From<Data> for ::risingwave_common::types::ScalarImpl {
+    fn from(v: Data) -> Self {
+        ::risingwave_common::types::StructValue::new(
+                vec![
+                    ::risingwave_common::types::ToOwnedDatum::to_owned_datum(v.v1),
+                    ::risingwave_common::types::ToOwnedDatum::to_owned_datum(v.v2)
+                ],
+            )
+            .into()
+    }
+}

--- a/src/common/fields-derive/src/gen/test_output.rs
+++ b/src/common/fields-derive/src/gen/test_output.rs
@@ -1,4 +1,5 @@
 impl ::risingwave_common::types::Fields for Data {
+    const PRIMARY_KEY: Option<&'static [usize]> = Some(&[1usize, 0usize]);
     fn fields() -> Vec<(&'static str, ::risingwave_common::types::DataType)> {
         vec![
             ("v1", < i16 as ::risingwave_common::types::WithDataType >
@@ -20,9 +21,6 @@ impl ::risingwave_common::types::Fields for Data {
                 ::risingwave_common::types::ToOwnedDatum::to_owned_datum(self.r#type)
             ],
         )
-    }
-    fn primary_key() -> &'static [usize] {
-        &[1usize, 0usize]
     }
 }
 impl From<Data> for ::risingwave_common::types::ScalarImpl {

--- a/src/common/fields-derive/src/lib.rs
+++ b/src/common/fields-derive/src/lib.rs
@@ -145,6 +145,18 @@ mod tests {
         prettyplease::unparse(&output)
     }
 
+    fn do_test(code: &str, expected_path: &str) {
+        let input: TokenStream = str::parse(code).unwrap();
+
+        let output = super::gen(input).unwrap();
+
+        let output = pretty_print(output);
+
+        let expected = expect_test::expect_file![expected_path];
+
+        expected.assert_eq(&output);
+    }
+
     #[test]
     fn test_gen() {
         let code = indoc! {r#"
@@ -159,14 +171,33 @@ mod tests {
             }
         "#};
 
-        let input: TokenStream = str::parse(code).unwrap();
+        do_test(code, "gen/test_output.rs");
+    }
 
-        let output = super::gen(input).unwrap();
+    #[test]
+    fn test_no_pk() {
+        let code = indoc! {r#"
+            #[derive(Fields)]
+            struct Data {
+                v1: i16,
+                v2: String,
+            }
+        "#};
 
-        let output = pretty_print(output);
+        do_test(code, "gen/test_no_pk.rs");
+    }
 
-        let expected = expect_test::expect_file!["gen/test_output.rs"];
+    #[test]
+    fn test_empty_pk() {
+        let code = indoc! {r#"
+            #[derive(Fields)]
+            #[primary_key()]
+            struct Data {
+                v1: i16,
+                v2: String,
+            }
+        "#};
 
-        expected.assert_eq(&output);
+        do_test(code, "gen/test_empty_pk.rs");
     }
 }

--- a/src/common/src/types/fields.rs
+++ b/src/common/src/types/fields.rs
@@ -58,16 +58,17 @@ use crate::util::chunk_coalesce::DataChunkBuilder;
 /// }
 /// ```
 pub trait Fields {
+    /// The primary key of the table.
+    ///
+    /// - `None` if the primary key is not applicable.
+    /// - `Some(&[])` if the primary key is empty, i.e., there'll be at most one row in the table.
+    const PRIMARY_KEY: Option<&'static [usize]>;
+
     /// Return the schema of the struct.
     fn fields() -> Vec<(&'static str, DataType)>;
 
     /// Convert the struct to an `OwnedRow`.
     fn into_owned_row(self) -> OwnedRow;
-
-    /// The primary key of the table.
-    fn primary_key() -> &'static [usize] {
-        &[]
-    }
 
     /// Create a [`DataChunkBuilder`](crate::util::chunk_coalesce::DataChunkBuilder) with the schema of the struct.
     fn data_chunk_builder(capacity: usize) -> DataChunkBuilder {

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_cast.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_cast.rs
@@ -22,6 +22,7 @@ use crate::expr::cast_map_array;
 /// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-cast.html`]
 #[derive(Fields)]
 struct PgCast {
+    #[primary_key]
     oid: i32,
     castsource: i32,
     casttarget: i32,

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_settings.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_settings.rs
@@ -21,6 +21,7 @@ use crate::catalog::system_catalog::SysCatalogReaderImpl;
 /// The catalog `pg_settings` stores settings.
 /// Ref: [`https://www.postgresql.org/docs/current/view-pg-settings.html`]
 #[derive(Fields)]
+#[primary_key(name, context)]
 struct PgSetting {
     name: String,
     setting: String,

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_branched_objects.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_branched_objects.rs
@@ -19,6 +19,7 @@ use crate::catalog::system_catalog::SysCatalogReaderImpl;
 use crate::error::Result;
 
 #[derive(Fields)]
+#[primary_key(object_id, sst_id)] // TODO: is this correct?
 struct RwHummockBranchedObject {
     object_id: i64,
     sst_id: i64,

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_pinned_snapshots.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_pinned_snapshots.rs
@@ -20,6 +20,7 @@ use crate::error::Result;
 
 #[derive(Fields)]
 struct RwHummockPinnedSnapshot {
+    #[primary_key]
     worker_node_id: i32,
     min_pinned_snapshot_id: i64,
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_pinned_versions.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_pinned_versions.rs
@@ -20,6 +20,7 @@ use crate::error::Result;
 
 #[derive(Fields)]
 struct RwHummockPinnedVersion {
+    #[primary_key]
     worker_node_id: i32,
     min_pinned_version_id: i64,
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_version.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_version.rs
@@ -22,6 +22,7 @@ use crate::error::Result;
 
 #[derive(Fields)]
 struct RwHummockVersion {
+    #[primary_key]
     version_id: i64,
     max_committed_epoch: i64,
     safe_epoch: i64,

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_meta_snapshot.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_meta_snapshot.rs
@@ -21,6 +21,7 @@ use crate::error::Result;
 
 #[derive(Fields)]
 struct RwMetaSnapshot {
+    #[primary_key]
     meta_snapshot_id: i64,
     hummock_version_id: i64,
     // the smallest epoch this meta snapshot includes


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See #15125 for the background.

We should not default to empty primary key for `#[derive(Fields)]` without specifying primary keys, or the semantics will be "at most one row".

The ultimate solution could be making the `pk` field of `TableDesc` and `TableCatalog` to be an `Option`. However, this may require a much more significant refactor. Note that we're only misusing the primary key of the system table, so I simply add a requirement for specifying the primary key for `system_table` proc macro in this PR.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
