### PR TITLE
chore: set `buf breaking` rule back to `WIRE_JSON`

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,7 +1,8 @@
 version: v1
 breaking:
   use:
-    - WIRE # https://docs.buf.build/breaking/rules
+    - WIRE_JSON # https://docs.buf.build/breaking/rules
+                # https://github.com/risingwavelabs/risingwave/issues/15030
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See #15030 for the background.

Again, the check is not enforced in CI. We can safely ignore it...
- if the message is never persisted,
- or any time before the SQL meta store is released and marked as stable.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
