### PR TITLE
feat: try to reduce memory usage in scaling

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -42,7 +42,7 @@ use risingwave_pb::meta::table_fragments::{self, ActorStatus, PbFragment, State}
 use risingwave_pb::meta::FragmentParallelUnitMappings;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    Dispatcher, DispatcherType, FragmentTypeFlag, PbStreamActor, StreamActor, StreamNode,
+    Dispatcher, DispatcherType, FragmentTypeFlag, PbStreamActor, StreamNode,
 };
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot::Receiver;
@@ -116,7 +116,7 @@ pub struct CustomFragmentInfo {
     pub vnode_mapping: Option<ParallelUnitMapping>,
     pub state_table_ids: Vec<u32>,
     pub upstream_fragment_ids: Vec<u32>,
-    pub actor_template: StreamActor,
+    pub actor_template: PbStreamActor,
     pub actors: Vec<CustomActorInfo>,
 }
 
@@ -813,7 +813,7 @@ impl ScaleController {
         &self,
         worker_nodes: &HashMap<WorkerId, WorkerNode>,
         actor_infos_to_broadcast: BTreeMap<ActorId, ActorInfo>,
-        node_actors_to_create: HashMap<WorkerId, Vec<StreamActor>>,
+        node_actors_to_create: HashMap<WorkerId, Vec<PbStreamActor>>,
         broadcast_worker_ids: HashSet<WorkerId>,
     ) -> MetaResult<()> {
         self.stream_rpc_manager
@@ -1522,7 +1522,7 @@ impl ScaleController {
         fragment_actor_bitmap: &HashMap<FragmentId, HashMap<ActorId, Bitmap>>,
         no_shuffle_upstream_actor_map: &HashMap<ActorId, HashMap<FragmentId, ActorId>>,
         no_shuffle_downstream_actors_map: &HashMap<ActorId, HashMap<FragmentId, ActorId>>,
-        new_actor: &mut StreamActor,
+        new_actor: &mut PbStreamActor,
     ) -> MetaResult<()> {
         let fragment = &ctx.fragment_map.get(&new_actor.fragment_id).unwrap();
         let mut applied_upstream_fragment_actor_ids = HashMap::new();

--- a/src/meta/src/stream/test_scale.rs
+++ b/src/meta/src/stream/test_scale.rs
@@ -21,7 +21,6 @@ mod tests {
     use risingwave_common::buffer::Bitmap;
     use risingwave_common::hash::{ActorMapping, ParallelUnitId, ParallelUnitMapping, VirtualNode};
     use risingwave_pb::common::ParallelUnit;
-    use risingwave_pb::stream_plan::CustomActorInfo;
 
     use crate::model::ActorId;
     use crate::stream::scale::rebalance_actor_vnode;

--- a/src/meta/src/stream/test_scale.rs
+++ b/src/meta/src/stream/test_scale.rs
@@ -24,8 +24,8 @@ mod tests {
     use risingwave_pb::stream_plan::CustomActorInfo;
 
     use crate::model::ActorId;
-    use crate::stream::CustomActorInfo;
     use crate::stream::scale::rebalance_actor_vnode;
+    use crate::stream::CustomActorInfo;
 
     fn simulated_parallel_unit_nums(min: Option<usize>, max: Option<usize>) -> Vec<usize> {
         let mut raw = vec![1, 3, 12, 42, VirtualNode::COUNT];

--- a/src/meta/src/stream/test_scale.rs
+++ b/src/meta/src/stream/test_scale.rs
@@ -21,9 +21,10 @@ mod tests {
     use risingwave_common::buffer::Bitmap;
     use risingwave_common::hash::{ActorMapping, ParallelUnitId, ParallelUnitMapping, VirtualNode};
     use risingwave_pb::common::ParallelUnit;
-    use risingwave_pb::stream_plan::StreamActor;
+    use risingwave_pb::stream_plan::CustomActorInfo;
 
     use crate::model::ActorId;
+    use crate::stream::CustomActorInfo;
     use crate::stream::scale::rebalance_actor_vnode;
 
     fn simulated_parallel_unit_nums(min: Option<usize>, max: Option<usize>) -> Vec<usize> {
@@ -39,13 +40,13 @@ mod tests {
         raw
     }
 
-    fn build_fake_actors(info: &[(ActorId, ParallelUnitId)]) -> Vec<StreamActor> {
+    fn build_fake_actors(info: &[(ActorId, ParallelUnitId)]) -> Vec<CustomActorInfo> {
         let parallel_units = generate_parallel_units(info);
 
         let vnode_bitmaps = ParallelUnitMapping::build(&parallel_units).to_bitmaps();
 
         info.iter()
-            .map(|(actor_id, parallel_unit_id)| StreamActor {
+            .map(|(actor_id, parallel_unit_id)| CustomActorInfo {
                 actor_id: *actor_id,
                 vnode_bitmap: vnode_bitmaps
                     .get(parallel_unit_id)
@@ -64,7 +65,7 @@ mod tests {
             .collect_vec()
     }
 
-    fn check_affinity_for_scale_in(bitmap: &Bitmap, actor: &StreamActor) {
+    fn check_affinity_for_scale_in(bitmap: &Bitmap, actor: &CustomActorInfo) {
         let prev_bitmap = Bitmap::from(actor.vnode_bitmap.as_ref().unwrap());
 
         for idx in 0..VirtualNode::COUNT {


### PR DESCRIPTION
Signed-off-by: Shanicky Chen <peng@risingwave-labs.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR attempts to reduce meta memory usage during the scaling process by substituting the original `PbStreamActor` and `PbFragment` with custom-designed `CustomActorInfo` and `CustomFragmentInfo`, thereby reducing memory usage by minimizing the memory replication of nodes.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
