### PR TITLE
chore(revert): add name column back in pg_user for backward compatibility

### DIFF
--- a/e2e_test/batch/catalog/pg_user.slt.part
+++ b/e2e_test/batch/catalog/pg_user.slt.part
@@ -1,5 +1,5 @@
 query ITTT
-SELECT usesysid, usename, usecreatedb, usesuper, passwd FROM pg_catalog.pg_user order by usesysid;
+SELECT * FROM pg_catalog.pg_user order by usesysid;
 ----
 1 root t t ********
 2 postgres t t ********

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_user.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_user.rs
@@ -22,7 +22,6 @@ use risingwave_frontend_macro::system_catalog;
     "pg_catalog.pg_user",
     "SELECT id AS usesysid,
         name,
-        name AS usename,
         create_db AS usecreatedb,
         is_super AS usesuper,
         '********' AS passwd
@@ -31,7 +30,6 @@ use risingwave_frontend_macro::system_catalog;
 #[derive(Fields)]
 struct PgUser {
     usesysid: i32,
-    name: String, // FIXME: For backward compatibility, remove it when the cloud update it.
     usename: String,
     usecreatedb: bool,
     usesuper: bool,


### PR DESCRIPTION
Reverts risingwavelabs/risingwave#15266

Resolve #15250 .

Already fixed in https://github.com/risingwavelabs/risingwave-cloud/pull/6244