### PR TITLE
refactor: do not output suppressed count when it's zero

### DIFF
--- a/src/common/src/log.rs
+++ b/src/common/src/log.rs
@@ -75,10 +75,16 @@ mod tests {
     use std::sync::LazyLock;
     use std::time::Duration;
 
+    use tracing_subscriber::util::SubscriberInitExt;
+
     use super::*;
 
     #[tokio::test]
     async fn demo() {
+        let _logger = tracing_subscriber::fmt::Subscriber::builder()
+            .with_max_level(tracing::Level::ERROR)
+            .set_default();
+
         let mut interval = tokio::time::interval(Duration::from_millis(100));
         for _ in 0..100 {
             interval.tick().await;
@@ -89,7 +95,7 @@ mod tests {
             });
 
             if let Ok(suppressed_count) = RATE_LIMITER.check() {
-                println!("failed to foo bar. suppressed_count = {:?}", suppressed_count);
+                tracing::error!(suppressed_count, "failed to foo bar");
             }
         }
     }

--- a/src/connector/src/parser/avro/util.rs
+++ b/src/connector/src/parser/avro/util.rs
@@ -97,11 +97,11 @@ fn avro_type_mapping(schema: &Schema) -> ConnectorResult<DataType> {
                     LazyLock::new(LogSuppresser::default);
                 if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                     tracing::warn!(
-                    "RisingWave supports decimal precision up to {}, but got {}. Will truncate. ({} suppressed)",
-                    Decimal::MAX_PRECISION,
-                    suppressed_count,
-                    precision
-                );
+                        suppressed_count,
+                        "RisingWave supports decimal precision up to {}, but got {}. Will truncate.",
+                        Decimal::MAX_PRECISION,
+                        precision
+                    );
                 }
             }
             DataType::Decimal

--- a/src/connector/src/parser/mysql.rs
+++ b/src/connector/src/parser/mysql.rs
@@ -33,8 +33,13 @@ macro_rules! handle_data_type {
         match res {
             Ok(val) => val.map(|v| ScalarImpl::from(v)),
             Err(err) => {
-                if let Ok(sc) = LOG_SUPPERSSER.check() {
-                    tracing::error!("parse column `{}` fail: {} ({} suppressed)", $name, err, sc);
+                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
+                    tracing::error!(
+                        column = $name,
+                        error = %err.as_report(),
+                        suppressed_count,
+                        "parse column failed",
+                    );
                 }
                 None
             }
@@ -45,8 +50,13 @@ macro_rules! handle_data_type {
         match res {
             Ok(val) => val.map(|v| ScalarImpl::from(<$rw_type>::from(v))),
             Err(err) => {
-                if let Ok(sc) = LOG_SUPPERSSER.check() {
-                    tracing::error!("parse column `{}` fail: {} ({} suppressed)", $name, err, sc);
+                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
+                    tracing::error!(
+                        column = $name,
+                        error = %err.as_report(),
+                        suppressed_count,
+                        "parse column failed",
+                    );
                 }
                 None
             }
@@ -106,7 +116,7 @@ pub fn mysql_row_to_owned_row(mysql_row: &mut MysqlRow, schema: &Schema) -> Owne
                             if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                                 tracing::error!(
                                     suppressed_count,
-                                    column_name = name,
+                                    column = name,
                                     error = %err.as_report(),
                                     "parse column failed",
                                 );
@@ -125,7 +135,7 @@ pub fn mysql_row_to_owned_row(mysql_row: &mut MysqlRow, schema: &Schema) -> Owne
                             if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                                 tracing::error!(
                                     suppressed_count,
-                                    column_name = name,
+                                    column = name,
                                     error = %err.as_report(),
                                     "parse column failed",
                                 );

--- a/src/connector/src/parser/postgres.rs
+++ b/src/connector/src/parser/postgres.rs
@@ -39,12 +39,12 @@ macro_rules! handle_list_data_type {
                 }
             }
             Err(err) => {
-                if let Ok(sc) = LOG_SUPPERSSER.check() {
+                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                     tracing::error!(
-                        "parse column \"{}\" fail: {} ({} suppressed)",
-                        $name,
-                        err,
-                        sc
+                        column = $name,
+                        error = %err.as_report(),
+                        suppressed_count,
+                        "parse column failed",
                     );
                 }
             }
@@ -61,12 +61,12 @@ macro_rules! handle_list_data_type {
                 }
             }
             Err(err) => {
-                if let Ok(sc) = LOG_SUPPERSSER.check() {
+                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                     tracing::error!(
-                        "parse column \"{}\" fail: {} ({} suppressed)",
-                        $name,
-                        err,
-                        sc
+                        column = $name,
+                        error = %err.as_report(),
+                        suppressed_count,
+                        "parse column failed",
                     );
                 }
             }
@@ -80,12 +80,12 @@ macro_rules! handle_data_type {
         match res {
             Ok(val) => val.map(|v| ScalarImpl::from(v)),
             Err(err) => {
-                if let Ok(sc) = LOG_SUPPERSSER.check() {
+                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                     tracing::error!(
-                        "parse column \"{}\" fail: {} ({} suppressed)",
-                        $name,
-                        err,
-                        sc
+                        column = $name,
+                        error = %err.as_report(),
+                        suppressed_count,
+                        "parse column failed",
                     );
                 }
                 None
@@ -97,12 +97,12 @@ macro_rules! handle_data_type {
         match res {
             Ok(val) => val.map(|v| ScalarImpl::from(<$rw_type>::from(v))),
             Err(err) => {
-                if let Ok(sc) = LOG_SUPPERSSER.check() {
+                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                     tracing::error!(
-                        "parse column \"{}\" fail: {} ({} suppressed)",
-                        $name,
-                        err,
-                        sc
+                        column = $name,
+                        error = %err.as_report(),
+                        suppressed_count,
+                        "parse column failed",
                     );
                 }
                 None
@@ -147,10 +147,10 @@ pub fn postgres_row_to_owned_row(row: tokio_postgres::Row, schema: &Schema) -> O
                             match res {
                                 Ok(val) => val.map(|v| ScalarImpl::from(v.to_string())),
                                 Err(err) => {
-                                    if let Ok(sc) = LOG_SUPPERSSER.check() {
+                                    if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                                         tracing::error!(
-                                            suppressed_count = sc,
-                                            column_name = name,
+                                            suppressed_count,
+                                            column = name,
                                             error = %err.as_report(),
                                             "parse uuid column failed",
                                         );
@@ -181,10 +181,10 @@ pub fn postgres_row_to_owned_row(row: tokio_postgres::Row, schema: &Schema) -> O
                     match res {
                         Ok(val) => val.map(|v| ScalarImpl::from(v.into_boxed_slice())),
                         Err(err) => {
-                            if let Ok(sc) = LOG_SUPPERSSER.check() {
+                            if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                                 tracing::error!(
-                                    suppressed_count = sc,
-                                    column_name = name,
+                                    suppressed_count,
+                                    column = name,
                                     error = %err.as_report(),
                                     "parse column failed",
                                 );
@@ -278,10 +278,10 @@ pub fn postgres_row_to_owned_row(row: tokio_postgres::Row, schema: &Schema) -> O
                                     }
                                 }
                                 Err(err) => {
-                                    if let Ok(sc) = LOG_SUPPERSSER.check() {
+                                    if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
                                         tracing::error!(
-                                            suppressed_count = sc,
-                                            column_name = name,
+                                            suppressed_count,
+                                            column = name,
                                             error = %err.as_report(),
                                             "parse column failed",
                                         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Make `LogSuppressor::check` returns `Option<NonZeroUsize>` and record the option value in tracing events. When the suppressed count is zero, the field will be omitted in the event.

Also fixed direct error formatting in `mysql` and `postgres` parser. These are corner cases that are not covered by the lints. Tracked in https://github.com/risingwavelabs/risingwave/issues/15330.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
