### PR TITLE
fix(connector): better locating and error reporting for connector library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9590,6 +9590,7 @@ dependencies = [
  "cfg-or-panic",
  "chrono",
  "expect-test",
+ "fs-err",
  "futures",
  "itertools 0.12.0",
  "jni",

--- a/src/jni_core/Cargo.toml
+++ b/src/jni_core/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 bytes = "1"
 cfg-or-panic = "0.2"
 chrono = { version = "0.4", default-features = false }
+fs-err = "2"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.12"
 jni = "0.21.1"

--- a/src/jni_core/src/jvm_runtime.rs
+++ b/src/jni_core/src/jvm_runtime.rs
@@ -63,30 +63,14 @@ impl JavaVmWrapper {
         } else {
             tracing::info!("environment variable CONNECTOR_LIBS_PATH is not specified, use default path `./libs` instead");
             std::env::current_exe()
-                .and_then(|p| p.fs_err_canonicalize())
+                .and_then(|p| p.fs_err_canonicalize()) // resolve symlink of the current executable
                 .context("unable to get path of the executable")?
                 .parent()
                 .expect("not root")
                 .join("libs")
         };
 
-        let libs_path = libs_path
-            .fs_err_canonicalize()
-            .context("invalid path for connector libs")?;
-
-        if !libs_path.exists() {
-            bail!(
-                "CONNECTOR_LIBS_PATH \"{}\" does not exist",
-                libs_path.display()
-            );
-        }
-        if !libs_path.is_dir() {
-            bail!(
-                "CONNECTOR_LIBS_PATH \"{}\" is not a directory",
-                libs_path.display()
-            );
-        }
-
+        // No need to validate the path now, as it will be further checked when calling `fs::read_dir` later.
         Ok(libs_path)
     }
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This acts as a preparation step of https://github.com/risingwavelabs/homebrew-risingwave/issues/28.

- Canonicalize the path of `current_exe` before looking for the sibling `libs` directory. So it's based on the real path of the binary (like `/opt/homebrew/Cellar/risingwave/1.6/bin/risingwave`), instead of the symbolic link (`/opt/homebrew/bin/risingwave`). `opt/homebrew/bin/libs` will make no sense.

- Use `fs_err` as the replacement of `std::fs` to provide better error reporting.

- Use `LazyLock::get_or_try_init` instead of storing the `Err` variant into the static variable once the initialization fails. The main motivation is to resolve the error source issue, but the advised behavior appears to make more sense to me as well.
	https://github.com/risingwavelabs/risingwave/blob/d616c1c677af0f1e9029ef55daee695ee14f82a8/src/jni_core/src/jvm_runtime.rs#L45-L47

----

Preview of the UI:

> I run `.risingwave/bin/risingwave/playground`, which is a symbolic link of `target/debug/risingwave`

```diff
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: gRPC request to meta service failed: Internal error
  2: failed to create source worker
  3: failed to create SplitEnumerator
  4: jvm not initialized properly
- 5: CONNECTOR_LIBS_PATH "/Users/bugenzhao/Developer/S/risingwave-opensource/.risingwave/bin/risingwave/./libs" is not a directory
+ 5: failed to read connector libs
+ 6: failed to read directory `/Users/bugenzhao/Developer/S/risingwave-opensource/target/debug/libs`
+ 7: No such file or directory (os error 2)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
