### PR TITLE
fix(dashboard): only show real-time back-pressure rate from Prometheus data source

### DIFF
--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -344,10 +344,13 @@ export default function Streaming() {
         if (actorBackPressures) {
           for (const m of actorBackPressures.outputBufferBlockingDuration) {
             if (m.sample.length > 0) {
-              // We issue an instant query to Prometheus to get the most recent value.
+              // Note: We issue an instant query to Prometheus to get the most recent value.
               // So there should be only one sample here.
-              console.assert(m.sample.length === 1)
-              const value = m.sample[0].value * 100
+              //
+              // Due to https://github.com/risingwavelabs/risingwave/issues/15280, it's still
+              // possible that an old version of meta service returns a range-query result.
+              // So we take the one with the latest timestamp here.
+              const value = _(m.sample).maxBy((s) => s.timestamp)!.value * 100
               map.set(
                 `${m.metric.fragment_id}_${m.metric.downstream_fragment_id}`,
                 value

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -45,10 +45,6 @@ import {
   calculateBPRate,
   getActorBackPressures,
   getBackPressureWithoutPrometheus,
-  p50,
-  p90,
-  p95,
-  p99,
 } from "../lib/api/metric"
 import { getFragments, getStreamingJobs } from "../lib/api/streaming"
 import { FragmentBox } from "../lib/layout"
@@ -179,9 +175,6 @@ function buildFragmentDependencyAsEdges(
 
 const SIDEBAR_WIDTH = 200
 
-type BackPressureAlgo = "p50" | "p90" | "p95" | "p99"
-const backPressureAlgos: BackPressureAlgo[] = ["p50", "p90", "p95", "p99"]
-
 type BackPressureDataSource = "Embedded" | "Prometheus"
 const backPressureDataSources: BackPressureDataSource[] = [
   "Embedded",
@@ -193,16 +186,15 @@ export default function Streaming() {
   const { response: fragmentList } = useFetch(getFragments)
 
   const [relationId, setRelationId] = useQueryState("id", parseAsInteger)
-  const [backPressureAlgo, setBackPressureAlgo] = useQueryState("backPressure")
   const [selectedFragmentId, setSelectedFragmentId] = useState<number>()
   // used to get the data source
-  const [backPressureDataSourceAlgo, setBackPressureDataSourceAlgo] =
-    useState("Embedded")
+  const [backPressureDataSource, setBackPressureDataSource] =
+    useState<BackPressureDataSource>("Embedded")
 
   const { response: actorBackPressures } = useFetch(
     getActorBackPressures,
     INTERVAL,
-    backPressureDataSourceAlgo === "Prometheus" && backPressureAlgo !== null
+    backPressureDataSource === "Prometheus"
   )
 
   const fragmentDependencyCallback = useCallback(() => {
@@ -234,6 +226,8 @@ export default function Streaming() {
   }, [relationId, relationList, setRelationId])
 
   // get back pressure rate without prometheus
+  // TODO(bugen): extract the following logic to a hook and unify the interface
+  // with Prometheus data source.
   const [backPressuresMetricsWithoutPromtheus, setBackPressuresMetrics] =
     useState<BackPressuresMetrics>()
   const [previousBP, setPreviousBP] = useState<BackPressureInfo[]>([])
@@ -241,7 +235,7 @@ export default function Streaming() {
   const toast = useErrorToast()
 
   useEffect(() => {
-    if (backPressureDataSourceAlgo === "Embedded") {
+    if (backPressureDataSource === "Embedded") {
       const interval = setInterval(() => {
         const fetchNewBP = async () => {
           const newBP = await getBackPressureWithoutPrometheus()
@@ -253,7 +247,7 @@ export default function Streaming() {
       }, INTERVAL)
       return () => clearInterval(interval)
     }
-  }, [currentBP, backPressureDataSourceAlgo])
+  }, [currentBP, backPressureDataSource])
 
   useEffect(() => {
     if (currentBP !== null && previousBP !== null) {
@@ -330,14 +324,11 @@ export default function Streaming() {
   }
 
   const backPressures = useMemo(() => {
-    if (
-      (actorBackPressures && backPressureAlgo && backPressureAlgo) ||
-      backPressuresMetricsWithoutPromtheus
-    ) {
+    if (actorBackPressures || backPressuresMetricsWithoutPromtheus) {
       let map = new Map()
 
       if (
-        backPressureDataSourceAlgo === "Embedded" &&
+        backPressureDataSource === "Embedded" &&
         backPressuresMetricsWithoutPromtheus
       ) {
         for (const m of backPressuresMetricsWithoutPromtheus.outputBufferBlockingDuration) {
@@ -347,41 +338,29 @@ export default function Streaming() {
           )
         }
       } else if (
-        backPressureDataSourceAlgo !== "Embedded" &&
+        backPressureDataSource === "Prometheus" &&
         actorBackPressures
       ) {
-        for (const m of actorBackPressures.outputBufferBlockingDuration) {
-          let algoFunc
-          switch (backPressureAlgo) {
-            case "p50":
-              algoFunc = p50
-              break
-            case "p90":
-              algoFunc = p90
-              break
-            case "p95":
-              algoFunc = p95
-              break
-            case "p99":
-              algoFunc = p99
-              break
-            default:
-              return
+        if (actorBackPressures) {
+          for (const m of actorBackPressures.outputBufferBlockingDuration) {
+            if (m.sample.length > 0) {
+              // We issue an instant query to Prometheus to get the most recent value.
+              // So there should be only one sample here.
+              console.assert(m.sample.length === 1)
+              const value = m.sample[0].value * 100
+              map.set(
+                `${m.metric.fragment_id}_${m.metric.downstream_fragment_id}`,
+                value
+              )
+            }
           }
-
-          const value = algoFunc(m.sample) * 100
-          map.set(
-            `${m.metric.fragment_id}_${m.metric.downstream_fragment_id}`,
-            value
-          )
         }
       }
       return map
     }
   }, [
-    backPressureDataSourceAlgo,
+    backPressureDataSource,
     actorBackPressures,
-    backPressureAlgo,
     backPressuresMetricsWithoutPromtheus,
   ])
 
@@ -456,9 +435,11 @@ export default function Streaming() {
           <FormControl>
             <FormLabel>Back Pressure Data Source</FormLabel>
             <Select
-              value={backPressureDataSourceAlgo}
+              value={backPressureDataSource}
               onChange={(event) =>
-                setBackPressureDataSourceAlgo(event.target.value)
+                setBackPressureDataSource(
+                  event.target.value as BackPressureDataSource
+                )
               }
             >
               {backPressureDataSources.map((algo) => (
@@ -468,26 +449,6 @@ export default function Streaming() {
               ))}
             </Select>
           </FormControl>
-          {backPressureDataSourceAlgo === "Prometheus" && (
-            <FormControl>
-              <FormLabel>Back Pressure Algorithm</FormLabel>
-              <Select
-                value={backPressureAlgo ?? undefined}
-                onChange={(event) => {
-                  setBackPressureAlgo(event.target.value as BackPressureAlgo)
-                }}
-              >
-                <option value="" disabled selected hidden>
-                  Please select
-                </option>
-                {backPressureAlgos.map((algo) => (
-                  <option value={algo} key={algo}>
-                    {algo}
-                  </option>
-                ))}
-              </Select>
-            </FormControl>
-          )}
           <Flex height="full" width="full" flexDirection="column">
             <Text fontWeight="semibold">Fragments</Text>
             {fragmentDependencyDag && (


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

For back-pressure visualization in dashboard from the Prometheus data source, issue an instant query instead of a range query with a 30 min window, to fetch the real-time value of the recent 1 min.

Also remove the option for sampling algorithms as they're not applicable any more.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
