### PR TITLE
chore: use system linker in macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,14 +19,12 @@ rustflags = [
 
 [target.x86_64-apple-darwin]
 rustflags = [
-    "-Ctarget-feature=+sse4.2",                             # use a generally available feature, since it's not for production
-    "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld",
+    "-Ctarget-feature=+sse4.2", # use a generally available feature, since it's not for production
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
     # neon is enabled by default
-    "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld",
 ]
 
 # Flags for all targets.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -80,7 +80,7 @@ RiseDev is the development mode of RisingWave. To develop RisingWave, you need t
 To install the dependencies on macOS, run:
 
 ```shell
-brew install postgresql cmake protobuf tmux cyrus-sasl llvm
+brew install postgresql cmake protobuf tmux cyrus-sasl
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The performance of the system linker has improved a lot in Xcode 15 (shipped with macOS 14 and enabled by default). See https://news.ycombinator.com/item?id=36218330.

A simple benchmark on compiling `cmd_all` and linking the binary:

```
ld-new (default) 9.38s
lld             13.40s
ld-classic      14.45s
```

I believe it could outperforms further more under the `release` profile.

So let's switch to the system linker to improve the experience and reduce the number of dependencies.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
