### PR TITLE
fix(cdc-connector): allow empty passwords

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/SourceValidateHandler.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/SourceValidateHandler.java
@@ -63,9 +63,17 @@ public class SourceValidateHandler {
     }
 
     private static void ensurePropNotBlank(Map<String, String> props, String name) {
+        ensurePropsExists(props, name);
         if (StringUtils.isBlank(props.get(name))) {
             throw ValidatorUtils.invalidArgument(
-                    String.format("'%s' cannot be empty, please check the WITH properties", name));
+                    String.format("'%s' cannot be empty. Please check the WITH properties", name));
+        }
+    }
+
+    private static void ensurePropsExists(Map<String, String> props, String name) {
+        if (!props.containsKey(name)) {
+            throw ValidatorUtils.invalidArgument(
+                    String.format("'%s' is not found. Please check the WITH properties", name));
         }
     }
 
@@ -74,6 +82,7 @@ public class SourceValidateHandler {
         ensurePropNotBlank(props, DbzConnectorConfig.PORT);
         ensurePropNotBlank(props, DbzConnectorConfig.DB_NAME);
         ensurePropNotBlank(props, DbzConnectorConfig.USER);
+        ensurePropsExists(props, DbzConnectorConfig.PASSWORD);
         // ensure table name is passed by user in non-sharing mode
         if (!isMultiTableShared) {
             ensurePropNotBlank(props, DbzConnectorConfig.TABLE_NAME);

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/SourceValidateHandler.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/SourceValidateHandler.java
@@ -65,7 +65,7 @@ public class SourceValidateHandler {
     private static void ensurePropNotBlank(Map<String, String> props, String name) {
         if (StringUtils.isBlank(props.get(name))) {
             throw ValidatorUtils.invalidArgument(
-                    String.format("'%s' not found, please check the WITH properties", name));
+                    String.format("'%s' cannot be empty, please check the WITH properties", name));
         }
     }
 
@@ -74,7 +74,6 @@ public class SourceValidateHandler {
         ensurePropNotBlank(props, DbzConnectorConfig.PORT);
         ensurePropNotBlank(props, DbzConnectorConfig.DB_NAME);
         ensurePropNotBlank(props, DbzConnectorConfig.USER);
-        ensurePropNotBlank(props, DbzConnectorConfig.PASSWORD);
         // ensure table name is passed by user in non-sharing mode
         if (!isMultiTableShared) {
             ensurePropNotBlank(props, DbzConnectorConfig.TABLE_NAME);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Allow passwords to be empty for CDC connectors. Tested with my local PostgresQL instance.

Before:

```
dev=> CREATE SOURCE pg_mydb WITH (
    connector = 'postgres-cdc',
    hostname = '127.0.0.1',
    port = '5432',
    username = 'eric',
    password = '',
    database.name = 'test',
    slot.name = 'rw_slot'
);
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: gRPC request to meta service failed: Internal error
  2: failed to create source worker
  3: failed to create SplitEnumerator
  4: source cannot pass validation
  5: INVALID_ARGUMENT: 'password' not found, please check the WITH properties
```


After:

```
dev=> CREATE SOURCE pg_mydb WITH (
    connector = 'postgres-cdc',
    hostname = '127.0.0.1',
    port = '5432',
    username = 'eric',
    password = '',
    database.name = 'test',
    slot.name = 'rw_slot'
);
CREATE_SOURCE

dev=> CREATE TABLE t1 (
    k bigint,
    v varchar,
    PRIMARY KEY(k)
) FROM pg_mydb TABLE 'public.t1';
CREATE_TABLE

dev=> select * from t1;
 k |  v
---+-----
 1 | foo
(1 row)
```



## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
