### PR TITLE
fix: fix compile err in release build of risectl

### DIFF
--- a/ci/scripts/check.sh
+++ b/ci/scripts/check.sh
@@ -30,6 +30,10 @@ sccache --zero-stats
 echo "--- Run clippy check (release)"
 cargo clippy --release --all-targets --features "rw-static-link,enable_test_epoch_in_release" --locked -- -D warnings
 
+echo "--- Run cargo check on building the release binary (release)"
+cargo check -p risingwave_cmd_all --features "rw-static-link" --profile release
+cargo check -p risingwave_cmd --bin risectl --features "rw-static-link" --profile release
+
 echo "--- Show sccache stats"
 sccache --show-stats
 sccache --zero-stats

--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -64,7 +64,7 @@ fi
 
 echo "--- Build risingwave release binary"
 cargo build -p risingwave_cmd_all --features "rw-static-link" --profile release
-cargo build --bin risectl --features "rw-static-link" --profile release
+cargo build -p risingwave_cmd --bin risectl --features "rw-static-link" --profile release
 cd target/release && chmod +x risingwave risectl
 
 echo "--- Upload nightly binary to s3"

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -33,6 +33,7 @@
 #![feature(error_generic_member_access)]
 #![feature(register_tool)]
 #![register_tool(rw)]
+#![recursion_limit = "256"]
 
 use std::time::Duration;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled.

The compile error is introduced in https://github.com/risingwavelabs/risingwave/pull/15365. Previously we use `cargo build --bin risectl` to build risectl without specifying the crate via `-p risingwave_cmd`, which makes cargo use the union of features used in all crates in the workspace. `risingwave_simulation` enables `enable_test_epoch` in its dependency list rather than in the dev dependency, which makes the feature union includes the `enable_test_epoch` by accidence. In this PR, by specifying the crate via `-p risingwave_cmd`, the feature enabled in `risingwave_simulation` will not be included in the future union, and then the `enable_test_epoch` will not be enabled when building `risectl`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
