### PR TITLE
feat(lints): lint on formatting `Report` in anyhow construction

### DIFF
--- a/lints/Cargo.lock
+++ b/lints/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "dylint_linting",
  "dylint_testing",
  "itertools 0.12.0",
+ "thiserror-ext",
  "tracing",
 ]
 
@@ -983,6 +984,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-ext"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368fdd73eb5f0df62797d1a5d1dca41ca4137a62f250980787ffe33e530b5d8b"
+dependencies = [
+ "thiserror",
+ "thiserror-ext-derive",
+]
+
+[[package]]
+name = "thiserror-ext-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc1991800eaf856df8d097c909b487fdee13db47ffa293136c91cde6de4abee"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/lints/Cargo.toml
+++ b/lints/Cargo.toml
@@ -23,6 +23,7 @@ dylint_testing = "2.6.0"
 
 # UI test dependencies
 anyhow = "1"
+thiserror-ext = "0.1"
 tracing = "0.1"
 
 [package.metadata.rust-analyzer]

--- a/lints/ui/format_error.rs
+++ b/lints/ui/format_error.rs
@@ -73,4 +73,11 @@ fn main() {
 
     let _ = anyhow!("{}", anyhow_err);
     let _ = anyhow!("some error occurred: {:?}", anyhow_err);
+
+    use thiserror_ext::AsReport;
+
+    let _ = anyhow!("{}", err.as_report());
+    let _ = anyhow!("some error occurred: {}", err.as_report());
+    let _ = anyhow!("{:?}", anyhow_err.as_report());
+    let _ = anyhow!("some error occurred: {:?}", anyhow_err.as_report());
 }

--- a/lints/ui/format_error.stderr
+++ b/lints/ui/format_error.stderr
@@ -344,5 +344,37 @@ LL |     let _ = anyhow!("some error occurred: {:?}", anyhow_err);
    |
    = help: consider using `.context(..)` to attach additional message to the error and make it an error source instead
 
-error: aborting due to 43 previous errors
+error: should not format error directly
+  --> $DIR/format_error.rs:79:27
+   |
+LL |     let _ = anyhow!("{}", err.as_report());
+   |                           ^^^^^^^^^^^^^^^
+   |
+   = help: consider directly wrapping the error with `anyhow::anyhow!(..)` instead of formatting its report
+
+error: should not format error directly
+  --> $DIR/format_error.rs:80:48
+   |
+LL |     let _ = anyhow!("some error occurred: {}", err.as_report());
+   |                                                ^^^^^^^^^^^^^^^
+   |
+   = help: consider using `anyhow::Context::(with_)context` to attach additional message to the error and make it an error source instead
+
+error: should not format error directly
+  --> $DIR/format_error.rs:81:29
+   |
+LL |     let _ = anyhow!("{:?}", anyhow_err.as_report());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider directly wrapping the error with `anyhow::anyhow!(..)` instead of formatting its report
+
+error: should not format error directly
+  --> $DIR/format_error.rs:82:50
+   |
+LL |     let _ = anyhow!("some error occurred: {:?}", anyhow_err.as_report());
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `anyhow::Context::(with_)context` to attach additional message to the error and make it an error source instead
+
+error: aborting due to 47 previous errors
 

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -914,17 +914,17 @@ pub async fn run_test_file(file_path: &Path, file_content: &str) -> Result<()> {
 
     let mut failed_num = 0;
     let cases: Vec<TestCase> = serde_yaml::from_str(file_content).map_err(|e| {
-        if let Some(loc) = e.location() {
-            anyhow!(
-                "failed to parse yaml: {}, at {}:{}:{}",
-                e.as_report(),
+        let context = if let Some(loc) = e.location() {
+            format!(
+                "failed to parse yaml at {}:{}:{}",
                 file_path.display(),
                 loc.line(),
                 loc.column()
             )
         } else {
-            anyhow!("failed to parse yaml: {}", e.as_report())
-        }
+            "failed to parse yaml".to_owned()
+        };
+        anyhow::anyhow!(e).context(context)
     })?;
     let cases = resolve_testcase_id(cases).expect("failed to resolve");
     let mut outputs = vec![];

--- a/src/frontend/planner_test/tests/planner_test_runner.rs
+++ b/src/frontend/planner_test/tests/planner_test_runner.rs
@@ -14,8 +14,9 @@
 
 use std::ffi::OsStr;
 
-use libtest_mimic::{Arguments, Trial};
+use libtest_mimic::{Arguments, Failed, Trial};
 use risingwave_planner_test::{run_test_file, test_data_dir};
+use thiserror_ext::AsReport;
 use tokio::runtime::Runtime;
 use walkdir::WalkDir;
 
@@ -47,8 +48,9 @@ fn main() {
                 let path = test_data_dir().join("input").join(file_name);
 
                 let file_content = std::fs::read_to_string(&path).unwrap();
-                build_runtime().block_on(run_test_file(&path, &file_content))?;
-                Ok(())
+                build_runtime()
+                    .block_on(run_test_file(&path, &file_content))
+                    .map_err(|e| Failed::from(e.as_report()))
             }));
         }
     }

--- a/src/frontend/planner_test/tests/planner_test_runner.rs
+++ b/src/frontend/planner_test/tests/planner_test_runner.rs
@@ -50,6 +50,8 @@ fn main() {
                 let file_content = std::fs::read_to_string(&path).unwrap();
                 build_runtime()
                     .block_on(run_test_file(&path, &file_content))
+                    // Manually convert to `Failed`, otherwise it will use `Display` impl of
+                    // `anyhow::Error` which loses the source chain.
                     .map_err(|e| Failed::from(e.as_report()))
             }));
         }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -20,7 +20,7 @@ use std::mem::{replace, take};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
+use anyhow::Context;
 use arc_swap::ArcSwap;
 use fail::fail_point;
 use itertools::Itertools;
@@ -973,12 +973,11 @@ impl CheckpointControl {
         }
 
         if let CompletingCommand::Completing { join_handle, .. } = &mut self.completing_command {
-            let join_result = join_handle
-                .await
-                .map_err(|e| {
-                    anyhow!("failed to join completing command: {:?}", e.as_report()).into()
-                })
-                .and_then(|result| result);
+            let join_result: MetaResult<_> = try {
+                join_handle
+                    .await
+                    .context("failed to join completing command")??
+            };
             // It's important to reset the completing_command after await no matter the result is err
             // or not, and otherwise the join handle will be polled again after ready.
             if let Err(e) = &join_result {

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -40,6 +40,7 @@
 #![feature(is_sorted)]
 #![feature(btree_cursors)]
 #![feature(assert_matches)]
+#![feature(try_blocks)]
 
 #[macro_use]
 extern crate tracing;

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use parking_lot::Mutex;
@@ -162,15 +162,7 @@ impl StreamActorManagerState {
         let (join_result, sender) = pending_on_none(self.creating_actors.next()).await;
         (
             sender,
-            join_result
-                .map_err(|join_error| {
-                    anyhow!(
-                        "failed to join creating actors futures: {:?}",
-                        join_error.as_report()
-                    )
-                    .into()
-                })
-                .and_then(|result| result),
+            try { join_result.context("failed to join creating actors futures")?? },
         )
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Inspired by #15109:

`format_error` lint should not be simply workarounded by adding an `.as_report()` method call. For example, we've started to instruct developers to use `anyhow::Context` if they're formatting errors in an `anyhow!` macro call since #14957.

This PR further enforce this by also adding the lints on the `Report`s in `anyhow!` calls. The UI test clearly shows the changes:

https://github.com/risingwavelabs/risingwave/blob/294b520b2a1ff00023b634b981c8731f8657da0a/lints/ui/format_error.stderr#L347-L378

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
