### PR TITLE
fix(frontend): accept all boolean literals for boolean config entry

### DIFF
--- a/e2e_test/batch/config.slt
+++ b/e2e_test/batch/config.slt
@@ -8,3 +8,12 @@ query T
 show application_name;
 ----
 slt
+
+statement ok
+set synchronize_seqscans to on;
+
+statement ok
+set synchronize_seqscans to f;
+
+statement ok
+set synchronize_seqscans to default;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Just like how we parse boolean for literals, we should also accept them as config values.

https://github.com/risingwavelabs/risingwave/blob/2cb7481c5ea9bd3fcaeea87d199d411efc9d00c6/src/common/src/cast/mod.rs#L27-L31

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
