### PR TITLE
fix(scale): Add skip_create_new_actors to RescheduleOptions

### DIFF
--- a/src/meta/service/src/scale_service.rs
+++ b/src/meta/service/src/scale_service.rs
@@ -210,6 +210,7 @@ impl ScaleService for ScaleServiceImpl {
                     .collect(),
                 RescheduleOptions {
                     resolve_no_shuffle_upstream,
+                    skip_create_new_actors: false,
                 },
                 Some(table_parallelisms),
             )

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -697,6 +697,7 @@ impl GlobalBarrierManagerContext {
                     plan,
                     RescheduleOptions {
                         resolve_no_shuffle_upstream: true,
+                        skip_create_new_actors: true,
                     },
                     Some(&mut compared_table_parallelisms),
                 )
@@ -828,6 +829,7 @@ impl GlobalBarrierManagerContext {
                     plan,
                     RescheduleOptions {
                         resolve_no_shuffle_upstream: true,
+                        skip_create_new_actors: true,
                     },
                     Some(&mut compared_table_parallelisms),
                 )

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -2818,6 +2818,7 @@ impl GlobalStreamManager {
             reschedules,
             RescheduleOptions {
                 resolve_no_shuffle_upstream: false,
+                skip_create_new_actors: false,
             },
             None,
         )

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -727,6 +727,7 @@ impl GlobalStreamManager {
                     reschedules,
                     RescheduleOptions {
                         resolve_no_shuffle_upstream: false,
+                        skip_create_new_actors: false,
                     },
                     Some(table_parallelism_assignment),
                 )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The offline scaling process should skip the create actor stage.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


