### PR TITLE
fix(sink): add cassandra batch size and fix bigquery array null

### DIFF
--- a/integration_tests/big-query-sink/create_sink.sql
+++ b/integration_tests/big-query-sink/create_sink.sql
@@ -23,7 +23,7 @@ FROM
     -- bigquery.dataset= '${dataset_id}',
     -- bigquery.table= '${table_id}',
     -- access_key = '${aws_access_key}',
-    -- secret_access = '${aws_secret_access}',
+    -- secret_key = '${aws_secret_key}',
     -- region = '${aws_region}',
     -- force_append_only='true',
 -- );

--- a/integration_tests/cassandra-and-scylladb-sink/create_source.sql
+++ b/integration_tests/cassandra-and-scylladb-sink/create_source.sql
@@ -11,10 +11,10 @@ CREATE table user_behaviors (
     connector = 'datagen',
     fields.user_id.kind = 'sequence',
     fields.user_id.start = '1',
-    fields.user_id.end = '10000000',
+    fields.user_id.end = '1000',
     fields.user_name.kind = 'random',
     fields.user_name.length = '10',
-    datagen.rows.per.second = '1000000'
+    datagen.rows.per.second = '10'
 ) FORMAT PLAIN ENCODE JSON;
 
 CREATE TABLE cassandra_types (

--- a/integration_tests/cassandra-and-scylladb-sink/create_source.sql
+++ b/integration_tests/cassandra-and-scylladb-sink/create_source.sql
@@ -11,10 +11,10 @@ CREATE table user_behaviors (
     connector = 'datagen',
     fields.user_id.kind = 'sequence',
     fields.user_id.start = '1',
-    fields.user_id.end = '1000',
+    fields.user_id.end = '10000000',
     fields.user_name.kind = 'random',
     fields.user_name.length = '10',
-    datagen.rows.per.second = '10'
+    datagen.rows.per.second = '1000000'
 ) FORMAT PLAIN ENCODE JSON;
 
 CREATE TABLE cassandra_types (

--- a/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraConfig.java
+++ b/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraConfig.java
@@ -107,7 +107,7 @@ public class CassandraConfig extends CommonSinkConfig {
     public CassandraConfig withMaxBatchRows(Integer maxBatchRows) {
         if (maxBatchRows > 65536 || maxBatchRows < 1) {
             throw new IllegalArgumentException(
-                    "cassandra.max_batch_rows must be <= 65535 and >= 1");
+                    "Cassandra sink option: maxBatchRows must be <= 65535 and >= 1");
         }
         this.maxBatchRows = maxBatchRows;
         return this;
@@ -119,7 +119,8 @@ public class CassandraConfig extends CommonSinkConfig {
 
     public CassandraConfig withRequestTimeoutMs(Integer requestTimeoutMs) {
         if (requestTimeoutMs < 1) {
-            throw new IllegalArgumentException("cassandra.request_timeout_ms must be >= 1");
+            throw new IllegalArgumentException(
+                    "Cassandra sink option: requestTimeoutMs must be >= 1");
         }
         this.requestTimeoutMs = requestTimeoutMs;
         return this;

--- a/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraConfig.java
+++ b/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraConfig.java
@@ -45,6 +45,9 @@ public class CassandraConfig extends CommonSinkConfig {
     @JsonProperty(value = "cassandra.max_batch_rows")
     private Integer maxBatchRows = 512;
 
+    @JsonProperty(value = "cassandra.request_timeout_ms")
+    private Integer requestTimeoutMs = 2000;
+
     @JsonCreator
     public CassandraConfig(
             @JsonProperty(value = "cassandra.url") String url,
@@ -102,7 +105,23 @@ public class CassandraConfig extends CommonSinkConfig {
     }
 
     public CassandraConfig withMaxBatchRows(Integer maxBatchRows) {
+        if (maxBatchRows > 65536 || maxBatchRows < 1) {
+            throw new IllegalArgumentException(
+                    "cassandra.max_batch_rows must be <= 65535 and >= 1");
+        }
         this.maxBatchRows = maxBatchRows;
+        return this;
+    }
+
+    public Integer getRequestTimeoutMs() {
+        return requestTimeoutMs;
+    }
+
+    public CassandraConfig withRequestTimeoutMs(Integer requestTimeoutMs) {
+        if (requestTimeoutMs < 1) {
+            throw new IllegalArgumentException("cassandra.request_timeout_ms must be >= 1");
+        }
+        this.requestTimeoutMs = requestTimeoutMs;
         return this;
     }
 }

--- a/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraConfig.java
+++ b/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraConfig.java
@@ -42,6 +42,9 @@ public class CassandraConfig extends CommonSinkConfig {
     @JsonProperty(value = "cassandra.password")
     private String password;
 
+    @JsonProperty(value = "cassandra.max_batch_rows")
+    private Integer maxBatchRows = 512;
+
     @JsonCreator
     public CassandraConfig(
             @JsonProperty(value = "cassandra.url") String url,
@@ -91,6 +94,15 @@ public class CassandraConfig extends CommonSinkConfig {
 
     public CassandraConfig withPassword(String password) {
         this.password = password;
+        return this;
+    }
+
+    public Integer getMaxBatchRows() {
+        return maxBatchRows;
+    }
+
+    public CassandraConfig withMaxBatchRows(Integer maxBatchRows) {
+        this.maxBatchRows = maxBatchRows;
         return this;
     }
 }

--- a/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraSink.java
+++ b/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraSink.java
@@ -18,6 +18,8 @@ package com.risingwave.connector;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.cql.*;
 import com.risingwave.connector.api.TableSchema;
 import com.risingwave.connector.api.sink.SinkRow;
@@ -50,9 +52,16 @@ public class CassandraSink extends SinkWriterBase {
             throw new IllegalArgumentException(
                     "Invalid cassandraURL: expected `host:port`, got " + url);
         }
+
+        DriverConfigLoader loader =
+                DriverConfigLoader.programmaticBuilder()
+                        .withInt(DefaultDriverOption.REQUEST_TIMEOUT, config.getRequestTimeoutMs())
+                        .build();
+
         // check connection
         CqlSessionBuilder sessionBuilder =
                 CqlSession.builder()
+                        .withConfigLoader(loader)
                         .addContactPoint(
                                 new InetSocketAddress(hostPort[0], Integer.parseInt(hostPort[1])))
                         .withKeyspace(config.getKeyspace())

--- a/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraSink.java
+++ b/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraSink.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 public class CassandraSink extends SinkWriterBase {
     private static final Logger LOG = LoggerFactory.getLogger(CassandraSink.class);
-    private static final Integer MAX_BATCH_SIZE = 1024 * 16;
 
     private final CqlSession session;
     private final List<SinkRow> updateRowCache = new ArrayList<>(1);
@@ -163,7 +162,7 @@ public class CassandraSink extends SinkWriterBase {
     }
 
     private void tryCommit() {
-        if (batchBuilder.getStatementsCount() >= MAX_BATCH_SIZE) {
+        if (batchBuilder.getStatementsCount() >= config.getMaxBatchRows()) {
             sync();
         }
     }

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -100,7 +100,7 @@ impl AwsAuthProps {
                 ),
             ))
         } else {
-            bail!("Both \"access_key\" and \"secret_access\" are required.")
+            bail!("Both \"access_key\" and \"secret_key\" are required.")
         }
     }
 

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -28,7 +28,7 @@ use risingwave_common::catalog::Schema;
 use risingwave_common::types::DataType;
 use serde_derive::Deserialize;
 use serde_json::Value;
-use serde_with::serde_as;
+use serde_with::{serde_as, DisplayFromStr};
 use url::Url;
 use with_options::WithOptions;
 use yup_oauth2::ServiceAccountKey;
@@ -45,6 +45,7 @@ use crate::sink::{
 
 pub const BIGQUERY_SINK: &str = "bigquery";
 
+#[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
 pub struct BigQueryCommon {
     #[serde(rename = "bigquery.local.path")]
@@ -58,6 +59,7 @@ pub struct BigQueryCommon {
     #[serde(rename = "bigquery.table")]
     pub table: String,
     #[serde(rename = "bigquery.max_batch_rows", default = "default_max_batch_rows")]
+    #[serde_as(as = "DisplayFromStr")]
     pub max_batch_rows: usize,
 }
 

--- a/src/connector/src/sink/doris.rs
+++ b/src/connector/src/sink/doris.rs
@@ -39,7 +39,7 @@ use super::doris_starrocks_connector::{
     POOL_IDLE_TIMEOUT,
 };
 use super::{Result, SinkError, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT};
-use crate::sink::encoder::{JsonEncoder, RowEncoder, TimestampHandlingMode};
+use crate::sink::encoder::{JsonEncoder, RowEncoder};
 use crate::sink::writer::{LogSinkerOf, SinkWriterExt};
 use crate::sink::{DummySinkCommitCoordinator, Sink, SinkParam, SinkWriter, SinkWriterParam};
 
@@ -294,12 +294,7 @@ impl DorisSinkWriter {
             inserter_inner_builder: doris_insert_builder,
             is_append_only,
             client: None,
-            row_encoder: JsonEncoder::new_with_doris(
-                schema,
-                None,
-                TimestampHandlingMode::String,
-                decimal_map,
-            ),
+            row_encoder: JsonEncoder::new_with_doris(schema, None, decimal_map),
         })
     }
 

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -207,6 +207,7 @@ fn datum_to_json_object(
             if let CustomJsonType::BigQuery = custom_json_type
                 && matches!(field.data_type(), DataType::List(_))
             {
+                // Bigquery need to convert null of array to empty array https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
                 return Ok(Value::Array(vec![]));
             } else {
                 return Ok(Value::Null);

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -144,6 +144,8 @@ pub enum CustomJsonType {
     Es,
     // starrocks' need jsonb is struct
     StarRocks(HashMap<String, (u8, u8)>),
+    // bigquery need null array -> []
+    BigQuery,
     None,
 }
 

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -35,7 +35,7 @@ use with_options::WithOptions;
 use super::doris_starrocks_connector::{
     HeaderBuilder, InserterInner, InserterInnerBuilder, DORIS_SUCCESS_STATUS, STARROCKS_DELETE_SIGN,
 };
-use super::encoder::{JsonEncoder, RowEncoder, TimestampHandlingMode};
+use super::encoder::{JsonEncoder, RowEncoder};
 use super::writer::LogSinkerOf;
 use super::{SinkError, SinkParam, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT};
 use crate::sink::writer::SinkWriterExt;
@@ -367,12 +367,7 @@ impl StarrocksSinkWriter {
             inserter_innet_builder: starrocks_insert_builder,
             is_append_only,
             client: None,
-            row_encoder: JsonEncoder::new_with_starrocks(
-                schema,
-                None,
-                TimestampHandlingMode::String,
-                decimal_map,
-            ),
+            row_encoder: JsonEncoder::new_with_starrocks(schema, None, decimal_map),
         })
     }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -17,6 +17,10 @@ BigQueryConfig:
   - name: bigquery.table
     field_type: String
     required: true
+  - name: bigquery.max_batch_rows
+    field_type: usize
+    required: false
+    default: '1024'
   - name: region
     field_type: String
     required: false


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
in this pr, we add bigquery's `max_batch_rows`  and cassandra's `max_batch_rows` `request_timeout` to fix problems of excessive data size.
And we fix bigquery array null can't insert error,(the array null will be converted to []. )
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

`In cassandra sink.` Add two optional option. 
`cassandra.max_batch_rows: `Number of batch rows sent at a time defaults is 512, 
It should be less than 65535 according to cassandra, and ensures that the size of each batch(max_batch_rows * size of each row) is less than 50kb (Configuration items for cassandra: batch_size_fail_threshold_in_kb)
`cassandra.request_timeout_ms: `Waiting time for each batch, default is 2000ms
it not recommended to change, if you encounter timeout time is not enough, prioritize to reduce batch size


`In bigquery sink,` Add optional option 
`bigquery.max_batch_rows:` Number of batch rows sent at a time defaults is 1024, 

Also due to this document, we will convert an array with a null value to an empty array
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
