### PR TITLE
feat(standalone): add extra opts to single node

### DIFF
--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -240,7 +240,7 @@ fn standalone(opts: StandaloneOpts) {
 /// We will start a standalone instance, with all nodes in the same process.
 fn single_node(opts: SingleNodeOpts) {
     opts.create_store_directories().unwrap();
-    let opts = risingwave_cmd_all::map_single_node_opts_to_standalone_opts(&opts);
+    let opts = risingwave_cmd_all::normalized_single_node_opts(&opts);
     let settings = risingwave_rt::LoggerSettings::from_opts(&opts)
         .with_target("risingwave_storage", Level::WARN)
         .with_thread_name(true);

--- a/src/cmd_all/src/common.rs
+++ b/src/cmd_all/src/common.rs
@@ -14,10 +14,6 @@
 
 use std::ffi::OsString;
 
-pub fn osstrs_from_iter<T: Into<OsString>>(s: impl IntoIterator<Item = T>) -> Vec<OsString> {
-    s.into_iter().map(Into::into).collect()
-}
-
 pub fn osstrs<T: Into<OsString> + AsRef<std::ffi::OsStr>>(s: impl AsRef<[T]>) -> Vec<OsString> {
     s.as_ref().iter().map(OsString::from).collect()
 }

--- a/src/cmd_all/src/common.rs
+++ b/src/cmd_all/src/common.rs
@@ -14,6 +14,10 @@
 
 use std::ffi::OsString;
 
+pub fn osstrs_from_iter<T: Into<OsString>>(s: impl IntoIterator<Item = T>) -> Vec<OsString> {
+    s.into_iter().map(Into::into).collect()
+}
+
 pub fn osstrs<T: Into<OsString> + AsRef<std::ffi::OsStr>>(s: impl AsRef<[T]>) -> Vec<OsString> {
     s.as_ref().iter().map(OsString::from).collect()
 }

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -516,14 +516,16 @@ mod tests {
         check(
             hash_map,
             expect![[r#"
-            RawOpts {
-                inner: {
-                    "--some-opt-2": "abc",
-                    "--some-flag": "",
-                    "--some-opt": "some value",
-                    "--another-flag": "",
-                },
-            }"#]],
+                RawOpts {
+                    flags: {
+                        "--some-flag",
+                        "--another-flag",
+                    },
+                    opts: {
+                        "--some-opt-2": "abc",
+                        "--some-opt": "some value",
+                    },
+                }"#]],
         )
     }
 }

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -476,3 +476,24 @@ impl SingleNodeOpts {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use expect_test::{expect, Expect};
+
+    use super::*;
+
+    fn check(actual: impl Debug, expect: Expect) {
+        let actual = format!("{:#?}", actual);
+        expect.assert_eq(&actual);
+    }
+
+    #[test]
+    fn test_raw_opts_from_str() {
+        let str = "--some-opt \"some value\" --some-flag --another-flag --some-opt-2 abc";
+        let hash_map = RawOpts::from(str);
+        check(hash_map, expect![])
+    }
+}

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -247,6 +247,8 @@ pub fn normalized_single_node_opts(opts: &SingleNodeOpts) -> NormalizedSingleNod
     let meta_opts = if opts.disable_meta {
         None
     } else {
+        // let mut meta_opts = meta_opts.map(|o| MetaNodeOpts::parse_from(osstrs(o)));
+
         Some(meta_opts)
     };
     let compute_opts = if opts.disable_compute {

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -298,12 +298,19 @@ impl From<&str> for RawOpts {
             };
             assert!(arg.starts_with("--"));
             let key = args.next().unwrap();
+
+            // No next arg, current key must be a flag.
             let Some(arg2) = args.peek() else {
+                inner.insert(key, "".to_string());
                 break;
             };
+
+            // Next arg is a key, current key must be a flag.
             if arg2.starts_with("--") {
+                inner.insert(key, "".to_string());
                 continue;
             } else {
+                // Next arg must be a value if it's not a key.
                 inner.insert(key, args.next().unwrap());
             }
         }
@@ -494,6 +501,14 @@ mod tests {
     fn test_raw_opts_from_str() {
         let str = "--some-opt \"some value\" --some-flag --another-flag --some-opt-2 abc";
         let hash_map = RawOpts::from(str);
-        check(hash_map, expect![])
+        check(hash_map, expect![[r#"
+            RawOpts {
+                inner: {
+                    "--some-opt-2": "abc",
+                    "--some-flag": "",
+                    "--some-opt": "some value",
+                    "--another-flag": "",
+                },
+            }"#]])
     }
 }

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 use anyhow::Result;
@@ -269,6 +269,7 @@ pub fn normalized_single_node_opts(opts: &SingleNodeOpts) -> NormalizedSingleNod
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RawOpts {
+    flags: HashSet<String>,
     opts: HashMap<String, String>,
 }
 
@@ -287,7 +288,8 @@ impl PartialOrd for RawOpts {
 
 impl From<&str> for RawOpts {
     fn from(s: &str) -> Self {
-        let mut inner = HashMap::new();
+        let mut opts = HashMap::new();
+        let mut flags = HashSet::new();
         let args = split(s).unwrap();
         let mut args = args.into_iter().peekable();
         loop {
@@ -299,20 +301,20 @@ impl From<&str> for RawOpts {
 
             // No next arg, current key must be a flag.
             let Some(arg2) = args.peek() else {
-                inner.insert(key, "".to_string());
+                flags.insert(key);
                 break;
             };
 
             // Next arg is a key, current key must be a flag.
             if arg2.starts_with("--") {
-                inner.insert(key, "".to_string());
+                flags.insert(key);
                 continue;
             } else {
                 // Next arg must be a value if it's not a key.
-                inner.insert(key, args.next().unwrap());
+                opts.insert(key, args.next().unwrap());
             }
         }
-        Self { opts: inner }
+        Self { flags, opts }
     }
 }
 
@@ -329,7 +331,10 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { opts: inner }
+        Self {
+            flags: Default::default(),
+            opts: inner,
+        }
     }
 
     fn default_meta_opts() -> Self {
@@ -350,7 +355,10 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { opts: inner }
+        Self {
+            flags: Default::default(),
+            opts: inner,
+        }
     }
 
     fn default_compute_opts() -> Self {
@@ -365,7 +373,10 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { opts: inner }
+        Self {
+            flags: Default::default(),
+            opts: inner,
+        }
     }
 
     fn default_compactor_opts() -> Self {
@@ -379,7 +390,10 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { opts: inner }
+        Self {
+            flags: Default::default(),
+            opts: inner,
+        }
     }
 }
 

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -148,98 +148,96 @@ pub fn normalized_single_node_opts(opts: &SingleNodeOpts) -> NormalizedSingleNod
     let mut compactor_opts = RawOpts::default_compactor_opts();
 
     if let Some(prometheus_listener_addr) = &opts.prometheus_listener_addr {
-        meta_opts.inner.insert(
+        meta_opts.opts.insert(
             "--prometheus-listener-addr".to_string(),
             prometheus_listener_addr.clone(),
         );
-        compute_opts.inner.insert(
+        compute_opts.opts.insert(
             "--prometheus-listener-addr".to_string(),
             prometheus_listener_addr.clone(),
         );
-        frontend_opts.inner.insert(
+        frontend_opts.opts.insert(
             "--prometheus-listener-addr".to_string(),
             prometheus_listener_addr.clone(),
         );
-        compactor_opts.inner.insert(
+        compactor_opts.opts.insert(
             "--prometheus-listener-addr".to_string(),
             prometheus_listener_addr.clone(),
         );
     }
     if let Some(config_path) = &opts.config_path {
         meta_opts
-            .inner
+            .opts
             .insert("--config-path".to_string(), config_path.clone());
         compute_opts
-            .inner
+            .opts
             .insert("--config-path".to_string(), config_path.clone());
         frontend_opts
-            .inner
+            .opts
             .insert("--config-path".to_string(), config_path.clone());
         compactor_opts
-            .inner
+            .opts
             .insert("--config-path".to_string(), config_path.clone());
     }
     if let Some(store_directory) = &opts.store_directory {
         let state_store_url = make_single_node_state_store_url(store_directory);
         let meta_store_endpoint = make_single_node_sql_endpoint(store_directory);
         meta_opts
-            .inner
+            .opts
             .insert("--state-store".to_string(), state_store_url);
         meta_opts
-            .inner
+            .opts
             .insert("--sql-endpoint".to_string(), meta_store_endpoint);
     }
     if let Some(meta_addr) = &opts.meta_addr {
         meta_opts
-            .inner
+            .opts
             .insert("--listen-addr".to_string(), meta_addr.to_string());
         meta_opts
-            .inner
+            .opts
             .insert("--advertise-addr".to_string(), meta_addr.to_string());
         compute_opts
-            .inner
+            .opts
             .insert("--meta-address".to_string(), meta_addr.to_string());
         frontend_opts
-            .inner
+            .opts
             .insert("--meta-addr".to_string(), meta_addr.to_string());
         compactor_opts
-            .inner
+            .opts
             .insert("--meta-address".to_string(), meta_addr.to_string());
     }
     if let Some(compute_addr) = &opts.compute_addr {
         compute_opts
-            .inner
+            .opts
             .insert("--listen-addr".to_string(), compute_addr.to_string());
     }
     if let Some(frontend_addr) = &opts.frontend_addr {
         frontend_opts
-            .inner
+            .opts
             .insert("--listen-addr".to_string(), frontend_addr.to_string());
     }
     if let Some(compactor_addr) = &opts.compactor_addr {
         compactor_opts
-            .inner
+            .opts
             .insert("--listen-addr".to_string(), compactor_addr.to_string());
     }
     if let Some(frontend_node_override_opts) = &opts.frontend_node_override_opts {
         frontend_opts
-            .inner
-            .extend(frontend_node_override_opts.inner.clone());
+            .opts
+            .extend(frontend_node_override_opts.opts.clone());
     }
     if let Some(meta_node_override_opts) = &opts.meta_node_override_opts {
-        meta_opts
-            .inner
-            .extend(meta_node_override_opts.inner.clone());
+        meta_opts.opts.extend(meta_node_override_opts.opts.clone());
     }
     if let Some(compute_node_override_opts) = &opts.compute_node_override_opts {
         compute_opts
-            .inner
-            .extend(compute_node_override_opts.inner.clone());
+            .opts
+            .extend(compute_node_override_opts.opts.clone());
     }
     if let Some(compactor_node_override_opts) = &opts.compactor_node_override_opts {
         compactor_opts
-            .inner
-            .extend(compactor_node_override_opts.inner.clone());
+            .opts
+            .extend(compactor_node_override_opts.opts.clone());
     }
     let frontend_opts = if opts.disable_frontend {
         None
@@ -271,7 +269,7 @@ pub fn normalized_single_node_opts(opts: &SingleNodeOpts) -> NormalizedSingleNod
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RawOpts {
-    inner: HashMap<String, String>,
+    opts: HashMap<String, String>,
 }
 
 // FIXME(kwannoel): This is a placeholder implementation
@@ -314,7 +312,7 @@ impl From<&str> for RawOpts {
                 inner.insert(key, args.next().unwrap());
             }
         }
-        Self { inner }
+        Self { opts: inner }
     }
 }
 
@@ -331,7 +329,7 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { inner }
+        Self { opts: inner }
     }
 
     fn default_meta_opts() -> Self {
@@ -352,7 +350,7 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { inner }
+        Self { opts: inner }
     }
 
     fn default_compute_opts() -> Self {
@@ -367,7 +365,7 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { inner }
+        Self { opts: inner }
     }
 
     fn default_compactor_opts() -> Self {
@@ -381,7 +379,7 @@ impl RawOpts {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        Self { inner }
+        Self { opts: inner }
     }
 }
 
@@ -501,7 +499,9 @@ mod tests {
     fn test_raw_opts_from_str() {
         let str = "--some-opt \"some value\" --some-flag --another-flag --some-opt-2 abc";
         let hash_map = RawOpts::from(str);
-        check(hash_map, expect![[r#"
+        check(
+            hash_map,
+            expect![[r#"
             RawOpts {
                 inner: {
                     "--some-opt-2": "abc",
@@ -509,6 +509,7 @@ mod tests {
                     "--some-opt": "some value",
                     "--another-flag": "",
                 },
-            }"#]])
+            }"#]],
+        )
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

First step in unifying single node and standalone.

Here were the previous explored approaches:
1. Reparse the options, and use them to update the node level structs. Didn't work, because if there's any missing options, they were replaced by defaults. Then the node level structs fields will be replaced by defaults. (#15044)
2. Create a builder, didn't work either. Too much work. Needs to create a builder for each opt, generate parser for them, write a macro to use the builder to update the options structs.

The current approach is simple.

We just set default options per node as a hashmap / hashset of string arguments:
```
hashmap for kvs:
--some-option=1
--some-option-2=abc

hashset for flags:
--some-flag
...
```

Subsequently, process level option will override these options if necessary. This can be done just be inserting into the hashmap.
Then extra node level options will finally override these options if necessary. This can be done just by inserting into the hashmap.

Finally, we flatten the each node's collection of args into a sequence of strings:
```
["--some-option", "1", "--some-flag"]
```

Then pass these options into their corresponding node.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
