### PR TITLE
fix(optimizer): decorrelate SimpleAgg with `array_agg`/`jsonb_agg`/`jsonb_object_agg`

### DIFF
--- a/e2e_test/batch/subquery/subquery.slt.part
+++ b/e2e_test/batch/subquery/subquery.slt.part
@@ -135,9 +135,9 @@ NULL 0
 query II
 select a, (select array_agg(t1.a) filter (where t1.a is distinct from 1) from t1 where t1.a <> t.b) from t1 as t order by 1;
 ----
-1 {NULL}
+1 NULL
 2 {2}
-NULL {NULL}
+NULL NULL
 
 statement ok
 drop table t1;

--- a/e2e_test/batch/subquery/subquery.slt.part
+++ b/e2e_test/batch/subquery/subquery.slt.part
@@ -132,6 +132,13 @@ select a, (select count(*) from t1 where t1.a <> t.b) from t1 as t order by 1;
 2 2
 NULL 0
 
+query II
+select a, (select array_agg(t1.a) filter (where t1.a is distinct from 1) from t1 where t1.a <> t.b) from t1 as t order by 1;
+----
+1 {NULL}
+2 {2}
+NULL {NULL}
+
 statement ok
 drop table t1;
 

--- a/src/frontend/planner_test/tests/testdata/input/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/subquery_expr_correlated.yaml
@@ -46,6 +46,13 @@
   expected_outputs:
   - optimized_logical_plan_for_batch
   - logical_plan
+- name: 'Like `count(*)`, SimpleAgg also need to rewrite `array_agg` for the extra null row due to outer join #14735'
+  sql: |
+    create table t1(a int, b int);
+    select a, (select array_agg(t1.a) filter (where t1.a is distinct from 1) from t1 where t1.a <> t.b) from t1 as t order by 1;
+  expected_outputs:
+  - logical_plan
+  - optimized_logical_plan_for_batch
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -160,16 +160,17 @@
             └─LogicalFilter { predicate: (t1.a <> CorrelatedInputRef { index: 1, correlated_id: 1 }) }
               └─LogicalScan { table: t1, columns: [t1.a, t1.b, t1._row_id] }
   optimized_logical_plan_for_batch: |-
-    LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.b, t1.b), output: [t1.a, array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
+    LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.b, t1.b), output: [t1.a, array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32) AND IsNotNull(1:Int32))] }
     ├─LogicalScan { table: t1, columns: [t1.a, t1.b] }
-    └─LogicalAgg { group_key: [t1.b], aggs: [array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
-      └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.b, t1.b), output: [t1.b, t1.a] }
+    └─LogicalAgg { group_key: [t1.b], aggs: [array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32) AND IsNotNull(1:Int32))] }
+      └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.b, t1.b), output: [t1.b, t1.a, 1:Int32] }
         ├─LogicalAgg { group_key: [t1.b], aggs: [] }
         │ └─LogicalScan { table: t1, columns: [t1.b] }
-        └─LogicalJoin { type: Inner, on: (t1.a <> t1.b), output: all }
-          ├─LogicalAgg { group_key: [t1.b], aggs: [] }
-          │ └─LogicalScan { table: t1, columns: [t1.b] }
-          └─LogicalScan { table: t1, columns: [t1.a] }
+        └─LogicalProject { exprs: [t1.b, t1.a, 1:Int32] }
+          └─LogicalJoin { type: Inner, on: (t1.a <> t1.b), output: all }
+            ├─LogicalAgg { group_key: [t1.b], aggs: [] }
+            │ └─LogicalScan { table: t1, columns: [t1.b] }
+            └─LogicalScan { table: t1, columns: [t1.a] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -1049,16 +1050,16 @@
     FROM array_types AS t0;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_agg(array_types.x)] }
+    └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_agg(array_types.x) filter(IsNotNull(1:Int32))] }
       ├─BatchExchange { order: [], dist: HashShard(array_types.x) }
       │ └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
-      └─BatchHashAgg { group_key: [array_types.x], aggs: [array_agg(array_types.x)] }
-        └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_types.x, array_types.x] }
+      └─BatchHashAgg { group_key: [array_types.x], aggs: [array_agg(array_types.x) filter(IsNotNull(1:Int32))] }
+        └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_types.x, array_types.x, 1:Int32] }
           ├─BatchHashAgg { group_key: [array_types.x], aggs: [] }
           │ └─BatchExchange { order: [], dist: HashShard(array_types.x) }
           │   └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
           └─BatchExchange { order: [], dist: HashShard(array_types.x) }
-            └─BatchProject { exprs: [array_types.x, array_types.x] }
+            └─BatchProject { exprs: [array_types.x, array_types.x, 1:Int32] }
               └─BatchHashAgg { group_key: [array_types.x], aggs: [] }
                 └─BatchExchange { order: [], dist: HashShard(array_types.x) }
                   └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -146,6 +146,30 @@
           │ └─LogicalScan { table: t1, columns: [t1.y] }
           └─LogicalProject { exprs: [t2.y, 1:Int32] }
             └─LogicalScan { table: t2, columns: [t2.y], predicate: IsNotNull(t2.y) }
+- name: 'Like `count(*)`, SimpleAgg also need to rewrite `array_agg` for the extra null row due to outer join #14735'
+  sql: |
+    create table t1(a int, b int);
+    select a, (select array_agg(t1.a) filter (where t1.a is distinct from 1) from t1 where t1.a <> t.b) from t1 as t order by 1;
+  logical_plan: |-
+    LogicalProject { exprs: [t1.a, array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalScan { table: t1, columns: [t1.a, t1.b, t1._row_id] }
+      └─LogicalProject { exprs: [array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
+        └─LogicalAgg { aggs: [array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
+          └─LogicalProject { exprs: [t1.a] }
+            └─LogicalFilter { predicate: (t1.a <> CorrelatedInputRef { index: 1, correlated_id: 1 }) }
+              └─LogicalScan { table: t1, columns: [t1.a, t1.b, t1._row_id] }
+  optimized_logical_plan_for_batch: |-
+    LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.b, t1.b), output: [t1.a, array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
+    ├─LogicalScan { table: t1, columns: [t1.a, t1.b] }
+    └─LogicalAgg { group_key: [t1.b], aggs: [array_agg(t1.a) filter(IsDistinctFrom(t1.a, 1:Int32))] }
+      └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.b, t1.b), output: [t1.b, t1.a] }
+        ├─LogicalAgg { group_key: [t1.b], aggs: [] }
+        │ └─LogicalScan { table: t1, columns: [t1.b] }
+        └─LogicalJoin { type: Inner, on: (t1.a <> t1.b), output: all }
+          ├─LogicalAgg { group_key: [t1.b], aggs: [] }
+          │ └─LogicalScan { table: t1, columns: [t1.b] }
+          └─LogicalScan { table: t1, columns: [t1.a] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);

--- a/src/frontend/src/optimizer/rule/apply_agg_transpose_rule.rs
+++ b/src/frontend/src/optimizer/rule/apply_agg_transpose_rule.rs
@@ -140,9 +140,49 @@ impl Rule for ApplyAggTransposeRule {
                 // convert count(*) to count(1).
                 let pos_of_constant_column = node.schema().len() - 1;
                 agg_calls.iter_mut().for_each(|agg_call| {
-                    if agg_call.agg_kind == AggKind::Count && agg_call.inputs.is_empty() {
-                        let input_ref = InputRef::new(pos_of_constant_column, DataType::Int32);
-                        agg_call.inputs.push(input_ref);
+                    match agg_call.agg_kind {
+                        AggKind::Count if agg_call.inputs.is_empty() => {
+                            let input_ref = InputRef::new(pos_of_constant_column, DataType::Int32);
+                            agg_call.inputs.push(input_ref);
+                        }
+                        AggKind::ArrayAgg
+                        | AggKind::JsonbAgg
+                        | AggKind::JsonbObjectAgg => {
+                            let input_ref = InputRef::new(pos_of_constant_column, DataType::Int32);
+                            let cond = FunctionCall::new(ExprType::IsNotNull, vec![input_ref.into()]).unwrap();
+                            agg_call.filter.conjunctions.push(cond.into());
+                        }
+                        AggKind::Count
+                        | AggKind::Sum
+                        | AggKind::Sum0
+                        | AggKind::Avg
+                        | AggKind::Min
+                        | AggKind::Max
+                        | AggKind::BitAnd
+                        | AggKind::BitOr
+                        | AggKind::BitXor
+                        | AggKind::BoolAnd
+                        | AggKind::BoolOr
+                        | AggKind::StringAgg
+                        // not in PostgreSQL
+                        | AggKind::ApproxCountDistinct
+                        | AggKind::FirstValue
+                        | AggKind::LastValue
+                        | AggKind::InternalLastSeenValue
+                        // All statistical aggregates only consider non-null inputs.
+                        | AggKind::VarPop
+                        | AggKind::VarSamp
+                        | AggKind::StddevPop
+                        | AggKind::StddevSamp
+                        // All ordered-set aggregates ignore null values in their aggregated input.
+                        | AggKind::PercentileCont
+                        | AggKind::PercentileDisc
+                        | AggKind::Mode
+                        // `grouping` has no *aggregate* input and unreachable when `is_scalar_agg`.
+                        | AggKind::Grouping
+                        => {
+                            // no-op when `agg(0 rows) == agg(1 row of nulls)`
+                        }
                     }
                 });
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix one of the problems identified by #14735.

Consider the following case:
```
create table dim(k int, name varchar);
insert into dim values (4, 'A'), (7, 'B'), (9, 'C');
create table fact(k int, v varchar);
insert into fact values (4, 'x'), (4, 'y'), (9, null);

select name, (select count(*) from fact where fact.k = dim.k) from dim;
```

After decorrelation, this will be transformed into a left outer join followed by a group aggregate. It is necessary to preserve the group for `(7, 'B')` with a row of nulls produced by outer join, but `count(*)` is treated specially to return `0` rather than `1`. Similarly when the aggregate is `array_agg(v)` rather than `count(*)`, we want `null` ([NOT](https://www.postgresql.org/docs/16/functions-aggregate.html#:~:text=array_agg%20returns%20null%20rather%20than%20an%20empty%20array%20when%20there%20are%20no%20input%20rows) `{}`) rather than `{null}`.

This is achieved by leveraging the [filter clause](https://www.postgresql.org/docs/16/sql-expressions.html#SYNTAX-AGGREGATES) of aggregate. There is a nonnull constant column before outer join so we can exclude extra nulls produced by outer join based on this column. It remains correct if applied to all aggregates, but we only do it when necessary.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
