### PR TITLE
fix(planner): array-construction subquery shall return `{}` rather than `null`

### DIFF
--- a/e2e_test/batch/subquery/array_construct.slt.part
+++ b/e2e_test/batch/subquery/array_construct.slt.part
@@ -29,3 +29,14 @@ query T
 select array(select unnest from unnest(array['c', 'a', 'b']) with ordinality order by ordinality desc);
 ----
 {b,a,c}
+
+# Test 0 rows.
+query T
+select array_agg(n) from generate_series(1, 5, 2) as t(n) where n > 10;
+----
+NULL
+
+query T
+select array(select n from generate_series(1, 5, 2) as t(n) where n > 10);
+----
+NULL

--- a/e2e_test/batch/subquery/array_construct.slt.part
+++ b/e2e_test/batch/subquery/array_construct.slt.part
@@ -39,4 +39,4 @@ NULL
 query T
 select array(select n from generate_series(1, 5, 2) as t(n) where n > 10);
 ----
-NULL
+{}

--- a/src/frontend/planner_test/tests/testdata/output/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery.yaml
@@ -863,11 +863,12 @@
   batch_plan: |-
     BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
     ├─BatchValues { rows: [[]] }
-    └─BatchSimpleAgg { aggs: [array_agg(1:Int32)] }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchHashAgg { group_key: [1:Int32], aggs: [] }
-          └─BatchExchange { order: [], dist: HashShard(1:Int32) }
-            └─BatchValues { rows: [[1:Int32], [2:Int32]] }
+    └─BatchProject { exprs: [Coalesce(array_agg(1:Int32), ARRAY[]:List(Int32)) as $expr1] }
+      └─BatchSimpleAgg { aggs: [array_agg(1:Int32)] }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchHashAgg { group_key: [1:Int32], aggs: [] }
+            └─BatchExchange { order: [], dist: HashShard(1:Int32) }
+              └─BatchValues { rows: [[1:Int32], [2:Int32]] }
 - name: Only table-in-out functions can have subquery parameters. issue 14734
   sql: |
     SELECT anon_1.f1 AS "IntegerRange(0, -2, 1)" FROM unnest(CASE WHEN (nullif(1, 0) IS NOT NULL AND sign(1) = sign( -2 - 0)) THEN array_remove(array((SELECT generate_series(0,  -2, 1) AS generate_series_1)),  -2) ELSE CAST(ARRAY[] AS SMALLINT[]) END) AS anon_1(f1);

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -967,20 +967,20 @@
     select Array(select c from t2 where b = d) arr from t1;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: LeftOuter, predicate: t1.b = t2.d, output: [array_agg(t2.c)] }
+    └─BatchHashJoin { type: LeftOuter, predicate: t1.b = t2.d, output: [$expr1] }
       ├─BatchExchange { order: [], dist: HashShard(t1.b) }
       │ └─BatchScan { table: t1, columns: [t1.b], distribution: SomeShard }
-      └─BatchProject { exprs: [array_agg(t2.c), t2.d] }
+      └─BatchProject { exprs: [Coalesce(array_agg(t2.c), ARRAY[]:List(Int32)) as $expr1, t2.d] }
         └─BatchHashAgg { group_key: [t2.d], aggs: [array_agg(t2.c)] }
           └─BatchExchange { order: [], dist: HashShard(t2.d) }
             └─BatchScan { table: t2, columns: [t2.c, t2.d], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [arr, t1._row_id(hidden), t1.b(hidden), t2.d(hidden)], stream_key: [t1._row_id, t1.b], pk_columns: [t1._row_id, t1.b], pk_conflict: NoCheck }
     └─StreamExchange { dist: HashShard(t1._row_id, t1.b) }
-      └─StreamHashJoin { type: LeftOuter, predicate: t1.b = t2.d, output: [array_agg(t2.c), t1._row_id, t1.b, t2.d] }
+      └─StreamHashJoin { type: LeftOuter, predicate: t1.b = t2.d, output: [$expr1, t1._row_id, t1.b, t2.d] }
         ├─StreamExchange { dist: HashShard(t1.b) }
         │ └─StreamTableScan { table: t1, columns: [t1.b, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
-        └─StreamProject { exprs: [array_agg(t2.c), t2.d] }
+        └─StreamProject { exprs: [Coalesce(array_agg(t2.c), ARRAY[]:List(Int32)) as $expr1, t2.d] }
           └─StreamHashAgg { group_key: [t2.d], aggs: [array_agg(t2.c), count] }
             └─StreamExchange { dist: HashShard(t2.d) }
               └─StreamTableScan { table: t2, columns: [t2.c, t2.d, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
@@ -1000,13 +1000,13 @@
     ORDER BY 1;
   batch_plan: |-
     BatchExchange { order: [rw_users.name ASC], dist: Single }
-    └─BatchProject { exprs: [rw_users.name, rw_users.is_super, true:Boolean, rw_users.create_user, rw_users.create_db, rw_users.can_login, -1:Int32, null:Timestamptz, array_agg(rw_users.name), true:Boolean, true:Boolean] }
+    └─BatchProject { exprs: [rw_users.name, rw_users.is_super, true:Boolean, rw_users.create_user, rw_users.create_db, rw_users.can_login, -1:Int32, null:Timestamptz, $expr1, true:Boolean, true:Boolean] }
       └─BatchSort { order: [rw_users.name ASC] }
         └─BatchHashJoin { type: LeftOuter, predicate: rw_users.id = null:Int32, output: all }
           ├─BatchExchange { order: [], dist: HashShard(rw_users.id) }
           │ └─BatchFilter { predicate: Not(RegexpEq(rw_users.name, '^pg_':Varchar)) }
           │   └─BatchScan { table: rw_users, columns: [rw_users.id, rw_users.name, rw_users.is_super, rw_users.create_db, rw_users.create_user, rw_users.can_login], distribution: Single }
-          └─BatchProject { exprs: [array_agg(rw_users.name), null:Int32] }
+          └─BatchProject { exprs: [Coalesce(array_agg(rw_users.name), ARRAY[]:List(Varchar)) as $expr1, null:Int32] }
             └─BatchHashAgg { group_key: [null:Int32], aggs: [array_agg(rw_users.name)] }
               └─BatchExchange { order: [], dist: HashShard(null:Int32) }
                 └─BatchHashJoin { type: Inner, predicate: null:Int32 = rw_users.id, output: [rw_users.name, null:Int32] }
@@ -1025,19 +1025,20 @@
     FROM array_types AS t0;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_agg(array_types.x)] }
+    └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [$expr1] }
       ├─BatchExchange { order: [], dist: HashShard(array_types.x) }
       │ └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
-      └─BatchHashAgg { group_key: [array_types.x], aggs: [array_agg(array_types.x)] }
-        └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_types.x, array_types.x] }
-          ├─BatchHashAgg { group_key: [array_types.x], aggs: [] }
-          │ └─BatchExchange { order: [], dist: HashShard(array_types.x) }
-          │   └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
-          └─BatchExchange { order: [], dist: HashShard(array_types.x) }
-            └─BatchProject { exprs: [array_types.x, array_types.x] }
-              └─BatchHashAgg { group_key: [array_types.x], aggs: [] }
-                └─BatchExchange { order: [], dist: HashShard(array_types.x) }
-                  └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
+      └─BatchProject { exprs: [array_types.x, Coalesce(array_agg(array_types.x), ARRAY[]:List(List(Int64))) as $expr1] }
+        └─BatchHashAgg { group_key: [array_types.x], aggs: [array_agg(array_types.x)] }
+          └─BatchHashJoin { type: LeftOuter, predicate: array_types.x IS NOT DISTINCT FROM array_types.x, output: [array_types.x, array_types.x] }
+            ├─BatchHashAgg { group_key: [array_types.x], aggs: [] }
+            │ └─BatchExchange { order: [], dist: HashShard(array_types.x) }
+            │   └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: HashShard(array_types.x) }
+              └─BatchProject { exprs: [array_types.x, array_types.x] }
+                └─BatchHashAgg { group_key: [array_types.x], aggs: [] }
+                  └─BatchExchange { order: [], dist: HashShard(array_types.x) }
+                    └─BatchScan { table: array_types, columns: [array_types.x], distribution: SomeShard }
 - name: a case can't be optimized by PullUpCorrelatedPredicateAggRule
   sql: |
     CREATE TABLE T (A INT, B INT);

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -183,21 +183,22 @@ impl PlanRoot {
     pub fn into_array_agg(self) -> Result<PlanRef> {
         use generic::Agg;
         use plan_node::PlanAggCall;
-        use risingwave_common::types::DataType;
+        use risingwave_common::types::{DataType, ListValue};
         use risingwave_expr::aggregate::AggKind;
 
-        use crate::expr::InputRef;
+        use crate::expr::{ExprImpl, ExprType, FunctionCall, InputRef};
         use crate::utils::{Condition, IndexSet};
 
         let Ok(select_idx) = self.out_fields.ones().exactly_one() else {
             bail!("subquery must return only one column");
         };
         let input_column_type = self.plan.schema().fields()[select_idx].data_type();
-        Ok(Agg::new(
+        let return_type = DataType::List(input_column_type.clone().into());
+        let agg = Agg::new(
             vec![PlanAggCall {
                 agg_kind: AggKind::ArrayAgg,
-                return_type: DataType::List(input_column_type.clone().into()),
-                inputs: vec![InputRef::new(select_idx, input_column_type)],
+                return_type: return_type.clone(),
+                inputs: vec![InputRef::new(select_idx, input_column_type.clone())],
                 distinct: false,
                 order_by: self.required_order.column_orders,
                 filter: Condition::true_cond(),
@@ -205,8 +206,19 @@ impl PlanRoot {
             }],
             IndexSet::empty(),
             self.plan,
-        )
-        .into())
+        );
+        Ok(LogicalProject::create(
+            agg.into(),
+            vec![FunctionCall::new(
+                ExprType::Coalesce,
+                vec![
+                    InputRef::new(0, return_type).into(),
+                    ExprImpl::literal_list(ListValue::empty(&input_column_type), input_column_type),
+                ],
+            )
+            .unwrap()
+            .into()],
+        ))
     }
 
     /// Apply logical optimization to the plan for stream.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix one of the problems identified by #14735.

Previously, we rewrite `array(select ...)` into `(select array_agg(...) ...)`. This is not equivalent when the input is empty, where `array_agg` is expected to return `null` ([doc](https://www.postgresql.org/docs/16/functions-aggregate.html#:~:text=array_agg%20returns%20null%20rather%20than%20an%20empty%20array%20when%20there%20are%20no%20input%20rows)) but `array(select ...)` is expected to return `{}`. So we have to include an extra step to `coalesce` the `null` into an empty list.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
