### PR TITLE
feat(binder): support binding `pg_catalog.text`

### DIFF
--- a/e2e_test/batch/types/pg_catalog.slt.part
+++ b/e2e_test/batch/types/pg_catalog.slt.part
@@ -1,0 +1,47 @@
+statement ok
+create table myy_table (val int);
+
+# Tab-completion for table name
+query TT
+SELECT c.relname,
+       NULL::pg_catalog.text
+FROM pg_catalog.pg_class c
+WHERE c.relkind IN ('r',
+                    'S',
+                    'v',
+                    'm',
+                    'f',
+                    'p')
+  AND (c.relname) LIKE 'myy\_%'
+  AND pg_catalog.pg_table_is_visible(c.oid)
+  AND c.relnamespace <>
+    (SELECT oid
+     FROM pg_catalog.pg_namespace
+     WHERE nspname = 'pg_catalog')
+UNION ALL
+SELECT NULL::pg_catalog.text,
+       n.nspname
+FROM pg_catalog.pg_namespace n
+WHERE n.nspname LIKE 'myy\_%'
+  AND n.nspname NOT LIKE E'pg\\_%'
+----
+myy_table	NULL
+
+# Tab-completion for column name in the given table
+query TT
+SELECT a.attname,
+       NULL::pg_catalog.text
+FROM pg_catalog.pg_attribute a,
+     pg_catalog.pg_class c
+WHERE c.oid = a.attrelid
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+  AND (a.attname) LIKE 'v%'
+  AND c.relname = 'myy_table'
+  AND pg_catalog.pg_table_is_visible(c.oid)
+LIMIT 1000
+----
+val	NULL
+
+statement ok
+drop table myy_table;


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In new version of `psql` client (15+ ?), the query for tab-completing the table name has changed, where table names and schema names now reside in different columns and the other one will be filled with `NULL::pg_catalog.text`.

We are currently unable to bind the `pg_catalog.text` type, which is preventing us from supporting those completions.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
