### PR TITLE
refactor(risedev): deprecate steps for building dashboard

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -352,46 +352,6 @@ alias = "build-risingwave"
 [tasks.build]
 alias = "build-risingwave"
 
-[tasks.extract-dashboard-artifact]
-private = true
-category = "RiseDev - Build"
-description = "Extract dashboard artifact"
-condition = { env_not_set = ["ENABLE_BUILD_DASHBOARD"] }
-script = '''
-#!/usr/bin/env bash
-
-# we allow this script to fail
-
-echo "Extracting dashboard artifacts to ${PREFIX_UI}"
-
-rm -rf "${PREFIX_UI}"
-git worktree prune
-git worktree add "${PREFIX_UI}" origin/dashboard-artifact
-'''
-
-[tasks.export-dashboard]
-private = true
-category = "RiseDev - Build"
-description = "Build dashboard"
-condition = { env_set = [
-  "ENABLE_BUILD_DASHBOARD",
-], files_modified = { input = [
-  "./dashboard/**/*.js",
-  "./dashboard/**/*.ts*",
-  "./dashboard/package.json",
-  "./dashboard/next.config.js",
-], output = [
-  "./dashboard/out/**/*.html",
-] } }
-script = """
-#!/usr/bin/env bash
-set -e
-
-rm -rf "${PREFIX_UI}"
-cd dashboard && npm run build-static
-cd .. && ln -s "$(pwd)/dashboard/out" "${PREFIX_UI}"
-"""
-
 [tasks.build-risingwave]
 category = "RiseDev - Build"
 description = "Build Rust components"
@@ -548,8 +508,6 @@ dependencies = [
   "build-risingwave",
   "build-connector-node",
   "post-build-risingwave",
-  "extract-dashboard-artifact",
-  "export-dashboard",
   "prepare-config",
 ]
 

--- a/ci/scripts/standalone-utils.sh
+++ b/ci/scripts/standalone-utils.sh
@@ -20,8 +20,7 @@ start_standalone_without_compactor() {
         --backend etcd \
         --etcd-endpoints 127.0.0.1:2388 \
         --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 \
-        --data-directory hummock_001 \
-        --dashboard-ui-path $RW_PREFIX/ui" \
+        --data-directory hummock_001" \
      --compute-opts=" \
         --listen-addr 127.0.0.1:5688 \
         --prometheus-listener-addr 127.0.0.1:1222 \
@@ -55,8 +54,7 @@ start_standalone() {
         --backend etcd \
         --etcd-endpoints 127.0.0.1:2388 \
         --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 \
-        --data-directory hummock_001 \
-        --dashboard-ui-path $RW_PREFIX/ui" \
+        --data-directory hummock_001" \
      --compute-opts=" \
         --listen-addr 127.0.0.1:5688 \
         --prometheus-listener-addr 127.0.0.1:1222 \

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -28,44 +28,37 @@ TODO: Find a suitable testing framework
 
 ## Development
 
-Start the RisingWave database, and create tables by removing drop tables from `tpch_snapshot.slt`
+Start a RisingWave cluster, create some tables and materialized views for testing purposes.
+For example:
 
 ```bash
 ./risedev d
-sqllogictest -p 4566 -d dev './e2e_test/streaming/tpch_snapshot.slt'
+sqllogictest -p 4566 -d dev './e2e_test/nexmark/create_tables.slt.part'
+sqllogictest -p 4566 -d dev './e2e_test/streaming/nexmark/create_views.slt.part'
 ```
 
-Install Dependencies.
+Install dependencies and start the development server.
 
 ```bash
 npm i
-```
-
-The website will be served at port 3000. It requests data from the mock server at port 32333.
-
-```bash
 npm run dev
 ```
 
-You should also run:
-
-```bash
-./mock/fetch.sh # dump current data from RisingWave meta node to be used by mock server
-node mock-server.js
-```
-
-To start a mock API server when developing.
+The dashboard is now served at port 3000.
+Go to the Settings page at `http://localhost:3000/settings/` and set the API endpoint to
+`http://localhost:5691/api` in order to connect to the meta node of the running cluster.
 
 ## Test with RisingWave meta node
 
-To replace the built static files in RisingWave with your newest code,
-run the following scripts in the root directory.
+The approach above is the best way to develop the dashboard since it supports hot reload and debugging.
+However, if you still want to test how the dashboard behaves when it's served as static files within the meta node,
+you can ask RiseDev to build the dashboard from the source code by running the following command.
 
 ```bash
-./risedev export-dashboard
+./risedev configure enable dashboard
 ```
 
-The dashboard will be served by meta node at port 5691.
+The dashboard built with the latest sources will be served by meta node at port 5691.
 
 ## Deployment
 
@@ -79,7 +72,7 @@ Build static files for standalone deployment without node.js. The built files ar
 Check more details at [Static HTML Export](https://nextjs.org/docs/advanced-features/static-html-export).
 
 ```bash
-npm run build-static
+npm run build
 ```
 
 The built files are generated at `./out`.

--- a/src/cmd_all/scripts/standalone-demo-full.sh
+++ b/src/cmd_all/scripts/standalone-demo-full.sh
@@ -22,8 +22,7 @@ start_standalone() {
                     --etcd-endpoints 127.0.0.1:2388 \
                     --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 \
                     --data-directory hummock_001 \
-                    --config-path src/config/standalone-example.toml \
-                    --dashboard-ui-path $RW_PREFIX/ui" \
+                    --config-path src/config/standalone-example.toml" \
                  --compute-opts=" \
                     --config-path src/config/standalone-example.toml \
                     --listen-addr 127.0.0.1:5688 \

--- a/src/risedevtool/common.toml
+++ b/src/risedevtool/common.toml
@@ -14,7 +14,6 @@ PREFIX_CONFIG = "${PREFIX}/config"
 PREFIX_DATA = "${PREFIX}/data"
 PREFIX_LOG = "${PREFIX}/log"
 PREFIX_TMP = "${PREFIX}/tmp"
-PREFIX_UI = "${PREFIX}/ui"
 PREFIX_DOCKER = "${PREFIX}/rw-docker"
 PREFIX_PROFILING = "${PREFIX}/profiling"
 

--- a/src/risedevtool/config/src/main.rs
+++ b/src/risedevtool/config/src/main.rs
@@ -68,7 +68,6 @@ pub enum Components {
     Tracing,
     RustComponents,
     BuildConnectorNode,
-    Dashboard,
     Release,
     Sanitizer,
     DynamicLinking,
@@ -88,7 +87,6 @@ impl Components {
             Self::Redis => "[Component] Redis",
             Self::BuildConnectorNode => "[Build] Build RisingWave Connector (Java)",
             Self::RustComponents => "[Build] Rust components",
-            Self::Dashboard => "[Build] Dashboard",
             Self::Tracing => "[Component] Tracing: Grafana Tempo",
             Self::Release => "[Build] Enable release mode",
             Self::Sanitizer => "[Build] Enable sanitizer",
@@ -133,10 +131,6 @@ Required if you want to create source from Emulated Google Pub/sub.
 Required if you want to build compute-node and meta-node.
 Otherwise you will need to manually download and copy it
 to RiseDev directory."
-            }
-            Self::Dashboard => {
-                "
-Required if you want to build dashboard from source."
             }
             Self::Tracing => {
                 "
@@ -200,7 +194,6 @@ As a result, RisingWave will dump the core on panics.
             "ENABLE_KAFKA" => Some(Self::Kafka),
             "ENABLE_PUBSUB" => Some(Self::Pubsub),
             "ENABLE_BUILD_RUST" => Some(Self::RustComponents),
-            "ENABLE_BUILD_DASHBOARD" => Some(Self::Dashboard),
             "ENABLE_COMPUTE_TRACING" => Some(Self::Tracing),
             "ENABLE_RELEASE_PROFILE" => Some(Self::Release),
             "ENABLE_DYNAMIC_LINKING" => Some(Self::DynamicLinking),
@@ -222,7 +215,6 @@ As a result, RisingWave will dump the core on panics.
             Self::Pubsub => "ENABLE_PUBSUB",
             Self::Redis => "ENABLE_REDIS",
             Self::RustComponents => "ENABLE_BUILD_RUST",
-            Self::Dashboard => "ENABLE_BUILD_DASHBOARD",
             Self::Tracing => "ENABLE_COMPUTE_TRACING",
             Self::Release => "ENABLE_RELEASE_PROFILE",
             Self::Sanitizer => "ENABLE_SANITIZER",

--- a/src/risedevtool/config/src/main.rs
+++ b/src/risedevtool/config/src/main.rs
@@ -68,6 +68,7 @@ pub enum Components {
     Tracing,
     RustComponents,
     BuildConnectorNode,
+    Dashboard,
     Release,
     Sanitizer,
     DynamicLinking,
@@ -87,6 +88,7 @@ impl Components {
             Self::Redis => "[Component] Redis",
             Self::BuildConnectorNode => "[Build] Build RisingWave Connector (Java)",
             Self::RustComponents => "[Build] Rust components",
+            Self::Dashboard => "[Build] Dashboard",
             Self::Tracing => "[Component] Tracing: Grafana Tempo",
             Self::Release => "[Build] Enable release mode",
             Self::Sanitizer => "[Build] Enable sanitizer",
@@ -131,6 +133,15 @@ Required if you want to create source from Emulated Google Pub/sub.
 Required if you want to build compute-node and meta-node.
 Otherwise you will need to manually download and copy it
 to RiseDev directory."
+            }
+            Self::Dashboard => {
+                "
+Required if you want to build dashboard from source.
+This is generally not the option you want to use to develop the
+dashboard. Instead, directly run `npm run dev` in the dashboard
+directory to start the development server, set the API endpoint
+to a running RisingWave cluster in the settings page.
+"
             }
             Self::Tracing => {
                 "
@@ -194,6 +205,7 @@ As a result, RisingWave will dump the core on panics.
             "ENABLE_KAFKA" => Some(Self::Kafka),
             "ENABLE_PUBSUB" => Some(Self::Pubsub),
             "ENABLE_BUILD_RUST" => Some(Self::RustComponents),
+            "ENABLE_BUILD_DASHBOARD" => Some(Self::Dashboard),
             "ENABLE_COMPUTE_TRACING" => Some(Self::Tracing),
             "ENABLE_RELEASE_PROFILE" => Some(Self::Release),
             "ENABLE_DYNAMIC_LINKING" => Some(Self::DynamicLinking),
@@ -215,6 +227,7 @@ As a result, RisingWave will dump the core on panics.
             Self::Pubsub => "ENABLE_PUBSUB",
             Self::Redis => "ENABLE_REDIS",
             Self::RustComponents => "ENABLE_BUILD_RUST",
+            Self::Dashboard => "ENABLE_BUILD_DASHBOARD",
             Self::Tracing => "ENABLE_COMPUTE_TRACING",
             Self::Release => "ENABLE_RELEASE_PROFILE",
             Self::Sanitizer => "ENABLE_SANITIZER",

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -196,9 +196,6 @@ impl Task for MetaNodeService {
         cmd.arg("--config-path")
             .arg(Path::new(&prefix_config).join("risingwave.toml"));
 
-        cmd.arg("--dashboard-ui-path")
-            .arg(env::var("PREFIX_UI").unwrap_or_else(|_| ".risingwave/ui".to_owned()));
-
         if !self.config.user_managed {
             ctx.run_command(ctx.tmux_run(cmd)?)?;
             ctx.pb.set_message("started");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See https://github.com/risingwavelabs/risingwave/issues/15280#issuecomment-1993795653 for the background. This is a preparation for #15656.

Assets will be embedded into the binary and built with Rust build script, so there'll be no step for manually build them.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
