### PR TITLE
fix(expr): handle invalid local time during daylight saving forward

### DIFF
--- a/e2e_test/batch/functions/at_time_zone.slt.part
+++ b/e2e_test/batch/functions/at_time_zone.slt.part
@@ -10,11 +10,13 @@ select '2021-12-31 16:00:00'::timestamp AT TIME ZONE 'us/pacific';
 ----
 2022-01-01 00:00:00+00:00
 
-# Unlike PostgreSQL, we do not support invalid local time during daylight saving forward yet.
-statement error
+# invalid local time during daylight saving forward are interpreted as before the transition.
+query T
 select '2022-03-13 02:00:00'::timestamp AT TIME ZONE 'us/pacific';
+----
+2022-03-13 10:00:00+00:00
 
-# Like PostgreSQL, ambiguous local time during daylight saving backward are interpreted as after the transition.
+# ambiguous local time during daylight saving backward are interpreted as after the transition.
 query T
 select '2022-11-06 01:00:00'::timestamp AT TIME ZONE 'us/pacific';
 ----


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Recently US timezone started Daylight Saving Time since 2024-03-10 02:00. RisingWave could not correctly convert timestamps to local time during 2024-03-10 02:00-03:00.

```sql
dev=> select '2024-03-10 02:00'::timestamp AT TIME ZONE 'us/pacific';
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: Expr error
  2: Invalid parameter local timestamp: fail to interpret local timestamp "2024-03-10 02:00:00" in time zone "US/Pacific"
```

This PR fixes this error and makes its behavior consistent with postgres.

```sql
dev=> select '2024-03-10 02:00'::timestamp AT TIME ZONE 'us/pacific';
         ?column?          
---------------------------
 2024-03-10 10:00:00+00:00
(1 row)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
