### PR TITLE
feat: throw an error if unable to find downstream actor index during the scaling process.

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -1837,7 +1837,7 @@ impl ScaleController {
                     for actor in &fragment.actors {
                         let prev =
                             actor_fragment_id_map_for_check.insert(actor.actor_id, *fragment_id);
-                        
+
                         debug_assert!(prev.is_none());
                     }
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

~Under the latest table resize policy, there are occasional instances of not being able to find downstream actor information from the dispatcher.~

~During the resize process, it is necessary to build an actor index. However, a peculiar phenomenon was observed during the organization of the no-shuffle dependency.~

~Theoretically, the table fragments obtained by the fragment manager should contain all actor information. However, while traversing each actor's dispatcher, there are occasional incidents where the downstream actor id corresponding actor cannot be found, hence existing a ghost actor.~

~At present, this problem has only occurred a few times and is difficult to reproduce. Therefore, this PR has changed the warning here to throw an error and directly return. The expected impacts will be on the auto scale and alter parallelism statements.~

It looks like we've found the reason; it's due to a bizarre debug_assert. Let's deal with this assert, and then just return directly if we encounter any problems (to continue with the functionality of this PR).

## Checklist


- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


