### PR TITLE
refactor(storage): normalize error message

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -28,7 +28,7 @@ pub enum ErrorKind {
         HummockError,
     ),
 
-    #[error("Deserialize row error {0}.")]
+    #[error("Deserialize row error: {0}")]
     DeserializeRow(
         #[from]
         #[backtrace]

--- a/src/storage/src/hummock/error.rs
+++ b/src/storage/src/hummock/error.rs
@@ -21,47 +21,47 @@ use tokio::sync::oneshot::error::RecvError;
 #[derive(Error, Debug, thiserror_ext::Box)]
 #[thiserror_ext(newtype(name = HummockError, backtrace, report_debug))]
 pub enum HummockErrorInner {
-    #[error("Magic number mismatch: expected {expected}, found: {found}.")]
+    #[error("Magic number mismatch: expected {expected}, found: {found}")]
     MagicMismatch { expected: u32, found: u32 },
-    #[error("Invalid format version: {0}.")]
+    #[error("Invalid format version: {0}")]
     InvalidFormatVersion(u32),
-    #[error("Checksum mismatch: expected {expected}, found: {found}.")]
+    #[error("Checksum mismatch: expected {expected}, found: {found}")]
     ChecksumMismatch { expected: u64, found: u64 },
-    #[error("Invalid block.")]
+    #[error("Invalid block")]
     InvalidBlock,
-    #[error("Encode error {0}.")]
+    #[error("Encode error: {0}")]
     EncodeError(String),
-    #[error("Decode error {0}.")]
+    #[error("Decode error: {0}")]
     DecodeError(String),
-    #[error("ObjectStore failed with IO error {0}.")]
+    #[error("ObjectStore failed with IO error: {0}")]
     ObjectIoError(
         #[from]
         #[backtrace]
         ObjectError,
     ),
-    #[error("Meta error {0}.")]
+    #[error("Meta error: {0}")]
     MetaError(String),
-    #[error("SharedBuffer error {0}.")]
+    #[error("SharedBuffer error: {0}")]
     SharedBufferError(String),
-    #[error("Wait epoch error {0}.")]
+    #[error("Wait epoch error: {0}")]
     WaitEpoch(String),
-    #[error("Barrier read is unavailable for now. Likely the cluster is recovering.")]
+    #[error("Barrier read is unavailable for now. Likely the cluster is recovering")]
     ReadCurrentEpoch,
-    #[error("Expired Epoch: watermark {safe_epoch}, epoch {epoch}.")]
+    #[error("Expired Epoch: watermark {safe_epoch}, epoch {epoch}")]
     ExpiredEpoch { safe_epoch: u64, epoch: u64 },
-    #[error("CompactionExecutor error {0}.")]
+    #[error("CompactionExecutor error: {0}")]
     CompactionExecutor(String),
-    #[error("FileCache error {0}.")]
+    #[error("FileCache error: {0}")]
     FileCache(String),
-    #[error("SstObjectIdTracker error {0}.")]
+    #[error("SstObjectIdTracker error: {0}")]
     SstObjectIdTrackerError(String),
-    #[error("CompactionGroup error {0}.")]
+    #[error("CompactionGroup error: {0}")]
     CompactionGroupError(String),
-    #[error("SstableUpload error {0}.")]
+    #[error("SstableUpload error: {0}")]
     SstableUploadError(String),
-    #[error("Read backup error {0}.")]
+    #[error("Read backup error: {0}")]
     ReadBackupError(String),
-    #[error("Other error {0}.")]
+    #[error("Other error: {0}")]
     Other(String),
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Normalize the error message from `storage` crate to make `thiserror_ext::Report` works better with that.

When formatting the source chain of an error with `thiserror_ext::Report`, the `source` part will be trimmed if it's a suffix of the message of its parent. This requires us to avoid adding any trailing characters like `.` in the message.

```diff
- ObjectStore failed with IO error Internal error: read timeout.: Internal error: read timeout
+ ObjectStore failed with IO error: Internal error: read timeout
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
