### PR TITLE
feat(stream): introduce "insane" mode to generate inconsistent data on the stream

### DIFF
--- a/src/common/src/field_generator/varchar.rs
+++ b/src/common/src/field_generator/varchar.rs
@@ -32,8 +32,10 @@ impl VarcharRandomVariableLengthField {
     }
 
     pub fn generate_string(&mut self, offset: u64) -> String {
+        let len = rand::thread_rng().gen_range(0..=DEFAULT_LENGTH * 2);
         StdRng::seed_from_u64(offset ^ self.seed)
             .sample_iter(&Alphanumeric)
+            .take(len)
             .map(char::from)
             .collect()
     }

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -79,11 +79,8 @@ const WATERMARK_CACHE_ENTRIES: usize = 16;
 type DefaultWatermarkBufferStrategy = WatermarkBufferByEpoch<STATE_CLEANING_PERIOD_EPOCH>;
 
 fn insane_random_drop() -> bool {
-    const INSANE_RANDOM_DROP_PROB: f64 = 0.4;
-
     use rand::Rng;
-    let mut rng = rand::thread_rng();
-    rng.gen_bool(INSANE_RANDOM_DROP_PROB)
+    rand::thread_rng().gen_bool(0.3)
 }
 
 /// `StateTableInner` is the interface accessing relational data in KV(`StateStore`) with

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -93,6 +93,7 @@ mod subscription;
 pub mod subtask;
 mod temporal_join;
 mod top_n;
+mod troublemaker;
 mod union;
 mod values;
 mod watermark;
@@ -145,6 +146,7 @@ pub use temporal_join::*;
 pub use top_n::{
     AppendOnlyGroupTopNExecutor, AppendOnlyTopNExecutor, GroupTopNExecutor, TopNExecutor,
 };
+pub use troublemaker::TroublemakerExecutor;
 pub use union::UnionExecutor;
 pub use utils::DummyExecutor;
 pub use values::ValuesExecutor;

--- a/src/stream/src/executor/troublemaker.rs
+++ b/src/stream/src/executor/troublemaker.rs
@@ -126,7 +126,10 @@ impl TroublemakerExecutor {
         record: Record<impl Row>,
     ) -> SmallVec<[(Op, OwnedRow); 2]> {
         let record = if vars.met_delete_before && rand::thread_rng().gen_bool(0.5) {
-            // Change the `Op`
+            // Change the `Op`.
+            // Because we don't know the `append_only` property of the stream, we can't
+            // generate `Delete` arbitrarily. So we just generate `Delete` after we saw
+            // `Delete` or `Update` before.
             match record {
                 Record::Insert { new_row } => Record::Delete {
                     old_row: new_row.into_owned_row(),
@@ -140,7 +143,7 @@ impl TroublemakerExecutor {
                 },
             }
         } else {
-            // Just convert the rows to owned rows, without changing the `Op`
+            // Just convert the rows to owned rows, without changing the `Op`.
             match record {
                 Record::Insert { new_row } => Record::Insert {
                     new_row: new_row.into_owned_row(),

--- a/src/stream/src/executor/troublemaker.rs
+++ b/src/stream/src/executor/troublemaker.rs
@@ -24,7 +24,7 @@ use risingwave_common::util::iter_util::ZipEqFast;
 
 use super::{BoxedMessageStream, Execute, Executor, Message, StreamExecutorError};
 
-/// TroublemakerExecutor is used to make some trouble in the stream graph. Specifically,
+/// [`TroublemakerExecutor`] is used to make some trouble in the stream graph. Specifically,
 /// it is attached to `StreamScan` and `Source` executors in **insane mode**. It randomly
 /// corrupts the stream chunks it receives and sends them downstream, making the stream
 /// inconsistent. This should ONLY BE USED IN INSANE MODE FOR TESTING PURPOSES.
@@ -48,6 +48,7 @@ impl TroublemakerExecutor {
             crate::consistency::insane(),
             "we should only make trouble in insane mode"
         );
+        tracing::info!("we got a troublemaker");
         Self {
             input,
             inner: Inner { chunk_size },
@@ -151,14 +152,14 @@ fn randomize_row(data_types: &[DataType], row: OwnedRow) -> OwnedRow {
     let mut data = row.into_inner();
 
     for (datum, data_type) in data.iter_mut().zip_eq_fast(data_types) {
-        match rand::thread_rng().gen_range(0..3) {
-            0 => {
+        match rand::thread_rng().gen_range(0..4) {
+            0 | 1 => {
                 // don't change the value
             }
-            1 => {
+            2 => {
                 *datum = None;
             }
-            2 => {
+            3 => {
                 *datum = match data_type {
                     DataType::Boolean => Some(ScalarImpl::Bool(rand::random())),
                     DataType::Int16 => Some(ScalarImpl::Int16(rand::random())),

--- a/src/stream/src/executor/troublemaker.rs
+++ b/src/stream/src/executor/troublemaker.rs
@@ -1,0 +1,69 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use futures::StreamExt;
+use futures_async_stream::try_stream;
+use risingwave_common::array::Op;
+
+use super::{BoxedMessageStream, Execute, Executor, Message, StreamExecutorError};
+
+/// TroublemakerExecutor is used to make some trouble in the stream graph. Specifically,
+/// it is attached to `StreamScan` and `Source` executors in **insane mode**. It randomly
+/// corrupts the stream chunks it receives and sends them downstream, making the stream
+/// inconsistent. This should ONLY BE USED IN INSANE MODE FOR TESTING PURPOSES.
+pub struct TroublemakerExecutor {
+    input: Executor,
+}
+
+struct ExecutionVars {
+    // TODO()
+}
+
+impl TroublemakerExecutor {
+    pub fn new(input: Executor) -> Self {
+        assert!(
+            crate::consistency::insane(),
+            "we should only make trouble in insane mode"
+        );
+        Self { input }
+    }
+
+    #[try_stream(ok = Message, error = StreamExecutorError)]
+    async fn execute_inner(self) {
+        let mut vars = ExecutionVars {};
+
+        #[for_await]
+        for msg in self.input.execute() {
+            let msg = msg?;
+            match msg {
+                Message::Chunk(chunk) => {
+                    // TODO(): make some trouble
+                    yield Message::Chunk(chunk);
+                }
+                Message::Barrier(barrier) => {
+                    yield Message::Barrier(barrier);
+                }
+                _ => yield msg,
+            }
+        }
+    }
+}
+
+impl Execute for TroublemakerExecutor {
+    fn execute(self: Box<Self>) -> BoxedMessageStream {
+        self.execute_inner().boxed()
+    }
+}

--- a/src/stream/src/from_proto/mview.rs
+++ b/src/stream/src/from_proto/mview.rs
@@ -116,6 +116,6 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
         )
         .await;
 
-        Ok((params.info, exec.boxed()).into())
+        Ok((params.info, exec).into())
     }
 }

--- a/src/stream/src/from_proto/source/trad_source.rs
+++ b/src/stream/src/from_proto/source/trad_source.rs
@@ -38,7 +38,7 @@ use super::*;
 use crate::executor::source::{FsListExecutor, StreamSourceCore};
 use crate::executor::source_executor::SourceExecutor;
 use crate::executor::state_table_handler::SourceStateTableHandler;
-use crate::executor::FlowControlExecutor;
+use crate::executor::{FlowControlExecutor, TroublemakerExecutor};
 
 const FS_CONNECTORS: &[&str] = &["s3"];
 pub struct SourceExecutorBuilder;
@@ -252,7 +252,14 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             let rate_limit = source.rate_limit.map(|x| x as _);
             let exec =
                 FlowControlExecutor::new((info, exec).into(), params.actor_context, rate_limit);
-            Ok((params.info, exec).into())
+
+            if crate::consistency::insane() {
+                let mut info = params.info.clone();
+                info.identity = format!("{} (troubled)", info.identity);
+                Ok((params.info, TroublemakerExecutor::new((info, exec).into())).into())
+            } else {
+                Ok((params.info, exec).into())
+            }
         } else {
             // If there is no external stream source, then no data should be persisted. We pass a
             // `PanicStateStore` type here for indication.

--- a/src/stream/src/from_proto/source/trad_source.rs
+++ b/src/stream/src/from_proto/source/trad_source.rs
@@ -256,7 +256,14 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             if crate::consistency::insane() {
                 let mut info = params.info.clone();
                 info.identity = format!("{} (troubled)", info.identity);
-                Ok((params.info, TroublemakerExecutor::new((info, exec).into())).into())
+                Ok((
+                    params.info,
+                    TroublemakerExecutor::new(
+                        (info, exec).into(),
+                        params.env.config().developer.chunk_size,
+                    ),
+                )
+                    .into())
             } else {
                 Ok((params.info, exec).into())
             }

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -157,7 +157,14 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
         if crate::consistency::insane() {
             let mut info = params.info.clone();
             info.identity = format!("{} (troubled)", info.identity);
-            Ok((params.info, TroublemakerExecutor::new((info, exec).into())).into())
+            Ok((
+                params.info,
+                TroublemakerExecutor::new(
+                    (info, exec).into(),
+                    params.env.config().developer.chunk_size,
+                ),
+            )
+                .into())
         } else {
             Ok((params.info, exec).into())
         }

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -54,3 +54,15 @@ pub mod task;
 
 #[cfg(test)]
 risingwave_expr_impl::enable!();
+
+mod consistency {
+    use std::sync::LazyLock;
+
+    use risingwave_common::util::env_var::env_var_is_true;
+
+    static INSANE_MODE: LazyLock<bool> = LazyLock::new(|| env_var_is_true("RW_ENABLE_INSANE_MODE"));
+
+    pub fn insane() -> bool {
+        *INSANE_MODE
+    }
+}

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -56,6 +56,8 @@ pub mod task;
 risingwave_expr_impl::enable!();
 
 mod consistency {
+    //! This module contains global variables and methods to access the stream consistency settings.
+
     use std::sync::LazyLock;
 
     use risingwave_common::util::env_var::env_var_is_true;

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -62,7 +62,8 @@ mod consistency {
 
     use risingwave_common::util::env_var::env_var_is_true;
 
-    static INSANE_MODE: LazyLock<bool> = LazyLock::new(|| env_var_is_true("RW_ENABLE_INSANE_MODE"));
+    static INSANE_MODE: LazyLock<bool> =
+        LazyLock::new(|| env_var_is_true("RW_UNSAFE_ENABLE_INSANE_MODE"));
 
     pub fn insane() -> bool {
         *INSANE_MODE


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

RFC: https://www.notion.so/risingwave-labs/RFC-Tolerate-Inconsistency-in-Stream-f6233f46da2c458f9f03b415b9d82cc1?pvs=4

This PR introduces "insane" mode to produce inconsistent stream on `StreamScan` and `Source`. This mode can be turned on by setting env var `RW_UNSAFE_ENABLE_INSANE_MODE=true`. The purpose is to help locate panic points in executors that will panic when facing inconsistent stream.

When "insane" mode is enabled, a `TroublemakerExecutor` will be attached right behind each `StreamScan` and `Source`. The "troublemaker" will randomly change the `Op` and row data in stream chunks pass through it.

State tables will randomly discard operations applied on them when "insane" mode is enabled.

We may setup a scheduled CI pipeline to run our longevity test (and/or possibly other tests) with "insane" mode enabled, so that we can test our robustness on inconsistent data stream.

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
