### PR TITLE
chore: bump mimimal glibc version to 2.28 for linux binary release

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -122,23 +122,23 @@ services:
       - ..:/risingwave
 
   release-env-x86:
-    # build binaries on a earlier Linux distribution (therefore with earlier version GLIBC)
-    # See https://github.com/risingwavelabs/risingwave/issues/4556 for more details.
+    # Build binaries on a earlier Linux distribution (therefore with earlier version GLIBC)
+    # `manylinux_2_28` is based on AlmaLinux 8 with GLIBC 2.28.
     #
     # GLIBC versions on some systems:
-    # Amazon Linux 2: 2.26 (EOL 2025-06-30) (We will definitely want to support this)
-    # AL2023: 2.34
-    # Ubuntu 18.04: 2.27 (Already EOL 2023-05-31)
-    # Ubuntu 20.04: 2.31
+    # - Amazon Linux 2023 (AL2023): 2.34
+    # - Ubuntu 20.04: 2.31
     #
-    # manylinux2014: CentOS 7 (EOL 2024-06-30), GLIBC 2.17
-    image: quay.io/pypa/manylinux2014_x86_64
+    # Systems that we don't provide support for:
+    # - Ubuntu 18.04: 2.27 (Already EOL 2023-05-31)
+    # - Amazon Linux 2: 2.26 (Originally EOL 2023-06-30, superseded by AL2023)
+    image: quay.io/pypa/manylinux_2_28_x86_64
     working_dir: /mnt
     volumes:
       - ..:/mnt
 
   release-env-arm:
-    image: quay.io/pypa/manylinux2014_aarch64
+    image: quay.io/pypa/manylinux_2_28_aarch64
     working_dir: /mnt
     volumes:
       - ..:/mnt

--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -16,18 +16,14 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zi
 unzip -q awscliv2.zip && ./aws/install && mv /usr/local/bin/aws /bin/aws
 
 echo "--- Install lld"
-# The lld in the CentOS 7 repository is too old and contains a bug that causes a linker error.
-# So we install a newer version here. (17.0.6, latest version at the time of writing)
-# It is manually built in the same environent and uploaded to S3.
-aws s3 cp s3://rw-ci-deps-dist/llvm-lld-manylinux2014_${ARCH}.tar.gz .
-tar -zxvf llvm-lld-manylinux2014_${ARCH}.tar.gz --directory=/usr/local
+dnf install -y lld
 ld.lld --version
 
 echo "--- Install dependencies for openssl"
-yum install -y perl-core
+dnf install -y perl-core
 
 echo "--- Install java and maven"
-yum install -y java-11-openjdk java-11-openjdk-devel wget python3 python3-devel cyrus-sasl-devel
+dnf install -y java-11-openjdk java-11-openjdk-devel wget python3 python3-devel cyrus-sasl-devel
 pip3 install toml-cli
 wget https://rw-ci-deps-dist.s3.amazonaws.com/apache-maven-3.9.3-bin.tar.gz && tar -zxvf apache-maven-3.9.3-bin.tar.gz
 export PATH="${REPO_ROOT}/apache-maven-3.9.3/bin:$PATH"
@@ -91,7 +87,6 @@ if [[ -n "${BUILDKITE_TAG}" ]]; then
   ls -l
 
   echo "--- Install gh cli"
-  yum install -y dnf
   dnf install -y 'dnf-command(config-manager)'
   dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
   dnf install -y gh
@@ -123,7 +118,3 @@ if [[ -n "${BUILDKITE_TAG}" ]]; then
   tar -czvf risingwave-"${BUILDKITE_TAG}"-${ARCH}-unknown-linux-all-in-one.tar.gz risingwave libs
   gh release upload "${BUILDKITE_TAG}" risingwave-"${BUILDKITE_TAG}"-${ARCH}-unknown-linux-all-in-one.tar.gz
 fi
-
-
-
-


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In #4556, we switched to the `manylinux2014` Linux distro to ensure that the released artifact can run on systems with GLIBC versions as old as 2.17. However, this is becoming troublesome as the toolchain is also affected as described in #15749.

After some consideration and discussion with @xxchan, I think it's the time to bump the minimal GLIBC version to 2.28. Reasons:

- Originally, Amazon Linux 2 with GLIBC 2.26 was set to reach its EOL in June 2023 but was later postponed to June 2025. However, the default image used for launching a new EC2 instance is now Amazon Linux 2023, which has GLIBC 2.34. So problems similar to #4566 is unlikely to happen anymore.

- The Linux binary release is not designed to use in production. For the cases that users want to play around with RisingWave (e.g. standalone mode) on their own Linux machines, I believe it's okay to assume they're on a relatively new system.

See the comments on `release-env-x86` to find the updated reference of GLIBC version.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
