### PR TITLE
perf(storage): add foyer memory cache to block cache bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b0a4ca5d917e684c9267e8e2bcec4b3e0c27dd91c84945c20c09ddff906cac"
+checksum = "b5c17111344df2de260140472855e2d84e0e8e3bffd4faed840f12f6de6f23da"
 dependencies = [
  "ahash 0.8.6",
  "bitflags 2.4.2",
@@ -8243,7 +8243,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -113,7 +113,7 @@ harness = false
 # debug = true
 
 [[bench]]
-name = "bench_lru_cache"
+name = "bench_block_cache"
 harness = false
 
 [[bench]]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title.

Results:

```
> RUST_BACKTRACE=1 cargo bench -p risingwave_storage --bench bench_block_cache
    Finished bench [optimized + debuginfo] target(s) in 0.55s
     Running benches/bench_block_cache.rs (target/release/deps/bench_block_cache-5eef57be0565b6eb)
Gnuplot not found, using plotters backend
10000 keys cost time: [58.7025ms, 73.819638ms, 74.843664ms, 61.132846ms, 64.005928ms, 69.41919ms, 70.693193ms, 57.888342ms,
io count: 0
block-cache             time:   [22.031 µs 22.049 µs 22.073 µs]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

10000 keys cost time: [50.792286ms, 46.903693ms, 47.226715ms, 50.607702ms, 46.449778ms, 46.399804ms, 45.893722ms, 50.976257ms,
io count: 0
block-cache #2          time:   [8.6459 µs 8.6478 µs 8.6499 µs]

10000 keys cost time: [60.269569ms, 60.575607ms, 59.280615ms, 52.836382ms, 59.54085ms, 54.07ms, 57.124789ms, 59.908013ms,
io count: 0
block-cache #3          time:   [7.0618 µs 7.0630 µs 7.0643 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild

10000 keys cost time: [55.86885ms, 54.532482ms, 58.668835ms, 58.109284ms, 55.574371ms, 50.146272ms, 50.254223ms, 50.77413ms,
io count: 0
block-cache #4          time:   [7.9698 µs 7.9759 µs 7.9819 µs]

1000 keys cost time: [823.044232ms, 844.510906ms, 832.768917ms, 829.529823ms, 841.321556ms, 847.696299ms, 814.428445ms, 841.305887ms,
io count: 6208
block-cache #5          time:   [2.3033 µs 2.3068 µs 2.3103 µs]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

1000 keys cost time: [828.349395ms, 850.726316ms, 844.350821ms, 843.280135ms, 827.273883ms, 856.026387ms, 825.134058ms, 835.81912ms,
io count: 6280
block-cache #6          time:   [828.11 ns 830.28 ns 832.78 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

1000 keys cost time: [824.098319ms, 851.633185ms, 833.64442ms, 844.229745ms, 823.012738ms, 847.406902ms, 825.143497ms, 833.631626ms,
io count: 6279
block-cache #7          time:   [678.28 ns 678.41 ns 678.54 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

1000 keys cost time: [828.614085ms, 860.369551ms, 824.355683ms, 850.866111ms, 821.140935ms, 854.039891ms, 820.071272ms, 824.339333ms,
io count: 6284
block-cache #8          time:   [776.20 ns 776.31 ns 776.42 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild

200 keys cost time: [173.489694ms, 187.480503ms, 182.162598ms, 179.990934ms, 183.224858ms, 181.060235ms, 181.046109ms, 188.559834ms,
io count: 1340
block-cache #9          time:   [484.05 ns 485.54 ns 487.15 ns]
Found 17 outliers among 100 measurements (17.00%)
  15 (15.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe

200 keys cost time: [176.684805ms, 180.944828ms, 179.884333ms, 178.823267ms, 182.008921ms, 175.595335ms, 183.065379ms, 191.512653ms,
io count: 1355
block-cache #10         time:   [206.28 ns 206.83 ns 207.53 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

200 keys cost time: [176.761467ms, 184.224566ms, 184.239785ms, 176.748973ms, 175.67899ms, 176.745607ms, 183.156908ms, 188.452373ms,
io count: 1354
block-cache #11         time:   [198.02 ns 198.14 ns 198.26 ns]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild

200 keys cost time: [174.339204ms, 179.658682ms, 182.88947ms, 181.820738ms, 180.742941ms, 176.444756ms, 184.988469ms, 189.217416ms,
io count: 1352
block-cache #12         time:   [211.86 ns 212.20 ns 212.61 ns]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
