### PR TITLE
fix(meta): avoid reschedule deadlock with `drop` / `cancel` stream job

### DIFF
--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -665,7 +665,9 @@ impl GlobalBarrierManagerContext {
     }
 
     async fn scale_actors(&self, all_nodes: Vec<WorkerNode>) -> MetaResult<()> {
-        let _guard = self.scale_controller.reschedule_lock.write().await;
+        let Ok(_guard) = self.scale_controller.reschedule_lock.try_write() else {
+            return Err(anyhow!("scale_actors failed to acquire reschedule_lock").into());
+        };
         match &self.metadata_manager {
             MetadataManager::V1(_) => self.scale_actors_v1(all_nodes).await,
             MetadataManager::V2(_) => self.scale_actors_v2(all_nodes).await,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Thanks to @yezizp2012 for proposing and discussing this solution.

Close #15296 

<img width="815" alt="Screenshot 2024-03-26 at 11 26 02 AM" src="https://github.com/risingwavelabs/risingwave/assets/47273164/cef29f9c-95d3-4baf-9e4b-4a79652d5753">

The issue occurs because drop statement is executed while recovery is in progress.
Then:
1. Recovery cannot proceed because it cannot acquire the reschedule lock.
2. Drop cannot proceed because it waits for recovery of barrier manager.

Solution:
1. To resolve this deadlock, we let the recovery fail its current loop.
2. At this point, the drop command has already queued the `DropStreamingJob` command.
3. In the next recovery loop, we have the `pre_apply_drop_cancel` which occurs before the `scale_actors` step.
4. The queued drop command will immediately execute through this fast path.
5. Then, the drop command will succeed and release the reschedule lock.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
