### PR TITLE
fix(frontend): only use arrangement backfill for non-singleton upstream

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -140,7 +140,7 @@ pub struct ConfigMap {
     streaming_enable_bushy_join: bool,
 
     /// Enable arrangement backfill for streaming queries. Defaults to false.
-    #[parameter(default = false)]
+    #[parameter(default = true)]
     streaming_use_arrangement_backfill: bool,
 
     /// Allow `jsonb` in stream key

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -140,7 +140,7 @@ pub struct ConfigMap {
     streaming_enable_bushy_join: bool,
 
     /// Enable arrangement backfill for streaming queries. Defaults to false.
-    #[parameter(default = true)]
+    #[parameter(default = false)]
     streaming_use_arrangement_backfill: bool,
 
     /// Allow `jsonb` in stream key

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -67,6 +67,13 @@ impl StreamTableScan {
                 None => Distribution::SomeShard,
             }
         };
+        // For single distribution, we can't use arrangement backfill.
+        let stream_scan_type = match stream_scan_type {
+            StreamScanType::ArrangementBackfill if distribution == Distribution::Single => {
+                StreamScanType::Backfill
+            }
+            _ => stream_scan_type,
+        };
 
         let base = PlanBase::new_stream_with_core(
             &core,

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -332,7 +332,7 @@ where
 
         // Upstream must have dist_key_in_pk_indices, otherwise that means it is singleton distribution,
         // and it should use `no_shuffle_backfill` instead.
-        if IS_REPLICATED {
+        if IS_REPLICATED && is_consistent_op {
             assert!(!dist_key_in_pk_indices.is_empty());
         }
         let distribution =

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -330,6 +330,11 @@ where
             pk_indices.iter().position(|&i| vnode_col_idx == i)
         });
 
+        // Upstream must have dist_key_in_pk_indices, otherwise that means it is singleton distribution,
+        // and it should use `no_shuffle_backfill` instead.
+        if IS_REPLICATED {
+            assert!(!dist_key_in_pk_indices.is_empty());
+        }
         let distribution =
             TableDistribution::new(vnodes, dist_key_in_pk_indices, vnode_col_idx_in_pk);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

If table scan's distribution is singleton, we should use no shuffle backfill instead, since arrangement backfill may have issues with its vnode bitmap and fails `e2e parallel (memory) tests`. See https://buildkite.com/risingwavelabs/main-cron/builds/2213.

Anyway, if table scan's distribution is singleton, its parallelism can't be scaled out either. So it will always have the same distribution as upstream, and we can use no shuffle backfill in that case to avoid replication overhead.

Passing test: https://buildkite.com/risingwavelabs/pull-request/builds/45614#018e7bce-d8a0-4135-9743-a16c23575a77

You can ignore the failing sink tests. They are independent to this and are fixed in https://github.com/risingwavelabs/risingwave/pull/14846.

Same for the planner tests.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
