### PR TITLE
refactor(stream): reuse StreamReaderWithPause for SourceBackfill

### DIFF
--- a/src/stream/src/executor/stream_reader.rs
+++ b/src/stream/src/executor/stream_reader.rs
@@ -104,6 +104,10 @@ impl<const BIASED: bool, M: Send + 'static> StreamReaderWithPause<BIASED, M> {
         assert!(self.paused, "not paused");
         self.paused = false;
     }
+
+    pub fn into_inner(self) -> (ReaderArm<M>, ReaderArm<M>) {
+        self.inner.into_inner()
+    }
 }
 
 impl<const BIASED: bool, M> Stream for StreamReaderWithPause<BIASED, M> {


### PR DESCRIPTION
- add planner testsI hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

@tabVersion asks me why they are very alike, except only some small parts (why not reuse code)? I thought one large previous reason doesn't hold any more (previously there's a complex design for abortable stream). So I made a quick attempt for this change. 

This refactor can make `SourceBackfillExecutor` and `SourceExecutor` more alike, so make it possible to reuse more code between them.

However, I'm hesitant about the change:
- I forgot another big reason why I didn't do it at the beginning until I almost finished this refactor: Here in the forward stream, we must "return" the `input` stream from the backfill stream. However, we can only get the mapped `Either::Left` stream, so we pay unnecessary cost (on a hot path).
<img width="1070" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/37948597/c91ba21e-7d99-437d-9beb-bdb31c2d90c4">
  
  The current code doesn't have this problem because we passed `&mut input` to the select stream. However, that makes us not able to use functions to replace another side of the merged stream (due to lifetime issue), and result in the strange code.

- It does make the code look slightly better. But even after the change, it may be still very hard to reuse large sections of code. Most places are the same except a few places. e.g., `FsSourceExecutor` is in similar situation...


So not planned to merge yet (until make sure the overhead is acceptable & we can do further refactor). Open to save work & seek comments.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
