### PR TITLE
fix(meta): do not panic on specified parallelism greater than vnode count

### DIFF
--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -538,7 +538,7 @@ impl CatalogController {
         streaming_job: &StreamingJob,
         ctx: &StreamContext,
         version: &PbTableVersion,
-        default_parallelism: &Option<NonZeroUsize>,
+        specified_parallelism: &Option<NonZeroUsize>,
     ) -> MetaResult<ObjectId> {
         let id = streaming_job.id();
         let inner = self.inner.write().await;
@@ -557,7 +557,7 @@ impl CatalogController {
             return Err(MetaError::permission_denied("table version is stale"));
         }
 
-        let parallelism = match default_parallelism {
+        let parallelism = match specified_parallelism {
             None => StreamingParallelism::Adaptive,
             Some(n) => StreamingParallelism::Fixed(n.get() as _),
         };

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -30,6 +30,7 @@
 #![test_runner(risingwave_test_runner::test_runner::run_failpont_tests)]
 #![feature(is_sorted)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(const_option)]
 
 pub mod backup_restore;
 pub mod barrier;

--- a/src/meta/src/rpc/ddl_controller_v2.rs
+++ b/src/meta/src/rpc/ddl_controller_v2.rs
@@ -328,7 +328,7 @@ impl DdlController {
                     &streaming_job,
                     &stream_ctx,
                     table.get_version()?,
-                    &fragment_graph.default_parallelism(),
+                    &fragment_graph.specified_parallelism(),
                 )
                 .await? as u32;
 
@@ -469,7 +469,7 @@ impl DdlController {
                 &streaming_job,
                 &ctx,
                 table.get_version()?,
-                &fragment_graph.default_parallelism(),
+                &fragment_graph.specified_parallelism(),
             )
             .await?;
 

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -307,7 +307,7 @@ pub struct StreamFragmentGraph {
 
     /// The default parallelism of the job, specified by the `STREAMING_PARALLELISM` session
     /// variable. If not specified, all active parallel units will be used.
-    default_parallelism: Option<NonZeroUsize>,
+    specified_parallelism: Option<NonZeroUsize>,
 }
 
 impl StreamFragmentGraph {
@@ -380,7 +380,7 @@ impl StreamFragmentGraph {
             .map(TableId::from)
             .collect();
 
-        let default_parallelism = if let Some(Parallelism { parallelism }) = proto.parallelism {
+        let specified_parallelism = if let Some(Parallelism { parallelism }) = proto.parallelism {
             Some(NonZeroUsize::new(parallelism as usize).context("parallelism should not be 0")?)
         } else {
             None
@@ -391,7 +391,7 @@ impl StreamFragmentGraph {
             downstreams,
             upstreams,
             dependent_table_ids,
-            default_parallelism,
+            specified_parallelism,
         })
     }
 
@@ -486,9 +486,9 @@ impl StreamFragmentGraph {
         &self.dependent_table_ids
     }
 
-    /// Get the default parallelism of the job.
-    pub fn default_parallelism(&self) -> Option<NonZeroUsize> {
-        self.default_parallelism
+    /// Get the parallelism of the job, if specified by the user.
+    pub fn specified_parallelism(&self) -> Option<NonZeroUsize> {
+        self.specified_parallelism
     }
 
     /// Get downstreams of a fragment.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolve https://github.com/risingwavelabs/risingwave/issues/15900#issuecomment-2021859103 and supplement #11388.

To reproduce:

1. Start RisingWave with a compute node of `--parallelism 9999`
2. `set streaming_parallelism to 8888`
3. then create a streaming job

Also rename the parallelism specified by session variable from `default_parallelism` into `specified_parallelism` to avoid confusion with the meta opt with the same name.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
