### PR TITLE
fix(playground): should enable dev dashboard

### DIFF
--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -193,6 +193,7 @@ pub fn map_single_node_opts_to_standalone_opts(opts: SingleNodeOpts) -> ParsedSt
     // Set listen addresses (force to override)
     meta_opts.listen_addr = "0.0.0.0:5690".to_string();
     meta_opts.advertise_addr = "127.0.0.1:5690".to_string();
+    meta_opts.dashboard_host = Some("0.0.0.0:5691".to_string());
     compute_opts.listen_addr = "0.0.0.0:5688".to_string();
     compactor_opts.listen_addr = "0.0.0.0:6660".to_string();
     if let Some(frontend_addr) = &opts.node_opts.listen_addr {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

#15897 switched `playground` to `single-node` mode and there's a regression that the dashboard is disabled since `dashboard_host` is not set. This actually applies to all single node deployments.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
