### PR TITLE
chore(ci): disable arrangement backfill for in-memory e2e parallel tests

### DIFF
--- a/src/config/ci-mem.toml
+++ b/src/config/ci-mem.toml
@@ -7,6 +7,7 @@ in_flight_barrier_nums = 10
 
 [streaming.developer]
 stream_exchange_concurrent_barriers = 10
+stream_enable_arrangement_backfill = false
 
 [batch]
 enable_barrier_read = true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

These tests use an in-memory object store per CN instance. See: https://github.com/risingwavelabs/risingwave/blob/1e848526ba487836d72a29b5390689f712b50e0d/src/risedevtool/src/task/meta_node_service.rs#L131

In Arrangement Backfill, when we read from checkpointed data, and it can be from a different CN instance.
Given the following scenario:

```
create materialized view Y as ...;
create materialized view X as select * from Y;
```

1. singleton arrangement backfill executor X scheduled to worker node A.
2. singleton materialize executor Y scheduled to worker node B.
3. Later Y writes vnode=0 (because its singleton) and commits it to object store.
4. X can't read vnode=0, because it has different object store.

X state is now inconsistent.

It doesn't happen in no shuffle backfill, since both X and Y will always be scheduled to the same worker node and access the same object store as a result.

We can just disable arrangement backfill for these tests, from bugen:


> I believe in-memory tests are still valuable for checking whether each parallelism operates on its own data partition (most of the time), covering the behavior of batch scheduler and so on.

So we should keep these tests still.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
