### PR TITLE
feat(batch): initial cursor implementation

### DIFF
--- a/e2e_test/batch/transaction/cursor.slt
+++ b/e2e_test/batch/transaction/cursor.slt
@@ -1,0 +1,91 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table a(aid int, c1 int);
+
+statement ok
+insert into a values(1, 11), (2, 12), (3, 13);
+
+statement ok
+create table test(a int,b varchar);
+
+statement ok
+insert into test values(1, 'hello'), (2, 'world'), (3, 'risingwave'), (4, 'labs');
+
+statement error DECLARE CURSOR can only be used in transaction blocks
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2 ORDER BY a;
+
+statement ok
+START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+statement ok
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2 ORDER BY a;
+
+statement error cursor "test_cursor" already exists
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2;
+
+statement error table or source not found: test
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test_non_existent where a > 2;
+
+statement error cursor "test_cursor_non_existent" does not exist
+FETCH NEXT from test_cursor_non_existent;
+
+query II
+FETCH NEXT from test_cursor;
+----
+3 risingwave
+
+query II
+FETCH NEXT from test_cursor;
+----
+4 labs
+
+query II
+FETCH NEXT from test_cursor;
+----
+
+statement error cursor "test_cursor_non_existent" does not exist
+CLOSE test_cursor_non_existent;
+
+statement ok
+CLOSE test_cursor;
+
+statement error cursor "test_cursor" does not exist
+FETCH NEXT from test_cursor;
+
+statement ok
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test JOIN a ON test.a > 1 and a.aid = test.a ORDER BY test.a;
+
+query IIII
+FETCH NEXT from test_cursor;
+----
+2 world   2 12
+
+query IIII
+FETCH NEXT from test_cursor;
+----
+3 risingwave   3 13
+
+query IIII
+FETCH NEXT from test_cursor;
+----
+
+statement ok
+COMMIT;
+
+statement ok
+drop table test;
+
+statement ok
+drop table a;

--- a/e2e_test/batch/transaction/cursor.slt
+++ b/e2e_test/batch/transaction/cursor.slt
@@ -13,10 +13,14 @@ create table test(a int,b varchar);
 statement ok
 insert into test values(1, 'hello'), (2, 'world'), (3, 'risingwave'), (4, 'labs');
 
-statement error DECLARE CURSOR can only be used in transaction blocks
+# Currently, we allow declaring cursors out of TRANSACTION, because we don't have RW txn support. In PG, it's not allowed
+statement ok
 DECLARE
     test_cursor CURSOR FOR
         SELECT * FROM test where a > 2 ORDER BY a;
+
+statement ok
+CLOSE test_cursor;
 
 statement ok
 START TRANSACTION ISOLATION LEVEL REPEATABLE READ;

--- a/e2e_test/batch/transaction/cursor_multi_conn.slt
+++ b/e2e_test/batch/transaction/cursor_multi_conn.slt
@@ -1,0 +1,87 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table test(a int,b varchar);
+
+statement ok
+insert into test values(1, 'hello'), (2, 'world'), (3, 'risingwave');
+
+statement ok
+START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+statement ok
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2 ORDER BY a;
+
+query II
+FETCH NEXT from test_cursor;
+----
+3 risingwave
+
+connection other
+statement ok
+flush;
+
+connection other
+statement ok
+insert into test values(4, 'labs');
+
+connection other
+statement ok
+flush;
+
+connection other
+query II
+SELECT * FROM test where a > 2 ORDER BY a;
+----
+3 risingwave
+4 labs
+
+connection other
+statement ok
+START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+connection other
+statement ok
+DECLARE
+    test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2 ORDER BY a;
+
+connection other
+query II
+FETCH NEXT from test_cursor;
+----
+3 risingwave
+
+connection other
+query II
+FETCH NEXT from test_cursor;
+----
+4 labs
+
+connection other
+query II
+FETCH NEXT from test_cursor;
+----
+
+connection other
+statement ok
+COMMIT;
+
+query II
+FETCH NEXT from test_cursor;
+----
+
+statement ok
+COMMIT;
+
+query II
+SELECT * FROM test where a > 2 ORDER BY a;
+----
+3 risingwave
+4 labs
+
+statement ok
+drop table test;

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -29,8 +29,8 @@ use anyhow::{anyhow, bail, Result};
 pub use resolve_id::*;
 use risingwave_frontend::handler::util::SourceSchemaCompatExt;
 use risingwave_frontend::handler::{
-    create_index, create_mv, create_schema, create_source, create_table, create_view, drop_table,
-    explain, variable, HandlerArgs,
+    close_cursor, create_index, create_mv, create_schema, create_source, create_table, create_view,
+    declare_cursor, drop_table, explain, fetch_cursor, variable, HandlerArgs,
 };
 use risingwave_frontend::session::SessionImpl;
 use risingwave_frontend::test_utils::{create_proto_file, get_explain_output, LocalFrontend};
@@ -569,6 +569,16 @@ impl TestCase {
                 } => {
                     create_schema::handle_create_schema(handler_args, schema_name, if_not_exists)
                         .await?;
+                }
+                Statement::DeclareCursor { cursor_name, query } => {
+                    declare_cursor::handle_declare_cursor(handler_args, cursor_name, *query)
+                        .await?;
+                }
+                Statement::FetchCursor { cursor_name, count } => {
+                    fetch_cursor::handle_fetch_cursor(handler_args, cursor_name, count).await?;
+                }
+                Statement::CloseCursor { cursor_name } => {
+                    close_cursor::handle_close_cursor(handler_args, cursor_name).await?;
                 }
                 _ => return Err(anyhow!("Unsupported statement type")),
             }

--- a/src/frontend/src/handler/close_cursor.rs
+++ b/src/frontend/src/handler/close_cursor.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_sqlparser::ast::ObjectName;
+
+use super::RwPgResponse;
+use crate::error::Result;
+use crate::handler::HandlerArgs;
+
+pub async fn handle_close_cursor(
+    handler_args: HandlerArgs,
+    cursor_name: Option<ObjectName>,
+) -> Result<RwPgResponse> {
+    if let Some(name) = cursor_name {
+        handler_args.session.drop_cursor(name).await?;
+    } else {
+        handler_args.session.drop_all_cursors().await;
+    }
+    Ok(PgResponse::empty_result(StatementType::CLOSE_CURSOR))
+}

--- a/src/frontend/src/handler/declare_cursor.rs
+++ b/src/frontend/src/handler/declare_cursor.rs
@@ -1,0 +1,55 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_sqlparser::ast::{ObjectName, Query, Statement};
+
+use super::query::{gen_batch_plan_by_statement, gen_batch_plan_fragmenter};
+use super::RwPgResponse;
+use crate::error::{ErrorCode, Result};
+use crate::handler::HandlerArgs;
+use crate::session::cursor::Cursor;
+use crate::OptimizerContext;
+
+pub async fn handle_declare_cursor(
+    handler_args: HandlerArgs,
+    cursor_name: ObjectName,
+    query: Query,
+) -> Result<RwPgResponse> {
+    let session = handler_args.session.clone();
+    if !session.is_in_transaction() {
+        return Err(ErrorCode::InternalError(
+            "DECLARE CURSOR can only be used in transaction blocks".to_string(),
+        )
+        .into());
+    }
+
+    let plan_fragmenter_result = {
+        let context = OptimizerContext::from_handler_args(handler_args);
+        let plan_result = gen_batch_plan_by_statement(
+            &session,
+            context.into(),
+            Statement::Query(Box::new(query.clone())),
+        )?;
+        gen_batch_plan_fragmenter(&session, plan_result)?
+    };
+
+    session
+        .add_cursor(
+            cursor_name,
+            Cursor::new(plan_fragmenter_result, session.clone()).await?,
+        )
+        .await?;
+    Ok(PgResponse::empty_result(StatementType::DECLARE_CURSOR))
+}

--- a/src/frontend/src/handler/declare_cursor.rs
+++ b/src/frontend/src/handler/declare_cursor.rs
@@ -17,7 +17,7 @@ use risingwave_sqlparser::ast::{ObjectName, Query, Statement};
 
 use super::query::{gen_batch_plan_by_statement, gen_batch_plan_fragmenter};
 use super::RwPgResponse;
-use crate::error::{ErrorCode, Result};
+use crate::error::Result;
 use crate::handler::HandlerArgs;
 use crate::session::cursor::Cursor;
 use crate::OptimizerContext;
@@ -28,12 +28,6 @@ pub async fn handle_declare_cursor(
     query: Query,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
-    if !session.is_in_transaction() {
-        return Err(ErrorCode::InternalError(
-            "DECLARE CURSOR can only be used in transaction blocks".to_string(),
-        )
-        .into());
-    }
 
     let plan_fragmenter_result = {
         let context = OptimizerContext::from_handler_args(handler_args);

--- a/src/frontend/src/handler/fetch_cursor.rs
+++ b/src/frontend/src/handler/fetch_cursor.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_sqlparser::ast::ObjectName;
+
+use super::RwPgResponse;
+use crate::error::Result;
+use crate::handler::HandlerArgs;
+
+pub async fn handle_fetch_cursor(
+    handler_args: HandlerArgs,
+    cursor_name: ObjectName,
+    count: Option<i32>,
+) -> Result<RwPgResponse> {
+    let session = handler_args.session;
+    let (rows, pg_descs) = session.cursor_next(&cursor_name, count).await?;
+    Ok(PgResponse::builder(StatementType::FETCH_CURSOR)
+        .values(rows.into(), pg_descs)
+        .into())
+}

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -30,7 +30,6 @@ use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_sqlparser::ast::*;
 
 use self::util::{DataChunkToRowSetAdapter, SourceSchemaCompatExt};
-use self::variable::handle_set_time_zone;
 use crate::catalog::table_catalog::TableType;
 use crate::error::{ErrorCode, Result};
 use crate::handler::cancel_job::handle_cancel;
@@ -50,6 +49,7 @@ mod alter_table_column;
 mod alter_table_with_sr;
 pub mod alter_user;
 pub mod cancel_job;
+pub mod close_cursor;
 mod comment;
 pub mod create_connection;
 mod create_database;
@@ -65,6 +65,7 @@ pub mod create_table;
 pub mod create_table_as;
 pub mod create_user;
 pub mod create_view;
+pub mod declare_cursor;
 pub mod describe;
 mod drop_connection;
 mod drop_database;
@@ -80,6 +81,7 @@ pub mod drop_user;
 mod drop_view;
 pub mod explain;
 pub mod extended_handle;
+pub mod fetch_cursor;
 mod flush;
 pub mod handle_privilege;
 mod kill_process;
@@ -509,7 +511,9 @@ pub async fn handle(
             variable,
             value,
         } => variable::handle_set(handler_args, variable, value),
-        Statement::SetTimeZone { local: _, value } => handle_set_time_zone(handler_args, value),
+        Statement::SetTimeZone { local: _, value } => {
+            variable::handle_set_time_zone(handler_args, value)
+        }
         Statement::ShowVariable { variable } => variable::handle_show(handler_args, variable).await,
         Statement::CreateIndex {
             name,
@@ -920,6 +924,15 @@ pub async fn handle(
             object_name,
             comment,
         } => comment::handle_comment(handler_args, object_type, object_name, comment).await,
+        Statement::DeclareCursor { cursor_name, query } => {
+            declare_cursor::handle_declare_cursor(handler_args, cursor_name, *query).await
+        }
+        Statement::FetchCursor { cursor_name, count } => {
+            fetch_cursor::handle_fetch_cursor(handler_args, cursor_name, count).await
+        }
+        Statement::CloseCursor { cursor_name } => {
+            close_cursor::handle_close_cursor(handler_args, cursor_name).await
+        }
         _ => bail_not_implemented!("Unhandled statement: {}", stmt),
     }
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -253,7 +253,7 @@ fn determine_query_mode(batch_plan: PlanRef) -> QueryMode {
     }
 }
 
-struct BatchPlanFragmenterResult {
+pub struct BatchPlanFragmenterResult {
     pub(crate) plan_fragmenter: BatchPlanFragmenter,
     pub(crate) query_mode: QueryMode,
     pub(crate) schema: Schema,
@@ -261,7 +261,7 @@ struct BatchPlanFragmenterResult {
     pub(crate) _dependent_relations: Vec<TableId>,
 }
 
-fn gen_batch_plan_fragmenter(
+pub fn gen_batch_plan_fragmenter(
     session: &SessionImpl,
     plan_result: BatchQueryPlanResult,
 ) -> Result<BatchPlanFragmenterResult> {
@@ -450,7 +450,7 @@ async fn execute(
         .into())
 }
 
-async fn distribute_execute(
+pub async fn distribute_execute(
     session: Arc<SessionImpl>,
     query: Query,
     can_timeout_cancel: bool,
@@ -472,8 +472,7 @@ async fn distribute_execute(
         .map_err(|err| err.into())
 }
 
-#[expect(clippy::unused_async)]
-async fn local_execute(
+pub async fn local_execute(
     session: Arc<SessionImpl>,
     query: Query,
     can_timeout_cancel: bool,

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -298,11 +298,11 @@ pub fn gen_batch_plan_fragmenter(
     })
 }
 
-async fn execute(
+pub async fn create_stream(
     session: Arc<SessionImpl>,
     plan_fragmenter_result: BatchPlanFragmenterResult,
     formats: Vec<Format>,
-) -> Result<RwPgResponse> {
+) -> Result<(PgResponseStream, Vec<PgFieldDescriptor>)> {
     let BatchPlanFragmenterResult {
         plan_fragmenter,
         query_mode,
@@ -326,7 +326,6 @@ async fn execute(
         _ => {}
     }
 
-    let query_start_time = Instant::now();
     let query = plan_fragmenter.generate_complete_query().await?;
     tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
 
@@ -337,10 +336,7 @@ async fn execute(
         .collect::<Vec<PgFieldDescriptor>>();
     let column_types = schema.fields().iter().map(|f| f.data_type()).collect_vec();
 
-    // Used in counting row count.
-    let first_field_format = formats.first().copied().unwrap_or(Format::Text);
-
-    let mut row_stream = match query_mode {
+    let row_stream = match query_mode {
         QueryMode::Auto => unreachable!(),
         QueryMode::Local => PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
             local_execute(session.clone(), query, can_timeout_cancel).await?,
@@ -358,6 +354,23 @@ async fn execute(
             ))
         }
     };
+
+    Ok((row_stream, pg_descs))
+}
+
+async fn execute(
+    session: Arc<SessionImpl>,
+    plan_fragmenter_result: BatchPlanFragmenterResult,
+    formats: Vec<Format>,
+) -> Result<RwPgResponse> {
+    // Used in counting row count.
+    let first_field_format = formats.first().copied().unwrap_or(Format::Text);
+    let query_mode = plan_fragmenter_result.query_mode;
+    let stmt_type = plan_fragmenter_result.stmt_type;
+
+    let query_start_time = Instant::now();
+    let (mut row_stream, pg_descs) =
+        create_stream(session.clone(), plan_fragmenter_result, formats).await?;
 
     let row_cnt: Option<i32> = match stmt_type {
         StatementType::SELECT
@@ -450,7 +463,7 @@ async fn execute(
         .into())
 }
 
-pub async fn distribute_execute(
+async fn distribute_execute(
     session: Arc<SessionImpl>,
     query: Query,
     can_timeout_cancel: bool,
@@ -472,7 +485,8 @@ pub async fn distribute_execute(
         .map_err(|err| err.into())
 }
 
-pub async fn local_execute(
+#[expect(clippy::unused_async)]
+async fn local_execute(
     session: Arc<SessionImpl>,
     query: Query,
     can_timeout_cancel: bool,

--- a/src/frontend/src/handler/transaction.rs
+++ b/src/frontend/src/handler/transaction.rs
@@ -66,7 +66,6 @@ pub async fn handle_begin(
                     Read-write transaction is not supported yet. Please specify `READ ONLY` to start a read-only transaction.\n\
                     For compatibility, this statement will still succeed but no transaction is actually started.";
                 builder = builder.notice(MESSAGE);
-                *session.in_rw_txn.lock() = true;
                 return Ok(builder.into());
             }
         }
@@ -89,7 +88,6 @@ pub async fn handle_commit(
 
     session.txn_commit_explicit();
     session.drop_all_cursors().await;
-    *session.in_rw_txn.lock() = false;
 
     Ok(RwPgResponse::empty_result(stmt_type))
 }
@@ -107,7 +105,6 @@ pub async fn handle_rollback(
 
     session.txn_rollback_explicit();
     session.drop_all_cursors().await;
-    *session.in_rw_txn.lock() = false;
 
     Ok(RwPgResponse::empty_result(stmt_type))
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -583,12 +583,6 @@ pub struct SessionImpl {
     /// Last idle instant
     last_idle_instant: Arc<Mutex<Option<Instant>>>,
 
-    /// Whether in a Read-Write Transaction. We need this because we don't really start a
-    /// transaction when the transaction is read-write but cursors should only be declared
-    /// within transaction blocks. This flag is used to determine whether the session is in
-    /// a transaction
-    pub in_rw_txn: Mutex<bool>,
-
     /// The cursors declared in the transaction.
     cursors: tokio::sync::Mutex<HashMap<ObjectName, cursor::Cursor>>,
 }
@@ -630,7 +624,6 @@ impl SessionImpl {
             notices: Default::default(),
             exec_context: Mutex::new(None),
             last_idle_instant: Default::default(),
-            in_rw_txn: Default::default(),
             cursors: Default::default(),
         }
     }
@@ -658,7 +651,6 @@ impl SessionImpl {
             ))
             .into(),
             last_idle_instant: Default::default(),
-            in_rw_txn: Default::default(),
             cursors: Default::default(),
         }
     }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -112,6 +112,7 @@ use crate::user::UserId;
 use crate::{FrontendOpts, PgResponseStream};
 
 pub(crate) mod current;
+pub(crate) mod cursor;
 pub(crate) mod transaction;
 
 /// The global environment for the frontend server.
@@ -581,6 +582,15 @@ pub struct SessionImpl {
 
     /// Last idle instant
     last_idle_instant: Arc<Mutex<Option<Instant>>>,
+
+    /// Whether in a Read-Write Transaction. We need this because we don't really start a
+    /// transaction when the transaction is read-write but cursors should only be declared
+    /// within transaction blocks. This flag is used to determine whether the session is in
+    /// a transaction
+    pub in_rw_txn: Mutex<bool>,
+
+    /// The cursors declared in the transaction.
+    cursors: tokio::sync::Mutex<HashMap<ObjectName, cursor::Cursor>>,
 }
 
 #[derive(Error, Debug)]
@@ -620,6 +630,8 @@ impl SessionImpl {
             notices: Default::default(),
             exec_context: Mutex::new(None),
             last_idle_instant: Default::default(),
+            in_rw_txn: Default::default(),
+            cursors: Default::default(),
         }
     }
 
@@ -646,6 +658,8 @@ impl SessionImpl {
             ))
             .into(),
             last_idle_instant: Default::default(),
+            in_rw_txn: Default::default(),
+            cursors: Default::default(),
         }
     }
 

--- a/src/frontend/src/session/cursor.rs
+++ b/src/frontend/src/session/cursor.rs
@@ -64,13 +64,14 @@ impl Cursor {
     pub async fn next(&mut self, count: Option<i32>) -> Result<Vec<Row>> {
         // `FETCH NEXT` is equivalent to `FETCH 1`.
         let fetch_count = count.unwrap_or(1);
-        let mut ans = vec![];
         if fetch_count <= 0 {
             Err(crate::error::ErrorCode::InternalError(
                 "FETCH a non-positive count is not supported yet".to_string(),
             )
             .into())
         } else {
+            // min with 100 to avoid allocating too many memory at once.
+            let mut ans = Vec::with_capacity(std::cmp::min(100, fetch_count) as usize);
             let mut cur = 0;
             while cur < fetch_count
                 && let Some(row) = self.next_once().await?

--- a/src/frontend/src/session/cursor.rs
+++ b/src/frontend/src/session/cursor.rs
@@ -89,14 +89,6 @@ impl Cursor {
 }
 
 impl SessionImpl {
-    pub fn is_in_transaction(&self) -> bool {
-        *self.in_rw_txn.lock()
-            || match &*self.txn.lock() {
-                transaction::State::Initial | transaction::State::Implicit(_) => false,
-                transaction::State::Explicit(_) => true,
-            }
-    }
-
     pub async fn add_cursor(&self, cursor_name: ObjectName, cursor: Cursor) -> Result<()> {
         if self
             .cursors

--- a/src/frontend/src/session/cursor.rs
+++ b/src/frontend/src/session/cursor.rs
@@ -21,7 +21,7 @@ use pgwire::pg_response::StatementType;
 use pgwire::types::Row;
 use risingwave_sqlparser::ast::ObjectName;
 
-use super::{transaction, PgResponseStream};
+use super::PgResponseStream;
 use crate::error::{ErrorCode, Result, RwError};
 use crate::handler::query::{create_stream, BatchPlanFragmenterResult};
 use crate::session::SessionImpl;

--- a/src/frontend/src/session/cursor.rs
+++ b/src/frontend/src/session/cursor.rs
@@ -1,0 +1,192 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use futures::StreamExt;
+use itertools::Itertools;
+use pgwire::pg_field_descriptor::PgFieldDescriptor;
+use pgwire::pg_response::StatementType;
+use pgwire::types::Row;
+use risingwave_common::session_config::QueryMode;
+use risingwave_sqlparser::ast::ObjectName;
+
+use super::{transaction, PgResponseStream};
+use crate::error::{ErrorCode, Result, RwError};
+use crate::handler::query::{distribute_execute, local_execute, BatchPlanFragmenterResult};
+use crate::handler::util::{to_pg_field, DataChunkToRowSetAdapter};
+use crate::session::SessionImpl;
+
+pub struct Cursor {
+    row_stream: PgResponseStream,
+    pg_descs: Vec<PgFieldDescriptor>,
+    remaining_rows: VecDeque<Row>,
+}
+
+impl Cursor {
+    pub async fn new(
+        plan_fragmenter_result: BatchPlanFragmenterResult,
+        session: Arc<SessionImpl>,
+    ) -> Result<Self> {
+        let (row_stream, pg_descs) = Self::create_stream(plan_fragmenter_result, session).await?;
+        Ok(Self {
+            row_stream,
+            pg_descs,
+            remaining_rows: VecDeque::<Row>::new(),
+        })
+    }
+
+    async fn create_stream(
+        plan_fragmenter_result: BatchPlanFragmenterResult,
+        session: Arc<SessionImpl>,
+    ) -> Result<(PgResponseStream, Vec<PgFieldDescriptor>)> {
+        let BatchPlanFragmenterResult {
+            plan_fragmenter,
+            query_mode,
+            schema,
+            stmt_type,
+            ..
+        } = plan_fragmenter_result;
+        assert_eq!(stmt_type, StatementType::SELECT);
+
+        let can_timeout_cancel = true;
+
+        let query = plan_fragmenter.generate_complete_query().await?;
+        tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
+
+        let pg_descs = schema
+            .fields()
+            .iter()
+            .map(to_pg_field)
+            .collect::<Vec<PgFieldDescriptor>>();
+        let column_types = schema.fields().iter().map(|f| f.data_type()).collect_vec();
+
+        let row_stream: PgResponseStream = match query_mode {
+            QueryMode::Auto => unreachable!(),
+            QueryMode::Local => PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
+                local_execute(session.clone(), query, can_timeout_cancel).await?,
+                column_types,
+                vec![],
+                session.clone(),
+            )),
+            // Local mode do not support cancel tasks.
+            QueryMode::Distributed => {
+                PgResponseStream::DistributedQuery(DataChunkToRowSetAdapter::new(
+                    distribute_execute(session.clone(), query, can_timeout_cancel).await?,
+                    column_types,
+                    vec![],
+                    session.clone(),
+                ))
+            }
+        };
+
+        Ok((row_stream, pg_descs))
+    }
+
+    pub async fn next_once(&mut self) -> Result<Option<Row>> {
+        while self.remaining_rows.is_empty() {
+            let rows = self.row_stream.next().await;
+            let rows = match rows {
+                None => return Ok(None),
+                Some(row) => {
+                    row.map_err(|err| RwError::from(ErrorCode::InternalError(format!("{}", err))))?
+                }
+            };
+            self.remaining_rows = rows.into_iter().collect();
+        }
+        let row = self.remaining_rows.pop_front().unwrap();
+        Ok(Some(row))
+    }
+
+    pub async fn next(&mut self, count: Option<i32>) -> Result<Vec<Row>> {
+        // `FETCH NEXT` is equivalent to `FETCH 1`.
+        let fetch_count = count.unwrap_or(1);
+        let mut ans = vec![];
+        if fetch_count <= 0 {
+            Err(crate::error::ErrorCode::InternalError(
+                "FETCH a non-positive count is not supported yet".to_string(),
+            )
+            .into())
+        } else {
+            let mut cur = 0;
+            while cur < fetch_count
+                && let Some(row) = self.next_once().await?
+            {
+                cur += 1;
+                ans.push(row);
+            }
+            Ok(ans)
+        }
+    }
+
+    pub fn pg_descs(&self) -> Vec<PgFieldDescriptor> {
+        self.pg_descs.clone()
+    }
+}
+
+impl SessionImpl {
+    pub fn is_in_transaction(&self) -> bool {
+        *self.in_rw_txn.lock()
+            || match &*self.txn.lock() {
+                transaction::State::Initial | transaction::State::Implicit(_) => false,
+                transaction::State::Explicit(_) => true,
+            }
+    }
+
+    pub async fn add_cursor(&self, cursor_name: ObjectName, cursor: Cursor) -> Result<()> {
+        if self
+            .cursors
+            .lock()
+            .await
+            .try_insert(cursor_name.clone(), cursor)
+            .is_err()
+        {
+            return Err(ErrorCode::CatalogError(
+                format!("cursor \"{cursor_name}\" already exists").into(),
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    pub async fn drop_all_cursors(&self) {
+        self.cursors.lock().await.clear();
+    }
+
+    pub async fn drop_cursor(&self, cursor_name: ObjectName) -> Result<()> {
+        match self.cursors.lock().await.remove(&cursor_name) {
+            Some(_) => Ok(()),
+            None => Err(ErrorCode::CatalogError(
+                format!("cursor \"{cursor_name}\" does not exist").into(),
+            )
+            .into()),
+        }
+    }
+
+    pub async fn cursor_next(
+        &self,
+        cursor_name: &ObjectName,
+        count: Option<i32>,
+    ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
+        if let Some(cursor) = self.cursors.lock().await.get_mut(cursor_name) {
+            Ok((cursor.next(count).await?, cursor.pg_descs()))
+        } else {
+            Err(
+                ErrorCode::CatalogError(format!("cursor \"{cursor_name}\" does not exist").into())
+                    .into(),
+            )
+        }
+    }
+}

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1493,13 +1493,13 @@ pub enum Statement {
     },
     /// DECLARE CURSOR
     DeclareCursor {
-        /// View name
         cursor_name: ObjectName,
         query: Box<Query>,
     },
     /// FETCH FROM CURSOR
     FetchCursor {
         cursor_name: ObjectName,
+        /// Number of rows to fetch. `None` means `FETCH ALL`.
         count: Option<i32>,
     },
     /// CLOSE CURSOR

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1491,6 +1491,21 @@ pub enum Statement {
         param: Ident,
         value: SetVariableValue,
     },
+    /// DECLARE CURSOR
+    DeclareCursor {
+        /// View name
+        cursor_name: ObjectName,
+        query: Box<Query>,
+    },
+    /// FETCH FROM CURSOR
+    FetchCursor {
+        cursor_name: ObjectName,
+        count: Option<i32>,
+    },
+    /// CLOSE CURSOR
+    CloseCursor {
+        cursor_name: Option<ObjectName>,
+    },
     /// FLUSH the current barrier.
     ///
     /// Note: RisingWave specific statement.
@@ -2044,6 +2059,23 @@ impl fmt::Display for Statement {
                     f,
                     "{param} = {value}",
                 )
+            }
+            Statement::DeclareCursor { cursor_name, query } => {
+                write!(f, "DECLARE {} CURSOR FOR {}", cursor_name, query)
+            },
+            Statement::FetchCursor { cursor_name , count} => {
+                if let Some(count) = count {
+                    write!(f, "FETCH {} FROM {}", count, cursor_name)
+                } else {
+                    write!(f, "FETCH NEXT FROM {}", cursor_name)
+                }
+            },
+            Statement::CloseCursor { cursor_name } => {
+                if let Some(name) = cursor_name {
+                    write!(f, "CLOSE {}", name)
+                } else {
+                    write!(f, "CLOSE ALL")
+                }
             }
             Statement::Flush => {
                 write!(f, "FLUSH")

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -278,6 +278,9 @@ impl Parser {
                 Keyword::EXECUTE => Ok(self.parse_execute()?),
                 Keyword::PREPARE => Ok(self.parse_prepare()?),
                 Keyword::COMMENT => Ok(self.parse_comment()?),
+                Keyword::DECLARE => Ok(self.parse_declare_cursor()?),
+                Keyword::FETCH => Ok(self.parse_fetch_cursor()?),
+                Keyword::CLOSE => Ok(self.parse_close_cursor()?),
                 Keyword::FLUSH => Ok(Statement::Flush),
                 Keyword::WAIT => Ok(Statement::Wait),
                 _ => self.expected(
@@ -5409,6 +5412,40 @@ impl Parser {
             object_name,
             comment,
         })
+    }
+
+    /// Parse a SQL DECLARE statement
+    pub fn parse_declare_cursor(&mut self) -> Result<Statement, ParserError> {
+        let cursor_name = self.parse_object_name()?;
+        self.expect_keyword(Keyword::CURSOR)?;
+        self.expect_keyword(Keyword::FOR)?;
+        let query = Box::new(self.parse_query()?);
+        Ok(Statement::DeclareCursor { cursor_name, query })
+    }
+
+    /// Parse a SQL FETCH statement
+    pub fn parse_fetch_cursor(&mut self) -> Result<Statement, ParserError> {
+        let count = if self.parse_keyword(Keyword::NEXT) {
+            None
+        } else {
+            let count_str = self.parse_number_value()?;
+            Some(count_str.parse::<i32>().map_err(|e| {
+                ParserError::ParserError(format!("Could not parse '{}' as i32: {}", count_str, e))
+            })?)
+        };
+        self.expect_keyword(Keyword::FROM)?;
+        let cursor_name = self.parse_object_name()?;
+        Ok(Statement::FetchCursor { cursor_name, count })
+    }
+
+    /// Parse a SQL CLOSE statement
+    pub fn parse_close_cursor(&mut self) -> Result<Statement, ParserError> {
+        let cursor_name = if self.parse_keyword(Keyword::ALL) {
+            None
+        } else {
+            Some(self.parse_object_name()?)
+        };
+        Ok(Statement::CloseCursor { cursor_name })
     }
 }
 

--- a/src/tests/simulation/src/slt.rs
+++ b/src/tests/simulation/src/slt.rs
@@ -161,6 +161,8 @@ const KILL_IGNORE_FILES: &[&str] = &[
     "transaction/read_only_multi_conn.slt",
     "transaction/read_only.slt",
     "transaction/tolerance.slt",
+    "transaction/cursor.slt",
+    "transaction/cursor_multi_conn.slt",
 ];
 
 /// Wait for background mv to finish creating

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -100,6 +100,9 @@ pub enum StatementType {
     ROLLBACK,
     SET_TRANSACTION,
     CANCEL_COMMAND,
+    DECLARE_CURSOR,
+    FETCH_CURSOR,
+    CLOSE_CURSOR,
     WAIT,
     KILL,
 }
@@ -290,6 +293,9 @@ impl StatementType {
                 }
             },
             Statement::Explain { .. } => Ok(StatementType::EXPLAIN),
+            Statement::DeclareCursor { .. } => Ok(StatementType::DECLARE_CURSOR),
+            Statement::FetchCursor { .. } => Ok(StatementType::FETCH_CURSOR),
+            Statement::CloseCursor { .. } => Ok(StatementType::CLOSE_CURSOR),
             Statement::Flush => Ok(StatementType::FLUSH),
             Statement::Wait => Ok(StatementType::WAIT),
             _ => Err("unsupported statement type".to_string()),
@@ -336,6 +342,7 @@ impl StatementType {
                 | StatementType::DELETE_RETURNING
                 | StatementType::UPDATE_RETURNING
                 | StatementType::CANCEL_COMMAND
+                | StatementType::FETCH_CURSOR
         )
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Introduce `CURSOR` in this PR. Currently, the cursors are mainly used by [fdw](https://github.com/risingwavelabs/risingwave/issues/14318).  So, to simplify, only the minimum function/syntax set required by `fdw` is added in this PR. 

However, this PR is still imperfect due to two reasons:
- The `fdw` allows PgSQL to access a foreign database like a normal table. When there is data access, the `fdw` will convert SQL to AST, then convert AST into SQL query, and then fetch data using a cursor from RW. The conversion can sometimes include some unsupported features/syntax. For example, the `fdw` will convert `LIMIT 5` in the original SQL to `LIMIT 5::BIGINT`, which is not supported by RW. As a result, the users cannot read from rw using `fdw` with `LIMIT`. I'll update this part in the following PRs.
- In this PR, to allow modification to `HashMap<ObjectName, Curosr>` in `SessionImpl`, I used a `tokio::sync::Mutex`. The lock is actually useless as `SessionImpl` is always accessed by only one thread. The same thing applied to other fields in `SessionImpl`. The mutexes in `SessionImpl` are only used to allow modification to the fields. This is not graceful enough. The better way is to separate the current `SessionImpl` into `SessionImpl`(mutable) and `SessionImplInfo`(immutable). At most positions where the current `SessionImpl` is used, it is only read, so `SessionImplInfo` is enough. In DML execution, the new `SessionImpl` is updated. Will try creating a PR to solve this problem later.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
