### PR TITLE
fix: correctly implement default subcommand for `single-node`

### DIFF
--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(assert_matches)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+use std::ffi::OsString;
 use std::str::FromStr;
 
-use anyhow::Result;
-use clap::error::ErrorKind;
-use clap::{command, ArgMatches, Args, Command, FromArgMatches};
+use clap::error::Result as ClapResult;
+use clap::{command, ArgMatches, Args, Command, CommandFactory, FromArgMatches};
 use risingwave_cmd::{compactor, compute, ctl, frontend, meta};
 use risingwave_cmd_all::{SingleNodeOpts, StandaloneOpts};
 use risingwave_common::git_sha;
@@ -86,7 +87,7 @@ const VERSION: &str = {
 };
 
 /// Component to launch.
-#[derive(Clone, Copy, EnumIter, EnumString, Display, IntoStaticStr)]
+#[derive(Debug, Clone, Copy, EnumIter, EnumString, Display, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 enum Component {
     Compute,
@@ -171,8 +172,12 @@ impl Component {
     }
 }
 
-#[cfg_attr(coverage, coverage(off))]
-fn main() -> Result<()> {
+/// Parse the given arguments and return the component and its matches.
+fn parse_args<I, T>(args: I) -> ClapResult<(Component, ArgMatches)>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
     let risingwave = || {
         command!(BINARY_NAME)
             .about("All-in-one executable for components of RisingWave")
@@ -188,39 +193,38 @@ fn main() -> Result<()> {
             risingwave()
                 .subcommand_value_name("COMPONENT")
                 .subcommand_help_heading("Components")
-                .subcommand_required(true)
-                .subcommands(Component::commands()),
+                .subcommands(Component::commands())
+                // Make single node the "default subcommand"
+                .args_conflicts_with_subcommands(true)
+                .args(SingleNodeOpts::command().get_arguments()),
         );
 
-    let matches = match command.try_get_matches() {
-        Ok(m) => m,
-        Err(e)
-            if e.kind() == ErrorKind::MissingSubcommand
-                || e.kind() == ErrorKind::UnknownArgument =>
-        {
-            // `$ ./risingwave`
-            // NOTE(kwannoel): This is a hack to make `risingwave`
-            // work as an alias of `risingwave single-process`.
-            // If invocation is not a multicall and there's no subcommand,
-            // we will try to invoke it as a single node.
-            let command = Component::SingleNode.augment_args(risingwave());
-            let matches = command.get_matches();
-            Component::SingleNode.start(&matches);
-            return Ok(());
-        }
-        Err(e) => {
-            e.exit();
-        }
+    let matches = command.try_get_matches_from(args)?;
+    let multicall = matches.subcommand().unwrap();
+
+    let (component_name, matches) = if multicall.0 == BINARY_NAME {
+        // This is not a multicall. Match argv[1] as a component.
+        (multicall.1)
+            .subcommand()
+            // If there's no subcommand, it must be single node ("default subcommand").
+            .unwrap_or_else(|| (Component::SingleNode.into(), multicall.1))
+    } else {
+        multicall
     };
 
-    let multicall = matches.subcommand().unwrap();
-    let argv_1 = multicall.1.subcommand();
-    let (component_name, matches) = argv_1.unwrap_or(multicall);
+    let component = Component::from_str(component_name).unwrap(); // always succeeds
+    let matches = matches.clone();
 
-    let component = Component::from_str(component_name)?;
-    component.start(matches);
+    Ok((component, matches))
+}
 
-    Ok(())
+#[cfg_attr(coverage, coverage(off))]
+fn main() {
+    let (component, matches) = parse_args(std::env::args_os())
+        .map_err(|e| e.exit())
+        .unwrap();
+
+    component.start(&matches);
 }
 
 fn standalone(opts: StandaloneOpts) {
@@ -242,4 +246,80 @@ fn single_node(opts: SingleNodeOpts) {
         .with_thread_name(true);
     risingwave_rt::init_risingwave_logger(settings);
     risingwave_rt::main_okk(risingwave_cmd_all::standalone(opts)).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+
+    use clap::error::ErrorKind;
+
+    use super::{parse_args, Component};
+
+    #[test]
+    fn test_basic() {
+        let (c, _) =
+            parse_args(["./risingwave", "meta", "--advertise-addr", "1.2.3.4:5678"]).unwrap();
+        assert_matches!(c, Component::Meta);
+    }
+
+    #[test]
+    fn test_multicall() {
+        let (c, _) = parse_args(["./meta-node", "--advertise-addr", "1.2.3.4:5678"]).unwrap();
+        assert_matches!(c, Component::Meta);
+    }
+
+    #[test]
+    fn test_missing_sub_subcommand() {
+        let e = parse_args(["./risingwave", "ctl"]).unwrap_err();
+        assert_matches!(
+            e.kind(),
+            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        );
+    }
+
+    #[test]
+    fn test_sub_expected_subcommand_but_got_unknown_arg() {
+        let e = parse_args(["./risingwave", "ctl", "--foo"]).unwrap_err();
+        assert_matches!(e.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn test_issue_16065() {
+        let e = parse_args([
+            "./risingwave",
+            "ctl",
+            "meta",
+            "unregister-worker",
+            "my-bad-arg",
+        ])
+        .unwrap_err();
+        assert_matches!(e.kind(), ErrorKind::UnknownArgument);
+        assert!(e.to_string().contains("my-bad-arg"), "{e}")
+    }
+
+    #[test]
+    fn test_default_subcommand_single_node() {
+        let (c, _) = parse_args(["./risingwave"]).unwrap();
+        assert_matches!(c, Component::SingleNode);
+    }
+
+    #[test]
+    fn test_default_subcommand_single_node_with_args() {
+        let (c, _) = parse_args(["./risingwave", "--in-memory"]).unwrap();
+        assert_matches!(c, Component::SingleNode);
+    }
+
+    #[test]
+    fn test_default_subcommand_single_node_with_unknown_args() {
+        let e = parse_args(["./risingwave", "--foo"]).unwrap_err();
+        assert_matches!(e.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn test_default_subcommand_single_node_with_other_explicit_subcommand() {
+        let e = parse_args(["./risingwave", "--in-memory", "ctl"]).unwrap_err();
+        assert_matches!(e.kind(), ErrorKind::ArgumentConflict);
+        assert!(e.to_string().contains("cannot be used with"), "{e}");
+    }
 }

--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -148,7 +148,8 @@ impl Component {
             Component::Frontend => FrontendOpts::augment_args(cmd),
             Component::Compactor => CompactorOpts::augment_args(cmd),
             Component::Ctl => CtlOpts::augment_args(cmd),
-            Component::Playground => cmd,
+            Component::Playground => cmd
+                .about("Shortcut for `single-node --in-memory`, should not be used in production"),
             Component::Standalone => StandaloneOpts::augment_args(cmd),
             Component::SingleNode => SingleNodeOpts::augment_args(cmd),
         }
@@ -158,14 +159,8 @@ impl Component {
     fn commands() -> Vec<Command> {
         Self::iter()
             .map(|c| {
-                let is_playground = matches!(c, Component::Playground);
                 let name: &'static str = c.into();
                 let command = Command::new(name).visible_aliases(c.aliases());
-                let command = if is_playground {
-                    command.hide(true)
-                } else {
-                    command
-                };
                 c.augment_args(command)
             })
             .collect()


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In #15847 and #15897 we made `single-node` the default in CLI if there's no other explicit subcommand specified. However, the approach that matches on the error kind leads to some unexpected side effects like #16065.

This PR utilizes a more recommended approach ([ref](https://github.com/clap-rs/clap/blob/731d18f300919a396eee62253f31239b9b02a943/examples/git.rs#L32-L39)) to achieve the same behavior, which resolves #16065 and also improves the help messages like the following:

```
All-in-one executable for components of RisingWave

Usage: risingwave [OPTIONS]
       risingwave <COMPONENT>

Components:
  compute      The worker node that executes query plans and handles data ingestion and output [aliases: compute-node, compute_node]
  meta         The central metadata management service [aliases: meta-node, meta_node]
  frontend     The stateless proxy that parses SQL queries and performs planning and optimizations of query jobs [aliases: frontend-node, frontend_node]
  compactor    The stateless worker node that compacts data for the storage engine [aliases: compactor-node, compactor_node]
  ctl          The DevOps tool that provides internal access to the RisingWave cluster [aliases: risectl]
  single_node  [default] The Single Node mode. Start all services in one process, with process-level options. This will be executed if no subcommand is specified [aliases: single-node, single]
  help         Print this message or the help of the given subcommand(s)

Options:
      --prometheus-listener-addr <PROMETHEUS_LISTENER_ADDR>
          The address prometheus polls metrics from [env: RW_SINGLE_NODE_PROMETHEUS_LISTENER_ADDR=]
      --config-path <CONFIG_PATH>
          The path to the cluster configuration file [env: RW_SINGLE_NODE_CONFIG_PATH=]
      --store-directory <STORE_DIRECTORY>
          The store directory used by meta store and object store [env: RW_SINGLE_NODE_STORE_DIRECTORY=]
      --in-memory
          Start RisingWave in-memory [env: RW_SINGLE_NODE_IN_MEMORY=]
      --total-memory-bytes <TOTAL_MEMORY_BYTES>
          Total available memory for the compute node in bytes. Used by both computing and storage
      --parallelism <PARALLELISM>
          The parallelism that the compute node will register to the scheduler of the meta service
      --listen-addr <LISTEN_ADDR>
          The address that this service listens to. Usually the localhost + desired port
      --prometheus-endpoint <PROMETHEUS_ENDPOINT>
          The HTTP REST-API address of the Prometheus instance associated to this cluster. This address is used to serve `PromQL` queries to Prometheus. It is also used by Grafana Dashboard Service to fetch metrics and visualize them
      --prometheus-selector <PROMETHEUS_SELECTOR>
          The additional selector used when querying Prometheus
      --compaction-worker-threads-number <COMPACTION_WORKER_THREADS_NUMBER>
          
  -h, --help
          Print help (see more with '--help')
  -V, --version
          Print version
```

Also add some tests to enforce the parsing behavior.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
