### PR TITLE
feat(source): use fragment id only as Kafka consumer group id

### DIFF
--- a/e2e_test/source_inline/kafka/consumer_group.slt
+++ b/e2e_test/source_inline/kafka/consumer_group.slt
@@ -41,7 +41,7 @@ b
 c
 
 
-# There are 4 consumer groups, 1 for batch query (not listed below), 3 for MV.
+# There are 2 consumer groups, 1 for batch query (not listed below), 1 for MV.
 # All of them are "Empty" state with 0 members, because we manually `assign` partitions to them.
 # At the begginning, the MV's consumer group will not occur. They will be created after committing offset to Kafka.
 # (enable.auto.commit defaults to true, and auto.commit.interval.ms defaults to 5s)
@@ -50,28 +50,22 @@ sleep 5s
 system ok
 ./e2e_test/source_inline/kafka/consumer_group.mjs --mv mv list-members
 ----
-0,0,0
+0
 
 
-# The lag for batch query's group is 0, and each MV parition's group is 2 (1 of 3 consumed).
+# The lag for MV's group is 0.
 system ok
 ./e2e_test/source_inline/kafka/consumer_group.mjs --mv mv list-lags
 ----
-2,2,2
+0
 
 
 # We try to interfere by creating consumers that subscribing to the topic with the RW's group id.
 system ok
-./e2e_test/source_inline/kafka/consumer_group.mjs --mv mv list-groups | tr ',' '\\n' | xargs -P4 -I {} sh -c "timeout 40s rpk topic consume test_consumer_group -g {}" &
+./e2e_test/source_inline/kafka/consumer_group.mjs --mv mv list-groups | tr ',' '\\n' | xargs -P4 -I {} sh -c "rpk topic consume test_consumer_group -g {}" &
 
 # Wait a while for them to subscribe to the topic.
 sleep 15s
-
-# The lag is changed to 0
-system ok
-./e2e_test/source_inline/kafka/consumer_group.mjs --mv mv list-lags
-----
-0,0,0
 
 
 system ok
@@ -96,6 +90,9 @@ f
 
 statement ok
 DROP SOURCE s CASCADE;
+
+system ok
+pkill rpk
 
 system ok
 rpk topic delete test_consumer_group

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -168,7 +168,6 @@ pub struct SourceEnumeratorInfo {
 pub struct SourceContext {
     pub actor_id: u32,
     pub source_id: TableId,
-    // There should be a 1-1 mapping between `source_id` & `fragment_id`
     pub fragment_id: u32,
     pub source_name: String,
     pub metrics: Arc<SourceMetrics>,

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -82,9 +82,11 @@ pub struct RdKafkaPropertiesConsumer {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub fetch_max_bytes: Option<usize>,
 
-    /// Automatically and periodically commit offsets in the background.
-    /// Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
-    /// To circumvent this behaviour set specific start offsets per partition in the call to assign().
+    /// Whether to automatically and periodically commit offsets in the background.
+    ///
+    /// Note that RisingWave does NOT rely on committed offsets. Committing offset is only for exposing the
+    /// progress for monitoring. Setting this to false can avoid creating consumer groups.
+    ///
     /// default: true
     #[serde(rename = "properties.enable.auto.commit")]
     #[serde_as(as = "Option<DisplayFromStr>")]

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -66,8 +66,6 @@ impl SplitReader for KafkaSplitReader {
 
         // disable partition eof
         config.set("enable.partition.eof", "false");
-        // change to `RdKafkaPropertiesConsumer::enable_auto_commit` to enable auto commit
-        // config.set("enable.auto.commit", "false");
         config.set("auto.offset.reset", "smallest");
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         config.set("bootstrap.servers", bootstrap_servers);
@@ -77,10 +75,7 @@ impl SplitReader for KafkaSplitReader {
 
         config.set(
             "group.id",
-            format!(
-                "rw-consumer-{}-{}",
-                source_ctx.fragment_id, source_ctx.actor_id
-            ),
+            format!("rw-consumer-{}", source_ctx.fragment_id),
         );
 
         let client_ctx = PrivateLinkConsumerContext::new(

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -208,7 +208,7 @@ KafkaProperties:
     required: false
   - name: properties.enable.auto.commit
     field_type: bool
-    comments: 'Automatically and periodically commit offsets in the background.  Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.  To circumvent this behaviour set specific start offsets per partition in the call to assign().  default: true'
+    comments: 'Whether to automatically and periodically commit offsets in the background.   Note that RisingWave does NOT rely on committed offsets. Committing offset is only for exposing the  progress for monitoring. Setting this to false can avoid creating consumer groups.   default: true'
     required: false
   - name: broker.rewrite.endpoints
     field_type: HashMap<String,String>


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We use `assign` to manually assign topics and partitions to Kafka consumers, instead of `subscribe`. In this case, consumer group related features are not used at all.

https://github.com/risingwavelabs/risingwave/blob/65440fb67754a5c8a47eec4a2c4a7dfcef1be75e/src/connector/src/source/kafka/source/reader.rs#L115

- This change is **safe**: There will be no conflicts between different actors in the same group. 
  - (**most importantly**) When they read data, the committed offsets in the group are not used at all. (Unless using group offset on startup. For existing sources, stored offsets will be used)
    - Note that even if we create multiple Kafka consumers `assign`ed to the same partitions, they can both consume 1 copy of data without conflict. They work **independently**.
  - They only update the committed offsets of their assigned partitions. So they will not override other actors' committed offset.
- This change increase **utility**: The committed offset is only for monitoring progress/lag. For this usage, it also make more sense to use a group id at the job (fragment) level, instead of actor level.
- This change reduces the number of consumer groups greatly, and thus can reduce user's confusion.

For more details explaining stuff, check this doc: https://www.notion.so/risingwave-labs/Notes-on-Kafka-Consumer-Consumer-Group-6bafdbab58b34ad7917fe47645f9a862

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
