### PR TITLE
fix(direct cdc): use `time.precision.mode=connect`

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/resources/debezium.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/debezium.properties
@@ -11,7 +11,7 @@ decimal.handling.mode=${debezium.decimal.handling.mode:-string}
 interval.handling.mode=string
 max.batch.size=${debezium.max.batch.size:-1024}
 max.queue.size=${debezium.max.queue.size:-8192}
-time.precision.mode=adaptive_time_microseconds
+time.precision.mode=connect
 # Quoted from the debezium document:
 # > Your application should always properly stop the engine to ensure graceful and complete
 # > shutdown and that each source record is sent to the application exactly one time.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

According to Debeizum docs,

- `adaptive_time_microseconds` or `adaptive`: using either millisecond, microsecond, or nanosecond precision values based on the database column’s type.
- `connect` always represents time and timestamp values using Kafka Connect’s built-in representations for Time, Date, and Timestamp, which use millisecond precision regardless of the database columns' precision.

Our implementation simply inherits the implementation of [Kafka Connect's JsonConverter](https://github.com/a0x8o/kafka/blob/master/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java)

https://github.com/risingwavelabs/risingwave/blob/c364ef3f35723ce7032c92a469831b0ab4dcf8c5/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzJsonConverter.java#L34-L38

Thus, we should use `time.precision.mode=connect` accordingly.




## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
