### PR TITLE
fix(test): remove auto setting implicit flush from recovery test

### DIFF
--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -525,7 +525,7 @@ steps:
     retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
-    command: "TEST_NUM=8 KILL_RATE=0.4 BACKGROUND_DDL_RATE=0.0 ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=8 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 ci/scripts/deterministic-recovery-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/skip-ci") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"

--- a/e2e_test/ddl/index.slt
+++ b/e2e_test/ddl/index.slt
@@ -124,6 +124,9 @@ statement ok
 insert into t values ('{"k": "abc" }'::jsonb);
 
 statement ok
+flush;
+
+statement ok
 create index idx on t(j->'k');
 
 statement ok

--- a/e2e_test/streaming/basic.slt
+++ b/e2e_test/streaming/basic.slt
@@ -32,6 +32,9 @@ statement ok
 insert into t5 values ('-inf');
 
 statement ok
+flush;
+
+statement ok
 create materialized view mv1 as select * from t1;
 
 statement ok

--- a/e2e_test/streaming/bug_fixes/mv_on_singleton_mv_4153.slt
+++ b/e2e_test/streaming/bug_fixes/mv_on_singleton_mv_4153.slt
@@ -4,6 +4,9 @@ create table t (v int);
 statement ok
 insert into t values (666), (233), (233);
 
+statement ok
+flush;
+
 # Create singleton mview
 statement ok
 create materialized view mv as select v from t order by v limit 10;

--- a/e2e_test/streaming/demo/ecommerce.slt
+++ b/e2e_test/streaming/demo/ecommerce.slt
@@ -77,6 +77,9 @@ INSERT INTO parcel_events
 ('76', '2022-08-10 12:31:22.07', 'parcel_shipped');
 
 statement ok
+flush;
+
+statement ok
 CREATE MATERIALIZED VIEW abnormal_delivery AS
 SELECT
     t1.order_id AS order_id,
@@ -102,9 +105,6 @@ FROM
     ) t2 ON t1.order_id = t2.order_id
 where
     t2.event_timestamp - t1.event_timestamp > interval '7 days';
-
-statement ok
-flush;
 
 query IT rowsort
 SELECT * FROM abnormal_delivery;

--- a/e2e_test/streaming/demo/ecommerce.slt
+++ b/e2e_test/streaming/demo/ecommerce.slt
@@ -20,6 +20,9 @@ values
     ('63', '74', 390.383406, '2022-07-19 12:31:22.07');
 
 statement ok
+flush;
+
+statement ok
 CREATE MATERIALIZED VIEW order_details AS
 SELECT
     order_id,
@@ -29,9 +32,6 @@ FROM
     order_events
 GROUP BY
     order_id;
-
-statement ok
-flush;
 
 query IRR rowsort
 SELECT * FROM order_details;

--- a/e2e_test/streaming/demo/metric_analysis.slt
+++ b/e2e_test/streaming/demo/metric_analysis.slt
@@ -39,6 +39,9 @@ INSERT INTO tcp_metrics VALUES
 ('812b4ba287f5ee0bc9d43bbf5bbe87fb', '3', '2022-06-08 09:39:54', 'download_speed', 'all', '149.7339243859982');
 
 statement ok
+FLUSH;
+
+statement ok
 CREATE MATERIALIZED VIEW high_util_tcp_metrics AS
 SELECT
     tcp.device_id AS device_id,

--- a/e2e_test/streaming/natural_and_cross_join.slt
+++ b/e2e_test/streaming/natural_and_cross_join.slt
@@ -23,6 +23,9 @@ INSERT INTO departments (department_name, department_id) VALUES
     ('Engineering', 1),
     ('HR', 2);
 
+statement ok
+flush
+
 # Create materialized view with NATURAL JOIN
 statement ok
 CREATE MATERIALIZED VIEW employee_department_natural_join AS
@@ -36,9 +39,6 @@ CREATE MATERIALIZED VIEW employee_department_cross_join AS
 SELECT e.employee_name, d.department_name
 FROM employees e CROSS JOIN departments d
 ORDER BY e.employee_name, d.department_name;
-
-statement ok
-flush
 
 # Test NATURAL JOIN
 query TT rowsort

--- a/e2e_test/streaming/non_strict_mode.slt
+++ b/e2e_test/streaming/non_strict_mode.slt
@@ -11,6 +11,9 @@ statement ok
 insert into t values (0),(1),(2),(NULL);
 
 statement ok
+flush;
+
+statement ok
 create materialized view mv_proj as select x, 10/x as v from t;
 
 statement ok
@@ -59,6 +62,9 @@ create table t(x varchar);
 
 statement ok
 insert into t values ('two'), ('4');
+
+statement ok
+flush;
 
 statement ok
 create materialized view mv_coalesce as select coalesce(x::int, 0) as v from t;

--- a/e2e_test/streaming/rate_limit/basic.slt
+++ b/e2e_test/streaming/rate_limit/basic.slt
@@ -29,6 +29,9 @@ DROP MATERIALIZED VIEW m;
 statement ok
 delete from t1;
 
+statement ok
+FLUSH;
+
 # Test with small rate_limit. In this case, the stream chunk needs to be split
 
 statement ok

--- a/e2e_test/streaming/time_window.slt
+++ b/e2e_test/streaming/time_window.slt
@@ -13,6 +13,9 @@ insert into t1 values
     (8, 3, 8, '2022-01-01 11:02:00');
 
 statement ok
+flush;
+
+statement ok
 create materialized view mv_tumble as
 select * from tumble(t1, created_at, interval '30' minute);
 
@@ -43,9 +46,6 @@ create materialized view mv_hop_agg_2 as
 select uid, sum(v) as sum_v, window_start
 from hop(t1, created_at, interval '15' minute, interval '30' minute)
 group by window_start, uid;
-
-statement ok
-flush;
 
 query IITTT
 select row_id, uid, created_at, window_start, window_end

--- a/e2e_test/streaming/time_window_join.slt
+++ b/e2e_test/streaming/time_window_join.slt
@@ -13,6 +13,9 @@ statement ok
 insert into RightTable values (timestamp '2020-04-15 12:01', 2, 'R2'), (timestamp '2020-04-15 12:04', 3, 'R3'), (timestamp '2020-04-15 12:05', 4, 'R4');
 
 statement ok
+flush;
+
+statement ok
 CREATE MATERIALIZED VIEW mv_window_join AS
 SELECT L.num AS L_Num, L.id AS L_Id, R.num AS R_Num, R.id AS R_Id,
     COALESCE(L.window_start, R.window_start) AS window_start,
@@ -21,9 +24,6 @@ FROM TUMBLE(LeftTable, row_time, interval '5' minute) AS L
 FULL JOIN
 TUMBLE(RightTable, row_time, interval '5' minute) AS R
 ON L.num = R.num AND L.window_start = R.window_start AND L.window_end = R.window_end;
-
-statement ok
-flush;
 
 query ITITTT rowsort
 SELECT * FROM mv_window_join;

--- a/src/tests/simulation/src/client.rs
+++ b/src/tests/simulation/src/client.rs
@@ -129,10 +129,6 @@ impl RisingWave {
                 tracing::error!("postgres connection error: {e}");
             }
         });
-        // for recovery
-        client
-            .simple_query("SET RW_IMPLICIT_FLUSH TO true;")
-            .await?;
         // replay all SET statements
         for stmt in SetStmtsIterator::new(set_stmts) {
             client.simple_query(&stmt).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Enabling `RW_IMPLICIT_FLUSH` at the beginning of each session in recovery test is no longer required, since we have retained this setting after restart.

Previously we might kill the cluster in all commands except for some on the whitelist. Even a `comment` record could trigger a kill. (cc @xxchan 😄) This is unnecessary and will cause unexpected kill between `insert` and `flush`. So after discussion with @yezizp2012, we decide not to kill by default, and only enable killing in specific `create` and `drop` statements. This will make recovery test more precise and efficient.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
