### PR TITLE
feat(meta): make blocking sink default + support background sink

### DIFF
--- a/e2e_test/backfill/sink/create_sink.slt
+++ b/e2e_test/backfill/sink/create_sink.slt
@@ -27,4 +27,5 @@ with (
 )
 FORMAT DEBEZIUM ENCODE JSON;
 
+statement ok
 SET BACKGROUND_DDL=false;

--- a/e2e_test/backfill/sink/create_sink.slt
+++ b/e2e_test/backfill/sink/create_sink.slt
@@ -12,6 +12,9 @@ statement ok
 insert into t select * from generate_series(1, 10000);
 
 statement ok
+SET BACKGROUND_DDL=true;
+
+statement ok
 create sink s as select x.v1 as v1
 from t x join t y
     on x.v1 = y.v1

--- a/e2e_test/backfill/sink/create_sink.slt
+++ b/e2e_test/backfill/sink/create_sink.slt
@@ -26,3 +26,5 @@ with (
     allow.auto.create.topics=true,
 )
 FORMAT DEBEZIUM ENCODE JSON;
+
+SET BACKGROUND_DDL=false;

--- a/e2e_test/streaming/rate_limit/snapshot_amplification.slt
+++ b/e2e_test/streaming/rate_limit/snapshot_amplification.slt
@@ -18,11 +18,17 @@ statement ok
 flush;
 
 statement ok
+SET BACKGROUND_DDL=true;
+
+statement ok
 CREATE SINK sink AS
     SELECT x.i1 as i1 FROM table x
         JOIN table s1 ON x.i1 = s1.i1
             JOIN table s2 ON x.i1 = s2.i1
     WITH (connector = 'blackhole');
+
+statement ok
+SET BACKGROUND_DDL=false;
 
 # Let sink amplify...
 skipif in-memory

--- a/e2e_test/streaming/rate_limit/upstream_amplification.slt
+++ b/e2e_test/streaming/rate_limit/upstream_amplification.slt
@@ -19,12 +19,18 @@ WITH (
 ) FORMAT PLAIN ENCODE JSON;
 
 statement ok
+SET BACKGROUND_DDL=true;
+
+statement ok
 CREATE SINK sink AS
     SELECT x.i1 as i1 FROM source_table x
         JOIN source_table s1 ON x.i1 = s1.i1
             JOIN source_table s2 ON x.i1 = s2.i1
                 JOIN source_table s3 ON x.i1 = s3.i1
     WITH (connector = 'blackhole');
+
+statement ok
+SET BACKGROUND_DDL=false;
 
 # The following sequence of FLUSH should be fast, since barrier should be able to bypass sink.
 # Otherwise, these FLUSH will take a long time to complete, and trigger timeout.

--- a/src/connector/src/sink/catalog/desc.rs
+++ b/src/connector/src/sink/catalog/desc.rs
@@ -107,7 +107,7 @@ impl SinkDesc {
             target_table: self.target_table,
             created_at_cluster_version: None,
             initialized_at_cluster_version: None,
-            create_type: CreateType::Foreground,
+            create_type: self.create_type,
         }
     }
 

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -23,6 +23,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::hash::ActorMapping;
 use risingwave_connector::source::SplitImpl;
 use risingwave_hummock_sdk::HummockEpoch;
+use risingwave_pb::catalog::CreateType;
 use risingwave_pb::meta::table_fragments::PbActorStatus;
 use risingwave_pb::meta::PausedReason;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
@@ -164,6 +165,7 @@ pub enum Command {
         init_split_assignment: SplitAssignment,
         definition: String,
         ddl_type: DdlType,
+        create_type: CreateType,
         replace_table: Option<ReplaceTablePlan>,
     },
     /// `CancelStreamingJob` command generates a `Stop` barrier including the actors of the given

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -290,6 +290,7 @@ impl StreamingJob {
             Self::MaterializedView(table) => {
                 table.get_create_type().unwrap_or(CreateType::Foreground)
             }
+            Self::Sink(s, _) => s.get_create_type().unwrap_or(CreateType::Foreground),
             _ => CreateType::Foreground,
         }
     }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -461,6 +461,7 @@ impl GlobalStreamManager {
             definition: definition.to_string(),
             ddl_type,
             replace_table: replace_table_command,
+            create_type,
         };
         tracing::debug!("sending Command::CreateStreamingJob");
         if let Err(err) = self.barrier_scheduler.run_command(command).await {

--- a/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
@@ -440,7 +440,7 @@ async fn test_foreground_index_cancel() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_sink_create() -> Result<()> {
+async fn test_background_sink_create() -> Result<()> {
     init_logger();
     let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
     let mut session = cluster.start_session();
@@ -450,6 +450,7 @@ async fn test_sink_create() -> Result<()> {
 
     let mut session2 = cluster.start_session();
     tokio::spawn(async move {
+        session2.run(SET_BACKGROUND_DDL).await.unwrap();
         session2.run(SET_RATE_LIMIT_2).await.unwrap();
         session2
             .run("CREATE SINK s FROM t WITH (connector='blackhole');")


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Part of #15587 

1. Change sink to block by default again, until backfill completes.
2. If background ddl set, then we let create sink immediately succeed.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

This PR contains user-facing-changes to the behaviour of sink creation.
After this PR, we will block until backfill completes.
Before this PR, we will immediately let sink finish creating, once first barrier completes. After this PR, if this is the desired behaviour, set `BACKGROUND_DDL=true`.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
