### PR TITLE
feat(error): provide service name on the client side of gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10360,6 +10360,7 @@ dependencies = [
  "madsim-tokio",
  "madsim-tonic",
  "moka",
+ "paste",
  "rand",
  "risingwave_common",
  "risingwave_error",

--- a/src/batch/src/error.rs
+++ b/src/batch/src/error.rs
@@ -150,13 +150,6 @@ impl From<ValueEncodingError> for BatchError {
     }
 }
 
-impl From<tonic::Status> for BatchError {
-    fn from(status: tonic::Status) -> Self {
-        // Always wrap the status into a `RpcError`.
-        Self::from(RpcError::from(status))
-    }
-}
-
 impl<'a> From<&'a BatchError> for Status {
     fn from(err: &'a BatchError) -> Self {
         err.to_status(tonic::Code::Internal, "batch")

--- a/src/batch/src/execution/grpc_exchange.rs
+++ b/src/batch/src/execution/grpc_exchange.rs
@@ -20,6 +20,7 @@ use risingwave_expr::expr_context::capture_expr_context;
 use risingwave_pb::batch_plan::exchange_source::LocalExecutePlan::{self, Plan};
 use risingwave_pb::batch_plan::TaskOutputId;
 use risingwave_pb::task_service::{ExecuteRequest, GetDataResponse};
+use risingwave_rpc_client::error::RpcError;
 use risingwave_rpc_client::ComputeClient;
 use tonic::Streaming;
 
@@ -81,7 +82,7 @@ impl ExchangeSource for GrpcExchangeSource {
             }
             Some(r) => r,
         };
-        let task_data = res?;
+        let task_data = res.map_err(RpcError::from_batch_status)?;
         let data = DataChunk::from_protobuf(task_data.get_record_batch()?)?.compact();
         trace!(
             "Receiver taskOutput = {:?}, data = {:?}",

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -94,8 +94,8 @@ pub enum ObserverError {
 }
 
 impl From<tonic::Status> for ObserverError {
-    fn from(value: tonic::Status) -> Self {
-        Self::Rpc(value.into())
+    fn from(status: tonic::Status) -> Self {
+        Self::Rpc(RpcError::from_meta_status(status))
     }
 }
 

--- a/src/error/src/tonic.rs
+++ b/src/error/src/tonic.rs
@@ -165,7 +165,7 @@ impl std::fmt::Display for TonicStatusWrapper {
             .and_then(|s| s.downcast_ref::<ServerError>())
             .and_then(|s| s.service_name.as_ref())
             // if no service name from the server side, use the client side one
-            .or_else(|| self.client_side_service_name.as_ref())
+            .or(self.client_side_service_name.as_ref())
         {
             write!(f, " to {} service", service_name)?;
         }

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -45,6 +45,7 @@ use risingwave_pb::batch_plan::{
 use risingwave_pb::common::{BatchQueryEpoch, HostAddress, WorkerNode};
 use risingwave_pb::plan_common::ExprContext;
 use risingwave_pb::task_service::{CancelTaskRequest, TaskInfoResponse};
+use risingwave_rpc_client::error::RpcError;
 use risingwave_rpc_client::ComputeClientPoolRef;
 use rw_futures_util::select_all;
 use thiserror_ext::AsReport;
@@ -525,7 +526,7 @@ impl StageRunner {
                         |_| StageState::Failed,
                         QueryMessage::Stage(Failed {
                             id: self.stage.id,
-                            reason: SchedulerError::from(e),
+                            reason: RpcError::from_batch_status(e).into(),
                         }),
                     )
                     .await;

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -17,7 +17,6 @@ use risingwave_common::session_config::QueryMode;
 use risingwave_connector::error::ConnectorError;
 use risingwave_rpc_client::error::RpcError;
 use thiserror::Error;
-use tonic::{Code, Status};
 
 use crate::error::{ErrorCode, RwError};
 use crate::scheduler::plan_fragmenter::QueryId;
@@ -67,16 +66,6 @@ pub enum SchedulerError {
         #[backtrace]
         anyhow::Error,
     ),
-}
-
-/// Only if the code is Internal, change it to Execution Error. Otherwise convert to Rpc Error.
-impl From<tonic::Status> for SchedulerError {
-    fn from(s: Status) -> Self {
-        match s.code() {
-            Code::Internal => Self::TaskExecutionError(s.message().to_string()),
-            _ => Self::RpcError(s.into()),
-        }
-    }
 }
 
 impl From<SchedulerError> for RwError {

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -24,6 +24,7 @@ hyper = "0.14" # required by tonic
 itertools = { workspace = true }
 lru = { workspace = true }
 moka = { version = "0.12", features = ["future"] }
+paste = "1"
 rand = { workspace = true }
 risingwave_common = { workspace = true }
 risingwave_error = { workspace = true }

--- a/src/rpc_client/src/compactor_client.rs
+++ b/src/rpc_client/src/compactor_client.rs
@@ -30,7 +30,7 @@ use tokio::sync::RwLock;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tonic::transport::{Channel, Endpoint};
 
-use crate::error::Result;
+use crate::error::{Result, RpcError};
 use crate::retry_rpc;
 const ENDPOINT_KEEP_ALIVE_INTERVAL_SEC: u64 = 60;
 const ENDPOINT_KEEP_ALIVE_TIMEOUT_SEC: u64 = 60;
@@ -59,7 +59,8 @@ impl CompactorClient {
             .monitor_client
             .to_owned()
             .stack_trace(StackTraceRequest::default())
-            .await?
+            .await
+            .map_err(RpcError::from_compactor_status)?
             .into_inner())
     }
 }

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -44,7 +44,6 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::transport::{Channel, Endpoint};
 use tonic::Streaming;
-use tower::ServiceBuilder;
 
 use crate::error::{Result, RpcError};
 use crate::{RpcClient, RpcClientPool};

--- a/src/rpc_client/src/error.rs
+++ b/src/rpc_client/src/error.rs
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 use risingwave_common::util::meta_addr::MetaAddressStrategyParseError;
+use risingwave_error::tonic::TonicStatusWrapperExt as _;
 use thiserror::Error;
+use thiserror_ext::Construct;
 
 pub type Result<T, E = RpcError> = std::result::Result<T, E>;
 
 // Re-export these types as they're commonly used together with `RpcError`.
 pub use risingwave_error::tonic::{ToTonicStatus, TonicStatusWrapper};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Construct)]
 pub enum RpcError {
     #[error(transparent)]
     TransportError(Box<tonic::transport::Error>),
@@ -48,8 +50,23 @@ impl From<tonic::transport::Error> for RpcError {
     }
 }
 
-impl From<tonic::Status> for RpcError {
-    fn from(s: tonic::Status) -> Self {
-        RpcError::GrpcStatus(Box::new(TonicStatusWrapper::new(s)))
-    }
+/// Intentionally not implemented to enforce using `RpcError::from_xxx_status`, so that
+/// the service name can always be included in the error message.
+impl !From<tonic::Status> for RpcError {}
+
+macro_rules! impl_from_status {
+    ($($service:ident),* $(,)?) => {
+        paste::paste! {
+            impl RpcError {
+                $(
+                    #[doc = "Convert a gRPC status from " $service " service into an [`RpcError`]."]
+                    pub fn [<from_ $service _status>](s: tonic::Status) -> Self {
+                        Self::grpc_status(s.with_client_side_service_name(stringify!($service)))
+                    }
+                )*
+            }
+        }
+    };
 }
+
+impl_from_status!(stream, batch, meta, compute, compactor, connector);

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1591,7 +1591,11 @@ impl MetaMemberManagement {
     async fn refresh_members(&mut self) -> Result<()> {
         let leader_addr = match self.members.as_mut() {
             Either::Left(client) => {
-                let resp = client.to_owned().members(MembersRequest {}).await?;
+                let resp = client
+                    .to_owned()
+                    .members(MembersRequest {})
+                    .await
+                    .map_err(RpcError::from_meta_status)?;
                 let resp = resp.into_inner();
                 resp.members.into_iter().find(|member| member.is_leader)
             }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1554,7 +1554,7 @@ impl GrpcMetaClientCore {
 
 /// Client to meta server. Cloning the instance is lightweight.
 ///
-/// It is a wrapper of tonic client. See [`crate::rpc_client_method_impl`].
+/// It is a wrapper of tonic client. See [`crate::meta_rpc_client_method_impl`].
 #[derive(Debug, Clone)]
 struct GrpcMetaClient {
     member_monitor_event_sender: mpsc::Sender<Sender<Result<()>>>,

--- a/src/rpc_client/src/sink_coordinate_client.rs
+++ b/src/rpc_client/src/sink_coordinate_client.rs
@@ -67,8 +67,12 @@ impl CoordinatorStreamHandle {
             move |rx| async move {
                 init_stream(rx)
                     .await
-                    .map(|response| response.into_inner().map_err(RpcError::from))
-                    .map_err(RpcError::from)
+                    .map(|response| {
+                        response
+                            .into_inner()
+                            .map_err(RpcError::from_connector_status)
+                    })
+                    .map_err(RpcError::from_connector_status)
             },
         )
         .await?;

--- a/src/rpc_client/src/stream_client.rs
+++ b/src/rpc_client/src/stream_client.rs
@@ -30,7 +30,7 @@ use tonic::transport::Endpoint;
 
 use crate::error::{Result, RpcError};
 use crate::tracing::{Channel, TracingInjectedChannelExt};
-use crate::{rpc_client_method_impl, RpcClient, RpcClientPool, UnboundedBidiStreamHandle};
+use crate::{stream_rpc_client_method_impl, RpcClient, RpcClientPool, UnboundedBidiStreamHandle};
 
 #[derive(Clone)]
 pub struct StreamClient(StreamServiceClient<Channel>);
@@ -79,7 +79,7 @@ macro_rules! for_all_stream_rpc {
 }
 
 impl StreamClient {
-    for_all_stream_rpc! { rpc_client_method_impl }
+    for_all_stream_rpc! { stream_rpc_client_method_impl }
 }
 
 pub type StreamingControlHandle =
@@ -98,8 +98,8 @@ impl StreamClient {
                 client
                     .streaming_control_stream(UnboundedReceiverStream::new(rx))
                     .await
-                    .map(|response| response.into_inner().map_err(RpcError::from))
-                    .map_err(RpcError::from)
+                    .map(|response| response.into_inner().map_err(RpcError::from_stream_status))
+                    .map_err(RpcError::from_stream_status)
             })
             .await?;
         match first_rsp {

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -217,7 +217,7 @@ impl RemoteInput {
                     // TODO(error-handling): maintain the source chain
                     return Err(StreamExecutorError::channel_closed(format!(
                         "RemoteInput tonic error: {}",
-                        TonicStatusWrapper::from(e).as_report()
+                        TonicStatusWrapper::new(e).as_report()
                     )));
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In #13282, we introduced `ServerError` to be encoded inside the gRPC (HTTP) response and passed through the wire, so that the client could gain more information about the error occurred on the server. The most significant part is the `service_name`, so that we can know the target of the failing gRPC request.

However, [`tonic::Status`] is used for both client and server side. If there's something wrong with the server side and the error is directly created on the client side, the approach above is not applicable. In this case, the caller should set a "client side" service name to provide better error message. This is what this PR is for.

For example, run `FLUSH` after the meta node crashed:

```diff
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
- 1: gRPC request failed: The service is currently unavailable
+ 1: gRPC request to meta service failed: The service is currently unavailable
  2: transport error
  3: error trying to connect
  4: tcp connect error
  5: Connection refused (os error 61)
```

We're able to know there's something wrong with the meta node in the error message.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
