### PR TITLE
fix(source): change kafka "offset" to be left inclusive and right exclusive

### DIFF
--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     fn test_split_impl_get_fn() -> Result<()> {
-        let split = KafkaSplit::new(0, Some(0), Some(0), "demo".to_string());
+        let split = KafkaSplit::new("demo".to_string(), 0, Some(0), Some(0));
         let split_impl = SplitImpl::Kafka(split.clone());
         let get_value = split_impl.into_kafka().unwrap();
         println!("{:?}", get_value);

--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -314,6 +314,7 @@ impl KafkaSplitEnumerator {
         let mut result = HashMap::with_capacity(partitions.len());
 
         for elem in offsets.elements_for_topic(self.topic.as_str()) {
+            println!("[rc] offset {:?}", elem.offset());
             match elem.offset() {
                 Offset::Offset(offset) => {
                     result.insert(elem.partition(), Some(offset));

--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -319,7 +319,7 @@ impl KafkaSplitEnumerator {
                 Offset::Offset(offset) => {
                     result.insert(elem.partition(), Some(offset));
                 }
-                Offset::End => {
+                _ => {
                     let (_, high_watermark) = self
                         .client
                         .fetch_watermarks(
@@ -330,7 +330,6 @@ impl KafkaSplitEnumerator {
                         .await?;
                     result.insert(elem.partition(), Some(high_watermark));
                 }
-                _ => unreachable!(),
             }
         }
 

--- a/src/connector/src/source/kafka/split.rs
+++ b/src/connector/src/source/kafka/split.rs
@@ -22,8 +22,44 @@ use crate::source::{SplitId, SplitMetaData};
 pub struct KafkaSplit {
     pub(crate) topic: String,
     pub(crate) partition: i32,
+
+    /// The offset pointing to the first message to read from the partition. Inclusive.
     pub(crate) start_offset: Option<i64>,
+    /// The offset pointing to the next position of the last message to read from the partition. Exclusive.
     pub(crate) stop_offset: Option<i64>,
+
+    /// The version of the split metadata. `None` means version 0.
+    version: Option<u32>,
+}
+
+/// The current version of the split metadata.
+/// Please increment this version and write a migration script below when you make a change to
+/// the split metadata.
+const CURRENT_VERSION: u32 = 1;
+
+static MIGRATION_SCRIPTS: &[fn(serde_json::Value) -> serde_json::Value] =
+    &[/* 0: 0 -> 1 */ migration::v0_to_v1];
+
+mod migration {
+    pub fn v0_to_v1(mut value: serde_json::Value) -> serde_json::Value {
+        // In v0, the `start_offset` field represented the last seen offset, which means when
+        // initializing a reader from the split, we should add 1 to the offset. But in the case
+        // of timestamp offset, it happended that we forgot to substract 1 from the offset
+        // when creating `KafkaSplit`, causing the first message to be missed.
+        // See https://github.com/risingwavelabs/risingwave/issues/16046 for more.
+        //
+        // In v1, we normalize the `start_offset` field to represent the first message to read
+        // from the partition. So we need to add 1 to any v0 `start_offset` field. We also
+        // normalize the `stop_offset` field to represent the next position of the last message,
+        // while fortunately, although not documented, the v0 `stop_offset` field was already
+        // representing the next position of the last message.
+
+        let start_offset = value["start_offset"]
+            .as_i64()
+            .map(|start_offset| start_offset + 1);
+        value["start_offset"] = start_offset.into();
+        value
+    }
 }
 
 impl SplitMetaData for KafkaSplit {
@@ -33,7 +69,14 @@ impl SplitMetaData for KafkaSplit {
     }
 
     fn restore_from_json(value: JsonbVal) -> ConnectorResult<Self> {
-        serde_json::from_value(value.take()).map_err(Into::into)
+        let mut value = value.take();
+        let mut version: u32 = value["version"].as_u64().unwrap_or(0) as u32;
+        while version < CURRENT_VERSION {
+            value = MIGRATION_SCRIPTS[version as usize](value);
+            version += 1;
+        }
+        value["version"] = CURRENT_VERSION.into();
+        serde_json::from_value(value).map_err(Into::into)
     }
 
     fn encode_to_json(&self) -> JsonbVal {
@@ -41,27 +84,47 @@ impl SplitMetaData for KafkaSplit {
     }
 
     fn update_offset(&mut self, last_seen_offset: String) -> ConnectorResult<()> {
-        self.start_offset = Some(last_seen_offset.as_str().parse::<i64>().unwrap());
+        let last_seen_offset = last_seen_offset.as_str().parse::<i64>().unwrap();
+        self.start_offset = Some(last_seen_offset + 1);
         Ok(())
     }
 }
 
 impl KafkaSplit {
     pub fn new(
+        topic: String,
         partition: i32,
         start_offset: Option<i64>,
         stop_offset: Option<i64>,
-        topic: String,
     ) -> KafkaSplit {
         KafkaSplit {
             topic,
             partition,
             start_offset,
             stop_offset,
+            version: Some(CURRENT_VERSION),
         }
     }
 
     pub fn get_topic_and_partition(&self) -> (String, i32) {
         (self.topic.clone(), self.partition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::JsonbVal;
+
+    use super::KafkaSplit;
+    use crate::source::SplitMetaData;
+
+    #[test]
+    fn test_migration_from_v0_to_v1() {
+        let test = serde_json::json!({"partition": 0, "start_offset": 2, "stop_offset": null, "topic": "test"});
+        let value = JsonbVal::from(test);
+
+        let split = KafkaSplit::restore_from_json(value).unwrap();
+        assert_eq!(split.start_offset, Some(3));
+        assert_eq!(split.version, Some(1));
     }
 }

--- a/src/connector/src/source/kafka/split.rs
+++ b/src/connector/src/source/kafka/split.rs
@@ -44,7 +44,7 @@ mod migration {
     pub fn v0_to_v1(mut value: serde_json::Value) -> serde_json::Value {
         // In v0, the `start_offset` field represented the last seen offset, which means when
         // initializing a reader from the split, we should add 1 to the offset. But in the case
-        // of timestamp offset, it happended that we forgot to substract 1 from the offset
+        // of timestamp offset, it happened that we forgot to subtract 1 from the offset
         // when creating `KafkaSplit`, causing the first message to be missed.
         // See https://github.com/risingwavelabs/risingwave/issues/16046 for more.
         //

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -298,7 +298,7 @@ pub(crate) mod tests {
             store,
         )
         .await;
-        let split_impl = SplitImpl::Kafka(KafkaSplit::new(0, Some(0), None, "test".into()));
+        let split_impl = SplitImpl::Kafka(KafkaSplit::new("test".into(), 0, Some(0), None));
         let serialized = split_impl.encode_to_bytes();
         let serialized_json = split_impl.encode_to_json();
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://www.notion.so/risingwave-labs/Which-s-Next-The-Source-Offset-Confusion-17ac5498bc3640a383b21a7ea8bbee58?pvs=4

Previously what we stored to `start_offset` field in `KafkaSplit` metadata is actually "last seen/consumed offset", and this had two problems:

1. When `scan.startup.timestamp.millis` is set, we have to subtract 1 from the offset derived from the given timestamp.
2. When initializing a Kafka reader, we have to add 1 back to the offset.

When these are mixed with Kafka low/high watermark, the code became very hard to understand and correctly maintain.

This PR gives the `start_offset` and `stop_offset` concepts a clear definition, i.e. when start to consume from Kafka, `start_offset` represents the first offset to read (inclusive), `stop_offset` represents the last offset to read PLUS 1 (exclusive). The new definitions match the low/high watermark definition in Kafka, so hopefully can be more intuitive.

To include some background of other `XxxSplit` structs (https://github.com/risingwavelabs/risingwave/pull/16256#discussion_r1560705754):

> IMO we should `+1` if possible when `update_offset` (unfortunately some source platforms don't allow simply doing addition on offset), that's in my mind the most elegant and clear solution. But in our current actual implementation, we have 3 cases:
>
> 1. `+1` when creating reader (Kafka), will be fixed in https://github.com/risingwavelabs/risingwave/pull/16257
> 2. Set offset to `AfterSequenceNumber(last_seen_offset)` (Kinesis), correct and exactly once.
> 3. Read from `last_seen_offset` on recovery, meaning duplicated items (Debezium CDC). The duplication seem unavoidable, see https://debezium.io/documentation/reference/stable/development/engine.html#_handling_failures.

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
