### PR TITLE
feat(rise-ctl): add fix dirty upstream fragment ids for streaming job

### DIFF
--- a/src/ctl/src/cmd_impl/debug.rs
+++ b/src/ctl/src/cmd_impl/debug.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod fix_table_fragments;
 mod meta_store;
 
+pub use fix_table_fragments::*;
 pub use meta_store::*;

--- a/src/ctl/src/cmd_impl/debug/fix_table_fragments.rs
+++ b/src/ctl/src/cmd_impl/debug/fix_table_fragments.rs
@@ -1,0 +1,76 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use etcd_client::ConnectOptions;
+use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
+use risingwave_meta::model::{MetadataModel, TableFragments};
+use risingwave_meta::storage::{EtcdMetaStore, WrappedEtcdClient};
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+
+use crate::DebugCommon;
+
+pub async fn fix_table_fragments(
+    common: DebugCommon,
+    table_id: u32,
+    dirty_fragment_ids: Vec<u32>,
+) -> anyhow::Result<()> {
+    let DebugCommon {
+        etcd_endpoints,
+        etcd_username,
+        etcd_password,
+        enable_etcd_auth,
+        ..
+    } = common;
+
+    let client = if enable_etcd_auth {
+        let options = ConnectOptions::default().with_user(
+            etcd_username.clone().unwrap_or_default(),
+            etcd_password.clone().unwrap_or_default(),
+        );
+        WrappedEtcdClient::connect(etcd_endpoints.clone(), Some(options), true).await?
+    } else {
+        WrappedEtcdClient::connect(etcd_endpoints.clone(), None, false).await?
+    };
+
+    let meta_store = EtcdMetaStore::new(client);
+
+    let mut table_fragments = TableFragments::select(&meta_store, &table_id)
+        .await?
+        .expect("table fragments not found");
+
+    for fragment in table_fragments.fragments.values_mut() {
+        fragment
+            .upstream_fragment_ids
+            .retain(|id| !dirty_fragment_ids.contains(id));
+        for actor in &mut fragment.actors {
+            visit_stream_node_cont(actor.nodes.as_mut().unwrap(), |node| {
+                if let Some(NodeBody::Union(_)) = node.node_body {
+                    node.input.retain_mut(|input| {
+                        if let Some(NodeBody::Merge(merge_node)) = &mut input.node_body
+                            && dirty_fragment_ids.contains(&merge_node.upstream_fragment_id)
+                        {
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                }
+                true
+            })
+        }
+    }
+
+    table_fragments.insert(&meta_store).await?;
+    Ok(())
+}

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -141,8 +141,9 @@ pub enum DebugCommands {
         #[command(flatten)]
         common: DebugCommon,
     },
-    /// Fix table fragments info.
-    FixTableFragments {
+    /// Fix table fragments by cleaning up some un-exist fragments, which happens when the upstream
+    /// streaming job is failed to create and the fragments are not cleaned up due to some unidentified issues.
+    FixDirtyUpstreams {
         #[command(flatten)]
         common: DebugCommon,
 
@@ -864,7 +865,7 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                 .await?
         }
         Commands::Debug(DebugCommands::Dump { common }) => cmd_impl::debug::dump(common).await?,
-        Commands::Debug(DebugCommands::FixTableFragments {
+        Commands::Debug(DebugCommands::FixDirtyUpstreams {
             common,
             table_id,
             dirty_fragment_ids,

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -141,6 +141,17 @@ pub enum DebugCommands {
         #[command(flatten)]
         common: DebugCommon,
     },
+    /// Fix table fragments info.
+    FixTableFragments {
+        #[command(flatten)]
+        common: DebugCommon,
+
+        #[clap(long)]
+        table_id: u32,
+
+        #[clap(long, value_delimiter = ',')]
+        dirty_fragment_ids: Vec<u32>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -853,6 +864,11 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                 .await?
         }
         Commands::Debug(DebugCommands::Dump { common }) => cmd_impl::debug::dump(common).await?,
+        Commands::Debug(DebugCommands::FixTableFragments {
+            common,
+            table_id,
+            dirty_fragment_ids,
+        }) => cmd_impl::debug::fix_table_fragments(common, table_id, dirty_fragment_ids).await?,
         Commands::Throttle(ThrottleCommands::Source(args)) => {
             apply_throttle(context, risingwave_pb::meta::PbThrottleTarget::Source, args).await?
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Background: we found that in the environment of a certain customer, when the `create sink into table` statement failed unexpectedly, the deleted fragment information still remained in the streaming graph of the downstream table, which caused cluster recovery to fail. They should be cleaned by kernel automatically but not. The root cause has not been identified yet. This PR adds a fix script to solve this problem. The user's environment has been fixed, and the root cause is still being investigated.

Usage:
```
./risedev ctl debug fix-dirty-upstreams --table-d 1 --dirty-fragment-ids 1
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
