### PR TITLE
feat(frontend, meta): support `RECOVER` command to trigger recovery

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -266,6 +266,10 @@ message ApplyThrottleResponse {
   common.Status status = 1;
 }
 
+message RecoverRequest {}
+
+message RecoverResponse {}
+
 service StreamManagerService {
   rpc Flush(FlushRequest) returns (FlushResponse);
   rpc Pause(PauseRequest) returns (PauseResponse);
@@ -277,6 +281,7 @@ service StreamManagerService {
   rpc ListActorStates(ListActorStatesRequest) returns (ListActorStatesResponse);
   rpc ListObjectDependencies(ListObjectDependenciesRequest) returns (ListObjectDependenciesResponse);
   rpc ApplyThrottle(ApplyThrottleRequest) returns (ApplyThrottleResponse);
+  rpc Recover(RecoverRequest) returns (RecoverResponse);
 }
 
 // Below for cluster service.

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -87,6 +87,7 @@ pub mod handle_privilege;
 mod kill_process;
 pub mod privilege;
 pub mod query;
+mod recover;
 pub mod show;
 mod transaction;
 pub mod util;
@@ -509,6 +510,7 @@ pub async fn handle(
         }
         Statement::Flush => flush::handle_flush(handler_args).await,
         Statement::Wait => wait::handle_wait(handler_args).await,
+        Statement::Recover => recover::handle_recover(handler_args).await,
         Statement::SetVariable {
             local: _,
             variable,

--- a/src/frontend/src/handler/recover.rs
+++ b/src/frontend/src/handler/recover.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::pg_response::{PgResponse, StatementType};
+
+use super::RwPgResponse;
+use crate::error::Result;
+use crate::handler::HandlerArgs;
+use crate::session::SessionImpl;
+
+pub(super) async fn handle_recover(handler_args: HandlerArgs) -> Result<RwPgResponse> {
+    // Notify the meta client to recover the data.
+    do_recover(&handler_args.session).await?;
+    Ok(PgResponse::empty_result(StatementType::RECOVER))
+}
+
+pub(crate) async fn do_recover(session: &SessionImpl) -> Result<()> {
+    let client = session.env().meta_client();
+    client.recover().await?;
+    Ok(())
+}

--- a/src/frontend/src/handler/recover.rs
+++ b/src/frontend/src/handler/recover.rs
@@ -21,7 +21,7 @@ use crate::session::SessionImpl;
 
 pub(super) async fn handle_recover(handler_args: HandlerArgs) -> Result<RwPgResponse> {
     // Only permit recovery for super users.
-    if handler_args.session.is_super_user() {
+    if !handler_args.session.is_super_user() {
         return Err(ErrorCode::PermissionDenied(
             "only superusers can trigger adhoc recovery".to_string(),
         )

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -52,6 +52,8 @@ pub trait FrontendMetaClient: Send + Sync {
 
     async fn wait(&self) -> Result<()>;
 
+    async fn recover(&self) -> Result<()>;
+
     async fn cancel_creating_jobs(&self, jobs: PbJobs) -> Result<Vec<u32>>;
 
     async fn list_table_fragments(
@@ -135,6 +137,10 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn wait(&self) -> Result<()> {
         self.0.wait().await
+    }
+
+    async fn recover(&self) -> Result<()> {
+        self.0.recover().await
     }
 
     async fn cancel_creating_jobs(&self, infos: PbJobs) -> Result<Vec<u32>> {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1055,6 +1055,10 @@ impl FrontendMetaClient for MockFrontendMetaClient {
     async fn list_compact_task_progress(&self) -> RpcResult<Vec<CompactTaskProgress>> {
         unimplemented!()
     }
+
+    async fn recover(&self) -> RpcResult<()> {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
-use risingwave_meta::manager::MetadataManager;
+use risingwave_meta::manager::{LocalNotification, MetadataManager};
 use risingwave_meta::model;
 use risingwave_meta::model::ActorId;
 use risingwave_meta::stream::ThrottleConfig;
@@ -417,6 +417,10 @@ impl StreamManagerService for StreamServiceImpl {
         &self,
         _request: Request<RecoverRequest>,
     ) -> Result<Response<RecoverResponse>, Status> {
-        todo!()
+        self.env
+            .notification_manager()
+            .notify_local_subscribers(LocalNotification::AdhocRecovery)
+            .await;
+        Ok(Response::new(RecoverResponse {}))
     }
 }

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -411,4 +411,12 @@ impl StreamManagerService for StreamServiceImpl {
             dependencies,
         }))
     }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn recover(
+        &self,
+        _request: Request<RecoverRequest>,
+    ) -> Result<Response<RecoverResponse>, Status> {
+        todo!()
+    }
 }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -118,6 +118,8 @@ enum RecoveryReason {
     Bootstrap,
     /// After failure.
     Failover(MetaError),
+    /// Manually triggered
+    Adhoc,
 }
 
 /// Status of barrier manager.
@@ -1030,6 +1032,9 @@ impl GlobalBarrierManagerContext {
             }
             BarrierManagerStatus::Recovering(RecoveryReason::Failover(e)) => {
                 Err(anyhow::anyhow!(e.clone()).context("The cluster is recovering"))?
+            }
+            BarrierManagerStatus::Recovering(RecoveryReason::Adhoc) => {
+                bail!("The cluster is recovering-adhoc")
             }
             BarrierManagerStatus::Running => Ok(()),
         }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -824,7 +824,7 @@ impl GlobalBarrierManager {
             let latest_snapshot = self.context.hummock_manager.latest_snapshot();
             let prev_epoch = TracedEpoch::new(latest_snapshot.committed_epoch.into()); // we can only recover from the committed epoch
             let span = tracing::info_span!(
-                "failure_recovery",
+                "adhoc_recovery",
                 error = %err.as_report(),
                 prev_epoch = prev_epoch.value().0
             );

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -654,16 +654,16 @@ impl GlobalBarrierManager {
                     }
                 }
 
-                // Checkpoint frequency changes.
                 notification = local_notification_rx.recv() => {
                     let notification = notification.unwrap();
-                    // Handle barrier interval and checkpoint frequency changes
                     match notification {
+                        // Handle barrier interval and checkpoint frequency changes.
                         LocalNotification::SystemParamsChange(p) => {
                             self.scheduled_barriers.set_min_interval(Duration::from_millis(p.barrier_interval_ms() as u64));
                             self.scheduled_barriers
                                 .set_checkpoint_frequency(p.checkpoint_frequency() as usize)
                         },
+                        // Handle adhoc recovery triggered by user.
                         LocalNotification::AdhocRecovery => {
                             self.adhoc_recovery().await;
                         }

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -119,6 +119,10 @@ pub enum MetaErrorInner {
         #[backtrace]
         anyhow::Error,
     ),
+
+    // Indicates that recovery was triggered manually.
+    #[error("adhoc recovery triggered")]
+    AdhocRecovery,
 }
 
 impl MetaError {

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -47,6 +47,7 @@ pub enum LocalNotification {
     SystemParamsChange(SystemParamsReader),
     FragmentMappingsUpsert(Vec<FragmentId>),
     FragmentMappingsDelete(Vec<FragmentId>),
+    AdhocRecovery,
 }
 
 #[derive(Debug)]

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -798,6 +798,12 @@ impl MetaClient {
         Ok(())
     }
 
+    pub async fn recover(&self) -> Result<()> {
+        let request = RecoverRequest {};
+        self.inner.recover(request).await?;
+        Ok(())
+    }
+
     pub async fn cancel_creating_jobs(&self, jobs: PbJobs) -> Result<Vec<u32>> {
         let request = CancelCreatingJobsRequest { jobs: Some(jobs) };
         let resp = self.inner.cancel_creating_jobs(request).await?;
@@ -1903,6 +1909,7 @@ macro_rules! for_all_meta_rpc {
             ,{ stream_client, list_fragment_distribution, ListFragmentDistributionRequest, ListFragmentDistributionResponse }
             ,{ stream_client, list_actor_states, ListActorStatesRequest, ListActorStatesResponse }
             ,{ stream_client, list_object_dependencies, ListObjectDependenciesRequest, ListObjectDependenciesResponse }
+            ,{ stream_client, recover, RecoverRequest, RecoverResponse }
             ,{ ddl_client, create_table, CreateTableRequest, CreateTableResponse }
             ,{ ddl_client, alter_name, AlterNameRequest, AlterNameResponse }
             ,{ ddl_client, alter_owner, AlterOwnerRequest, AlterOwnerResponse }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1519,6 +1519,8 @@ pub enum Statement {
     /// WAIT for ALL running stream jobs to finish.
     /// It will block the current session the condition is met.
     Wait,
+    /// Trigger stream job recover
+    Recover,
 }
 
 impl fmt::Display for Statement {
@@ -2106,6 +2108,10 @@ impl fmt::Display for Statement {
             }
             Statement::Kill(process_id) => {
                 write!(f, "KILL {}", process_id)?;
+                Ok(())
+            }
+            Statement::Recover => {
+                write!(f, "RECOVER")?;
                 Ok(())
             }
         }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -402,6 +402,7 @@ define_keywords!(
     READ,
     READS,
     REAL,
+    RECOVER,
     RECURSIVE,
     REF,
     REFERENCES,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -283,6 +283,7 @@ impl Parser {
                 Keyword::CLOSE => Ok(self.parse_close_cursor()?),
                 Keyword::FLUSH => Ok(Statement::Flush),
                 Keyword::WAIT => Ok(Statement::Wait),
+                Keyword::RECOVER => Ok(Statement::Recover),
                 _ => self.expected(
                     "an SQL statement",
                     Token::Word(w).with_location(token.location),

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -105,6 +105,7 @@ pub enum StatementType {
     CLOSE_CURSOR,
     WAIT,
     KILL,
+    RECOVER,
 }
 
 impl std::fmt::Display for StatementType {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Closes https://github.com/risingwavelabs/risingwave/issues/14700

The current shortcoming of this approach is that while recovery is triggered, the command does not wait for recovery to complete, it operates in an async way. Welcome any ideas for improvement. If not we can improve it later.

Path of recover command:
```
Frontend -> Meta Client -> Stream Manager -> Notification Service -> Barrier Manager -> trigger recovery
```



<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

The user can use the command: `RECOVER` to trigger an adhoc `recovery`. This can be used in cases where barrier latency is high, and we want to force a recovery to kick-in, so commands like `cancel, drop` can immediately take effect.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
