### PR TITLE
fix(meta): fix potentially removing sst objects between min pinned and checkpoint version

### DIFF
--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -191,7 +191,10 @@ impl HummockManager {
         let versioning = versioning_guard.deref_mut();
         assert!(new_checkpoint.version.id >= versioning.checkpoint.version.id);
         versioning.checkpoint = new_checkpoint;
-        versioning.mark_objects_for_deletion();
+        // Not delete stale objects when archive is enabled
+        if !self.env.opts.enable_hummock_data_archive {
+            versioning.mark_objects_for_deletion();
+        }
 
         let min_pinned_version_id = versioning.min_pinned_version_id();
         trigger_gc_stat(&self.metrics, &versioning.checkpoint, min_pinned_version_id);

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -23,7 +23,9 @@ use risingwave_hummock_sdk::compaction_group::hummock_version_ext::{
 };
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::HummockVersionId;
-use risingwave_pb::hummock::hummock_version_checkpoint::{PbStaleObjects, StaleObjects};
+use risingwave_pb::hummock::hummock_version_checkpoint::{
+    StaleObjects as PbStaleObjects, StaleObjects,
+};
 use risingwave_pb::hummock::{PbHummockVersionArchive, PbHummockVersionCheckpoint};
 use thiserror_ext::AsReport;
 
@@ -127,39 +129,38 @@ impl HummockManager {
         }
         let mut archive: Option<PbHummockVersionArchive> = None;
         let mut stale_objects = old_checkpoint.stale_objects.clone();
-        if !self.env.opts.enable_hummock_data_archive {
-            // `object_sizes` is used to calculate size of stale objects.
-            let mut object_sizes = object_size_map(&old_checkpoint.version);
-            for (_, version_delta) in versioning
-                .hummock_version_deltas
-                .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
-            {
-                for group_deltas in version_delta.group_deltas.values() {
-                    let summary = summarize_group_deltas(group_deltas);
-                    object_sizes.extend(
-                        summary
-                            .insert_table_infos
-                            .iter()
-                            .map(|t| (t.object_id, t.file_size)),
-                    );
-                }
-                let removed_object_ids = version_delta.gc_object_ids.clone();
-                if removed_object_ids.is_empty() {
-                    continue;
-                }
-                let total_file_size = removed_object_ids
-                    .iter()
-                    .map(|t| object_sizes.get(t).copied().unwrap())
-                    .sum::<u64>();
-                stale_objects.insert(
-                    version_delta.id,
-                    StaleObjects {
-                        id: removed_object_ids,
-                        total_file_size,
-                    },
+        // `object_sizes` is used to calculate size of stale objects.
+        let mut object_sizes = object_size_map(&old_checkpoint.version);
+        for (_, version_delta) in versioning
+            .hummock_version_deltas
+            .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
+        {
+            for group_deltas in version_delta.group_deltas.values() {
+                let summary = summarize_group_deltas(group_deltas);
+                object_sizes.extend(
+                    summary
+                        .insert_table_infos
+                        .iter()
+                        .map(|t| (t.object_id, t.file_size)),
                 );
             }
-        } else {
+            let removed_object_ids = version_delta.gc_object_ids.clone();
+            if removed_object_ids.is_empty() {
+                continue;
+            }
+            let total_file_size = removed_object_ids
+                .iter()
+                .map(|t| object_sizes.get(t).copied().unwrap())
+                .sum::<u64>();
+            stale_objects.insert(
+                version_delta.id,
+                StaleObjects {
+                    id: removed_object_ids,
+                    total_file_size,
+                },
+            );
+        }
+        if self.env.opts.enable_hummock_data_archive {
             archive = Some(PbHummockVersionArchive {
                 version: Some(old_checkpoint.version.to_protobuf()),
                 version_deltas: versioning

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -609,7 +609,10 @@ impl HummockManager {
         };
 
         versioning_guard.objects_to_delete.clear();
-        versioning_guard.mark_objects_for_deletion();
+        // Not delete stale objects when archive is enabled
+        if !self.env.opts.enable_hummock_data_archive {
+            versioning_guard.mark_objects_for_deletion();
+        }
 
         self.initial_compaction_group_config_after_load(versioning_guard)
             .await?;

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -21,6 +21,7 @@ use risingwave_hummock_sdk::HummockSstableObjectId;
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
 use risingwave_pb::hummock::VacuumTask;
 use thiserror_ext::AsReport;
+use tracing::warn;
 
 use super::CompactorManagerRef;
 use crate::backup_restore::BackupManagerRef;
@@ -112,6 +113,12 @@ impl VacuumManager {
         let mut batch_idx = 0;
         let batch_size = 500usize;
         let mut sent_batch = Vec::with_capacity(objects_to_delete.len());
+        if self.env.opts.enable_hummock_data_archive {
+            if !objects_to_delete.is_empty() {
+                warn!(?objects_to_delete, "objects not deleted in vacuum due to enable_hummock_data_archive");
+            }
+            return Ok(objects_to_delete);
+        }
         while batch_idx < objects_to_delete.len() {
             if batch_idx != 0 && self.env.opts.vacuum_spin_interval_ms != 0 {
                 tokio::time::sleep(Duration::from_millis(self.env.opts.vacuum_spin_interval_ms))

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -21,7 +21,6 @@ use risingwave_hummock_sdk::HummockSstableObjectId;
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
 use risingwave_pb::hummock::VacuumTask;
 use thiserror_ext::AsReport;
-use tracing::warn;
 
 use super::CompactorManagerRef;
 use crate::backup_restore::BackupManagerRef;
@@ -113,15 +112,6 @@ impl VacuumManager {
         let mut batch_idx = 0;
         let batch_size = 500usize;
         let mut sent_batch = Vec::with_capacity(objects_to_delete.len());
-        if self.env.opts.enable_hummock_data_archive {
-            if !objects_to_delete.is_empty() {
-                warn!(
-                    ?objects_to_delete,
-                    "objects not deleted in vacuum due to enable_hummock_data_archive"
-                );
-            }
-            return Ok(objects_to_delete);
-        }
         while batch_idx < objects_to_delete.len() {
             if batch_idx != 0 && self.env.opts.vacuum_spin_interval_ms != 0 {
                 tokio::time::sleep(Duration::from_millis(self.env.opts.vacuum_spin_interval_ms))

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -115,7 +115,10 @@ impl VacuumManager {
         let mut sent_batch = Vec::with_capacity(objects_to_delete.len());
         if self.env.opts.enable_hummock_data_archive {
             if !objects_to_delete.is_empty() {
-                warn!(?objects_to_delete, "objects not deleted in vacuum due to enable_hummock_data_archive");
+                warn!(
+                    ?objects_to_delete,
+                    "objects not deleted in vacuum due to enable_hummock_data_archive"
+                );
             }
             return Ok(objects_to_delete);
         }

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -37,7 +37,7 @@ use crate::manager::{
     NotificationManagerRef,
 };
 use crate::model::ClusterId;
-use crate::storage::{MemStore, MetaStore, MetaStoreBoxExt, MetaStoreRef};
+use crate::storage::{MetaStore, MetaStoreRef};
 use crate::MetaResult;
 
 #[derive(Clone)]
@@ -480,6 +480,8 @@ impl MetaSrvEnv {
     }
 
     pub async fn for_test_opts(opts: MetaOpts) -> Self {
+        use crate::storage::{MemStore, MetaStoreBoxExt};
+
         Self::new(
             opts,
             risingwave_common::system_param::system_params_for_test(),

--- a/src/storage/backup/src/lib.rs
+++ b/src/storage/backup/src/lib.rs
@@ -51,7 +51,7 @@ pub type MetaBackupJobId = u64;
 pub struct MetaSnapshotMetadata {
     pub id: MetaSnapshotId,
     pub hummock_version_id: HummockVersionId,
-    pub ssts: Vec<HummockSstableObjectId>,
+    pub ssts: HashSet<HummockSstableObjectId>,
     pub max_committed_epoch: u64,
     pub safe_epoch: u64,
     #[serde(default)]
@@ -69,9 +69,7 @@ impl MetaSnapshotMetadata {
         Self {
             id,
             hummock_version_id: v.id,
-            ssts: HashSet::<HummockSstableObjectId>::from_iter(v.get_object_ids())
-                .into_iter()
-                .collect_vec(),
+            ssts: v.get_object_ids(),
             max_committed_epoch: v.max_committed_epoch,
             safe_epoch: v.safe_epoch,
             format_version,

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -158,7 +158,7 @@ impl HummockVersion {
     }
 
     /// This function does NOT dedup.
-    pub fn get_object_ids(&self) -> Vec<u64> {
+    pub fn get_object_ids(&self) -> HashSet<HummockSstableObjectId> {
         self.get_combined_levels()
             .flat_map(|level| {
                 level
@@ -166,7 +166,7 @@ impl HummockVersion {
                     .iter()
                     .map(|table_info| table_info.get_object_id())
             })
-            .collect_vec()
+            .collect()
     }
 
     pub fn level_iter<F: FnMut(&Level) -> bool>(

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -157,7 +157,6 @@ impl HummockVersion {
         })
     }
 
-    /// This function does NOT dedup.
     pub fn get_object_ids(&self) -> HashSet<HummockSstableObjectId> {
         self.get_combined_levels()
             .flat_map(|level| {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously in full gc, in the `extend_objects_to_delete_from_scan` method, we marked the sst objects in the latest version plus the `gc_object_ids` of hummock version delta as tracked object ids, so that the gc will not remove these sst objects that are potentially used by some pinned version. 

However, hummock version delta will be truncated at hummock version checkpoint. Therefore, we only track the sst objects in the versions between the checkpoint version and the latest version, and the versions between the min pinned version and the checkpoint version will not be tracked, and we may potentially remove some sst objects used by a pinned version.

In this PR, we change the tracked object ids to be: sst objects in the latest version + `gc_object_ids` of version deltas between checkpoint version and the latest version  + `stale_objects` of `HummockVersionCheckpoint` of epoch higher than min pinned version.

Previously `stale_objects` will not be set in checkpoint when `enable_hummock_data_archive` is enabled so that the sst won't be reclaimed and we can debug with it. In this PR, we change to set the `stale_objects` anyway, and when `enable_hummock_data_archive` is enabled we won't send request to compactor to do the real object cleaning task.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
