### PR TITLE
feat(source): `encode json` option `timestamptz.handling.mode`

### DIFF
--- a/e2e_test/source/basic/handling_mode.slt
+++ b/e2e_test/source/basic/handling_mode.slt
@@ -1,0 +1,136 @@
+statement error unrecognized
+create table t (
+  payload struct<after struct<"case" varchar, at timestamptz>>)
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format plain encode json (timestamptz.handling.mode = 'mili');
+
+# spelling error on config name would raise a non-fatal notice and use the default
+statement ok
+create table plain_guess (
+  "case" varchar,
+  payload struct<after struct<"case" varchar, at timestamptz>>)
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format plain encode json (timestamptz.handling.mod = 'mili');
+
+statement ok
+create table plain_milli (
+  "case" varchar,
+  payload struct<after struct<"case" varchar, at timestamptz>>)
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format plain encode json (timestamptz.handling.mode = 'milli');
+
+statement ok
+create table plain_micro (
+  "case" varchar,
+  payload struct<after struct<"case" varchar, at timestamptz>>)
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format plain encode json (timestamptz.handling.mode = 'micro');
+
+statement ok
+create table plain_utc (
+  "case" varchar,
+  payload struct<after struct<"case" varchar, at timestamptz>>)
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format plain encode json (timestamptz.handling.mode = 'utc_string');
+
+statement ok
+create table plain_naive (
+  "case" varchar,
+  payload struct<after struct<"case" varchar, at timestamptz>>)
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format plain encode json (timestamptz.handling.mode = 'utc_without_suffix');
+
+statement ok
+create table debezium_milli (
+  "case" varchar, at timestamptz, primary key("case"))
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='message_queue:29092',
+  topic = 'json_timestamptz_handling_mode')
+format debezium encode json (timestamptz.handling.mode = 'milli');
+
+sleep 2s
+
+query TT
+select "case", (payload).after.at from plain_guess order by 1;
+----
+0 number small  1970-01-01 00:01:40+00:00
+1 number recent 2024-04-11 02:00:00.123456+00:00
+2 string utc    2024-04-11 02:00:00.654321+00:00
+3 string naive  NULL
+
+query TT
+select "case", (payload).after.at from plain_milli order by 1;
+----
+0 number small   1970-01-01 00:00:00.100+00:00
+1 number recent 56246-07-01 08:02:03.456+00:00
+2 string utc     2024-04-11 02:00:00.654321+00:00
+3 string naive   NULL
+
+query TT
+select "case", (payload).after.at from plain_micro order by 1;
+----
+0 number small  1970-01-01 00:00:00.000100+00:00
+1 number recent 2024-04-11 02:00:00.123456+00:00
+2 string utc    2024-04-11 02:00:00.654321+00:00
+3 string naive  NULL
+
+query TT
+select "case", (payload).after.at from plain_utc order by 1;
+----
+0 number small  NULL
+1 number recent NULL
+2 string utc    2024-04-11 02:00:00.654321+00:00
+3 string naive  NULL
+
+query TT
+select "case", (payload).after.at from plain_naive order by 1;
+----
+0 number small  NULL
+1 number recent NULL
+2 string utc    NULL
+3 string naive  2024-04-11 02:00:00.234321+00:00
+
+query TT
+select "case", at from debezium_milli order by 1;
+----
+0 number small   1970-01-01 00:00:00.100+00:00
+1 number recent 56246-07-01 08:02:03.456+00:00
+2 string utc     2024-04-11 02:00:00.654321+00:00
+3 string naive   NULL
+
+statement ok
+drop table plain_guess;
+
+statement ok
+drop table plain_milli;
+
+statement ok
+drop table plain_micro;
+
+statement ok
+drop table plain_utc;
+
+statement ok
+drop table plain_naive;
+
+statement ok
+drop table debezium_milli;

--- a/scripts/source/test_data/json_timestamptz_handling_mode.1
+++ b/scripts/source/test_data/json_timestamptz_handling_mode.1
@@ -1,0 +1,4 @@
+{"case":"0 number small","payload":{"after":{"case":"0 number small","at":100},"op":"r"}}
+{"case":"1 number recent","payload":{"after":{"case":"1 number recent","at":1712800800123456},"op":"r"}}
+{"case":"2 string utc","payload":{"after":{"case":"2 string utc","at":"2024-04-11T02:00:00.654321Z"},"op":"r"}}
+{"case":"3 string naive","payload":{"after":{"case":"3 string naive","at":"2024-04-11 02:00:00.234321"},"op":"r"}}

--- a/src/connector/benches/parser.rs
+++ b/src/connector/benches/parser.rs
@@ -77,6 +77,7 @@ fn create_parser(
         key_encoding_config: None,
         encoding_config: EncodingProperties::Json(JsonProperties {
             use_schema_registry: false,
+            timestamptz_handling: None,
         }),
         protocol_config: ProtocolProperties::Plain,
     };

--- a/src/connector/src/parser/json_parser.rs
+++ b/src/connector/src/parser/json_parser.rs
@@ -595,6 +595,7 @@ mod tests {
             key_encoding_config: None,
             encoding_config: EncodingProperties::Json(JsonProperties {
                 use_schema_registry: false,
+                timestamptz_handling: None,
             }),
             protocol_config: ProtocolProperties::Upsert,
         };

--- a/src/connector/src/parser/maxwell/simd_json_parser.rs
+++ b/src/connector/src/parser/maxwell/simd_json_parser.rs
@@ -36,6 +36,7 @@ mod tests {
             key_encoding_config: None,
             encoding_config: EncodingProperties::Json(JsonProperties {
                 use_schema_registry: false,
+                timestamptz_handling: None,
             }),
             protocol_config: ProtocolProperties::Maxwell,
         };

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -45,6 +45,7 @@ pub use self::mysql::mysql_row_to_owned_row;
 use self::plain_parser::PlainParser;
 pub use self::postgres::postgres_row_to_owned_row;
 use self::simd_json_parser::DebeziumJsonAccessBuilder;
+pub use self::unified::json::TimestamptzHandling;
 use self::unified::AccessImpl;
 use self::upsert_parser::UpsertParser;
 use self::util::get_kafka_topic;
@@ -1006,6 +1007,7 @@ impl SpecificParserConfig {
         key_encoding_config: None,
         encoding_config: EncodingProperties::Json(JsonProperties {
             use_schema_registry: false,
+            timestamptz_handling: None,
         }),
         protocol_config: ProtocolProperties::Plain,
     };
@@ -1046,6 +1048,7 @@ pub struct CsvProperties {
 #[derive(Debug, Default, Clone)]
 pub struct JsonProperties {
     pub use_schema_registry: bool,
+    pub timestamptz_handling: Option<TimestamptzHandling>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -1200,10 +1203,14 @@ impl SpecificParserConfig {
                 SourceEncode::Json,
             ) => EncodingProperties::Json(JsonProperties {
                 use_schema_registry: info.use_schema_registry,
+                timestamptz_handling: TimestamptzHandling::from_options(
+                    &info.format_encode_options,
+                )?,
             }),
             (SourceFormat::DebeziumMongo, SourceEncode::Json) => {
                 EncodingProperties::Json(JsonProperties {
                     use_schema_registry: false,
+                    timestamptz_handling: None,
                 })
             }
             (SourceFormat::Plain, SourceEncode::Bytes) => {

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -877,7 +877,7 @@ impl AccessBuilderImpl {
                 AccessBuilderImpl::Bytes(BytesAccessBuilder::new(config)?)
             }
             EncodingProperties::Json(config) => {
-                AccessBuilderImpl::Json(JsonAccessBuilder::new(config.use_schema_registry)?)
+                AccessBuilderImpl::Json(JsonAccessBuilder::new(config)?)
             }
             _ => unreachable!(),
         };

--- a/src/connector/src/parser/plain_parser.rs
+++ b/src/connector/src/parser/plain_parser.rs
@@ -14,6 +14,7 @@
 
 use risingwave_common::bail;
 
+use super::unified::json::TimestamptzHandling;
 use super::{
     AccessBuilderImpl, ByteStreamSourceParser, EncodingProperties, EncodingType,
     SourceStreamChunkRowWriter, SpecificParserConfig,
@@ -66,7 +67,7 @@ impl PlainParser {
         };
 
         let transaction_meta_builder = Some(AccessBuilderImpl::DebeziumJson(
-            DebeziumJsonAccessBuilder::new()?,
+            DebeziumJsonAccessBuilder::new(TimestamptzHandling::GuessNumberUnit)?,
         ));
         Ok(Self {
             key_builder,

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -30,7 +30,7 @@ const NAME_STRATEGY_KEY: &str = "schema.registry.name.strategy";
 #[derive(Debug, thiserror::Error, thiserror_ext::Macro)]
 #[error("Invalid option: {message}")]
 pub struct InvalidOptionError {
-    message: String,
+    pub message: String,
     // #[backtrace]
     // source: Option<risingwave_common::error::BoxedError>,
 }

--- a/src/connector/src/source/datagen/source/generator.rs
+++ b/src/connector/src/source/datagen/source/generator.rs
@@ -276,6 +276,7 @@ mod tests {
                 protocol_config: ProtocolProperties::Plain,
                 encoding_config: EncodingProperties::Json(crate::parser::JsonProperties {
                     use_schema_registry: false,
+                    timestamptz_handling: None,
                 }),
                 key_encoding_config: None,
             },

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -438,7 +438,10 @@ pub(crate) async fn bind_columns_from_source(
             Format::Plain | Format::Upsert | Format::Maxwell | Format::Canal | Format::Debezium,
             Encode::Json,
         ) => {
-            if source_schema.format == Format::Debezium {
+            if matches!(
+                source_schema.format,
+                Format::Plain | Format::Upsert | Format::Debezium
+            ) {
                 // Parse the value but throw it away.
                 // It would be too late to report error in `SpecificParserConfig::new`,
                 // which leads to recovery loop.

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -32,7 +32,7 @@ use risingwave_connector::parser::additional_columns::{
 };
 use risingwave_connector::parser::{
     schema_to_columns, AvroParserConfig, DebeziumAvroParserConfig, ProtobufParserConfig,
-    SpecificParserConfig, DEBEZIUM_IGNORE_KEY,
+    SpecificParserConfig, TimestamptzHandling, DEBEZIUM_IGNORE_KEY,
 };
 use risingwave_connector::schema::schema_registry::{
     name_strategy_from_str, SchemaRegistryAuth, SCHEMA_REGISTRY_PASSWORD, SCHEMA_REGISTRY_USERNAME,
@@ -438,6 +438,18 @@ pub(crate) async fn bind_columns_from_source(
             Format::Plain | Format::Upsert | Format::Maxwell | Format::Canal | Format::Debezium,
             Encode::Json,
         ) => {
+            if source_schema.format == Format::Debezium {
+                // Parse the value but throw it away.
+                // It would be too late to report error in `SpecificParserConfig::new`,
+                // which leads to recovery loop.
+                TimestamptzHandling::from_options(&format_encode_options_to_consume)
+                    .map_err(|err| InvalidInputSyntax(err.message))?;
+                try_consume_string_from_options(
+                    &mut format_encode_options_to_consume,
+                    TimestamptzHandling::OPTION_KEY,
+                );
+            }
+
             let schema_config = get_json_schema_location(&mut format_encode_options_to_consume)?;
             stream_source_info.use_schema_registry =
                 json_schema_infer_use_schema_registry(&schema_config);

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -607,6 +607,7 @@ pub async fn transform_upstream(upstream: BoxedMessageStream, schema: &Schema) {
         key_encoding_config: None,
         encoding_config: EncodingProperties::Json(JsonProperties {
             use_schema_registry: false,
+            timestamptz_handling: None,
         }),
         // the cdc message is generated internally so the key must exist.
         protocol_config: ProtocolProperties::Debezium(DebeziumProps::default()),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Similar to sink, we allow specifying timestamptz number units:
* `micro`
* `milli`
* `guess_number_unit`: This has been the default, but limits the range to `[1973-03-03 09:46:40, 5138-11-16 09:46:40)`
* `utc_string`: This format is least ambiguous and can mostly be inferred correctly without the need to be specified.
* `utc_without_suffix`: This allows the user to acknowledge naive timestamp is in UTC rather than local time.

Note the corresponding `format` has to be one of `plain | upsert | debezium`. The following `format`s do NOT accept this option as of now:
* `debezium_mongo`
* `canal`
* `maxwell`

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

https://docs.risingwave.com/docs/current/supported-sources-and-formats/#debezium-json

When using `format plain | upsert | debezium encode json` (but not `format debezium_mongo | canal | maxwell encode json`), there is a new option `timestamptz.handling.mode`. There are 5 possible choices. See description above for the meaning of each one.