### PR TITLE
feat(playground): prevent multiple instances from starting at a time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9213,6 +9213,7 @@ dependencies = [
  "console",
  "const-str",
  "expect-test",
+ "fd-lock",
  "home",
  "madsim-tokio",
  "prometheus",

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = "1"
 clap = { workspace = true }
 console = "0.15"
 const-str = "0.5"
+fd-lock = "4"
 home = "0.5"
 prometheus = { version = "0.13" }
 risingwave_cmd = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolve #11169. See https://github.com/risingwavelabs/risingwave/issues/11169#issuecomment-2006410609.

Only applied to `playground` mode, because we allow specifying addresses for general single-node mode, where starting multiple instances could make some sense.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
