### PR TITLE
refactor(streaming): do not print backtrace for exchange channel closed error

### DIFF
--- a/src/stream/src/error.rs
+++ b/src/stream/src/error.rs
@@ -20,6 +20,7 @@ use risingwave_pb::PbFieldNotFound;
 use risingwave_rpc_client::error::ToTonicStatus;
 use risingwave_storage::error::StorageError;
 
+use crate::executor::exchange::error::ExchangeChannelClosed;
 use crate::executor::{Barrier, StreamExecutorError};
 use crate::task::ActorId;
 
@@ -104,6 +105,12 @@ impl From<PbFieldNotFound> for StreamError {
 
 impl From<ConnectorError> for StreamError {
     fn from(err: ConnectorError) -> Self {
+        StreamExecutorError::from(err).into()
+    }
+}
+
+impl From<ExchangeChannelClosed> for StreamError {
+    fn from(err: ExchangeChannelClosed) -> Self {
         StreamExecutorError::from(err).into()
     }
 }

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -26,6 +26,7 @@ use risingwave_rpc_client::error::RpcError;
 use risingwave_storage::error::StorageError;
 use strum_macros::AsRefStr;
 
+use super::exchange::error::ExchangeChannelClosed;
 use super::Barrier;
 
 /// A specialized Result type for streaming executors.
@@ -83,6 +84,13 @@ pub enum ErrorKind {
 
     #[error("Channel closed: {0}")]
     ChannelClosed(String),
+
+    #[error(transparent)]
+    ExchangeChannelClosed(
+        #[from]
+        #[backtrace]
+        ExchangeChannelClosed,
+    ),
 
     #[error("Failed to align barrier: expected `{0:?}` but got `{1:?}`")]
     AlignBarrier(Box<Barrier>, Box<Barrier>),

--- a/src/stream/src/executor/exchange/error.rs
+++ b/src/stream/src/executor/exchange/error.rs
@@ -16,9 +16,17 @@ use risingwave_rpc_client::error::TonicStatusWrapper;
 
 use crate::task::ActorId;
 
+/// The error type for the exchange channel closed unexpectedly.
+///
+/// In most cases, this error happens when the upstream or downstream actor
+/// exits or panics on other errors, or the network connection is broken.
+/// Therefore, this error is usually not the root case of the failure in the
+/// streaming graph.
 #[derive(Debug)]
 pub struct ExchangeChannelClosed {
     message: String,
+
+    /// `Some` if there is a gRPC error from the remote actor.
     source: Option<TonicStatusWrapper>,
 }
 
@@ -36,6 +44,13 @@ impl std::error::Error for ExchangeChannelClosed {
     fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
         use std::backtrace::Backtrace;
 
+        // Always provide a fake disabled backtrace, so that the upper layer will
+        // not capture any other backtraces or include the backtrace in the error
+        // log.
+        //
+        // Otherwise, when an actor exits on a significant error, all connected
+        // actor will then exit with the `ExchangeChannelClosed` error, resulting
+        // in a very noisy log with flood of useless backtraces.
         static DISABLED_BACKTRACE: Backtrace = Backtrace::disabled();
         request.provide_ref::<Backtrace>(&DISABLED_BACKTRACE);
 
@@ -46,6 +61,8 @@ impl std::error::Error for ExchangeChannelClosed {
 }
 
 impl ExchangeChannelClosed {
+    /// Creates a new error indicating that the exchange channel from the local
+    /// upstream actor is closed unexpectedly.
     pub fn local_input(upstream: ActorId) -> Self {
         Self {
             message: format!(
@@ -55,6 +72,8 @@ impl ExchangeChannelClosed {
         }
     }
 
+    /// Creates a new error indicating that the exchange channel from the remote
+    /// upstream actor is closed unexpectedly, with an optional gRPC error as the cause.
     pub fn remote_input(upstream: ActorId, source: Option<tonic::Status>) -> Self {
         Self {
             message: format!(
@@ -64,6 +83,8 @@ impl ExchangeChannelClosed {
         }
     }
 
+    /// Creates a new error indicating that the exchange channel to the downstream
+    /// actor is closed unexpectedly.
     pub fn output(downstream: ActorId) -> Self {
         Self {
             message: format!(

--- a/src/stream/src/executor/exchange/error.rs
+++ b/src/stream/src/executor/exchange/error.rs
@@ -1,0 +1,75 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_rpc_client::error::TonicStatusWrapper;
+
+use crate::task::ActorId;
+
+#[derive(Debug)]
+pub struct ExchangeChannelClosed {
+    message: String,
+    source: Option<TonicStatusWrapper>,
+}
+
+impl std::fmt::Display for ExchangeChannelClosed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ExchangeChannelClosed {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|s| s as _)
+    }
+
+    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        use std::backtrace::Backtrace;
+
+        static DISABLED_BACKTRACE: Backtrace = Backtrace::disabled();
+        request.provide_ref::<Backtrace>(&DISABLED_BACKTRACE);
+
+        if let Some(source) = &self.source {
+            source.provide(request);
+        }
+    }
+}
+
+impl ExchangeChannelClosed {
+    pub fn local_input(upstream: ActorId) -> Self {
+        Self {
+            message: format!(
+                "exchange channel from local upstream actor {upstream} closed unexpectedly"
+            ),
+            source: None,
+        }
+    }
+
+    pub fn remote_input(upstream: ActorId, source: Option<tonic::Status>) -> Self {
+        Self {
+            message: format!(
+                "exchange channel from remote upstream actor {upstream} closed unexpectedly"
+            ),
+            source: source.map(Into::into),
+        }
+    }
+
+    pub fn output(downstream: ActorId) -> Self {
+        Self {
+            message: format!(
+                "exchange channel to downstream actor {downstream} closed unexpectedly"
+            ),
+            source: None,
+        }
+    }
+}

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -81,6 +81,8 @@ impl LocalInput {
         while let Some(msg) = channel.recv().verbose_instrument_await(span.clone()).await {
             yield msg;
         }
+        // Always emit an error outside the loop. This is because we use barrier as the control
+        // message to stop the stream. Reaching here means the channel is closed unexpectedly.
         Err(ExchangeChannelClosed::local_input(actor_id))?
     }
 }
@@ -218,6 +220,8 @@ impl RemoteInput {
             }
         }
 
+        // Always emit an error outside the loop. This is because we use barrier as the control
+        // message to stop the stream. Reaching here means the channel is closed unexpectedly.
         Err(ExchangeChannelClosed::remote_input(up_down_ids.0, None))?
     }
 }

--- a/src/stream/src/executor/exchange/mod.rs
+++ b/src/stream/src/executor/exchange/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod error;
 pub mod input;
 pub mod output;
 pub mod permit;

--- a/src/stream/src/executor/exchange/output.rs
+++ b/src/stream/src/executor/exchange/output.rs
@@ -14,13 +14,12 @@
 
 use std::fmt::Debug;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 use await_tree::InstrumentAwait;
 use educe::Educe;
 use risingwave_common::util::addr::is_local_address;
-use tokio::sync::mpsc::error::SendError;
 
+use super::error::ExchangeChannelClosed;
 use super::permit::Sender;
 use crate::error::StreamResult;
 use crate::executor::Message;
@@ -74,14 +73,7 @@ impl Output for LocalOutput {
             .send(message)
             .verbose_instrument_await(self.span.clone())
             .await
-            .map_err(|SendError(message)| {
-                anyhow!(
-                    "failed to send message to actor {}, message: {:?}",
-                    self.actor_id,
-                    message
-                )
-                .into()
-            })
+            .map_err(|_| ExchangeChannelClosed::output(self.actor_id).into())
     }
 
     fn actor_id(&self) -> ActorId {
@@ -128,14 +120,7 @@ impl Output for RemoteOutput {
             .send(message)
             .verbose_instrument_await(self.span.clone())
             .await
-            .map_err(|SendError(message)| {
-                anyhow!(
-                    "failed to send message to actor {}, message: {:?}",
-                    self.actor_id,
-                    message
-                )
-                .into()
-            })
+            .map_err(|_| ExchangeChannelClosed::output(self.actor_id).into())
     }
 
     fn actor_id(&self) -> ActorId {

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -307,15 +307,14 @@ impl Stream for SelectReceivers {
                         }
                     }
                 }
-                // If one upstream is finished, we finish the whole stream with an error. This
-                // should not happen normally as we use the barrier as the control message.
-                Some((None, r)) => {
-                    return Poll::Ready(Some(Err(StreamExecutorError::channel_closed(format!(
-                        "exchange from actor {} to actor {} closed unexpectedly",
-                        r.actor_id(),
-                        self.actor_id
-                    )))))
-                }
+                // We use barrier as the control message of the stream. That is, we always stop the
+                // actors actively when we receive a `Stop` mutation, instead of relying on the stream
+                // termination.
+                //
+                // Besides, in abnormal cases when the other side of the `Input` closes unexpectedly,
+                // we also yield an `Err(ExchangeChannelClosed)`, which will hit the `Err` arm above.
+                // So this branch will never be reached in all cases.
+                Some((None, _)) => unreachable!(),
                 // There's no active upstreams. Process the barrier and resume the blocked ones.
                 None => break,
             }

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -847,7 +847,7 @@ pub fn try_find_root_actor_failure<'a>(
     fn stream_executor_error_score(e: &StreamExecutorError) -> i32 {
         use crate::executor::error::ErrorKind;
         match e.inner() {
-            ErrorKind::ChannelClosed(_) => 0,
+            ErrorKind::ChannelClosed(_) | ErrorKind::ExchangeChannelClosed(_) => 0,
             ErrorKind::Internal(_) => 1,
             _ => 999,
         }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

An actor will exit when an error occurs. Subsequently, all upstream or downstream actors that are connected with the failed actor will exit as well, since the exchange channel will be closed.

Therefore, we often see a flood of `ERROR` lines in the log saying that multiple actors have exited, where the backtrace can be really verbose and prevent us from identifying the root cause in a glance.

Since the backtrace for "exchange channel closed" is insignificant, this PR now prevents printing it by providing a fake `Disabled` backtrace when requested. This could make the error log much more clearer.


Example:

```
2024-04-19T14:24:12.518161+08:00 ERROR   rw-streaming risingwave_stream::task::stream_manager: actor exit with error actor_id=24 error=Executor error: exchange channel from local upstream actor 3 closed unexpectedly
2024-04-19T14:24:12.518245+08:00 ERROR   rw-streaming risingwave_stream::task::stream_manager: actor exit with error actor_id=26 error=Executor error: exchange channel from local upstream actor 3 closed unexpectedly
2024-04-19T14:24:12.518261+08:00 ERROR   rw-streaming risingwave_stream::task::stream_manager: actor exit with error actor_id=21 error=Executor error: exchange channel from local upstream actor 3 closed unexpectedly
2024-04-19T14:24:12.517644+08:00 ERROR   rw-streaming risingwave_stream::task::stream_manager: actor exit with error actor_id=23 error=Executor error: Chunk operation error: Division by zero

Backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/e4c626dd9a17a23270bf8e7158e59cf2b9c04840/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
...
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
