### PR TITLE
chore: bump `thiserror-ext` to v0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8448,7 +8448,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -12675,9 +12675,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext"
-version = "0.0.11"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a6a1db013d9f7175962ec64a0fb90760832062e29f6664f1aefee91d072a50"
+checksum = "a7c19760dc47062bca5c1b3699b032111c93802d51ac47660db11b08afc6bad2"
 dependencies = [
  "thiserror",
  "thiserror-ext-derive",
@@ -12685,9 +12685,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext-derive"
-version = "0.0.11"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c358cfea7a4a0f4554d4df6533f9b652d44c0108e99db3685f28f30b0954aa"
+checksum = "667c8c48f68021098038115926c64d9950b0582062ae63f7d30638b1168daf03"
 dependencies = [
  "either",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ deltalake = { git = "https://github.com/risingwavelabs/delta-rs", rev = "5c2dccd
 itertools = "0.12.0"
 lru = { git = "https://github.com/risingwavelabs/lru-rs.git", rev = "2682b85" }
 parquet = "50"
-thiserror-ext = "0.0.11"
+thiserror-ext = "0.1.2"
 tikv-jemalloc-ctl = { git = "https://github.com/risingwavelabs/jemallocator.git", rev = "64a2d9" }
 tikv-jemallocator = { git = "https://github.com/risingwavelabs/jemallocator.git", features = [
     "profiling",

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -23,7 +23,6 @@ use risingwave_expr::ExprError;
 use risingwave_pb::PbFieldNotFound;
 use risingwave_rpc_client::error::{RpcError, TonicStatusWrapper};
 use thiserror::Error;
-use thiserror_ext::Box;
 use tokio::task::JoinError;
 
 /// The error type for the frontend crate, acting as the top-level error type for the
@@ -33,8 +32,8 @@ use tokio::task::JoinError;
 // - Some variants are never constructed.
 // - Some variants store a type-erased `BoxedError` to resolve the reverse dependency.
 //   It's not necessary anymore as the error type is now defined at the top-level.
-#[derive(Error, Debug, Box)]
-#[thiserror_ext(newtype(name = RwError, backtrace, report_debug))]
+#[derive(Error, thiserror_ext::ReportDebug, thiserror_ext::Box)]
+#[thiserror_ext(newtype(name = RwError, backtrace))]
 pub enum ErrorCode {
     #[error("internal error: {0}")]
     InternalError(String),

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -26,8 +26,10 @@ use crate::storage::MetaStoreError;
 
 pub type MetaResult<T> = std::result::Result<T, MetaError>;
 
-#[derive(thiserror::Error, Debug, thiserror_ext::Arc, thiserror_ext::Construct)]
-#[thiserror_ext(newtype(name = MetaError, backtrace, report_debug))]
+#[derive(
+    thiserror::Error, thiserror_ext::ReportDebug, thiserror_ext::Arc, thiserror_ext::Construct,
+)]
+#[thiserror_ext(newtype(name = MetaError, backtrace))]
 pub enum MetaErrorInner {
     #[error("MetaStore transaction error: {0}")]
     TransactionError(

--- a/src/object_store/src/object/error.rs
+++ b/src/object_store/src/object/error.rs
@@ -24,8 +24,8 @@ use thiserror::Error;
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot::error::RecvError;
 
-#[derive(Error, Debug, thiserror_ext::Box, thiserror_ext::Construct)]
-#[thiserror_ext(newtype(name = ObjectError, backtrace, report_debug))]
+#[derive(Error, thiserror_ext::ReportDebug, thiserror_ext::Box, thiserror_ext::Construct)]
+#[thiserror_ext(newtype(name = ObjectError, backtrace))]
 pub enum ObjectErrorInner {
     #[error("s3 error: {0}")]
     S3(#[source] BoxedError),

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -18,8 +18,8 @@ use thiserror::Error;
 use crate::hummock::HummockError;
 use crate::mem_table::MemTableError;
 
-#[derive(Error, Debug, thiserror_ext::Box)]
-#[thiserror_ext(newtype(name = StorageError, backtrace, report_debug))]
+#[derive(Error, thiserror_ext::ReportDebug, thiserror_ext::Box)]
+#[thiserror_ext(newtype(name = StorageError, backtrace))]
 pub enum ErrorKind {
     #[error("Hummock error: {0}")]
     Hummock(

--- a/src/storage/src/hummock/error.rs
+++ b/src/storage/src/hummock/error.rs
@@ -18,8 +18,8 @@ use thiserror_ext::AsReport;
 use tokio::sync::oneshot::error::RecvError;
 
 // TODO(error-handling): should prefer use error types than strings.
-#[derive(Error, Debug, thiserror_ext::Box)]
-#[thiserror_ext(newtype(name = HummockError, backtrace, report_debug))]
+#[derive(Error, thiserror_ext::ReportDebug, thiserror_ext::Box)]
+#[thiserror_ext(newtype(name = HummockError, backtrace))]
 pub enum HummockErrorInner {
     #[error("Magic number mismatch: expected {expected}, found: {found}")]
     MagicMismatch { expected: u32, found: u32 },

--- a/src/stream/src/error.rs
+++ b/src/stream/src/error.rs
@@ -29,12 +29,12 @@ pub type StreamResult<T> = std::result::Result<T, StreamError>;
 /// The error type for streaming tasks.
 #[derive(
     thiserror::Error,
-    Debug,
+    thiserror_ext::ReportDebug,
     thiserror_ext::Arc,
     thiserror_ext::ContextInto,
     thiserror_ext::Construct,
 )]
-#[thiserror_ext(newtype(name = StreamError, backtrace, report_debug))]
+#[thiserror_ext(newtype(name = StreamError, backtrace))]
 pub enum ErrorKind {
     #[error("Storage error: {0}")]
     Storage(

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -32,8 +32,10 @@ use super::Barrier;
 pub type StreamExecutorResult<T> = std::result::Result<T, StreamExecutorError>;
 
 /// The error type for streaming executors.
-#[derive(thiserror::Error, Debug, thiserror_ext::Box, thiserror_ext::Construct)]
-#[thiserror_ext(newtype(name = StreamExecutorError, backtrace, report_debug))]
+#[derive(
+    thiserror::Error, thiserror_ext::ReportDebug, thiserror_ext::Box, thiserror_ext::Construct,
+)]
+#[thiserror_ext(newtype(name = StreamExecutorError, backtrace))]
 #[derive(AsRefStr)]
 pub enum ErrorKind {
     #[error("Storage error: {0}")]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Notable changes:

- https://docs.rs/thiserror-ext/0.1.2/thiserror_ext/derive.ReportDebug.html
- https://github.com/risingwavelabs/thiserror-ext/pull/6 for #16362

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
