### PR TITLE
test: refine root cause identification test of recovery

### DIFF
--- a/e2e_test/error_ui/simple/recovery.slt
+++ b/e2e_test/error_ui/simple/recovery.slt
@@ -12,19 +12,25 @@ statement ok
 insert into t values (1);
 
 # Wait for recovery to complete.
-sleep 10s
+sleep 15s
 
 # Check that there's a log entry for barrier collection failure on the mata node.
-# The message should contain the root cause of the failure: "Division by zero".
+# Extract the message to check that it contains the root cause of the failure.
 query T
-select info::varchar like
-'%Actor % exited unexpectedly: Executor error: Chunk operation error: Division by zero%'
-from rw_catalog.rw_event_logs
-where event_type = 'COLLECT_BARRIER_FAIL'
-order by timestamp desc
-limit 1;
+with error as (
+    select info->'collectBarrierFail'->'error' #>> '{}' as error
+    from rw_catalog.rw_event_logs
+    where event_type = 'COLLECT_BARRIER_FAIL'
+    order by timestamp desc
+    limit 1
+)
+select (regexp_matches(
+    error,
+    'Actor \d+ exited unexpectedly: (.*);'
+))[1] as error
+from error;
 ----
-t
+Executor error: Chunk operation error: Division by zero
 
 statement ok
 drop table t cascade;

--- a/e2e_test/error_ui/simple/recovery.slt
+++ b/e2e_test/error_ui/simple/recovery.slt
@@ -24,13 +24,13 @@ with error as (
     order by timestamp desc
     limit 1
 )
-select (regexp_matches(
-    error,
-    'Actor \d+ exited unexpectedly: (.*);'
-))[1] as error
+select
+case when error like '%Actor % exited unexpectedly: Executor error: Chunk operation error: Division by zero%' then 'ok'
+     else error
+end as result
 from error;
 ----
-Executor error: Chunk operation error: Division by zero
+ok
 
 statement ok
 drop table t cascade;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Supplement of #16397.

- Increase the delay before checking the recovery event. Hope this can resolve [recent CI failure](https://buildkite.com/risingwavelabs/main-cron/builds/2394#018f016e-44f0-445c-bdf9-9163b1760449/3804-3898).
- Show error message in the query result (instead of comparing them then getting `t` or `f`) to provide better observability.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
