### PR TITLE
fix: fix missing FK and wrong column type for subscription table

### DIFF
--- a/src/meta/model_v2/migration/src/m20230908_072257_init.rs
+++ b/src/meta/model_v2/migration/src/m20230908_072257_init.rs
@@ -1222,7 +1222,7 @@ enum Function {
 }
 
 #[derive(DeriveIden)]
-enum Object {
+pub(crate) enum Object {
     Table,
     Oid,
     ObjType,

--- a/src/meta/model_v2/migration/src/m20240304_074901_subscription.rs
+++ b/src/meta/model_v2/migration/src/m20240304_074901_subscription.rs
@@ -37,6 +37,17 @@ impl MigrationTrait for Migration {
                             .string()
                             .not_null(),
                     )
+                    .foreign_key(
+                        &mut ForeignKey::create()
+                            .name("FK_subscription_object_id")
+                            .from(Subscription::Table, Subscription::SubscriptionId)
+                            .to(
+                                crate::m20230908_072257_init::Object::Table,
+                                crate::m20230908_072257_init::Object::Oid,
+                            )
+                            .on_delete(ForeignKeyAction::Cascade)
+                            .to_owned(),
+                    )
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model_v2/migration/src/m20240417_062305_subscription_internal_table_name.rs
+++ b/src/meta/model_v2/migration/src/m20240417_062305_subscription_internal_table_name.rs
@@ -10,7 +10,7 @@ impl MigrationTrait for Migration {
                 MigrationTable::alter()
                     .table(Subscription::Table)
                     .add_column(
-                        ColumnDef::new(Subscription::SubscriptionInternalTableName).integer(),
+                        ColumnDef::new(Subscription::SubscriptionInternalTableName).string(),
                     )
                     .to_owned(),
             )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR fixed two issues:
1. `subscription_internal_table_name` was mistakenly defined as `integer`, it is actually `string`. This will cause creation to fail, if it is null then sqlite has made it compatible, so there's no problem with ci. Direct modification of the type is safe, as this migration does not exist in version v1.8.x.
2. The foreign key constraint between `subscription` and `object` is not defined, which will lead to dirty data remaining in the `subscription` table when cascade dropping upstream. This will not cause any inconsistency. Note that directly modifying this migration file will not have backward compatible issues, it will only apply this foreign key constraint to new clusters.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
