### PR TITLE
fix(planner): from-scalar-function shall also flatten struct fields similar to from-table-function

### DIFF
--- a/src/expr/impl/src/scalar/jsonb_record.rs
+++ b/src/expr/impl/src/scalar/jsonb_record.rs
@@ -41,6 +41,14 @@ use risingwave_expr::{function, ExprError, Result};
 /// )).*;
 /// ----
 /// 1 {2,"a b"} (4,"a b c")
+///
+/// query II
+/// select * from jsonb_populate_record(
+///    null::struct<a int, b int>,
+///    '{"a": 1, "b": 2}'
+/// );
+/// ----
+/// 1 2
 /// ```
 #[function("jsonb_populate_record(struct, jsonb) -> struct")]
 fn jsonb_populate_record(

--- a/src/frontend/planner_test/tests/testdata/input/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/expr.yaml
@@ -443,6 +443,11 @@
     select * from max();
   expected_outputs:
   - binder_error
+- sql: |
+    create table t (k int, j jsonb);
+    select a * k + b from t, jsonb_populate_record(null::struct<a int, b int>, j);
+  expected_outputs:
+  - batch_plan
 - name: Grafana issue-10134
   sql: |
     SELECT * FROM

--- a/src/frontend/planner_test/tests/testdata/output/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/expr.yaml
@@ -615,6 +615,23 @@
 - sql: |
     select * from max();
   binder_error: 'Invalid input syntax: aggregate functions are not allowed in FROM'
+- sql: |
+    create table t (k int, j jsonb);
+    select a * k + b from t, jsonb_populate_record(null::struct<a int, b int>, j);
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [((Field($expr1, 0:Int32) * t.k) + Field($expr1, 1:Int32)) as $expr2] }
+      └─BatchHashJoin { type: Inner, predicate: t.j IS NOT DISTINCT FROM t.j, output: all }
+        ├─BatchExchange { order: [], dist: HashShard(t.j) }
+        │ └─BatchScan { table: t, columns: [t.k, t.j], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: HashShard(t.j) }
+          └─BatchProject { exprs: [t.j, JsonbPopulateRecord(null:Struct(StructType { field_names: ["a", "b"], field_types: [Int32, Int32] }), t.j) as $expr1] }
+            └─BatchNestedLoopJoin { type: Inner, predicate: true, output: all }
+              ├─BatchExchange { order: [], dist: Single }
+              │ └─BatchHashAgg { group_key: [t.j], aggs: [] }
+              │   └─BatchExchange { order: [], dist: HashShard(t.j) }
+              │     └─BatchScan { table: t, columns: [t.j], distribution: SomeShard }
+              └─BatchValues { rows: [[]] }
 - name: Grafana issue-10134
   sql: |
     SELECT * FROM

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr.yaml
@@ -316,7 +316,8 @@
     LogicalProject { exprs: [b.b1, ] }
     └─LogicalApply { type: Inner, on: true, correlated_id: 1 }
       ├─LogicalScan { table: b, columns: [b.b1, b._row_id] }
-      └─LogicalValues { rows: [[Repeat(CorrelatedInputRef { index: 0, correlated_id: 1 }, 2:Int32)]], schema: Schema { fields: [:Varchar] } }
+      └─LogicalProject { exprs: [] }
+        └─LogicalValues { rows: [[Repeat(CorrelatedInputRef { index: 0, correlated_id: 1 }, 2:Int32)]], schema: Schema { fields: [:Varchar] } }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
     └─BatchProject { exprs: [b.b1, Repeat(b.b1, 2:Int32) as $expr1] }

--- a/src/frontend/planner_test/tests/testdata/output/with_ordinality.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/with_ordinality.yaml
@@ -187,10 +187,13 @@
                             └─StreamTableScan { table: t, columns: [t.arr, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     select * from abs(1) WITH ORDINALITY;
-  batch_plan: 'BatchValues { rows: [[1:Int32, 1:Int64]] }'
+  batch_plan: |-
+    BatchProject { exprs: [, 1:Int64] }
+    └─BatchValues { rows: [[1:Int32]] }
   stream_plan: |-
     StreamMaterialize { columns: [abs, ordinality, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck }
-    └─StreamValues { rows: [[1:Int32, 1:Int64, 0:Int64]] }
+    └─StreamProject { exprs: [, 1:Int64, _row_id] }
+      └─StreamValues { rows: [[1:Int32, 0:Int64]] }
 - sql: |
     create table t(x int , arr int[]);
     select * from t, abs(x) WITH ORDINALITY;

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -197,22 +197,29 @@ impl Planner {
                 Ok(LogicalTableFunction::new(*tf, with_ordinality, self.ctx()).into())
             }
             expr => {
-                let mut schema = Schema {
+                let schema = Schema {
                     // TODO: should be named
                     fields: vec![Field::unnamed(expr.return_type())],
                 };
-                if with_ordinality {
-                    schema
-                        .fields
-                        .push(Field::with_name(DataType::Int64, "ordinality"));
-                    Ok(LogicalValues::create(
-                        vec![vec![expr, ExprImpl::literal_bigint(1)]],
-                        schema,
-                        self.ctx(),
-                    ))
+                let expr_return_type = expr.return_type();
+                let root = LogicalValues::create(vec![vec![expr]], schema, self.ctx());
+                let input_ref = ExprImpl::from(InputRef::new(0, expr_return_type.clone()));
+                let mut exprs = if let DataType::Struct(st) = expr_return_type {
+                    st.iter()
+                        .enumerate()
+                        .map(|(i, (_, ty))| {
+                            let idx = ExprImpl::literal_int(i.try_into().unwrap());
+                            let args = vec![input_ref.clone(), idx];
+                            FunctionCall::new_unchecked(ExprType::Field, args, ty.clone()).into()
+                        })
+                        .collect()
                 } else {
-                    Ok(LogicalValues::create(vec![vec![expr]], schema, self.ctx()))
+                    vec![input_ref]
+                };
+                if with_ordinality {
+                    exprs.push(ExprImpl::literal_bigint(1));
                 }
+                Ok(LogicalProject::create(root, exprs))
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

A panic mentioned in `jsonb_populate_record` #13421 but actually affects all scalar functions returning structs:
```
dev=> select * from jsonb_populate_record(
    null::struct<a int, b int>,
    '{"a": 1, "b": 2}' 
);
ERROR:  Panicked when processing: insert at index 1 exceeds fixbitset size 1
```

On the binder side, it is already flattened: #10317 `binder/relation/table_function.rs`.
When planned into a `LogicalTableFunction`, it is also flattened: #8644 `LogicalTableFunction::new`.
But when planned into a `LogicalValues`, it is single column and mismatching the binder's schema.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
