### PR TITLE
fix(error): do not directly format `BoxedError`

### DIFF
--- a/lints/ui/format_error.rs
+++ b/lints/ui/format_error.rs
@@ -80,4 +80,13 @@ fn main() {
     let _ = anyhow!("some error occurred: {}", err.as_report());
     let _ = anyhow!("{:?}", anyhow_err.as_report());
     let _ = anyhow!("some error occurred: {:?}", anyhow_err.as_report());
+
+    let box_dyn_err_1: Box<dyn Error> = Box::new(err.clone());
+    let box_dyn_err_2: Box<dyn Error + Send> = Box::new(err.clone());
+    let box_dyn_err_3: Box<dyn Error + Send + Sync> = Box::new(err.clone());
+
+    // TODO: fail to lint
+    let _ = format!("{}", box_dyn_err_1);
+    info!("{}", box_dyn_err_2);
+    let _ = box_dyn_err_3.to_string();
 }

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -237,3 +237,10 @@ impl From<JoinError> for RwError {
         ErrorCode::Uncategorized(join_error.into()).into()
     }
 }
+
+// For errors without a concrete type, put them into `Uncategorized`.
+impl From<BoxedError> for RwError {
+    fn from(e: BoxedError) -> Self {
+        ErrorCode::Uncategorized(e.into()).into()
+    }
+}

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -241,6 +241,9 @@ impl From<JoinError> for RwError {
 // For errors without a concrete type, put them into `Uncategorized`.
 impl From<BoxedError> for RwError {
     fn from(e: BoxedError) -> Self {
-        ErrorCode::Uncategorized(e.into()).into()
+        // Show that the error is of `BoxedKind`, instead of `AdhocKind` which loses the sources.
+        // This is essentially expanded from `anyhow::anyhow!(e)`.
+        let e = anyhow::__private::kind::BoxedKind::anyhow_kind(&e).new(e);
+        ErrorCode::Uncategorized(e).into()
     }
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -386,9 +386,7 @@ async fn execute(
                         "no affected rows in output".to_string(),
                     )))
                 }
-                Some(row) => {
-                    row.map_err(|err| RwError::from(ErrorCode::InternalError(format!("{}", err))))?
-                }
+                Some(row) => row?,
             };
             let affected_rows_str = first_row_set[0].values()[0]
                 .as_ref()

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -50,6 +50,7 @@ impl DistributedQueryStream {
 }
 
 impl Stream for DistributedQueryStream {
+    // TODO(error-handling): use a concrete error type.
     type Item = Result<DataChunk, BoxedError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -55,6 +55,7 @@ use crate::scheduler::task_context::FrontendBatchTaskContext;
 use crate::scheduler::{ReadSnapshot, SchedulerError, SchedulerResult};
 use crate::session::{FrontendEnv, SessionImpl};
 
+// TODO(error-handling): use a concrete error type.
 pub type LocalQueryStream = ReceiverStream<Result<DataChunk, BoxedError>>;
 pub struct LocalQueryExecution {
     sql: String,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Background:

@arkbriar encountered such an error message when running e2e tests of operators, where the cause (source) for the creation failure was missing.

```
ERROR:  Failed to run the query
 
Caused by:
  internal error: failed to create RPC client to e2e-compute-0.e2e-compute:5688
``` 

----

Following the [guidelines](https://www.notion.so/risingwave-labs/A-Guide-to-Error-Handling-that-Just-Works-Part-I-e108f8d0845b4bddaa0e5843791a8cac?pvs=4#571b6922de894ed78d1a6b00df0f3de4), we should not directly format an error type.

This should be covered by the lints. Due to limited knowledge of the compiler, however, I don't find the way to match a `Box<dyn Error>` type (which does not implement `Error` trait actually). So I just leave some TODOs in the lint tests.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
