### PR TITLE
doc: remove invalid markdown alert

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -97,7 +97,7 @@ Then you'll be able to compile and start RiseDev!
 >
 > `.cargo/config.toml` contains `rustflags` configurations like `-Clink-arg` and `-Ctarget-feature`. Since it will be [merged](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) with `$HOME/.cargo/config.toml`, check the config files and make sure they don't conflict if you have global `rustflags` configurations for e.g. linker there.
 
-> [!INFO]
+> [!TIP]
 >
 > If you want to build RisingWave with `embedded-python-udf` feature, you need to install Python 3.12.
 >


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?


_INFO_ is an invalid markdown alert extension. Replacing it with _TIP_.

Valid alerts are _Note_, _Tip_, _Caution_, _Warning_, _Important_ 


**Before**

<img width="1025" alt="Screenshot 1" src="https://github.com/risingwavelabs/risingwave/assets/87475799/291f4f70-9f12-4cc4-96f6-f52571d128f0">

**After** 

<img width="1065" alt="Screenshot 2" src="https://github.com/risingwavelabs/risingwave/assets/87475799/032e8a35-cc40-4495-b531-71d4054ac6b4">
