### PR TITLE
chore: unify show cluster result with system catalog

### DIFF
--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -21,7 +21,7 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use pgwire::pg_server::Session;
 use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, DEFAULT_SCHEMA_NAME};
-use risingwave_common::types::{DataType, Fields};
+use risingwave_common::types::{DataType, Fields, Timestamptz};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_connector::source::kafka::PRIVATELINK_CONNECTION;
 use risingwave_expr::scalar::like::{i_like_default, like_default};
@@ -188,12 +188,15 @@ impl From<Arc<IndexCatalog>> for ShowIndexRow {
 #[derive(Fields)]
 #[fields(style = "Title Case")]
 struct ShowClusterRow {
+    id: i32,
     addr: String,
+    r#type: String,
     state: String,
     parallel_units: String,
-    is_streaming: String,
-    is_serving: String,
-    is_unschedulable: String,
+    is_streaming: Option<bool>,
+    is_serving: Option<bool>,
+    is_unschedulable: Option<bool>,
+    started_at: Option<Timestamptz>,
 }
 
 #[derive(Fields)]
@@ -386,17 +389,22 @@ pub async fn handle_show_object(
                 .into());
         }
         ShowObject::Cluster => {
-            let workers = session.env().worker_node_manager().list_worker_nodes();
-            let rows = workers.into_iter().map(|worker| {
+            let workers = session.env().meta_client().list_all_nodes().await?;
+            let rows = workers.into_iter().sorted_by_key(|w| w.id).map(|worker| {
                 let addr: HostAddr = worker.host.as_ref().unwrap().into();
-                let property = worker.property.as_ref().unwrap();
+                let property = worker.property.as_ref();
                 ShowClusterRow {
+                    id: worker.id as _,
                     addr: addr.to_string(),
+                    r#type: worker.get_type().unwrap().as_str_name().into(),
                     state: worker.get_state().unwrap().as_str_name().to_string(),
                     parallel_units: worker.parallel_units.into_iter().map(|pu| pu.id).join(", "),
-                    is_streaming: property.is_streaming.to_string(),
-                    is_serving: property.is_serving.to_string(),
-                    is_unschedulable: property.is_unschedulable.to_string(),
+                    is_streaming: property.map(|p| p.is_streaming),
+                    is_serving: property.map(|p| p.is_serving),
+                    is_unschedulable: property.map(|p| p.is_unschedulable),
+                    started_at: worker
+                        .started_at
+                        .map(|ts| Timestamptz::from_secs(ts as i64).unwrap()),
                 }
             });
             return Ok(PgResponse::builder(StatementType::SHOW_COMMAND)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Close #16564 . After this PR, `show cluster` will return rows as follows:
```sql
dev=> show cluster;
 Id |      Addr      |           Type           |  State  | Parallel Units | Is Streaming | Is Serving | Is Unschedulable |        Started At
----+----------------+--------------------------+---------+----------------+--------------+------------+------------------+---------------------------
  0 | 127.0.0.1:5690 | WORKER_TYPE_META         | RUNNING |                |              |            |                  | 2024-05-07 07:57:18+00:00
  1 | 127.0.0.1:5688 | WORKER_TYPE_COMPUTE_NODE | RUNNING | 0, 1, 2, 3     | t            | t          | f                | 2024-05-07 07:57:21+00:00
  2 | 127.0.0.1:4566 | WORKER_TYPE_FRONTEND     | RUNNING |                |              |            |                  | 2024-05-07 07:57:24+00:00
  3 | 127.0.0.1:6660 | WORKER_TYPE_COMPACTOR    | RUNNING |                |              |            |                  | 2024-05-07 07:57:24+00:00
(4 rows)
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


Add information about other components for `show cluster` command.

</details>
