### PR TITLE
test(connector): test postgres source and sink recovery

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -58,6 +58,9 @@ echo "--- starting risingwave cluster"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
 risedev ci-start ci-1cn-1fe-with-recovery
 
+echo "--- postgres recovery test"
+risedev slt './e2e_test/sink/recovery/pg.slt'
+
 echo "--- mongodb cdc test"
 # install the mongo shell
 wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -53,7 +53,7 @@ select count(*) from t;
 statement ok
 create table t2 (v1 int primary key) with (
   connector = 'postgres-cdc',
-  hostname = 'db'
+  hostname = 'db',
   port = '5432',
   username = 'postgres'
   password = 'postgres',

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -1,0 +1,91 @@
+statement ok
+create table t as select generate_series as v1 from generate_series(1, 1000000);
+
+system ok
+PGPASSWORD=connector psql -d test -h localhost -p 5432 -U test -c "drop table if exists t;"
+
+system ok
+PGPASSWORD=connector psql -d test -h localhost -p 5432 -U test -c "create table t(v1 int primary key);"
+
+system ok
+PGPASSWORD=connector psql -d test -h localhost -p 5432 -U test -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO test;"
+
+statement ok
+set background_ddl=true;
+
+statement ok
+create sink pg_sink from t with (
+    connector = 'jdbc',
+    jdbc.url = 'jdbc:postgresql://localhost:5432/test?user=test&password=connector',
+    table.name = 't',
+    type = 'upsert',
+    primary_key = 'v1'
+);
+
+sleep 5s
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+sleep 10s
+
+statement ok
+recover;
+
+query I
+select count(*) from t;
+----
+1000000
+
+# Sink back into RW from PG
+statement ok
+create table t2 (v1 int primary key) with (
+ connector = 'postgres-cdc',
+ hostname = 'localhost',
+ port = '5432',
+ username = 'test',
+ password = 'connector',
+ database.name = 'test',
+ table.name = 't',
+);
+
+sleep 5s
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+statement ok
+recover;
+
+sleep 1s
+
+statement ok
+recover;
+
+sleep 10s
+
+query I
+select count(*) from t2;
+----
+1000000

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -16,7 +16,7 @@ set background_ddl=true;
 statement ok
 create sink pg_sink from t with (
     connector = 'jdbc',
-    jdbc.url = 'jdbc:postgresql://localhost:5432/test?user=test&password=connector',
+    jdbc.url='jdbc:postgresql://db:5432/test?user=test&password=connector',
     table.name = 't',
     type = 'upsert',
     primary_key = 'v1'
@@ -52,13 +52,14 @@ select count(*) from t;
 # Sink back into RW from PG
 statement ok
 create table t2 (v1 int primary key) with (
- connector = 'postgres-cdc',
- hostname = 'localhost',
- port = '5432',
- username = 'test',
- password = 'connector',
- database.name = 'test',
- table.name = 't',
+  connector = 'postgres-cdc',
+  hostname = '${PGHOST:localhost}',
+  port = '${PGPORT:5432}',
+  username = '${PGUSER:$USER}',
+  password = '${PGPASSWORD:}',
+  database.name = '${PGDATABASE:postgres}',
+  table.name = 't',
+  slot.name = 'pg_recovery_test_slot'
 );
 
 sleep 5s

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -8,7 +8,7 @@ system ok
 PGPASSWORD=postgres psql -d postgres -h db -p 5432 -U postgres -c "create table t(v1 int primary key);"
 
 system ok
-PGPASSWORD=postgres psql -d postgres -h db -p 5432 -U postgres -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO test;"
+PGPASSWORD=postgres psql -d postgres -h db -p 5432 -U postgres -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO postgres;"
 
 statement ok
 set background_ddl=true;

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -2,13 +2,13 @@ statement ok
 create table t as select generate_series as v1 from generate_series(1, 1000000);
 
 system ok
-PGPASSWORD=connector psql -d test -h db -p 5432 -U test -c "drop table if exists t;"
+PGPASSWORD=postgres psql -d postgres -h db -p 5432 -U postgres -c "drop table if exists t;"
 
 system ok
-PGPASSWORD=connector psql -d test -h db -p 5432 -U test -c "create table t(v1 int primary key);"
+PGPASSWORD=postgres psql -d postgres -h db -p 5432 -U postgres -c "create table t(v1 int primary key);"
 
 system ok
-PGPASSWORD=connector psql -d test -h db -p 5432 -U test -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO test;"
+PGPASSWORD=postgres psql -d postgres -h db -p 5432 -U postgres -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO test;"
 
 statement ok
 set background_ddl=true;
@@ -16,7 +16,7 @@ set background_ddl=true;
 statement ok
 create sink pg_sink from t with (
     connector = 'jdbc',
-    jdbc.url='jdbc:postgresql://db:5432/test?user=test&password=connector',
+    jdbc.url='jdbc:postgresql://db:5432/postgres?user=postgres&password=postgres',
     table.name = 't',
     type = 'upsert',
     primary_key = 'v1'

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -55,9 +55,9 @@ create table t2 (v1 int primary key) with (
   connector = 'postgres-cdc',
   hostname = 'db',
   port = '5432',
-  username = 'postgres'
+  username = 'postgres',
   password = 'postgres',
-  database.name = 'postgres'.
+  database.name = 'postgres',
   table.name = 't',
   slot.name = 'pg_recovery_test_slot'
 );

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -53,11 +53,11 @@ select count(*) from t;
 statement ok
 create table t2 (v1 int primary key) with (
   connector = 'postgres-cdc',
-  hostname = '${PGHOST:localhost}',
-  port = '${PGPORT:5432}',
-  username = '${PGUSER:$USER}',
-  password = '${PGPASSWORD:}',
-  database.name = '${PGDATABASE:postgres}',
+  hostname = 'db'
+  port = '5432',
+  username = 'postgres'
+  password = 'postgres',
+  database.name = 'postgres'.
   table.name = 't',
   slot.name = 'pg_recovery_test_slot'
 );

--- a/e2e_test/sink/recovery/pg.slt
+++ b/e2e_test/sink/recovery/pg.slt
@@ -2,13 +2,13 @@ statement ok
 create table t as select generate_series as v1 from generate_series(1, 1000000);
 
 system ok
-PGPASSWORD=connector psql -d test -h localhost -p 5432 -U test -c "drop table if exists t;"
+PGPASSWORD=connector psql -d test -h db -p 5432 -U test -c "drop table if exists t;"
 
 system ok
-PGPASSWORD=connector psql -d test -h localhost -p 5432 -U test -c "create table t(v1 int primary key);"
+PGPASSWORD=connector psql -d test -h db -p 5432 -U test -c "create table t(v1 int primary key);"
 
 system ok
-PGPASSWORD=connector psql -d test -h localhost -p 5432 -U test -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO test;"
+PGPASSWORD=connector psql -d test -h db -p 5432 -U test -c "GRANT SELECT, INSERT, UPDATE, DELETE ON t TO test;"
 
 statement ok
 set background_ddl=true;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Looks like if we do a series of recovery, CN segfaults.

In production I suppose we will apply recovery. But CN should not segfault in the first place.

CN log:
```
 thread="rw-dbz-engine-runner-12006" class="org.apache.kafka.connect.json.JsonConverterConfig"
2024-05-15T15:03:17.084739+08:00  INFO risingwave_connector_node: JDBC connection: autoCommit = false, trxn = 2 thread="Thread-107" class="com.risingwave.connector.JDBCSink"
2024-05-15T15:03:17.084629+08:00  INFO risingwave_connector_node: JDBC connection: autoCommit = false, trxn = 2 thread="Thread-109" class="com.risingwave.connector.JDBCSink"
2024-05-15T15:03:17.0849+08:00  INFO risingwave_jni_core: send error error=channel closed
2024-05-15T15:03:17.084957+08:00  INFO risingwave_jni_core: send error error=channel closed
2024-05-15T15:03:17.084977+08:00 ERROR risingwave_connector_node: sink writer error: : io.grpc.StatusRuntimeException: INTERNAL: unable to send response
	at io.grpc.Status.asRuntimeException(Status.java:530)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:38)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:24)
	at com.risingwave.connector.SinkWriterStreamObserver.onNext(SinkWriterStreamObserver.java:108)
	at com.risingwave.connector.JniSinkWriterHandler.runJniSinkWriterThread(JniSinkWriterHandler.java:40)
 thread="Thread-107" class="com.risingwave.connector.SinkWriterStreamObserver"
2024-05-15T15:03:17.085013+08:00 ERROR risingwave_connector_node: sink writer error: : io.grpc.StatusRuntimeException: INTERNAL: unable to send response
	at io.grpc.Status.asRuntimeException(Status.java:530)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:38)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:24)
	at com.risingwave.connector.SinkWriterStreamObserver.onNext(SinkWriterStreamObserver.java:108)
	at com.risingwave.connector.JniSinkWriterHandler.runJniSinkWriterThread(JniSinkWriterHandler.java:40)
 thread="Thread-109" class="com.risingwave.connector.SinkWriterStreamObserver"
2024-05-15T15:03:17.085115+08:00 ERROR risingwave_connector_node: JniSinkWriterHandler onError: : io.grpc.StatusRuntimeException: INTERNAL: unable to send response
	at io.grpc.Status.asRuntimeException(Status.java:530)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:38)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:24)
	at com.risingwave.connector.SinkWriterStreamObserver.onNext(SinkWriterStreamObserver.java:108)
	at com.risingwave.connector.JniSinkWriterHandler.runJniSinkWriterThread(JniSinkWriterHandler.java:40)
 thread="Thread-109" class="com.risingwave.connector.JniSinkWriterResponseObserver"
2024-05-15T15:03:17.085118+08:00 ERROR risingwave_connector_node: JniSinkWriterHandler onError: : io.grpc.StatusRuntimeException: INTERNAL: unable to send response
	at io.grpc.Status.asRuntimeException(Status.java:530)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:38)
	at com.risingwave.connector.JniSinkWriterResponseObserver.onNext(JniSinkWriterResponseObserver.java:24)
	at com.risingwave.connector.SinkWriterStreamObserver.onNext(SinkWriterStreamObserver.java:108)
	at com.risingwave.connector.JniSinkWriterHandler.runJniSinkWriterThread(JniSinkWriterHandler.java:40)
 thread="Thread-107" class="com.risingwave.connector.JniSinkWriterResponseObserver"
2024-05-15T15:03:17.085252+08:00  INFO risingwave_connector_node: Flush offsets successfully, partition: {server=RW_CDC_12006}, offsets: {transaction_id=null, lsn_proc=880235920, messageType=INSERT, lsn_commit=880212792, lsn=880235920, txId=18364, ts_usec=1715756590666573} thread="rw-dbz-engine-runner-12006" class="com.risingwave.connector.cdc.debezium.internal.ConfigurableOffsetBackingStore"
2024-05-15T15:03:17.086192+08:00  INFO risingwave_connector_node: Starting PostgresConnectorTask with configuration: thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086316+08:00  INFO risingwave_connector_node:    connector.class = io.debezium.connector.postgresql.PostgresConnector thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086337+08:00  INFO risingwave_connector_node:    max.queue.size = 8192 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086356+08:00  INFO risingwave_connector_node:    slot.name = rw_cdc_c5a911bb95c644e9aade60ac976e5063 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086376+08:00  INFO risingwave_connector_node:    publication.name = rw_publication thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086395+08:00  INFO risingwave_connector_node:    topic.heartbeat.prefix = RW_CDC_HeartBeat_ thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086413+08:00  INFO risingwave_connector_node:    provide.transaction.metadata = false thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086432+08:00  INFO risingwave_connector_node:    topic.prefix = RW_CDC_12006 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.08645+08:00  INFO risingwave_connector_node:    decimal.handling.mode = string thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086468+08:00  INFO risingwave_connector_node:    offset.storage.file.filename =  thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086487+08:00  INFO risingwave_connector_node:    interval.handling.mode = string thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086505+08:00  INFO risingwave_connector_node:    converters = datetime thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086523+08:00  INFO risingwave_connector_node:    errors.retry.delay.initial.ms = 300 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086542+08:00  INFO risingwave_connector_node:    datetime.type = com.risingwave.connector.cdc.debezium.converters.DatetimeTypeConverter thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.08656+08:00  INFO risingwave_connector_node:    value.converter = org.apache.kafka.connect.json.JsonConverter thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086579+08:00  INFO risingwave_connector_node:    key.converter = org.apache.kafka.connect.json.JsonConverter thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086597+08:00  INFO risingwave_connector_node:    publication.autocreate.mode = disabled thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086616+08:00  INFO risingwave_connector_node:    database.user = test thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086641+08:00  INFO risingwave_connector_node:    database.dbname = test thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.08666+08:00  INFO risingwave_connector_node:    offset.storage = com.risingwave.connector.cdc.debezium.internal.ConfigurableOffsetBackingStore thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086679+08:00  INFO risingwave_connector_node:    time.precision.mode = connect thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086697+08:00  INFO risingwave_connector_node:    offset.flush.timeout.ms = 5000 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086715+08:00  INFO risingwave_connector_node:    errors.retry.delay.max.ms = 10000 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086733+08:00  INFO risingwave_connector_node:    heartbeat.interval.ms = 300000 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086753+08:00  INFO risingwave_connector_node:    offset.storage.risingwave.state.value = {"sourcePartition":{"server":"RW_CDC_12006"},"sourceOffset":{"transaction_id":null,"lsn_proc":880235920,"messageType":"INSERT","lsn_commit":880212792,"lsn":880235920,"txId":18364,"ts_usec":1715756590666573},"isHeartbeat":false} thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086772+08:00  INFO risingwave_connector_node:    plugin.name = pgoutput thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086793+08:00  INFO risingwave_connector_node:    database.port = 5432 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086811+08:00  INFO risingwave_connector_node:    offset.flush.interval.ms = 60000 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086829+08:00  INFO risingwave_connector_node:    schema.history.internal = io.debezium.relational.history.MemorySchemaHistory thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086848+08:00  INFO risingwave_connector_node:    errors.max.retries = -1 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086875+08:00  INFO risingwave_connector_node:    database.hostname = localhost thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086894+08:00  INFO risingwave_connector_node:    database.password = ******** thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086913+08:00  INFO risingwave_connector_node:    name = localhost:5432:test.public.t thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086931+08:00  INFO risingwave_connector_node:    debezium.embedded.shutdown.pause.before.interrupt.ms = 1 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.08695+08:00  INFO risingwave_connector_node:    max.batch.size = 1024 thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086968+08:00  INFO risingwave_connector_node:    table.include.list = public.t thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.086986+08:00  INFO risingwave_connector_node:    snapshot.mode = never thread="rw-dbz-engine-runner-12006" class="io.debezium.connector.common.BaseSourceTask"
2024-05-15T15:03:17.08704+08:00  INFO risingwave_connector_node: Loading the custom source info struct maker plugin: io.debezium.connector.postgresql.PostgresSourceInfoStructMaker thread="rw-dbz-engine-runner-12006" class="io.debezium.config.CommonConnectorConfig"
2024-05-15T15:03:17.087323+08:00  INFO risingwave_connector_node: Loading the custom topic naming strategy plugin: io.debezium.schema.SchemaTopicNamingStrategy thread="rw-dbz-engine-runner-12006" class="io.debezium.config.CommonConnectorConfig"
2024-05-15T15:03:17.09449+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12005, instance_id: 133
2024-05-15T15:03:17.09507+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12007, instance_id: 134
2024-05-15T15:03:17.095509+08:00 DEBUG risingwave_stream::from_proto::row_id_gen: row id gen executor: Some(1111111111111111111111111111111111111111111111111111111111111111000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
2024-05-15T15:03:17.095719+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 135
2024-05-15T15:03:17.096083+08:00 DEBUG risingwave_stream::from_proto::row_id_gen: row id gen executor: Some(0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111111111111111111111111111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000000)
2024-05-15T15:03:17.096515+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 136
2024-05-15T15:03:17.097443+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12004, instance_id: 137
2024-05-15T15:03:17.097706+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 138
2024-05-15T15:03:17.098114+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12007, instance_id: 139
2024-05-15T15:03:17.098496+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12007, instance_id: 140
2024-05-15T15:03:17.098786+08:00 DEBUG risingwave_stream::from_proto::row_id_gen: row id gen executor: Some(0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001111111111111111111111111111111111111111111111111111111111111111)
2024-05-15T15:03:17.099265+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 141
2024-05-15T15:03:17.100326+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12004, instance_id: 142
2024-05-15T15:03:17.100524+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 143
2024-05-15T15:03:17.100834+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12007, instance_id: 144
2024-05-15T15:03:17.101348+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12004, instance_id: 145
2024-05-15T15:03:17.101485+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 146
2024-05-15T15:03:17.101775+08:00 DEBUG risingwave_stream::from_proto::row_id_gen: row id gen executor: Some(0000000000000000000000000000000000000000000000000000000000000000111111111111111111111111111111111111111111111111111111111111111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
2024-05-15T15:03:17.102029+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 147
2024-05-15T15:03:17.102569+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12005, instance_id: 148
2024-05-15T15:03:17.102933+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12005, instance_id: 149
2024-05-15T15:03:17.103184+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12005, instance_id: 150
2024-05-15T15:03:17.104021+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12004, instance_id: 151
2024-05-15T15:03:17.104255+08:00 DEBUG risingwave_storage::hummock::event_handler::hummock_event_handler: new read version registered: table_id: 12001, instance_id: 152
2024-05-15T15:03:17.105404+08:00 DEBUG actor{otel.name="Actor 12013" actor_id=12013}:executor{otel.name="StreamScan 2EED0000272A"}: risingwave_stream::executor::backfill::arrangement_backfill: Arrangement Backfill Executor started
2024-05-15T15:03:17.105527+08:00 DEBUG actor{otel.name="Actor 12015" actor_id=12015}:executor{otel.name="StreamScan 2EEF0000272A"}: risingwave_stream::executor::backfill::arrangement_backfill: Arrangement Backfill Executor started
2024-05-15T15:03:17.105609+08:00 DEBUG actor{otel.name="Actor 12016" actor_id=12016}:executor{otel.name="StreamScan 2EF00000272A"}: risingwave_stream::executor::backfill::arrangement_backfill: Arrangement Backfill Executor started
2024-05-15T15:03:17.106057+08:00 DEBUG actor{otel.name="Actor 12014" actor_id=12014}:executor{otel.name="StreamScan 2EEE0000272A"}: risingwave_stream::executor::backfill::arrangement_backfill: Arrangement Backfill Executor started
2024-05-15T15:03:17.107544+08:00 DEBUG actor{otel.name="Actor 12021" actor_id=12021}:executor{otel.name="Source 2EF500002716"}: risingwave_stream::executor::source::source_executor: source exector: actor 12021 boot with splits: []
2024-05-15T15:03:17.107544+08:00 DEBUG actor{otel.name="Actor 12024" actor_id=12024}:executor{otel.name="Source 2EF800002716"}: risingwave_stream::executor::source::source_executor: source exector: actor 12024 boot with splits: [PostgresCdc(DebeziumCdcSplit { mysql_split: None, postgres_split: Some(PostgresCdcSplit { inner: CdcSplitBase { split_id: 12006, start_offset: None, snapshot_done: false }, server_addr: None }), citus_split: None, mongodb_split: None, _phantom: PhantomData<risingwave_connector::source::cdc::Postgres> })]
2024-05-15T15:03:17.107587+08:00 DEBUG actor{otel.name="Actor 12021" actor_id=12021}:executor{otel.name="Source 2EF500002716"}: risingwave_stream::executor::source::source_executor: start with state state=None
2024-05-15T15:03:17.107777+08:00 DEBUG risingwave_stream::executor::source::source_executor: wait epoch worker start success
2024-05-15T15:03:17.107813+08:00 DEBUG actor{otel.name="Actor 12022" actor_id=12022}:executor{otel.name="Source 2EF600002716"}: risingwave_stream::executor::source::source_executor: source exector: actor 12022 boot with splits: []
2024-05-15T15:03:17.107824+08:00 DEBUG actor{otel.name="Actor 12024" actor_id=12024}:executor{otel.name="Source 2EF800002716"}: risingwave_stream::executor::source::source_executor: start with state state=Some([PostgresCdc(DebeziumCdcSplit { mysql_split: None, postgres_split: Some(PostgresCdcSplit { inner: CdcSplitBase { split_id: 12006, start_offset: Some("{\"sourcePartition\":{\"server\":\"RW_CDC_12006\"},\"sourceOffset\":{\"transaction_id\":null,\"lsn_proc\":880235920,\"messageType\":\"INSERT\",\"lsn_commit\":880212792,\"lsn\":880235920,\"txId\":18364,\"ts_usec\":1715756590666573},\"isHeartbeat\":false}"), snapshot_done: true }, server_addr: None }), citus_split: None, mongodb_split: None, _phantom: PhantomData<risingwave_connector::source::cdc::Postgres> })])
2024-05-15T15:03:17.107854+08:00 DEBUG actor{otel.name="Actor 12022" actor_id=12022}:executor{otel.name="Source 2EF600002716"}: risingwave_stream::executor::source::source_executor: start with state state=None
2024-05-15T15:03:17.107876+08:00 DEBUG actor{otel.name="Actor 12024" actor_id=12024}:executor{otel.name="Source 2EF800002716"}: risingwave_connector::source::reader::reader: spawning connector split reader splits=[PostgresCdc(DebeziumCdcSplit { mysql_split: None, postgres_split: Some(PostgresCdcSplit { inner: CdcSplitBase { split_id: 12006, start_offset: Some("{\"sourcePartition\":{\"server\":\"RW_CDC_12006\"},\"sourceOffset\":{\"transaction_id\":null,\"lsn_proc\":880235920,\"messageType\":\"INSERT\",\"lsn_commit\":880212792,\"lsn\":880235920,\"txId\":18364,\"ts_usec\":1715756590666573},\"isHeartbeat\":false}"), snapshot_done: true }, server_addr: None }), citus_split: None, mongodb_split: None, _phantom: PhantomData<risingwave_connector::source::cdc::Postgres> })] prop=CdcProperties { properties: {"password": "connector", "hostname": "localhost", "slot.name": "rw_cdc_c5a911bb95c644e9aade60ac976e5063", "schema.name": "public", "database.name": "test", "publication.create.enable": "true", "table.name": "t", "publication.name": "rw_publication", "port": "5432", "username": "test"}, table_schema: TableSchema { columns: [], pk_indices: [] }, is_cdc_source_job: false, is_backfill_table: false, _phantom: PhantomData<risingwave_connector::source::cdc::Postgres> }
2024-05-15T15:03:17.108016+08:00 DEBUG risingwave_stream::executor::source::source_executor: wait epoch worker start success
2024-05-15T15:03:17.108035+08:00 DEBUG risingwave_stream::executor::source::source_executor: wait epoch worker start success
2024-05-15T15:03:17.108073+08:00 DEBUG actor{otel.name="Actor 12023" actor_id=12023}:executor{otel.name="Source 2EF700002716"}: risingwave_stream::executor::source::source_executor: source exector: actor 12023 boot with splits: []
2024-05-15T15:03:17.108094+08:00 DEBUG actor{otel.name="Actor 12023" actor_id=12023}:executor{otel.name="Source 2EF700002716"}: risingwave_stream::executor::source::source_executor: start with state state=None
2024-05-15T15:03:17.108427+08:00 DEBUG risingwave_stream::executor::source::source_executor: wait epoch worker start success
2024-05-15T15:03:17.108671+08:00 DEBUG jni::wrapper::java_vm::vm: Attached thread  (ThreadId(76)). 5 threads attached    
2024-05-15T15:03:17.114316+08:00 DEBUG jni::wrapper::java_vm::vm: Attached thread  (ThreadId(77)). 6 threads attached    
2024-05-15T15:03:17.115284+08:00 DEBUG jni::wrapper::java_vm::vm: Attached thread  (ThreadId(78)). 7 threads attached    
2024-05-15T15:03:17.11618+08:00 DEBUG jni::wrapper::java_vm::vm: Attached thread  (ThreadId(79)). 8 threads attached    
2024-05-15T15:03:17.120874+08:00 DEBUG jni::wrapper::java_vm::vm: Attached thread  (ThreadId(80)). 9 threads attached    
Wed May 15 07:03:17 UTC 2024 [risedev]: Program exited with 139

```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
