### PR TITLE
refactor(object-store): remove async_trait macro on StreamingUploader and refine object store macro

### DIFF
--- a/src/connector/src/sink/snowflake.rs
+++ b/src/connector/src/sink/snowflake.rs
@@ -22,7 +22,7 @@ use bytes::{Bytes, BytesMut};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
-use risingwave_object_store::object::{ObjectStore, StreamingUploader};
+use risingwave_object_store::object::{ObjectStore, OpendalStreamingUploader, StreamingUploader};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_with::serde_as;
@@ -184,7 +184,7 @@ pub struct SnowflakeSinkWriter {
     /// note: the option here *implicitly* indicates whether we have at
     /// least call `streaming_upload` once during this epoch,
     /// which is mainly used to prevent uploading empty data.
-    streaming_uploader: Option<(Box<dyn StreamingUploader>, String)>,
+    streaming_uploader: Option<(OpendalStreamingUploader, String)>,
 }
 
 impl SnowflakeSinkWriter {
@@ -242,7 +242,7 @@ impl SnowflakeSinkWriter {
     /// and `streaming_upload` being called the first time.
     /// i.e., lazily initialization of the internal `streaming_uploader`.
     /// plus, this function is *pure*, the `&mut self` here is to make rustc (and tokio) happy.
-    async fn new_streaming_uploader(&mut self) -> Result<(Box<dyn StreamingUploader>, String)> {
+    async fn new_streaming_uploader(&mut self) -> Result<(OpendalStreamingUploader, String)> {
         let file_suffix = self.file_suffix();
         let path = generate_s3_file_name(self.s3_client.s3_path(), &file_suffix);
         let uploader = self

--- a/src/object_store/src/object/mem.rs
+++ b/src/object_store/src/object/mem.rs
@@ -28,8 +28,7 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 
 use super::{
-    BoxedStreamingUploader, ObjectError, ObjectMetadata, ObjectRangeBounds, ObjectResult,
-    ObjectStore, StreamingUploader,
+    ObjectError, ObjectMetadata, ObjectRangeBounds, ObjectResult, ObjectStore, StreamingUploader,
 };
 use crate::object::{ObjectDataStream, ObjectMetadataIter};
 
@@ -64,7 +63,6 @@ pub struct InMemStreamingUploader {
     objects: Arc<Mutex<HashMap<String, (ObjectMetadata, Bytes)>>>,
 }
 
-#[async_trait::async_trait]
 impl StreamingUploader for InMemStreamingUploader {
     async fn write_bytes(&mut self, data: Bytes) -> ObjectResult<()> {
         fail_point!("mem_write_bytes_err", |_| Err(ObjectError::internal(
@@ -74,7 +72,7 @@ impl StreamingUploader for InMemStreamingUploader {
         Ok(())
     }
 
-    async fn finish(self: Box<Self>) -> ObjectResult<()> {
+    async fn finish(self) -> ObjectResult<()> {
         fail_point!("mem_finish_streaming_upload_err", |_| Err(
             ObjectError::internal("mem finish streaming upload error")
         ));
@@ -101,6 +99,8 @@ pub struct InMemObjectStore {
 
 #[async_trait::async_trait]
 impl ObjectStore for InMemObjectStore {
+    type StreamingUploader = InMemStreamingUploader;
+
     fn get_object_prefix(&self, _obj_id: u64) -> String {
         String::default()
     }
@@ -121,12 +121,12 @@ impl ObjectStore for InMemObjectStore {
         }
     }
 
-    async fn streaming_upload(&self, path: &str) -> ObjectResult<BoxedStreamingUploader> {
-        Ok(Box::new(InMemStreamingUploader {
+    async fn streaming_upload(&self, path: &str) -> ObjectResult<Self::StreamingUploader> {
+        Ok(InMemStreamingUploader {
             path: path.to_string(),
             buf: BytesMut::new(),
             objects: self.objects.clone(),
-        }))
+        })
     }
 
     async fn read(&self, path: &str, range: impl ObjectRangeBounds) -> ObjectResult<Bytes> {

--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -161,23 +161,21 @@ macro_rules! enum_map {
                 {$variant:ident, $_type_name:ty}
             ),*
         },
-        $source_enum_type:ident,
-        $target_enum_type:ident,
         $object_store:expr,
         $var_name:ident,
         $func:expr
     ) => {
         match $object_store {
             $(
-                $source_enum_type::$variant($var_name) => $target_enum_type::$variant({
+                ObjectStoreEnum::$variant($var_name) => ObjectStoreEnum::$variant({
                     $func
                 }),
             )*
         }
     };
-    ($source_enum_type:ident, $target_enum_type:ident, $object_store:expr, |$var_name:ident| $func:expr) => {
+    ($object_store:expr, |$var_name:ident| $func:expr) => {
         for_all_object_store! {
-            enum_map, $source_enum_type, $target_enum_type, $object_store, $var_name, $func
+            enum_map, $object_store, $var_name, $func
         }
     };
 }
@@ -286,7 +284,7 @@ impl ObjectStoreImpl {
     }
 
     pub async fn streaming_upload(&self, path: &str) -> ObjectResult<ObjectStreamingUploader> {
-        Ok(enum_map!(Self, StreamingUploaderImpl, self, |store| {
+        Ok(enum_map!(self, |store| {
             store.streaming_upload(path).await?
         }))
     }

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -27,8 +27,8 @@ use risingwave_common::range::RangeBoundsExt;
 use thiserror_ext::AsReport;
 
 use crate::object::{
-    prefix, BoxedStreamingUploader, ObjectDataStream, ObjectError, ObjectMetadata,
-    ObjectMetadataIter, ObjectRangeBounds, ObjectResult, ObjectStore, StreamingUploader,
+    prefix, ObjectDataStream, ObjectError, ObjectMetadata, ObjectMetadataIter, ObjectRangeBounds,
+    ObjectResult, ObjectStore, StreamingUploader,
 };
 
 /// Opendal object storage.
@@ -70,6 +70,8 @@ impl OpendalObjectStore {
 
 #[async_trait::async_trait]
 impl ObjectStore for OpendalObjectStore {
+    type StreamingUploader = OpendalStreamingUploader;
+
     fn get_object_prefix(&self, obj_id: u64) -> String {
         match self.engine_type {
             EngineType::S3 => prefix::s3::get_object_prefix(obj_id),
@@ -94,11 +96,11 @@ impl ObjectStore for OpendalObjectStore {
         }
     }
 
-    async fn streaming_upload(&self, path: &str) -> ObjectResult<BoxedStreamingUploader> {
-        Ok(Box::new(
+    async fn streaming_upload(&self, path: &str) -> ObjectResult<Self::StreamingUploader> {
+        Ok(
             OpendalStreamingUploader::new(self.op.clone(), path.to_string(), self.config.clone())
                 .await?,
-        ))
+        )
     }
 
     async fn read(&self, path: &str, range: impl ObjectRangeBounds) -> ObjectResult<Bytes> {
@@ -280,7 +282,6 @@ impl OpendalStreamingUploader {
 
 const OPENDAL_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 
-#[async_trait::async_trait]
 impl StreamingUploader for OpendalStreamingUploader {
     async fn write_bytes(&mut self, data: Bytes) -> ObjectResult<()> {
         self.writer.write(data).await?;
@@ -288,7 +289,7 @@ impl StreamingUploader for OpendalStreamingUploader {
         Ok(())
     }
 
-    async fn finish(mut self: Box<Self>) -> ObjectResult<()> {
+    async fn finish(mut self) -> ObjectResult<()> {
         match self.writer.close().await {
             Ok(_) => (),
             Err(err) => {

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -246,6 +246,10 @@ impl ObjectStore for OpendalObjectStore {
             EngineType::Fs => "Fs",
         }
     }
+
+    fn support_streaming_upload(&self) -> bool {
+        self.op.info().native_capability().write_can_multi
+    }
 }
 
 /// Store multiple parts in a map, and concatenate them on finish.

--- a/src/object_store/src/object/sim/mod.rs
+++ b/src/object_store/src/object/sim/mod.rs
@@ -35,8 +35,8 @@ use risingwave_common::range::RangeBoundsExt;
 use self::client::Client;
 use self::service::Response;
 use super::{
-    BoxedStreamingUploader, Bytes, ObjectDataStream, ObjectError, ObjectMetadata,
-    ObjectMetadataIter, ObjectRangeBounds, ObjectResult, ObjectStore, StreamingUploader,
+    Bytes, ObjectDataStream, ObjectError, ObjectMetadata, ObjectMetadataIter, ObjectRangeBounds,
+    ObjectResult, ObjectStore, StreamingUploader,
 };
 
 pub struct SimStreamingUploader {

--- a/src/object_store/src/object/sim/mod.rs
+++ b/src/object_store/src/object/sim/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(madsim)]
+
 mod client;
 mod error;
 use bytes::{BufMut, BytesMut};

--- a/src/object_store/src/object/sim/mod.rs
+++ b/src/object_store/src/object/sim/mod.rs
@@ -53,14 +53,13 @@ impl SimStreamingUploader {
     }
 }
 
-#[async_trait::async_trait]
 impl StreamingUploader for SimStreamingUploader {
     async fn write_bytes(&mut self, data: Bytes) -> ObjectResult<()> {
         self.buf.put(data);
         Ok(())
     }
 
-    async fn finish(mut self: Box<Self>) -> ObjectResult<()> {
+    async fn finish(mut self) -> ObjectResult<()> {
         if self.buf.is_empty() {
             Err(ObjectError::internal("upload empty object"))
         } else {
@@ -115,6 +114,8 @@ pub struct SimObjectStore {
 
 #[async_trait::async_trait]
 impl ObjectStore for SimObjectStore {
+    type StreamingUploader = SimStreamingUploader;
+
     fn get_object_prefix(&self, _obj_id: u64) -> String {
         String::default()
     }
@@ -136,11 +137,11 @@ impl ObjectStore for SimObjectStore {
         }
     }
 
-    async fn streaming_upload(&self, path: &str) -> ObjectResult<BoxedStreamingUploader> {
-        Ok(Box::new(SimStreamingUploader::new(
+    async fn streaming_upload(&self, path: &str) -> ObjectResult<Self::StreamingUploader> {
+        Ok(SimStreamingUploader::new(
             self.client.clone(),
             path.to_string(),
-        )))
+        ))
     }
 
     async fn read(&self, path: &str, range: impl ObjectRangeBounds) -> ObjectResult<Bytes> {

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -27,7 +27,7 @@ use risingwave_common::config::StorageMemoryConfig;
 use risingwave_hummock_sdk::{HummockSstableObjectId, OBJECT_SUFFIX};
 use risingwave_hummock_trace::TracedCachePolicy;
 use risingwave_object_store::object::{
-    ObjectError, ObjectMetadataIter, ObjectStoreRef, ObjectStreamingUploader,
+    ObjectError, ObjectMetadataIter, ObjectStoreRef, ObjectStreamingUploader, StreamingUploader,
 };
 use risingwave_pb::hummock::SstableInfo;
 use serde::{Deserialize, Serialize};

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -27,7 +27,7 @@ use risingwave_common::config::StorageMemoryConfig;
 use risingwave_hummock_sdk::{HummockSstableObjectId, OBJECT_SUFFIX};
 use risingwave_hummock_trace::TracedCachePolicy;
 use risingwave_object_store::object::{
-    ObjectError, ObjectMetadataIter, ObjectStoreRef, ObjectStreamingUploader, StreamingUploader,
+    ObjectError, ObjectMetadataIter, ObjectStoreRef, ObjectStreamingUploader,
 };
 use risingwave_pb::hummock::SstableInfo;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Removed `#[async_trait]` on `StreamingUploader` trait, and avoid using box dyn on streaming uploader, so that each call on `write_bytes` won't create a boxed future. `StreamingUploader` now becomes an associated type of `ObjectStore`. An `StreamingUploaderImpl` enum will be used to manually dispatch to different variant.

Refined the macro used in object store trait. Previously, we have many macros that lists all variants of object store. With this PR, we only need to declare the list of all variants in a single macro `for_all_object_store`, and all other macros will call `for_all_object_store` to get the list of object store variants.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
