### PR TITLE
refactor(meta): simplify hummock manager val transaction

### DIFF
--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -23,12 +23,10 @@ use risingwave_hummock_sdk::{
 use risingwave_pb::hummock::{HummockPinnedSnapshot, HummockPinnedVersion, ValidationTask};
 
 use crate::hummock::error::{Error, Result};
-use crate::hummock::manager::{
-    commit_multi_var, create_trx_wrapper, start_measure_real_process_timer,
-};
+use crate::hummock::manager::{commit_multi_var, start_measure_real_process_timer};
 use crate::hummock::HummockManager;
 use crate::manager::{MetaStoreImpl, MetadataManager, META_NODE_ID};
-use crate::model::{BTreeMapTransaction, BTreeMapTransactionWrapper, ValTransaction};
+use crate::model::BTreeMapTransaction;
 use crate::storage::MetaStore;
 
 #[derive(Default)]
@@ -55,16 +53,8 @@ impl ContextInfo {
             anyhow::anyhow!("failpoint internal error")
         )));
 
-        let mut pinned_versions = create_trx_wrapper!(
-            meta_store_ref,
-            BTreeMapTransactionWrapper,
-            BTreeMapTransaction::new(&mut self.pinned_versions,)
-        );
-        let mut pinned_snapshots = create_trx_wrapper!(
-            meta_store_ref,
-            BTreeMapTransactionWrapper,
-            BTreeMapTransaction::new(&mut self.pinned_snapshots,)
-        );
+        let mut pinned_versions = BTreeMapTransaction::new(&mut self.pinned_versions);
+        let mut pinned_snapshots = BTreeMapTransaction::new(&mut self.pinned_snapshots);
         for context_id in context_ids.as_ref() {
             pinned_versions.remove(*context_id);
             pinned_snapshots.remove(*context_id);

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -29,10 +29,10 @@ use risingwave_pb::hummock::subscribe_compaction_event_response::Event as Respon
 use risingwave_pb::hummock::FullScanTask;
 
 use crate::hummock::error::{Error, Result};
-use crate::hummock::manager::{commit_multi_var, create_trx_wrapper};
+use crate::hummock::manager::commit_multi_var;
 use crate::hummock::HummockManager;
 use crate::manager::MetadataManager;
-use crate::model::{BTreeMapTransaction, BTreeMapTransactionWrapper, ValTransaction};
+use crate::model::BTreeMapTransaction;
 use crate::storage::MetaStore;
 
 #[derive(Default)]
@@ -105,11 +105,8 @@ impl HummockManager {
         if !context_info.version_safe_points.is_empty() {
             return Ok((0, deltas_to_delete.len()));
         }
-        let mut hummock_version_deltas = create_trx_wrapper!(
-            self.meta_store_ref(),
-            BTreeMapTransactionWrapper,
-            BTreeMapTransaction::new(&mut versioning.hummock_version_deltas,)
-        );
+        let mut hummock_version_deltas =
+            BTreeMapTransaction::new(&mut versioning.hummock_version_deltas);
         let batch = deltas_to_delete
             .iter()
             .take(batch_size)

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -41,7 +41,7 @@ use crate::manager::cluster::WorkerId;
 use crate::manager::{commit_meta, commit_meta_with_trx, LocalNotification, MetaSrvEnv};
 use crate::model::{
     ActorId, BTreeMapTransaction, FragmentId, MetadataModel, MigrationPlan, TableFragments,
-    TableParallelism, ValTransaction,
+    TableParallelism,
 };
 use crate::storage::Transaction;
 use crate::stream::{to_build_actor_info, SplitAssignment, TableRevision};

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -49,7 +49,7 @@ use user::*;
 use crate::manager::{
     IdCategory, MetaSrvEnv, NotificationVersion, StreamingJob, IGNORED_NOTIFICATION_VERSION,
 };
-use crate::model::{BTreeMapTransaction, MetadataModel, TableFragments, ValTransaction};
+use crate::model::{BTreeMapTransaction, MetadataModel, TableFragments};
 use crate::storage::Transaction;
 use crate::{MetaError, MetaResult};
 
@@ -83,6 +83,7 @@ macro_rules! commit_meta_with_trx {
         {
             use tracing::Instrument;
             use $crate::storage::meta_store::MetaStore;
+            use $crate::model::{InMemValTransaction, ValTransaction};
             async {
                 // Apply the change in `ValTransaction` to trx
                 $(

--- a/src/meta/src/manager/catalog/user.rs
+++ b/src/meta/src/manager/catalog/user.rs
@@ -155,7 +155,7 @@ mod tests {
 
     use super::*;
     use crate::manager::{commit_meta, CatalogManager};
-    use crate::model::{BTreeMapTransaction, ValTransaction};
+    use crate::model::BTreeMapTransaction;
     use crate::storage::Transaction;
 
     fn make_test_user(id: u32, name: &str) -> UserInfo {

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -38,7 +38,7 @@ use tokio::sync::{RwLock, RwLockReadGuard};
 use tokio::task::JoinHandle;
 
 use crate::manager::{IdCategory, LocalNotification, MetaSrvEnv};
-use crate::model::{MetadataModel, ValTransaction, VarTransaction, Worker, INVALID_EXPIRE_AT};
+use crate::model::{MetadataModel, ValTransaction, VarTransaction, Worker, INVALID_EXPIRE_AT, InMemValTransaction};
 use crate::storage::{MetaStore, Transaction};
 use crate::{MetaError, MetaResult};
 

--- a/src/meta/src/manager/session_params.rs
+++ b/src/meta/src/manager/session_params.rs
@@ -22,7 +22,7 @@ use thiserror_ext::AsReport;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use crate::model::{ValTransaction, VarTransaction};
+use crate::model::{InMemValTransaction, ValTransaction, VarTransaction};
 use crate::storage::{MetaStore, MetaStoreRef, Snapshot, Transaction};
 use crate::MetaResult;
 

--- a/src/meta/src/manager/system_param/mod.rs
+++ b/src/meta/src/manager/system_param/mod.rs
@@ -32,7 +32,7 @@ use tracing::info;
 
 use self::model::SystemParamsModel;
 use super::NotificationManagerRef;
-use crate::model::{ValTransaction, VarTransaction};
+use crate::model::{InMemValTransaction, ValTransaction, VarTransaction};
 use crate::storage::{MetaStore, MetaStoreRef, Transaction};
 use crate::{MetaError, MetaResult};
 

--- a/src/meta/src/model/mod.rs
+++ b/src/meta/src/model/mod.rs
@@ -23,7 +23,6 @@ mod user;
 use std::collections::btree_map::{Entry, VacantEntry};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
 use async_trait::async_trait;
@@ -34,7 +33,6 @@ pub use notification::*;
 use prost::Message;
 pub use stream::*;
 
-use crate::hummock::model::ext::Transaction as TransactionV2;
 use crate::storage::{MetaStore, MetaStoreError, Snapshot, Transaction};
 
 /// A global, unique identifier of an actor
@@ -222,20 +220,16 @@ where
     }
 }
 
-/// Trait that wraps a local memory value and applies the change to the local memory value on
-/// `commit` or leaves the local memory value untouched on `abort`.
-pub trait ValTransaction: Sized {
-    type TXN;
+pub trait InMemValTransaction: Sized {
     /// Commit the change to local memory value
     fn commit(self);
+}
 
+/// Trait that wraps a local memory value and applies the change to the local memory value on
+/// `commit` or leaves the local memory value untouched on `abort`.
+pub trait ValTransaction<TXN>: InMemValTransaction {
     /// Apply the change (upsert or delete) to `txn`
-    async fn apply_to_txn(&self, txn: &mut Self::TXN) -> MetadataModelResult<()>;
-
-    /// Abort the `VarTransaction` and leave the local memory value untouched
-    fn abort(self) {
-        drop(self);
-    }
+    async fn apply_to_txn(&self, txn: &mut TXN) -> MetadataModelResult<()>;
 }
 
 /// Transaction wrapper for a variable.
@@ -244,28 +238,23 @@ pub trait ValTransaction: Sized {
 /// When `commit` is called, the change to `new_value` will be applied to the `orig_value_ref`
 /// When `abort` is called, the `VarTransaction` is dropped and the local memory value is
 /// untouched.
-pub struct VarTransaction<'a, TXN, T: Transactional<TXN>> {
+pub struct VarTransaction<'a, T> {
     orig_value_ref: &'a mut T,
     new_value: Option<T>,
-    _phantom: PhantomData<TXN>,
 }
 
-impl<'a, TXN, T> VarTransaction<'a, TXN, T>
-where
-    T: Transactional<TXN>,
-{
+impl<'a, T> VarTransaction<'a, T> {
     /// Create a `VarTransaction` that wraps a raw variable
-    pub fn new(val_ref: &'a mut T) -> VarTransaction<'a, TXN, T> {
+    pub fn new(val_ref: &'a mut T) -> VarTransaction<'a, T> {
         VarTransaction {
             // lazy initialization
             new_value: None,
             orig_value_ref: val_ref,
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<'a, TXN, T: Transactional<TXN>> Deref for VarTransaction<'a, TXN, T> {
+impl<'a, T> Deref for VarTransaction<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -276,10 +265,7 @@ impl<'a, TXN, T: Transactional<TXN>> Deref for VarTransaction<'a, TXN, T> {
     }
 }
 
-impl<'a, TXN, T> DerefMut for VarTransaction<'a, TXN, T>
-where
-    T: Clone + Transactional<TXN>,
-{
+impl<'a, T: Clone> DerefMut for VarTransaction<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         if self.new_value.is_none() {
             self.new_value.replace(self.orig_value_ref.clone());
@@ -288,19 +274,22 @@ where
     }
 }
 
-impl<'a, TXN, T> ValTransaction for VarTransaction<'a, TXN, T>
+impl<'a, T> InMemValTransaction for VarTransaction<'a, T>
 where
-    T: Transactional<TXN> + PartialEq,
+    T: PartialEq,
 {
-    type TXN = TXN;
-
     fn commit(self) {
         if let Some(new_value) = self.new_value {
             *self.orig_value_ref = new_value;
         }
     }
+}
 
-    async fn apply_to_txn(&self, txn: &mut Self::TXN) -> MetadataModelResult<()> {
+impl<'a, TXN, T> ValTransaction<TXN> for VarTransaction<'a, T>
+where
+    T: Transactional<TXN> + PartialEq,
+{
+    async fn apply_to_txn(&self, txn: &mut TXN) -> MetadataModelResult<()> {
         if let Some(new_value) = &self.new_value {
             // Apply the change to `txn` only when the value is modified
             if *self.orig_value_ref != *new_value {
@@ -423,27 +412,25 @@ enum BTreeMapOp<V> {
 /// are stored in `staging`. On `commit`, it will apply the changes stored in `staging` to the in
 /// memory btree map. When serve `get` and `get_mut`, it merges the value stored in `staging` and
 /// `tree_ref`.
-pub struct BTreeMapTransaction<'a, K: Ord, V, TXN = Transaction> {
+pub struct BTreeMapTransaction<'a, K: Ord, V> {
     /// A reference to the original `BTreeMap`. All access to this field should be immutable,
     /// except when we commit the staging changes to the original map.
     tree_ref: &'a mut BTreeMap<K, V>,
     /// Store all the staging changes that will be applied to the original map on commit
     staging: BTreeMap<K, BTreeMapOp<V>>,
-    _phantom: PhantomData<TXN>,
 }
 
-impl<'a, K: Ord + Debug, V: Clone, TXN> BTreeMapTransaction<'a, K, V, TXN> {
-    pub fn new(tree_ref: &'a mut BTreeMap<K, V>) -> BTreeMapTransaction<'a, K, V, TXN> {
+impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransaction<'a, K, V> {
+    pub fn new(tree_ref: &'a mut BTreeMap<K, V>) -> BTreeMapTransaction<'a, K, V> {
         Self {
             tree_ref,
             staging: BTreeMap::default(),
-            _phantom: PhantomData,
         }
     }
 
     /// Start a `BTreeMapEntryTransaction` when the `key` exists
     #[allow(dead_code)]
-    pub fn new_entry_txn(&mut self, key: K) -> Option<BTreeMapEntryTransaction<'_, K, V, TXN>> {
+    pub fn new_entry_txn(&mut self, key: K) -> Option<BTreeMapEntryTransaction<'_, K, V>> {
         BTreeMapEntryTransaction::new(self.tree_ref, key, None)
     }
 
@@ -454,17 +441,13 @@ impl<'a, K: Ord + Debug, V: Clone, TXN> BTreeMapTransaction<'a, K, V, TXN> {
         &mut self,
         key: K,
         default_val: V,
-    ) -> BTreeMapEntryTransaction<'_, K, V, TXN> {
+    ) -> BTreeMapEntryTransaction<'_, K, V> {
         BTreeMapEntryTransaction::new(self.tree_ref, key, Some(default_val))
             .expect("default value is provided and should return `Some`")
     }
 
     /// Start a `BTreeMapEntryTransaction` that inserts the `val` into `key`.
-    pub fn new_entry_insert_txn(
-        &mut self,
-        key: K,
-        val: V,
-    ) -> BTreeMapEntryTransaction<'_, K, V, TXN> {
+    pub fn new_entry_insert_txn(&mut self, key: K, val: V) -> BTreeMapEntryTransaction<'_, K, V> {
         BTreeMapEntryTransaction::new_insert(self.tree_ref, key, val)
     }
 
@@ -564,16 +547,16 @@ impl<'a, K: Ord + Debug, V: Clone, TXN> BTreeMapTransaction<'a, K, V, TXN> {
     }
 }
 
-impl<'a, K: Ord + Debug, V: Transactional<TXN> + Clone, TXN> ValTransaction
-    for BTreeMapTransaction<'a, K, V, TXN>
-{
-    type TXN = TXN;
-
+impl<'a, K: Ord + Debug, V: Clone> InMemValTransaction for BTreeMapTransaction<'a, K, V> {
     fn commit(self) {
         self.commit_memory();
     }
+}
 
-    async fn apply_to_txn(&self, txn: &mut Self::TXN) -> MetadataModelResult<()> {
+impl<'a, K: Ord + Debug, V: Transactional<TXN> + Clone, TXN> ValTransaction<TXN>
+    for BTreeMapTransaction<'a, K, V>
+{
+    async fn apply_to_txn(&self, txn: &mut TXN) -> MetadataModelResult<()> {
         // Add the staging operation to txn
         for (k, op) in &self.staging {
             match op {
@@ -590,26 +573,24 @@ impl<'a, K: Ord + Debug, V: Transactional<TXN> + Clone, TXN> ValTransaction
 }
 
 /// Transaction wrapper for a `BTreeMap` entry value of given `key`
-pub struct BTreeMapEntryTransaction<'a, K, V, TXN> {
+pub struct BTreeMapEntryTransaction<'a, K, V> {
     tree_ref: &'a mut BTreeMap<K, V>,
     pub key: K,
     pub new_value: V,
-    _phantom: PhantomData<TXN>,
 }
 
-impl<'a, K: Ord + Debug, V: Clone, TXN> BTreeMapEntryTransaction<'a, K, V, TXN> {
+impl<'a, K: Ord + Debug, V: Clone> BTreeMapEntryTransaction<'a, K, V> {
     /// Create a `ValTransaction` that wraps a `BTreeMap` entry of the given `key`.
     /// If the tree does not contain `key`, the `default_val` will be used as the initial value
     pub fn new_insert(
         tree_ref: &'a mut BTreeMap<K, V>,
         key: K,
         value: V,
-    ) -> BTreeMapEntryTransaction<'a, K, V, TXN> {
+    ) -> BTreeMapEntryTransaction<'a, K, V> {
         BTreeMapEntryTransaction {
             new_value: value,
             tree_ref,
             key,
-            _phantom: PhantomData,
         }
     }
 
@@ -623,7 +604,7 @@ impl<'a, K: Ord + Debug, V: Clone, TXN> BTreeMapEntryTransaction<'a, K, V, TXN> 
         tree_ref: &'a mut BTreeMap<K, V>,
         key: K,
         default_val: Option<V>,
-    ) -> Option<BTreeMapEntryTransaction<'a, K, V, TXN>> {
+    ) -> Option<BTreeMapEntryTransaction<'a, K, V>> {
         tree_ref
             .get(&key)
             .cloned()
@@ -632,12 +613,11 @@ impl<'a, K: Ord + Debug, V: Clone, TXN> BTreeMapEntryTransaction<'a, K, V, TXN> 
                 new_value: orig_value,
                 tree_ref,
                 key,
-                _phantom: PhantomData,
             })
     }
 }
 
-impl<'a, K, V, TXN> Deref for BTreeMapEntryTransaction<'a, K, V, TXN> {
+impl<'a, K, V> Deref for BTreeMapEntryTransaction<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
@@ -645,22 +625,22 @@ impl<'a, K, V, TXN> Deref for BTreeMapEntryTransaction<'a, K, V, TXN> {
     }
 }
 
-impl<'a, K, V, TXN> DerefMut for BTreeMapEntryTransaction<'a, K, V, TXN> {
+impl<'a, K, V> DerefMut for BTreeMapEntryTransaction<'a, K, V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.new_value
     }
 }
 
-impl<'a, K: Ord, V: PartialEq + Transactional<TXN>, TXN> ValTransaction
-    for BTreeMapEntryTransaction<'a, K, V, TXN>
-{
-    type TXN = TXN;
-
+impl<'a, K: Ord, V: PartialEq> InMemValTransaction for BTreeMapEntryTransaction<'a, K, V> {
     fn commit(self) {
         self.tree_ref.insert(self.key, self.new_value);
     }
+}
 
-    async fn apply_to_txn(&self, txn: &mut Self::TXN) -> MetadataModelResult<()> {
+impl<'a, K: Ord, V: PartialEq + Transactional<TXN>, TXN> ValTransaction<TXN>
+    for BTreeMapEntryTransaction<'a, K, V>
+{
+    async fn apply_to_txn(&self, txn: &mut TXN) -> MetadataModelResult<()> {
         if !self.tree_ref.contains_key(&self.key)
             || *self.tree_ref.get(&self.key).unwrap() != self.new_value
         {
@@ -670,263 +650,153 @@ impl<'a, K: Ord, V: PartialEq + Transactional<TXN>, TXN> ValTransaction
     }
 }
 
-pub enum BTreeMapTransactionWrapper<'a, K: Ord, V> {
-    V1(BTreeMapTransaction<'a, K, V, Transaction>),
-    V2(BTreeMapTransaction<'a, K, V, TransactionV2>),
-}
-
-impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransactionWrapper<'a, K, V> {
-    pub fn tree_ref(&self) -> &BTreeMap<K, V> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.tree_ref,
-            BTreeMapTransactionWrapper::V2(v) => v.tree_ref,
-        }
-    }
-
-    pub fn tree_mut(&mut self) -> &mut BTreeMap<K, V> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.tree_ref,
-            BTreeMapTransactionWrapper::V2(v) => v.tree_ref,
-        }
-    }
-
-    /// Get the value of the provided key by merging the staging value and the original value
-    pub fn get(&self, key: &K) -> Option<&V> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.get(key),
-            BTreeMapTransactionWrapper::V2(v) => v.get(key),
-        }
-    }
-
-    pub fn contains_key(&self, key: &K) -> bool {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.contains_key(key),
-            BTreeMapTransactionWrapper::V2(v) => v.contains_key(key),
-        }
-    }
-
-    pub fn get_mut(&mut self, key: K) -> Option<BTreeMapTransactionValueGuard<'_, K, V>> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.get_mut(key),
-            BTreeMapTransactionWrapper::V2(v) => v.get_mut(key),
-        }
-    }
-
-    pub fn insert(&mut self, key: K, value: V) {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.insert(key, value),
-            BTreeMapTransactionWrapper::V2(v) => v.insert(key, value),
-        }
-    }
-
-    pub fn remove(&mut self, key: K) -> Option<V> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.remove(key),
-            BTreeMapTransactionWrapper::V2(v) => v.remove(key),
-        }
-    }
-
-    pub fn commit_memory(self) {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v.commit_memory(),
-            BTreeMapTransactionWrapper::V2(v) => v.commit_memory(),
-        }
-    }
-
-    pub fn new_entry_txn_or_default(
-        &mut self,
-        key: K,
-        default_val: V,
-    ) -> BTreeMapEntryTransactionWrapper<'_, K, V> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => BTreeMapEntryTransactionWrapper::V1(
-                BTreeMapEntryTransaction::new(v.tree_ref, key, Some(default_val))
-                    .expect("default value is provided and should return `Some`"),
-            ),
-            BTreeMapTransactionWrapper::V2(v) => BTreeMapEntryTransactionWrapper::V2(
-                BTreeMapEntryTransaction::new(v.tree_ref, key, Some(default_val))
-                    .expect("default value is provided and should return `Some`"),
-            ),
-        }
-    }
-
-    pub fn new_entry_insert_txn(
-        &mut self,
-        key: K,
-        val: V,
-    ) -> BTreeMapEntryTransactionWrapper<'_, K, V> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => BTreeMapEntryTransactionWrapper::V1(
-                BTreeMapEntryTransaction::new_insert(v.tree_ref, key, val),
-            ),
-            BTreeMapTransactionWrapper::V2(v) => BTreeMapEntryTransactionWrapper::V2(
-                BTreeMapEntryTransaction::new_insert(v.tree_ref, key, val),
-            ),
-        }
-    }
-}
-
-impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransactionWrapper<'a, K, V> {
-    pub fn into_v1(self) -> BTreeMapTransaction<'a, K, V, Transaction> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v,
-            BTreeMapTransactionWrapper::V2(_) => panic!("expect V1, found V2"),
-        }
-    }
-
-    pub fn as_v1_ref(&self) -> &BTreeMapTransaction<'a, K, V, Transaction> {
-        match self {
-            BTreeMapTransactionWrapper::V1(v) => v,
-            BTreeMapTransactionWrapper::V2(_) => panic!("expect V1, found V2"),
-        }
-    }
-
-    pub fn into_v2(self) -> BTreeMapTransaction<'a, K, V, TransactionV2> {
-        match self {
-            BTreeMapTransactionWrapper::V1(_) => panic!("expect V2, found V1"),
-            BTreeMapTransactionWrapper::V2(v) => v,
-        }
-    }
-
-    pub fn as_v2_ref(&self) -> &BTreeMapTransaction<'a, K, V, TransactionV2> {
-        match self {
-            BTreeMapTransactionWrapper::V1(_) => panic!("expect V2, found V1"),
-            BTreeMapTransactionWrapper::V2(v) => v,
-        }
-    }
-}
-
-pub enum BTreeMapEntryTransactionWrapper<'a, K, V> {
-    V1(BTreeMapEntryTransaction<'a, K, V, Transaction>),
-    V2(BTreeMapEntryTransaction<'a, K, V, TransactionV2>),
-}
-
-impl<'a, K: Ord + Debug, V: Clone> Deref for BTreeMapEntryTransactionWrapper<'a, K, V> {
-    type Target = V;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            BTreeMapEntryTransactionWrapper::V1(v) => v.deref(),
-            BTreeMapEntryTransactionWrapper::V2(v) => v.deref(),
-        }
-    }
-}
-
-impl<'a, K: Ord + Debug, V: Clone> DerefMut for BTreeMapEntryTransactionWrapper<'a, K, V> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            BTreeMapEntryTransactionWrapper::V1(v) => v.deref_mut(),
-            BTreeMapEntryTransactionWrapper::V2(v) => v.deref_mut(),
-        }
-    }
-}
-
-impl<'a, K: Ord + Debug, V: Clone> BTreeMapEntryTransactionWrapper<'a, K, V> {
-    pub fn as_v1_ref(&self) -> &BTreeMapEntryTransaction<'a, K, V, Transaction> {
-        match self {
-            BTreeMapEntryTransactionWrapper::V1(v) => v,
-            BTreeMapEntryTransactionWrapper::V2(_) => {
-                panic!("expect V1, found V2")
-            }
-        }
-    }
-
-    pub fn into_v1(self) -> BTreeMapEntryTransaction<'a, K, V, Transaction> {
-        match self {
-            BTreeMapEntryTransactionWrapper::V1(v) => v,
-            BTreeMapEntryTransactionWrapper::V2(_) => {
-                panic!("expect V1, found V2")
-            }
-        }
-    }
-
-    pub fn as_v2_ref(&self) -> &BTreeMapEntryTransaction<'a, K, V, TransactionV2> {
-        match self {
-            BTreeMapEntryTransactionWrapper::V1(_) => {
-                panic!("expect V2, found V1")
-            }
-            BTreeMapEntryTransactionWrapper::V2(v) => v,
-        }
-    }
-
-    pub fn into_v2(self) -> BTreeMapEntryTransaction<'a, K, V, TransactionV2> {
-        match self {
-            BTreeMapEntryTransactionWrapper::V1(_) => {
-                panic!("expect V2, found V1")
-            }
-            BTreeMapEntryTransactionWrapper::V2(v) => v,
-        }
-    }
-}
-
-pub enum VarTransactionWrapper<'a, T: Transactional<Transaction> + Transactional<TransactionV2>> {
-    V1(VarTransaction<'a, Transaction, T>),
-    V2(VarTransaction<'a, TransactionV2, T>),
-}
-
-impl<'a, T: Transactional<Transaction> + Transactional<TransactionV2>>
-    VarTransactionWrapper<'a, T>
-{
-    pub fn as_v1_ref(&self) -> &VarTransaction<'a, Transaction, T> {
-        match self {
-            VarTransactionWrapper::V1(v) => v,
-            VarTransactionWrapper::V2(_) => {
-                panic!("expect V1, found V2")
-            }
-        }
-    }
-
-    pub fn into_v1(self) -> VarTransaction<'a, Transaction, T> {
-        match self {
-            VarTransactionWrapper::V1(v) => v,
-            VarTransactionWrapper::V2(_) => {
-                panic!("expect V1, found V2")
-            }
-        }
-    }
-
-    pub fn as_v2_ref(&self) -> &VarTransaction<'a, TransactionV2, T> {
-        match self {
-            VarTransactionWrapper::V1(_) => {
-                panic!("expect V2, found V1")
-            }
-            VarTransactionWrapper::V2(v) => v,
-        }
-    }
-
-    pub fn into_v2(self) -> VarTransaction<'a, TransactionV2, T> {
-        match self {
-            VarTransactionWrapper::V1(_) => {
-                panic!("expect V2, found V1")
-            }
-            VarTransactionWrapper::V2(v) => v,
-        }
-    }
-}
-
-impl<'a, T: Transactional<Transaction> + Transactional<TransactionV2>> Deref
-    for VarTransactionWrapper<'a, T>
-{
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            VarTransactionWrapper::V1(v) => v.deref(),
-            VarTransactionWrapper::V2(v) => v.deref(),
-        }
-    }
-}
-
-impl<'a, T: Transactional<Transaction> + Transactional<TransactionV2> + Clone> DerefMut
-    for VarTransactionWrapper<'a, T>
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            VarTransactionWrapper::V1(v) => v.deref_mut(),
-            VarTransactionWrapper::V2(v) => v.deref_mut(),
-        }
-    }
-}
+// pub enum ValTransactionEnum<V1, V2> {
+//     V1(V1),
+//     V2(V2),
+// }
+//
+// impl<V1, V2> ValTransactionEnum<V1, V2> {
+//     pub fn into_v1(self) -> V1 {
+//         match self {
+//             ValTransactionEnum::V1(v) => v,
+//             ValTransactionEnum::V2(_) => panic!("expect V1, found V2"),
+//         }
+//     }
+//
+//     pub fn as_v1_ref(&self) -> &V1 {
+//         match self {
+//             ValTransactionEnum::V1(v) => v,
+//             ValTransactionEnum::V2(_) => panic!("expect V1, found V2"),
+//         }
+//     }
+//
+//     pub fn into_v2(self) -> V2 {
+//         match self {
+//             ValTransactionEnum::V1(_) => panic!("expect V2, found V1"),
+//             ValTransactionEnum::V2(v) => v,
+//         }
+//     }
+//
+//     pub fn as_v2_ref(&self) -> &V2 {
+//         match self {
+//             ValTransactionEnum::V1(_) => panic!("expect V2, found V1"),
+//             ValTransactionEnum::V2(v) => v,
+//         }
+//     }
+// }
+//
+// impl<V1: Deref, V2> Deref for ValTransactionEnum<V1, V2>
+// where
+//     V2: Deref<Target = V1::Target>,
+// {
+//     type Target = V1::Target;
+//
+//     fn deref(&self) -> &Self::Target {
+//         match self {
+//             ValTransactionEnum::V1(v) => v.deref(),
+//             ValTransactionEnum::V2(v) => v.deref(),
+//         }
+//     }
+// }
+//
+// impl<V1: DerefMut, V2> DerefMut for ValTransactionEnum<V1, V2>
+// where
+//     V2: DerefMut<Target = V1::Target>,
+// {
+//     fn deref_mut(&mut self) -> &mut Self::Target {
+//         match self {
+//             ValTransactionEnum::V1(v) => v.deref_mut(),
+//             ValTransactionEnum::V2(v) => v.deref_mut(),
+//         }
+//     }
+// }
+//
+// pub type BTreeMapTransactionWrapper<'a, K, V> = ValTransactionEnum<
+//     BTreeMapTransaction<'a, K, V, Transaction>,
+//     BTreeMapTransaction<'a, K, V, TransactionV2>,
+// >;
+//
+// impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransactionWrapper<'a, K, V> {
+//     pub fn tree_ref(&self) -> &BTreeMap<K, V> {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => v.tree_ref,
+//             BTreeMapTransactionWrapper::V2(v) => v.tree_ref,
+//         }
+//     }
+//
+//     /// Get the value of the provided key by merging the staging value and the original value
+//     pub fn get(&self, key: &K) -> Option<&V> {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => v.get(key),
+//             BTreeMapTransactionWrapper::V2(v) => v.get(key),
+//         }
+//     }
+//
+//     pub fn contains_key(&self, key: &K) -> bool {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => v.contains_key(key),
+//             BTreeMapTransactionWrapper::V2(v) => v.contains_key(key),
+//         }
+//     }
+//
+//     pub fn get_mut(&mut self, key: K) -> Option<BTreeMapTransactionValueGuard<'_, K, V>> {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => v.get_mut(key),
+//             BTreeMapTransactionWrapper::V2(v) => v.get_mut(key),
+//         }
+//     }
+//
+//     pub fn insert(&mut self, key: K, value: V) {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => v.insert(key, value),
+//             BTreeMapTransactionWrapper::V2(v) => v.insert(key, value),
+//         }
+//     }
+//
+//     pub fn remove(&mut self, key: K) -> Option<V> {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => v.remove(key),
+//             BTreeMapTransactionWrapper::V2(v) => v.remove(key),
+//         }
+//     }
+//
+//     pub fn new_entry_txn_or_default(
+//         &mut self,
+//         key: K,
+//         default_val: V,
+//     ) -> BTreeMapEntryTransactionWrapper<'_, K, V> {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => BTreeMapEntryTransactionWrapper::V1(
+//                 BTreeMapEntryTransaction::new(v.tree_ref, key, Some(default_val))
+//                     .expect("default value is provided and should return `Some`"),
+//             ),
+//             BTreeMapTransactionWrapper::V2(v) => BTreeMapEntryTransactionWrapper::V2(
+//                 BTreeMapEntryTransaction::new(v.tree_ref, key, Some(default_val))
+//                     .expect("default value is provided and should return `Some`"),
+//             ),
+//         }
+//     }
+//
+//     pub fn new_entry_insert_txn(
+//         &mut self,
+//         key: K,
+//         val: V,
+//     ) -> BTreeMapEntryTransactionWrapper<'_, K, V> {
+//         match self {
+//             BTreeMapTransactionWrapper::V1(v) => BTreeMapEntryTransactionWrapper::V1(
+//                 BTreeMapEntryTransaction::new_insert(v.tree_ref, key, val),
+//             ),
+//             BTreeMapTransactionWrapper::V2(v) => BTreeMapEntryTransactionWrapper::V2(
+//                 BTreeMapEntryTransaction::new_insert(v.tree_ref, key, val),
+//             ),
+//         }
+//     }
+// }
+//
+// pub type BTreeMapEntryTransactionWrapper<'a, K, V> = ValTransactionEnum<
+//     BTreeMapEntryTransaction<'a, K, V, Transaction>,
+//     BTreeMapEntryTransaction<'a, K, V, TransactionV2>,
+// >;
 
 #[cfg(test)]
 mod tests {
@@ -984,18 +854,6 @@ mod tests {
         );
         num_txn.commit();
         assert_eq!("modified", kv.value);
-    }
-
-    #[test]
-    fn test_simple_var_transaction_abort() {
-        let mut kv = TestTransactional {
-            key: "key",
-            value: "original",
-        };
-        let mut num_txn = VarTransaction::new(&mut kv);
-        num_txn.value = "modified";
-        num_txn.abort();
-        assert_eq!("original", kv.value);
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Currently, for the val transaction in hummock manager, we need to create a enum wrapper for meta store v1 and v2 respectively. The reason for this is because the created val transaction is associated to a specific meta store version (either v1 or v2). However, the association between the val transaction and meta store version is based on a `_phantom`, which means the association is not necessary, and we can decouple val transaction with meta store version easily.

In this PR, we will decouple the created val transaction with the meta store version, and after this, we don't need an enum wrapper for val transaction any more, and the `create_trx_wrapper` macro is removed.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
