### PR TITLE
fix(risedev): use correct arch when downloading Grafana

### DIFF
--- a/src/risedevtool/common.toml
+++ b/src/risedevtool/common.toml
@@ -5,7 +5,6 @@ OS = { source = "${CARGO_MAKE_RUST_TARGET_OS}", mapping = { linux = "linux", mac
 ARCH = { source = "${CARGO_MAKE_RUST_TARGET_ARCH}", mapping = { x86_64 = "amd64", aarch64 = "arm64" } }
 SYSTEM = "${OS}-${ARCH}"
 SYSTEM_UNDERSCORE = "${OS}_${ARCH}"
-SYSTEM_AMD64 = "${OS}-amd64" # some components do not support darwin-arm64 for now, use amd64 for fallback
 PREFIX = "${PWD}/.risingwave"
 JAVA_DIR = "${PWD}/java"
 PREFIX_USR_BIN = "${PWD}/.bin"

--- a/src/risedevtool/grafana.toml
+++ b/src/risedevtool/grafana.toml
@@ -1,9 +1,9 @@
 extend = "common.toml"
 
 [env]
-GRAFANA_SYSTEM = "${SYSTEM_AMD64}"
+GRAFANA_SYSTEM = "${SYSTEM}"
 GRAFANA_DOWNLOAD_PATH = "${PREFIX_TMP}/grafana.tar.gz"
-GRAFANA_VERSION = "10.0.0"
+GRAFANA_VERSION = "10.4.3"
 GRAFANA_RELEASE = "grafana-${GRAFANA_VERSION}"
 GRAFANA_DOWNLOAD_TAR_GZ = "https://dl.grafana.com/oss/release/${GRAFANA_RELEASE}.${GRAFANA_SYSTEM}.tar.gz"
 
@@ -25,7 +25,7 @@ echo "Grafana not found, download ${GRAFANA_RELEASE}"
 curl -fL -o "${GRAFANA_DOWNLOAD_PATH}" "${GRAFANA_DOWNLOAD_TAR_GZ}"
 tar -xf "${GRAFANA_DOWNLOAD_PATH}" -C "${PREFIX_TMP}"
 rm -rf "${PREFIX_BIN}/grafana"
-mv "${PREFIX_TMP}/${GRAFANA_RELEASE}" "${PREFIX_BIN}/grafana"
+mv "${PREFIX_TMP}/grafana-v${GRAFANA_VERSION}" "${PREFIX_BIN}/grafana"
 rm "${GRAFANA_DOWNLOAD_PATH}"
 touch "${PREFIX_BIN}/grafana/RISEDEV-VERSION-${GRAFANA_VERSION}"
 '''


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Grafana now releases binary for `darwin-arm64`. Let's directly use it instead of relying on Rosetta 2 to run `amd64` binary.

This also fixes the problem that the previous implementation will download `linux-amd64` for `linux-arm64`. 🤡

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
