### PR TITLE
fix: make watermark filter after rowIdGen

### DIFF
--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -797,11 +797,6 @@ impl PlanRoot {
         )
         .into();
 
-        // Add WatermarkFilter node.
-        if !watermark_descs.is_empty() {
-            stream_plan = StreamWatermarkFilter::new(stream_plan, watermark_descs).into();
-        }
-
         // Add RowIDGen node if needed.
         if let Some(row_id_index) = row_id_index {
             match kind {
@@ -817,6 +812,11 @@ impl PlanRoot {
                     .into();
                 }
             }
+        }
+
+        // Add WatermarkFilter node.
+        if !watermark_descs.is_empty() {
+            stream_plan = StreamWatermarkFilter::new(stream_plan, watermark_descs).into();
         }
 
         let conflict_behavior = match on_conflict {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title, because the watermarkfilter's state table might rely on the vnode of the row_id_gen
```
dev=> explain CREATE TABLE t (
    index int ,                                                                                                             time timestamptz,
    WATERMARK FOR time AS time - INTERVAL '5' SECOND
) APPEND ONLY;
                                                                          QUERY PLAN

------------------------------------------------------------------------------------------------------------------------
--------------------------------------
 StreamMaterialize { columns: [index, time, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict:
 NoCheck, watermark_columns: [time] }
 └─StreamWatermarkFilter { watermark_descs: [Desc { column: time, expr: (time - '00:00:05':Interval) }], output_watermar
ks: [time] }
   └─StreamRowIdGen { row_id_index: 2 }
     └─StreamUnion { all: true }
       └─StreamExchange [no_shuffle] { dist: SomeShard }
         └─StreamDml { columns: [index, time, _row_id] }
           └─StreamSource
(7 rows)
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
