### PR TITLE
chore(catalog): avoid rw_catalog in pg_tables

### DIFF
--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tables.rs
@@ -34,7 +34,8 @@ use risingwave_frontend_macro::system_catalog;
                 schema_id,
                 owner
                 FROM rw_catalog.rw_system_tables) AS t
-        JOIN rw_catalog.rw_schemas s ON t.schema_id = s.id"
+        JOIN rw_catalog.rw_schemas s ON t.schema_id = s.id
+        AND s.name <> 'rw_catalog'"
 )]
 #[derive(Fields)]
 struct PgTable {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Avoid the `rw_catalog.rw_*` tables in the `pg_catalog.pg_tables`. 

The reason for this is that metabase will list all the normal tables by filtering out `pg_catalog.pg_*` and `information schema.*` from the result of `pg_catalog.pg_tables` and check the privileges of these tables using `has_table_privileges`. `has_table_privilege` requires the table's `oid` to check privileges. Some of `rw_catalog.rw_` have no `oid`, as a result, metabase will stuck at `syncing tables` stage due to the failure of `has_table_privilege` check. So to avoid this, I removed all the `rw_catalog.rw_*` tables from `pg_catalog.pg_tables`'s result. 

It makes sense because when a user use `pg_catalog.pg_tables`, he wants to see the result just like postgres. Hiding tables under `rw_catalog` makes the experience aligned. Or if you have any better idea, please feel free to comment.

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
