### PR TITLE
fix: Mixing arrangement backfill and no shuffle backfill can lead to scale failure.

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -2595,9 +2595,7 @@ impl ScaleController {
         // We trace the upstreams of each downstream under the hierarchy until we reach the top
         // for every no_shuffle relation.
         while let Some(fragment_id) = queue.pop_front() {
-            if !no_shuffle_target_fragment_ids.contains(&fragment_id)
-                && !no_shuffle_source_fragment_ids.contains(&fragment_id)
-            {
+            if !no_shuffle_target_fragment_ids.contains(&fragment_id) {
                 continue;
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<img width="414" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/1997790/7ab316e3-af87-49d1-ab59-f9c5590de61b">

Fragment 6144 has multiple downstream materialized views and it mixes no shuffle backfill with arrangement backfill. This causes the fragment to have multiple types of dispatchers (hash and no_shuffle). During the recovery phase, while propagating upstream no shuffle, we only check if the upstream is a no shuffle source. This inaccurately copies the downstream hash dispatcher's target scale plan to this fragment. This PR fixes the issue.

AKA

> A no_shuffle downstream of a no_shuffle upstream should be connected through a no_shuffle link.

<img width="401" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/1997790/4f84f8f8-cf6f-4cc0-abb3-8d78786a0ad4">



## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
