### PR TITLE
perf(connector): support zero-copy `access` during parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,9 +266,6 @@ redundant_explicit_links = "allow"
 [profile.dev]
 lto = 'off'
 
-[profile.bench]
-lto = 'off'
-
 [profile.release]
 debug = "full"
 split-debuginfo = "packed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,9 @@ redundant_explicit_links = "allow"
 [profile.dev]
 lto = 'off'
 
+[profile.bench]
+lto = 'off'
+
 [profile.release]
 debug = "full"
 split-debuginfo = "packed"

--- a/src/common/src/types/cow.rs
+++ b/src/common/src/types/cow.rs
@@ -17,7 +17,7 @@ use super::{Datum, DatumRef, ToDatumRef, ToOwnedDatum};
 /// 🐮 A borrowed [`DatumRef`] or an owned [`Datum`].
 #[derive(Debug, Clone)]
 pub enum DatumCow<'a> {
-    Ref(DatumRef<'a>),
+    Borrowed(DatumRef<'a>),
     Owned(Datum),
 }
 
@@ -36,14 +36,14 @@ impl From<Datum> for DatumCow<'_> {
 
 impl<'a> From<DatumRef<'a>> for DatumCow<'a> {
     fn from(datum: DatumRef<'a>) -> Self {
-        DatumCow::Ref(datum)
+        DatumCow::Borrowed(datum)
     }
 }
 
 impl ToDatumRef for DatumCow<'_> {
     fn to_datum_ref(&self) -> DatumRef<'_> {
         match self {
-            DatumCow::Ref(datum) => *datum,
+            DatumCow::Borrowed(datum) => *datum,
             DatumCow::Owned(datum) => datum.to_datum_ref(),
         }
     }
@@ -52,7 +52,7 @@ impl ToDatumRef for DatumCow<'_> {
 impl ToOwnedDatum for DatumCow<'_> {
     fn to_owned_datum(self) -> Datum {
         match self {
-            DatumCow::Ref(datum) => datum.to_owned_datum(),
+            DatumCow::Borrowed(datum) => datum.to_owned_datum(),
             DatumCow::Owned(datum) => datum,
         }
     }

--- a/src/common/src/types/cow.rs
+++ b/src/common/src/types/cow.rs
@@ -15,6 +15,9 @@
 use super::{Datum, DatumRef, ToDatumRef, ToOwnedDatum};
 
 /// 🐮 A borrowed [`DatumRef`] or an owned [`Datum`].
+///
+/// We do not use [`std::borrow::Cow`] because it requires the borrowed variant
+/// to be a reference, whereas what we have is a [`DatumRef`] with a lifetime.
 #[derive(Debug, Clone)]
 pub enum DatumCow<'a> {
     Borrowed(DatumRef<'a>),

--- a/src/common/src/types/cow.rs
+++ b/src/common/src/types/cow.rs
@@ -1,0 +1,59 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{Datum, DatumRef, ToDatumRef, ToOwnedDatum};
+
+/// 🐮 A borrowed [`DatumRef`] or an owned [`Datum`].
+#[derive(Debug, Clone)]
+pub enum DatumCow<'a> {
+    Ref(DatumRef<'a>),
+    Owned(Datum),
+}
+
+impl PartialEq for DatumCow<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_datum_ref() == other.to_datum_ref()
+    }
+}
+impl Eq for DatumCow<'_> {}
+
+impl From<Datum> for DatumCow<'_> {
+    fn from(datum: Datum) -> Self {
+        DatumCow::Owned(datum)
+    }
+}
+
+impl<'a> From<DatumRef<'a>> for DatumCow<'a> {
+    fn from(datum: DatumRef<'a>) -> Self {
+        DatumCow::Ref(datum)
+    }
+}
+
+impl ToDatumRef for DatumCow<'_> {
+    fn to_datum_ref(&self) -> DatumRef<'_> {
+        match self {
+            DatumCow::Ref(datum) => *datum,
+            DatumCow::Owned(datum) => datum.to_datum_ref(),
+        }
+    }
+}
+
+impl ToOwnedDatum for DatumCow<'_> {
+    fn to_owned_datum(self) -> Datum {
+        match self {
+            DatumCow::Ref(datum) => datum.to_owned_datum(),
+            DatumCow::Owned(datum) => datum,
+        }
+    }
+}

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -45,6 +45,7 @@ use crate::{
     for_all_scalar_variants, for_all_type_pairs,
 };
 
+mod cow;
 mod datetime;
 mod decimal;
 mod fields;
@@ -72,6 +73,7 @@ mod with_data_type;
 pub use fields::Fields;
 pub use risingwave_fields_derive::Fields;
 
+pub use self::cow::DatumCow;
 pub use self::datetime::{Date, Time, Timestamp};
 pub use self::decimal::{Decimal, PowError as DecimalPowError};
 pub use self::interval::{test_utils, DateTimeField, Interval, IntervalDisplay};

--- a/src/connector/benches/json_vs_plain_parser.rs
+++ b/src/connector/benches/json_vs_plain_parser.rs
@@ -83,7 +83,8 @@ mod old_json_parser {
             let mut errors = Vec::new();
             for value in values {
                 let accessor = JsonAccess::new(value);
-                match writer.do_insert(|column| accessor.access(&[&column.name], &column.data_type))
+                match writer
+                    .do_insert(|column| accessor.access_cow(&[&column.name], &column.data_type))
                 {
                     Ok(_) => {}
                     Err(err) => errors.push(err),

--- a/src/connector/benches/nexmark_integration.rs
+++ b/src/connector/benches/nexmark_integration.rs
@@ -58,7 +58,7 @@ fn make_batch() -> Vec<SourceMessage> {
 
     generator
         .by_ref()
-        .take(1024)
+        .take(16384)
         .map(|(i, e)| {
             let payload = serde_json::to_vec(&e).unwrap();
             SourceMessage {

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -266,6 +266,7 @@ impl<'a> AvroParseOptions<'a> {
     }
 }
 
+// TODO: No need to use two lifetimes here.
 pub struct AvroAccess<'a, 'b> {
     value: &'a Value,
     options: AvroParseOptions<'b>,

--- a/src/connector/codec/src/decoder/mod.rs
+++ b/src/connector/codec/src/decoder/mod.rs
@@ -56,7 +56,6 @@ pub trait Access {
     /// and we use different `path` to access one column at a time.
     ///
     /// e.g., for Avro, we access `["col_name"]`; for Debezium Avro, we access `["before", "col_name"]`.
-    // #[deprecated(note = "Use `access_cow` instead.")]
     fn access(&self, path: &[&str], type_expected: &DataType) -> AccessResult<Datum> {
         self.access_cow(path, type_expected)
             .map(ToOwnedDatum::to_owned_datum)
@@ -66,13 +65,12 @@ pub trait Access {
     /// If not overridden, it will call forward to `access` and always wrap the result in [`DatumCow::Owned`].
     ///
     /// This should be preferred over `access` for both callers and implementors.
-    // TODO: remove `access` and make this the only method.
+    // TODO: implement this method in all parsers and remove `access` method.
     fn access_cow<'a>(
         &'a self,
         path: &[&str],
         type_expected: &DataType,
     ) -> AccessResult<DatumCow<'a>> {
-        // #[expect(deprecated)]
         self.access(path, type_expected).map(Into::into)
     }
 }

--- a/src/connector/codec/src/decoder/mod.rs
+++ b/src/connector/codec/src/decoder/mod.rs
@@ -61,7 +61,7 @@ pub trait Access {
             .map(ToOwnedDatum::to_owned_datum)
     }
 
-    /// Similar to `access`, but may return a borrowed [`DatumCow::Ref`] to avoid unnecessary allocation.
+    /// Similar to `access`, but may return a borrowed [`DatumCow::Borrowed`] to avoid unnecessary allocation.
     /// If not overridden, it will call forward to `access` and always wrap the result in [`DatumCow::Owned`].
     ///
     /// This should be preferred over `access` for both callers and implementors.

--- a/src/connector/src/parser/common.rs
+++ b/src/connector/src/parser/common.rs
@@ -18,10 +18,10 @@ use simd_json::BorrowedValue;
 /// Get a value from a json object by key, case insensitive.
 ///
 /// Returns `None` if the given json value is not an object, or the key is not found.
-pub(crate) fn json_object_get_case_insensitive<'a, 'b>(
-    v: &'b simd_json::BorrowedValue<'a>,
-    key: &'b str,
-) -> Option<&'b BorrowedValue<'a>> {
+pub(crate) fn json_object_get_case_insensitive<'b>(
+    v: &'b simd_json::BorrowedValue<'b>,
+    key: &str,
+) -> Option<&'b BorrowedValue<'b>> {
     let obj = v.as_object()?;
     let value = obj.get(key);
     if value.is_some() {

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -87,7 +87,6 @@ mod util;
 
 pub use debezium::DEBEZIUM_IGNORE_KEY;
 use risingwave_common::buffer::BitmapBuilder;
-pub use unified::json::JsonBorrowAccess;
 pub use unified::{AccessError, AccessResult};
 
 /// A builder for building a [`StreamChunk`] from [`SourceColumnDesc`].

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -429,7 +429,7 @@ impl JsonParseOptions {
                 .map_err(|_| create_error())?
                 .into(),
             // ---- Varchar -----
-            (DataType::Varchar, ValueType::String) => return Ok(DatumCow::Ref(Some(value.as_str().unwrap().into()))),
+            (DataType::Varchar, ValueType::String) => return Ok(DatumCow::Borrowed(Some(value.as_str().unwrap().into()))),
             (
                 DataType::Varchar,
                 ValueType::Bool

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -22,8 +22,8 @@ use risingwave_common::array::{ListValue, StructValue};
 use risingwave_common::cast::{i64_to_timestamp, i64_to_timestamptz, str_to_bytea};
 use risingwave_common::log::LogSuppresser;
 use risingwave_common::types::{
-    DataType, Date, Decimal, Int256, Interval, JsonbVal, ScalarImpl, ScalarRefImpl, Time,
-    Timestamp, Timestamptz,
+    DataType, Date, Datum, Decimal, Int256, Interval, JsonbVal, ScalarImpl, Time, Timestamp,
+    Timestamptz, ToOwnedDatum,
 };
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_connector_codec::decoder::utils::extract_decimal;
@@ -201,20 +201,11 @@ impl JsonParseOptions {
         }
     }
 
-    pub fn parse_borrow<'a>(
+    pub fn parse<'a>(
         &self,
         value: &'a BorrowedValue<'a>,
         type_expected: &DataType,
     ) -> AccessResult<DatumCow<'a>> {
-        Ok(match (type_expected, value.value_type()) {
-            (DataType::Varchar, ValueType::String) => {
-                DatumCow::Ref(Some(ScalarRefImpl::Utf8(value.as_str().unwrap().into())))
-            }
-            _ => self.parse(value, type_expected)?.into(),
-        })
-    }
-
-    pub fn parse(&self, value: &BorrowedValue<'_>, type_expected: &DataType) -> AccessResult {
         let create_error = || AccessError::TypeError {
             expected: format!("{:?}", type_expected),
             got: value.value_type().to_string(),
@@ -222,9 +213,9 @@ impl JsonParseOptions {
         };
 
         let v: ScalarImpl = match (type_expected, value.value_type()) {
-            (_, ValueType::Null) => return Ok(None),
+            (_, ValueType::Null) => return Ok(Datum::None.into()),
             // ---- Boolean -----
-            (DataType::Boolean , ValueType::Bool) => value.as_bool().unwrap().into(),
+            (DataType::Boolean, ValueType::Bool) => value.as_bool().unwrap().into(),
 
             (
                 DataType::Boolean,
@@ -438,7 +429,7 @@ impl JsonParseOptions {
                 .map_err(|_| create_error())?
                 .into(),
             // ---- Varchar -----
-            (DataType::Varchar , ValueType::String) => value.as_str().unwrap().into(),
+            (DataType::Varchar, ValueType::String) => return Ok(DatumCow::Ref(Some(value.as_str().unwrap().into()))),
             (
                 DataType::Varchar,
                 ValueType::Bool
@@ -548,7 +539,7 @@ impl JsonParseOptions {
                                 }
                                 &BorrowedValue::Static(simd_json::StaticNode::Null)
                             });
-                        self.parse(field_value, field_type)
+                        self.parse(field_value, field_type).map(|d| d.to_owned_datum())
                     })
                     .collect::<Result<_, _>>()?,
             )
@@ -564,7 +555,7 @@ impl JsonParseOptions {
                 let mut value = value.as_str().unwrap().as_bytes().to_vec();
                 let value =
                     simd_json::to_borrowed_value(&mut value[..]).map_err(|_| create_error())?;
-                return self.parse(&value, type_expected);
+                return self.parse(&value, type_expected).map(|d| d.to_owned_datum().into());
             }
 
             // ---- List -----
@@ -619,30 +610,31 @@ impl JsonParseOptions {
 
             (_expected, _got) => Err(create_error())?,
         };
-        Ok(Some(v))
+        Ok(DatumCow::Owned(Some(v)))
     }
 }
 
-pub struct JsonAccess<'a, 'b> {
-    value: BorrowedValue<'b>,
+pub struct JsonAccess<'a> {
+    value: BorrowedValue<'a>,
     options: &'a JsonParseOptions,
 }
 
-impl<'a, 'b> JsonAccess<'a, 'b> {
-    pub fn new_with_options(value: BorrowedValue<'b>, options: &'a JsonParseOptions) -> Self {
+impl<'a> JsonAccess<'a> {
+    pub fn new_with_options(value: BorrowedValue<'a>, options: &'a JsonParseOptions) -> Self {
         Self { value, options }
     }
 
-    pub fn new(value: BorrowedValue<'b>) -> Self {
+    pub fn new(value: BorrowedValue<'a>) -> Self {
         Self::new_with_options(value, &JsonParseOptions::DEFAULT)
     }
 }
 
-impl<'a, 'b> Access for JsonAccess<'a, 'b>
-where
-    'a: 'b,
-{
-    fn access(&self, path: &[&str], type_expected: &DataType) -> AccessResult {
+impl Access for JsonAccess<'_> {
+    fn access_cow<'a>(
+        &'a self,
+        path: &[&str],
+        type_expected: &DataType,
+    ) -> AccessResult<DatumCow<'a>> {
         let mut value = &self.value;
         for (idx, &key) in path.iter().enumerate() {
             if let Some(sub_value) = if self.options.ignoring_keycase {
@@ -660,48 +652,5 @@ where
         }
 
         self.options.parse(value, type_expected)
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct JsonBorrowAccess<'a, 'b> {
-    value: &'b BorrowedValue<'b>,
-    options: &'a JsonParseOptions,
-}
-
-impl<'a, 'b> JsonBorrowAccess<'a, 'b> {
-    pub fn new(value: &'b BorrowedValue<'b>) -> Self {
-        Self {
-            value,
-            options: &JsonParseOptions::DEFAULT,
-        }
-    }
-}
-
-impl<'a, 'b> JsonBorrowAccess<'a, 'b>
-where
-    'a: 'b,
-{
-    pub fn access(&self, path: &[&str], type_expected: &DataType) -> AccessResult<DatumCow<'b>> {
-        let value = {
-            let mut value = self.value;
-            for (idx, &key) in path.iter().enumerate() {
-                if let Some(sub_value) = if self.options.ignoring_keycase {
-                    json_object_get_case_insensitive(value, key)
-                } else {
-                    value.get(key)
-                } {
-                    value = sub_value;
-                } else {
-                    Err(AccessError::Undefined {
-                        name: key.to_string(),
-                        path: path.iter().take(idx).join("."),
-                    })?;
-                }
-            }
-            value
-        };
-
-        self.options.parse_borrow(value, type_expected)
     }
 }

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -35,7 +35,7 @@ use thiserror_ext::AsReport;
 
 use super::{Access, AccessError, AccessResult};
 use crate::parser::common::json_object_get_case_insensitive;
-use crate::parser::CowDatum;
+use crate::parser::DatumCow;
 use crate::schema::{bail_invalid_option_error, InvalidOptionError};
 
 #[derive(Clone, Debug)]
@@ -205,10 +205,10 @@ impl JsonParseOptions {
         &self,
         value: &'a BorrowedValue<'a>,
         type_expected: &DataType,
-    ) -> AccessResult<CowDatum<'a>> {
+    ) -> AccessResult<DatumCow<'a>> {
         Ok(match (type_expected, value.value_type()) {
             (DataType::Varchar, ValueType::String) => {
-                CowDatum::Ref(Some(ScalarRefImpl::Utf8(value.as_str().unwrap().into())))
+                DatumCow::Ref(Some(ScalarRefImpl::Utf8(value.as_str().unwrap().into())))
             }
             _ => self.parse(value, type_expected)?.into(),
         })
@@ -682,7 +682,7 @@ impl<'a, 'b> JsonBorrowAccess<'a, 'b>
 where
     'a: 'b,
 {
-    pub fn access(&self, path: &[&str], type_expected: &DataType) -> AccessResult<CowDatum<'b>> {
+    pub fn access(&self, path: &[&str], type_expected: &DataType) -> AccessResult<DatumCow<'b>> {
         let value = {
             let mut value = self.value;
             for (idx, &key) in path.iter().enumerate() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add a new method named `access_cow` to `Access` trait, allowing implementors to return a borrowed `DatumRef`, to achieve zero-copy parsing.

Currently only `Varchar` field in `JSON` returns a borrowed `ScalarRef`. This improves the performance by ~11% in micro-benchmark `nexmark_integration`. Will adopt it more in following PRs.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
