### PR TITLE
fix(backfill): make tombstone iteration progress across all vnodes per epoch

### DIFF
--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -126,7 +126,7 @@ test_snapshot_and_upstream_read() {
 
 # Lots of upstream tombstone, backfill should still proceed.
 test_backfill_tombstone() {
-  echo "--- e2e, test_backfill_tombstone"
+  echo "--- e2e, test_backfill_tombstone, streaming_use_arrangement_backfill=$1"
   risedev ci-start $CLUSTER_PROFILE
   risedev psql -c "
   CREATE TABLE tomb (v1 int)
@@ -151,7 +151,7 @@ test_backfill_tombstone() {
     done
   ' 1>deletes.log 2>&1 &
 
-  risedev psql -c "CREATE MATERIALIZED VIEW m1 as select * from tomb;"
+  risedev psql -c "SET STREAMING_USE_ARRANGEMENT_BACKFILL=$1; CREATE MATERIALIZED VIEW m1 as select * from tomb;"
   echo "--- Kill cluster"
   kill_cluster
   wait
@@ -284,7 +284,8 @@ test_backfill_snapshot_with_wider_rows() {
 main() {
   set -euo pipefail
   test_snapshot_and_upstream_read
-  test_backfill_tombstone
+  test_backfill_tombstone "true"
+  test_backfill_tombstone "false"
   test_replication_with_column_pruning
   test_sink_backfill_recovery
 

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -872,7 +872,7 @@ steps:
     key: "e2e-sqlserver-sink-tests"
     command: "ci/scripts/e2e-sqlserver-sink-test.sh -p ci-release"
     if: |
-      !(build.pull_request.labels includes "ci/main-cron/skip-ci") && build.env("CI_STEPS") == null
+      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-e2e-sqlserver-sink-tests"
       || build.env("CI_STEPS") =~ /(^|,)e2e-sqlserver-sink-tests?(,|$$)/
     depends_on:

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -692,7 +692,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 26
+    timeout_in_minutes: 35
     retry: *auto-retry
 
   - label: "e2e standalone binary test"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -692,7 +692,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 22
+    timeout_in_minutes: 26
     retry: *auto-retry
 
   - label: "e2e standalone binary test"

--- a/e2e_test/backfill/runtime/validate_rows_arrangement.slt
+++ b/e2e_test/backfill/runtime/validate_rows_arrangement.slt
@@ -1,4 +1,7 @@
 query I
-select (select count(*) from arrangement_backfill) = (select count(*) from t);
+select v1 from arrangement_backfill where v1 not in (select v1 from t);
 ----
-t
+
+query I
+select v1 from t where v1 not in (select v1 from arrangement_backfill);
+----

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -39,6 +39,7 @@
 use std::iter::{self, TrustedLen};
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, Not, Range, RangeInclusive};
 
+use fixedbitset::FixedBitSet;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_pb::common::buffer::CompressionType;
 use risingwave_pb::common::PbBuffer;
@@ -461,16 +462,10 @@ impl Bitmap {
         }
     }
 
-    pub fn set_bit(&mut self, idx: usize) {
-        assert!(idx < self.len());
-        if let Some(bits) = &mut self.bits {
-            bits[idx / BITS] |= 1 << (idx % BITS);
-        } else {
-            self.count_ones += 1;
-            if self.count_ones == self.num_bits {
-                self.bits = None;
-            }
-        }
+    /// Used to convert to a mutable bitmap.
+    pub fn to_fixed_bitset(&self) -> FixedBitSet {
+        let iter = self.iter_ones();
+        FixedBitSet::from_iter(iter)
     }
 }
 

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -460,6 +460,18 @@ impl Bitmap {
             count_ones: range.len(),
         }
     }
+
+    pub fn set_bit(&mut self, idx: usize) {
+        assert!(idx < self.len());
+        if let Some(bits) = &mut self.bits {
+            bits[idx / BITS] |= 1 << (idx % BITS);
+        } else {
+            self.count_ones += 1;
+            if self.count_ones == self.num_bits {
+                self.bits = None;
+            }
+        }
+    }
 }
 
 impl From<usize> for Bitmap {

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -122,17 +122,17 @@ impl StreamTableScan {
 
     /// Build catalog for backfill state
     ///
-    /// Schema: | vnode | pk ... | `pk_inclusive` | `backfill_finished` | `row_count` |
+    /// Schema: | vnode | pk ... | `yielded` | `backfill_finished` | `row_count` |
     ///
     /// key:    | vnode |
-    /// value:  | pk ... | `pk_inclusive` | `backfill_finished` | `row_count` |
+    /// value:  | pk ... | `yielded` | `backfill_finished` | `row_count` |
     ///
     /// When we update the backfill progress,
     /// we update it for all vnodes.
     ///
     /// `pk` refers to the upstream pk which we use to track the backfill progress.
     ///
-    /// `pk_inclusive` is a boolean which indicates if the backfill has also yielded this pk,
+    /// `yielded` is a boolean which indicates if the backfill has also yielded this pk,
     /// OR it just maintained the progress up to this pk, but we can still yield it.
     ///
     /// `vnode` is the corresponding vnode of the upstream's distribution key.
@@ -162,10 +162,10 @@ impl StreamTableScan {
             catalog_builder.add_column(&Field::from(col));
         }
 
-        // `pk_inclusive` column
+        // `yielded` column
         // Only present for arrangement backfill.
         if is_arrangement_backfill {
-            catalog_builder.add_column(&Field::with_name(DataType::Boolean, "pk_inclusive"));
+            catalog_builder.add_column(&Field::with_name(DataType::Boolean, "yielded"));
         }
 
         // `backfill_finished` column

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -346,6 +346,11 @@ where
                         debug_assert!(builders.values().all(|b| b.is_empty()));
                         let (_, snapshot) = backfill_stream.into_inner();
                         let mut remaining_vnodes = vnode_bitset.clone();
+                        // Records which were purely used to update the current pos,
+                        // to persist the tombstone iteration progress.
+                        // They need to be buffered in case the snapshot read completes,
+                        // Then we must yield them downstream.
+                        let mut skip_buffer = Vec::with_capacity(1000);
                         let mut yielded = false;
 
                         #[for_await]
@@ -358,6 +363,20 @@ where
                                     // End of the snapshot read stream.
                                     // We let the barrier handling logic take care of upstream updates.
                                     // But we still want to exit backfill loop, so we mark snapshot read complete.
+                                    for (vnode, row) in skip_buffer {
+                                        let builder = builders.get_mut(&vnode).unwrap();
+                                        if let Some(chunk) = builder.append_one_row(row) {
+                                            yield Message::Chunk(Self::handle_snapshot_chunk(
+                                                chunk,
+                                                vnode,
+                                                &pk_in_output_indices,
+                                                &mut backfill_state,
+                                                &mut cur_barrier_snapshot_processed_rows,
+                                                &mut total_snapshot_processed_rows,
+                                                &self.output_indices,
+                                            )?);
+                                        }
+                                    }
                                     snapshot_read_complete = true;
                                     break;
                                 }
@@ -400,6 +419,7 @@ where
                                             }
                                             yielded = true;
                                         } else {
+                                            skip_buffer.push((vnode, row.clone()));
                                             let new_pos = row.project(&pk_in_output_indices);
                                             assert_eq!(new_pos.len(), pk_in_output_indices.len());
                                             backfill_state.update_progress(
@@ -415,6 +435,7 @@ where
                                             break;
                                         }
                                     } else {
+                                        skip_buffer.push((vnode, row.clone()));
                                         continue;
                                     }
                                 }

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -215,6 +215,7 @@ where
             'backfill_loop: loop {
                 let mut cur_barrier_snapshot_processed_rows: u64 = 0;
                 let mut cur_barrier_upstream_processed_rows: u64 = 0;
+                let mut snapshot_read_complete = false;
                 let mut has_snapshot_read = false;
 
                 // NOTE(kwannoel): Scope it so that immutable reference to `upstream_table` can be
@@ -354,14 +355,10 @@ where
                             };
                             match msg? {
                                 None => {
-                                    // NOTE(kwannoel): We can't finish backfill here.
-                                    // There could be some records skipped.
-                                    //
-                                    // There are two ways we can improve this.
-                                    // 1. We can support vnode level backfill completion.
-                                    //    so in this part we will only iterate across vnodes
-                                    //    which are not yet finished.
-                                    // 2. We can buffer any skipped records, and yield them here.
+                                    // End of the snapshot read stream.
+                                    // We let the barrier handling logic take care of upstream updates.
+                                    // But we still want to exit backfill loop, so we mark snapshot read complete.
+                                    snapshot_read_complete = true;
                                     break;
                                 }
                                 Some((vnode, row)) => {
@@ -579,6 +576,12 @@ where
                 }
 
                 yield Message::Barrier(barrier);
+
+                // We will switch snapshot at the start of the next iteration of the backfill loop.
+                // Unless snapshot read is already completed.
+                if snapshot_read_complete {
+                    break 'backfill_loop;
+                }
             }
         }
 

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -346,7 +346,7 @@ where
                         debug_assert!(builders.values().all(|b| b.is_empty()));
                         let (_, snapshot) = backfill_stream.into_inner();
                         let mut remaining_vnodes = vnode_bitset.clone();
-                        let mut yielded = false;
+                        let yielded = false;
 
                         #[for_await]
                         for msg in snapshot {
@@ -398,7 +398,8 @@ where
                                                     &self.output_indices,
                                                 )?);
                                             }
-                                            yielded = true;
+                                            // yielded = true;
+                                            break;
                                         } else {
                                             let new_pos = row.project(&pk_in_output_indices);
                                             assert_eq!(new_pos.len(), pk_in_output_indices.len());

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -562,7 +562,7 @@ where
                         // (there's no epoch before the first epoch).
                         for vnode in upstream_table.vnodes().iter_vnodes() {
                             backfill_state
-                                .finish_progress(vnode, upstream_table.pk_indices().len());
+                                .finish_progress(vnode, upstream_table.pk_indices().len())?;
                         }
 
                         persist_state_per_vnode(

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -140,7 +140,8 @@ where
         let first_epoch = first_barrier.epoch;
         self.state_table.init_epoch(first_barrier.epoch);
 
-        let progress_per_vnode = get_progress_per_vnode(&self.state_table).await?;
+        let progress_per_vnode =
+            get_progress_per_vnode(&self.state_table, pk_in_output_indices.len()).await?;
 
         let is_completely_finished = progress_per_vnode.iter().all(|(_, p)| {
             matches!(

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -690,20 +690,20 @@ where
         let mut iterators = vec![];
         for vnode in upstream_table.vnodes().iter_vnodes() {
             let backfill_progress = backfill_state.get_progress(&vnode)?;
-            let (current_pos, inclusive) = match backfill_progress {
+            let (current_pos, exclusive) = match backfill_progress {
                 BackfillProgressPerVnode::NotStarted => (None, false),
                 BackfillProgressPerVnode::Completed { current_pos, .. } => {
                     (Some(current_pos.clone()), false)
                 }
                 BackfillProgressPerVnode::InProgress {
                     current_pos,
-                    pos_inclusive,
+                    yielded,
                     ..
-                } => (Some(current_pos.clone()), *pos_inclusive),
+                } => (Some(current_pos.clone()), *yielded),
             };
 
             let range_bounds =
-                compute_bounds(upstream_table.pk_indices(), inclusive, current_pos.clone());
+                compute_bounds(upstream_table.pk_indices(), exclusive, current_pos.clone());
             if range_bounds.is_none() {
                 continue;
             }

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use std::collections::HashMap;
 
 use either::Either;
@@ -21,6 +20,7 @@ use itertools::Itertools;
 use risingwave_common::array::{DataChunk, Op};
 use risingwave_common::bail;
 use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
+use risingwave_common::row::RowExt;
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 use risingwave_storage::store::PrefetchOptions;
@@ -344,6 +344,8 @@ where
                     if !has_snapshot_read && !paused && rate_limit_ready {
                         debug_assert!(builders.values().all(|b| b.is_empty()));
                         let (_, snapshot) = backfill_stream.into_inner();
+                        let mut remaining_vnodes = vnodes.as_ref().clone();
+
                         #[for_await]
                         for msg in snapshot {
                             let Either::Right(msg) = msg else {
@@ -358,20 +360,30 @@ where
                                     break;
                                 }
                                 Some((vnode, row)) => {
-                                    let builder = builders.get_mut(&vnode).unwrap();
-                                    if let Some(chunk) = builder.append_one_row(row) {
-                                        yield Message::Chunk(Self::handle_snapshot_chunk(
-                                            chunk,
+                                    // FIXME(kwannoel):
+                                    // Perhaps we should introduce a custom stream combinator,
+                                    // so we can iterate on individual streams here.
+                                    // Otherwise here we will iterate across all vnodes,
+                                    // even if some vnode is already done.
+                                    // We could actually drop the snapshot iteration stream
+                                    // for that vnode once we have read at least 1 record from it.
+                                    let vnode_idx = vnode.to_index();
+                                    if !remaining_vnodes.is_set(vnode_idx) {
+                                        let new_pos = row.project(&pk_in_output_indices);
+                                        assert_eq!(new_pos.len(), pk_in_output_indices.len());
+                                        backfill_state.update_progress(
                                             vnode,
-                                            &pk_in_output_indices,
-                                            &mut backfill_state,
-                                            &mut cur_barrier_snapshot_processed_rows,
-                                            &mut total_snapshot_processed_rows,
-                                            &self.output_indices,
-                                        )?);
+                                            new_pos.to_owned_row(),
+                                            false,
+                                            0,
+                                        )?;
+                                        remaining_vnodes.set_bit(vnode_idx);
+                                        if remaining_vnodes.is_empty() {
+                                            break;
+                                        }
+                                    } else {
+                                        continue;
                                     }
-
-                                    break;
                                 }
                             }
                         }

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -351,7 +351,6 @@ where
                         // to persist the tombstone iteration progress.
                         // They need to be buffered in case the snapshot read completes,
                         // Then we must yield them downstream.
-                        let mut yielded = false;
 
                         #[for_await]
                         for msg in snapshot {
@@ -376,44 +375,14 @@ where
                                     // for that vnode once we have read at least 1 record from it.
                                     let vnode_idx = vnode.to_index();
                                     if remaining_vnodes.contains(vnode_idx) {
-                                        // FIXME(kwannoel): This is not needed.
-                                        // The main point of reading the snapshot here is to
-                                        // skip over long tombstone ranges,
-                                        // not to guarantee that snapshot read makes progress.
-                                        // Because skipping over long tombstone ranges is a transient step,
-                                        // once we skip over the initial run, we don't need to do it again.
-                                        //
-                                        // If we hit this code section, it means snapshot read is really slow.
-                                        // Even if we yielded a record here, the backfill progress will still be slow,
-                                        // since we only return one record per epoch.
-                                        // Consider barrier interval at 1s.
-                                        // And upstream has 1M records.
-                                        // So we take 1M seconds to finish backfill, which is 11.57 days.
-                                        // So that's basically the same as never finishing backfill.
-                                        if !yielded {
-                                            let builder = builders.get_mut(&vnode).unwrap();
-                                            if let Some(chunk) = builder.append_one_row(row) {
-                                                yield Message::Chunk(Self::handle_snapshot_chunk(
-                                                    chunk,
-                                                    vnode,
-                                                    &pk_in_output_indices,
-                                                    &mut backfill_state,
-                                                    &mut cur_barrier_snapshot_processed_rows,
-                                                    &mut total_snapshot_processed_rows,
-                                                    &self.output_indices,
-                                                )?);
-                                            }
-                                            yielded = true;
-                                        } else {
-                                            let new_pos = row.project(&pk_in_output_indices);
-                                            assert_eq!(new_pos.len(), pk_in_output_indices.len());
-                                            backfill_state.update_progress(
-                                                vnode,
-                                                new_pos.to_owned_row(),
-                                                false,
-                                                0,
-                                            )?;
-                                        }
+                                        let new_pos = row.project(&pk_in_output_indices);
+                                        assert_eq!(new_pos.len(), pk_in_output_indices.len());
+                                        backfill_state.update_progress(
+                                            vnode,
+                                            new_pos.to_owned_row(),
+                                            false,
+                                            0,
+                                        )?;
 
                                         remaining_vnodes.set(vnode_idx, false);
                                         if remaining_vnodes.is_empty() {

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -673,7 +673,7 @@ where
         epoch: u64,
         current_pos: Option<OwnedRow>,
     ) {
-        let range_bounds = compute_bounds(upstream_table.pk_indices(), false, current_pos);
+        let range_bounds = compute_bounds(upstream_table.pk_indices(), true, current_pos);
         let range_bounds = match range_bounds {
             None => {
                 yield None;

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -673,7 +673,7 @@ where
         epoch: u64,
         current_pos: Option<OwnedRow>,
     ) {
-        let range_bounds = compute_bounds(upstream_table.pk_indices(), current_pos);
+        let range_bounds = compute_bounds(upstream_table.pk_indices(), false, current_pos);
         let range_bounds = match range_bounds {
             None => {
                 yield None;

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -95,6 +95,7 @@ impl BackfillState {
         &mut self,
         vnode: VirtualNode,
         new_pos: OwnedRow,
+        yielded: bool,
         snapshot_row_count_delta: u64,
     ) -> StreamExecutorResult<()> {
         let state = self.get_current_state(&vnode);
@@ -102,7 +103,7 @@ impl BackfillState {
             BackfillProgressPerVnode::NotStarted => {
                 *state = BackfillProgressPerVnode::InProgress {
                     current_pos: new_pos,
-                    yielded: true,
+                    yielded,
                     snapshot_row_count: snapshot_row_count_delta,
                 };
             }
@@ -111,7 +112,7 @@ impl BackfillState {
             } => {
                 *state = BackfillProgressPerVnode::InProgress {
                     current_pos: new_pos,
-                    yielded: true,
+                    yielded,
                     snapshot_row_count: *snapshot_row_count + snapshot_row_count_delta,
                 };
             }
@@ -643,7 +644,7 @@ pub(crate) fn update_pos_by_vnode(
 ) -> StreamExecutorResult<()> {
     let new_pos = get_new_pos(chunk, pk_in_output_indices);
     assert_eq!(new_pos.len(), pk_in_output_indices.len());
-    backfill_state.update_progress(vnode, new_pos, snapshot_row_count_delta)?;
+    backfill_state.update_progress(vnode, new_pos, true, snapshot_row_count_delta)?;
     Ok(())
 }
 

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -135,13 +135,8 @@ impl BackfillState {
             BackfillProgressPerVnode::InProgress {
                 current_pos,
                 snapshot_row_count,
-                yielded,
-            } => {
-                if !*yielded {
-                    bail!("the current_pos: {current_pos:?} must be yielded downstream before backfill finishes");
-                }
-                (current_pos.clone(), *snapshot_row_count)
-            }
+                ..
+            } => (current_pos.clone(), *snapshot_row_count),
             BackfillProgressPerVnode::Completed { .. } => {
                 return Ok(());
             }
@@ -701,7 +696,7 @@ pub(crate) fn construct_initial_finished_state(pos_len: usize) -> OwnedRow {
 }
 
 /// `pk_indices`: Just used to check if the current pos is empty.
-/// `inclusive`: Whether it's inclusive of the current pos.
+/// `exclusive`: Whether the snapshot read iteration is exclusive of the current pos.
 /// `current_pos`: The current pos to start scanning from.
 pub(crate) fn compute_bounds(
     pk_indices: &[usize],

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -153,8 +153,9 @@ impl BackfillState {
                 let mut encoded_state = vec![None; current_pos.len() + METADATA_STATE_LEN];
                 encoded_state[0] = Some(vnode.to_scalar().into());
                 encoded_state[1..current_pos.len() + 1].clone_from_slice(current_pos.as_inner());
-                encoded_state[current_pos.len() + 1] = Some(false.into());
-                encoded_state[current_pos.len() + 2] = Some((snapshot_row_count as i64).into());
+                encoded_state[current_pos.len() + 1] = Some(yielded.into());
+                encoded_state[current_pos.len() + 2] = Some(false.into());
+                encoded_state[current_pos.len() + 3] = Some((snapshot_row_count as i64).into());
                 encoded_state
             }
             BackfillProgressPerVnode::Completed {
@@ -165,7 +166,8 @@ impl BackfillState {
                 encoded_state[0] = Some(vnode.to_scalar().into());
                 encoded_state[1..current_pos.len() + 1].clone_from_slice(current_pos.as_inner());
                 encoded_state[current_pos.len() + 1] = Some(true.into());
-                encoded_state[current_pos.len() + 2] = Some((snapshot_row_count as i64).into());
+                encoded_state[current_pos.len() + 2] = Some(true.into());
+                encoded_state[current_pos.len() + 3] = Some((snapshot_row_count as i64).into());
                 encoded_state
             }
         };
@@ -182,8 +184,9 @@ impl BackfillState {
                 encoded_state[0] = Some(vnode.to_scalar().into());
                 encoded_state[1..committed_pos.len() + 1]
                     .clone_from_slice(committed_pos.as_inner());
-                encoded_state[committed_pos.len() + 1] = Some(false.into());
-                encoded_state[committed_pos.len() + 2] = Some((snapshot_row_count as i64).into());
+                encoded_state[committed_pos.len() + 1] = Some(yielded.into());
+                encoded_state[committed_pos.len() + 2] = Some(false.into());
+                encoded_state[committed_pos.len() + 3] = Some((snapshot_row_count as i64).into());
                 Some(encoded_state)
             }
             BackfillProgressPerVnode::Completed {
@@ -196,7 +199,8 @@ impl BackfillState {
                 encoded_state[1..committed_pos.len() + 1]
                     .clone_from_slice(committed_pos.as_inner());
                 encoded_state[committed_pos.len() + 1] = Some(true.into());
-                encoded_state[committed_pos.len() + 2] = Some((snapshot_row_count as i64).into());
+                encoded_state[committed_pos.len() + 2] = Some(true.into());
+                encoded_state[committed_pos.len() + 3] = Some((snapshot_row_count as i64).into());
                 Some(encoded_state)
             }
         };

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -658,8 +658,12 @@ pub(crate) fn construct_initial_finished_state(pos_len: usize) -> OwnedRow {
     OwnedRow::new(vec![None; pos_len])
 }
 
+/// `pk_indices`: Just used to check if the current pos is empty.
+/// `inclusive`: Whether it's inclusive of the current pos.
+/// `current_pos`: The current pos to start scanning from.
 pub(crate) fn compute_bounds(
     pk_indices: &[usize],
+    inclusive: bool,
     current_pos: Option<OwnedRow>,
 ) -> Option<(Bound<OwnedRow>, Bound<OwnedRow>)> {
     // `current_pos` is None means it needs to scan from the beginning, so we use Unbounded to
@@ -672,8 +676,13 @@ pub(crate) fn compute_bounds(
             assert!(pk_indices.is_empty());
             return None;
         }
+        let lower_bound = if inclusive {
+            Bound::Included(current_pos)
+        } else {
+            Bound::Excluded(current_pos)
+        };
 
-        Some((Bound::Excluded(current_pos), Bound::Unbounded))
+        Some((lower_bound, Bound::Unbounded))
     } else {
         Some((Bound::Unbounded, Bound::Unbounded))
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

_Thanks @hzxa21 for sharing his diagnosis and ideas to solve it._

Resolve #17267 

This is required because if we only yield the progress of a single vnode, the tombstone iteration of the other vnodes are dropped.
This is not an issue in no shuffle backfill, because the current pos is maintained on a parallelism level for all vnodes in it, rather than on vnode level like arrangement backfill.

We cannot simply yield all the scanned records downstream however, otherwise in each epoch, we now have the invariant of 256 records per epoch for backfill. If the processing latency of 256 records is high, barrier latency will be high.
So what we do is to add an `yielded` flag. In the case where there's no snapshot read in an epoch, we will set `yielded` flag to false, and continue to bump the current progress. Since we don't yield the records which were read from the snapshot, in the subsequent epoch, we will scan these same records, but use an inclusive bound with them, so they will be included in the newly scanned snapshot.

For normal snapshot read, `yielded` will always be true.

Want to add a separate test later.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
