### PR TITLE
feat(catalog): support attoptions in pg_attribute

### DIFF
--- a/e2e_test/batch/catalog/pg_attribute.slt.part
+++ b/e2e_test/batch/catalog/pg_attribute.slt.part
@@ -42,5 +42,10 @@ tmp_idx	id1	{2,1,3,5}
 tmp_idx	id2	{2,1,3,5}
 tmp_idx	id3	{2,1,3,5}
 
+query T
+select attoptions from pg_catalog.pg_attribute LIMIT 1;
+----
+NULL
+
 statement ok
 drop table tmp;

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
@@ -39,6 +39,7 @@ use risingwave_frontend_macro::system_catalog;
               ELSE ''::varchar
             END AS attgenerated,
             -1 AS atttypmod,
+            NULL::text[] AS attoptions,
             0 AS attcollation
         FROM rw_catalog.rw_columns c
         WHERE c.is_hidden = false"
@@ -56,5 +57,6 @@ struct PgAttribute {
     attidentity: String,
     attgenerated: String,
     atttypmod: i32,
+    attoptions: Vec<String>,
     attcollation: i32,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

RisingWave doesn't support storage attributes for columns. Therefore, we can just set attoptions to be always null.

## Checklist

- [x] I have added necessary unit tests and integration tests
