### PR TITLE
fix: fix type mismatch of compressed_binary column in function table

### DIFF
--- a/src/meta/model_v2/migration/src/lib.rs
+++ b/src/meta/model_v2/migration/src/lib.rs
@@ -12,6 +12,7 @@ mod m20240418_142249_function_runtime;
 mod m20240506_112555_subscription_partial_ckpt;
 mod m20240525_090457_secret;
 mod m20240617_070131_index_column_properties;
+mod m20240618_072634_function_compressed_binary;
 
 pub struct Migrator;
 
@@ -28,6 +29,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240418_142249_function_runtime::Migration),
             Box::new(m20240506_112555_subscription_partial_ckpt::Migration),
             Box::new(m20240525_090457_secret::Migration),
+            Box::new(m20240618_072634_function_compressed_binary::Migration),
             Box::new(m20240617_070131_index_column_properties::Migration),
         ]
     }

--- a/src/meta/model_v2/migration/src/m20240618_072634_function_compressed_binary.rs
+++ b/src/meta/model_v2/migration/src/m20240618_072634_function_compressed_binary.rs
@@ -33,6 +33,7 @@ impl MigrationTrait for Migration {
             }
             DbBackend::Sqlite => {
                 // Sqlite does not support modifying column type, so we need to do data migration and column renaming.
+                // Note that: all these DDLs are not transactional, so if some of them fail, we need to manually run it again.
                 let conn = manager.get_connection();
                 conn.execute(Statement::from_string(
                     DatabaseBackend::Sqlite,
@@ -61,7 +62,7 @@ impl MigrationTrait for Migration {
     }
 
     async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
-        // DO nothing, the operations in `up` are idempotent(except SQLite) and required to fix the column type mismatch.
+        // DO nothing, the operations in `up` are idempotent and required to fix the column type mismatch.
         Ok(())
     }
 }

--- a/src/meta/model_v2/migration/src/m20240618_072634_function_compressed_binary.rs
+++ b/src/meta/model_v2/migration/src/m20240618_072634_function_compressed_binary.rs
@@ -61,7 +61,7 @@ impl MigrationTrait for Migration {
     }
 
     async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
-        // DO nothing, the operations in `up` are idempotent and required to fix the column type mismatch.
+        // DO nothing, the operations in `up` are idempotent(except SQLite) and required to fix the column type mismatch.
         Ok(())
     }
 }

--- a/src/meta/model_v2/migration/src/m20240618_072634_function_compressed_binary.rs
+++ b/src/meta/model_v2/migration/src/m20240618_072634_function_compressed_binary.rs
@@ -1,0 +1,73 @@
+use sea_orm_migration::prelude::*;
+
+use crate::sea_orm::{DatabaseBackend, DbBackend, Statement};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Fix mismatch column `compressed_binary` type and do data migration
+        match manager.get_database_backend() {
+            DbBackend::MySql => {
+                // Creating function with compressed binary will fail in previous version, so we can
+                // safely assume that the column is always empty and we can just modify the column type
+                // without any data migration.
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Function::Table)
+                            .modify_column(
+                                ColumnDef::new(Function::CompressedBinary).blob(BlobSize::Medium),
+                            )
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DbBackend::Postgres => {
+                manager.get_connection().execute(Statement::from_string(
+                    DatabaseBackend::Postgres,
+                    "ALTER TABLE function ALTER COLUMN compressed_binary TYPE bytea USING compressed_binary::bytea",
+                )).await?;
+            }
+            DbBackend::Sqlite => {
+                // Sqlite does not support modifying column type, so we need to do data migration and column renaming.
+                let conn = manager.get_connection();
+                conn.execute(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "ALTER TABLE function ADD COLUMN compressed_binary_new BLOB",
+                ))
+                .await?;
+                conn.execute(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "UPDATE function SET compressed_binary_new = compressed_binary",
+                ))
+                .await?;
+                conn.execute(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "ALTER TABLE function DROP COLUMN compressed_binary",
+                ))
+                .await?;
+                conn.execute(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "ALTER TABLE function RENAME COLUMN compressed_binary_new TO compressed_binary",
+                ))
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // DO nothing, the operations in `up` are idempotent and required to fix the column type mismatch.
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Function {
+    Table,
+    CompressedBinary,
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The column `compressed_binary` of table `function` was defined as `varchar` in sql backend but as `Vec<u8>` in rust type, which will cause cluster unable to get recovered if any UDFs with compressed binary was created:
```
mismatched types; Rust type `core::option::Option<alloc::vec::Vec<u8>>` (as SQL type `BYTEA`) is not compatible with SQL type `VARCHAR`
```
Already tested it locally with three kinds of sql backends. Haven't found a suitable way to test and cover it yet.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
