### PR TITLE
feat(sink): minor improvements for starrocks sink

### DIFF
--- a/src/connector/src/sink/doris_starrocks_connector.rs
+++ b/src/connector/src/sink/doris_starrocks_connector.rs
@@ -173,7 +173,7 @@ impl HeaderBuilder {
 /// The reason we handle the redirection manually is that if we let `reqwest` handle the redirection
 /// automatically, it will remove sensitive headers (such as Authorization) during the redirection,
 /// and there's no way to prevent this behavior.
-fn try_get_be_url(resp: &Response, fe_host: String) -> Result<Option<Url>> {
+fn try_get_be_url(resp: &Response, fe_host: &str) -> Result<Option<Url>> {
     match resp.status() {
         StatusCode::TEMPORARY_REDIRECT => {
             let be_url = resp
@@ -199,7 +199,7 @@ fn try_get_be_url(resp: &Response, fe_host: String) -> Result<Option<Url>> {
                     // if be host is 127.0.0.1, we may can't connect to it directly,
                     // so replace it with fe host
                     parsed_be_url
-                        .set_host(Some(fe_host.as_str()))
+                        .set_host(Some(fe_host))
                         .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?;
                 }
             }
@@ -267,7 +267,7 @@ impl InserterInnerBuilder {
             .await
             .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?;
 
-        let be_url = try_get_be_url(&resp, self.fe_host.clone())?
+        let be_url = try_get_be_url(&resp, self.fe_host.as_str())?
             .ok_or_else(|| SinkError::DorisStarrocksConnect(anyhow!("Can't get doris BE url",)))?;
 
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
@@ -376,6 +376,64 @@ impl InserterInner {
     }
 }
 
+enum StreamLoadResponse {
+    BeRequest(Request),
+    HttpResponse(Response),
+}
+
+/// Send the request and handle redirection if any.
+/// The reason we handle the redirection manually is that if we let `reqwest` handle the redirection
+/// automatically, it will remove sensitive headers (such as Authorization) during the redirection,
+/// and there's no way to prevent this behavior.
+/// Please note, the FE address that user specified might be a FE follower not the leader, in this case,
+/// the follower FE will redirect request to leader FE and then to BE.
+async fn send_stream_load_request(
+    client: Client,
+    mut request: Request,
+    fe_host: &str,
+) -> Result<StreamLoadResponse> {
+    // possible redirection paths:
+    // RW <-> follower FE -> leader FE -> BE
+    // RW <-> leader FE -> BE
+    // RW <-> leader FE
+    for _ in 0..2 {
+        let original_http_port = request.url().port();
+        let mut request_for_redirection = request
+            .try_clone()
+            .ok_or_else(|| SinkError::DorisStarrocksConnect(anyhow!("Can't clone request")))?;
+        let resp = client.execute(request).await.map_err(|err| {
+            SinkError::DorisStarrocksConnect(
+                anyhow!(err).context("sending stream load request failed"),
+            )
+        })?;
+        let be_url = try_get_be_url(&resp, fe_host)?;
+        match be_url {
+            Some(be_url) => {
+                // we used an unconventional method to detect if we are currently redirecting to FE leader, i.e.,
+                // by comparing the port of the redirected url with that of the original request, if they are same, we consider
+                // this is a FE address. Because in practice, no one would deploy their `StarRocks` cluster with the same
+                // http port for both FE and BE. However, this is a potentially problematic assumption,
+                // we may investigate a better way to do this. For example, we could use the `show backends` command to check
+                // if the host of the redirected url is in the list. However, `show backends` requires
+                // the system-level privilege, which could break the backward compatibility.
+                let redirected_port = be_url.port();
+                *request_for_redirection.url_mut() = be_url;
+                if redirected_port == original_http_port {
+                    // redirected to FE, continue another round.
+                    request = request_for_redirection;
+                } else {
+                    // we got BE address here
+                    return Ok(StreamLoadResponse::BeRequest(request_for_redirection));
+                }
+            }
+            None => return Ok(StreamLoadResponse::HttpResponse(resp)),
+        }
+    }
+    Err(SinkError::DorisStarrocksConnect(anyhow!(
+        "redirection occur more than twice when sending stream load request"
+    )))
+}
+
 pub struct MetaRequestSender {
     client: Client,
     request: Request,
@@ -391,40 +449,17 @@ impl MetaRequestSender {
         }
     }
 
-    /// Send the request and handle redirection if any.
-    /// The reason we handle the redirection manually is that if we let `reqwest` handle the redirection
-    /// automatically, it will remove sensitive headers (such as Authorization) during the redirection,
-    /// and there's no way to prevent this behavior.
-    ///
-    /// Another interesting point is that some of the `StarRocks` transactional APIs will respond directly from FE.
-    /// For example, the request to `/api/transaction/commit` endpoint does not seem to redirect to BE.
     pub async fn send(self) -> Result<Bytes> {
-        let request = self.request;
-        let mut request_for_redirection = request
-            .try_clone()
-            .ok_or_else(|| SinkError::DorisStarrocksConnect(anyhow!("Can't clone request")))?;
-
-        let resp = self
-            .client
-            .execute(request)
-            .await
-            .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?;
-
-        let be_url = try_get_be_url(&resp, self.fe_host)?;
-
-        match be_url {
-            Some(be_url) => {
-                *request_for_redirection.url_mut() = be_url;
-
-                self.client
-                    .execute(request_for_redirection)
-                    .await
-                    .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?
-                    .bytes()
-                    .await
-                    .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))
-            }
-            None => resp
+        match send_stream_load_request(self.client.clone(), self.request, &self.fe_host).await? {
+            StreamLoadResponse::BeRequest(be_request) => self
+                .client
+                .execute(be_request)
+                .await
+                .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?
+                .bytes()
+                .await
+                .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err))),
+            StreamLoadResponse::HttpResponse(resp) => resp
                 .bytes()
                 .await
                 .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err))),
@@ -551,30 +586,26 @@ impl StarrocksTxnRequestBuilder {
 
     pub async fn build_txn_inserter(&self, label: String) -> Result<InserterInner> {
         let request = self.build_request(self.url_load.clone(), Method::PUT, label)?;
-        let mut request_for_redirection = request
-            .try_clone()
-            .ok_or_else(|| SinkError::DorisStarrocksConnect(anyhow!("Can't clone request")))?;
-
-        let resp = self
-            .client
-            .execute(request)
-            .await
-            .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?;
-
-        let be_url = try_get_be_url(&resp, self.fe_host.clone())?
-            .ok_or_else(|| SinkError::DorisStarrocksConnect(anyhow!("Can't get doris BE url",)))?;
-        *request_for_redirection.url_mut() = be_url;
-
+        let mut be_request =
+            match send_stream_load_request(self.client.clone(), request, &self.fe_host).await? {
+                StreamLoadResponse::BeRequest(be_request) => be_request,
+                StreamLoadResponse::HttpResponse(resp) => {
+                    return Err(SinkError::DorisStarrocksConnect(anyhow!(
+                        "expect a be request but got a response: {:?}",
+                        resp
+                    )))
+                }
+            };
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
         let body = Body::wrap_stream(
             tokio_stream::wrappers::UnboundedReceiverStream::new(receiver).map(Ok::<_, Infallible>),
         );
-        *request_for_redirection.body_mut() = Some(body);
+        *be_request.body_mut() = Some(body);
 
         let client = self.client.clone();
         let handle: JoinHandle<Result<Vec<u8>>> = tokio::spawn(async move {
             let response = client
-                .execute(request_for_redirection)
+                .execute(be_request)
                 .await
                 .map_err(|err| SinkError::DorisStarrocksConnect(anyhow!(err)))?;
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -826,6 +826,21 @@ StarrocksConfig:
     field_type: String
     comments: Enable partial update
     required: false
+  - name: starrocks.stream_load.delete_sign.field
+    field_type: String
+    comments: Specify the name of the `StarRocks` delete sign field used in upsert mode; defaults to `__op`.  this option is available only when the `StarRocks` table model is `Unique` or `Aggregation`.
+    required: false
+    default: STARROCKS_DELETE_SIGN . to_string ()
+  - name: starrocks.stream_load.delete_sign.upsert
+    field_type: String
+    comments: Specify the value that signifies the upsert operation; defaults to `0`.  this option is available only when the `StarRocks` table model is `Unique` or `Aggregation`.
+    required: false
+    default: STARROCKS_DELETE_SIGN_UPSERT . to_string ()
+  - name: starrocks.stream_load.delete_sign.delete
+    field_type: String
+    comments: Specify the value that signifies the delete operation; defaults to `1`.  this option is available only when the `StarRocks` table model is `Unique` or `Aggregation`.
+    required: false
+    default: STARROCKS_DELETE_SIGN_DELETE . to_string ()
   - name: r#type
     field_type: String
     required: true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds 3 minor improvements for StarRocks sink

#### 1. Support upserting `Aggregation` and `Unique` models
We currently only support upserting the `Primary Key` model, which is sufficient in most cases. However, the `Primary Key` model does not allow the table's primary key to exceed 128 bytes, which may be too restrictive in some cases. For example, in our environment, there are 10+ tables whose primary key exceed 128 bytes, a typical case is a MV's primary key is composed of 4 uuid strings, resulting in a primary key size of 144 bytes. As a result, we cannot sink these tables into StarRocks within RisingWave. The adhoc workaround is we sink these tables to kafka, and then we use flink to consume these topics and sink them to StarRocks.

Below is a demonstration of a **unique model** table `demo_unique`, with its primary key consisting of (pk1, pk2, pk3, pk4). The op field signifies the record's current operation, for example, `u` stands for `upsert` and `d` stands for `delete`.
| pk1                                       | pk2                                       | pk3                                       | pk4                                       | op |
|-------------------------------------------|-------------------------------------------|-------------------------------------------|-------------------------------------------|----|
| 7e672c80-6d31-45d4-84ce-5353f332d6e8      | 87202e74-b020-4676-b13f-2d87e06a114e      | 852045ec-3605-4adc-86a5-8f20a0d2e155      | 706cd645-ad43-42a6-9bae-5490a64472d7      | u  |
| 9c5b79d6-49b6-4f10-ac5c-1f359c1a4be4      | 28556f11-7f26-49b2-a095-5b82326aef8c      | b2aedcca-122e-4b57-a1f9-bdea5b60d642      | a1272ee7-5a90-4d8d-8b7c-c61fe4ec4f9c      | d  |

Under this PR, we can sink this MV to StarRocks directly, with no additional workaround needed:
```sql
CREATE SINK demo_unique_sink
FROM demo_upsert WITH (
    connector = 'starrocks',
    type = 'upsert',
    starrocks.host = 'starrocks-fe',
    starrocks.mysqlport = '9030',
    starrocks.httpport = '8030',
    starrocks.user = 'root',
    starrocks.password = '123456',
    starrocks.database = 'demo',
    starrocks.table = 'demo_unique',
    primary_key='pk1,pk2,pk3,pk4',
    starrocks.stream_load.delete_sign.field='op',
    starrocks.stream_load.delete_sign.upsert='u',
    starrocks.stream_load.delete_sign.delete='d',
    commit_checkpoint_interval='10'
);
```

Notes
* The reason we allow users to specify the `delete_sign_field` is because:
  1. The default value of `starrocks.stream_load.delete_sign.field` is `__op` which is the reserved keyword in StarRocks, and StarRocks by default prohibits creating a table with an `__op` field.
  2. Users who want to migrate their ETL workflow to RisingWave may have their specific `delete_sign` field name or values. As mentioned above, the `delete_sign_field` of table `demo_unique` is `op`, where the value `u` stands for `upsert` and `d` stands for `delete`. With this ability, users can easily migrate their jobs to RisingWave without changing their queries to adapt to RisingWave.
* Options related to `starrocks.stream_load.delete_sign.*` are only allowed when the StarRocks table's model is `Unique` or `Aggregation` in upsert mode.

#### 2. Allow `starrocks.host` to be an FE follower
This may be a bug fix because the current implementation assumes that `stream load` requests made to `starrocks.host` will in turn redirect to a BE. This assumption is only makes sense if the address denoted by `starrocks.host` is an FE leader. However, if the address of `starrocks.host` is an FE follower, the follower will redirect the request to the FE leader not a BE. In fact, the FE leader can change over time. For example, when the StarRocks cluster restarts, the previous leader may become a follower. we found this problem recently because after we upgraded the StarRocks cluster, and the StarRocks sink kept failing due to the FE leader change. Please see the comments of `send_stream_load_request` for more details.

#### 3. quoting the column names in `stream load` http request header
If the field name of the StarRocks table is a keyword, for example:
```sql
create table demo(
    `id` bigint not null,
    `order` int not null
)
unique key(`id`)
distributed by hash(`id`);
```
The `order` field is a keyword, if we send `stream load` request without quoting it, the StarRocks will respond with an error.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
