### PR TITLE
Update Docker README to use Scarf endpoints

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 ## Published images
 
-- `latest` on GHCR (latest nightly build): `ghcr.io/risingwavelabs/risingwave:latest`
+- `latest` on GHCR (latest nightly build): `docker.risingwave.com/risingwavelabs/risingwave:latest`
 - `latest` on Docker Hub (latest release): `risingwavelabs/risingwave:latest`
 - Other tags available on both GHCR and Docker Hub:
   - `nightly-yyyyMMdd`, e.g., `nightly-20230108`
@@ -34,7 +34,7 @@ To ensure you are using the latest version of RisingWave image,
 
 ```
 # Ensure risingwave image is of latest version
-docker pull ghcr.io/risingwavelabs/risingwave:latest
+docker pull docker.risingwave.com/risingwavelabs/risingwave:latest
 ```
 
 ### playground
@@ -42,7 +42,7 @@ To start a RisingWave playground, run
 
 ```
 # Start playground
-docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:latest playground
+docker run -it --pull=always -p 4566:4566 -p 5691:5691 docker.risingwave.com/risingwavelabs/risingwave:latest playground
 ```
 
 ### standalone minio


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

This PR updates the RisingWave Docker README instructions to fetch the RisingWave container image via a Scarf endpoint. This allows RisingWave maintainers to collect basic de-identified download and adoption metrics.  It does not affect where the containers are being hosted, as Scarf is only redirecting traffic back to GHCR. 

This change was suggested by the RisingWave product team in direct discussions. To test this, download RisingWave using the new endpoint (e.g. docker pull docker.risingwave.com/risingwavelabs/risingwave) and verify that the risingwavelabs/risingwave container downloads without issue.

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation


## Release note
