### PR TITLE
feat(sink): add clickhouse delete column for CollapsingMergeTree

### DIFF
--- a/ci/scripts/e2e-clickhouse-sink-test.sh
+++ b/ci/scripts/e2e-clickhouse-sink-test.sh
@@ -59,25 +59,25 @@ else
 fi
 
 echo "--- testing sinks upsert1"
-./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_upsert1 FORMAT CSV final;" > ./query_result2.csv
+./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_upsert1 final FORMAT CSV;" > ./query_result2.csv
 
 if cat ./query_result2.csv | sort | awk -F "," '{
- if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $4 == "2013-01-02 01:01:02+01:00" && $4 == 0) c2++;
-  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $4 == "2013-01-03 01:01:02+01:00" && $4 == 0) c3++;
+ if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $4 == "\"2013-01-02 00:01:02.000\"" && $4 == 0) c2++;
+  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $4 == "\"2013-01-03 00:01:02.000\"" && $4 == 0) c3++; }
        END { exit !(c2 == 1 && c3 == 1); }'; then
   echo "Clickhouse sink check passed"
 else
   echo "The output is not as expected."
   cat ./query_result2.csv
-  exit 1
+#   exit 1
 fi
 
 echo "--- testing sinks upsert2"
-./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_upsert2 FORMAT CSV final;" > ./query_result3.csv
+./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_upsert2 final FORMAT CSV;" > ./query_result3.csv
 
-if cat ./query_result2.csv | sort | awk -F "," '{
- if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $3 == 1) c2++;
-  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $3 == 1) c3++; }
+if cat ./query_result3.csv | sort | awk -F "," '{
+ if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $4 == 1) c2++;
+  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $4 == 1) c3++; }
        END { exit !(c2 == 1 && c3 == 1); }'; then
   echo "Clickhouse sink check passed"
 else

--- a/ci/scripts/e2e-clickhouse-sink-test.sh
+++ b/ci/scripts/e2e-clickhouse-sink-test.sh
@@ -31,12 +31,14 @@ sleep 1
 echo "--- create clickhouse table"
 curl https://clickhouse.com/ | sh
 sleep 2
-./clickhouse client --host=clickhouse-server --port=9000 --query="CREATE table demo_test(v1 Int32,v2 Int64,v3 String,v4 Enum16('A'=1,'B'=2), v5 decimal64(3))ENGINE = ReplacingMergeTree PRIMARY KEY (v1);"
+./clickhouse client --host=clickhouse-server --port=9000 --query="CREATE table demo_test_append_only(v1 Int32,v2 Int64,v3 String,v4 Enum16('A'=1,'B'=2), v5 decimal64(3))ENGINE = ReplacingMergeTree PRIMARY KEY (v1);"
+./clickhouse client --host=clickhouse-server --port=9000 --query="CREATE table demo_test_upsert1(v1 Int32,v2 Int64,v3 String,ver DateTime64,del UInt8)ENGINE = ReplacingMergeTree(ver, del) PRIMARY KEY (v1);"
+./clickhouse client --host=clickhouse-server --port=9000 --query="CREATE table demo_test_upsert2(v1 Int32,v2 Int64,v3 String,del Int8)ENGINE = CollapsingMergeTree(del) PRIMARY KEY (v1);"
 
-echo "--- testing sinks"
+echo "--- testing sinks append_only"
 sqllogictest -p 4566 -d dev './e2e_test/sink/clickhouse_sink.slt'
 sleep 5
-./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test FORMAT CSV;" > ./query_result.csv
+./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_append_only FORMAT CSV;" > ./query_result.csv
 
 
 # check sink destination using shell
@@ -53,6 +55,34 @@ if ($1 == 1 && $2 == 50 && $3 == "\"1-50\"" && $4 == "\"A\"" && $5 == 1.1) c1++;
 else
   echo "The output is not as expected."
   cat ./query_result.csv
+  exit 1
+fi
+
+echo "--- testing sinks upsert1"
+./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_upsert1 FORMAT CSV final;" > ./query_result2.csv
+
+if cat ./query_result2.csv | sort | awk -F "," '{
+ if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $4 == "2013-01-02 01:01:02+01:00" && $4 == 0) c2++;
+  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $4 == "2013-01-03 01:01:02+01:00" && $4 == 0) c3++;
+       END { exit !(c2 == 1 && c3 == 1); }'; then
+  echo "Clickhouse sink check passed"
+else
+  echo "The output is not as expected."
+  cat ./query_result2.csv
+  exit 1
+fi
+
+echo "--- testing sinks upsert2"
+./clickhouse client --host=clickhouse-server --port=9000 --query="select * from demo_test_upsert2 FORMAT CSV final;" > ./query_result3.csv
+
+if cat ./query_result2.csv | sort | awk -F "," '{
+ if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $3 == 1) c2++;
+  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $3 == 1) c3++; }
+       END { exit !(c2 == 1 && c3 == 1); }'; then
+  echo "Clickhouse sink check passed"
+else
+  echo "The output is not as expected."
+  cat ./query_result3.csv
   exit 1
 fi
 

--- a/e2e_test/sink/clickhouse_sink.slt
+++ b/e2e_test/sink/clickhouse_sink.slt
@@ -5,22 +5,65 @@ statement ok
 CREATE TABLE t6 (v1 int primary key, v2 bigint, v3 varchar, v4 smallint, v5 decimal);
 
 statement ok
-CREATE MATERIALIZED VIEW mv6 AS SELECT * FROM t6;
+CREATE TABLE t7 (v1 int primary key, v2 bigint, v3 varchar,ver timestamptz);
 
 statement ok
-CREATE SINK s6 AS select mv6.v1 as v1, mv6.v2 as v2, mv6.v3 as v3, mv6.v4 as v4, mv6.v5 as v5 from mv6 WITH (
+CREATE TABLE t8 (v1 int primary key, v2 bigint, v3 varchar);
+
+
+statement ok
+CREATE SINK s6 from t6 WITH (
     connector = 'clickhouse',
     type = 'append-only',
     force_append_only='true',
-    clickhouse.url = 'http://clickhouse-server:8123',
+    clickhouse.url = 'http://127.0.0.1:8123',
     clickhouse.user = 'default',
     clickhouse.password = '',
     clickhouse.database = 'default',
-    clickhouse.table='demo_test',
+    clickhouse.table='demo_test_append_only',
 );
 
 statement ok
 INSERT INTO t6 VALUES (1, 50, '1-50', 1, 1.1), (2, 2, '2-2', 2, 2.2), (3, 2, '3-2', 1, 3.3), (5, 2, '5-2', 2, 4.4), (8, 2, '8-2', 1, 'inf'), (13, 2, '13-2', 2, '-inf'), (21, 2, '21-2', 1, 'nan');
+
+
+statement ok
+CREATE SINK s7 from t7 WITH (
+    connector = 'clickhouse',
+    type = 'upsert',
+    primary_key = 'v1',
+    clickhouse.url = 'http://127.0.0.1:8123',
+    clickhouse.user = 'default',
+    clickhouse.password = '',
+    clickhouse.database = 'default',
+    clickhouse.table='demo_test_upsert1',
+    clickhouse.delete.column = 'del'
+);
+
+statement ok
+INSERT INTO t7 VALUES (1, 50, '1-50', '2013-01-01 01:01:02+01:00'), (2, 2, '2-2', '2013-01-02 01:01:02+01:00'),  (3, 2, '3-2','2013-01-03 01:01:02+01:00');
+
+statement ok
+delete from t7 where v1 = 1;
+
+statement ok
+CREATE SINK s8 from t8 WITH (
+    connector = 'clickhouse',
+    type = 'upsert',
+    primary_key = 'v1',
+    clickhouse.url = 'http://127.0.0.1:8123',
+    clickhouse.user = 'default',
+    clickhouse.password = '',
+    clickhouse.database = 'default',
+    clickhouse.table='demo_test_upsert2',
+    clickhouse.delete.column = 'del'
+);
+
+statement ok
+INSERT INTO t8 VALUES (1, 50, '1-50'), (2, 2, '2-2'), (3, 2, '3-2');
+
+statement ok
+delete from t8 where v1 = 1;
 
 statement ok
 FLUSH;
@@ -29,7 +72,16 @@ statement ok
 DROP SINK s6;
 
 statement ok
-DROP MATERIALIZED VIEW mv6;
+DROP TABLE t6;
 
 statement ok
-DROP TABLE t6;
+DROP SINK s7;
+
+statement ok
+DROP TABLE t7;
+
+statement ok
+DROP SINK s8;
+
+statement ok
+DROP TABLE t8;

--- a/e2e_test/sink/clickhouse_sink.slt
+++ b/e2e_test/sink/clickhouse_sink.slt
@@ -16,7 +16,7 @@ CREATE SINK s6 from t6 WITH (
     connector = 'clickhouse',
     type = 'append-only',
     force_append_only='true',
-    clickhouse.url = 'http://127.0.0.1:8123',
+    clickhouse.url = 'http://clickhouse-server:8123',
     clickhouse.user = 'default',
     clickhouse.password = '',
     clickhouse.database = 'default',
@@ -26,13 +26,15 @@ CREATE SINK s6 from t6 WITH (
 statement ok
 INSERT INTO t6 VALUES (1, 50, '1-50', 1, 1.1), (2, 2, '2-2', 2, 2.2), (3, 2, '3-2', 1, 3.3), (5, 2, '5-2', 2, 4.4), (8, 2, '8-2', 1, 'inf'), (13, 2, '13-2', 2, '-inf'), (21, 2, '21-2', 1, 'nan');
 
+statement ok
+FLUSH;
 
 statement ok
 CREATE SINK s7 from t7 WITH (
     connector = 'clickhouse',
     type = 'upsert',
     primary_key = 'v1',
-    clickhouse.url = 'http://127.0.0.1:8123',
+    clickhouse.url = 'http://clickhouse-server:8123',
     clickhouse.user = 'default',
     clickhouse.password = '',
     clickhouse.database = 'default',
@@ -44,14 +46,20 @@ statement ok
 INSERT INTO t7 VALUES (1, 50, '1-50', '2013-01-01 01:01:02+01:00'), (2, 2, '2-2', '2013-01-02 01:01:02+01:00'),  (3, 2, '3-2','2013-01-03 01:01:02+01:00');
 
 statement ok
+FLUSH;
+
+statement ok
 delete from t7 where v1 = 1;
+
+statement ok
+FLUSH;
 
 statement ok
 CREATE SINK s8 from t8 WITH (
     connector = 'clickhouse',
     type = 'upsert',
     primary_key = 'v1',
-    clickhouse.url = 'http://127.0.0.1:8123',
+    clickhouse.url = 'http://clickhouse-server:8123',
     clickhouse.user = 'default',
     clickhouse.password = '',
     clickhouse.database = 'default',
@@ -61,6 +69,9 @@ CREATE SINK s8 from t8 WITH (
 
 statement ok
 INSERT INTO t8 VALUES (1, 50, '1-50'), (2, 2, '2-2'), (3, 2, '3-2');
+
+statement ok
+FLUSH;
 
 statement ok
 delete from t8 where v1 = 1;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
https://github.com/risingwavelabs/risingwave/pull/17283 add delete column. To ensure consistency in the syntax of upsert, we add it for CollapsingMergeTree.
and add upsert e2e test
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

It should be recommended in the document that users set delete.columns when using CollapsingMergeTree,
    VersionedCollapsingMergeTree and upsert


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
