### PR TITLE
feat(frontend): add stateless two-phase `ApproxPercentile`

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -436,6 +436,8 @@ message AggCall {
     LAST_VALUE = 25;
     GROUPING = 26;
     INTERNAL_LAST_SEEN_VALUE = 27;
+    APPROX_PERCENTILE = 28;
+
     // user defined aggregate function
     USER_DEFINED = 100;
     // wraps a scalar function that takes a list as input as an aggregate function.

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -47,6 +47,15 @@ impl Field {
             name: self.name.to_string(),
         }
     }
+
+    pub fn new(name: impl Into<String>, data_type: DataType) -> Self {
+        Self {
+            data_type,
+            name: name.into(),
+            sub_fields: vec![],
+            type_name: String::new(),
+        }
+    }
 }
 
 impl From<&ColumnDesc> for Field {

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -47,15 +47,6 @@ impl Field {
             name: self.name.to_string(),
         }
     }
-
-    pub fn new(name: impl Into<String>, data_type: DataType) -> Self {
-        Self {
-            data_type,
-            name: name.into(),
-            sub_fields: vec![],
-            type_name: String::new(),
-        }
-    }
 }
 
 impl From<&ColumnDesc> for Field {

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -446,11 +446,13 @@ pub mod agg_kinds {
     macro_rules! ordered_set {
         () => {
             AggKind::Builtin(
-                PbAggKind::PercentileCont | PbAggKind::PercentileDisc | PbAggKind::Mode,
+                PbAggKind::PercentileCont | PbAggKind::PercentileDisc | PbAggKind::Mode | PbAggKind::ApproxPercentile
             )
         };
     }
     pub use ordered_set;
+
+    use crate::aggregate::{AggKind, PbAggKind};
 }
 
 impl AggKind {

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -339,6 +339,7 @@ pub mod agg_kinds {
                 | PbAggKind::Count
                 | PbAggKind::Avg
                 | PbAggKind::ApproxCountDistinct
+                | PbAggKind::ApproxPercentile
                 | PbAggKind::VarPop
                 | PbAggKind::VarSamp
                 | PbAggKind::StddevPop

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -314,6 +314,9 @@ pub mod agg_kinds {
                     | PbAggKind::VarPop
                     | PbAggKind::VarSamp
                     | PbAggKind::Grouping,
+                    // ApproxPercentile always uses custom agg executors,
+                    // rather than an aggregation operator
+                    | PbAggKind::ApproxPercentile
             )
         };
     }

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -313,7 +313,7 @@ pub mod agg_kinds {
                     | PbAggKind::StddevSamp
                     | PbAggKind::VarPop
                     | PbAggKind::VarSamp
-                    | PbAggKind::Grouping,
+                    | PbAggKind::Grouping
                     // ApproxPercentile always uses custom agg executors,
                     // rather than an aggregation operator
                     | PbAggKind::ApproxPercentile
@@ -446,13 +446,14 @@ pub mod agg_kinds {
     macro_rules! ordered_set {
         () => {
             AggKind::Builtin(
-                PbAggKind::PercentileCont | PbAggKind::PercentileDisc | PbAggKind::Mode | PbAggKind::ApproxPercentile
+                PbAggKind::PercentileCont
+                    | PbAggKind::PercentileDisc
+                    | PbAggKind::Mode
+                    | PbAggKind::ApproxPercentile,
             )
         };
     }
     pub use ordered_set;
-
-    use crate::aggregate::{AggKind, PbAggKind};
 }
 
 impl AggKind {

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -339,7 +339,6 @@ pub mod agg_kinds {
                 | PbAggKind::Count
                 | PbAggKind::Avg
                 | PbAggKind::ApproxCountDistinct
-                | PbAggKind::ApproxPercentile
                 | PbAggKind::VarPop
                 | PbAggKind::VarSamp
                 | PbAggKind::StddevPop

--- a/src/expr/impl/src/aggregate/approx_percentile.rs
+++ b/src/expr/impl/src/aggregate/approx_percentile.rs
@@ -1,0 +1,139 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+
+use risingwave_common::array::*;
+use risingwave_common::row::Row;
+use risingwave_common::types::*;
+use risingwave_common_estimate_size::EstimateSize;
+use risingwave_expr::aggregate::{AggCall, AggStateDyn, AggregateFunction, AggregateState};
+use risingwave_expr::{build_aggregate, Result};
+
+/// Computes the approx percentile, a value corresponding to the specified fraction within the
+/// ordered set of aggregated argument values. This will interpolate between adjacent input items if
+/// needed.
+///
+/// ```slt
+/// statement ok
+/// create table t(x int, y bigint, z real, w double, v varchar);
+///
+/// statement ok
+/// insert into t values(1,10,100,1000,'10000'),(2,20,200,2000,'20000'),(3,30,300,3000,'30000');
+///
+/// query R
+/// select percentile_cont(0.45) within group (order by x desc) from t;
+/// ----
+/// 2.1
+///
+/// query R
+/// select percentile_cont(0.45) within group (order by y desc) from t;
+/// ----
+/// 21
+///
+/// query R
+/// select percentile_cont(0.45) within group (order by z desc) from t;
+/// ----
+/// 210
+///
+/// query R
+/// select percentile_cont(0.45) within group (order by w desc) from t;
+/// ----
+/// 2100
+///
+/// query R
+/// select percentile_cont(NULL) within group (order by w desc) from t;
+/// ----
+/// NULL
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[build_aggregate("approx_percentile(float8) -> float8")]
+fn build(agg: &AggCall) -> Result<Box<dyn AggregateFunction>> {
+    let fraction = agg.direct_args[0]
+        .literal()
+        .map(|x| (*x.as_float64()).into());
+    Ok(Box::new(ApproxPercentile { fraction }))
+}
+
+pub struct ApproxPercentile {
+    fraction: Option<f64>,
+}
+
+#[derive(Debug, Default, EstimateSize)]
+struct State(Vec<f64>);
+
+impl AggStateDyn for State {}
+
+impl ApproxPercentile {
+    fn add_datum(&self, state: &mut State, datum_ref: DatumRef<'_>) {
+        if let Some(datum) = datum_ref.to_owned_datum() {
+            state.0.push((*datum.as_float64()).into());
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AggregateFunction for ApproxPercentile {
+    fn return_type(&self) -> DataType {
+        DataType::Float64
+    }
+
+    fn create_state(&self) -> Result<AggregateState> {
+        Ok(AggregateState::Any(Box::<State>::default()))
+    }
+
+    async fn update(&self, state: &mut AggregateState, input: &StreamChunk) -> Result<()> {
+        let state = state.downcast_mut();
+        for (_, row) in input.rows() {
+            self.add_datum(state, row.datum_at(0));
+        }
+        Ok(())
+    }
+
+    async fn update_range(
+        &self,
+        state: &mut AggregateState,
+        input: &StreamChunk,
+        range: Range<usize>,
+    ) -> Result<()> {
+        let state = state.downcast_mut();
+        for (_, row) in input.rows_in(range) {
+            self.add_datum(state, row.datum_at(0));
+        }
+        Ok(())
+    }
+
+    async fn get_result(&self, state: &AggregateState) -> Result<Datum> {
+        let state = &state.downcast_ref::<State>().0;
+        Ok(
+            if let Some(fraction) = self.fraction
+                && !state.is_empty()
+            {
+                let rn = fraction * (state.len() - 1) as f64;
+                let crn = f64::ceil(rn);
+                let frn = f64::floor(rn);
+                let result = if crn == frn {
+                    state[crn as usize]
+                } else {
+                    (crn - rn) * state[frn as usize] + (rn - frn) * state[crn as usize]
+                };
+                Some(result.into())
+            } else {
+                None
+            },
+        )
+    }
+}

--- a/src/expr/impl/src/aggregate/approx_percentile.rs
+++ b/src/expr/impl/src/aggregate/approx_percentile.rs
@@ -21,45 +21,6 @@ use risingwave_common_estimate_size::EstimateSize;
 use risingwave_expr::aggregate::{AggCall, AggStateDyn, AggregateFunction, AggregateState};
 use risingwave_expr::{build_aggregate, Result};
 
-/// Computes the approx percentile, a value corresponding to the specified fraction within the
-/// ordered set of aggregated argument values. This will interpolate between adjacent input items if
-/// needed.
-///
-/// ```slt
-/// statement ok
-/// create table t(x int, y bigint, z real, w double, v varchar);
-///
-/// statement ok
-/// insert into t values(1,10,100,1000,'10000'),(2,20,200,2000,'20000'),(3,30,300,3000,'30000');
-///
-/// query R
-/// select percentile_cont(0.45) within group (order by x desc) from t;
-/// ----
-/// 2.1
-///
-/// query R
-/// select percentile_cont(0.45) within group (order by y desc) from t;
-/// ----
-/// 21
-///
-/// query R
-/// select percentile_cont(0.45) within group (order by z desc) from t;
-/// ----
-/// 210
-///
-/// query R
-/// select percentile_cont(0.45) within group (order by w desc) from t;
-/// ----
-/// 2100
-///
-/// query R
-/// select percentile_cont(NULL) within group (order by w desc) from t;
-/// ----
-/// NULL
-///
-/// statement ok
-/// drop table t;
-/// ```
 #[build_aggregate("approx_percentile(float8) -> float8")]
 fn build(agg: &AggCall) -> Result<Box<dyn AggregateFunction>> {
     let fraction = agg.direct_args[0]

--- a/src/expr/impl/src/aggregate/mod.rs
+++ b/src/expr/impl/src/aggregate/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod approx_count_distinct;
+mod approx_percentile;
 mod array_agg;
 mod bit_and;
 mod bit_or;

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1028,3 +1028,24 @@
   expected_outputs:
     - logical_plan
     - stream_plan
+- name: test simple approx_percentile with duplicate approx_percentile
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as x, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as y from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+- name: test simple approx_percentile with different approx_percentile
+  sql: |
+    CREATE TABLE t (v1 int, v2 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as x, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v2) as y from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+- name: test simple approx_percentile with different approx_percentile interleaved with stateless simple aggs
+  sql: |
+    CREATE TABLE t (v1 int, v2 int);
+    SELECT sum(v1) as s1, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as x, count(*), sum(v2) as s2, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v2) as y from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1049,3 +1049,10 @@
   expected_outputs:
     - logical_plan
     - stream_plan
+- name: test simple approx_percentile with descending order
+  sql: |
+    CREATE TABLE t (v1 int, v2 int);
+    SELECT sum(v1) as s1, approx_percentile(0.2, 0.01) WITHIN GROUP (order by v1 desc) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1000,9 +1000,24 @@
   expected_outputs:
     - batch_plan
     - stream_plan
-- sql: |
+- name: test simple approx_percentile alone
+  sql: |
     CREATE TABLE t (v1 int);
     SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+- name: test simple approx_percentile with other simple aggs
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+- name: test simple approx_percentile with other simple aggs (sum, count)
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1), count(v1) from t;
   expected_outputs:
     - logical_plan
     - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1002,6 +1002,6 @@
     - stream_plan
 - sql: |
     CREATE TABLE t (v1 int);
-    SELECT approx_percentile(v1, 0.5, 0.01) from t;
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) from t;
   expected_outputs:
-    - stream_plan
+    - logical_plan

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1000,3 +1000,8 @@
   expected_outputs:
     - batch_plan
     - stream_plan
+- sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(v1, 0.5, 0.01) from t;
+  expected_outputs:
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1005,3 +1005,4 @@
     SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) from t;
   expected_outputs:
     - logical_plan
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -1000,6 +1000,13 @@
   expected_outputs:
     - batch_plan
     - stream_plan
+- name: test duplicate agg
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT sum(v1) as x, count(v1) as y, sum(v1) as z, count(v1) as w from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
 - name: test simple approx_percentile alone
   sql: |
     CREATE TABLE t (v1 int);
@@ -1017,7 +1024,7 @@
 - name: test simple approx_percentile with other simple aggs (sum, count)
   sql: |
     CREATE TABLE t (v1 int);
-    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1), count(v1) from t;
+    SELECT sum(v1) as s1, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1) as s2, count(v1) from t;
   expected_outputs:
     - logical_plan
     - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1891,7 +1891,7 @@
   stream_plan: |-
     StreamMaterialize { columns: [approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamGlobalApproxPercentile
-      └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
         └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
           └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: test simple approx_percentile with other simple aggs
@@ -1907,7 +1907,7 @@
     StreamMaterialize { columns: [approx_percentile, sum], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [approx_percentile:Float64, sum(sum(t.v1)):Int64] }
       ├─StreamGlobalApproxPercentile
-      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │   └─StreamShare { id: 2 }
       │     └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
       │       └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -1931,7 +1931,7 @@
     └─StreamProject { exprs: [sum(sum(t.v1)), approx_percentile, sum(sum(t.v1)), sum0(count(t.v1))] }
       └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count(t.v1)):Int64] }
         ├─StreamGlobalApproxPercentile
-        │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+        │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
         │   └─StreamShare { id: 2 }
         │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
         │       └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -1954,7 +1954,7 @@
     StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamProject { exprs: [approx_percentile, approx_percentile] }
       └─StreamGlobalApproxPercentile
-        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
           └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: test simple approx_percentile with different approx_percentile
@@ -1970,11 +1970,11 @@
     StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
       ├─StreamGlobalApproxPercentile
-      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │   └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
       │     └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamGlobalApproxPercentile
-        └─StreamLocalApproxPercentile { percentile_col: $expr4, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+        └─StreamLocalApproxPercentile { percentile_col: $expr4, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
           └─StreamProject { exprs: [t.v1::Float64 as $expr3, t.v2::Float64 as $expr4, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: test simple approx_percentile with different approx_percentile interleaved with stateless simple aggs
@@ -1991,12 +1991,12 @@
     └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count):Int64, sum(sum(t.v2)):Int64, approx_percentile:Float64] }
       ├─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
       │ ├─StreamGlobalApproxPercentile
-      │ │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │ │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │ │   └─StreamShare { id: 2 }
       │ │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
       │ │       └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
       │ └─StreamGlobalApproxPercentile
-      │   └─StreamLocalApproxPercentile { percentile_col: $expr2, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │   └─StreamLocalApproxPercentile { percentile_col: $expr2, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │     └─StreamShare { id: 2 }
       │       └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
       │         └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -2006,3 +2006,26 @@
             └─StreamShare { id: 2 }
               └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
                 └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test simple approx_percentile with descending order
+  sql: |
+    CREATE TABLE t (v1 int, v2 int);
+    SELECT sum(v1) as s1, approx_percentile(0.2, 0.01) WITHIN GROUP (order by v1 desc) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [sum(t.v1), approx_percentile($expr1)] }
+    └─LogicalAgg { aggs: [sum(t.v1), approx_percentile($expr1)] }
+      └─LogicalProject { exprs: [t.v1, t.v1::Float64 as $expr1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [s1, approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64] }
+      ├─StreamGlobalApproxPercentile
+      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.8:Float64, relative_error: 0.01:Float64 }
+      │   └─StreamShare { id: 2 }
+      │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
+      │       └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamSimpleAgg { aggs: [sum(sum(t.v1)), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessSimpleAgg { aggs: [sum(t.v1)] }
+            └─StreamShare { id: 2 }
+              └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
+                └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1863,7 +1863,8 @@
             └─StreamHashAgg { group_key: [t.a, t.b], aggs: [sum(t.c), sum(t.d), count(t.d), max(t.e), count] }
               └─StreamExchange { dist: HashShard(t.a, t.b) }
                 └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t.d, t.e, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-- sql: |
+- name: test simple approx_percentile alone
+  sql: |
     CREATE TABLE t (v1 int);
     SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) from t;
   logical_plan: |-
@@ -1873,8 +1874,53 @@
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [approx_percentile], stream_key: [approx_percentile], pk_columns: [approx_percentile], pk_conflict: NoCheck }
-    └─StreamExchange { dist: HashShard(approx_percentile) }
+    └─StreamGlobalApproxPercentile
+      └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+        └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
+          └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test simple approx_percentile with other simple aggs
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [approx_percentile($expr1), sum(t.v1)] }
+    └─LogicalAgg { aggs: [approx_percentile($expr1), sum(t.v1)] }
+      └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [approx_percentile, sum], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamKeyedMerge { output: [approx_percentile($expr10011):Float64, sum(t.v1):Int64] }
+      ├─StreamSimpleAgg { aggs: [sum(sum(t.v1)), count] }
+      │ └─StreamExchange { dist: Single }
+      │   └─StreamStatelessSimpleAgg { aggs: [sum(t.v1)] }
+      │     └─StreamShare { id: 2 }
+      │       └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+      │         └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamGlobalApproxPercentile
         └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
-          └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
-            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+          └─StreamShare { id: 2 }
+            └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+              └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test simple approx_percentile with other simple aggs (sum, count)
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1), count(v1) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [approx_percentile($expr1), sum(t.v1), count(t.v1)] }
+    └─LogicalAgg { aggs: [approx_percentile($expr1), sum(t.v1), count(t.v1)] }
+      └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [approx_percentile, sum, count], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamKeyedMerge { output: [approx_percentile($expr10011):Float64, sum(t.v1):Int64, count(t.v1):Int64] }
+      ├─StreamSimpleAgg { aggs: [sum(sum(t.v1)), sum0(count(t.v1)), count] }
+      │ └─StreamExchange { dist: Single }
+      │   └─StreamStatelessSimpleAgg { aggs: [sum(t.v1), count(t.v1)] }
+      │     └─StreamShare { id: 2 }
+      │       └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+      │         └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamGlobalApproxPercentile
+        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+          └─StreamShare { id: 2 }
+            └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+              └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1867,14 +1867,14 @@
     CREATE TABLE t (v1 int);
     SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) from t;
   logical_plan: |-
-    LogicalProject { exprs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
-    └─LogicalAgg { aggs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
-      └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
+    LogicalProject { exprs: [approx_percentile($expr1)] }
+    └─LogicalAgg { aggs: [approx_percentile($expr1)] }
+      └─LogicalProject { exprs: [t.v1::Float64 as $expr1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
-      └─StreamSimpleAgg { aggs: [approx_percentile($expr1 order_by(t.v1 ASC)), count] }
-        └─StreamExchange { dist: Single }
-          └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+    StreamMaterialize { columns: [approx_percentile], stream_key: [approx_percentile], pk_columns: [approx_percentile], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(approx_percentile) }
+      └─StreamGlobalApproxPercentile
+        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+          └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1889,7 +1889,7 @@
       └─LogicalProject { exprs: [t.v1::Float64 as $expr1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [approx_percentile], stream_key: [approx_percentile], pk_columns: [approx_percentile], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamGlobalApproxPercentile
       └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
         └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
@@ -1904,7 +1904,7 @@
       └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [approx_percentile, sum], stream_key: [approx_percentile], pk_columns: [approx_percentile], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [approx_percentile, sum], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [approx_percentile:Float64, sum(sum(t.v1)):Int64] }
       ├─StreamGlobalApproxPercentile
       │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
@@ -1927,7 +1927,7 @@
       └─LogicalProject { exprs: [t.v1, t.v1::Float64 as $expr1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [s1, approx_percentile, s2, count], stream_key: [s2], pk_columns: [s2], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [s1, approx_percentile, s2, count], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamProject { exprs: [sum(sum(t.v1)), approx_percentile, sum(sum(t.v1)), sum0(count(t.v1))] }
       └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count(t.v1)):Int64] }
         ├─StreamGlobalApproxPercentile

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1863,3 +1863,11 @@
             └─StreamHashAgg { group_key: [t.a, t.b], aggs: [sum(t.c), sum(t.d), count(t.d), max(t.e), count] }
               └─StreamExchange { dist: HashShard(t.a, t.b) }
                 └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t.d, t.e, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
+    └─LogicalAgg { aggs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
+      └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1941,3 +1941,68 @@
               └─StreamShare { id: 2 }
                 └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
                   └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test simple approx_percentile with duplicate approx_percentile
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as x, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as y from t;
+  logical_plan: |-
+    LogicalProject { exprs: [approx_percentile($expr1), approx_percentile($expr1)] }
+    └─LogicalAgg { aggs: [approx_percentile($expr1)] }
+      └─LogicalProject { exprs: [t.v1::Float64 as $expr1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [approx_percentile, approx_percentile] }
+      └─StreamGlobalApproxPercentile
+        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+          └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test simple approx_percentile with different approx_percentile
+  sql: |
+    CREATE TABLE t (v1 int, v2 int);
+    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as x, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v2) as y from t;
+  logical_plan: |-
+    LogicalProject { exprs: [approx_percentile($expr1), approx_percentile($expr2)] }
+    └─LogicalAgg { aggs: [approx_percentile($expr1), approx_percentile($expr2)] }
+      └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
+      ├─StreamGlobalApproxPercentile
+      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │   └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
+      │     └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamGlobalApproxPercentile
+        └─StreamLocalApproxPercentile { percentile_col: $expr4, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+          └─StreamProject { exprs: [t.v1::Float64 as $expr3, t.v2::Float64 as $expr4, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test simple approx_percentile with different approx_percentile interleaved with stateless simple aggs
+  sql: |
+    CREATE TABLE t (v1 int, v2 int);
+    SELECT sum(v1) as s1, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1) as x, count(*), sum(v2) as s2, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v2) as y from t;
+  logical_plan: |-
+    LogicalProject { exprs: [sum(t.v1), approx_percentile($expr1), count, sum(t.v2), approx_percentile($expr2)] }
+    └─LogicalAgg { aggs: [sum(t.v1), approx_percentile($expr1), count, sum(t.v2), approx_percentile($expr2)] }
+      └─LogicalProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [s1, x, count, s2, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count):Int64, sum(sum(t.v2)):Int64, approx_percentile:Float64] }
+      ├─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
+      │ ├─StreamGlobalApproxPercentile
+      │ │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │ │   └─StreamShare { id: 2 }
+      │ │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
+      │ │       └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      │ └─StreamGlobalApproxPercentile
+      │   └─StreamLocalApproxPercentile { percentile_col: $expr2, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │     └─StreamShare { id: 2 }
+      │       └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
+      │         └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamSimpleAgg { aggs: [sum(sum(t.v1)), sum0(count), sum(sum(t.v2)), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessSimpleAgg { aggs: [sum(t.v1), count, sum(t.v2)] }
+            └─StreamShare { id: 2 }
+              └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
+                └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1871,3 +1871,10 @@
     └─LogicalAgg { aggs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
       └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [approx_percentile($expr1 order_by(t.v1 ASC))] }
+      └─StreamSimpleAgg { aggs: [approx_percentile($expr1 order_by(t.v1 ASC)), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1890,7 +1890,7 @@
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
-    └─StreamGlobalApproxPercentile
+    └─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
         └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
           └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -1906,7 +1906,7 @@
   stream_plan: |-
     StreamMaterialize { columns: [approx_percentile, sum], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [approx_percentile:Float64, sum(sum(t.v1)):Int64] }
-      ├─StreamGlobalApproxPercentile
+      ├─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │   └─StreamShare { id: 2 }
       │     └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
@@ -1930,7 +1930,7 @@
     StreamMaterialize { columns: [s1, approx_percentile, s2, count], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamProject { exprs: [sum(sum(t.v1)), approx_percentile, sum(sum(t.v1)), sum0(count(t.v1))] }
       └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count(t.v1)):Int64] }
-        ├─StreamGlobalApproxPercentile
+        ├─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
         │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
         │   └─StreamShare { id: 2 }
         │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
@@ -1953,7 +1953,7 @@
   stream_plan: |-
     StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamProject { exprs: [approx_percentile, approx_percentile] }
-      └─StreamGlobalApproxPercentile
+      └─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
         └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
           └─StreamProject { exprs: [t.v1::Float64 as $expr1, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -1970,12 +1970,12 @@
     StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
       ├─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
-      │ ├─StreamGlobalApproxPercentile
+      │ ├─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │ │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │ │   └─StreamShare { id: 2 }
       │ │     └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
       │ │       └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-      │ └─StreamGlobalApproxPercentile
+      │ └─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │   └─StreamLocalApproxPercentile { percentile_col: $expr2, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │     └─StreamShare { id: 2 }
       │       └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
@@ -1999,12 +1999,12 @@
     StreamMaterialize { columns: [s1, x, count, s2, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count):Int64, sum(sum(t.v2)):Int64, approx_percentile:Float64] }
       ├─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
-      │ ├─StreamGlobalApproxPercentile
+      │ ├─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │ │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │ │   └─StreamShare { id: 2 }
       │ │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
       │ │       └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-      │ └─StreamGlobalApproxPercentile
+      │ └─StreamGlobalApproxPercentile { quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │   └─StreamLocalApproxPercentile { percentile_col: $expr2, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
       │     └─StreamShare { id: 2 }
       │       └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t.v2, t.v2::Float64 as $expr2, t._row_id] }
@@ -2027,7 +2027,7 @@
   stream_plan: |-
     StreamMaterialize { columns: [s1, approx_percentile], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64] }
-      ├─StreamGlobalApproxPercentile
+      ├─StreamGlobalApproxPercentile { quantile: 0.8:Float64, relative_error: 0.01:Float64 }
       │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.8:Float64, relative_error: 0.01:Float64 }
       │   └─StreamShare { id: 2 }
       │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1863,6 +1863,22 @@
             └─StreamHashAgg { group_key: [t.a, t.b], aggs: [sum(t.c), sum(t.d), count(t.d), max(t.e), count] }
               └─StreamExchange { dist: HashShard(t.a, t.b) }
                 └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t.d, t.e, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: test duplicate agg
+  sql: |
+    CREATE TABLE t (v1 int);
+    SELECT sum(v1) as x, count(v1) as y, sum(v1) as z, count(v1) as w from t;
+  logical_plan: |-
+    LogicalProject { exprs: [sum(t.v1), count(t.v1), sum(t.v1), count(t.v1)] }
+    └─LogicalAgg { aggs: [sum(t.v1), count(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, z, w], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [sum(sum(t.v1)), sum0(count(t.v1)), sum(sum(t.v1)), sum0(count(t.v1))] }
+      └─StreamSimpleAgg { aggs: [sum(sum(t.v1)), sum0(count(t.v1)), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessSimpleAgg { aggs: [sum(t.v1), count(t.v1)] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: test simple approx_percentile alone
   sql: |
     CREATE TABLE t (v1 int);
@@ -1888,39 +1904,40 @@
       └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [approx_percentile, sum], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
-    └─StreamKeyedMerge { output: [approx_percentile($expr10011):Float64, sum(t.v1):Int64] }
-      ├─StreamSimpleAgg { aggs: [sum(sum(t.v1)), count] }
-      │ └─StreamExchange { dist: Single }
-      │   └─StreamStatelessSimpleAgg { aggs: [sum(t.v1)] }
-      │     └─StreamShare { id: 2 }
-      │       └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
-      │         └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-      └─StreamGlobalApproxPercentile
-        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
-          └─StreamShare { id: 2 }
-            └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
-              └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+    StreamMaterialize { columns: [approx_percentile, sum], stream_key: [approx_percentile], pk_columns: [approx_percentile], pk_conflict: NoCheck }
+    └─StreamKeyedMerge { output: [approx_percentile:Float64, sum(sum(t.v1)):Int64] }
+      ├─StreamGlobalApproxPercentile
+      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+      │   └─StreamShare { id: 2 }
+      │     └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+      │       └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamSimpleAgg { aggs: [sum(sum(t.v1)), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessSimpleAgg { aggs: [sum(t.v1)] }
+            └─StreamShare { id: 2 }
+              └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
+                └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: test simple approx_percentile with other simple aggs (sum, count)
   sql: |
     CREATE TABLE t (v1 int);
-    SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1), count(v1) from t;
+    SELECT sum(v1) as s1, approx_percentile(0.5, 0.01) WITHIN GROUP (order by v1), sum(v1) as s2, count(v1) from t;
   logical_plan: |-
-    LogicalProject { exprs: [approx_percentile($expr1), sum(t.v1), count(t.v1)] }
-    └─LogicalAgg { aggs: [approx_percentile($expr1), sum(t.v1), count(t.v1)] }
-      └─LogicalProject { exprs: [t.v1::Float64 as $expr1, t.v1] }
+    LogicalProject { exprs: [sum(t.v1), approx_percentile($expr1), sum(t.v1), count(t.v1)] }
+    └─LogicalAgg { aggs: [sum(t.v1), approx_percentile($expr1), count(t.v1)] }
+      └─LogicalProject { exprs: [t.v1, t.v1::Float64 as $expr1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [approx_percentile, sum, count], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
-    └─StreamKeyedMerge { output: [approx_percentile($expr10011):Float64, sum(t.v1):Int64, count(t.v1):Int64] }
-      ├─StreamSimpleAgg { aggs: [sum(sum(t.v1)), sum0(count(t.v1)), count] }
-      │ └─StreamExchange { dist: Single }
-      │   └─StreamStatelessSimpleAgg { aggs: [sum(t.v1), count(t.v1)] }
-      │     └─StreamShare { id: 2 }
-      │       └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
-      │         └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-      └─StreamGlobalApproxPercentile
-        └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
-          └─StreamShare { id: 2 }
-            └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v1, t._row_id] }
-              └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+    StreamMaterialize { columns: [s1, approx_percentile, s2, count], stream_key: [s2], pk_columns: [s2], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [sum(sum(t.v1)), approx_percentile, sum(sum(t.v1)), sum0(count(t.v1))] }
+      └─StreamKeyedMerge { output: [sum(sum(t.v1)):Int64, approx_percentile:Float64, sum0(count(t.v1)):Int64] }
+        ├─StreamGlobalApproxPercentile
+        │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Decimal, relative_error: 0.01:Decimal }
+        │   └─StreamShare { id: 2 }
+        │     └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
+        │       └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+        └─StreamSimpleAgg { aggs: [sum(sum(t.v1)), sum0(count(t.v1)), count] }
+          └─StreamExchange { dist: Single }
+            └─StreamStatelessSimpleAgg { aggs: [sum(t.v1), count(t.v1)] }
+              └─StreamShare { id: 2 }
+                └─StreamProject { exprs: [t.v1, t.v1::Float64 as $expr1, t._row_id] }
+                  └─StreamTableScan { table: t, columns: [t.v1, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1969,14 +1969,23 @@
   stream_plan: |-
     StreamMaterialize { columns: [x, y], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
-      ├─StreamGlobalApproxPercentile
-      │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
-      │   └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
-      │     └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-      └─StreamGlobalApproxPercentile
-        └─StreamLocalApproxPercentile { percentile_col: $expr4, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
-          └─StreamProject { exprs: [t.v1::Float64 as $expr3, t.v2::Float64 as $expr4, t._row_id] }
-            └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      ├─StreamKeyedMerge { output: [approx_percentile:Float64, approx_percentile:Float64] }
+      │ ├─StreamGlobalApproxPercentile
+      │ │ └─StreamLocalApproxPercentile { percentile_col: $expr1, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
+      │ │   └─StreamShare { id: 2 }
+      │ │     └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
+      │ │       └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      │ └─StreamGlobalApproxPercentile
+      │   └─StreamLocalApproxPercentile { percentile_col: $expr2, quantile: 0.5:Float64, relative_error: 0.01:Float64 }
+      │     └─StreamShare { id: 2 }
+      │       └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
+      │         └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamSimpleAgg { aggs: [count] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessSimpleAgg { aggs: [] }
+            └─StreamShare { id: 2 }
+              └─StreamProject { exprs: [t.v1::Float64 as $expr1, t.v2::Float64 as $expr2, t._row_id] }
+                └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: test simple approx_percentile with different approx_percentile interleaved with stateless simple aggs
   sql: |
     CREATE TABLE t (v1 int, v2 int);

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -568,7 +568,11 @@ impl Binder {
         );
 
         if f.distinct {
-            if matches!(kind, AggKind::Builtin(PbAggKind::ApproxCountDistinct)) {
+            if matches!(
+                kind,
+                AggKind::Builtin(PbAggKind::ApproxCountDistinct)
+                | AggKind::Builtin(PbAggKind::ApproxPercentile)
+            ) {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
                     "DISTINCT is not allowed for approximate aggregation `{}`",
                     kind

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -535,7 +535,7 @@ impl Binder {
                         "direct arg in `{}` must between 0.0 and 1.0",
                         kind
                     ))
-                        .into());
+                    .into());
                 }
                 // note that the fraction can be NULL
                 *percentile = Literal::new(percentile_datum, DataType::Float64).into();
@@ -562,7 +562,7 @@ impl Binder {
                         "direct arg in `{}` must between 0.0 and 1.0",
                         kind
                     ))
-                        .into());
+                    .into());
                 }
                 // note that the fraction can be NULL
                 *relative_error = Literal::new(relative_error_datum, DataType::Float64).into();

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -515,7 +515,11 @@ impl Binder {
                 }
             }
             (AggKind::Builtin(PbAggKind::Mode), [], [_arg]) => {}
-            (AggKind::Builtin(PbAggKind::ApproxPercentile), [percentile, relative_error], [_percentile_col]) => {
+            (
+                AggKind::Builtin(PbAggKind::ApproxPercentile),
+                [percentile, relative_error],
+                [_percentile_col],
+            ) => {
                 Self::decimal_to_float64(percentile, &kind)?;
                 Self::decimal_to_float64(relative_error, &kind)?;
             }
@@ -579,7 +583,7 @@ impl Binder {
             if matches!(
                 kind,
                 AggKind::Builtin(PbAggKind::ApproxCountDistinct)
-                | AggKind::Builtin(PbAggKind::ApproxPercentile)
+                    | AggKind::Builtin(PbAggKind::ApproxPercentile)
             ) {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
                     "DISTINCT is not allowed for approximate aggregation `{}`",

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -511,6 +511,7 @@ impl Binder {
                 }
             }
             (AggKind::Builtin(PbAggKind::Mode), [], [_arg]) => {}
+            (AggKind::Builtin(PbAggKind::ApproxPercentile), [_arg, _arg2], [_arg3]) => {}
             _ => {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
                     "invalid direct args or within group argument for `{}` aggregation",

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -511,7 +511,62 @@ impl Binder {
                 }
             }
             (AggKind::Builtin(PbAggKind::Mode), [], [_arg]) => {}
-            (AggKind::Builtin(PbAggKind::ApproxPercentile), [_arg, _arg2], [_arg3]) => {}
+            (AggKind::Builtin(PbAggKind::ApproxPercentile), [percentile, relative_error], [_percentile_col]) => {
+                percentile
+                    .cast_implicit_mut(DataType::Float64)
+                    .map_err(|_e| {
+                        ErrorCode::InvalidInputSyntax(format!(
+                            "direct arg in `{}` must be castable to float64",
+                            kind
+                        ))
+                    })?;
+
+                let Some(Ok(percentile_datum)) = percentile.try_fold_const() else {
+                    bail_not_implemented!(
+                        issue = 14079,
+                        "variable as direct argument of ordered-set aggregate",
+                    )
+                };
+
+                if let Some(ref percentile_scalar) = percentile_datum
+                    && !(0.0..=1.0).contains(&percentile_scalar.as_float64().0)
+                {
+                    return Err(ErrorCode::InvalidInputSyntax(format!(
+                        "direct arg in `{}` must between 0.0 and 1.0",
+                        kind
+                    ))
+                        .into());
+                }
+                // note that the fraction can be NULL
+                *percentile = Literal::new(percentile_datum, DataType::Float64).into();
+
+                relative_error
+                    .cast_implicit_mut(DataType::Float64)
+                    .map_err(|_e| {
+                        ErrorCode::InvalidInputSyntax(format!(
+                            "direct arg in `{}` must be castable to float64",
+                            kind
+                        ))
+                    })?;
+                let Some(Ok(relative_error_datum)) = relative_error.try_fold_const() else {
+                    bail_not_implemented!(
+                        issue = 14079,
+                        "variable as direct argument of ordered-set aggregate",
+                    )
+                };
+
+                if let Some(ref relative_error_scalar) = relative_error_datum
+                    && !(0.0..=1.0).contains(&relative_error_scalar.as_float64().0)
+                {
+                    return Err(ErrorCode::InvalidInputSyntax(format!(
+                        "direct arg in `{}` must between 0.0 and 1.0",
+                        kind
+                    ))
+                        .into());
+                }
+                // note that the fraction can be NULL
+                *relative_error = Literal::new(relative_error_datum, DataType::Float64).into();
+            }
             _ => {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
                     "invalid direct args or within group argument for `{}` aggregation",

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -763,4 +763,221 @@ mod tests {
 
         expected.assert_eq(&format!("{:#?}", bound));
     }
+
+    #[tokio::test]
+    async fn test_bind_approx_percentile() {
+        let stmt = risingwave_sqlparser::parser::Parser::parse_sql(
+            "SELECT approx_percentile(0.5, 0.01) WITHIN GROUP (ORDER BY generate_series) FROM generate_series(1, 100)",
+        ).unwrap().into_iter().next().unwrap();
+        let parse_expected = expect![[r#"
+            Query(
+                Query {
+                    with: None,
+                    body: Select(
+                        Select {
+                            distinct: All,
+                            projection: [
+                                UnnamedExpr(
+                                    Function(
+                                        Function {
+                                            name: ObjectName(
+                                                [
+                                                    Ident {
+                                                        value: "approx_percentile",
+                                                        quote_style: None,
+                                                    },
+                                                ],
+                                            ),
+                                            args: [
+                                                Unnamed(
+                                                    Expr(
+                                                        Value(
+                                                            Number(
+                                                                "0.5",
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                Unnamed(
+                                                    Expr(
+                                                        Value(
+                                                            Number(
+                                                                "0.01",
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ],
+                                            variadic: false,
+                                            over: None,
+                                            distinct: false,
+                                            order_by: [],
+                                            filter: None,
+                                            within_group: Some(
+                                                OrderByExpr {
+                                                    expr: Identifier(
+                                                        Ident {
+                                                            value: "generate_series",
+                                                            quote_style: None,
+                                                        },
+                                                    ),
+                                                    asc: None,
+                                                    nulls_first: None,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                            from: [
+                                TableWithJoins {
+                                    relation: TableFunction {
+                                        name: ObjectName(
+                                            [
+                                                Ident {
+                                                    value: "generate_series",
+                                                    quote_style: None,
+                                                },
+                                            ],
+                                        ),
+                                        alias: None,
+                                        args: [
+                                            Unnamed(
+                                                Expr(
+                                                    Value(
+                                                        Number(
+                                                            "1",
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                            Unnamed(
+                                                Expr(
+                                                    Value(
+                                                        Number(
+                                                            "100",
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ],
+                                        with_ordinality: false,
+                                    },
+                                    joins: [],
+                                },
+                            ],
+                            lateral_views: [],
+                            selection: None,
+                            group_by: [],
+                            having: None,
+                        },
+                    ),
+                    order_by: [],
+                    limit: None,
+                    offset: None,
+                    fetch: None,
+                },
+            )"#]];
+        parse_expected.assert_eq(&format!("{:#?}", stmt));
+
+        let mut binder = mock_binder();
+        let bound = binder.bind(stmt).unwrap();
+
+        let expected = expect![[r#"
+            Query(
+                BoundQuery {
+                    body: Select(
+                        BoundSelect {
+                            distinct: All,
+                            select_items: [
+                                AggCall(
+                                    AggCall {
+                                        agg_kind: ApproxPercentile,
+                                        return_type: Float64,
+                                        args: [
+                                            FunctionCall(
+                                                FunctionCall {
+                                                    func_type: Cast,
+                                                    return_type: Float64,
+                                                    inputs: [
+                                                        InputRef(
+                                                            InputRef {
+                                                                index: 0,
+                                                                data_type: Int32,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ],
+                                        filter: Condition {
+                                            conjunctions: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                            aliases: [
+                                Some(
+                                    "approx_percentile",
+                                ),
+                            ],
+                            from: Some(
+                                TableFunction {
+                                    expr: TableFunction(
+                                        FunctionCall {
+                                            function_type: GenerateSeries,
+                                            return_type: Int32,
+                                            args: [
+                                                Literal(
+                                                    Literal {
+                                                        data: Some(
+                                                            Int32(
+                                                                1,
+                                                            ),
+                                                        ),
+                                                        data_type: Some(
+                                                            Int32,
+                                                        ),
+                                                    },
+                                                ),
+                                                Literal(
+                                                    Literal {
+                                                        data: Some(
+                                                            Int32(
+                                                                100,
+                                                            ),
+                                                        ),
+                                                        data_type: Some(
+                                                            Int32,
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    with_ordinality: false,
+                                },
+                            ),
+                            where_clause: None,
+                            group_by: GroupKey(
+                                [],
+                            ),
+                            having: None,
+                            schema: Schema {
+                                fields: [
+                                    approx_percentile:Float64,
+                                ],
+                            },
+                        },
+                    ),
+                    order: [],
+                    limit: None,
+                    offset: None,
+                    with_ties: false,
+                    extra_order_exprs: [],
+                },
+            )"#]];
+
+        expected.assert_eq(&format!("{:#?}", bound));
+    }
 }

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -780,6 +780,7 @@ mod tests {
                                 UnnamedExpr(
                                     Function(
                                         Function {
+                                            aggregate: false,
                                             name: ObjectName(
                                                 [
                                                     Ident {
@@ -892,7 +893,9 @@ mod tests {
                             select_items: [
                                 AggCall(
                                     AggCall {
-                                        agg_kind: ApproxPercentile,
+                                        agg_kind: Builtin(
+                                            ApproxPercentile,
+                                        ),
                                         return_type: Float64,
                                         args: [
                                             FunctionCall(
@@ -933,30 +936,29 @@ mod tests {
                                         direct_args: [
                                             Literal {
                                                 data: Some(
-                                                    Decimal(
-                                                        Normalized(
+                                                    Float64(
+                                                        OrderedFloat(
                                                             0.5,
                                                         ),
                                                     ),
                                                 ),
                                                 data_type: Some(
-                                                    Decimal,
+                                                    Float64,
                                                 ),
                                             },
                                             Literal {
                                                 data: Some(
-                                                    Decimal(
-                                                        Normalized(
+                                                    Float64(
+                                                        OrderedFloat(
                                                             0.01,
                                                         ),
                                                     ),
                                                 ),
                                                 data_type: Some(
-                                                    Decimal,
+                                                    Float64,
                                                 ),
                                             },
                                         ],
-                                        user_defined: false,
                                     },
                                 ),
                             ],

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -913,6 +913,50 @@ mod tests {
                                         filter: Condition {
                                             conjunctions: [],
                                         },
+                                        distinct: false,
+                                        order_by: OrderBy {
+                                            sort_exprs: [
+                                                OrderByExpr {
+                                                    expr: InputRef(
+                                                        InputRef {
+                                                            index: 0,
+                                                            data_type: Int32,
+                                                        },
+                                                    ),
+                                                    order_type: OrderType {
+                                                        direction: Ascending,
+                                                        nulls_are: Largest,
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        direct_args: [
+                                            Literal {
+                                                data: Some(
+                                                    Decimal(
+                                                        Normalized(
+                                                            0.5,
+                                                        ),
+                                                    ),
+                                                ),
+                                                data_type: Some(
+                                                    Decimal,
+                                                ),
+                                            },
+                                            Literal {
+                                                data: Some(
+                                                    Decimal(
+                                                        Normalized(
+                                                            0.01,
+                                                        ),
+                                                    ),
+                                                ),
+                                                data_type: Some(
+                                                    Decimal,
+                                                ),
+                                            },
+                                        ],
+                                        user_defined: false,
                                     },
                                 ),
                             ],

--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -38,6 +38,10 @@ impl std::fmt::Debug for AggCall {
                 .field("return_type", &self.return_type)
                 .field("args", &self.args)
                 .field("filter", &self.filter)
+                .field("distinct", &self.distinct)
+                .field("order_by", &self.order_by)
+                .field("direct_args", &self.direct_args)
+                .field("user_defined", &self.user_defined.is_some())
                 .finish()
         } else {
             let mut builder = f.debug_tuple(&format!("{}", self.agg_kind));

--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -41,7 +41,6 @@ impl std::fmt::Debug for AggCall {
                 .field("distinct", &self.distinct)
                 .field("order_by", &self.order_by)
                 .field("direct_args", &self.direct_args)
-                .field("user_defined", &self.user_defined.is_some())
                 .finish()
         } else {
             let mut builder = f.debug_tuple(&format!("{}", self.agg_kind));

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -107,7 +107,8 @@ impl<PlanRef: GenericPlanRef> Agg<PlanRef> {
                 let agg_kind_ok = !matches!(call.agg_kind, agg_kinds::simply_cannot_two_phase!());
                 let order_ok = matches!(
                     call.agg_kind,
-                    agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile
+                    agg_kinds::result_unaffected_by_order_by!()
+                        | AggKind::Builtin(PbAggKind::ApproxPercentile)
                 ) || call.order_by.is_empty();
                 let distinct_ok =
                     matches!(call.agg_kind, agg_kinds::result_unaffected_by_distinct!())
@@ -135,7 +136,7 @@ impl<PlanRef: GenericPlanRef> Agg<PlanRef> {
         self.agg_calls.iter().all(|c| {
             matches!(c.agg_kind, agg_kinds::single_value_state!())
                 || (matches!(c.agg_kind, agg_kinds::single_value_state_iff_in_append_only!() if stream_input_append_only))
-                || (matches!(c.agg_kind, AggKind::ApproxPercentile))
+                || (matches!(c.agg_kind, AggKind::Builtin(PbAggKind::ApproxPercentile)))
         })
     }
 

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -105,7 +105,7 @@ impl<PlanRef: GenericPlanRef> Agg<PlanRef> {
             && !self.agg_calls.is_empty()
             && self.agg_calls.iter().all(|call| {
                 let agg_kind_ok = !matches!(call.agg_kind, agg_kinds::simply_cannot_two_phase!());
-                let order_ok = matches!(call.agg_kind, agg_kinds::result_unaffected_by_order_by!())
+                let order_ok = matches!(call.agg_kind, agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile)
                     || call.order_by.is_empty();
                 let distinct_ok =
                     matches!(call.agg_kind, agg_kinds::result_unaffected_by_distinct!())

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -133,6 +133,7 @@ impl<PlanRef: GenericPlanRef> Agg<PlanRef> {
         self.agg_calls.iter().all(|c| {
             matches!(c.agg_kind, agg_kinds::single_value_state!())
                 || (matches!(c.agg_kind, agg_kinds::single_value_state_iff_in_append_only!() if stream_input_append_only))
+                || (matches!(c.agg_kind, AggKind::ApproxPercentile))
         })
     }
 

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -105,8 +105,10 @@ impl<PlanRef: GenericPlanRef> Agg<PlanRef> {
             && !self.agg_calls.is_empty()
             && self.agg_calls.iter().all(|call| {
                 let agg_kind_ok = !matches!(call.agg_kind, agg_kinds::simply_cannot_two_phase!());
-                let order_ok = matches!(call.agg_kind, agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile)
-                    || call.order_by.is_empty();
+                let order_ok = matches!(
+                    call.agg_kind,
+                    agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile
+                ) || call.order_by.is_empty();
                 let distinct_ok =
                     matches!(call.agg_kind, agg_kinds::result_unaffected_by_distinct!())
                         || !call.distinct;

--- a/src/frontend/src/optimizer/plan_node/generic/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! This module contains the generic plan nodes that are shared by all the plan nodes.
+//! They are meant to reuse the common fields between logical, batch and stream nodes.
+
 use std::borrow::Cow;
 use std::hash::Hash;
 

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -290,7 +290,7 @@ impl LogicalAgg {
             .into());
         }
 
-        let shared_input = LogicalShare::new(stream_input).to_stream(ctx)?;
+        let shared_input: PlanRef = StreamShare::new_from_input(stream_input).into();
         let (approx_percentile_agg_call, non_approx_percentile_agg_calls, lhs_mapping, rhs_mapping) =
             self.extract_approx_percentile();
         let approx_percentile_agg =

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -303,8 +303,12 @@ impl LogicalAgg {
         .with_grouping_sets(self.grouping_sets().clone())
         .with_enable_two_phase(self.core().enable_two_phase)
         .into();
-        let agg_merge =
-            StreamKeyedMerge::new(simple_agg_without_approx_percentile, approx_percentile_agg);
+        let agg_merge = StreamKeyedMerge::new(
+            simple_agg_without_approx_percentile,
+            approx_percentile_agg,
+            lhs_mapping,
+            rhs_mapping,
+        );
         Ok(agg_merge.into())
     }
 

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -297,7 +297,7 @@ impl LogicalAgg {
         let mut approx_percentile_col_mapping = Vec::with_capacity(estimated_len);
         let mut non_approx_percentile_col_mapping = Vec::with_capacity(estimated_len);
         for (output_idx, agg_call) in self.agg_calls().iter().enumerate() {
-            if agg_call.agg_kind == AggKind::ApproxPercentile {
+            if agg_call.agg_kind == AggKind::Builtin(PbAggKind::ApproxPercentile) {
                 approx_percentile_agg_calls.push(agg_call.clone());
                 approx_percentile_col_mapping.push(Some(output_idx));
             } else {
@@ -643,7 +643,7 @@ impl LogicalAggBuilder {
                     _ => unreachable!(),
                 }
             }
-            AggKind::ApproxPercentile => {
+            AggKind::Builtin(PbAggKind::ApproxPercentile) => {
                 if agg_call.order_by.sort_exprs[0].order_type == OrderType::descending() {
                     // Rewrite DESC into 1.0-percentile for approx_percentile.
                     let prev_percentile = agg_call.direct_args[0].clone();

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -326,8 +326,10 @@ impl LogicalAgg {
     ) -> PlanRef {
         let local_approx_percentile =
             StreamLocalApproxPercentile::new(input, approx_percentile_agg_call);
-        let global_approx_percentile =
-            StreamGlobalApproxPercentile::new(local_approx_percentile.into());
+        let global_approx_percentile = StreamGlobalApproxPercentile::new(
+            local_approx_percentile.into(),
+            approx_percentile_agg_call,
+        );
         global_approx_percentile.into()
     }
 

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -314,16 +314,16 @@ impl LogicalAgg {
             }
         }
         let normal = AggInfo {
-            calls: approx_percentile_agg_calls,
+            calls: non_approx_percentile_agg_calls,
             col_mapping: ColIndexMapping::new(
-                approx_percentile_col_mapping,
+                non_approx_percentile_col_mapping,
                 self.agg_calls().len(),
             ),
         };
         let approx = AggInfo {
-            calls: non_approx_percentile_agg_calls,
+            calls: approx_percentile_agg_calls,
             col_mapping: ColIndexMapping::new(
-                non_approx_percentile_col_mapping,
+                approx_percentile_col_mapping,
                 self.agg_calls().len(),
             ),
         };

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -645,6 +645,7 @@ impl LogicalAggBuilder {
             }
             AggKind::ApproxPercentile => {
                 if agg_call.order_by.sort_exprs[0].order_type == OrderType::descending() {
+                    // Rewrite DESC into 1.0-percentile for approx_percentile.
                     let prev_percentile = agg_call.direct_args[0].clone();
                     let new_percentile = 1.0
                         - prev_percentile

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -63,8 +63,6 @@ impl LogicalAgg {
     fn gen_stateless_two_phase_streaming_agg_plan(&self, stream_input: PlanRef) -> Result<PlanRef> {
         debug_assert!(self.group_key().is_empty());
         let mut core = self.core.clone();
-        let schema = self.base.schema().clone();
-        println!("agg schema: {:?}", schema);
 
         // First, handle approx percentile.
         let has_approx_percentile = self
@@ -114,12 +112,11 @@ impl LogicalAgg {
         ));
         if let Some((approx_percentile_agg, lhs_mapping, rhs_mapping)) = approx_percentile_info {
             let keyed_merge = StreamKeyedMerge::new(
-                global_agg.into(),
                 approx_percentile_agg,
+                global_agg.into(),
                 lhs_mapping,
                 rhs_mapping,
-                schema,
-            );
+            )?;
             Ok(keyed_merge.into())
         } else {
             Ok(global_agg.into())

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -290,7 +290,6 @@ impl LogicalAgg {
         }
     }
 
-    // TODO(kwannoel): Handle multiple approx_percentile.
     fn separate_normal_and_special_agg(&self) -> SeparatedAggInfo {
         let estimated_len = self.agg_calls().len() - 1;
         let mut approx_percentile_agg_calls = Vec::with_capacity(estimated_len);
@@ -748,7 +747,6 @@ impl LogicalAggBuilder {
     /// 2. Add the agg call to current `Agg`, and return an `InputRef` to it.
     ///
     /// Note that the rewriter does not traverse into inputs of agg calls.
-    /// FIXME(kwannoel): Rewrite the desc approx percentile for descending order.
     fn try_rewrite_agg_call(&mut self, mut agg_call: AggCall) -> Result<ExprImpl> {
         if matches!(agg_call.agg_kind, agg_kinds::must_have_order_by!())
             && agg_call.order_by.sort_exprs.is_empty()

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -893,10 +893,13 @@ mod stream_exchange;
 mod stream_expand;
 mod stream_filter;
 mod stream_fs_fetch;
+mod stream_global_approx_percentile;
 mod stream_group_topn;
 mod stream_hash_agg;
 mod stream_hash_join;
 mod stream_hop_window;
+mod stream_keyed_merge;
+mod stream_local_approx_percentile;
 mod stream_materialize;
 mod stream_now;
 mod stream_over_window;
@@ -1002,10 +1005,13 @@ pub use stream_exchange::StreamExchange;
 pub use stream_expand::StreamExpand;
 pub use stream_filter::StreamFilter;
 pub use stream_fs_fetch::StreamFsFetch;
+pub use stream_global_approx_percentile::StreamGlobalApproxPercentile;
 pub use stream_group_topn::StreamGroupTopN;
 pub use stream_hash_agg::StreamHashAgg;
 pub use stream_hash_join::StreamHashJoin;
 pub use stream_hop_window::StreamHopWindow;
+pub use stream_keyed_merge::StreamKeyedMerge;
+pub use stream_local_approx_percentile::StreamLocalApproxPercentile;
 pub use stream_materialize::StreamMaterialize;
 pub use stream_now::StreamNow;
 pub use stream_over_window::StreamOverWindow;
@@ -1150,6 +1156,9 @@ macro_rules! for_all_plan_nodes {
             , { Stream, OverWindow }
             , { Stream, FsFetch }
             , { Stream, ChangeLog }
+            , { Stream, GlobalApproxPercentile }
+            , { Stream, LocalApproxPercentile }
+            , { Stream, KeyedMerge }
         }
     };
 }
@@ -1276,6 +1285,9 @@ macro_rules! for_stream_plan_nodes {
             , { Stream, OverWindow }
             , { Stream, FsFetch }
             , { Stream, ChangeLog }
+            , { Stream, GlobalApproxPercentile }
+            , { Stream, LocalApproxPercentile }
+            , { Stream, KeyedMerge }
         }
     };
 }

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use fixedbitset::FixedBitSet;
 use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
@@ -38,15 +39,16 @@ pub struct StreamGlobalApproxPercentile {
 impl StreamGlobalApproxPercentile {
     pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
         let schema = Schema::new(vec![Field::new("approx_percentile", DataType::Float64)]);
+        let watermark_columns = FixedBitSet::with_capacity(1);
         let base = PlanBase::new_stream(
             input.ctx(),
             schema,
-            input.stream_key().map(|k| k.to_vec()),
+            Some(vec![0]),
             input.functional_dependency().clone(),
             input.distribution().clone(),
             input.append_only(),
             input.emit_on_window_close(),
-            input.watermark_columns().clone(),
+            watermark_columns,
             input.columns_monotonicity().clone(),
         );
         Self { base, input }
@@ -92,6 +94,5 @@ impl ExprRewritable for StreamGlobalApproxPercentile {
 
 impl ExprVisitable for StreamGlobalApproxPercentile {
     fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
-        unimplemented!()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -42,7 +42,10 @@ pub struct StreamGlobalApproxPercentile {
 
 impl StreamGlobalApproxPercentile {
     pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
-        let schema = Schema::new(vec![Field::new("approx_percentile", DataType::Float64)]);
+        let schema = Schema::new(vec![Field::with_name(
+            DataType::Float64,
+            "approx_percentile",
+        )]);
         let watermark_columns = FixedBitSet::with_capacity(1);
         let base = PlanBase::new_stream(
             input.ctx(),

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -1,0 +1,78 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pretty_xmlish::XmlNode;
+use risingwave_pb::stream_plan::stream_node::PbNodeBody;
+
+use crate::expr::{ExprRewriter, ExprVisitor};
+use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
+use crate::optimizer::plan_node::generic::GenericPlanRef;
+use crate::optimizer::plan_node::utils::{childless_record, watermark_pretty, Distill};
+use crate::optimizer::plan_node::{
+    ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamHopWindow, StreamKeyedMerge,
+    StreamNode,
+};
+use crate::stream_fragmenter::BuildFragmentGraphState;
+use crate::PlanRef;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamGlobalApproxPercentile {
+    pub base: PlanBase<Stream>,
+}
+
+impl StreamGlobalApproxPercentile {
+    pub fn new(input: PlanRef) -> Self {
+        Self { base: todo!() }
+    }
+}
+
+impl Distill for StreamGlobalApproxPercentile {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        todo!()
+    }
+}
+
+impl PlanTreeNodeUnary for StreamGlobalApproxPercentile {
+    fn input(&self) -> PlanRef {
+        todo!()
+    }
+
+    fn clone_with_input(&self, input: PlanRef) -> Self {
+        todo!()
+    }
+}
+
+impl_plan_tree_node_for_unary! {StreamGlobalApproxPercentile}
+
+impl StreamNode for StreamGlobalApproxPercentile {
+    fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> PbNodeBody {
+        todo!()
+    }
+}
+
+impl ExprRewritable for StreamGlobalApproxPercentile {
+    fn has_rewritable_expr(&self) -> bool {
+        todo!()
+    }
+
+    fn rewrite_exprs(&self, _rewriter: &mut dyn ExprRewriter) -> PlanRef {
+        todo!()
+    }
+}
+
+impl ExprVisitable for StreamGlobalApproxPercentile {
+    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
+        todo!()
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -20,8 +20,8 @@ use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::utils::{childless_record, watermark_pretty, Distill};
 use crate::optimizer::plan_node::{
-    ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamHopWindow, StreamKeyedMerge,
-    StreamNode,
+    ExprRewritable, PlanAggCall, PlanBase, PlanTreeNodeUnary, Stream, StreamHopWindow,
+    StreamKeyedMerge, StreamNode,
 };
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::PlanRef;
@@ -32,7 +32,7 @@ pub struct StreamGlobalApproxPercentile {
 }
 
 impl StreamGlobalApproxPercentile {
-    pub fn new(input: PlanRef) -> Self {
+    pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
         Self { base: todo!() }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -29,11 +29,15 @@ use crate::PlanRef;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StreamGlobalApproxPercentile {
     pub base: PlanBase<Stream>,
+    input: PlanRef,
 }
 
 impl StreamGlobalApproxPercentile {
     pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
-        Self { base: todo!() }
+        Self {
+            base: todo!(),
+            input,
+        }
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -20,12 +20,11 @@ use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use crate::expr::{ExprRewriter, ExprVisitor};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
-use crate::optimizer::plan_node::generic::{GenericPlanRef, PhysicalPlanRef};
+use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::stream::StreamPlanRef;
-use crate::optimizer::plan_node::utils::{childless_record, watermark_pretty, Distill};
+use crate::optimizer::plan_node::utils::{childless_record, Distill};
 use crate::optimizer::plan_node::{
-    ExprRewritable, PlanAggCall, PlanBase, PlanTreeNodeUnary, Stream, StreamHopWindow,
-    StreamKeyedMerge, StreamNode,
+    ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamNode,
 };
 use crate::optimizer::property::Distribution;
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -38,7 +37,7 @@ pub struct StreamGlobalApproxPercentile {
 }
 
 impl StreamGlobalApproxPercentile {
-    pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
+    pub fn new(input: PlanRef) -> Self {
         let schema = Schema::new(vec![Field::new("approx_percentile", DataType::Float64)]);
         let watermark_columns = FixedBitSet::with_capacity(1);
         let base = PlanBase::new_stream(
@@ -94,5 +93,5 @@ impl ExprRewritable for StreamGlobalApproxPercentile {
 }
 
 impl ExprVisitable for StreamGlobalApproxPercentile {
-    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {}
+    fn visit_exprs(&self, _v: &mut dyn ExprVisitor) {}
 }

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -44,7 +44,7 @@ impl StreamGlobalApproxPercentile {
         let base = PlanBase::new_stream(
             input.ctx(),
             schema,
-            Some(vec![0]),
+            Some(vec![]),
             input.functional_dependency().clone(),
             Distribution::Single,
             input.append_only(),

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -27,6 +27,7 @@ use crate::optimizer::plan_node::{
     ExprRewritable, PlanAggCall, PlanBase, PlanTreeNodeUnary, Stream, StreamHopWindow,
     StreamKeyedMerge, StreamNode,
 };
+use crate::optimizer::property::Distribution;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::PlanRef;
 
@@ -45,7 +46,7 @@ impl StreamGlobalApproxPercentile {
             schema,
             Some(vec![0]),
             input.functional_dependency().clone(),
-            input.distribution().clone(),
+            Distribution::Single,
             input.append_only(),
             input.emit_on_window_close(),
             watermark_columns,
@@ -93,6 +94,5 @@ impl ExprRewritable for StreamGlobalApproxPercentile {
 }
 
 impl ExprVisitable for StreamGlobalApproxPercentile {
-    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
-    }
+    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {}
 }

--- a/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_approx_percentile.rs
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 use pretty_xmlish::XmlNode;
+use risingwave_common::catalog::{Field, Schema};
+use risingwave_common::types::DataType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use crate::expr::{ExprRewriter, ExprVisitor};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
-use crate::optimizer::plan_node::generic::GenericPlanRef;
+use crate::optimizer::plan_node::generic::{GenericPlanRef, PhysicalPlanRef};
+use crate::optimizer::plan_node::stream::StreamPlanRef;
 use crate::optimizer::plan_node::utils::{childless_record, watermark_pretty, Distill};
 use crate::optimizer::plan_node::{
     ExprRewritable, PlanAggCall, PlanBase, PlanTreeNodeUnary, Stream, StreamHopWindow,
@@ -34,26 +37,38 @@ pub struct StreamGlobalApproxPercentile {
 
 impl StreamGlobalApproxPercentile {
     pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
-        Self {
-            base: todo!(),
-            input,
-        }
+        let schema = Schema::new(vec![Field::new("approx_percentile", DataType::Float64)]);
+        let base = PlanBase::new_stream(
+            input.ctx(),
+            schema,
+            input.stream_key().map(|k| k.to_vec()),
+            input.functional_dependency().clone(),
+            input.distribution().clone(),
+            input.append_only(),
+            input.emit_on_window_close(),
+            input.watermark_columns().clone(),
+            input.columns_monotonicity().clone(),
+        );
+        Self { base, input }
     }
 }
 
 impl Distill for StreamGlobalApproxPercentile {
     fn distill<'a>(&self) -> XmlNode<'a> {
-        todo!()
+        childless_record("StreamGlobalApproxPercentile", vec![])
     }
 }
 
 impl PlanTreeNodeUnary for StreamGlobalApproxPercentile {
     fn input(&self) -> PlanRef {
-        todo!()
+        self.input.clone()
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        todo!()
+        Self {
+            base: self.base.clone(),
+            input,
+        }
     }
 }
 
@@ -67,16 +82,16 @@ impl StreamNode for StreamGlobalApproxPercentile {
 
 impl ExprRewritable for StreamGlobalApproxPercentile {
     fn has_rewritable_expr(&self) -> bool {
-        todo!()
+        false
     }
 
     fn rewrite_exprs(&self, _rewriter: &mut dyn ExprRewriter) -> PlanRef {
-        todo!()
+        unimplemented!()
     }
 }
 
 impl ExprVisitable for StreamGlobalApproxPercentile {
     fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
-        todo!()
+        unimplemented!()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
@@ -1,0 +1,88 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pretty_xmlish::XmlNode;
+use risingwave_pb::stream_plan::stream_node::PbNodeBody;
+use risingwave_pb::stream_plan::HopWindowNode;
+
+use crate::expr::{ExprRewriter, ExprVisitor};
+use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
+use crate::optimizer::plan_node::utils::Distill;
+use crate::optimizer::plan_node::{
+    ExprRewritable, PlanBase, PlanTreeNodeBinary, Stream, StreamHopWindow,
+    StreamLocalApproxPercentile, StreamNode,
+};
+use crate::stream_fragmenter::BuildFragmentGraphState;
+use crate::PlanRef;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamKeyedMerge {
+    pub lhs_input: PlanRef,
+    pub rhs_input: PlanRef,
+    pub base: PlanBase<Stream>,
+}
+
+impl StreamKeyedMerge {
+    pub fn new(lhs_input: PlanRef, rhs_input: PlanRef) -> Self {
+        Self {
+            lhs_input,
+            rhs_input,
+            base: todo!(),
+        }
+    }
+}
+
+impl Distill for StreamKeyedMerge {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        todo!()
+    }
+}
+
+impl PlanTreeNodeBinary for StreamKeyedMerge {
+    fn left(&self) -> PlanRef {
+        todo!()
+    }
+
+    fn right(&self) -> PlanRef {
+        todo!()
+    }
+
+    fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
+        todo!()
+    }
+}
+
+impl_plan_tree_node_for_binary! { StreamKeyedMerge }
+
+impl StreamNode for StreamKeyedMerge {
+    fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> PbNodeBody {
+        todo!()
+    }
+}
+
+impl ExprRewritable for StreamKeyedMerge {
+    fn has_rewritable_expr(&self) -> bool {
+        todo!()
+    }
+
+    fn rewrite_exprs(&self, _rewriter: &mut dyn ExprRewriter) -> PlanRef {
+        todo!()
+    }
+}
+
+impl ExprVisitable for StreamKeyedMerge {
+    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
+        todo!()
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
@@ -47,6 +47,7 @@ impl StreamKeyedMerge {
         lhs_mapping: ColIndexMapping,
         rhs_mapping: ColIndexMapping,
     ) -> Self {
+        // FIXME: schema is wrong.
         let base = PlanBase::new_stream(
             lhs_input.ctx(),
             lhs_input.schema().clone(),

--- a/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
@@ -19,17 +19,15 @@ use risingwave_common::bail;
 use risingwave_common::catalog::Schema;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
-use risingwave_pb::stream_plan::HopWindowNode;
 
 use crate::error::Result;
 use crate::expr::{ExprRewriter, ExprVisitor};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::generic::{GenericPlanRef, PhysicalPlanRef};
 use crate::optimizer::plan_node::stream::StreamPlanRef;
-use crate::optimizer::plan_node::utils::{childless_record, Distill, IndicesDisplay};
+use crate::optimizer::plan_node::utils::{childless_record, Distill};
 use crate::optimizer::plan_node::{
-    ExprRewritable, PlanBase, PlanTreeNodeBinary, Stream, StreamHopWindow,
-    StreamLocalApproxPercentile, StreamNode,
+    ExprRewritable, PlanBase, PlanTreeNodeBinary, Stream, StreamNode,
 };
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::PlanRef;
@@ -54,10 +52,10 @@ impl StreamKeyedMerge {
     ) -> Result<Self> {
         assert_eq!(lhs_mapping.target_size(), rhs_mapping.target_size());
         let mut schema_fields = Vec::with_capacity(lhs_mapping.target_size());
-        let mut o2i_lhs = lhs_mapping
+        let o2i_lhs = lhs_mapping
             .inverse()
             .ok_or_else(|| anyhow!("lhs_mapping should be invertible"))?;
-        let mut o2i_rhs = rhs_mapping
+        let o2i_rhs = rhs_mapping
             .inverse()
             .ok_or_else(|| anyhow!("rhs_mapping should be invertible"))?;
         for output_idx in 0..lhs_mapping.target_size() {
@@ -152,5 +150,5 @@ impl ExprRewritable for StreamKeyedMerge {
 }
 
 impl ExprVisitable for StreamKeyedMerge {
-    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {}
+    fn visit_exprs(&self, _v: &mut dyn ExprVisitor) {}
 }

--- a/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
@@ -62,7 +62,6 @@ impl StreamKeyedMerge {
             if let Some(lhs_idx) = o2i_lhs.try_map(output_idx) {
                 schema_fields.push(lhs_input.schema().fields()[lhs_idx].clone());
             } else if let Some(rhs_idx) = o2i_rhs.try_map(output_idx) {
-                println!("rhs schema: {:?}", rhs_input.schema().fields());
                 schema_fields.push(rhs_input.schema().fields()[rhs_idx].clone());
             } else {
                 bail!(

--- a/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_keyed_merge.rs
@@ -74,7 +74,6 @@ impl StreamKeyedMerge {
         let schema = Schema::new(schema_fields);
         let watermark_columns = FixedBitSet::with_capacity(schema.fields.len());
 
-        // FIXME: schema is wrong.
         let base = PlanBase::new_stream(
             lhs_input.ctx(),
             schema,
@@ -99,8 +98,6 @@ impl StreamKeyedMerge {
 impl Distill for StreamKeyedMerge {
     fn distill<'a>(&self) -> XmlNode<'a> {
         let mut out = Vec::with_capacity(1);
-        // out.push(("lhs_col_mapping", Pretty::debug(&self.lhs_mapping)));
-        // out.push(("rhs_col_mapping", Pretty::debug(&self.rhs_mapping)));
 
         if self.base.ctx().is_explain_verbose() {
             let f = |t| Pretty::debug(&t);

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -16,19 +16,15 @@ use fixedbitset::FixedBitSet;
 use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
-use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use crate::expr::{ExprRewriter, ExprVisitor, InputRef, InputRefDisplay, Literal};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::generic::{GenericPlanRef, PhysicalPlanRef};
 use crate::optimizer::plan_node::stream::StreamPlanRef;
-use crate::optimizer::plan_node::utils::{
-    childless_record, watermark_pretty, Distill, IndicesDisplay,
-};
+use crate::optimizer::plan_node::utils::{childless_record, watermark_pretty, Distill};
 use crate::optimizer::plan_node::{
-    ExprRewritable, PlanAggCall, PlanBase, PlanNode, PlanTreeNodeUnary, Stream,
-    StreamGlobalApproxPercentile, StreamHopWindow, StreamNode,
+    ExprRewritable, PlanAggCall, PlanBase, PlanTreeNodeUnary, Stream, StreamNode,
 };
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::PlanRef;
@@ -127,5 +123,5 @@ impl ExprRewritable for StreamLocalApproxPercentile {
 }
 
 impl ExprVisitable for StreamLocalApproxPercentile {
-    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {}
+    fn visit_exprs(&self, _v: &mut dyn ExprVisitor) {}
 }

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -74,8 +74,7 @@ impl StreamLocalApproxPercentile {
 
 impl Distill for StreamLocalApproxPercentile {
     fn distill<'a>(&self) -> XmlNode<'a> {
-        let mut out = Vec::with_capacity(4);
-        let output_type = DataType::Float64;
+        let mut out = Vec::with_capacity(5);
         out.push((
             "percentile_col",
             Pretty::display(&InputRefDisplay {

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -43,8 +43,8 @@ pub struct StreamLocalApproxPercentile {
 impl StreamLocalApproxPercentile {
     pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
         let schema = Schema::new(vec![
-            Field::new("bucket_id", DataType::Int64),
-            Field::new("count", DataType::Int64),
+            Field::with_name(DataType::Int64, "bucket_id"),
+            Field::with_name(DataType::Int64, "count"),
         ]);
         // FIXME(kwannoel): How does watermark work with FixedBitSet
         let watermark_columns = FixedBitSet::with_capacity(2);

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -127,6 +127,5 @@ impl ExprRewritable for StreamLocalApproxPercentile {
 }
 
 impl ExprVisitable for StreamLocalApproxPercentile {
-    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
-    }
+    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {}
 }

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use pretty_xmlish::XmlNode;
+use pretty_xmlish::{Pretty, XmlNode};
+use risingwave_common::catalog::{Field, Schema};
+use risingwave_common::types::DataType;
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
-use crate::expr::{ExprRewriter, ExprVisitor};
+use crate::expr::{ExprRewriter, ExprVisitor, InputRef, InputRefDisplay, Literal};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
-use crate::optimizer::plan_node::utils::Distill;
+use crate::optimizer::plan_node::generic::{GenericPlanRef, PhysicalPlanRef};
+use crate::optimizer::plan_node::stream::StreamPlanRef;
+use crate::optimizer::plan_node::utils::{childless_record, Distill, IndicesDisplay, watermark_pretty};
 use crate::optimizer::plan_node::{
-    ExprRewritable, PlanBase, PlanNode, PlanTreeNodeUnary, Stream, StreamGlobalApproxPercentile,
-    StreamHopWindow, StreamNode,
+    ExprRewritable, PlanAggCall, PlanBase, PlanNode, PlanTreeNodeUnary, Stream,
+    StreamGlobalApproxPercentile, StreamHopWindow, StreamNode,
 };
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::PlanRef;
@@ -28,27 +33,72 @@ use crate::PlanRef;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StreamLocalApproxPercentile {
     pub base: PlanBase<Stream>,
+    input: PlanRef,
+    quantile: Literal,
+    relative_error: Literal,
+    percentile_col: InputRef,
+    order_type: OrderType,
 }
 
 impl StreamLocalApproxPercentile {
-    pub fn new(input: PlanRef) -> Self {
-        Self { base: todo!() }
+    pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
+        let base = PlanBase::new_stream(
+            input.ctx(),
+            input.schema().clone(),
+            input.stream_key().map(|k| k.to_vec()),
+            input.functional_dependency().clone(),
+            input.distribution().clone(),
+            input.append_only(),
+            input.emit_on_window_close(),
+            input.watermark_columns().clone(),
+            input.columns_monotonicity().clone(),
+        );
+        Self {
+            base,
+            input,
+            quantile: approx_percentile_agg_call.direct_args[0].clone(),
+            relative_error: approx_percentile_agg_call.direct_args[1].clone(),
+            percentile_col: approx_percentile_agg_call.inputs[0].clone(),
+            order_type: approx_percentile_agg_call.order_by[0].order_type,
+        }
     }
 }
 
 impl Distill for StreamLocalApproxPercentile {
     fn distill<'a>(&self) -> XmlNode<'a> {
-        todo!()
+        let mut out = Vec::with_capacity(4);
+        let output_type = DataType::Float64;
+        out.push((
+            "percentile_col",
+            Pretty::display(&InputRefDisplay {
+                input_ref: &self.percentile_col,
+                input_schema: self.input.schema(),
+            }),
+        ));
+        out.push(("quantile", Pretty::debug(&self.quantile)));
+        out.push(("relative_error", Pretty::debug(&self.relative_error)));
+        out.push(("order_type", Pretty::display(&self.order_type)));
+        if let Some(ow) = watermark_pretty(self.base.watermark_columns(), self.schema()) {
+            out.push(("output_watermarks", ow));
+        }
+        childless_record("StreamLocalApproxPercentile", out)
     }
 }
 
 impl PlanTreeNodeUnary for StreamLocalApproxPercentile {
     fn input(&self) -> PlanRef {
-        todo!()
+        self.input.clone()
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        todo!()
+        Self {
+            base: self.base.clone(),
+            input,
+            quantile: self.quantile.clone(),
+            relative_error: self.relative_error.clone(),
+            percentile_col: self.percentile_col.clone(),
+            order_type: self.order_type,
+        }
     }
 }
 
@@ -62,16 +112,16 @@ impl StreamNode for StreamLocalApproxPercentile {
 
 impl ExprRewritable for StreamLocalApproxPercentile {
     fn has_rewritable_expr(&self) -> bool {
-        todo!()
+        false
     }
 
     fn rewrite_exprs(&self, _rewriter: &mut dyn ExprRewriter) -> PlanRef {
-        todo!()
+        unimplemented!()
     }
 }
 
 impl ExprVisitable for StreamLocalApproxPercentile {
     fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
-        todo!()
+        unimplemented!()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -1,0 +1,77 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pretty_xmlish::XmlNode;
+use risingwave_pb::stream_plan::stream_node::PbNodeBody;
+
+use crate::expr::{ExprRewriter, ExprVisitor};
+use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
+use crate::optimizer::plan_node::utils::Distill;
+use crate::optimizer::plan_node::{
+    ExprRewritable, PlanBase, PlanNode, PlanTreeNodeUnary, Stream, StreamGlobalApproxPercentile,
+    StreamHopWindow, StreamNode,
+};
+use crate::stream_fragmenter::BuildFragmentGraphState;
+use crate::PlanRef;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamLocalApproxPercentile {
+    pub base: PlanBase<Stream>,
+}
+
+impl StreamLocalApproxPercentile {
+    pub fn new(input: PlanRef) -> Self {
+        Self { base: todo!() }
+    }
+}
+
+impl Distill for StreamLocalApproxPercentile {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        todo!()
+    }
+}
+
+impl PlanTreeNodeUnary for StreamLocalApproxPercentile {
+    fn input(&self) -> PlanRef {
+        todo!()
+    }
+
+    fn clone_with_input(&self, input: PlanRef) -> Self {
+        todo!()
+    }
+}
+
+impl_plan_tree_node_for_unary! {StreamLocalApproxPercentile}
+
+impl StreamNode for StreamLocalApproxPercentile {
+    fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> PbNodeBody {
+        todo!()
+    }
+}
+
+impl ExprRewritable for StreamLocalApproxPercentile {
+    fn has_rewritable_expr(&self) -> bool {
+        todo!()
+    }
+
+    fn rewrite_exprs(&self, _rewriter: &mut dyn ExprRewriter) -> PlanRef {
+        todo!()
+    }
+}
+
+impl ExprVisitable for StreamLocalApproxPercentile {
+    fn visit_exprs(&self, v: &mut dyn ExprVisitor) {
+        todo!()
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/stream_share.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_share.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::RefCell;
+
 use pretty_xmlish::XmlNode;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::PbStreamNode;
@@ -49,6 +51,13 @@ impl StreamShare {
         };
 
         StreamShare { base, core }
+    }
+
+    pub fn new_from_input(input: PlanRef) -> Self {
+        let core = generic::Share {
+            input: RefCell::new(input),
+        };
+        Self::new(core)
     }
 }
 

--- a/src/frontend/src/optimizer/rule/apply_agg_transpose_rule.rs
+++ b/src/frontend/src/optimizer/rule/apply_agg_transpose_rule.rs
@@ -172,6 +172,7 @@ impl Rule for ApplyAggTransposeRule {
                         | PbAggKind::LastValue
                         | PbAggKind::InternalLastSeenValue
                         // All statistical aggregates only consider non-null inputs.
+                        | PbAggKind::ApproxPercentile
                         | PbAggKind::VarPop
                         | PbAggKind::VarSamp
                         | PbAggKind::StddevPop

--- a/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
+++ b/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
@@ -59,7 +59,8 @@ impl Rule for DistinctAggRule {
             let agg_kind_ok = !matches!(c.agg_kind, agg_kinds::simply_cannot_two_phase!());
             let order_ok = matches!(
                 c.agg_kind,
-                agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile
+                agg_kinds::result_unaffected_by_order_by!()
+                    | AggKind::Builtin(PbAggKind::ApproxPercentile)
             ) || c.order_by.is_empty();
             agg_kind_ok && order_ok
         }) {

--- a/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
+++ b/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
@@ -57,8 +57,10 @@ impl Rule for DistinctAggRule {
                 c.agg_kind
             );
             let agg_kind_ok = !matches!(c.agg_kind, agg_kinds::simply_cannot_two_phase!());
-            let order_ok = matches!(c.agg_kind, agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile)
-                || c.order_by.is_empty();
+            let order_ok = matches!(
+                c.agg_kind,
+                agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile
+            ) || c.order_by.is_empty();
             agg_kind_ok && order_ok
         }) {
             tracing::warn!("DistinctAggRule: unsupported agg kind, fallback to backend impl");

--- a/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
+++ b/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
@@ -57,7 +57,7 @@ impl Rule for DistinctAggRule {
                 c.agg_kind
             );
             let agg_kind_ok = !matches!(c.agg_kind, agg_kinds::simply_cannot_two_phase!());
-            let order_ok = matches!(c.agg_kind, agg_kinds::result_unaffected_by_order_by!())
+            let order_ok = matches!(c.agg_kind, agg_kinds::result_unaffected_by_order_by!() | AggKind::ApproxPercentile)
                 || c.order_by.is_empty();
             agg_kind_ok && order_ok
         }) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

*30% the changes in this PR are planner tests + binder tests*

This is part of #17531.

We add stateless two-phase simple approx percentile, integrating it with `gen_stateless_two_phase_streaming_agg_plan`.

`StreamLocalApproxPercentile` is the local phase for `approx_percentile`.
`StreamGlobalApproxPercentile` is the global phase.

We do not implement a `core` for either of these, since the fields they use are different (global step does not require any parameters, local step requires the parameters). Further, there's also no `logical` plan node which corresponds to these stream nodes, so there's no need to add a `core`, it will just be overhead.

We also add `KeyedMerge` which will combine the results from approx percentile and normal aggs, as well as pair-wise approx percentiles.

- [x] Add stateless two-phase approx percentile.
- [x] Fix the keyed merge schema.
- [x] Handle multiple approx percentiles.
- [x] Fix distribution of global approx percentile.
- [x] Handle DESC approx percentile.
- [x] Planner tests

### Subsequent PRs

- Handle vnode based two-phase approx percentile.
- Handle single phase approx percentile (embedded in expr framework).
- Write local approx percentile agg.
- Write global approx percentile agg.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
