### PR TITLE
chore: Add `serde` and `serde_json` v1 with derive to `Cargo.toml` in SQL migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11868,6 +11868,8 @@ version = "1.11.0-alpha"
 dependencies = [
  "async-std",
  "sea-orm-migration",
+ "serde",
+ "serde_json",
  "uuid",
 ]
 

--- a/src/meta/model_v2/migration/Cargo.toml
+++ b/src/meta/model_v2/migration/Cargo.toml
@@ -15,6 +15,8 @@ normal = ["workspace-hack"]
 
 [dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 
 [dependencies.sea-orm-migration]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Used to ensure clean dependencies in the pull request #17523 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
