### PR TITLE
refactor: graceful shutdown on frontend node

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -50,7 +50,6 @@ pub fn meta(opts: MetaNodeOpts) -> ! {
 
 pub fn frontend(opts: FrontendOpts) -> ! {
     init_risingwave_logger(LoggerSettings::from_opts(&opts));
-    // TODO(shutdown): pass the shutdown token
     main_okk(|shutdown| risingwave_frontend::start(opts, shutdown));
 }
 

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -51,7 +51,7 @@ pub fn meta(opts: MetaNodeOpts) -> ! {
 pub fn frontend(opts: FrontendOpts) -> ! {
     init_risingwave_logger(LoggerSettings::from_opts(&opts));
     // TODO(shutdown): pass the shutdown token
-    main_okk(|_| risingwave_frontend::start(opts));
+    main_okk(|shutdown| risingwave_frontend::start(opts, shutdown));
 }
 
 pub fn compactor(opts: CompactorOpts) -> ! {

--- a/src/cmd_all/src/standalone.rs
+++ b/src/cmd_all/src/standalone.rs
@@ -186,6 +186,9 @@ pub async fn standalone(
 ) {
     tracing::info!("launching Risingwave in standalone mode");
 
+    // TODO(shutdown): use the real one passed-in
+    let shutdown = CancellationToken::new();
+
     let mut is_in_memory = false;
     if let Some(opts) = meta_opts {
         is_in_memory = matches!(opts.backend, Some(MetaBackend::Mem));
@@ -215,15 +218,15 @@ pub async fn standalone(
     }
     if let Some(opts) = compute_opts {
         tracing::info!("starting compute-node thread with cli args: {:?}", opts);
-        // TODO(shutdown): pass the shutdown token
+        let shutdown = shutdown.clone();
         let _compute_handle =
-            tokio::spawn(
-                async move { risingwave_compute::start(opts, CancellationToken::new()).await },
-            );
+            tokio::spawn(async move { risingwave_compute::start(opts, shutdown).await });
     }
     if let Some(opts) = frontend_opts.clone() {
         tracing::info!("starting frontend-node thread with cli args: {:?}", opts);
-        let _frontend_handle = tokio::spawn(async move { risingwave_frontend::start(opts).await });
+        let shutdown = shutdown.clone();
+        let _frontend_handle =
+            tokio::spawn(async move { risingwave_frontend::start(opts, shutdown).await });
     }
     if let Some(opts) = compactor_opts {
         tracing::info!("starting compactor-node thread with cli args: {:?}", opts);

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -445,7 +445,8 @@ pub async fn compute_node_serve(
     // Wait for the shutdown signal.
     shutdown.cancelled().await;
 
-    // TODO(shutdown): gracefully unregister from the meta service.
+    // TODO(shutdown): gracefully unregister from the meta service (need to cautious since it may
+    // trigger auto-scaling)
 
     // NOTE(shutdown): We can't simply join the tonic server here because it only returns when all
     // existing connections are closed, while we have long-running streaming calls that never

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -443,7 +443,7 @@ pub async fn compute_node_serve(
     // All set, let the meta service know we're ready.
     meta_client.activate(&advertise_addr).await.unwrap();
     // Wait for the shutdown signal.
-    let _ = shutdown.cancelled().await;
+    shutdown.cancelled().await;
 
     // TODO(shutdown): gracefully unregister from the meta service.
 

--- a/src/ctl/src/common/context.rs
+++ b/src/ctl/src/common/context.rs
@@ -15,7 +15,6 @@
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::hummock::HummockStorage;
 use risingwave_storage::monitor::MonitoredStateStore;
-use thiserror_ext::AsReport;
 use tokio::sync::OnceCell;
 
 use crate::common::hummock_service::{HummockServiceOpts, Metrics};
@@ -63,17 +62,6 @@ impl CtlContext {
 
     pub async fn try_close(mut self) {
         tracing::info!("clean up context");
-        if let Some(meta_client) = self.meta_client.take() {
-            if let Err(e) = meta_client
-                .unregister(meta_client.host_addr().clone())
-                .await
-            {
-                tracing::warn!(
-                    error = %e.as_report(),
-                    worker_id = %meta_client.worker_id(),
-                    "failed to unregister ctl worker",
-                );
-            }
-        }
+        self.meta_client.take().unwrap().try_unregister().await;
     }
 }

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -61,6 +61,7 @@ pub mod session;
 mod stream_fragmenter;
 use risingwave_common::config::{MetricLevel, OverrideConfig};
 use risingwave_common::util::meta_addr::MetaAddressStrategy;
+use risingwave_common::util::tokio_util::sync::CancellationToken;
 pub use stream_fragmenter::build_graph;
 mod utils;
 pub use utils::{explain_stream_graph, WithOptions};
@@ -165,12 +166,15 @@ use std::pin::Pin;
 use pgwire::pg_protocol::TlsConfig;
 
 /// Start frontend
-pub fn start(opts: FrontendOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+pub fn start(
+    opts: FrontendOpts,
+    shutdown: CancellationToken,
+) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     // WARNING: don't change the function signature. Making it `async fn` will cause
     // slow compile in release mode.
     Box::pin(async move {
         let listen_addr = opts.listen_addr.clone();
-        let session_mgr = Arc::new(SessionManagerImpl::new(opts).await.unwrap());
+        let session_mgr = SessionManagerImpl::new(opts).await.unwrap();
         let redact_sql_option_keywords = Arc::new(
             session_mgr
                 .env()
@@ -180,11 +184,13 @@ pub fn start(opts: FrontendOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
                 .map(|s| s.to_lowercase())
                 .collect::<HashSet<_>>(),
         );
+
         pg_serve(
             &listen_addr,
             session_mgr,
             TlsConfig::new_default(),
             Some(redact_sql_option_keywords),
+            shutdown,
         )
         .await
         .unwrap()

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -44,6 +44,8 @@ use risingwave_rpc_client::{HummockMetaClient, MetaClient};
 /// in this trait so that the mocking can be simplified.
 #[async_trait::async_trait]
 pub trait FrontendMetaClient: Send + Sync {
+    async fn try_unregister(&self);
+
     async fn pin_snapshot(&self) -> Result<HummockSnapshot>;
 
     async fn get_snapshot(&self) -> Result<HummockSnapshot>;
@@ -130,6 +132,10 @@ pub struct FrontendMetaClientImpl(pub MetaClient);
 
 #[async_trait::async_trait]
 impl FrontendMetaClient for FrontendMetaClientImpl {
+    async fn try_unregister(&self) {
+        self.0.try_unregister().await;
+    }
+
     async fn pin_snapshot(&self) -> Result<HummockSnapshot> {
         self.0.pin_snapshot().await
     }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -1183,10 +1183,11 @@ impl SessionManager for SessionManagerImpl {
         self.delete_session(&session.session_id());
     }
 
-    async fn shutdown(&self) -> std::result::Result<(), BoxedError> {
+    async fn shutdown(&self) {
+        // Clean up the session map.
         self.env.sessions_map().write().clear();
-        // TODO(shutdown): unregister from meta service
-        Ok(())
+        // Unregister from the meta service.
+        self.env.meta_client().try_unregister().await;
     }
 }
 

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -1182,10 +1182,17 @@ impl SessionManager for SessionManagerImpl {
     fn end_session(&self, session: &Self::Session) {
         self.delete_session(&session.session_id());
     }
+
+    async fn shutdown(&self) -> std::result::Result<(), BoxedError> {
+        self.env.sessions_map().write().clear();
+        // TODO(shutdown): unregister from meta service
+        Ok(())
+    }
 }
 
 impl SessionManagerImpl {
     pub async fn new(opts: FrontendOpts) -> Result<Self> {
+        // TODO(shutdown): only save join handles that **need** to be shutdown
         let (env, join_handles, shutdown_senders) = FrontendEnv::init(opts).await?;
         Ok(Self {
             env,

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -928,6 +928,8 @@ pub struct MockFrontendMetaClient {}
 
 #[async_trait::async_trait]
 impl FrontendMetaClient for MockFrontendMetaClient {
+    async fn try_unregister(&self) {}
+
     async fn pin_snapshot(&self) -> RpcResult<HummockSnapshot> {
         Ok(HummockSnapshot {
             committed_epoch: 0,

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -140,14 +140,17 @@ impl ClusterService for ClusterServiceImpl {
     ) -> Result<Response<DeleteWorkerNodeResponse>, Status> {
         let req = request.into_inner();
         let host = req.get_host()?.clone();
-        match &self.metadata_manager {
-            MetadataManager::V1(mgr) => {
-                let _ = mgr.cluster_manager.delete_worker_node(host).await?;
-            }
-            MetadataManager::V2(mgr) => {
-                mgr.cluster_controller.delete_worker(host).await?;
-            }
-        }
+
+        let worker_node = match &self.metadata_manager {
+            MetadataManager::V1(mgr) => mgr.cluster_manager.delete_worker_node(host).await?,
+            MetadataManager::V2(mgr) => mgr.cluster_controller.delete_worker(host).await?,
+        };
+        tracing::info!(
+            host = ?worker_node.host,
+            id = worker_node.id,
+            r#type = ?worker_node.r#type(),
+            "deleted worker node",
+        );
 
         Ok(Response::new(DeleteWorkerNodeResponse { status: None }))
     }

--- a/src/meta/src/controller/cluster.rs
+++ b/src/meta/src/controller/cluster.rs
@@ -175,7 +175,7 @@ impl ClusterController {
         Ok(())
     }
 
-    pub async fn delete_worker(&self, host_address: HostAddress) -> MetaResult<()> {
+    pub async fn delete_worker(&self, host_address: HostAddress) -> MetaResult<WorkerNode> {
         let mut inner = self.inner.write().await;
         let worker = inner.delete_worker(host_address).await?;
         if worker.r#type() == PbWorkerType::ComputeNode {
@@ -190,10 +190,10 @@ impl ClusterController {
         // local notification.
         self.env
             .notification_manager()
-            .notify_local_subscribers(LocalNotification::WorkerNodeDeleted(worker))
+            .notify_local_subscribers(LocalNotification::WorkerNodeDeleted(worker.clone()))
             .await;
 
-        Ok(())
+        Ok(worker)
     }
 
     pub async fn update_schedulability(

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -477,7 +477,12 @@ impl Cluster {
                 .create_node()
                 .name(format!("frontend-{i}"))
                 .ip([192, 168, 2, i as u8].into())
-                .init(move || risingwave_frontend::start(opts.clone()))
+                .init(move || {
+                    risingwave_frontend::start(
+                        opts.clone(),
+                        CancellationToken::new(), // dummy
+                    )
+                })
                 .build();
         }
 
@@ -501,7 +506,12 @@ impl Cluster {
                 .name(format!("compute-{i}"))
                 .ip([192, 168, 3, i as u8].into())
                 .cores(conf.compute_node_cores)
-                .init(move || risingwave_compute::start(opts.clone(), CancellationToken::new()))
+                .init(move || {
+                    risingwave_compute::start(
+                        opts.clone(),
+                        CancellationToken::new(), // dummy
+                    )
+                })
                 .build();
         }
 

--- a/src/utils/pgwire/src/lib.rs
+++ b/src/utils/pgwire/src/lib.rs
@@ -19,6 +19,7 @@
 #![feature(lazy_cell)]
 #![feature(buf_read_has_data_left)]
 #![feature(round_char_boundary)]
+#![feature(never_type)]
 #![expect(clippy::doc_markdown, reason = "FIXME: later")]
 
 pub mod error;

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -60,8 +60,8 @@ pub trait SessionManager: Send + Sync + 'static {
     fn end_session(&self, session: &Self::Session);
 
     /// Run some cleanup tasks before the server shutdown.
-    fn shutdown(&self) -> impl Future<Output = Result<(), BoxedError>> + Send {
-        async { Ok(()) }
+    fn shutdown(&self) -> impl Future<Output = ()> + Send {
+        async {}
     }
 }
 
@@ -312,7 +312,7 @@ pub async fn pg_serve(
     // Stop accepting new connections.
     acceptor_runtime.shutdown_background();
     // Shutdown session manager, typically close all existing sessions.
-    session_mgr.shutdown().await?;
+    session_mgr.shutdown().await;
 
     Ok(())
 }
@@ -516,7 +516,7 @@ mod tests {
         let bind_addr = bind_addr.into();
         let pg_config = pg_config.into();
 
-        let session_mgr = Arc::new(MockSessionManager {});
+        let session_mgr = MockSessionManager {};
         tokio::spawn(async move {
             pg_serve(
                 &bind_addr,

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -281,25 +281,23 @@ pub async fn pg_serve(
 
     let session_mgr = Arc::new(session_mgr);
     let session_mgr_clone = session_mgr.clone();
-    let f = {
-        async move {
-            loop {
-                let conn_ret = listener.accept().await;
-                match conn_ret {
-                    Ok((stream, peer_addr)) => {
-                        tracing::info!(%peer_addr, "accept connection");
-                        worker_runtime.spawn(handle_connection(
-                            stream,
-                            session_mgr_clone.clone(),
-                            tls_config.clone(),
-                            Arc::new(peer_addr),
-                            redact_sql_option_keywords.clone(),
-                        ));
-                    }
+    let f = async move {
+        loop {
+            let conn_ret = listener.accept().await;
+            match conn_ret {
+                Ok((stream, peer_addr)) => {
+                    tracing::info!(%peer_addr, "accept connection");
+                    worker_runtime.spawn(handle_connection(
+                        stream,
+                        session_mgr_clone.clone(),
+                        tls_config.clone(),
+                        Arc::new(peer_addr),
+                        redact_sql_option_keywords.clone(),
+                    ));
+                }
 
-                    Err(e) => {
-                        tracing::error!(error = %e.as_report(), "failed to accept connection",);
-                    }
+                Err(e) => {
+                    tracing::error!(error = %e.as_report(), "failed to accept connection",);
                 }
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Follow-up of #17533. Implements graceful shutdown on frontend node, which

- stops all existing sessions
- unregisters from the meta service

Also improves the logging for unregistration.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
