### PR TITLE
refactor: graceful shutdown on compactor node

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -55,7 +55,6 @@ pub fn frontend(opts: FrontendOpts) -> ! {
 
 pub fn compactor(opts: CompactorOpts) -> ! {
     init_risingwave_logger(LoggerSettings::from_opts(&opts));
-    // TODO(shutdown): pass the shutdown token
     main_okk(|shutdown| risingwave_compactor::start(opts, shutdown));
 }
 

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -56,7 +56,7 @@ pub fn frontend(opts: FrontendOpts) -> ! {
 pub fn compactor(opts: CompactorOpts) -> ! {
     init_risingwave_logger(LoggerSettings::from_opts(&opts));
     // TODO(shutdown): pass the shutdown token
-    main_okk(|_| risingwave_compactor::start(opts));
+    main_okk(|shutdown| risingwave_compactor::start(opts, shutdown));
 }
 
 pub fn ctl(opts: CtlOpts) -> ! {

--- a/src/cmd_all/src/standalone.rs
+++ b/src/cmd_all/src/standalone.rs
@@ -230,8 +230,9 @@ pub async fn standalone(
     }
     if let Some(opts) = compactor_opts {
         tracing::info!("starting compactor-node thread with cli args: {:?}", opts);
+        let shutdown = shutdown.clone();
         let _compactor_handle =
-            tokio::spawn(async move { risingwave_compactor::start(opts).await });
+            tokio::spawn(async move { risingwave_compactor::start(opts, shutdown).await });
     }
 
     // wait for log messages to be flushed

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -26,6 +26,7 @@ use risingwave_common::telemetry::manager::TelemetryManager;
 use risingwave_common::telemetry::telemetry_env_enabled;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::resource_util::memory::system_memory_available_bytes;
+use risingwave_common::util::tokio_util::sync::CancellationToken;
 use risingwave_common::{GIT_SHA, RW_VERSION};
 use risingwave_common_heap_profiling::HeapProfiler;
 use risingwave_common_service::metrics_manager::MetricsManager;
@@ -52,8 +53,6 @@ use risingwave_storage::monitor::{
 };
 use risingwave_storage::opts::StorageOpts;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot::Sender;
-use tokio::task::JoinHandle;
 use tonic::transport::Endpoint;
 use tracing::info;
 
@@ -174,11 +173,14 @@ pub async fn prepare_start_parameters(
 }
 
 /// Fetches and runs compaction tasks.
+///
+/// Returns when the `shutdown` token is triggered.
 pub async fn compactor_serve(
     listen_addr: SocketAddr,
     advertise_addr: HostAddr,
     opts: CompactorOpts,
-) -> (JoinHandle<()>, JoinHandle<()>, Sender<()>) {
+    shutdown: CancellationToken,
+) {
     let config = load_config(&opts.config_path, &opts);
     info!("Starting compactor node",);
     info!("> config: {:?}", config);
@@ -200,7 +202,6 @@ pub async fn compactor_serve(
     .unwrap();
 
     info!("Assigned compactor id {}", meta_client.worker_id());
-    meta_client.activate(&advertise_addr).await.unwrap();
 
     let hummock_metrics = Arc::new(GLOBAL_HUMMOCK_METRICS.clone());
 
@@ -234,7 +235,7 @@ pub async fn compactor_serve(
 
     // use half of limit because any memory which would hold in meta-cache will be allocate by
     // limited at first.
-    let observer_join_handle = observer_manager.start().await;
+    let _observer_join_handle = observer_manager.start().await;
 
     let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
         hummock_meta_client.clone(),
@@ -259,6 +260,8 @@ pub async fn compactor_serve(
         task_progress_manager: Default::default(),
         await_tree_reg: await_tree_reg.clone(),
     };
+
+    // TODO(shutdown): don't collect sub-tasks as there's no need to gracefully shutdown them.
     let mut sub_tasks = vec![
         MetaClient::start_heartbeat_loop(
             meta_client.clone(),
@@ -287,50 +290,41 @@ pub async fn compactor_serve(
 
     let compactor_srv = CompactorServiceImpl::default();
     let monitor_srv = MonitorServiceImpl::new(await_tree_reg);
-    let (shutdown_send, mut shutdown_recv) = tokio::sync::oneshot::channel();
-    let join_handle = tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_service(CompactorServiceServer::new(compactor_srv))
-            .add_service(MonitorServiceServer::new(monitor_srv))
-            .monitored_serve_with_shutdown(
-                listen_addr,
-                "grpc-compactor-node-service",
-                TcpConfig {
-                    tcp_nodelay: true,
-                    keepalive_duration: None,
-                },
-                async move {
-                    tokio::select! {
-                        _ = tokio::signal::ctrl_c() => {},
-                        _ = &mut shutdown_recv => {
-                            for (join_handle, shutdown_sender) in sub_tasks {
-                                if shutdown_sender.send(()).is_err() {
-                                    tracing::warn!("Failed to send shutdown");
-                                    continue;
-                                }
-                                if join_handle.await.is_err() {
-                                    tracing::warn!("Failed to join shutdown");
-                                }
-                            }
-                        },
-                    }
-                },
-            )
-            .await
-    });
+    let server = tonic::transport::Server::builder()
+        .add_service(CompactorServiceServer::new(compactor_srv))
+        .add_service(MonitorServiceServer::new(monitor_srv))
+        .monitored_serve_with_shutdown(
+            listen_addr,
+            "grpc-compactor-node-service",
+            TcpConfig {
+                tcp_nodelay: true,
+                keepalive_duration: None,
+            },
+            shutdown.clone().cancelled_owned(),
+        );
+    let _server_handle = tokio::spawn(server);
 
     // Boot metrics service.
     if config.server.metrics_level > MetricLevel::Disabled {
         MetricsManager::boot_metrics_service(opts.prometheus_listener_addr.clone());
     }
 
-    (join_handle, observer_join_handle, shutdown_send)
+    // All set, let the meta service know we're ready.
+    meta_client.activate(&advertise_addr).await.unwrap();
+
+    // Wait for the shutdown signal.
+    shutdown.cancelled().await;
+    meta_client.try_unregister().await;
 }
 
+/// Fetches and runs compaction tasks under shared mode.
+///
+/// Returns when the `shutdown` token is triggered.
 pub async fn shared_compactor_serve(
     listen_addr: SocketAddr,
     opts: CompactorOpts,
-) -> (JoinHandle<()>, Sender<()>) {
+    shutdown: CancellationToken,
+) {
     let config = load_config(&opts.config_path, &opts);
     info!("Starting shared compactor node",);
     info!("> config: {:?}", config);
@@ -373,7 +367,6 @@ pub async fn shared_compactor_serve(
     // Run a background heap profiler
     heap_profiler.start();
 
-    let (shutdown_send, mut shutdown_recv) = tokio::sync::oneshot::channel();
     let compaction_executor = Arc::new(CompactionExecutor::new(
         opts.compaction_worker_threads_number,
     ));
@@ -387,44 +380,35 @@ pub async fn shared_compactor_serve(
         task_progress_manager: Default::default(),
         await_tree_reg,
     };
-    let join_handle = tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_service(CompactorServiceServer::new(compactor_srv))
-            .add_service(MonitorServiceServer::new(monitor_srv))
-            .monitored_serve_with_shutdown(
-                listen_addr,
-                "grpc-compactor-node-service",
-                TcpConfig {
-                    tcp_nodelay: true,
-                    keepalive_duration: None,
-                },
-                async move {
-                    let (join_handle, shutdown_sender) =
-                        risingwave_storage::hummock::compactor::start_shared_compactor(
-                            grpc_proxy_client,
-                            receiver,
-                            compactor_context,
-                        );
-                    tokio::select! {
-                        _ = tokio::signal::ctrl_c() => {},
-                        _ = &mut shutdown_recv => {
-                            if shutdown_sender.send(()).is_err() {
-                                tracing::warn!("Failed to send shutdown");
-                            }
-                            if join_handle.await.is_err() {
-                                tracing::warn!("Failed to join shutdown");
-                            }
-                        },
-                    }
-                },
-            )
-            .await
-    });
+
+    risingwave_storage::hummock::compactor::start_shared_compactor(
+        grpc_proxy_client,
+        receiver,
+        compactor_context,
+    );
+
+    let server = tonic::transport::Server::builder()
+        .add_service(CompactorServiceServer::new(compactor_srv))
+        .add_service(MonitorServiceServer::new(monitor_srv))
+        .monitored_serve_with_shutdown(
+            listen_addr,
+            "grpc-compactor-node-service",
+            TcpConfig {
+                tcp_nodelay: true,
+                keepalive_duration: None,
+            },
+            shutdown.clone().cancelled_owned(),
+        );
+
+    let _server_handle = tokio::spawn(server);
 
     // Boot metrics service.
     if config.server.metrics_level > MetricLevel::Disabled {
         MetricsManager::boot_metrics_service(opts.prometheus_listener_addr.clone());
     }
 
-    (join_handle, shutdown_send)
+    // Wait for the shutdown signal.
+    shutdown.cancelled().await;
+
+    // TODO(shutdown): shall we notify the proxy that we are shutting down?
 }

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -314,6 +314,7 @@ pub async fn compactor_serve(
 
     // Wait for the shutdown signal.
     shutdown.cancelled().await;
+    // Run shutdown logic.
     meta_client.try_unregister().await;
 }
 

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -30,6 +30,7 @@ use risingwave_common::config::{
 };
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::iter_util::ZipEqFast;
+use risingwave_common::util::tokio_util::sync::CancellationToken;
 use risingwave_hummock_sdk::key::TableKey;
 use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
 use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, FIRST_VERSION_ID};
@@ -172,7 +173,7 @@ async fn start_compactor_node(
         "--config-path",
         &config_path,
     ]);
-    risingwave_compactor::start(opts).await
+    risingwave_compactor::start(opts, CancellationToken::new() /* dummy */).await
 }
 
 pub fn start_compactor_thread(

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -530,7 +530,12 @@ impl Cluster {
                 .create_node()
                 .name(format!("compactor-{i}"))
                 .ip([192, 168, 4, i as u8].into())
-                .init(move || risingwave_compactor::start(opts.clone()))
+                .init(move || {
+                    risingwave_compactor::start(
+                        opts.clone(),
+                        CancellationToken::new(), // dummy
+                    )
+                })
                 .build();
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Follow-up of #17574. Implements graceful shutdown on frontend node, which

- unregisters from the meta service

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
