### PR TITLE
fix(risedev): fixes and improvements for `risedev-dev` running risingwave commands

### DIFF
--- a/src/risedevtool/run_command.sh
+++ b/src/risedevtool/run_command.sh
@@ -5,14 +5,30 @@
 echo "${@:3}"
 echo "logging to $1, and status to $2"
 
-"${@:3}" 2>&1 | tee "$1"
+# Strip ANSI color codes to make the log file readable.
+# trap '' INT: ignore interrupts in sed
+strip_ansi() {
+  (trap '' INT; sed -e 's/\x1b\[[0-9;]*m//g')
+}
 
+# Run the command and log the output to both the terminal and the log file.
+# tee -i: ignore interrupts in tee
+RW_LOG_FORCE_COLORFUL=1 "${@:3}" 2>&1 | tee -i >(strip_ansi > "$1")
+
+# Retrieve the return status.
 RET_STATUS="${PIPESTATUS[0]}"
 
-echo "status ${RET_STATUS}" > "$2"
+# If the status file exists, write the return status to it.
+#
+# The status file is used to detect early exits. Once `risedev-dev` finishes launching successfully,
+# it will clean up the status file, so it's safe to ignore it then.
+if [ -f "$2" ]; then
+    echo "status ${RET_STATUS}" > "$2"
+fi
 
+# Show the return status in both outputs.
 echo "$(date -u) [risedev]: Program exited with ${RET_STATUS}" >> "$1"
-echo "Program exited with ${RET_STATUS}, press Ctrl+C to continue."
+echo "Program exited with ${RET_STATUS}, press Ctrl+C again to close the window."
 
 while true; do
     read -r

--- a/src/risedevtool/src/task.rs
+++ b/src/risedevtool/src/task.rs
@@ -138,11 +138,7 @@ where
         if !id.is_empty() {
             self.pb.set_prefix(id.clone());
             self.id = Some(id.clone());
-
-            // Remove the old status file if exists to avoid confusion.
-            let status_file = self.status_dir.path().join(format!("{}.status", id));
-            fs_err::remove_file(&status_file).ok();
-            self.status_file = Some(status_file);
+            self.status_file = Some(self.status_dir.path().join(format!("{}.status", id)));
 
             // Remove the old log file if exists to avoid confusion.
             let log_file = Path::new(&env::var("PREFIX_LOG").unwrap())

--- a/src/utils/runtime/src/logger.rs
+++ b/src/utils/runtime/src/logger.rs
@@ -81,7 +81,8 @@ impl LoggerSettings {
         Self {
             name: name.into(),
             enable_tokio_console: false,
-            colorful: console::colors_enabled_stderr() && console::colors_enabled(),
+            colorful: env_var_is_true("RW_LOG_FORCE_COLORFUL")
+                || (console::colors_enabled_stderr() && console::colors_enabled()),
             stderr: false,
             with_thread_name: false,
             targets: vec![],


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Several fixes and improvements for `risedev-dev` running risingwave commands.

- Let risingwave processes handle Ctrl-C and run shutdown logic, instead of signaling `tee` which kills risingwave abnormally.

- Keep colors when checking logs in `tmux` windows.

- Ignore writing to the status file if it is not present, which is normal when `risedev-dev` successfully finishes launching all components and the temporary status file is cleaned up.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
