### PR TITLE
refactor: graceful shutdown on meta node & unify election path

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -45,7 +45,7 @@ pub fn compute(opts: ComputeNodeOpts) -> ! {
 pub fn meta(opts: MetaNodeOpts) -> ! {
     init_risingwave_logger(LoggerSettings::from_opts(&opts));
     // TODO(shutdown): pass the shutdown token
-    main_okk(|_| risingwave_meta_node::start(opts));
+    main_okk(|shutdown| risingwave_meta_node::start(opts, shutdown));
 }
 
 pub fn frontend(opts: FrontendOpts) -> ! {

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -44,7 +44,6 @@ pub fn compute(opts: ComputeNodeOpts) -> ! {
 
 pub fn meta(opts: MetaNodeOpts) -> ! {
     init_risingwave_logger(LoggerSettings::from_opts(&opts));
-    // TODO(shutdown): pass the shutdown token
     main_okk(|shutdown| risingwave_meta_node::start(opts, shutdown));
 }
 

--- a/src/cmd_all/src/standalone.rs
+++ b/src/cmd_all/src/standalone.rs
@@ -194,9 +194,10 @@ pub async fn standalone(
         is_in_memory = matches!(opts.backend, Some(MetaBackend::Mem));
         tracing::info!("starting meta-node thread with cli args: {:?}", opts);
 
+        let shutdown = shutdown.clone();
         let _meta_handle = tokio::spawn(async move {
             let dangerous_max_idle_secs = opts.dangerous_max_idle_secs;
-            risingwave_meta_node::start(opts).await;
+            risingwave_meta_node::start(opts, shutdown).await;
             tracing::warn!("meta is stopped, shutdown all nodes");
             if let Some(idle_exit_secs) = dangerous_max_idle_secs {
                 eprintln!("{}",

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -26,6 +26,7 @@ use redact::Secret;
 use risingwave_common::config::OverrideConfig;
 use risingwave_common::util::meta_addr::MetaAddressStrategy;
 use risingwave_common::util::resource_util;
+use risingwave_common::util::tokio_util::sync::CancellationToken;
 use risingwave_common::{GIT_SHA, RW_VERSION};
 use risingwave_common_heap_profiling::HeapProfiler;
 use risingwave_meta::*;
@@ -324,7 +325,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
             max_timeout_ms / 1000
         } + MIN_TIMEOUT_INTERVAL_SEC;
 
-        let (mut join_handle, leader_lost_handle, shutdown_send) = rpc_serve(
+        rpc_serve(
             add_info,
             backend,
             max_heartbeat_interval,
@@ -428,42 +429,10 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
             },
             config.system.into_init_system_params(),
             Default::default(),
+            CancellationToken::new(), // TODO: pass the shutdown token
         )
         .await
         .unwrap();
-
-        tracing::info!("Meta server listening at {}", listen_addr);
-
-        match leader_lost_handle {
-            None => {
-                tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {
-                        tracing::info!("receive ctrl+c");
-                        shutdown_send.send(()).unwrap();
-                        join_handle.await.unwrap()
-                    }
-                    res = &mut join_handle => res.unwrap(),
-                };
-            }
-            Some(mut handle) => {
-                tokio::select! {
-                    _ = &mut handle => {
-                        tracing::info!("receive leader lost signal");
-                        // When we lose leadership, we will exit as soon as possible.
-                    }
-                    _ = tokio::signal::ctrl_c() => {
-                        tracing::info!("receive ctrl+c");
-                        shutdown_send.send(()).unwrap();
-                        join_handle.await.unwrap();
-                        handle.abort();
-                    }
-                    res = &mut join_handle => {
-                        res.unwrap();
-                        handle.abort();
-                    },
-                };
-            }
-        };
     })
 }
 

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -205,7 +205,10 @@ use risingwave_common::config::{load_config, MetaBackend, RwConfig};
 use tracing::info;
 
 /// Start meta node
-pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+pub fn start(
+    opts: MetaNodeOpts,
+    shutdown: CancellationToken,
+) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     // WARNING: don't change the function signature. Making it `async fn` will cause
     // slow compile in release mode.
     Box::pin(async move {
@@ -429,7 +432,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
             },
             config.system.into_init_system_params(),
             Default::default(),
-            CancellationToken::new(), // TODO: pass the shutdown token
+            shutdown,
         )
         .await
         .unwrap();

--- a/src/meta/src/rpc/election/dummy.rs
+++ b/src/meta/src/rpc/election/dummy.rs
@@ -16,8 +16,14 @@ use tokio::sync::watch::{self, Receiver, Sender};
 
 use crate::{ElectionClient, ElectionMember, MetaResult};
 
+/// A dummy implementation of [`ElectionClient`] for scenarios where only one meta node is running,
+/// typically for testing purposes such as an in-memory meta store.
+///
+/// This can be used to unify the code paths no matter there's HA or not.
 pub struct DummyElectionClient {
     id: String,
+
+    /// A dummy watcher that never changes, indicating we are always the leader.
     dummy_watcher: Sender<bool>,
 }
 

--- a/src/meta/src/rpc/election/dummy.rs
+++ b/src/meta/src/rpc/election/dummy.rs
@@ -50,10 +50,8 @@ impl ElectionClient for DummyElectionClient {
     }
 
     async fn run_once(&self, _ttl: i64, mut stop: Receiver<()>) -> MetaResult<()> {
-        tokio::select! {
-            _ = stop.changed() => {}
-            _ = futures::future::pending::<()>() => {}
-        }
+        // Only exit when the stop signal is received.
+        let _ = stop.changed().await;
         Ok(())
     }
 

--- a/src/meta/src/rpc/election/dummy.rs
+++ b/src/meta/src/rpc/election/dummy.rs
@@ -1,0 +1,69 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tokio::sync::watch::{self, Receiver, Sender};
+
+use crate::{ElectionClient, ElectionMember, MetaResult};
+
+pub struct DummyElectionClient {
+    id: String,
+    dummy_watcher: Sender<bool>,
+}
+
+impl DummyElectionClient {
+    pub fn new(id: String) -> Self {
+        Self {
+            id,
+            dummy_watcher: watch::channel(true).0,
+        }
+    }
+
+    fn self_member(&self) -> ElectionMember {
+        ElectionMember {
+            id: self.id.clone(),
+            is_leader: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ElectionClient for DummyElectionClient {
+    fn id(&self) -> MetaResult<String> {
+        Ok(self.id.clone())
+    }
+
+    async fn run_once(&self, _ttl: i64, mut stop: Receiver<()>) -> MetaResult<()> {
+        tokio::select! {
+            _ = stop.changed() => {}
+            _ = futures::future::pending::<()>() => {}
+        }
+        Ok(())
+    }
+
+    fn subscribe(&self) -> Receiver<bool> {
+        self.dummy_watcher.subscribe()
+    }
+
+    async fn leader(&self) -> MetaResult<Option<ElectionMember>> {
+        Ok(Some(self.self_member()))
+    }
+
+    async fn get_members(&self) -> MetaResult<Vec<ElectionMember>> {
+        Ok(vec![self.self_member()])
+    }
+
+    fn is_leader(&self) -> bool {
+        true
+    }
+}

--- a/src/meta/src/rpc/election/etcd.rs
+++ b/src/meta/src/rpc/election/etcd.rs
@@ -36,7 +36,7 @@ pub struct EtcdElectionClient {
 
 #[async_trait::async_trait]
 impl ElectionClient for EtcdElectionClient {
-    async fn is_leader(&self) -> bool {
+    fn is_leader(&self) -> bool {
         *self.is_leader_sender.borrow()
     }
 

--- a/src/meta/src/rpc/election/etcd.rs
+++ b/src/meta/src/rpc/election/etcd.rs
@@ -404,7 +404,7 @@ mod tests {
 
         let leader = new_followers.into_iter().next().unwrap();
 
-        assert!(leader.1.is_leader().await);
+        assert!(leader.1.is_leader());
     }
 
     #[tokio::test]
@@ -434,7 +434,7 @@ mod tests {
         let mut leaders = vec![];
         let mut followers = vec![];
         for (sender, client) in clients {
-            if client.is_leader().await {
+            if client.is_leader() {
                 leaders.push((sender, client));
             } else {
                 followers.push((sender, client));
@@ -476,7 +476,7 @@ mod tests {
         }
 
         for client in &clients {
-            assert!(!client.1.is_leader().await);
+            assert!(!client.1.is_leader());
         }
 
         for (stop_sender, client) in &clients {

--- a/src/meta/src/rpc/election/mod.rs
+++ b/src/meta/src/rpc/election/mod.rs
@@ -66,8 +66,12 @@ impl ElectionClient for DummyElectionClient {
         Ok(self.id.clone())
     }
 
-    async fn run_once(&self, _ttl: i64, _stop: Receiver<()>) -> MetaResult<()> {
-        futures::future::pending().await
+    async fn run_once(&self, _ttl: i64, mut stop: Receiver<()>) -> MetaResult<()> {
+        tokio::select! {
+            _ = stop.changed() => {}
+            _ = futures::future::pending::<()>() => {}
+        }
+        Ok(())
     }
 
     fn subscribe(&self) -> Receiver<bool> {

--- a/src/meta/src/rpc/election/mod.rs
+++ b/src/meta/src/rpc/election/mod.rs
@@ -15,7 +15,7 @@ pub mod etcd;
 pub mod sql;
 
 use serde::Serialize;
-use tokio::sync::watch::Receiver;
+use tokio::sync::watch::{self, Receiver};
 
 use crate::MetaResult;
 
@@ -39,4 +39,50 @@ pub trait ElectionClient: Send + Sync + 'static {
     async fn leader(&self) -> MetaResult<Option<ElectionMember>>;
     async fn get_members(&self) -> MetaResult<Vec<ElectionMember>>;
     async fn is_leader(&self) -> bool;
+}
+
+pub struct DummyElectionClient {
+    id: String,
+    dummy_channel: watch::Sender<bool>,
+}
+
+impl DummyElectionClient {
+    pub fn new(id: String) -> Self {
+        let dummy_channel = watch::channel(true).0;
+        Self { id, dummy_channel }
+    }
+
+    fn self_member(&self) -> ElectionMember {
+        ElectionMember {
+            id: self.id.clone(),
+            is_leader: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ElectionClient for DummyElectionClient {
+    fn id(&self) -> MetaResult<String> {
+        Ok(self.id.clone())
+    }
+
+    async fn run_once(&self, _ttl: i64, _stop: Receiver<()>) -> MetaResult<()> {
+        futures::future::pending().await
+    }
+
+    fn subscribe(&self) -> Receiver<bool> {
+        self.dummy_channel.subscribe()
+    }
+
+    async fn leader(&self) -> MetaResult<Option<ElectionMember>> {
+        Ok(Some(self.self_member()))
+    }
+
+    async fn get_members(&self) -> MetaResult<Vec<ElectionMember>> {
+        Ok(vec![self.self_member()])
+    }
+
+    async fn is_leader(&self) -> bool {
+        true
+    }
 }

--- a/src/meta/src/rpc/election/mod.rs
+++ b/src/meta/src/rpc/election/mod.rs
@@ -38,7 +38,7 @@ pub trait ElectionClient: Send + Sync + 'static {
     fn subscribe(&self) -> Receiver<bool>;
     async fn leader(&self) -> MetaResult<Option<ElectionMember>>;
     async fn get_members(&self) -> MetaResult<Vec<ElectionMember>>;
-    async fn is_leader(&self) -> bool;
+    fn is_leader(&self) -> bool;
 }
 
 pub struct DummyElectionClient {
@@ -82,7 +82,7 @@ impl ElectionClient for DummyElectionClient {
         Ok(vec![self.self_member()])
     }
 
-    async fn is_leader(&self) -> bool {
+    fn is_leader(&self) -> bool {
         true
     }
 }

--- a/src/meta/src/rpc/election/mod.rs
+++ b/src/meta/src/rpc/election/mod.rs
@@ -36,6 +36,9 @@ pub trait ElectionClient: Send + Sync + 'static {
     }
 
     fn id(&self) -> MetaResult<String>;
+    /// Run the long-running election process.
+    ///
+    /// Returns when the leader status is lost, or the stop signal is received.
     async fn run_once(&self, ttl: i64, stop: Receiver<()>) -> MetaResult<()>;
     fn subscribe(&self) -> Receiver<bool>;
     async fn leader(&self) -> MetaResult<Option<ElectionMember>>;

--- a/src/meta/src/rpc/election/sql.rs
+++ b/src/meta/src/rpc/election/sql.rs
@@ -781,7 +781,7 @@ where
             .collect())
     }
 
-    async fn is_leader(&self) -> bool {
+    fn is_leader(&self) -> bool {
         *self.is_leader_sender.borrow()
     }
 }
@@ -842,7 +842,7 @@ mod tests {
         loop {
             receiver.changed().await.unwrap();
             if *receiver.borrow() {
-                assert!(sql_election_client.is_leader().await);
+                assert!(sql_election_client.is_leader());
                 break;
             }
         }
@@ -874,7 +874,7 @@ mod tests {
         let mut is_leaders = vec![];
 
         for client in clients {
-            is_leaders.push(client.is_leader().await);
+            is_leaders.push(client.is_leader());
         }
 
         assert!(is_leaders.iter().filter(|&x| *x).count() <= 1);

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -717,7 +717,7 @@ impl Default for MetaMetrics {
 
 pub fn start_worker_info_monitor(
     metadata_manager: MetadataManager,
-    election_client: Option<ElectionClientRef>,
+    election_client: ElectionClientRef,
     interval: Duration,
     meta_metrics: Arc<MetaMetrics>,
 ) -> (JoinHandle<()>, Sender<()>) {
@@ -754,9 +754,7 @@ pub fn start_worker_info_monitor(
                     .with_label_values(&[(worker_type.as_str_name())])
                     .set(worker_num as i64);
             }
-            if let Some(client) = &election_client
-                && let Ok(meta_members) = client.get_members().await
-            {
+            if let Ok(meta_members) = election_client.get_members().await {
                 meta_metrics
                     .worker_num
                     .with_label_values(&[WorkerType::Meta.as_str_name()])

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -154,7 +154,7 @@ pub async fn start_meta_node(listen_addr: String, state_store: String, config_pa
         "enable_compaction_deterministic should be set"
     );
 
-    risingwave_meta_node::start(meta_opts).await
+    risingwave_meta_node::start(meta_opts, CancellationToken::new() /* dummy */).await
 }
 
 async fn start_compactor_node(

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -455,7 +455,12 @@ impl Cluster {
                 .create_node()
                 .name(format!("meta-{i}"))
                 .ip([192, 168, 1, i as u8].into())
-                .init(move || risingwave_meta_node::start(opts.clone()))
+                .init(move || {
+                    risingwave_meta_node::start(
+                        opts.clone(),
+                        CancellationToken::new(), // dummy
+                    )
+                })
                 .build();
         }
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Follow-up of #17533, based on the ideas proposed in https://github.com/risingwavelabs/risingwave/issues/17351#issuecomment-2199698056.

- Add a "dummy" election client that always claims we are the leader, unifying the code path no matter whether there's HA.
- Not joining sub-tasks any more, since I've reviewed all of their implementations and found almost all of them are only designed to print a message when exiting (correct me if I'm wrong 🙏).

Still leave some TODOs which requires all components to be ready for graceful shutdown, or whose function signatures will change and then impact code of other components (in order to minimize changes in a single PR). 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
