### PR TITLE
refactor(meta): use upstream version of `etcd-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,8 +5022,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.12.1"
-source = "git+https://github.com/risingwavelabs/etcd-client.git?rev=4e84d40#4e84d40a84b35718d814cc2afccc9274c9d78e1e"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae697f3928e8c89ae6f4dcf788059f49fd01a76dc53e63628f5a33881f5715e"
 dependencies = [
  "http 0.2.9",
  "prost 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,8 +334,6 @@ tokio-stream = { git = "https://github.com/madsim-rs/tokio.git", rev = "fe39bb8e
 tokio-retry = { git = "https://github.com/madsim-rs/rust-tokio-retry.git", rev = "95e2fd3" }
 tokio-postgres = { git = "https://github.com/madsim-rs/rust-postgres.git", rev = "ac00d88" }
 futures-timer = { git = "https://github.com/madsim-rs/futures-timer.git", rev = "05b33b4" }
-# patch: unlimit 4MB message size for grpc client
-etcd-client = { git = "https://github.com/risingwavelabs/etcd-client.git", rev = "4e84d40" }
 # patch to remove preserve_order from serde_json
 deno_core = { git = "https://github.com/bakjos/deno_core", rev = "9b241c6" }
 # patch to user reqwest 0.12.2

--- a/src/meta/src/storage/wrapped_etcd_client.rs
+++ b/src/meta/src/storage/wrapped_etcd_client.rs
@@ -90,6 +90,18 @@ impl EtcdRefreshClient {
     }
 }
 
+#[easy_ext::ext(KvClientUnlimitedExt)]
+impl etcd_client::Client {
+    /// Gets a KV client with message size limit removed.
+    ///
+    /// Check the background at https://github.com/risingwavelabs/risingwave/pull/11277.
+    fn kv_client_unlimited(&self) -> etcd_client::KvClient {
+        self.kv_client()
+            .max_decoding_message_size(usize::MAX)
+            .max_encoding_message_size(usize::MAX)
+    }
+}
+
 macro_rules! impl_etcd_client_command_proxy {
     ($func:ident, $client:ident, ($($arg:ident : $sig:ty),+), $result:ty) => {
         impl WrappedEtcdClient {
@@ -131,10 +143,10 @@ macro_rules! impl_etcd_client_command_proxy {
     }
 }
 
-impl_etcd_client_command_proxy!(get, kv_client, (key: impl Into<Vec<u8>> + Clone, opts: Option<GetOptions>), GetResponse);
-impl_etcd_client_command_proxy!(put, kv_client, (key: impl Into<Vec<u8>> + Clone, value: impl Into<Vec<u8>> + Clone, opts: Option<PutOptions>), PutResponse);
-impl_etcd_client_command_proxy!(delete, kv_client, (key: impl Into<Vec<u8>> + Clone, opts: Option<DeleteOptions>), DeleteResponse);
-impl_etcd_client_command_proxy!(txn, kv_client, (txn: Txn), TxnResponse);
+impl_etcd_client_command_proxy!(get, kv_client_unlimited, (key: impl Into<Vec<u8>> + Clone, opts: Option<GetOptions>), GetResponse);
+impl_etcd_client_command_proxy!(put, kv_client_unlimited, (key: impl Into<Vec<u8>> + Clone, value: impl Into<Vec<u8>> + Clone, opts: Option<PutOptions>), PutResponse);
+impl_etcd_client_command_proxy!(delete, kv_client_unlimited, (key: impl Into<Vec<u8>> + Clone, opts: Option<DeleteOptions>), DeleteResponse);
+impl_etcd_client_command_proxy!(txn, kv_client_unlimited, (txn: Txn), TxnResponse);
 impl_etcd_client_command_proxy!(
     grant,
     lease_client,

--- a/src/meta/src/storage/wrapped_etcd_client.rs
+++ b/src/meta/src/storage/wrapped_etcd_client.rs
@@ -94,8 +94,12 @@ impl EtcdRefreshClient {
 impl etcd_client::Client {
     /// Gets a KV client with message size limit removed.
     ///
-    /// Check the background at https://github.com/risingwavelabs/risingwave/pull/11277.
+    /// Check the background at <https://github.com/risingwavelabs/risingwave/pull/11277>.
     fn kv_client_unlimited(&self) -> etcd_client::KvClient {
+        #[cfg(madsim)]
+        return self.kv_client();
+
+        #[cfg(not(madsim))]
         self.kv_client()
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We switched to a forked version of `etcd-client` in #11277. Later, the upstream version resolved the issue (https://github.com/etcdv3/etcd-client/pull/69) so I guess we can switch back to it.

This is a preparation of https://github.com/risingwavelabs/risingwave/issues/13695#issuecomment-2219905182.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
