### PR TITLE
fix(meta): Fix sink_into_table causes mv's depended_subscription_ids to be empty.

### DIFF
--- a/e2e_test/subscription/create_table_and_subscription.slt
+++ b/e2e_test/subscription/create_table_and_subscription.slt
@@ -9,3 +9,15 @@ flush;
 
 statement ok
 create subscription sub from t1 with(retention = '1D');
+
+statement ok
+create table t2 (v1 int, v2 int);
+
+statement ok
+create table t3 (v1 int primary key, v2 int);
+
+statement ok
+create subscription sub2 from t3 with(retention = '1D');
+
+statement ok
+create sink s1 into t3 from t2;

--- a/e2e_test/subscription/drop_table_and_subscription.slt
+++ b/e2e_test/subscription/drop_table_and_subscription.slt
@@ -3,3 +3,15 @@ drop subscription sub;
 
 statement ok
 drop table t1;
+
+statement ok
+drop sink s1;
+
+statement ok
+drop subscription sub2;
+
+statement ok
+drop table t3;
+
+statement ok
+drop table t2;

--- a/e2e_test/subscription/main.py
+++ b/e2e_test/subscription/main.py
@@ -262,7 +262,7 @@ def test_cursor_with_table_alter():
     drop_table_subscription()
 
 def test_cursor_fetch_n():
-    print(f"test_cursor_with_table_alter")
+    print(f"test_cursor_fetch_n")
     create_table_subscription()
     conn = psycopg2.connect(
         host="localhost",
@@ -304,6 +304,27 @@ def test_cursor_fetch_n():
     check_rows_data([10,100],row[3],3)
     drop_table_subscription()
 
+def test_rebuild_table():
+    print(f"test_rebuild_table")
+    create_table_subscription()
+    conn = psycopg2.connect(
+        host="localhost",
+        port="4566",
+        user="root",
+        database="dev"
+    )
+
+    execute_insert("declare cur subscription cursor for sub2",conn)
+    execute_insert("insert into t2 values(1,1)",conn)
+    execute_insert("flush",conn)
+    execute_insert("update t2 set v2 = 100 where v1 = 1",conn)
+    execute_insert("flush",conn)
+    row = execute_query("fetch 4 from cur",conn)
+    assert len(row) == 3
+    check_rows_data([1,1],row[0],1)
+    check_rows_data([1,1],row[1],4)
+    check_rows_data([1,100],row[2],3)
+
 if __name__ == "__main__":
     test_cursor_snapshot()
     test_cursor_op()
@@ -313,3 +334,4 @@ if __name__ == "__main__":
     test_cursor_since_begin()
     test_cursor_with_table_alter()
     test_cursor_fetch_n()
+    test_rebuild_table()

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -98,7 +98,6 @@ impl DdlServiceImpl {
             .map(ColIndexMapping::from_protobuf);
 
         let stream_job = StreamingJob::Table(source, table, job_type);
-
         ReplaceTableInfo {
             streaming_job: stream_job,
             fragment_graph,

--- a/src/meta/src/controller/catalog.rs
+++ b/src/meta/src/controller/catalog.rs
@@ -2679,6 +2679,7 @@ impl CatalogController {
             .all(&inner.db)
             .await?;
         let mut map = HashMap::new();
+        // Write object at the same time we write subscription, so we must be able to get obj
         for subscription in subscription_objs
             .into_iter()
             .map(|(subscription, obj)| ObjectModel(subscription, obj.unwrap()).into())

--- a/src/meta/src/controller/catalog.rs
+++ b/src/meta/src/controller/catalog.rs
@@ -2670,6 +2670,29 @@ impl CatalogController {
         Ok(subscription)
     }
 
+    pub async fn get_mv_depended_subscriptions(
+        &self,
+    ) -> MetaResult<HashMap<risingwave_common::catalog::TableId, HashMap<u32, u64>>> {
+        let inner = self.inner.read().await;
+        let subscription_objs = Subscription::find()
+            .find_also_related(Object)
+            .all(&inner.db)
+            .await?;
+        let mut map = HashMap::new();
+        for subscription in subscription_objs
+            .into_iter()
+            .map(|(subscription, obj)| ObjectModel(subscription, obj.unwrap()).into())
+        {
+            let subscription: PbSubscription = subscription;
+            map.entry(risingwave_common::catalog::TableId::from(
+                subscription.dependent_table_id,
+            ))
+            .or_insert(HashMap::new())
+            .insert(subscription.id, subscription.retention_seconds);
+        }
+        Ok(map)
+    }
+
     pub async fn find_creating_streaming_job_ids(
         &self,
         infos: Vec<PbCreatingJobInfo>,

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -4038,6 +4038,22 @@ impl CatalogManager {
         Ok(subscription.clone())
     }
 
+    pub async fn get_mv_depended_subscriptions(
+        &self,
+    ) -> MetaResult<HashMap<risingwave_common::catalog::TableId, HashMap<u32, u64>>> {
+        let guard = self.core.lock().await;
+        let mut map = HashMap::new();
+        for subscription in &guard.database.subscriptions.values() {
+            map.entry(risingwave_common::catalog::TableId::from(
+                subscription.dependent_table_id,
+            ))
+            .or_insert(HashMap::new())
+            .insert(subscription.id, subscription.retention_seconds);
+        }
+
+        Ok(map)
+    }
+
     pub async fn get_created_table_ids(&self) -> Vec<u32> {
         let guard = self.core.lock().await;
         guard

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -4043,7 +4043,7 @@ impl CatalogManager {
     ) -> MetaResult<HashMap<risingwave_common::catalog::TableId, HashMap<u32, u64>>> {
         let guard = self.core.lock().await;
         let mut map = HashMap::new();
-        for subscription in &guard.database.subscriptions.values() {
+        for subscription in guard.database.subscriptions.values() {
             map.entry(risingwave_common::catalog::TableId::from(
                 subscription.dependent_table_id,
             ))

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -822,11 +822,14 @@ impl MetadataManager {
         }
     }
 
-    #[expect(clippy::unused_async)]
     pub async fn get_mv_depended_subscriptions(
         &self,
     ) -> MetaResult<HashMap<TableId, HashMap<u32, u64>>> {
-        // TODO(subscription): support the correct logic when supporting L0 log store subscriptions
-        Ok(HashMap::new())
+        match self {
+            MetadataManager::V1(mgr) => mgr.catalog_manager.get_mv_depended_subscriptions().await,
+            MetadataManager::V2(mgr) => {
+                mgr.catalog_controller.get_mv_depended_subscriptions().await
+            }
+        }
     }
 }

--- a/src/meta/src/stream/mod.rs
+++ b/src/meta/src/stream/mod.rs
@@ -36,16 +36,16 @@ pub use stream_manager::*;
 pub(crate) fn to_build_actor_info(
     actor: StreamActor,
     subscriptions: &HashMap<TableId, HashMap<u32, u64>>,
-    fragment_table_id: TableId,
+    subscription_depend_table_id: TableId,
 ) -> BuildActorInfo {
     BuildActorInfo {
         actor: Some(actor),
         related_subscriptions: subscriptions
-            .get(&fragment_table_id)
+            .get(&subscription_depend_table_id)
             .into_iter()
             .map(|subscriptions| {
                 (
-                    fragment_table_id.table_id,
+                    subscription_depend_table_id.table_id,
                     SubscriptionIds {
                         subscription_ids: subscriptions.keys().cloned().collect(),
                     },

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -334,6 +334,7 @@ impl GlobalStreamManager {
         table_fragments: &TableFragments,
         building_locations: &Locations,
         existing_locations: &Locations,
+        subscription_depend_table_id: TableId,
     ) -> MetaResult<()> {
         let actor_map = table_fragments.actor_map();
 
@@ -367,7 +368,7 @@ impl GlobalStreamManager {
                             to_build_actor_info(
                                 actor_map[actor_id].clone(),
                                 &subscriptions,
-                                table_fragments.table_id(),
+                                subscription_depend_table_id,
                             )
                         })
                         .collect::<Vec<_>>();
@@ -406,8 +407,13 @@ impl GlobalStreamManager {
         let mut replace_table_command = None;
         let mut replace_table_id = None;
 
-        self.build_actors(&table_fragments, &building_locations, &existing_locations)
-            .await?;
+        self.build_actors(
+            &table_fragments,
+            &building_locations,
+            &existing_locations,
+            table_fragments.table_id(),
+        )
+        .await?;
         tracing::debug!(
             table_id = %table_fragments.table_id(),
             "built actors finished"
@@ -418,6 +424,7 @@ impl GlobalStreamManager {
                 &table_fragments,
                 &context.building_locations,
                 &context.existing_locations,
+                context.old_table_fragments.table_id(),
             )
             .await?;
 
@@ -504,8 +511,13 @@ impl GlobalStreamManager {
             existing_locations,
         }: ReplaceTableContext,
     ) -> MetaResult<()> {
-        self.build_actors(&table_fragments, &building_locations, &existing_locations)
-            .await?;
+        self.build_actors(
+            &table_fragments,
+            &building_locations,
+            &existing_locations,
+            old_table_fragments.table_id(),
+        )
+        .await?;
 
         let dummy_table_id = table_fragments.table_id();
         let init_split_assignment = self.source_manager.allocate_splits(&dummy_table_id).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

1. Fixed the get_mv_depended_subscriptions method not really querying all subscription
2. Use old_table_fragments.table_id to get subscriptions instead of table_fragments.table_id when replacing table

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
