### PR TITLE
fix(streaming): find and return root actor failure when injection failed

### DIFF
--- a/src/meta/src/rpc/ddl_controller_v2.rs
+++ b/src/meta/src/rpc/ddl_controller_v2.rs
@@ -94,7 +94,7 @@ impl DdlController {
         {
             Ok(version) => Ok(version),
             Err(err) => {
-                tracing::error!(id = job_id, error = ?err.as_report(), "failed to create streaming job");
+                tracing::error!(id = job_id, error = %err.as_report(), "failed to create streaming job");
                 let event = risingwave_pb::meta::event_log::EventCreateStreamJobFail {
                     id: streaming_job.id(),
                     name: streaming_job.name(),

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -661,7 +661,7 @@ impl LocalBarrierWorker {
     /// Broadcast a barrier to all senders. Save a receiver which will get notified when this
     /// barrier is finished, in managed mode.
     ///
-    /// Note that the error returned here is typically a [`StreamError::BarrierSend`], which is not
+    /// Note that the error returned here is typically a [`StreamError::barrier_send`], which is not
     /// the root cause of the failure. The caller should then call [`Self::try_find_root_failure`]
     /// to find the root cause.
     fn send_barrier(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After a source executor fails, the barrier manager may first realize that by finding the rx side is closed when injecting barriers, instead of receiving the error reported by the actor. This is because the barrier channel rx is immediately dropped when an executor exits, while error reporting happens later.

This PR makes it also call `try_find_root_failure` on barrier injection failure, making the error reporting more accurate.

Should address https://github.com/risingwavelabs/risingwave/issues/17389. The error message now looks like:

```
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: gRPC request to meta service failed: Internal error
  2: get error from control stream:
worker node 1, gRPC request to stream service failed:
Internal error:
failed to inject barrier: 
Actor 1 exited unexpectedly: 
Executor error: 
Connector error: 
failed to start cdc connector;
```

Still considering how to add a test to enforce it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
