### PR TITLE
feat(meta): pass streaming error score to meta to locate cluster-level root error

### DIFF
--- a/e2e_test/error_ui/simple/recovery.slt
+++ b/e2e_test/error_ui/simple/recovery.slt
@@ -25,7 +25,7 @@ with error as (
     limit 1
 )
 select
-case when error like '%Actor % exited unexpectedly: Executor error: %Numeric out of range%' then 'ok'
+case when error like '%get error from control stream, in worker node %: %Actor % exited unexpectedly: Executor error: %Numeric out of range%' then 'ok'
      else error
 end as result
 from error;

--- a/src/error/src/tonic.rs
+++ b/src/error/src/tonic.rs
@@ -239,6 +239,13 @@ impl std::error::Error for TonicStatusWrapper {
         // Delegate to `self.inner` as if we're transparent.
         self.inner.source()
     }
+
+    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        // The source error, typically a `ServerError`, may provide additional information through `extra`.
+        if let Some(source) = self.source() {
+            source.provide(request);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/error/src/tonic.rs
+++ b/src/error/src/tonic.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod extra;
+
 use std::borrow::Cow;
 use std::error::Error;
 use std::sync::Arc;
@@ -24,36 +26,8 @@ use tonic::metadata::{MetadataMap, MetadataValue};
 const ERROR_KEY: &str = "risingwave-error-bin";
 
 /// The service name that the error is from. Used to provide better error message.
+// TODO: also make it a field of `Extra`?
 type ServiceName = Cow<'static, str>;
-
-pub mod extra {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-    pub struct Score(pub i32);
-
-    #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-    pub(super) struct Extra {
-        pub score: Option<Score>,
-    }
-
-    impl Extra {
-        pub fn new<T>(error: &T) -> Self
-        where
-            T: ?Sized + std::error::Error,
-        {
-            Self {
-                score: std::error::request_value(error),
-            }
-        }
-
-        pub fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
-            if let Some(score) = self.score {
-                request.provide_value(score);
-            }
-        }
-    }
-}
 
 /// The error produced by the gRPC server and sent to the client on the wire.
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/error/src/tonic/extra.rs
+++ b/src/error/src/tonic/extra.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+/// The score of the error.
+///
+/// Currently, it's used to identify the root cause of streaming pipeline failures, i.e., which actor
+/// led to the failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Score(pub i32);
+
+/// Extra fields in errors that can be passed through the gRPC boundary.
+///
+/// - Field being set to `None` means it is not available.
+/// - To add a new field, also update the `provide` method.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub(super) struct Extra {
+    pub score: Option<Score>,
+}
+
+impl Extra {
+    /// Create a new [`Extra`] by [requesting](std::error::request_ref) each field from the given error.
+    pub fn new<T>(error: &T) -> Self
+    where
+        T: ?Sized + std::error::Error,
+    {
+        Self {
+            score: std::error::request_value(error),
+        }
+    }
+
+    /// Provide each field to the given [request](std::error::Request).
+    pub fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        if let Some(score) = self.score {
+            request.provide_value(score);
+        }
+    }
+}

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -565,8 +565,7 @@ fn merge_node_rpc_errors<E: Error + Send + Sync + 'static>(
     // Find the error with the highest score.
     let max_score = errors
         .iter()
-        .map(|(_, e)| request_value::<Score>(e))
-        .flatten()
+        .filter_map(|(_, e)| request_value::<Score>(e))
         .max();
 
     if let Some(max_score) = max_score {

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -537,41 +537,42 @@ where
 }
 
 fn merge_node_rpc_errors<E: Error + Send + Sync + 'static>(
-    message: impl Into<String>,
+    message: &str,
     errors: impl IntoIterator<Item = (WorkerId, E)>,
 ) -> MetaError {
+    use std::error::request_value;
+
     use risingwave_common::error::tonic::extra::Score;
 
     let errors = errors.into_iter().collect_vec();
 
     if errors.is_empty() {
-        return anyhow!(message.into()).into();
+        return anyhow!(message.to_owned()).into();
     }
 
     let max_score = errors
         .iter()
-        .map(|(_, e)| std::error::request_value::<Score>(e))
+        .map(|(_, e)| request_value::<Score>(e))
         .flatten()
         .max();
 
     if let Some(max_score) = max_score {
         let mut errors = errors;
         let (worker_id, error) = errors
-            .extract_if(|(_, e)| std::error::request_value::<Score>(e) == Some(max_score))
+            .extract_if(|(_, e)| request_value::<Score>(e) == Some(max_score))
             .next()
             .unwrap();
 
         anyhow::Error::from(error)
-            .context(format!("failure in worker node {}", worker_id))
-            .context(message.into())
+            .context(format!("{message}, in worker node {worker_id}"))
             .into()
     } else {
         use std::fmt::Write;
 
         let concat: String = errors
             .into_iter()
-            .fold(message.into() + ":", |mut s, (w, e)| {
-                write!(&mut s, " worker node {}, {};", w, e.as_report()).unwrap();
+            .fold(format!("{message}: "), |mut s, (w, e)| {
+                write!(&mut s, " in worker node {}, {};", w, e.as_report()).unwrap();
                 s
             });
         anyhow!(concat).into()

--- a/src/rpc_client/src/error.rs
+++ b/src/rpc_client/src/error.rs
@@ -28,7 +28,11 @@ pub enum RpcError {
     TransportError(Box<tonic::transport::Error>),
 
     #[error(transparent)]
-    GrpcStatus(Box<TonicStatusWrapper>),
+    GrpcStatus(
+        #[from]
+        #[backtrace]
+        Box<TonicStatusWrapper>,
+    ),
 
     #[error(transparent)]
     MetaAddressParse(#[from] MetaAddressStrategyParseError),
@@ -61,7 +65,7 @@ macro_rules! impl_from_status {
                 $(
                     #[doc = "Convert a gRPC status from " $service " service into an [`RpcError`]."]
                     pub fn [<from_ $service _status>](s: tonic::Status) -> Self {
-                        Self::grpc_status(s.with_client_side_service_name(stringify!($service)))
+                        Box::new(s.with_client_side_service_name(stringify!($service))).into()
                     }
                 )*
             }

--- a/src/rpc_client/src/error.rs
+++ b/src/rpc_client/src/error.rs
@@ -30,6 +30,9 @@ pub enum RpcError {
     #[error(transparent)]
     GrpcStatus(
         #[from]
+        // Typically it does not have a backtrace,
+        // but this is to let `thiserror` generate `provide` implementation to make `Extra` work.
+        // See `risingwave_error::tonic::extra`.
         #[backtrace]
         Box<TonicStatusWrapper>,
     ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Close #17368. Pass streaming error score to meta service to locate cluster-level root error. Instead of concatenating erros from all compute nodes, only show the root error in the recovery reason.

```
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: gRPC request to meta service failed: Internal error
  2: get error from control stream, in worker node 2
  3: gRPC request to stream service failed: Internal error
  4: failed to collect barrier for epoch [6802214756352000]
  5: Actor 13 exited unexpectedly
  6: Executor error
  7: Chunk operation error
  8: Numeric out of range
```

For implementation: a struct named `Extra` is added, which can be preserved across the gRPC boundary. The `request`-`provide` mechanism of Rust error handling (ref: https://doc.rust-lang.org/stable/std/error/struct.Request.html) is used to embed those extra information with minimal code changes.

Hide the whitespaces for better review experience.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
