### PR TITLE
fix: Kinesis: NextToken and StreamName cannot be provided together

### DIFF
--- a/src/connector/src/source/kinesis/enumerator/client.rs
+++ b/src/connector/src/source/kinesis/enumerator/client.rs
@@ -69,7 +69,7 @@ impl SplitEnumerator for KinesisSplitEnumerator {
                         next_token = None;
                         continue;
                     }
-                    bail!("Kinesis ListShards service error: {:?}", e.as_report())
+                    bail!("Kinesis ListShards service error: {}", e.to_report_string());
                 }
             };
             match list_shard_output.shards {

--- a/src/connector/src/source/kinesis/enumerator/client.rs
+++ b/src/connector/src/source/kinesis/enumerator/client.rs
@@ -17,7 +17,6 @@ use async_trait::async_trait;
 use aws_sdk_kinesis::types::Shard;
 use aws_sdk_kinesis::Client as kinesis_client;
 use risingwave_common::bail;
-use thiserror_ext::AsReport;
 
 use crate::error::ConnectorResult as Result;
 use crate::source::kinesis::split::KinesisOffset;

--- a/src/connector/src/source/kinesis/enumerator/client.rs
+++ b/src/connector/src/source/kinesis/enumerator/client.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use aws_sdk_kinesis::types::Shard;
 use aws_sdk_kinesis::Client as kinesis_client;
@@ -69,7 +70,7 @@ impl SplitEnumerator for KinesisSplitEnumerator {
                         next_token = None;
                         continue;
                     }
-                    bail!("Kinesis ListShards service error: {}", e.to_report_string());
+                    return Err(anyhow!(e).context("failed to list kinesis shards").into());
                 }
             };
             match list_shard_output.shards {

--- a/src/connector/src/source/kinesis/enumerator/client.rs
+++ b/src/connector/src/source/kinesis/enumerator/client.rs
@@ -69,7 +69,7 @@ impl SplitEnumerator for KinesisSplitEnumerator {
                         next_token = None;
                         continue;
                     }
-                    bail!("Kinesis ListShards service error: {}", e.as_report())
+                    bail!("Kinesis ListShards service error: {:?}", e.as_report())
                 }
             };
             match list_shard_output.shards {


### PR DESCRIPTION
…ption: NextToken and StreamName cannot be provided together."

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

* why did this happen? 
  * We did not meet a Kinesis has over 1k shards before. And we wrongly use the ListShards pagination API. 

as title, the constraint is described in API doc

https://docs.rs/aws-sdk-kinesis/latest/aws_sdk_kinesis/operation/list_shards/struct.ListShardsInput.html

> When the number of shards in the data stream is greater than the default value for the MaxResults parameter, or if you explicitly specify a value for MaxResults that is less than the number of shards in the data stream, the response includes a pagination token named NextToken. You can specify this NextToken value in a subsequent call to ListShards to list the next set of shards.
>
> Don't specify StreamName or StreamCreationTimestamp if you specify NextToken because the latter unambiguously identifies the stream.
> 
> You can optionally specify a value for the MaxResults parameter when you specify NextToken. If you specify a MaxResults value that is less than the number of shards that the operation returns if you don't specify MaxResults, the response will contain a new NextToken value. You can use the new NextToken value in a subsequent call to the ListShards operation.
> 
> Tokens expire after 300 seconds. When you obtain a value for NextToken in the response to a call to ListShards, you have 300 seconds to use that value. If you specify an expired token in a call to ListShards, you get ExpiredNextTokenException.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
