### PR TITLE
feat(sink): support encode jsonb data as dynamic json type in sink

### DIFF
--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -35,15 +35,19 @@ use super::{
 };
 use crate::sink::SinkError;
 
-pub struct JsonEncoder {
-    schema: Schema,
-    col_indices: Option<Vec<usize>>,
+pub struct JsonEncoderConfig {
     time_handling_mode: TimeHandlingMode,
     date_handling_mode: DateHandlingMode,
     timestamp_handling_mode: TimestampHandlingMode,
     timestamptz_handling_mode: TimestamptzHandlingMode,
     custom_json_type: CustomJsonType,
+}
+
+pub struct JsonEncoder {
+    schema: Schema,
+    col_indices: Option<Vec<usize>>,
     kafka_connect: Option<KafkaConnectParamsRef>,
+    config: JsonEncoderConfig,
 }
 
 impl JsonEncoder {
@@ -55,28 +59,34 @@ impl JsonEncoder {
         timestamptz_handling_mode: TimestamptzHandlingMode,
         time_handling_mode: TimeHandlingMode,
     ) -> Self {
-        Self {
-            schema,
-            col_indices,
+        let config = JsonEncoderConfig {
             time_handling_mode,
             date_handling_mode,
             timestamp_handling_mode,
             timestamptz_handling_mode,
             custom_json_type: CustomJsonType::None,
+        };
+        Self {
+            schema,
+            col_indices,
             kafka_connect: None,
+            config,
         }
     }
 
     pub fn new_with_es(schema: Schema, col_indices: Option<Vec<usize>>) -> Self {
-        Self {
-            schema,
-            col_indices,
+        let config = JsonEncoderConfig {
             time_handling_mode: TimeHandlingMode::String,
             date_handling_mode: DateHandlingMode::String,
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcWithoutSuffix,
             custom_json_type: CustomJsonType::Es,
+        };
+        Self {
+            schema,
+            col_indices,
             kafka_connect: None,
+            config,
         }
     }
 
@@ -85,28 +95,34 @@ impl JsonEncoder {
         col_indices: Option<Vec<usize>>,
         map: HashMap<String, u8>,
     ) -> Self {
-        Self {
-            schema,
-            col_indices,
+        let config = JsonEncoderConfig {
             time_handling_mode: TimeHandlingMode::Milli,
             date_handling_mode: DateHandlingMode::String,
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcWithoutSuffix,
             custom_json_type: CustomJsonType::Doris(map),
+        };
+        Self {
+            schema,
+            col_indices,
             kafka_connect: None,
+            config,
         }
     }
 
     pub fn new_with_starrocks(schema: Schema, col_indices: Option<Vec<usize>>) -> Self {
-        Self {
-            schema,
-            col_indices,
+        let config = JsonEncoderConfig {
             time_handling_mode: TimeHandlingMode::Milli,
             date_handling_mode: DateHandlingMode::String,
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcWithoutSuffix,
             custom_json_type: CustomJsonType::StarRocks,
+        };
+        Self {
+            schema,
+            col_indices,
             kafka_connect: None,
+            config,
         }
     }
 
@@ -139,16 +155,8 @@ impl RowEncoder for JsonEncoder {
         for idx in &col_indices {
             let field = &self.schema[*idx];
             let key = field.name.clone();
-            let value = datum_to_json_object(
-                field,
-                row.datum_at(*idx),
-                self.date_handling_mode,
-                self.timestamp_handling_mode,
-                self.timestamptz_handling_mode,
-                self.time_handling_mode,
-                &self.custom_json_type,
-            )
-            .map_err(|e| SinkError::Encode(e.to_report_string()))?;
+            let value = datum_to_json_object(field, row.datum_at(*idx), &self.config)
+                .map_err(|e| SinkError::Encode(e.to_report_string()))?;
             mappings.insert(key, value);
         }
 
@@ -179,11 +187,7 @@ impl SerTo<String> for Value {
 fn datum_to_json_object(
     field: &Field,
     datum: DatumRef<'_>,
-    date_handling_mode: DateHandlingMode,
-    timestamp_handling_mode: TimestampHandlingMode,
-    timestamptz_handling_mode: TimestamptzHandlingMode,
-    time_handling_mode: TimeHandlingMode,
-    custom_json_type: &CustomJsonType,
+    config: &JsonEncoderConfig,
 ) -> ArrayResult<Value> {
     let scalar_ref = match datum {
         None => {
@@ -223,7 +227,7 @@ fn datum_to_json_object(
             json!(v)
         }
         // Doris/Starrocks will convert out-of-bounds decimal and -INF, INF, NAN to NULL
-        (DataType::Decimal, ScalarRefImpl::Decimal(mut v)) => match custom_json_type {
+        (DataType::Decimal, ScalarRefImpl::Decimal(mut v)) => match &config.custom_json_type {
             CustomJsonType::Doris(map) => {
                 let s = map.get(&field.name).unwrap();
                 v.rescale(*s as u32);
@@ -233,21 +237,23 @@ fn datum_to_json_object(
                 json!(v.to_text())
             }
         },
-        (DataType::Timestamptz, ScalarRefImpl::Timestamptz(v)) => match timestamptz_handling_mode {
-            TimestamptzHandlingMode::UtcString => {
-                let parsed = v.to_datetime_utc();
-                let v = parsed.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
-                json!(v)
+        (DataType::Timestamptz, ScalarRefImpl::Timestamptz(v)) => {
+            match config.timestamptz_handling_mode {
+                TimestamptzHandlingMode::UtcString => {
+                    let parsed = v.to_datetime_utc();
+                    let v = parsed.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+                    json!(v)
+                }
+                TimestamptzHandlingMode::UtcWithoutSuffix => {
+                    let parsed = v.to_datetime_utc().naive_utc();
+                    let v = parsed.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
+                    json!(v)
+                }
+                TimestamptzHandlingMode::Micro => json!(v.timestamp_micros()),
+                TimestamptzHandlingMode::Milli => json!(v.timestamp_millis()),
             }
-            TimestamptzHandlingMode::UtcWithoutSuffix => {
-                let parsed = v.to_datetime_utc().naive_utc();
-                let v = parsed.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
-                json!(v)
-            }
-            TimestamptzHandlingMode::Micro => json!(v.timestamp_micros()),
-            TimestamptzHandlingMode::Milli => json!(v.timestamp_millis()),
-        },
-        (DataType::Time, ScalarRefImpl::Time(v)) => match time_handling_mode {
+        }
+        (DataType::Time, ScalarRefImpl::Time(v)) => match config.time_handling_mode {
             TimeHandlingMode::Milli => {
                 // todo: just ignore the nanos part to avoid leap second complex
                 json!(v.0.num_seconds_from_midnight() as i64 * 1000)
@@ -257,7 +263,7 @@ fn datum_to_json_object(
                 json!(a)
             }
         },
-        (DataType::Date, ScalarRefImpl::Date(v)) => match date_handling_mode {
+        (DataType::Date, ScalarRefImpl::Date(v)) => match config.date_handling_mode {
             DateHandlingMode::FromCe => json!(v.0.num_days_from_ce()),
             DateHandlingMode::FromEpoch => {
                 let duration = v.0 - NaiveDateTime::UNIX_EPOCH.date();
@@ -268,10 +274,14 @@ fn datum_to_json_object(
                 json!(a)
             }
         },
-        (DataType::Timestamp, ScalarRefImpl::Timestamp(v)) => match timestamp_handling_mode {
-            TimestampHandlingMode::Milli => json!(v.0.and_utc().timestamp_millis()),
-            TimestampHandlingMode::String => json!(v.0.format("%Y-%m-%d %H:%M:%S%.6f").to_string()),
-        },
+        (DataType::Timestamp, ScalarRefImpl::Timestamp(v)) => {
+            match config.timestamp_handling_mode {
+                TimestampHandlingMode::Milli => json!(v.0.and_utc().timestamp_millis()),
+                TimestampHandlingMode::String => {
+                    json!(v.0.format("%Y-%m-%d %H:%M:%S%.6f").to_string())
+                }
+            }
+        }
         (DataType::Bytea, ScalarRefImpl::Bytea(v)) => {
             json!(general_purpose::STANDARD.encode(v))
         }
@@ -279,7 +289,7 @@ fn datum_to_json_object(
         (DataType::Interval, ScalarRefImpl::Interval(v)) => {
             json!(v.as_iso_8601())
         }
-        (DataType::Jsonb, ScalarRefImpl::Jsonb(jsonb_ref)) => match custom_json_type {
+        (DataType::Jsonb, ScalarRefImpl::Jsonb(jsonb_ref)) => match &config.custom_json_type {
             CustomJsonType::Es | CustomJsonType::StarRocks => JsonbVal::from(jsonb_ref).take(),
             CustomJsonType::Doris(_) | CustomJsonType::None => {
                 json!(jsonb_ref.to_string())
@@ -290,21 +300,13 @@ fn datum_to_json_object(
             let mut vec = Vec::with_capacity(elems.len());
             let inner_field = Field::unnamed(Box::<DataType>::into_inner(datatype));
             for sub_datum_ref in elems {
-                let value = datum_to_json_object(
-                    &inner_field,
-                    sub_datum_ref,
-                    date_handling_mode,
-                    timestamp_handling_mode,
-                    timestamptz_handling_mode,
-                    time_handling_mode,
-                    custom_json_type,
-                )?;
+                let value = datum_to_json_object(&inner_field, sub_datum_ref, config)?;
                 vec.push(value);
             }
             json!(vec)
         }
         (DataType::Struct(st), ScalarRefImpl::Struct(struct_ref)) => {
-            match custom_json_type {
+            match config.custom_json_type {
                 CustomJsonType::Doris(_) => {
                     // We need to ensure that the order of elements in the json matches the insertion order.
                     let mut map = IndexMap::with_capacity(st.len());
@@ -312,15 +314,7 @@ fn datum_to_json_object(
                         st.iter()
                             .map(|(name, dt)| Field::with_name(dt.clone(), name)),
                     ) {
-                        let value = datum_to_json_object(
-                            &sub_field,
-                            sub_datum_ref,
-                            date_handling_mode,
-                            timestamp_handling_mode,
-                            timestamptz_handling_mode,
-                            time_handling_mode,
-                            custom_json_type,
-                        )?;
+                        let value = datum_to_json_object(&sub_field, sub_datum_ref, config)?;
                         map.insert(sub_field.name.clone(), value);
                     }
                     Value::String(
@@ -338,15 +332,7 @@ fn datum_to_json_object(
                         st.iter()
                             .map(|(name, dt)| Field::with_name(dt.clone(), name)),
                     ) {
-                        let value = datum_to_json_object(
-                            &sub_field,
-                            sub_datum_ref,
-                            date_handling_mode,
-                            timestamp_handling_mode,
-                            timestamptz_handling_mode,
-                            time_handling_mode,
-                            custom_json_type,
-                        )?;
+                        let value = datum_to_json_object(&sub_field, sub_datum_ref, config)?;
                         map.insert(sub_field.name.clone(), value);
                     }
                     json!(map)
@@ -454,17 +440,21 @@ mod tests {
             type_name: Default::default(),
         };
 
+        let config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::Milli,
+            date_handling_mode: DateHandlingMode::FromCe,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::None,
+        };
+
         let boolean_value = datum_to_json_object(
             &Field {
                 data_type: DataType::Boolean,
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Bool(false).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(boolean_value, json!(false));
@@ -475,11 +465,7 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Int16(16).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(int16_value, json!(16));
@@ -490,11 +476,7 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Int64(i64::MAX).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(
@@ -508,11 +490,7 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Serial(i64::MAX.into()).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(
@@ -528,14 +506,18 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Timestamptz(tstz_inner).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(tstz_value, "2018-01-26T18:30:09.453000Z");
+
+        let unix_wo_suffix_config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::Milli,
+            date_handling_mode: DateHandlingMode::FromCe,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcWithoutSuffix,
+            custom_json_type: CustomJsonType::None,
+        };
 
         let tstz_inner = "2018-01-26T18:30:09.453Z".parse().unwrap();
         let tstz_value = datum_to_json_object(
@@ -544,15 +526,18 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Timestamptz(tstz_inner).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcWithoutSuffix,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &unix_wo_suffix_config,
         )
         .unwrap();
         assert_eq!(tstz_value, "2018-01-26 18:30:09.453000");
 
+        let timestamp_milli_config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::String,
+            date_handling_mode: DateHandlingMode::FromCe,
+            timestamp_handling_mode: TimestampHandlingMode::Milli,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::None,
+        };
         let ts_value = datum_to_json_object(
             &Field {
                 data_type: DataType::Timestamp,
@@ -562,11 +547,7 @@ mod tests {
                 ScalarImpl::Timestamp(Timestamp::from_timestamp_uncheck(1000, 0))
                     .as_scalar_ref_impl(),
             ),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::Milli,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &timestamp_milli_config,
         )
         .unwrap();
         assert_eq!(ts_value, json!(1000 * 1000));
@@ -580,11 +561,7 @@ mod tests {
                 ScalarImpl::Timestamp(Timestamp::from_timestamp_uncheck(1000, 0))
                     .as_scalar_ref_impl(),
             ),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(ts_value, json!("1970-01-01 00:16:40.000000".to_string()));
@@ -599,11 +576,7 @@ mod tests {
                 ScalarImpl::Time(Time::from_num_seconds_from_midnight_uncheck(1000, 0))
                     .as_scalar_ref_impl(),
             ),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(time_value, json!(1000 * 1000));
@@ -617,17 +590,20 @@ mod tests {
                 ScalarImpl::Interval(Interval::from_month_day_usec(13, 2, 1000000))
                     .as_scalar_ref_impl(),
             ),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(interval_value, json!("P1Y1M2DT0H0M1S"));
 
         let mut map = HashMap::default();
         map.insert("aaa".to_string(), 5_u8);
+        let doris_config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::String,
+            date_handling_mode: DateHandlingMode::String,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::Doris(map),
+        };
         let decimal = datum_to_json_object(
             &Field {
                 data_type: DataType::Decimal,
@@ -635,11 +611,7 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Decimal(Decimal::try_from(1.1111111).unwrap()).as_scalar_ref_impl()),
-            DateHandlingMode::String,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::Doris(map),
+            &doris_config,
         )
         .unwrap();
         assert_eq!(decimal, json!("1.11111"));
@@ -650,41 +622,43 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Date(Date::from_ymd_uncheck(1970, 1, 1)).as_scalar_ref_impl()),
-            DateHandlingMode::FromCe,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &config,
         )
         .unwrap();
         assert_eq!(date_value, json!(719163));
 
+        let from_epoch_config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::Milli,
+            date_handling_mode: DateHandlingMode::FromEpoch,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::None,
+        };
         let date_value = datum_to_json_object(
             &Field {
                 data_type: DataType::Date,
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Date(Date::from_ymd_uncheck(1970, 1, 1)).as_scalar_ref_impl()),
-            DateHandlingMode::FromEpoch,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::None,
+            &from_epoch_config,
         )
         .unwrap();
         assert_eq!(date_value, json!(0));
 
+        let doris_config = JsonEncoderConfig {
+            time_handling_mode: TimeHandlingMode::String,
+            date_handling_mode: DateHandlingMode::String,
+            timestamp_handling_mode: TimestampHandlingMode::String,
+            timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
+            custom_json_type: CustomJsonType::Doris(HashMap::default()),
+        };
         let date_value = datum_to_json_object(
             &Field {
                 data_type: DataType::Date,
                 ..mock_field.clone()
             },
             Some(ScalarImpl::Date(Date::from_ymd_uncheck(2010, 10, 10)).as_scalar_ref_impl()),
-            DateHandlingMode::String,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::Doris(HashMap::default()),
+            &doris_config,
         )
         .unwrap();
         assert_eq!(date_value, json!("2010-10-10"));
@@ -705,11 +679,7 @@ mod tests {
                 ..mock_field.clone()
             },
             Some(ScalarRefImpl::Struct(StructRef::ValueRef { val: &value })),
-            DateHandlingMode::String,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::Milli,
-            &CustomJsonType::Doris(HashMap::default()),
+            &doris_config,
         )
         .unwrap();
         assert_eq!(interval_value, json!("{\"v3\":3,\"v2\":2,\"v1\":1}"));

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -561,6 +561,7 @@ mod tests {
             timestamp_handling_mode: TimestampHandlingMode::Milli,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
             custom_json_type: CustomJsonType::None,
+            encode_jsonb_mode: EncodeJsonbMode::Custom,
         };
         let ts_value = datum_to_json_object(
             &Field {
@@ -622,7 +623,7 @@ mod tests {
         let mut map = HashMap::default();
         map.insert("aaa".to_string(), 5_u8);
         let doris_config = JsonEncoderConfig {
-            time_handling_mode: TimeHandlingMode::Milli,
+            time_handling_mode: TimeHandlingMode::String,
             date_handling_mode: DateHandlingMode::String,
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
@@ -653,7 +654,7 @@ mod tests {
         assert_eq!(date_value, json!(719163));
 
         let from_epoch_config = JsonEncoderConfig {
-            time_handling_mode: TimeHandlingMode::Milli,
+            time_handling_mode: TimeHandlingMode::String,
             date_handling_mode: DateHandlingMode::FromEpoch,
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
@@ -712,7 +713,7 @@ mod tests {
         assert_eq!(interval_value, json!("{\"v3\":3,\"v2\":2,\"v1\":1}"));
 
         let encode_jsonb_obj_config = JsonEncoderConfig {
-            time_handling_mode: TimeHandlingMode::Milli,
+            time_handling_mode: TimeHandlingMode::String,
             date_handling_mode: DateHandlingMode::String,
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -309,7 +309,7 @@ fn datum_to_json_object(
                 EncodeJsonbMode::String => {
                     json!(jsonb_ref.to_string())
                 }
-                EncodeJsonbMode::Object => JsonbVal::from(jsonb_ref).take(),
+                EncodeJsonbMode::Dynamic => JsonbVal::from(jsonb_ref).take(),
                 EncodeJsonbMode::Custom => {
                     return Err(ArrayError::internal(
                         "jsonb type must be encoded as string or object".to_string(),
@@ -718,7 +718,7 @@ mod tests {
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
             custom_json_type: CustomJsonType::None,
-            encode_jsonb_mode: EncodeJsonbMode::Object,
+            encode_jsonb_mode: EncodeJsonbMode::Dynamic,
         };
         let json_value = datum_to_json_object(
             &Field {

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -312,7 +312,7 @@ fn datum_to_json_object(
                 EncodeJsonbMode::Dynamic => JsonbVal::from(jsonb_ref).take(),
                 EncodeJsonbMode::Custom => {
                     return Err(ArrayError::internal(
-                        "jsonb type must be encoded as string or object".to_string(),
+                        "jsonb type must be encoded as 'string' or 'dynamic' type".to_string(),
                     ));
                 }
             },

--- a/src/connector/src/sink/encoder/json.rs
+++ b/src/connector/src/sink/encoder/json.rs
@@ -468,7 +468,7 @@ mod tests {
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
             custom_json_type: CustomJsonType::None,
-            encode_jsonb_mode: EncodeJsonbMode::Custom,
+            encode_jsonb_mode: EncodeJsonbMode::String,
         };
 
         let boolean_value = datum_to_json_object(
@@ -540,7 +540,7 @@ mod tests {
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcWithoutSuffix,
             custom_json_type: CustomJsonType::None,
-            encode_jsonb_mode: EncodeJsonbMode::Custom,
+            encode_jsonb_mode: EncodeJsonbMode::String,
         };
 
         let tstz_inner = "2018-01-26T18:30:09.453Z".parse().unwrap();
@@ -561,7 +561,7 @@ mod tests {
             timestamp_handling_mode: TimestampHandlingMode::Milli,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
             custom_json_type: CustomJsonType::None,
-            encode_jsonb_mode: EncodeJsonbMode::Custom,
+            encode_jsonb_mode: EncodeJsonbMode::String,
         };
         let ts_value = datum_to_json_object(
             &Field {
@@ -659,7 +659,7 @@ mod tests {
             timestamp_handling_mode: TimestampHandlingMode::String,
             timestamptz_handling_mode: TimestamptzHandlingMode::UtcString,
             custom_json_type: CustomJsonType::None,
-            encode_jsonb_mode: EncodeJsonbMode::Custom,
+            encode_jsonb_mode: EncodeJsonbMode::String,
         };
         let date_value = datum_to_json_object(
             &Field {

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -152,12 +152,12 @@ pub enum CustomJsonType {
 
 /// How the jsonb type is encoded.
 ///
-/// - `string`: encode jsonb as string. `[1, true, "foo"] -> "[1, true, \"foo\"]"`
-/// - `object`: encode jsonb as json object. `[1, true, "foo"] -> [1, true, "foo"]`
-/// - `custom`: decided by [`CustomJsonType`].
+/// - `String`: encode jsonb as string. `[1, true, "foo"] -> "[1, true, \"foo\"]"`
+/// - `Dynamic`: encode jsonb as json object. `[1, true, "foo"] -> [1, true, "foo"]`
+/// - `Custom`: decided by [`CustomJsonType`].
 pub enum EncodeJsonbMode {
     String,
-    Object,
+    Dynamic,
     Custom,
 }
 
@@ -167,7 +167,7 @@ impl EncodeJsonbMode {
     pub fn from_options(options: &BTreeMap<String, String>) -> Result<Self> {
         match options.get(Self::OPTION_KEY).map(std::ops::Deref::deref) {
             Some("string") | None => Ok(Self::String),
-            Some("object") => Ok(Self::Object),
+            Some("dynamic") => Ok(Self::Dynamic),
             Some(v) => Err(super::SinkError::Config(anyhow::anyhow!(
                 "unrecognized {} value {}",
                 Self::OPTION_KEY,

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -154,15 +154,13 @@ pub enum CustomJsonType {
 ///
 /// - `String`: encode jsonb as string. `[1, true, "foo"] -> "[1, true, \"foo\"]"`
 /// - `Dynamic`: encode jsonb as json type dynamically. `[1, true, "foo"] -> [1, true, "foo"]`
-/// - `Custom`: decided by [`CustomJsonType`].
-pub enum EncodeJsonbMode {
+pub enum JsonbHandlingMode {
     String,
     Dynamic,
-    Custom,
 }
 
-impl EncodeJsonbMode {
-    pub const OPTION_KEY: &'static str = "encode.jsonb.mode";
+impl JsonbHandlingMode {
+    pub const OPTION_KEY: &'static str = "jsonb.handling.mode";
 
     pub fn from_options(options: &BTreeMap<String, String>) -> Result<Self> {
         match options.get(Self::OPTION_KEY).map(std::ops::Deref::deref) {

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -150,6 +150,33 @@ pub enum CustomJsonType {
     None,
 }
 
+/// How the jsonb type is encoded.
+///
+/// - `string`: encode jsonb as string. `[1, true, "foo"] -> "[1, true, \"foo\"]"`
+/// - `object`: encode jsonb as json object. `[1, true, "foo"] -> [1, true, "foo"]`
+/// - `custom`: decided by [`CustomJsonType`].
+pub enum EncodeJsonbMode {
+    String,
+    Object,
+    Custom,
+}
+
+impl EncodeJsonbMode {
+    pub const OPTION_KEY: &'static str = "encode.jsonb.mode";
+
+    pub fn from_options(options: &BTreeMap<String, String>) -> Result<Self> {
+        match options.get(Self::OPTION_KEY).map(std::ops::Deref::deref) {
+            Some("string") | None => Ok(Self::String),
+            Some("object") => Ok(Self::Object),
+            Some(v) => Err(super::SinkError::Config(anyhow::anyhow!(
+                "unrecognized {} value {}",
+                Self::OPTION_KEY,
+                v
+            ))),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct FieldEncodeError {
     message: String,

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -153,7 +153,7 @@ pub enum CustomJsonType {
 /// How the jsonb type is encoded.
 ///
 /// - `String`: encode jsonb as string. `[1, true, "foo"] -> "[1, true, \"foo\"]"`
-/// - `Dynamic`: encode jsonb as json object. `[1, true, "foo"] -> [1, true, "foo"]`
+/// - `Dynamic`: encode jsonb as json type dynamically. `[1, true, "foo"] -> [1, true, "foo"]`
 /// - `Custom`: decided by [`CustomJsonType`].
 pub enum EncodeJsonbMode {
     String,

--- a/src/connector/src/sink/formatter/debezium_json.rs
+++ b/src/connector/src/sink/formatter/debezium_json.rs
@@ -21,8 +21,8 @@ use tracing::warn;
 
 use super::{Result, SinkFormatter, StreamChunk};
 use crate::sink::encoder::{
-    DateHandlingMode, JsonEncoder, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
-    TimestamptzHandlingMode,
+    DateHandlingMode, EncodeJsonbMode, JsonEncoder, RowEncoder, TimeHandlingMode,
+    TimestampHandlingMode, TimestamptzHandlingMode,
 };
 use crate::tri;
 
@@ -69,6 +69,7 @@ impl DebeziumJsonFormatter {
             TimestampHandlingMode::Milli,
             TimestamptzHandlingMode::UtcString,
             TimeHandlingMode::Milli,
+            EncodeJsonbMode::String,
         );
         let val_encoder = JsonEncoder::new(
             schema.clone(),
@@ -77,6 +78,7 @@ impl DebeziumJsonFormatter {
             TimestampHandlingMode::Milli,
             TimestamptzHandlingMode::UtcString,
             TimeHandlingMode::Milli,
+            EncodeJsonbMode::String,
         );
         Self {
             schema,
@@ -397,6 +399,7 @@ mod tests {
             TimestampHandlingMode::Milli,
             TimestamptzHandlingMode::UtcString,
             TimeHandlingMode::Milli,
+            EncodeJsonbMode::String,
         );
         let json_chunk = chunk_to_json(chunk, &encoder).unwrap();
         let schema_json = schema_to_json(&schema, "test_db", "test_table");

--- a/src/connector/src/sink/formatter/debezium_json.rs
+++ b/src/connector/src/sink/formatter/debezium_json.rs
@@ -21,7 +21,7 @@ use tracing::warn;
 
 use super::{Result, SinkFormatter, StreamChunk};
 use crate::sink::encoder::{
-    DateHandlingMode, EncodeJsonbMode, JsonEncoder, RowEncoder, TimeHandlingMode,
+    DateHandlingMode, JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode,
     TimestampHandlingMode, TimestamptzHandlingMode,
 };
 use crate::tri;
@@ -69,7 +69,7 @@ impl DebeziumJsonFormatter {
             TimestampHandlingMode::Milli,
             TimestamptzHandlingMode::UtcString,
             TimeHandlingMode::Milli,
-            EncodeJsonbMode::String,
+            JsonbHandlingMode::String,
         );
         let val_encoder = JsonEncoder::new(
             schema.clone(),
@@ -78,7 +78,7 @@ impl DebeziumJsonFormatter {
             TimestampHandlingMode::Milli,
             TimestamptzHandlingMode::UtcString,
             TimeHandlingMode::Milli,
-            EncodeJsonbMode::String,
+            JsonbHandlingMode::String,
         );
         Self {
             schema,
@@ -399,7 +399,7 @@ mod tests {
             TimestampHandlingMode::Milli,
             TimestamptzHandlingMode::UtcString,
             TimeHandlingMode::Milli,
-            EncodeJsonbMode::String,
+            JsonbHandlingMode::String,
         );
         let json_chunk = chunk_to_json(chunk, &encoder).unwrap();
         let schema_json = schema_to_json(&schema, "test_db", "test_table");

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -31,7 +31,7 @@ use super::catalog::{SinkEncode, SinkFormat, SinkFormatDesc};
 use super::encoder::template::TemplateEncoder;
 use super::encoder::text::TextEncoder;
 use super::encoder::{
-    DateHandlingMode, EncodeJsonbMode, KafkaConnectParams, TimeHandlingMode,
+    DateHandlingMode, JsonbHandlingMode, KafkaConnectParams, TimeHandlingMode,
     TimestamptzHandlingMode,
 };
 use super::redis::{KEY_FORMAT, VALUE_FORMAT};
@@ -114,7 +114,7 @@ pub trait EncoderBuild: Sized {
 impl EncoderBuild for JsonEncoder {
     async fn build(b: EncoderParams<'_>, pk_indices: Option<Vec<usize>>) -> Result<Self> {
         let timestamptz_mode = TimestamptzHandlingMode::from_options(&b.format_desc.options)?;
-        let encode_jsonb_mode = EncodeJsonbMode::from_options(&b.format_desc.options)?;
+        let jsonb_handling_mode = JsonbHandlingMode::from_options(&b.format_desc.options)?;
         let encoder = JsonEncoder::new(
             b.schema,
             pk_indices,
@@ -122,7 +122,7 @@ impl EncoderBuild for JsonEncoder {
             TimestampHandlingMode::Milli,
             timestamptz_mode,
             TimeHandlingMode::Milli,
-            encode_jsonb_mode,
+            jsonb_handling_mode,
         );
         let encoder = if let Some(s) = b.format_desc.options.get("schemas.enable") {
             match s.to_lowercase().parse::<bool>() {

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -31,7 +31,8 @@ use super::catalog::{SinkEncode, SinkFormat, SinkFormatDesc};
 use super::encoder::template::TemplateEncoder;
 use super::encoder::text::TextEncoder;
 use super::encoder::{
-    DateHandlingMode, KafkaConnectParams, TimeHandlingMode, TimestamptzHandlingMode,
+    DateHandlingMode, EncodeJsonbMode, KafkaConnectParams, TimeHandlingMode,
+    TimestamptzHandlingMode,
 };
 use super::redis::{KEY_FORMAT, VALUE_FORMAT};
 use crate::sink::encoder::{
@@ -113,6 +114,7 @@ pub trait EncoderBuild: Sized {
 impl EncoderBuild for JsonEncoder {
     async fn build(b: EncoderParams<'_>, pk_indices: Option<Vec<usize>>) -> Result<Self> {
         let timestamptz_mode = TimestamptzHandlingMode::from_options(&b.format_desc.options)?;
+        let encode_jsonb_mode = EncodeJsonbMode::from_options(&b.format_desc.options)?;
         let encoder = JsonEncoder::new(
             b.schema,
             pk_indices,
@@ -120,6 +122,7 @@ impl EncoderBuild for JsonEncoder {
             TimestampHandlingMode::Milli,
             timestamptz_mode,
             TimeHandlingMode::Milli,
+            encode_jsonb_mode,
         );
         let encoder = if let Some(s) = b.format_desc.options.get("schemas.enable") {
             match s.to_lowercase().parse::<bool>() {

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -590,7 +590,7 @@ mod test {
 
     use super::*;
     use crate::sink::encoder::{
-        DateHandlingMode, JsonEncoder, TimeHandlingMode, TimestampHandlingMode,
+        DateHandlingMode, EncodeJsonbMode, JsonEncoder, TimeHandlingMode, TimestampHandlingMode,
         TimestamptzHandlingMode,
     };
     use crate::sink::formatter::AppendOnlyFormatter;
@@ -778,6 +778,7 @@ mod test {
                     TimestampHandlingMode::Milli,
                     TimestamptzHandlingMode::UtcString,
                     TimeHandlingMode::Milli,
+                    EncodeJsonbMode::String,
                 ),
             )),
         )

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -590,7 +590,7 @@ mod test {
 
     use super::*;
     use crate::sink::encoder::{
-        DateHandlingMode, EncodeJsonbMode, JsonEncoder, TimeHandlingMode, TimestampHandlingMode,
+        DateHandlingMode, JsonEncoder, JsonbHandlingMode, TimeHandlingMode, TimestampHandlingMode,
         TimestamptzHandlingMode,
     };
     use crate::sink::formatter::AppendOnlyFormatter;
@@ -778,7 +778,7 @@ mod test {
                     TimestampHandlingMode::Milli,
                     TimestamptzHandlingMode::UtcString,
                     TimeHandlingMode::Milli,
-                    EncodeJsonbMode::String,
+                    JsonbHandlingMode::String,
                 ),
             )),
         )

--- a/src/connector/src/sink/mqtt.rs
+++ b/src/connector/src/sink/mqtt.rs
@@ -31,7 +31,7 @@ use with_options::WithOptions;
 
 use super::catalog::{SinkEncode, SinkFormat, SinkFormatDesc};
 use super::encoder::{
-    DateHandlingMode, EncodeJsonbMode, JsonEncoder, ProtoEncoder, ProtoHeader, RowEncoder, SerTo,
+    DateHandlingMode, JsonEncoder, JsonbHandlingMode, ProtoEncoder, ProtoHeader, RowEncoder, SerTo,
     TimeHandlingMode, TimestampHandlingMode, TimestamptzHandlingMode,
 };
 use super::writer::AsyncTruncateSinkWriterExt;
@@ -221,7 +221,7 @@ impl MqttSinkWriter {
         }
 
         let timestamptz_mode = TimestamptzHandlingMode::from_options(&format_desc.options)?;
-        let encode_jsonb_mode = EncodeJsonbMode::from_options(&format_desc.options)?;
+        let jsonb_handling_mode = JsonbHandlingMode::from_options(&format_desc.options)?;
         let encoder = match format_desc.format {
             SinkFormat::AppendOnly => match format_desc.encode {
                 SinkEncode::Json => RowEncoderWrapper::Json(JsonEncoder::new(
@@ -231,7 +231,7 @@ impl MqttSinkWriter {
                     TimestampHandlingMode::Milli,
                     timestamptz_mode,
                     TimeHandlingMode::Milli,
-                    encode_jsonb_mode,
+                    jsonb_handling_mode,
                 )),
                 SinkEncode::Protobuf => {
                     let (descriptor, sid) = crate::schema::protobuf::fetch_descriptor(

--- a/src/connector/src/sink/mqtt.rs
+++ b/src/connector/src/sink/mqtt.rs
@@ -31,8 +31,8 @@ use with_options::WithOptions;
 
 use super::catalog::{SinkEncode, SinkFormat, SinkFormatDesc};
 use super::encoder::{
-    DateHandlingMode, JsonEncoder, ProtoEncoder, ProtoHeader, RowEncoder, SerTo, TimeHandlingMode,
-    TimestampHandlingMode, TimestamptzHandlingMode,
+    DateHandlingMode, EncodeJsonbMode, JsonEncoder, ProtoEncoder, ProtoHeader, RowEncoder, SerTo,
+    TimeHandlingMode, TimestampHandlingMode, TimestamptzHandlingMode,
 };
 use super::writer::AsyncTruncateSinkWriterExt;
 use super::{DummySinkCommitCoordinator, SinkWriterParam};
@@ -221,7 +221,7 @@ impl MqttSinkWriter {
         }
 
         let timestamptz_mode = TimestamptzHandlingMode::from_options(&format_desc.options)?;
-
+        let encode_jsonb_mode = EncodeJsonbMode::from_options(&format_desc.options)?;
         let encoder = match format_desc.format {
             SinkFormat::AppendOnly => match format_desc.encode {
                 SinkEncode::Json => RowEncoderWrapper::Json(JsonEncoder::new(
@@ -231,6 +231,7 @@ impl MqttSinkWriter {
                     TimestampHandlingMode::Milli,
                     timestamptz_mode,
                     TimeHandlingMode::Milli,
+                    encode_jsonb_mode,
                 )),
                 SinkEncode::Protobuf => {
                     let (descriptor, sid) = crate::schema::protobuf::fetch_descriptor(

--- a/src/connector/src/sink/nats.rs
+++ b/src/connector/src/sink/nats.rs
@@ -29,7 +29,7 @@ use tokio_retry::Retry;
 use with_options::WithOptions;
 
 use super::encoder::{
-    DateHandlingMode, EncodeJsonbMode, TimeHandlingMode, TimestamptzHandlingMode,
+    DateHandlingMode, JsonbHandlingMode, TimeHandlingMode, TimestamptzHandlingMode,
 };
 use super::utils::chunk_to_json;
 use super::{DummySinkCommitCoordinator, SinkWriterParam};
@@ -153,7 +153,7 @@ impl NatsSinkWriter {
                 TimestampHandlingMode::Milli,
                 TimestamptzHandlingMode::UtcWithoutSuffix,
                 TimeHandlingMode::Milli,
-                EncodeJsonbMode::String,
+                JsonbHandlingMode::String,
             ),
         })
     }

--- a/src/connector/src/sink/nats.rs
+++ b/src/connector/src/sink/nats.rs
@@ -28,7 +28,9 @@ use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 use with_options::WithOptions;
 
-use super::encoder::{DateHandlingMode, TimeHandlingMode, TimestamptzHandlingMode};
+use super::encoder::{
+    DateHandlingMode, EncodeJsonbMode, TimeHandlingMode, TimestamptzHandlingMode,
+};
 use super::utils::chunk_to_json;
 use super::{DummySinkCommitCoordinator, SinkWriterParam};
 use crate::connector_common::NatsCommon;
@@ -151,6 +153,7 @@ impl NatsSinkWriter {
                 TimestampHandlingMode::Milli,
                 TimestamptzHandlingMode::UtcWithoutSuffix,
                 TimeHandlingMode::Milli,
+                EncodeJsonbMode::String,
             ),
         })
     }

--- a/src/connector/src/sink/snowflake.rs
+++ b/src/connector/src/sink/snowflake.rs
@@ -34,7 +34,8 @@ use uuid::Uuid;
 use with_options::WithOptions;
 
 use super::encoder::{
-    JsonEncoder, RowEncoder, TimeHandlingMode, TimestampHandlingMode, TimestamptzHandlingMode,
+    EncodeJsonbMode, JsonEncoder, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
+    TimestamptzHandlingMode,
 };
 use super::writer::LogSinkerOf;
 use super::{SinkError, SinkParam};
@@ -193,6 +194,7 @@ impl SnowflakeSinkWriter {
                 TimestampHandlingMode::String,
                 TimestamptzHandlingMode::UtcString,
                 TimeHandlingMode::String,
+                EncodeJsonbMode::String,
             ),
             // initial value of `epoch` will be set to 0
             epoch: 0,

--- a/src/connector/src/sink/snowflake.rs
+++ b/src/connector/src/sink/snowflake.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 use with_options::WithOptions;
 
 use super::encoder::{
-    EncodeJsonbMode, JsonEncoder, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
+    JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
     TimestamptzHandlingMode,
 };
 use super::writer::LogSinkerOf;
@@ -194,7 +194,7 @@ impl SnowflakeSinkWriter {
                 TimestampHandlingMode::String,
                 TimestamptzHandlingMode::UtcString,
                 TimeHandlingMode::String,
-                EncodeJsonbMode::String,
+                JsonbHandlingMode::String,
             ),
             // initial value of `epoch` will be set to 0
             epoch: 0,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

close #11699

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

Add a option for `ENCODE JSON` in `WITH` clause .

`jsonb.handling.mode` can be set to either `string` or `dynamic`

- `string`: encode the `jsonb` type as a string. example: `{"k": 2} -> "{\"k\": 2}"`. Here a json object `jsonb` was encoded to a string.
- `dynamic`: dynamically encode the `jsonb` type as json type. example: `{"k": 2} -> {"k": 2}`. Here a json object `jsonb` was encoded to a json object.



## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
