### PR TITLE
fix: Refactor `auto_parallelism.rs` to initialize `session` after killing compute node

### DIFF
--- a/src/tests/simulation/tests/integration_tests/scale/auto_parallelism.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/auto_parallelism.rs
@@ -217,7 +217,6 @@ async fn test_active_online() -> Result<()> {
         true,
     );
     let mut cluster = Cluster::start(config.clone()).await?;
-    let mut session = cluster.start_session();
 
     // Keep one worker reserved for adding later.
     cluster
@@ -228,6 +227,8 @@ async fn test_active_online() -> Result<()> {
         MAX_HEARTBEAT_INTERVAL_SECS_CONFIG_FOR_AUTO_SCALE * 2,
     ))
     .await;
+
+    let mut session = cluster.start_session();
 
     session.run("create table t (v1 int);").await?;
     session
@@ -303,7 +304,6 @@ async fn test_auto_parallelism_control_with_fixed_and_auto_helper(
         enable_auto_parallelism_control,
     );
     let mut cluster = Cluster::start(config.clone()).await?;
-    let mut session = cluster.start_session();
 
     // Keep one worker reserved for adding later.
     let select_worker = "compute-2";
@@ -315,6 +315,8 @@ async fn test_auto_parallelism_control_with_fixed_and_auto_helper(
         MAX_HEARTBEAT_INTERVAL_SECS_CONFIG_FOR_AUTO_SCALE * 2,
     ))
     .await;
+
+    let mut session = cluster.start_session();
 
     session.run("create table t (v1 int);").await?;
 
@@ -490,10 +492,6 @@ async fn test_compatibility_with_low_level() -> Result<()> {
         true,
     );
     let mut cluster = Cluster::start(config.clone()).await?;
-    let mut session = cluster.start_session();
-    session
-        .run("SET streaming_use_arrangement_backfill = false;")
-        .await?;
 
     // Keep one worker reserved for adding later.
     let select_worker = "compute-2";
@@ -505,6 +503,11 @@ async fn test_compatibility_with_low_level() -> Result<()> {
         MAX_HEARTBEAT_INTERVAL_SECS_CONFIG_FOR_AUTO_SCALE * 2,
     ))
     .await;
+
+    let mut session = cluster.start_session();
+    session
+        .run("SET streaming_use_arrangement_backfill = false;")
+        .await?;
 
     session.run("create table t(v int);").await?;
 
@@ -631,7 +634,6 @@ async fn test_compatibility_with_low_level_and_arrangement_backfill() -> Result<
         true,
     );
     let mut cluster = Cluster::start(config.clone()).await?;
-    let mut session = cluster.start_session();
 
     // Keep one worker reserved for adding later.
     let select_worker = "compute-2";
@@ -643,6 +645,8 @@ async fn test_compatibility_with_low_level_and_arrangement_backfill() -> Result<
         MAX_HEARTBEAT_INTERVAL_SECS_CONFIG_FOR_AUTO_SCALE * 2,
     ))
     .await;
+
+    let mut session = cluster.start_session();
 
     session.run("create table t(v int);").await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When starting a integration test session, per-session statements are executed, such as creating a view to retrieve parallelism. During this time, a kill node might execute simultaneously, potentially causing a race condition that leads to the cluster being in recovery when the SQL is executed. 

Therefore, I have adjusted the order, placing the session start after the sleep period.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


