### PR TITLE
chore: add `production` profile for version release & add developer docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,11 +283,14 @@ private_intra_doc_links = "allow"
 redundant_explicit_links = "allow"
 
 [profile.dev]
-lto = 'off'
+lto = "off"
 
 [profile.release]
 debug = "full"
 split-debuginfo = "packed"
+lto = "off"
+
+[profile.production]
 lto = "thin"
 
 # The profile used for CI in main branch.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,8 @@ private_intra_doc_links = "allow"
 # Explicit lints don't hurt, and sometimes rust-analyzer works better with explicit links.
 redundant_explicit_links = "allow"
 
+# Tweak built-in profiles and define custom profiles.
+# See `docs/dev/src/build-and-run/profiles.md` for detailed information.
 [profile.dev]
 lto = "off"
 
@@ -293,9 +295,6 @@ lto = "off"
 [profile.production]
 lto = "thin"
 
-# The profile used for CI in main branch.
-# This profile inherits from the release profile, but turns on some checks and assertions for us to
-# better catch bugs in CI.
 [profile.ci-release]
 inherits = "release"
 incremental = false
@@ -305,9 +304,6 @@ split-debuginfo = "off"
 debug-assertions = true
 overflow-checks = true
 
-# The profile used for CI in pull requests.
-# External dependencies are built with optimization enabled, while crates in this workspace are built
-# with `dev` profile and full debug info. This is a trade-off between build time and e2e test time.
 [profile.ci-dev]
 inherits = "dev"
 incremental = false
@@ -321,9 +317,6 @@ opt-level = 3
 [profile.ci-dev.package."indextree"]
 opt-level = 3
 
-# The profile used for deterministic simulation tests in CI.
-# The simulator can only run single-threaded, so optimization is required to make the running time
-# reasonable. The optimization level is customized to speed up the build.
 [profile.ci-sim]
 inherits = "dev"
 incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,9 +326,9 @@ opt-level = 3
 # reasonable. The optimization level is customized to speed up the build.
 [profile.ci-sim]
 inherits = "dev"
-opt-level = 2
 incremental = false
-debug = 1
+debug = "line-tables-only"
+opt-level = 2
 
 [patch.crates-io]
 # Patch third-party crates for deterministic simulation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,10 +289,13 @@ lto = "off"
 
 [profile.release]
 debug = "full"
+incremental = true
 split-debuginfo = "packed"
 lto = "off"
 
 [profile.production]
+inherits = "release"
+incremental = false
 lto = "thin"
 
 [profile.ci-release]

--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -71,9 +71,9 @@ if [ "${ARCH}" == "aarch64" ]; then
   # see https://github.com/tikv/jemallocator/blob/802969384ae0c581255f3375ee2ba774c8d2a754/jemalloc-sys/build.rs#L218
   export JEMALLOC_SYS_WITH_LG_PAGE=16
 fi
-OPENSSL_STATIC=1 cargo build -p risingwave_cmd_all --features "rw-static-link" --features external-udf --features wasm-udf --features js-udf --profile release
-OPENSSL_STATIC=1 cargo build -p risingwave_cmd --bin risectl --features "rw-static-link" --profile release
-cd target/release && chmod +x risingwave risectl
+OPENSSL_STATIC=1 cargo build -p risingwave_cmd_all --features "rw-static-link" --features external-udf --features wasm-udf --features js-udf --profile production
+OPENSSL_STATIC=1 cargo build -p risingwave_cmd --bin risectl --features "rw-static-link" --profile production
+cd target/production && chmod +x risingwave risectl
 
 echo "--- Upload nightly binary to s3"
 if [ "${BUILDKITE_SOURCE}" == "schedule" ]; then
@@ -90,7 +90,7 @@ cd "${REPO_ROOT}"/java && mvn -B package -Dmaven.test.skip=true -Dno-build-rust
 if [[ -n "${BUILDKITE_TAG}" ]]; then
   echo "--- Collect all release assets"
   cd "${REPO_ROOT}" && mkdir release-assets && cd release-assets
-  cp -r "${REPO_ROOT}"/target/release/* .
+  cp -r "${REPO_ROOT}"/target/production/* .
   mv "${REPO_ROOT}"/java/connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz risingwave-connector-"${BUILDKITE_TAG}".tar.gz
   tar -zxvf risingwave-connector-"${BUILDKITE_TAG}".tar.gz libs
   ls -l

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN cargo install flamegraph
 # COPY --from=rust-planner /risingwave/recipe.json recipe.json
 
 # # Build dependencies - this can be cached if the dependencies don't change
-# RUN cargo chef cook --release --recipe-path recipe.json
+# RUN cargo chef cook --profile production --recipe-path recipe.json
 
 FROM rust-base AS rust-builder
 
@@ -70,11 +70,11 @@ ENV ENABLE_BUILD_DASHBOARD=1
 ENV OPENSSL_STATIC=1
 
 RUN cargo fetch && \
-  cargo build -p risingwave_cmd_all --release --features "rw-static-link" --features all-udf && \
+  cargo build -p risingwave_cmd_all --profile production --features "rw-static-link" --features all-udf && \
   mkdir -p /risingwave/bin && \
-    mv /risingwave/target/release/risingwave /risingwave/bin/ && \
-    mv /risingwave/target/release/risingwave.dwp /risingwave/bin/ && \
-  cp ./target/release/build/tikv-jemalloc-sys-*/out/build/bin/jeprof /risingwave/bin/ && \
+    mv /risingwave/target/production/risingwave /risingwave/bin/ && \
+    mv /risingwave/target/production/risingwave.dwp /risingwave/bin/ && \
+  cp ./target/production/build/tikv-jemalloc-sys-*/out/build/bin/jeprof /risingwave/bin/ && \
   chmod +x /risingwave/bin/jeprof && \
   mkdir -p /risingwave/lib && cargo clean
 

--- a/docker/Dockerfile.hdfs
+++ b/docker/Dockerfile.hdfs
@@ -1,3 +1,5 @@
+# FIXME: this file is not well maintained compared to the main Dockerfile and may not work as expected.
+
 FROM ubuntu:24.04 AS base
 
 ENV LANG en_US.utf8
@@ -102,15 +104,15 @@ ENV OPENSSL_STATIC=1
 RUN cargo fetch && \
   cargo build -p risingwave_cmd_all --release -p risingwave_object_store --features hdfs-backend --features "rw-static-link" --features all-udf && \
   mkdir -p /risingwave/bin && \
-    mv /risingwave/target/release/risingwave /risingwave/bin/ && \
-    mv /risingwave/target/release/risingwave.dwp /risingwave/bin/ && \
+  mv /risingwave/target/release/risingwave /risingwave/bin/ && \
+  mv /risingwave/target/release/risingwave.dwp /risingwave/bin/ && \
   cp ./target/release/build/tikv-jemalloc-sys-*/out/build/bin/jeprof /risingwave/bin/ && \
   chmod +x /risingwave/bin/jeprof && \
   mkdir -p /risingwave/lib && cargo clean
 
 RUN cd /risingwave/java && mvn -B package -Dmaven.test.skip=true -Dno-build-rust && \
-    mkdir -p /risingwave/bin/connector-node && \
-    tar -zxvf /risingwave/java/connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node
+  mkdir -p /risingwave/bin/connector-node && \
+  tar -zxvf /risingwave/java/connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node
 
 FROM ubuntu:24.04 as image-base
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates openjdk-17-jdk wget libsasl2-dev && rm -rf /var/lib/{apt,dpkg,cache,log}/

--- a/docker/aws/aws-build.sh
+++ b/docker/aws/aws-build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# FIXME: this script has not been maintained for a long time.
+
 set -e
 
 export DOCKER_BUILDKIT=1

--- a/docs/dev/src/SUMMARY.md
+++ b/docs/dev/src/SUMMARY.md
@@ -8,6 +8,7 @@
 # Building and debugging RisingWave
 
 - [Building and Running](./build-and-run/intro.md)
+    - [Profiles](./build-and-run/profiles.md)
 - [Testing](./tests/intro.md)
 - [Debugging](./debugging.md)
 - [Observability](./observability.md)

--- a/docs/dev/src/build-and-run/profiles.md
+++ b/docs/dev/src/build-and-run/profiles.md
@@ -1,0 +1,63 @@
+# Build Profiles
+
+RisingWave uses Cargo profiles to manage build settings. To briefly introduce Cargo profiles, here is a snippet from the [Cargo References](https://doc.rust-lang.org/cargo/reference/profiles.html):
+
+> Profiles provide a way to alter the compiler settings, influencing things like optimizations and debugging symbols.
+>
+> Cargo has 4 built-in profiles: `dev`, `release`, `test`, and `bench`. The profile is automatically chosen based on which command is being run if a profile is not specified on the command-line. In addition to the built-in profiles, custom user-defined profiles can also be specified.
+
+All profiles talked in this document are defined in the `Cargo.toml` file of the root directory of the project. Please always refer to it for the most up-to-date information.
+
+## Built-in Profiles
+
+RisingWave tweaks some settings of the built-in profiles to better fit its needs, in the sections of `[profile.<built-in-profile>]` in `Cargo.toml`. For example,
+
+- `dev`: for local development and testing
+
+  - completely disables [LTO](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) to speed up the build time
+
+- `release`: for local testing with near-production performance
+  - completely disables LTO to speed up the build time
+  - embeds full debug information to help with debugging in production
+
+## Custom Profiles
+
+RisingWave also defines some custom profiles that inherit from the built-in profiles, in the sections of `[profile.<custom-profile>]` in `Cargo.toml`. For example,
+
+- `ci-dev` and `ci-release`: for `pull-request` and `main` pipelines in CI
+
+  - inherits from the corresponding built-in profiles
+  - tweaks some settings to reduce the build time and binary size
+  - enables code optimizations for 3rd-party dependencies to improve CI performance
+
+- `ci-sim`: for `madsim` simulation tests in CI
+
+  - similar to `ci-dev`
+  - enables slight code optimizations for all crates to improve CI performance under single-threaded madsim simulation
+
+- `production`: for distribution and production deployment
+  - inherits from `release`
+  - enables aggressive code optimizations (like LTO) for maximum performance, at the cost of significantly increased build time
+
+## Comparisons
+
+To give a better idea of the differences between the profiles, here is a matrix comparing the profiles:
+
+| Profile      | Debug Info     | `cfg(debug_assertions)` | Performance | Build Time |
+| ------------ | -------------- | ----------------------- | ----------- | ---------- |
+| `dev`        | Full           | `true`                  | Bad         | Fastest    |
+| `release`    | Full           | `false`                 | Good        | Slow       |
+| `production` | Full           | `false`                 | Best        | Slowest    |
+| `ci-dev`     | Backtrace only | `true`                  | Medium      | Fast       |
+| `ci-release` | Backtrace only | `true`                  | Good        | Slow       |
+| `ci-sim`     | Backtrace only | `true`                  | Medium      | Medium     |
+
+Some miscellaneous notes:
+
+- Compared to "Backtrace only", "Full" debug information additionally includes the capability to attach a debugger at runtime or on core dumps, to inspect variables and stack traces.
+- There are also other subtle differences like incremental compilation settings, overflow checks, and more. They are not listed here for brevity.
+- `cfg(debug_assertions)` can be roughly used to determine whether it's a production environment or not. Note that even though `ci-release` contains `release` in its name, the `debug_assertions` are still enabled.
+
+## Choose a Profile
+
+By default, RisingWave (and RiseDev) uses the `dev` profile for local development and testing. To use `release` profile instead, you can set the corresponding configuration entry by running `risedev configure`. Other profiles are for their specific use cases and are not meant to be used directly by developers, thus not available with RiseDev.

--- a/docs/dev/src/build-and-run/profiles.md
+++ b/docs/dev/src/build-and-run/profiles.md
@@ -17,6 +17,7 @@ RisingWave tweaks some settings of the built-in profiles to better fit its needs
   - completely disables [LTO](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) to speed up the build time
 
 - `release`: for local testing with near-production performance
+
   - completely disables LTO to speed up the build time
   - embeds full debug information to help with debugging in production
 
@@ -24,20 +25,26 @@ RisingWave tweaks some settings of the built-in profiles to better fit its needs
 
 RisingWave also defines some custom profiles that inherit from the built-in profiles, in the sections of `[profile.<custom-profile>]` in `Cargo.toml`. For example,
 
-- `ci-dev` and `ci-release`: for `pull-request` and `main` pipelines in CI
+- `production`: for distribution and production deployment
 
-  - inherits from the corresponding built-in profiles
+  - inherits from `release`
+  - enables aggressive code optimizations (like LTO) for maximum performance, at the cost of significantly increased build time
+
+- `ci-dev`: for `pull-request` pipelines in CI
+
+  - inherits from `dev`
   - tweaks some settings to reduce the build time and binary size
   - enables code optimizations for 3rd-party dependencies to improve CI performance
 
-- `ci-sim`: for `madsim` simulation tests in CI
+- `ci-release`: for `main` and `main-cron` pipelines in CI
 
-  - similar to `ci-dev`
-  - enables slight code optimizations for all crates to improve CI performance under single-threaded madsim simulation
-
-- `production`: for distribution and production deployment
   - inherits from `release`
-  - enables aggressive code optimizations (like LTO) for maximum performance, at the cost of significantly increased build time
+  - tweaks some settings to reduce the build time and binary size
+  - enables more runtime checks (like debug assertions and overflow checks) to catch potential bugs
+
+- `ci-sim`: for `madsim` simulation tests in CI
+  - similar to `ci-dev`
+  - enables slight code optimizations for all crates to improve CI performance under single-threaded madsim execution
 
 ## Comparisons
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolve https://github.com/risingwavelabs/risingwave/issues/17725 in another way.

Rename `release` profile to `production`. Make `release` more friendly for local testing on optimized builds, like enabling incremental compilation and disabling LTO.

Add a separate page in developer docs introducing and comparising all our profiles.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
