### PR TITLE
feat: support prepared statements for `create MV`

### DIFF
--- a/src/frontend/src/binder/create_view.rs
+++ b/src/frontend/src/binder/create_view.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, Query, SqlOption};
+use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, SqlOption};
 
 use crate::binder::statement::RewriteExprsRecursive;
-use crate::binder::{BoundDelete, BoundQuery};
-use crate::error::Result;
+use crate::binder::BoundQuery;
 use crate::expr::ExprRewriter;
-use crate::optimizer::PlanRoot;
-use crate::Planner;
 
 /// Represents a bounded `CREATE MATERIALIZED VIEW` statement.
 #[derive(Debug, Clone)]

--- a/src/frontend/src/binder/create_view.rs
+++ b/src/frontend/src/binder/create_view.rs
@@ -1,0 +1,65 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, Query, SqlOption};
+
+use crate::binder::statement::RewriteExprsRecursive;
+use crate::binder::{BoundDelete, BoundQuery};
+use crate::error::Result;
+use crate::expr::ExprRewriter;
+use crate::optimizer::PlanRoot;
+use crate::Planner;
+
+/// Represents a bounded `CREATE MATERIALIZED VIEW` statement.
+#[derive(Debug, Clone)]
+pub struct BoundCreateView {
+    pub or_replace: bool,
+    pub materialized: bool, // always true currently
+    pub if_not_exists: bool,
+    pub name: ObjectName,
+    pub columns: Vec<Ident>,
+    pub query: Box<BoundQuery>, // reuse the BoundQuery struct
+    pub emit_mode: Option<EmitMode>,
+    pub with_options: Vec<SqlOption>,
+}
+
+impl BoundCreateView {
+    pub fn new(
+        or_replace: bool,
+        materialized: bool,
+        if_not_exists: bool,
+        name: ObjectName,
+        columns: Vec<Ident>,
+        query: BoundQuery,
+        emit_mode: Option<EmitMode>,
+        with_options: Vec<SqlOption>,
+    ) -> Self {
+        Self {
+            or_replace,
+            materialized,
+            if_not_exists,
+            name,
+            columns,
+            query: Box::new(query),
+            emit_mode,
+            with_options,
+        }
+    }
+}
+
+impl RewriteExprsRecursive for BoundCreateView {
+    fn rewrite_exprs_recursive(&mut self, rewriter: &mut impl ExprRewriter) {
+        self.query.rewrite_exprs_recursive(rewriter);
+    }
+}

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -29,6 +29,7 @@ use crate::error::Result;
 mod bind_context;
 mod bind_param;
 mod create;
+mod create_view;
 mod delete;
 mod expr;
 mod for_system;
@@ -43,6 +44,7 @@ mod update;
 mod values;
 
 pub use bind_context::{BindContext, Clause, LateralBindContext};
+pub use create_view::BoundCreateView;
 pub use delete::BoundDelete;
 pub use expr::{bind_data_type, bind_struct_field};
 pub use insert::BoundInsert;

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -32,7 +32,7 @@ use crate::binder::{Binder, BoundSetExpr};
 use crate::error::{ErrorCode, Result};
 use crate::expr::{CorrelatedId, Depth, ExprImpl, ExprRewriter};
 
-/// A validated (batch) sql query, including order and union.
+/// A validated sql query, including order and union.
 /// An example of its relationship with `BoundSetExpr` and `BoundSelect` can be found here: <https://bit.ly/3GQwgPz>
 #[derive(Debug, Clone)]
 pub struct BoundQuery {

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -32,7 +32,7 @@ use crate::binder::{Binder, BoundSetExpr};
 use crate::error::{ErrorCode, Result};
 use crate::expr::{CorrelatedId, Depth, ExprImpl, ExprRewriter};
 
-/// A validated sql query, including order and union.
+/// A validated (batch) sql query, including order and union.
 /// An example of its relationship with `BoundSetExpr` and `BoundSelect` can be found here: <https://bit.ly/3GQwgPz>
 #[derive(Debug, Clone)]
 pub struct BoundQuery {

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use either::Either;
 use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::acl::AclMode;
+use risingwave_common::catalog::TableId;
 use risingwave_pb::catalog::PbTable;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, Query};
@@ -79,11 +82,34 @@ pub(super) fn get_column_names(
     Ok(col_names)
 }
 
-/// Generate create MV plan, return plan and mv table info.
+/// Bind and generate create MV plan, return plan and mv table info.
 pub fn gen_create_mv_plan(
     session: &SessionImpl,
     context: OptimizerContextRef,
     query: Query,
+    name: ObjectName,
+    columns: Vec<Ident>,
+    emit_mode: Option<EmitMode>,
+) -> Result<(PlanRef, PbTable)> {
+    let mut binder = Binder::new_for_stream(session);
+    let bound = binder.bind_query(query)?;
+    gen_create_mv_plan_bound(
+        session,
+        context,
+        bound,
+        binder.included_relations(),
+        name,
+        columns,
+        emit_mode,
+    )
+}
+
+/// Generate create MV plan from a bound query
+pub fn gen_create_mv_plan_bound(
+    session: &SessionImpl,
+    context: OptimizerContextRef,
+    query: BoundQuery,
+    dependent_relations: HashSet<TableId>,
     name: ObjectName,
     columns: Vec<Ident>,
     emit_mode: Option<EmitMode>,
@@ -99,23 +125,17 @@ pub fn gen_create_mv_plan(
 
     let definition = context.normalized_sql().to_owned();
 
-    let (dependent_relations, bound) = {
-        let mut binder = Binder::new_for_stream(session);
-        let bound = binder.bind_query(query)?;
-        (binder.included_relations(), bound)
-    };
-
-    let check_items = resolve_query_privileges(&bound);
+    let check_items = resolve_query_privileges(&query);
     session.check_privileges(&check_items)?;
 
-    let col_names = get_column_names(&bound, session, columns)?;
+    let col_names = get_column_names(&query, session, columns)?;
 
     let emit_on_window_close = emit_mode == Some(EmitMode::OnWindowClose);
     if emit_on_window_close {
         context.warn_to_user("EMIT ON WINDOW CLOSE is currently an experimental feature. Please use it with caution.");
     }
 
-    let mut plan_root = Planner::new(context).plan_query(bound)?;
+    let mut plan_root = Planner::new(context).plan_query(query)?;
     if let Some(col_names) = col_names {
         for name in &col_names {
             check_valid_column_name(name)?;
@@ -156,6 +176,32 @@ pub async fn handle_create_mv(
     columns: Vec<Ident>,
     emit_mode: Option<EmitMode>,
 ) -> Result<RwPgResponse> {
+    let (dependent_relations, bound) = {
+        let mut binder = Binder::new_for_stream(handler_args.session.as_ref());
+        let bound = binder.bind_query(query)?;
+        (binder.included_relations(), bound)
+    };
+    handle_create_mv_bound(
+        handler_args,
+        if_not_exists,
+        name,
+        bound,
+        dependent_relations,
+        columns,
+        emit_mode,
+    )
+    .await
+}
+
+pub async fn handle_create_mv_bound(
+    handler_args: HandlerArgs,
+    if_not_exists: bool,
+    name: ObjectName,
+    query: BoundQuery,
+    dependent_relations: HashSet<TableId>,
+    columns: Vec<Ident>,
+    emit_mode: Option<EmitMode>,
+) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
 
     if let Either::Right(resp) = session.check_relation_name_duplicated(
@@ -176,15 +222,22 @@ pub async fn handle_create_mv(
             ))));
         }
 
-        let has_order_by = !query.order_by.is_empty();
+        let has_order_by = !query.order.is_empty();
         if has_order_by {
             context.warn_to_user(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
 It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
 "#.to_string());
         }
 
-        let (plan, table) =
-            gen_create_mv_plan(&session, context.into(), query, name, columns, emit_mode)?;
+        let (plan, table) = gen_create_mv_plan_bound(
+            &session,
+            context.into(),
+            query,
+            dependent_relations,
+            name,
+            columns,
+            emit_mode,
+        )?;
 
         let context = plan.plan_base().ctx().clone();
         let mut graph = build_graph(plan)?;

--- a/src/frontend/src/handler/extended_handle.rs
+++ b/src/frontend/src/handler/extended_handle.rs
@@ -47,6 +47,17 @@ pub struct PreparedResult {
     pub bound_result: BoundResult,
 }
 
+/// Partial was a concept in the PostgreSQL protocol.
+///
+/// In the extended-query protocol, execution of SQL commands is divided into multiple steps.
+/// The state retained between steps is represented by two types of objects: prepared statements
+/// and portals. A prepared statement represents the result of parsing and semantic analysis of a
+/// textual query string. A prepared statement is not in itself ready to execute, because it might
+/// lack specific values for parameters.
+/// A portal represents a ready-to-execute or already-partially-executed statement,
+/// with any missing parameter values filled in.
+///
+/// Reference: https://www.postgresql.org/docs/current/protocol-overview.html#PROTOCOL-QUERY-CONCEPTS
 #[expect(clippy::enum_variant_names)]
 #[derive(Clone)]
 pub enum Portal {
@@ -65,6 +76,7 @@ impl std::fmt::Display for Portal {
     }
 }
 
+/// See the docs of [`Portal`].
 #[derive(Clone)]
 pub struct PortalResult {
     pub statement: Statement,
@@ -97,7 +109,14 @@ pub fn handle_parse(
         | Statement::Update { .. } => {
             query::handle_parse(handler_args, statement, specific_param_types)
         }
-        Statement::CreateView { query, .. } => {
+        Statement::CreateView {
+            query,
+            materialized,
+            ..
+        } => {
+            if *materialized {
+                return query::handle_parse(handler_args, statement, specific_param_types);
+            }
             if have_parameter_in_query(query) {
                 bail_not_implemented!("CREATE VIEW with parameters");
             }
@@ -179,13 +198,8 @@ pub async fn handle_execute(session: Arc<SessionImpl>, portal: Portal) -> Result
             let _guard = session.txn_begin_implicit(); // TODO(bugen): is this behavior correct?
             let sql: Arc<str> = Arc::from(portal.statement.to_string());
             let handler_args = HandlerArgs::new(session, &portal.statement, sql)?;
-            match &portal.statement {
-                Statement::Query(_)
-                | Statement::Insert { .. }
-                | Statement::Delete { .. }
-                | Statement::Update { .. } => query::handle_execute(handler_args, portal).await,
-                _ => unreachable!(),
-            }
+
+            query::handle_execute(handler_args, portal).await
         }
         Portal::PureStatement(stmt) => {
             let sql: Arc<str> = Arc::from(stmt.to_string());

--- a/src/frontend/src/handler/extended_handle.rs
+++ b/src/frontend/src/handler/extended_handle.rs
@@ -57,7 +57,7 @@ pub struct PreparedResult {
 /// A portal represents a ready-to-execute or already-partially-executed statement,
 /// with any missing parameter values filled in.
 ///
-/// Reference: https://www.postgresql.org/docs/current/protocol-overview.html#PROTOCOL-QUERY-CONCEPTS
+/// Reference: <https://www.postgresql.org/docs/current/protocol-overview.html#PROTOCOL-QUERY-CONCEPTS>
 #[expect(clippy::enum_variant_names)]
 #[derive(Clone)]
 pub enum Portal {

--- a/src/frontend/src/handler/privilege.rs
+++ b/src/frontend/src/handler/privilege.rs
@@ -115,6 +115,7 @@ pub(crate) fn resolve_privileges(stmt: &BoundStatement) -> Vec<ObjectCheckItem> 
             objects.push(object);
         }
         BoundStatement::Query(ref query) => objects.extend(resolve_query_privileges(query)),
+        BoundStatement::CreateView(ref query) => objects.extend(resolve_query_privileges(query)),
     };
     objects
 }

--- a/src/frontend/src/handler/privilege.rs
+++ b/src/frontend/src/handler/privilege.rs
@@ -115,7 +115,9 @@ pub(crate) fn resolve_privileges(stmt: &BoundStatement) -> Vec<ObjectCheckItem> 
             objects.push(object);
         }
         BoundStatement::Query(ref query) => objects.extend(resolve_query_privileges(query)),
-        BoundStatement::CreateView(ref query) => objects.extend(resolve_query_privileges(query)),
+        BoundStatement::CreateView(ref create_view) => {
+            objects.extend(resolve_query_privileges(&create_view.query))
+        }
     };
     objects
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -34,7 +34,6 @@ use super::{create_mv, PgResponseStream, RwPgResponse};
 use crate::binder::{Binder, BoundCreateView, BoundStatement};
 use crate::catalog::TableId;
 use crate::error::{ErrorCode, Result, RwError};
-use crate::handler::create_mv::gen_create_mv_plan;
 use crate::handler::flush::do_flush;
 use crate::handler::privilege::resolve_privileges;
 use crate::handler::util::{to_pg_field, DataChunkToRowSetAdapter};

--- a/src/frontend/src/planner/query.rs
+++ b/src/frontend/src/planner/query.rs
@@ -25,6 +25,8 @@ pub const LIMIT_ALL_COUNT: u64 = u64::MAX / 2;
 
 impl Planner {
     /// Plan a [`BoundQuery`]. Need to bind before planning.
+    ///
+    /// Works for both batch query and streaming query (`CREATE MATERIALIZED VIEW`).
     pub fn plan_query(&mut self, query: BoundQuery) -> Result<PlanRoot> {
         let out_names = query.schema().names();
         let BoundQuery {

--- a/src/frontend/src/planner/statement.rs
+++ b/src/frontend/src/planner/statement.rs
@@ -24,7 +24,7 @@ impl Planner {
             BoundStatement::Delete(d) => self.plan_delete(*d),
             BoundStatement::Update(u) => self.plan_update(*u),
             BoundStatement::Query(q) => self.plan_query(*q),
-            BoundStatement::CreateView(q) => self.plan_query(*q), /* not sure whether it works from streaming query */
+            BoundStatement::CreateView(c) => self.plan_query(*c.query),
         }
     }
 }

--- a/src/frontend/src/planner/statement.rs
+++ b/src/frontend/src/planner/statement.rs
@@ -24,6 +24,7 @@ impl Planner {
             BoundStatement::Delete(d) => self.plan_delete(*d),
             BoundStatement::Update(u) => self.plan_update(*u),
             BoundStatement::Query(q) => self.plan_query(*q),
+            BoundStatement::CreateView(q) => self.plan_query(*q), /* not sure whether it works from streaming query */
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolves part of #16653

- [x] I will check whether `alter MV rename` works because it relies on a persisted `create materialized view` SQL query.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Supports `CREATE MATERIALIZED VIEW` with parameters as prepared statements.
