### PR TITLE
fix(test): skip creating secret file dir in simulation test

### DIFF
--- a/src/common/secret/src/secret_manager.rs
+++ b/src/common/secret/src/secret_manager.rs
@@ -48,6 +48,10 @@ impl LocalSecretManager {
                 .join(cluster_id)
                 .join(worker_id.to_string());
             std::fs::remove_dir_all(&secret_file_dir).ok();
+
+            // This will cause file creation conflict in simulation tests.
+            // Should skip testing secret files in simulation tests.
+            #[cfg(not(madsim))]
             std::fs::create_dir_all(&secret_file_dir).unwrap();
 
             Self {
@@ -87,7 +91,10 @@ impl LocalSecretManager {
             "Failed to remove secret directory")
             })
             .ok();
+
+        #[cfg(not(madsim))]
         std::fs::create_dir_all(&self.secret_file_dir).unwrap();
+
         for secret in secrets {
             secret_guard.insert(secret.id, secret.value);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Creating secret directories will cause file creation conflict in concurrent simulation tests.

This will not happen in any deployment because we use cluster id (uuid) to distinguish files from different cluster. But we are running `deterministic-it-test.sh` concurrently, and nextest is running multiple ut concurrently. So even with different madsim seed for each deterministic-it-test.sh, two ut in the same run share the same seed, causing the same uuid in different cluster (bc madsim hook the random function in uuid::new_v4)

We currently do not have e2e for secret file. Should skip testing secret files in simulation tests if we have in the future.

close #17740

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
