### PR TITLE
feat: also gracefully shutdown on SIGTERM

### DIFF
--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -97,12 +97,12 @@ where
         spawn_prof_thread(profile_path);
     }
 
-    let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt()).unwrap();
-    let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate()).unwrap();
-
     let future_with_shutdown = async move {
         let shutdown = CancellationToken::new();
         let mut fut = pin!(f(shutdown.clone()));
+
+        let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt()).unwrap();
+        let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate()).unwrap();
 
         tokio::select! {
             biased;

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -35,6 +35,7 @@ mod panic_hook;
 pub use panic_hook::*;
 mod prof;
 use prof::*;
+use tokio::signal::unix::SignalKind;
 
 /// Start RisingWave components with configs from environment variable.
 ///
@@ -96,24 +97,26 @@ where
         spawn_prof_thread(profile_path);
     }
 
+    let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt()).unwrap();
+    let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate()).unwrap();
+
     let future_with_shutdown = async move {
         let shutdown = CancellationToken::new();
         let mut fut = pin!(f(shutdown.clone()));
 
         tokio::select! {
             biased;
-            result = tokio::signal::ctrl_c() => {
-                result.expect("failed to receive ctrl-c signal");
-                tracing::info!("received ctrl-c, shutting down... (press ctrl-c again to force shutdown)");
 
-                // Send shutdown signal.
+            // Watch SIGINT, typically originating from user pressing ctrl-c.
+            // Attempt to shutdown gracefully and force shutdown on the next signal.
+            _ = sigint.recv() => {
+                tracing::info!("received ctrl-c, shutting down... (press ctrl-c again to force shutdown)");
                 shutdown.cancel();
 
                 // While waiting for the future to finish, listen for the second ctrl-c signal.
                 tokio::select! {
                     biased;
-                    result = tokio::signal::ctrl_c() => {
-                        result.expect("failed to receive ctrl-c signal");
+                    _ = sigint.recv() => {
                         tracing::warn!("forced shutdown");
 
                         // Directly exit the process **here** instead of returning from the future, since
@@ -123,6 +126,16 @@ where
                     _ = &mut fut => {},
                 }
             }
+
+            // Watch SIGTERM, typically originating from Kubernetes.
+            // Attempt to shutdown gracefully. No need to force shutdown since it will send SIGKILL after a timeout.
+            _ = sigterm.recv() => {
+                tracing::info!("received SIGTERM, shutting down...");
+                shutdown.cancel();
+                fut.await;
+            }
+
+            // Proceed with the future.
             _ = &mut fut => {},
         }
     };


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

...because Kubernetes will send `SIGTERM` when killing a pod.

As described in https://github.com/risingwavelabs/risingwave/pull/17662, this can empower more seamless scaling-in in Kubernetes deployments. (correct me if I'm wrong)

> After this PR, I suppose we can get rid of the extra manual step of `risingwave ctl meta unregister-worker` when scaling-in, as described in the [doc](https://arc.net/l/quote/nmndgyum).

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

The step 1 of manual unregistration of the compute node when scaling-in ([doc](https://docs.risingwave.com/docs/current/k8s-cluster-scaling/#scale-in)) is not necessary any more. Users can directly apply the new yaml file to trigger a graceful scale-in.
