### PR TITLE
feat: lazily create guarded metrics when first using it

### DIFF
--- a/src/batch/src/executor/log_row_seq_scan.rs
+++ b/src/batch/src/executor/log_row_seq_scan.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use futures::prelude::stream::StreamExt;
@@ -168,7 +167,7 @@ impl<S: StateStore> LogRowSeqScanExecutor<S> {
             old_epoch.clone(),
             new_epoch.clone(),
             chunk_size,
-            histogram.clone(),
+            histogram.as_ref().map(|h| &***h),
             Arc::new(schema.clone()),
         );
         #[for_await]
@@ -184,7 +183,7 @@ impl<S: StateStore> LogRowSeqScanExecutor<S> {
         old_epoch: BatchQueryEpoch,
         new_epoch: BatchQueryEpoch,
         chunk_size: usize,
-        histogram: Option<impl Deref<Target = Histogram>>,
+        histogram: Option<&Histogram>,
         schema: Arc<Schema>,
     ) {
         // Range Scan.

--- a/src/common/metrics/src/relabeled_metric.rs
+++ b/src/common/metrics/src/relabeled_metric.rs
@@ -15,6 +15,7 @@
 use prometheus::core::{MetricVec, MetricVecBuilder};
 use prometheus::{HistogramVec, IntCounterVec};
 
+use crate::guarded_metrics::lazy_guarded_metric::LazyGuardedMetrics;
 use crate::{
     LabelGuardedHistogramVec, LabelGuardedIntCounterVec, LabelGuardedIntGaugeVec,
     LabelGuardedMetric, LabelGuardedMetricVec, MetricLevel,
@@ -89,7 +90,10 @@ impl<T: MetricVecBuilder> RelabeledMetricVec<MetricVec<T>> {
 }
 
 impl<T: MetricVecBuilder, const N: usize> RelabeledMetricVec<LabelGuardedMetricVec<T, N>> {
-    pub fn with_label_values(&self, vals: &[&str; N]) -> LabelGuardedMetric<T::M, N> {
+    pub fn with_label_values(
+        &self,
+        vals: &[&str; N],
+    ) -> LabelGuardedMetric<LazyGuardedMetrics<T, N>, N> {
         if self.metric_level > self.relabel_threshold {
             // relabel first n labels to empty string
             let mut relabeled_vals = *vals;

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -20,7 +20,6 @@ mod storage_catalog;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::num::NonZeroU64;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context};
@@ -799,12 +798,8 @@ impl IcebergWriter {
             let prometheus_builder = PrometheusWriterBuilder::new(
                 dispatch_builder,
                 WriterMetrics::new(
-                    writer_param.sink_metrics.iceberg_write_qps.deref().clone(),
-                    writer_param
-                        .sink_metrics
-                        .iceberg_write_latency
-                        .deref()
-                        .clone(),
+                    (**writer_param.sink_metrics.iceberg_write_qps).clone(),
+                    (**writer_param.sink_metrics.iceberg_write_latency).clone(),
                 ),
             );
             let schema = Self::schema_with_extra_partition_col(&table, extra_partition_col_idx)?;
@@ -822,12 +817,8 @@ impl IcebergWriter {
             let prometheus_builder = PrometheusWriterBuilder::new(
                 dispatch_builder,
                 WriterMetrics::new(
-                    writer_param.sink_metrics.iceberg_write_qps.deref().clone(),
-                    writer_param
-                        .sink_metrics
-                        .iceberg_write_latency
-                        .deref()
-                        .clone(),
+                    (**writer_param.sink_metrics.iceberg_write_qps).clone(),
+                    (**writer_param.sink_metrics.iceberg_write_latency).clone(),
                 ),
             );
             let schema = table.current_arrow_schema()?;
@@ -879,12 +870,8 @@ impl IcebergWriter {
             let prometheus_builder = PrometheusWriterBuilder::new(
                 dispatch_builder,
                 WriterMetrics::new(
-                    writer_param.sink_metrics.iceberg_write_qps.deref().clone(),
-                    writer_param
-                        .sink_metrics
-                        .iceberg_write_latency
-                        .deref()
-                        .clone(),
+                    (**writer_param.sink_metrics.iceberg_write_qps).clone(),
+                    (**writer_param.sink_metrics.iceberg_write_latency).clone(),
                 ),
             );
             let schema = Self::schema_with_extra_partition_col(&table, extra_partition_col_idx)?;
@@ -902,12 +889,8 @@ impl IcebergWriter {
             let prometheus_builder = PrometheusWriterBuilder::new(
                 dispatch_builder,
                 WriterMetrics::new(
-                    writer_param.sink_metrics.iceberg_write_qps.deref().clone(),
-                    writer_param
-                        .sink_metrics
-                        .iceberg_write_latency
-                        .deref()
-                        .clone(),
+                    (**writer_param.sink_metrics.iceberg_write_qps).clone(),
+                    (**writer_param.sink_metrics.iceberg_write_latency).clone(),
                 ),
             );
             let schema = table.current_arrow_schema()?;

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -18,9 +18,8 @@ use std::task::{Context, Poll};
 
 use anyhow::Context as _;
 use futures::stream::{FusedStream, FuturesUnordered, StreamFuture};
-use prometheus::Histogram;
 use risingwave_common::config::MetricLevel;
-use risingwave_common::metrics::LabelGuardedMetric;
+use risingwave_common::metrics::LabelGuardedHistogram;
 use tokio::time::Instant;
 
 use super::exchange::input::BoxedInput;
@@ -285,7 +284,7 @@ pub struct SelectReceivers {
     /// watermark column index -> `BufferedWatermarks`
     buffered_watermarks: BTreeMap<usize, BufferedWatermarks<ActorId>>,
     /// If None, then we don't take `Instant::now()` and `observe` during `poll_next`
-    merge_barrier_align_duration: Option<LabelGuardedMetric<Histogram, 2>>,
+    merge_barrier_align_duration: Option<LabelGuardedHistogram<2>>,
 }
 
 impl Stream for SelectReceivers {
@@ -387,7 +386,7 @@ impl SelectReceivers {
     fn new(
         actor_id: u32,
         upstreams: Vec<BoxedInput>,
-        merge_barrier_align_duration: Option<LabelGuardedMetric<Histogram, 2>>,
+        merge_barrier_align_duration: Option<LabelGuardedHistogram<2>>,
     ) -> Self {
         assert!(!upstreams.is_empty());
         let upstream_actor_ids = upstreams.iter().map(|input| input.actor_id()).collect();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Only create create a labeled metrics when we use the metrics for the first time. This will be helpful for connector metrics. For example, currently some iceberg sink related metrics are passed to iceberg sink via `SinkMetrics` struct. However, we will create a label guarded metrics on these iceberg metrics even though the sink is not iceberg sink, which increases unnecessary labeled metrics.

In this PR, we change to initial the metric when we use the metrics for the firstly via `LazyLock`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
