### PR TITLE
feat(dashboard): include table definition in diagnose report

### DIFF
--- a/src/meta/src/manager/diagnose.rs
+++ b/src/meta/src/manager/diagnose.rs
@@ -469,7 +469,6 @@ impl DiagnoseCommand {
 
         let top_k = 10;
         let mut top_tombstone_delete_sst = BinaryHeap::with_capacity(top_k);
-        let mut top_range_delete_sst = BinaryHeap::with_capacity(top_k);
         for compaction_group in version.levels.values() {
             let mut visit_level = |level: &Level| {
                 sst_num += level.table_infos.len();
@@ -485,15 +484,6 @@ impl DiagnoseCommand {
                         delete_ratio: tombstone_delete_ratio,
                     };
                     top_k_sstables(top_k, &mut top_tombstone_delete_sst, e);
-
-                    let range_delete_ratio =
-                        sst.range_tombstone_count * 10000 / sst.total_key_count;
-                    let e = SstableSort {
-                        compaction_group_id: compaction_group.group_id,
-                        sst_id: sst.sst_id,
-                        delete_ratio: range_delete_ratio,
-                    };
-                    top_k_sstables(top_k, &mut top_range_delete_sst, e);
                 }
             };
             let Some(ref l0) = compaction_group.l0 else {
@@ -533,8 +523,6 @@ impl DiagnoseCommand {
         let _ = writeln!(s, "top tombstone delete ratio");
         let _ = writeln!(s, "{}", format_table(top_tombstone_delete_sst));
         let _ = writeln!(s);
-        let _ = writeln!(s, "top range delete ratio");
-        let _ = writeln!(s, "{}", format_table(top_range_delete_sst));
 
         let _ = writeln!(s);
         self.write_storage_prometheus(s).await;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

List definition of all sources/tables/materialized views/sinks in dashboard's diagnose report, **if sql meta backend is enabled**.
- The definition of source/table/sink will be redacted if no `secret` is used. i.e. the usage of secrets suggests that it's safe to display the definition.
- The diagnose report for the legancy etcd meta backend is not affected.


Sample diagnose report output:
```
TABLE
+----+------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id | name | schema_id | definition                                                                                                                                                                      |
+=========================================================================================================================================================================================================+
| 7  | t1   | 2         | CREATE TABLE t1 (v1 INT) WITH (connector = 'datagen', fields.v1.kind = 'sequence', datagen.rows.per.second = '1', dummy_password = secret some_secret) FORMAT PLAIN ENCODE JSON |
|----+------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 10 | t2   | 2         | [REDACTED]                                                                                                                                                                      |
+----+------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

close #12826

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
