### PR TITLE
feat(sink): add es retry_on_conflict and max_task_num

### DIFF
--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/BulkProcessorAdapter.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/BulkProcessorAdapter.java
@@ -19,9 +19,9 @@ package com.risingwave.connector;
 import java.util.concurrent.TimeUnit;
 
 public interface BulkProcessorAdapter {
-    public void addRow(String index, String key, String doc);
+    public void addRow(String index, String key, String doc) throws InterruptedException;
 
-    public void deleteRow(String index, String key);
+    public void deleteRow(String index, String key) throws InterruptedException;
 
     public void flush();
 

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/ElasticBulkProcessorAdapter.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/ElasticBulkProcessorAdapter.java
@@ -73,7 +73,7 @@ public class ElasticBulkProcessorAdapter implements BulkProcessorAdapter {
     }
 
     @Override
-    public void addRow(String index, String key, String doc) {
+    public void addRow(String index, String key, String doc) throws InterruptedException {
         UpdateRequest updateRequest;
         updateRequest = new UpdateRequest(index, "_doc", key).doc(doc, XContentType.JSON);
         updateRequest.docAsUpsert(true);
@@ -82,7 +82,7 @@ public class ElasticBulkProcessorAdapter implements BulkProcessorAdapter {
     }
 
     @Override
-    public void deleteRow(String index, String key) {
+    public void deleteRow(String index, String key) throws InterruptedException {
         DeleteRequest deleteRequest;
         deleteRequest = new DeleteRequest(index, "_doc", key);
         this.requestTracker.addWriteTask();

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/ElasticBulkProcessorAdapter.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/ElasticBulkProcessorAdapter.java
@@ -48,11 +48,10 @@ public class ElasticBulkProcessorAdapter implements BulkProcessorAdapter {
                                         RequestOptions.DEFAULT,
                                         bulkResponseActionListener),
                         new BulkListener(requestTracker));
-        // Possible feature: move these to config
-        // execute the bulk every 10 000 requests
-        builder.setBulkActions(config.getBulkActions());
-        // flush the bulk every 5mb
-        builder.setBulkSize(new ByteSizeValue(config.getBulkSize(), ByteSizeUnit.KB));
+        // flush the bulk every `batchNumMessages` rows
+        builder.setBulkActions(config.getBatchNumMessages());
+        // flush the bulk every `batchSizeKb` Kb
+        builder.setBulkSize(new ByteSizeValue(config.getBatchSizeKb(), ByteSizeUnit.KB));
         // flush the bulk every 5 seconds whatever the number of requests
         builder.setFlushInterval(TimeValue.timeValueSeconds(5));
         // Set the number of concurrent requests

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/ElasticBulkProcessorAdapter.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/ElasticBulkProcessorAdapter.java
@@ -39,7 +39,7 @@ public class ElasticBulkProcessorAdapter implements BulkProcessorAdapter {
     public ElasticBulkProcessorAdapter(
             RequestTracker requestTracker,
             ElasticRestHighLevelClientAdapter client,
-            int retryOnConflict) {
+            EsSinkConfig config) {
         BulkProcessor.Builder builder =
                 BulkProcessor.builder(
                         (bulkRequest, bulkResponseActionListener) ->
@@ -50,20 +50,20 @@ public class ElasticBulkProcessorAdapter implements BulkProcessorAdapter {
                         new BulkListener(requestTracker));
         // Possible feature: move these to config
         // execute the bulk every 10 000 requests
-        builder.setBulkActions(1000);
+        builder.setBulkActions(config.getBulkActions());
         // flush the bulk every 5mb
-        builder.setBulkSize(new ByteSizeValue(5, ByteSizeUnit.MB));
+        builder.setBulkSize(new ByteSizeValue(config.getBulkSize(), ByteSizeUnit.KB));
         // flush the bulk every 5 seconds whatever the number of requests
         builder.setFlushInterval(TimeValue.timeValueSeconds(5));
         // Set the number of concurrent requests
-        builder.setConcurrentRequests(1);
+        builder.setConcurrentRequests(config.getConcurrentRequests());
         // Set a custom backoff policy which will initially wait for 100ms, increase exponentially
         // and retries up to three times.
         builder.setBackoffPolicy(
                 BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), 3));
         this.esBulkProcessor = builder.build();
         this.requestTracker = requestTracker;
-        this.retryOnConflict = retryOnConflict;
+        this.retryOnConflict = config.getRetryOnConflict();
     }
 
     @Override

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
@@ -162,16 +162,19 @@ public class EsSink extends SinkWriterBase {
         } else {
             this.requestTracker = new RequestTracker(config.getMaxTaskNum());
         }
-
+        int retryOnConflict = config.getRetryOnConflict() == null ? 3 : config.getRetryOnConflict();
         // ApiCompatibilityMode is enabled to ensure the client can talk to newer version es sever.
         if (config.getConnector().equals("elasticsearch")) {
             ElasticRestHighLevelClientAdapter client =
                     new ElasticRestHighLevelClientAdapter(host, config);
-            this.bulkProcessor = new ElasticBulkProcessorAdapter(this.requestTracker, client);
+            this.bulkProcessor =
+                    new ElasticBulkProcessorAdapter(this.requestTracker, client, retryOnConflict);
         } else if (config.getConnector().equals("opensearch")) {
             OpensearchRestHighLevelClientAdapter client =
                     new OpensearchRestHighLevelClientAdapter(host, config);
-            this.bulkProcessor = new OpensearchBulkProcessorAdapter(this.requestTracker, client);
+            this.bulkProcessor =
+                    new OpensearchBulkProcessorAdapter(
+                            this.requestTracker, client, retryOnConflict);
         } else {
             throw new RuntimeException("Sink type must be elasticsearch or opensearch");
         }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
@@ -60,12 +60,6 @@ public class EsSink extends SinkWriterBase {
         // Count of write tasks in progress
         private int taskCount = 0;
 
-        private Integer maxTaskNum;
-
-        public RequestTracker(Integer maxTaskNum) {
-            this.maxTaskNum = maxTaskNum;
-        }
-
         void addErrResult(String errorMsg) {
             blockingQueue.add(new EsWriteResultResp(errorMsg));
         }
@@ -74,17 +68,12 @@ public class EsSink extends SinkWriterBase {
             blockingQueue.add(new EsWriteResultResp(numberOfActions));
         }
 
-        void addWriteTask() throws InterruptedException {
+        void addWriteTask() {
             taskCount++;
             EsWriteResultResp esWriteResultResp;
             while (true) {
-                if ((esWriteResultResp = this.blockingQueue.poll(10, TimeUnit.MILLISECONDS))
-                        != null) {
+                if ((esWriteResultResp = this.blockingQueue.poll()) != null) {
                     checkEsWriteResultResp(esWriteResultResp);
-                }
-
-                if (taskCount >= maxTaskNum) {
-                    continue;
                 } else {
                     return;
                 }
@@ -157,24 +146,18 @@ public class EsSink extends SinkWriterBase {
         }
 
         this.config = config;
-        if (config.getMaxTaskNum() == null) {
-            this.requestTracker = new RequestTracker(Integer.MAX_VALUE);
-        } else {
-            this.requestTracker = new RequestTracker(config.getMaxTaskNum());
-        }
-        int retryOnConflict = config.getRetryOnConflict() == null ? 3 : config.getRetryOnConflict();
+        this.requestTracker = new RequestTracker();
         // ApiCompatibilityMode is enabled to ensure the client can talk to newer version es sever.
         if (config.getConnector().equals("elasticsearch")) {
             ElasticRestHighLevelClientAdapter client =
                     new ElasticRestHighLevelClientAdapter(host, config);
             this.bulkProcessor =
-                    new ElasticBulkProcessorAdapter(this.requestTracker, client, retryOnConflict);
+                    new ElasticBulkProcessorAdapter(this.requestTracker, client, config);
         } else if (config.getConnector().equals("opensearch")) {
             OpensearchRestHighLevelClientAdapter client =
                     new OpensearchRestHighLevelClientAdapter(host, config);
             this.bulkProcessor =
-                    new OpensearchBulkProcessorAdapter(
-                            this.requestTracker, client, retryOnConflict);
+                    new OpensearchBulkProcessorAdapter(this.requestTracker, client, config);
         } else {
             throw new RuntimeException("Sink type must be elasticsearch or opensearch");
         }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
@@ -81,7 +81,9 @@ public class EsSink extends SinkWriterBase {
                 if ((esWriteResultResp = this.blockingQueue.poll(10, TimeUnit.MILLISECONDS))
                         != null) {
                     checkEsWriteResultResp(esWriteResultResp);
-                } else if (taskCount >= maxTaskNum) {
+                }
+
+                if (taskCount >= maxTaskNum) {
                     continue;
                 } else {
                     return;

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
@@ -60,10 +60,10 @@ public class EsSink extends SinkWriterBase {
         // Count of write tasks in progress
         private int taskCount = 0;
 
-        private Integer maxTaskCount;
+        private Integer maxTaskNum;
 
-        public RequestTracker(Integer maxTaskCount) {
-            this.maxTaskCount = maxTaskCount;
+        public RequestTracker(Integer maxTaskNum) {
+            this.maxTaskNum = maxTaskNum;
         }
 
         void addErrResult(String errorMsg) {
@@ -81,7 +81,7 @@ public class EsSink extends SinkWriterBase {
                 if ((esWriteResultResp = this.blockingQueue.poll(10, TimeUnit.MILLISECONDS))
                         != null) {
                     checkEsWriteResultResp(esWriteResultResp);
-                } else if (taskCount >= maxTaskCount) {
+                } else if (taskCount >= maxTaskNum) {
                     continue;
                 } else {
                     return;
@@ -155,10 +155,10 @@ public class EsSink extends SinkWriterBase {
         }
 
         this.config = config;
-        if (config.getMaxTaskCount() == null) {
+        if (config.getMaxTaskNum() == null) {
             this.requestTracker = new RequestTracker(Integer.MAX_VALUE);
         } else {
-            this.requestTracker = new RequestTracker(config.getMaxTaskCount());
+            this.requestTracker = new RequestTracker(config.getMaxTaskNum());
         }
 
         // ApiCompatibilityMode is enabled to ensure the client can talk to newer version es sever.

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
@@ -44,6 +44,9 @@ public class EsSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "max_task_num")
     private Integer maxTaskNum;
 
+    @JsonProperty(value = "retry_on_conflict")
+    private Integer retryOnConflict;
+
     @JsonCreator
     public EsSinkConfig(@JsonProperty(value = "url") String url) {
         this.url = url;
@@ -104,6 +107,15 @@ public class EsSinkConfig extends CommonSinkConfig {
 
     public EsSinkConfig withMaxTaskNum(Integer maxTaskNum) {
         this.maxTaskNum = maxTaskNum;
+        return this;
+    }
+
+    public Integer getRetryOnConflict() {
+        return retryOnConflict;
+    }
+
+    public EsSinkConfig withRetryOnConflict(Integer retryOnConflict) {
+        this.retryOnConflict = retryOnConflict;
         return this;
     }
 }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
@@ -41,11 +41,17 @@ public class EsSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "index_column")
     private String indexColumn;
 
-    @JsonProperty(value = "max_task_num")
-    private Integer maxTaskNum;
-
     @JsonProperty(value = "retry_on_conflict")
     private Integer retryOnConflict;
+
+    @JsonProperty(value = "bulk_actions")
+    private Integer bulkActions;
+
+    @JsonProperty(value = "bulk_size")
+    private Integer bulkSize;
+
+    @JsonProperty(value = "concurrent_requests")
+    private Integer concurrentRequests;
 
     @JsonCreator
     public EsSinkConfig(@JsonProperty(value = "url") String url) {
@@ -101,21 +107,39 @@ public class EsSinkConfig extends CommonSinkConfig {
         return this;
     }
 
-    public Integer getMaxTaskNum() {
-        return maxTaskNum;
+    public Integer getBulkActions() {
+        return this.bulkActions == null ? 1000 : this.bulkActions;
     }
 
-    public EsSinkConfig withMaxTaskNum(Integer maxTaskNum) {
-        this.maxTaskNum = maxTaskNum;
+    public EsSinkConfig withBulkActions(Integer bulkActions) {
+        this.bulkActions = bulkActions;
+        return this;
+    }
+
+    public Integer getBulkSize() {
+        return this.bulkSize == null ? 5 * 1024 : this.bulkSize;
+    }
+
+    public EsSinkConfig withBulkSize(Integer bulkSize) {
+        this.bulkSize = bulkSize;
         return this;
     }
 
     public Integer getRetryOnConflict() {
-        return retryOnConflict;
+        return this.retryOnConflict == null ? 3 : this.retryOnConflict;
     }
 
     public EsSinkConfig withRetryOnConflict(Integer retryOnConflict) {
         this.retryOnConflict = retryOnConflict;
+        return this;
+    }
+
+    public Integer getConcurrentRequests() {
+        return this.concurrentRequests == null ? 1 : this.concurrentRequests;
+    }
+
+    public EsSinkConfig withConcurrentRequests(Integer concurrentRequests) {
+        this.concurrentRequests = concurrentRequests;
         return this;
     }
 }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
@@ -41,6 +41,9 @@ public class EsSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "index_column")
     private String indexColumn;
 
+    @JsonProperty(value = "max_task_count")
+    private Integer maxTaskCount;
+
     @JsonCreator
     public EsSinkConfig(@JsonProperty(value = "url") String url) {
         this.url = url;
@@ -92,6 +95,15 @@ public class EsSinkConfig extends CommonSinkConfig {
 
     public EsSinkConfig withIndexColumn(String indexColumn) {
         this.indexColumn = indexColumn;
+        return this;
+    }
+
+    public Integer getMaxTaskCount() {
+        return maxTaskCount;
+    }
+
+    public EsSinkConfig withMaxTaskCount(Integer maxTaskCount) {
+        this.maxTaskCount = maxTaskCount;
         return this;
     }
 }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
@@ -44,11 +44,11 @@ public class EsSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "retry_on_conflict")
     private Integer retryOnConflict;
 
-    @JsonProperty(value = "bulk_actions")
-    private Integer bulkActions;
+    @JsonProperty(value = "batch_num_messages")
+    private Integer batchNumMessages;
 
-    @JsonProperty(value = "bulk_size")
-    private Integer bulkSize;
+    @JsonProperty(value = "batch_size_kb")
+    private Integer batchSizeKb;
 
     @JsonProperty(value = "concurrent_requests")
     private Integer concurrentRequests;
@@ -107,21 +107,21 @@ public class EsSinkConfig extends CommonSinkConfig {
         return this;
     }
 
-    public Integer getBulkActions() {
-        return this.bulkActions == null ? 1000 : this.bulkActions;
+    public Integer getBatchNumMessages() {
+        return this.batchNumMessages == null ? 1000 : this.batchNumMessages;
     }
 
-    public EsSinkConfig withBulkActions(Integer bulkActions) {
-        this.bulkActions = bulkActions;
+    public EsSinkConfig withBatchNumMessages(Integer batchNumMessages) {
+        this.batchNumMessages = batchNumMessages;
         return this;
     }
 
-    public Integer getBulkSize() {
-        return this.bulkSize == null ? 5 * 1024 : this.bulkSize;
+    public Integer getBatchSizeKb() {
+        return this.batchSizeKb == null ? 5 * 1024 : this.batchSizeKb;
     }
 
-    public EsSinkConfig withBulkSize(Integer bulkSize) {
-        this.bulkSize = bulkSize;
+    public EsSinkConfig withBatchSizeKb(Integer batchSizeKb) {
+        this.batchSizeKb = batchSizeKb;
         return this;
     }
 

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
@@ -41,8 +41,8 @@ public class EsSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "index_column")
     private String indexColumn;
 
-    @JsonProperty(value = "max_task_count")
-    private Integer maxTaskCount;
+    @JsonProperty(value = "max_task_num")
+    private Integer maxTaskNum;
 
     @JsonCreator
     public EsSinkConfig(@JsonProperty(value = "url") String url) {
@@ -98,12 +98,12 @@ public class EsSinkConfig extends CommonSinkConfig {
         return this;
     }
 
-    public Integer getMaxTaskCount() {
-        return maxTaskCount;
+    public Integer getMaxTaskNum() {
+        return maxTaskNum;
     }
 
-    public EsSinkConfig withMaxTaskCount(Integer maxTaskCount) {
-        this.maxTaskCount = maxTaskCount;
+    public EsSinkConfig withMaxTaskNum(Integer maxTaskNum) {
+        this.maxTaskNum = maxTaskNum;
         return this;
     }
 }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/OpensearchBulkProcessorAdapter.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/OpensearchBulkProcessorAdapter.java
@@ -73,7 +73,7 @@ public class OpensearchBulkProcessorAdapter implements BulkProcessorAdapter {
     }
 
     @Override
-    public void addRow(String index, String key, String doc) {
+    public void addRow(String index, String key, String doc) throws InterruptedException {
         UpdateRequest updateRequest;
         updateRequest = new UpdateRequest(index, key).doc(doc, XContentType.JSON);
         updateRequest.docAsUpsert(true);
@@ -82,7 +82,7 @@ public class OpensearchBulkProcessorAdapter implements BulkProcessorAdapter {
     }
 
     @Override
-    public void deleteRow(String index, String key) {
+    public void deleteRow(String index, String key) throws InterruptedException {
         DeleteRequest deleteRequest;
         deleteRequest = new DeleteRequest(index, key);
         this.requestTracker.addWriteTask();

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/OpensearchBulkProcessorAdapter.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/OpensearchBulkProcessorAdapter.java
@@ -48,11 +48,10 @@ public class OpensearchBulkProcessorAdapter implements BulkProcessorAdapter {
                                         RequestOptions.DEFAULT,
                                         bulkResponseActionListener),
                         new BulkListener(requestTracker));
-        // Possible feature: move these to config
-        // execute the bulk every 10 000 requests
-        builder.setBulkActions(config.getBulkActions());
-        // flush the bulk every 5mb
-        builder.setBulkSize(new ByteSizeValue(config.getBulkSize(), ByteSizeUnit.KB));
+        // flush the bulk every `batchNumMessages` rows
+        builder.setBulkActions(config.getBatchNumMessages());
+        // flush the bulk every `batchSizeKb` Kb
+        builder.setBulkSize(new ByteSizeValue(config.getBatchSizeKb(), ByteSizeUnit.KB));
         // flush the bulk every 5 seconds whatever the number of requests
         builder.setFlushInterval(TimeValue.timeValueSeconds(5));
         // Set the number of concurrent requests


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

max_task_num：Maximum number of lines written to es at the same time
retry_on_conflict：Number of retries for es ooc

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

We add two optional option for es sink
`retry_on_conflict `: default is 3. The num of retries after an optimistic lock failure for es
`batch_size_kb  `: the max size of each request batch
`batch_num_messages`: the max rows of each request batch
（batch exceeds the limit of `batch_size_kb   `or `batch_num_messages`, we will send a batch）
`concurrent_requests `:the max number of threads per degree of parallelism


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
