### PR TITLE
feat(sink): add Clickhouse Null engine

### DIFF
--- a/integration_tests/clickhouse-sink/clickhouse_prepare.sql
+++ b/integration_tests/clickhouse-sink/clickhouse_prepare.sql
@@ -30,3 +30,23 @@ CREATE table ck_types (
   c_struct Nested(s_int Int32, s_boolean Bool),
 )ENGINE = ReplacingMergeTree
 PRIMARY KEY (types_id);
+
+CREATE TABLE demo_test_null(
+    user_id Int32,
+    target_id String,
+    event_timestamp DateTime64,
+) ENGINE = Null;
+
+CREATE TABLE demo_test_target_null(
+    user_id Int32,
+    target_id String,
+    event_timestamp DateTime64
+) ENGINE = MergeTree()
+ORDER BY (user_id, event_timestamp);
+
+CREATE MATERIALIZED VIEW demo_mv_null TO demo_test_target_null AS
+SELECT
+    user_id,
+    target_id,
+    event_timestamp
+FROM demo_test_null;

--- a/integration_tests/clickhouse-sink/create_sink.sql
+++ b/integration_tests/clickhouse-sink/create_sink.sql
@@ -11,6 +11,19 @@ FROM
     clickhouse.table='demo_test',
 );
 
+CREATE SINK null_clickhouse_sink
+FROM
+    bhv_mv WITH (
+    connector = 'clickhouse',
+    type = 'append-only',
+    force_append_only='true',
+    clickhouse.url = 'http://clickhouse-server-1:8123',
+    clickhouse.user = 'default',
+    clickhouse.password = '',
+    clickhouse.database = 'default',
+    clickhouse.table='demo_test_null',
+);
+
 CREATE SINK ck_types_sink
 FROM
     ck_types WITH (

--- a/integration_tests/clickhouse-sink/sink_check.py
+++ b/integration_tests/clickhouse-sink/sink_check.py
@@ -2,7 +2,11 @@ import subprocess
 import sys
 
 
-relations = ['default.demo_test', 'default.ck_types']
+relations = [
+    'default.demo_test',
+    'default.demo_test_target_null',
+    'default.ck_types',
+]
 
 failed_cases = []
 for rel in relations:

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -90,6 +90,7 @@ enum ClickHouseEngine {
     #[expect(dead_code)]
     ReplicatedVersionedCollapsingMergeTree(String),
     ReplicatedGraphiteMergeTree,
+    Null,
 }
 impl ClickHouseEngine {
     pub fn is_collapsing_engine(&self) -> bool {
@@ -142,6 +143,7 @@ impl ClickHouseEngine {
     ) -> Result<Self> {
         match engine_name.engine.as_str() {
             "MergeTree" => Ok(ClickHouseEngine::MergeTree),
+            "Null" => Ok(ClickHouseEngine::Null),
             "ReplacingMergeTree" => {
                 let delete_column = config.common.delete_column.clone();
                 Ok(ClickHouseEngine::ReplacingMergeTree(delete_column))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Added support for the Clickhouse Null engine, which is useful for situations when source data does not need to be retained. 

Since the Null engine does not write to disk, it should also allow for better [performance](https://double.cloud/blog/posts/2022/12/performance-impact-of-materialized-views-in-clickhouse/) since it eliminates the impact of disk bound IO.

Tested locally:
![image](https://github.com/user-attachments/assets/c18f9059-c079-4ae6-b4fb-355fe18dd24a)

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
