### PR TITLE
feat(compaction): avoid trigger trivial move to large sub level

### DIFF
--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -262,7 +262,6 @@ impl IntraCompactionPicker {
             }
 
             // do not trivial move if the total file size is too large
-            println!("l0.sub_levels[idx].total_file_size {} self.config.sub_level_max_compaction_bytes {}", l0.sub_levels[idx].total_file_size, self.config.sub_level_max_compaction_bytes);
             if l0.sub_levels[idx].total_file_size > self.config.sub_level_max_compaction_bytes {
                 continue;
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The purpose of this PR is to limit trivial-move behaviour and avoid data stacking at L0.

Previously, the Hummock IntraCompactionPicker restricted the sub-level at which L0 intra compaction can be performed, but did not restrict trivial-move, which is not a uniform condition. Due to frequent trivial-move triggering, hummock may delay the timing of write-stop triggering and cause L0 to pile up a large amount of data. 

Therefore, I introduced a restriction on trivial-move task in this PR to avoid trivial-move to sub_levels exceeding max_bytes (e.g., 128m).



<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
