### PR TITLE
fix(connector): fix batch file source when there are no files

### DIFF
--- a/e2e_test/s3/fs_source_batch.py
+++ b/e2e_test/s3/fs_source_batch.py
@@ -145,7 +145,6 @@ def test_empty_source(config, prefix, fmt):
         s3.endpoint_url = 'https://{config['S3_ENDPOINT']}'
     ) FORMAT PLAIN ENCODE {_encode()};''')
 
-   
     stmt = f'select count(*), sum(id), sum(sex), sum(mark) from {_source()}'
     print(f'Execute {stmt}')
     cur.execute(stmt)
@@ -209,4 +208,3 @@ if __name__ == "__main__":
         client.remove_object(config["S3_BUCKET"], _s3(idx))
         
     test_empty_source(config, run_id, fmt)
-

--- a/e2e_test/s3/fs_source_batch.py
+++ b/e2e_test/s3/fs_source_batch.py
@@ -206,5 +206,5 @@ if __name__ == "__main__":
     # clean up s3 files
     for idx, _ in enumerate(formatted_files):
         client.remove_object(config["S3_BUCKET"], _s3(idx))
-        
+
     test_empty_source(config, run_id, fmt)

--- a/e2e_test/s3/fs_source_batch.py
+++ b/e2e_test/s3/fs_source_batch.py
@@ -109,6 +109,60 @@ def do_test(config, file_num, item_num_per_file, prefix, fmt):
     cur.close()
     conn.close()
 
+def test_empty_source(config, prefix, fmt):
+    conn = psycopg2.connect(
+        host="localhost",
+        port="4566",
+        user="root",
+        database="dev"
+    )
+
+    # Open a cursor to execute SQL statements
+    cur = conn.cursor()
+
+    def _source():
+        return f's3_test_empty_{fmt}'
+
+    def _encode():
+        if fmt == 'json':
+            return 'JSON'
+        else:
+            return f"CSV (delimiter = ',', without_header = {str('without' in fmt).lower()})"
+
+    # Execute a SELECT statement
+    cur.execute(f'''CREATE SOURCE {_source()}(
+        id int,
+        name TEXT,
+        sex int,
+        mark int,
+    ) WITH (
+        connector = 's3_v2',
+        match_pattern = '{prefix}*.{fmt}',
+        s3.region_name = '{config['S3_REGION']}',
+        s3.bucket_name = '{config['S3_BUCKET']}',
+        s3.credentials.access = '{config['S3_ACCESS_KEY']}',
+        s3.credentials.secret = '{config['S3_SECRET_KEY']}',
+        s3.endpoint_url = 'https://{config['S3_ENDPOINT']}'
+    ) FORMAT PLAIN ENCODE {_encode()};''')
+
+   
+    stmt = f'select count(*), sum(id), sum(sex), sum(mark) from {_source()}'
+    print(f'Execute {stmt}')
+    cur.execute(stmt)
+    result = cur.fetchone()
+
+    print('Got:', result)
+
+    def _assert_eq(field, got, expect):
+        assert got == expect, f'{field} assertion failed: got {got}, expect {expect}.'
+
+    _assert_eq('count(*)', result[0], 0)
+
+    print('Empty source test pass')
+
+    cur.execute(f'drop source {_source()}')
+    cur.close()
+    conn.close()
 
 if __name__ == "__main__":
     FILE_NUM = 4001
@@ -153,3 +207,6 @@ if __name__ == "__main__":
     # clean up s3 files
     for idx, _ in enumerate(formatted_files):
         client.remove_object(config["S3_BUCKET"], _s3(idx))
+        
+    test_empty_source(config, run_id, fmt)
+

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -385,8 +385,8 @@ impl StageRunner {
                 / self.stage.parallelism.unwrap() as f32)
                 .ceil() as usize)
                 .max(1);
-            // No file in source, schedule an empty task.
             if source_info.split_info().unwrap().is_empty() {
+                // No file in source, schedule an empty task.
                 const EMPTY_TASK_ID: u64 = 0;
                 let task_id = PbTaskId {
                     query_id: self.stage.query_id.id.clone(),
@@ -406,28 +406,31 @@ impl StageRunner {
                     worker,
                     expr_context.clone(),
                 ));
-            }
-            for (id, split) in source_info
-                .split_info()
-                .unwrap()
-                .chunks(chunk_size)
-                .enumerate()
-            {
-                let task_id = PbTaskId {
-                    query_id: self.stage.query_id.id.clone(),
-                    stage_id: self.stage.id,
-                    task_id: id as u64,
-                };
-                let plan_fragment = self
-                    .create_plan_fragment(id as u64, Some(PartitionInfo::Source(split.to_vec())));
-                let worker =
-                    self.choose_worker(&plan_fragment, id as u32, self.stage.dml_table_id)?;
-                futures.push(self.schedule_task(
-                    task_id,
-                    plan_fragment,
-                    worker,
-                    expr_context.clone(),
-                ));
+            } else {
+                for (id, split) in source_info
+                    .split_info()
+                    .unwrap()
+                    .chunks(chunk_size)
+                    .enumerate()
+                {
+                    let task_id = PbTaskId {
+                        query_id: self.stage.query_id.id.clone(),
+                        stage_id: self.stage.id,
+                        task_id: id as u64,
+                    };
+                    let plan_fragment = self.create_plan_fragment(
+                        id as u64,
+                        Some(PartitionInfo::Source(split.to_vec())),
+                    );
+                    let worker =
+                        self.choose_worker(&plan_fragment, id as u32, self.stage.dml_table_id)?;
+                    futures.push(self.schedule_task(
+                        task_id,
+                        plan_fragment,
+                        worker,
+                        expr_context.clone(),
+                    ));
+                }
             }
         } else if let Some(file_scan_info) = self.stage.file_scan_info.as_ref() {
             let chunk_size = (file_scan_info.file_location.len() as f32

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -380,7 +380,7 @@ impl StageRunner {
                 ));
             }
         } else if let Some(source_info) = self.stage.source_info.as_ref() {
-            // If their is no file in source, the `chunk_size` is set to 1.
+            // If there is no file in source, the `chunk_size` is set to 1.
             let chunk_size = ((source_info.split_info().unwrap().len() as f32
                 / self.stage.parallelism.unwrap() as f32)
                 .ceil() as usize)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Previously for batch read from file source, the task_parallelism is set to `(self.batch_parallelism / 2) as u32`, which by default is 2, and this will cause 2 issues:
- when their is only one file, another parallelism can not cancel normally.
- when their is no files in source, the  parallelism can not cancel.

This pr fix these two issues by
1. set the `task_parallelism` to `min(file_nums, (batch_parallelism / 2))`, and minimum value is 1.
2. When their is no files in source, schedule an empty task to prevent stuck.

close #17984
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
