### PR TITLE
refactor(meta): only retry on error when creating meta client

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -321,9 +321,6 @@ message AddWorkerNodeRequest {
 }
 
 message AddWorkerNodeResponse {
-  reserved 3;
-  reserved "system_params";
-  common.Status status = 1;
   optional uint32 node_id = 2;
   string cluster_id = 4;
 }

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -601,8 +601,15 @@ message MembersResponse {
   repeated MetaMember members = 1;
 }
 
+message IsServingLeaderRequest {}
+
+message IsServingLeaderResponse {
+  bool is_leader = 1;
+}
+
 service MetaMemberService {
   rpc Members(MembersRequest) returns (MembersResponse);
+  rpc IsServingLeader(IsServingLeaderRequest) returns (IsServingLeaderResponse);
 }
 
 // The schema for persisted system parameters.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -130,8 +130,7 @@ pub async fn compute_node_serve(
         },
         &config.meta,
     )
-    .await
-    .unwrap();
+    .await;
 
     let state_store_url = system_params.state_store();
 

--- a/src/ctl/src/common/meta_service.rs
+++ b/src/ctl/src/common/meta_service.rs
@@ -62,7 +62,7 @@ Note: the default value of `RW_META_ADDR` is 'http://127.0.0.1:5690'.";
             Property::default(),
             &MetaConfig::default(),
         )
-        .await?;
+        .await;
         let worker_id = client.worker_id();
         tracing::info!("registered as RiseCtl worker, worker_id = {}", worker_id);
         Ok(client)

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -267,7 +267,7 @@ impl FrontendEnv {
             Default::default(),
             &config.meta,
         )
-        .await?;
+        .await;
 
         let worker_id = meta_client.worker_id();
         info!("Assigned worker node id {}", worker_id);

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -349,7 +349,7 @@ pub async fn start_service_as_election_follower(
 ) {
     tracing::info!("starting follower services");
 
-    let meta_member_srv = MetaMemberServiceImpl::new(election_client);
+    let meta_member_srv = MetaMemberServiceImpl::new(election_client, false);
 
     let health_srv = HealthServiceImpl::new();
 
@@ -467,7 +467,7 @@ pub async fn start_service_as_election_leader(
     .unwrap();
     let object_store_media_type = hummock_manager.object_store_media_type();
 
-    let meta_member_srv = MetaMemberServiceImpl::new(election_client.clone());
+    let meta_member_srv = MetaMemberServiceImpl::new(election_client.clone(), true);
 
     let prometheus_client = opts.prometheus_endpoint.as_ref().map(|x| {
         use std::str::FromStr;

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -58,31 +58,18 @@ impl ClusterService for ClusterServiceImpl {
             .property
             .ok_or_else(|| MetaError::invalid_parameter("worker node property is not provided"))?;
         let resource = req.resource.unwrap_or_default();
-        let result = self
+
+        let worker_id = self
             .metadata_manager
             .add_worker_node(worker_type, host, property, resource)
-            .await;
+            .await?;
         let cluster_id = self.metadata_manager.cluster_id().to_string();
-        match result {
-            Ok(worker_id) => Ok(Response::new(AddWorkerNodeResponse {
-                status: None,
-                node_id: Some(worker_id),
-                cluster_id,
-            })),
-            Err(e) => {
-                if e.is_invalid_worker() {
-                    return Ok(Response::new(AddWorkerNodeResponse {
-                        status: Some(risingwave_pb::common::Status {
-                            code: risingwave_pb::common::status::Code::UnknownWorker as i32,
-                            message: e.to_report_string(),
-                        }),
-                        node_id: None,
-                        cluster_id,
-                    }));
-                }
-                Err(e.into())
-            }
-        }
+
+        Ok(Response::new(AddWorkerNodeResponse {
+            status: None,
+            node_id: Some(worker_id),
+            cluster_id,
+        }))
     }
 
     /// Update schedulability of a compute node. Will not affect actors which are already running on

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -25,7 +25,6 @@ use risingwave_pb::meta::{
     ListAllNodesResponse, UpdateWorkerNodeSchedulabilityRequest,
     UpdateWorkerNodeSchedulabilityResponse,
 };
-use thiserror_ext::AsReport;
 use tonic::{Request, Response, Status};
 
 use crate::MetaError;
@@ -66,7 +65,6 @@ impl ClusterService for ClusterServiceImpl {
         let cluster_id = self.metadata_manager.cluster_id().to_string();
 
         Ok(Response::new(AddWorkerNodeResponse {
-            status: None,
             node_id: Some(worker_id),
             cluster_id,
         }))

--- a/src/meta/service/src/meta_member_service.rs
+++ b/src/meta/service/src/meta_member_service.rs
@@ -65,8 +65,8 @@ impl MetaMemberService for MetaMemberServiceImpl {
         &self,
         _request: Request<IsServingLeaderRequest>,
     ) -> Result<Response<IsServingLeaderResponse>, Status> {
-        let is_leader = self.is_serving_leader && self.election_client.is_leader();
-
-        Ok(Response::new(IsServingLeaderResponse { is_leader }))
+        Ok(Response::new(IsServingLeaderResponse {
+            is_leader: self.is_serving_leader,
+        }))
     }
 }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -228,12 +228,12 @@ impl MetaClient {
         addr: &HostAddr,
         property: Property,
         meta_config: &MetaConfig,
-    ) -> Result<(Self, SystemParamsReader)> {
+    ) -> (Self, SystemParamsReader) {
         let ret =
             Self::register_new_inner(addr_strategy, worker_type, addr, property, meta_config).await;
 
         match ret {
-            Ok(ret) => Ok(ret),
+            Ok(ret) => ret,
             Err(err) => {
                 tracing::error!(error = %err.as_report(), "failed to register worker, exiting...");
                 std::process::exit(1);
@@ -241,7 +241,6 @@ impl MetaClient {
         }
     }
 
-    /// Register the current node to the cluster and set the corresponding worker id.
     async fn register_new_inner(
         addr_strategy: MetaAddressStrategy,
         worker_type: WorkerType,
@@ -279,21 +278,6 @@ impl MetaClient {
             })
             .await
             .context("failed to add worker node")?;
-
-        // if let Err(e) = &result {
-        //     let message = e.to_report_string();
-        //     if message.contains("CPU core limit") {
-        //         tracing::error!(error = message, "CPU core limit exceeded");
-        //         std::process::exit(1);
-        //     }
-        // }
-
-        // if let Some(status) = &add_worker_resp.status
-        //     && status.code() == risingwave_pb::common::status::Code::UnknownWorker
-        // {
-        //     tracing::error!("invalid worker: {}", status.message);
-        //     std::process::exit(1);
-        // }
 
         let system_params_resp = grpc_meta_client
             .get_system_params(GetSystemParamsRequest {})

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1622,10 +1622,21 @@ struct GrpcMetaClientCore {
     cloud_client: CloudServiceClient<Channel>,
     sink_coordinate_client: SinkCoordinationRpcClient,
     event_log_client: EventLogServiceClient<Channel>,
+
+    /// Whether we are sure that we're connecting to the leader.
+    is_leader: bool,
 }
 
 impl GrpcMetaClientCore {
-    pub(crate) fn new(channel: Channel) -> Self {
+    pub(crate) fn new_leader(channel: Channel) -> Self {
+        Self::new_inner(channel, true)
+    }
+
+    pub(crate) fn new_initial(channel: Channel) -> Self {
+        Self::new_inner(channel, false)
+    }
+
+    fn new_inner(channel: Channel, is_leader: bool) -> Self {
         let cluster_client = ClusterServiceClient::new(channel.clone());
         let meta_member_client = MetaMemberClient::new(channel.clone());
         let heartbeat_client = HeartbeatServiceClient::new(channel.clone());
@@ -1668,6 +1679,7 @@ impl GrpcMetaClientCore {
             cloud_client,
             sink_coordinate_client,
             event_log_client,
+            is_leader,
         }
     }
 }
@@ -1690,7 +1702,7 @@ struct MetaMemberGroup {
 struct MetaMemberManagement {
     core_ref: Arc<RwLock<GrpcMetaClientCore>>,
     members: Either<MetaMemberClient, MetaMemberGroup>,
-    current_leader: http::Uri,
+    current_leader: Option<http::Uri>,
     meta_config: MetaConfig,
 }
 
@@ -1701,11 +1713,6 @@ impl MetaMemberManagement {
         format!("http://{}:{}", addr.host, addr.port)
             .parse()
             .unwrap()
-    }
-
-    async fn recreate_core(&self, channel: Channel) {
-        let mut core = self.core_ref.write().await;
-        *core = GrpcMetaClientCore::new(channel);
     }
 
     async fn refresh_members(&mut self) -> Result<()> {
@@ -1778,7 +1785,7 @@ impl MetaMemberManagement {
         if let Some(leader) = leader_addr {
             let discovered_leader = Self::host_address_to_uri(leader.address.unwrap());
 
-            if discovered_leader != self.current_leader {
+            if self.current_leader.as_ref() != Some(&discovered_leader) {
                 tracing::info!("new meta leader {} discovered", discovered_leader);
 
                 let retry_strategy = GrpcMetaClient::retry_strategy_to_bound(
@@ -1792,9 +1799,12 @@ impl MetaMemberManagement {
                 })
                 .await?;
 
-                self.recreate_core(channel).await;
-                self.current_leader = discovered_leader;
+                let mut core = self.core_ref.write().await;
+                *core = GrpcMetaClientCore::new_leader(channel);
+                self.current_leader = Some(discovered_leader);
             }
+        } else {
+            tracing::warn!("no meta leader found");
         }
 
         Ok(())
@@ -1813,20 +1823,18 @@ impl GrpcMetaClient {
 
     fn start_meta_member_monitor(
         &self,
-        init_leader_addr: http::Uri,
         members: Either<MetaMemberClient, MetaMemberGroup>,
         force_refresh_receiver: Receiver<Sender<Result<()>>>,
         meta_config: MetaConfig,
     ) -> Result<()> {
         let core_ref: Arc<RwLock<GrpcMetaClientCore>> = self.core.clone();
-        let current_leader = init_leader_addr;
 
         let enable_period_tick = matches!(members, Either::Right(_));
 
         let member_management = MetaMemberManagement {
             core_ref,
             members,
-            current_leader,
+            current_leader: None,
             meta_config,
         };
 
@@ -1884,7 +1892,9 @@ impl GrpcMetaClient {
         receiver.await.map_err(|e| anyhow!(e))?
     }
 
-    /// Connect to the meta server from `addrs`.
+    /// Connect to the meta server based on given strategy.
+    ///
+    /// Only returns when successfully connected to a meta **leader** server.
     pub async fn new(strategy: &MetaAddressStrategy, config: MetaConfig) -> Result<Self> {
         let (channel, addr) = match strategy {
             MetaAddressStrategy::LoadBalance(addr) => {
@@ -1893,9 +1903,12 @@ impl GrpcMetaClient {
             MetaAddressStrategy::List(addrs) => Self::try_build_rpc_channel(addrs.clone()).await,
         }?;
         let (force_refresh_sender, force_refresh_receiver) = mpsc::channel(1);
+
+        // Note: so far we are only sure we can connect to a meta node through this `addr` and `channel`,
+        // but it's not guaranteed to be the leader service which we can make further progress on.
         let client = GrpcMetaClient {
             member_monitor_event_sender: force_refresh_sender,
-            core: Arc::new(RwLock::new(GrpcMetaClientCore::new(channel))),
+            core: Arc::new(RwLock::new(GrpcMetaClientCore::new_initial(channel))),
         };
 
         let meta_member_client = client.core.read().await.meta_member_client.clone();
@@ -1912,9 +1925,14 @@ impl GrpcMetaClient {
             }
         };
 
-        client.start_meta_member_monitor(addr, members, force_refresh_receiver, config)?;
+        client.start_meta_member_monitor(members, force_refresh_receiver, config)?;
 
-        client.force_refresh_leader().await?;
+        // Refresh the member list until we find and connect to the leader.
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        while !client.core.read().await.is_leader {
+            interval.tick().await;
+            client.force_refresh_leader().await?;
+        }
 
         Ok(client)
     }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -220,7 +220,29 @@ impl MetaClient {
     }
 
     /// Register the current node to the cluster and set the corresponding worker id.
+    ///
+    /// Retry if there's connection issue with the meta node. Exit the process if the registration fails.
     pub async fn register_new(
+        addr_strategy: MetaAddressStrategy,
+        worker_type: WorkerType,
+        addr: &HostAddr,
+        property: Property,
+        meta_config: &MetaConfig,
+    ) -> Result<(Self, SystemParamsReader)> {
+        let ret =
+            Self::register_new_inner(addr_strategy, worker_type, addr, property, meta_config).await;
+
+        match ret {
+            Ok(ret) => Ok(ret),
+            Err(err) => {
+                tracing::error!(error = %err.as_report(), "failed to register worker, exiting...");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    /// Register the current node to the cluster and set the corresponding worker id.
+    async fn register_new_inner(
         addr_strategy: MetaAddressStrategy,
         worker_type: WorkerType,
         addr: &HostAddr,
@@ -238,37 +260,46 @@ impl MetaClient {
         if property.is_unschedulable {
             tracing::warn!("worker {:?} registered as unschedulable", addr.clone());
         }
-        let init_result: Result<_> = tokio_retry::Retry::spawn(retry_strategy, || async {
-            let grpc_meta_client = GrpcMetaClient::new(&addr_strategy, meta_config.clone()).await?;
 
-            let add_worker_resp = grpc_meta_client
-                .add_worker_node(AddWorkerNodeRequest {
-                    worker_type: worker_type as i32,
-                    host: Some(addr.to_protobuf()),
-                    property: Some(property),
-                    resource: Some(risingwave_pb::common::worker_node::Resource {
-                        rw_version: RW_VERSION.to_string(),
-                        total_memory_bytes: system_memory_available_bytes() as _,
-                        total_cpu_cores: total_cpu_available() as _,
-                    }),
-                })
-                .await?;
-            if let Some(status) = &add_worker_resp.status
-                && status.code() == risingwave_pb::common::status::Code::UnknownWorker
-            {
-                tracing::error!("invalid worker: {}", status.message);
-                std::process::exit(1);
-            }
-
-            let system_params_resp = grpc_meta_client
-                .get_system_params(GetSystemParamsRequest {})
-                .await?;
-
-            Ok((add_worker_resp, system_params_resp, grpc_meta_client))
+        let grpc_meta_client = tokio_retry::Retry::spawn(retry_strategy, || {
+            GrpcMetaClient::new(&addr_strategy, meta_config.clone())
         })
-        .await;
+        .await?;
 
-        let (add_worker_resp, system_params_resp, grpc_meta_client) = init_result?;
+        let add_worker_resp = grpc_meta_client
+            .add_worker_node(AddWorkerNodeRequest {
+                worker_type: worker_type as i32,
+                host: Some(addr.to_protobuf()),
+                property: Some(property),
+                resource: Some(risingwave_pb::common::worker_node::Resource {
+                    rw_version: RW_VERSION.to_string(),
+                    total_memory_bytes: system_memory_available_bytes() as _,
+                    total_cpu_cores: total_cpu_available() as _,
+                }),
+            })
+            .await
+            .context("failed to add worker node")?;
+
+        // if let Err(e) = &result {
+        //     let message = e.to_report_string();
+        //     if message.contains("CPU core limit") {
+        //         tracing::error!(error = message, "CPU core limit exceeded");
+        //         std::process::exit(1);
+        //     }
+        // }
+
+        // if let Some(status) = &add_worker_resp.status
+        //     && status.code() == risingwave_pb::common::status::Code::UnknownWorker
+        // {
+        //     tracing::error!("invalid worker: {}", status.message);
+        //     std::process::exit(1);
+        // }
+
+        let system_params_resp = grpc_meta_client
+            .get_system_params(GetSystemParamsRequest {})
+            .await
+            .context("failed to get initial system params")?;
+
         let worker_id = add_worker_resp
             .node_id
             .expect("AddWorkerNodeResponse::node_id is empty");

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -197,8 +197,7 @@ pub async fn compactor_serve(
         Default::default(),
         &config.meta,
     )
-    .await
-    .unwrap();
+    .await;
 
     info!("Assigned compactor id {}", meta_client.worker_id());
 

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -238,7 +238,7 @@ async fn init_metadata_for_replay(
             std::process::exit(0);
         },
         ret = MetaClient::register_new(cluster_meta_endpoint.parse()?, WorkerType::RiseCtl, advertise_addr, Default::default(), &meta_config) => {
-            (meta_client, _) = ret.unwrap();
+            (meta_client, _) = ret;
         },
     }
     let worker_id = meta_client.worker_id();
@@ -254,7 +254,7 @@ async fn init_metadata_for_replay(
         Default::default(),
         &meta_config,
     )
-    .await?;
+    .await;
     new_meta_client.activate(advertise_addr).await.unwrap();
     if ci_mode {
         let table_to_check = tables.iter().find(|t| t.name == "nexmark_q7").unwrap();
@@ -286,7 +286,7 @@ async fn pull_version_deltas(
         Default::default(),
         &MetaConfig::default(),
     )
-    .await?;
+    .await;
     let worker_id = meta_client.worker_id();
     tracing::info!("Assigned pull worker id {}", worker_id);
     meta_client.activate(advertise_addr).await.unwrap();
@@ -335,7 +335,7 @@ async fn start_replay(
         Default::default(),
         &config.meta,
     )
-    .await?;
+    .await;
     let worker_id = meta_client.worker_id();
     tracing::info!("Assigned replay worker id {}", worker_id);
     meta_client.activate(&advertise_addr).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Once we successfully initialize the meta client, we are sure that there's no connection issue with the meta service.

Based on this, we only need to wrap the initialization step within `Retry`, while directly throw any error occurred in subsequent steps like `add_worker_node` and `get_system_params`. This eliminates the need for handling errors based on their variants.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
