### PR TITLE
fix(storage): fix calling apply_compact_ssts by mistake when commit_epoch

### DIFF
--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -580,7 +580,7 @@ impl HummockVersion {
                 })
                 .filter(|(_, delta)| !delta.is_empty())
                 .collect::<HashMap<_, _>>();
-            if is_commit_epoch {
+            if !is_commit_epoch {
                 assert!(
                     intra_level_delta.is_empty(),
                     "{:#?}\

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -554,43 +554,18 @@ impl HummockVersion {
     }
 
     pub fn apply_version_delta(&mut self, version_delta: &HummockVersionDelta) {
-        // TODO: should remove it
-        let version_clone = self.clone();
         assert_eq!(self.id, version_delta.prev_id);
 
-        let (changed_table_info, is_commit_epoch) = self.state_table_info.apply_delta(
+        let (changed_table_info, mut is_commit_epoch) = self.state_table_info.apply_delta(
             &version_delta.state_table_info_delta,
             &version_delta.removed_table_ids,
         );
 
-        if self.visible_table_committed_epoch() < version_delta.visible_table_committed_epoch() {
-            let intra_level_delta = version_delta
-                .group_deltas
-                .iter()
-                .map(|(group_id, group_delta)| {
-                    (
-                        *group_id,
-                        group_delta
-                            .group_deltas
-                            .iter()
-                            .filter(|delta| matches!(delta, GroupDelta::IntraLevel(_)))
-                            .map(|delta| format!("{:?}", delta))
-                            .collect_vec(),
-                    )
-                })
-                .filter(|(_, delta)| !delta.is_empty())
-                .collect::<HashMap<_, _>>();
-            if !is_commit_epoch {
-                assert!(
-                    intra_level_delta.is_empty(),
-                    "{:#?}\
-                 {:#?}\
-                  {:#?}",
-                    version_clone,
-                    version_delta,
-                    intra_level_delta
-                )
-            }
+        if !is_commit_epoch
+            && self.visible_table_committed_epoch() < version_delta.visible_table_committed_epoch()
+        {
+            is_commit_epoch = true;
+            warn!("max committed epoch bumped but no table committed epoch is changed");
         }
 
         // apply to `levels`, which is different compaction groups

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -554,12 +554,18 @@ impl HummockVersion {
     }
 
     pub fn apply_version_delta(&mut self, version_delta: &HummockVersionDelta) {
+        // TODO: should remove it
+        let version_clone = self.clone();
         assert_eq!(self.id, version_delta.prev_id);
 
         let (changed_table_info, is_commit_epoch) = self.state_table_info.apply_delta(
             &version_delta.state_table_info_delta,
             &version_delta.removed_table_ids,
         );
+
+        if self.visible_table_committed_epoch() < version_delta.visible_table_committed_epoch() {
+            assert!(is_commit_epoch, "{:#?} {:#?}", version_clone, version_delta);
+        }
 
         // apply to `levels`, which is different compaction groups
         for (compaction_group_id, group_deltas) in &version_delta.group_deltas {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In https://github.com/risingwavelabs/risingwave/pull/17973, we change the logic of checking whether the delta is caused by `commit_epoch` or not in `apply_version_delta`. Previously we check whether the `max_committed_epoch` bumped, and in https://github.com/risingwavelabs/risingwave/pull/17973 we changed to check whether the `committed_epoch` of any state table bumps. However, such logic will break the backward compatibility, since in older release versions, `state_table_info` is not maintained yet. Therefore in the latest code, when we apply these version deltas generated from old version before having the backward compatibility patch, the state table info is always empty, and then we will not run into the `commit_epoch` branch, and then hit some assertion failure in the `apply_compact_sst`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
