### PR TITLE
refactor(meta): only retry on connection error when registering worker node

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -321,9 +321,6 @@ message AddWorkerNodeRequest {
 }
 
 message AddWorkerNodeResponse {
-  reserved 3;
-  reserved "system_params";
-  common.Status status = 1;
   optional uint32 node_id = 2;
   string cluster_id = 4;
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -130,8 +130,7 @@ pub async fn compute_node_serve(
         },
         &config.meta,
     )
-    .await
-    .unwrap();
+    .await;
 
     let state_store_url = system_params.state_store();
 

--- a/src/ctl/src/common/meta_service.rs
+++ b/src/ctl/src/common/meta_service.rs
@@ -62,7 +62,7 @@ Note: the default value of `RW_META_ADDR` is 'http://127.0.0.1:5690'.";
             Property::default(),
             &MetaConfig::default(),
         )
-        .await?;
+        .await;
         let worker_id = client.worker_id();
         tracing::info!("registered as RiseCtl worker, worker_id = {}", worker_id);
         Ok(client)

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -267,7 +267,7 @@ impl FrontendEnv {
             Default::default(),
             &config.meta,
         )
-        .await?;
+        .await;
 
         let worker_id = meta_client.worker_id();
         info!("Assigned worker node id {}", worker_id);

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -25,7 +25,6 @@ use risingwave_pb::meta::{
     ListAllNodesResponse, UpdateWorkerNodeSchedulabilityRequest,
     UpdateWorkerNodeSchedulabilityResponse,
 };
-use thiserror_ext::AsReport;
 use tonic::{Request, Response, Status};
 
 use crate::MetaError;

--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -58,31 +58,16 @@ impl ClusterService for ClusterServiceImpl {
             .property
             .ok_or_else(|| MetaError::invalid_parameter("worker node property is not provided"))?;
         let resource = req.resource.unwrap_or_default();
-        let result = self
+        let worker_id = self
             .metadata_manager
             .add_worker_node(worker_type, host, property, resource)
-            .await;
+            .await?;
         let cluster_id = self.metadata_manager.cluster_id().to_string();
-        match result {
-            Ok(worker_id) => Ok(Response::new(AddWorkerNodeResponse {
-                status: None,
-                node_id: Some(worker_id),
-                cluster_id,
-            })),
-            Err(e) => {
-                if e.is_invalid_worker() {
-                    return Ok(Response::new(AddWorkerNodeResponse {
-                        status: Some(risingwave_pb::common::Status {
-                            code: risingwave_pb::common::status::Code::UnknownWorker as i32,
-                            message: e.to_report_string(),
-                        }),
-                        node_id: None,
-                        cluster_id,
-                    }));
-                }
-                Err(e.into())
-            }
-        }
+
+        Ok(Response::new(AddWorkerNodeResponse {
+            node_id: Some(worker_id),
+            cluster_id,
+        }))
     }
 
     /// Update schedulability of a compute node. Will not affect actors which are already running on

--- a/src/rpc_client/src/error.rs
+++ b/src/rpc_client/src/error.rs
@@ -87,6 +87,7 @@ impl RpcError {
             RpcError::GrpcStatus(status) => matches!(
                 status.inner().code(),
                 tonic::Code::Unavailable // server not started
+                 | tonic::Code::Unknown // could be transport error
                  | tonic::Code::Unimplemented // meta leader service not started
             ),
             RpcError::MetaAddressParse(_) => false,

--- a/src/rpc_client/src/error.rs
+++ b/src/rpc_client/src/error.rs
@@ -84,7 +84,10 @@ impl RpcError {
     pub fn is_connection_error(&self) -> bool {
         match self {
             RpcError::TransportError(_) => true,
-            RpcError::GrpcStatus(status) => status.inner().code() == tonic::Code::Unavailable,
+            RpcError::GrpcStatus(status) => matches!(
+                status.inner().code(),
+                tonic::Code::Unavailable | tonic::Code::Unimplemented
+            ),
             RpcError::MetaAddressParse(_) => false,
             RpcError::Internal(anyhow) => anyhow
                 .downcast_ref::<Self>()

--- a/src/rpc_client/src/error.rs
+++ b/src/rpc_client/src/error.rs
@@ -86,11 +86,12 @@ impl RpcError {
             RpcError::TransportError(_) => true,
             RpcError::GrpcStatus(status) => matches!(
                 status.inner().code(),
-                tonic::Code::Unavailable | tonic::Code::Unimplemented
+                tonic::Code::Unavailable // server not started
+                 | tonic::Code::Unimplemented // meta leader service not started
             ),
             RpcError::MetaAddressParse(_) => false,
             RpcError::Internal(anyhow) => anyhow
-                .downcast_ref::<Self>()
+                .downcast_ref::<Self>() // this skips all contexts attached to the error
                 .map_or(false, Self::is_connection_error),
         }
     }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -255,11 +255,13 @@ impl MetaClient {
                             total_cpu_cores: total_cpu_available() as _,
                         }),
                     })
-                    .await?;
+                    .await
+                    .context("failed to add worker node")?;
 
                 let system_params_resp = grpc_meta_client
                     .get_system_params(GetSystemParamsRequest {})
-                    .await?;
+                    .await
+                    .context("failed to get initial system params")?;
 
                 Ok((add_worker_resp, system_params_resp, grpc_meta_client))
             },

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -197,8 +197,7 @@ pub async fn compactor_serve(
         Default::default(),
         &config.meta,
     )
-    .await
-    .unwrap();
+    .await;
 
     info!("Assigned compactor id {}", meta_client.worker_id());
 

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -238,7 +238,7 @@ async fn init_metadata_for_replay(
             std::process::exit(0);
         },
         ret = MetaClient::register_new(cluster_meta_endpoint.parse()?, WorkerType::RiseCtl, advertise_addr, Default::default(), &meta_config) => {
-            (meta_client, _) = ret.unwrap();
+            (meta_client, _) = ret;
         },
     }
     let worker_id = meta_client.worker_id();
@@ -254,7 +254,7 @@ async fn init_metadata_for_replay(
         Default::default(),
         &meta_config,
     )
-    .await?;
+    .await;
     new_meta_client.activate(advertise_addr).await.unwrap();
     if ci_mode {
         let table_to_check = tables.iter().find(|t| t.name == "nexmark_q7").unwrap();
@@ -286,7 +286,7 @@ async fn pull_version_deltas(
         Default::default(),
         &MetaConfig::default(),
     )
-    .await?;
+    .await;
     let worker_id = meta_client.worker_id();
     tracing::info!("Assigned pull worker id {}", worker_id);
     meta_client.activate(advertise_addr).await.unwrap();
@@ -335,7 +335,7 @@ async fn start_replay(
         Default::default(),
         &config.meta,
     )
-    .await?;
+    .await;
     let worker_id = meta_client.worker_id();
     tracing::info!("Assigned replay worker id {}", worker_id);
     meta_client.activate(&advertise_addr).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Match the error variant when registering the worker node to the meta service, only retry if it's believed to be an issue of connection.

This eliminates the need for storing error in a separate field of `Status` in the RPC response.

This is an alternative of https://github.com/risingwavelabs/risingwave/pull/18049 and helps #18022.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
