### PR TITLE
feat: track progress for SourceBackfill (blocking DDL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11210,6 +11210,7 @@ dependencies = [
  "comfy-table",
  "crepe",
  "easy-ext",
+ "educe",
  "either",
  "enum-as-inner 0.6.0",
  "expect-test",

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -28,6 +28,7 @@ clap = { workspace = true }
 comfy-table = "7"
 crepe = "0.1"
 easy-ext = "1"
+educe = "0.6"
 either = "1"
 enum-as-inner = "0.6"
 etcd-client = { workspace = true }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -146,8 +146,10 @@ impl ReplaceTablePlan {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(educe::Educe, Clone)]
+#[educe(Debug)]
 pub struct CreateStreamingJobCommandInfo {
+    #[educe(Debug(ignore))]
     pub table_fragments: TableFragments,
     /// Refer to the doc on [`MetadataManager::get_upstream_root_fragments`] for the meaning of "root".
     pub upstream_root_actors: HashMap<TableId, Vec<ActorId>>,

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -281,7 +281,7 @@ pub(super) struct TrackingCommand {
 /// 4. With `actor_map` we can use an actor's `ActorId` to find the ID of the `StreamJob`.
 #[derive(Default, Debug)]
 pub(super) struct CreateMviewProgressTracker {
-    // XXX: which one should contain source backfill?
+    // TODO: add a specialized progress for source
     /// Progress of the create-mview DDL indicated by the `TableId`.
     progress_map: HashMap<TableId, (Progress, TrackingJob)>,
 

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -55,6 +55,7 @@ pub(super) struct Progress {
     upstream_mv_count: HashMap<TableId, usize>,
 
     /// Total key count in the upstream materialized view
+    /// TODO: implement this for source backfill
     upstream_total_key_count: u64,
 
     /// Consumed rows
@@ -122,6 +123,12 @@ impl Progress {
 
     /// Returns whether all backfill executors are done.
     fn is_done(&self) -> bool {
+        tracing::trace!(
+            "Progress::is_done? {}, {}, {:?}",
+            self.done_count,
+            self.states.len(),
+            self.states
+        );
         self.done_count == self.states.len()
     }
 
@@ -274,6 +281,7 @@ pub(super) struct TrackingCommand {
 /// 4. With `actor_map` we can use an actor's `ActorId` to find the ID of the `StreamJob`.
 #[derive(Default, Debug)]
 pub(super) struct CreateMviewProgressTracker {
+    // XXX: which one should contain source backfill?
     /// Progress of the create-mview DDL indicated by the `TableId`.
     progress_map: HashMap<TableId, (Progress, TrackingJob)>,
 
@@ -494,6 +502,7 @@ impl CreateMviewProgressTracker {
         replace_table: Option<&ReplaceTablePlan>,
         version_stats: &HummockVersionStats,
     ) -> Option<TrackingJob> {
+        tracing::trace!(?info, "add job to track");
         let (info, actors, replace_table_info) = {
             let CreateStreamingJobCommandInfo {
                 table_fragments, ..
@@ -596,6 +605,7 @@ impl CreateMviewProgressTracker {
         progress: &CreateMviewProgress,
         version_stats: &HummockVersionStats,
     ) -> Option<TrackingJob> {
+        tracing::trace!(?progress, "update progress");
         let actor = progress.backfill_actor_id;
         let Some(table_id) = self.actor_map.get(&actor).copied() else {
             // On restart, backfill will ALWAYS notify CreateMviewProgressTracker,

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -917,6 +917,7 @@ impl MetadataManager {
         &self,
         job: &StreamingJob,
     ) -> MetaResult<NotificationVersion> {
+        tracing::debug!("wait_streaming_job_finished: {job:?}");
         match self {
             MetadataManager::V1(mgr) => mgr.wait_streaming_job_finished(job).await,
             MetadataManager::V2(mgr) => mgr.wait_streaming_job_finished(job.id() as _).await,

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -362,7 +362,9 @@ impl TableFragments {
                 return vec![];
             }
             if (fragment.fragment_type_mask
-                & (FragmentTypeFlag::Values as u32 | FragmentTypeFlag::StreamScan as u32))
+                & (FragmentTypeFlag::Values as u32
+                    | FragmentTypeFlag::StreamScan as u32
+                    | FragmentTypeFlag::SourceScan as u32))
                 != 0
             {
                 actor_ids.extend(fragment.actors.iter().map(|actor| actor.actor_id));

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -441,6 +441,8 @@ pub struct ScaleController {
 
     pub env: MetaSrvEnv,
 
+    /// We will acquire lock during DDL to prevent scaling operations on jobs that are in the creating state.
+    /// e.g., a MV cannot be rescheduled during foreground backfill.
     pub reschedule_lock: RwLock<()>,
 }
 

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -14,6 +14,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::sync::Once;
 use std::time::Instant;
 
 use anyhow::anyhow;
@@ -30,6 +31,7 @@ use risingwave_connector::source::{
     BackfillInfo, BoxChunkSourceStream, SourceContext, SourceCtrlOpts, SplitId, SplitImpl,
     SplitMetaData,
 };
+use risingwave_hummock_sdk::HummockReadEpoch;
 use serde::{Deserialize, Serialize};
 use thiserror_ext::AsReport;
 
@@ -233,6 +235,7 @@ impl BackfillStage {
 }
 
 impl<S: StateStore> SourceBackfillExecutorInner<S> {
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         actor_ctx: ActorContextRef,
         info: ExecutorInfo,
@@ -352,7 +355,6 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
             splits: owned_splits,
         };
         backfill_stage.debug_assert_consistent();
-        tracing::debug!(?backfill_stage, "source backfill started");
 
         // Return the ownership of `stream_source_core` to the source executor.
         self.stream_source_core = core;
@@ -376,6 +378,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                 }
             }
         }
+        tracing::debug!(?backfill_stage, "source backfill started");
 
         fn select_strategy(_: &mut ()) -> PollNext {
             futures::stream::PollNext::Left
@@ -413,9 +416,23 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
             pause_reader!();
         }
 
+        let state_store = self.backfill_state_store.state_store.state_store().clone();
+        static STATE_TABLE_INITIALIZED: Once = Once::new();
+        tokio::spawn(async move {
+            // This is for self.backfill_finished() to be safe.
+            // We wait for 1st epoch's curr, i.e., the 2nd epoch's prev.
+            let epoch = barrier.epoch.curr;
+            tracing::info!("waiting for epoch: {}", epoch);
+            state_store
+                .try_wait_epoch(HummockReadEpoch::Committed(epoch))
+                .await
+                .expect("failed to wait epoch");
+            STATE_TABLE_INITIALIZED.call_once(|| ());
+            tracing::info!("finished waiting for epoch: {}", epoch);
+        });
         yield Message::Barrier(barrier);
 
-        if !self.backfill_finished(&backfill_stage.states).await? {
+        {
             let source_backfill_row_count = self
                 .metrics
                 .source_backfill_row_count
@@ -550,13 +567,6 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                     );
                                 }
 
-                                // TODO: use a specialized progress for source?
-                                // self.progress.update(
-                                //     barrier.epoch,
-                                //     snapshot_read_epoch,
-                                //     total_snapshot_processed_rows,
-                                // );
-
                                 self.backfill_state_store
                                     .set_states(backfill_stage.states.clone())
                                     .await?;
@@ -565,10 +575,26 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                     .commit(barrier.epoch)
                                     .await?;
 
-                                yield Message::Barrier(barrier);
+                                if self.should_report_finished(&backfill_stage.states) {
+                                    // TODO: use a specialized progress for source
+                                    // Currently, `CreateMviewProgress` is designed for MV backfill, and rw_ddl_progress calculates
+                                    // progress based on the number of consumed rows and an estimated total number of rows from hummock.
+                                    // For now, we just rely on the same code path, and for source backfill, the progress will always be 99.99%.
+                                    tracing::info!("progress finish");
+                                    let epoch = barrier.epoch;
+                                    self.progress.finish(epoch, 114514);
+                                    // yield barrier after reporting progress
+                                    yield Message::Barrier(barrier);
 
-                                if self.backfill_finished(&backfill_stage.states).await? {
-                                    break 'backfill_loop;
+                                    // After we reported finished, we still don't exit the loop.
+                                    // Because we need to handle split migration.
+                                    if STATE_TABLE_INITIALIZED.is_completed()
+                                        && self.backfill_finished(&backfill_stage.states).await?
+                                    {
+                                        break 'backfill_loop;
+                                    }
+                                } else {
+                                    yield Message::Barrier(barrier);
                                 }
                             }
                             Message::Chunk(chunk) => {
@@ -640,7 +666,6 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
             }
         }
 
-        let mut first_barrier_after_finish = true;
         let mut splits: HashSet<SplitId> = backfill_stage.states.keys().cloned().collect();
         // Make sure `Finished` state is persisted.
         self.backfill_state_store
@@ -679,7 +704,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                 self.apply_split_change_forward_stage(
                                     actor_splits,
                                     &mut splits,
-                                    true,
+                                    false,
                                 )
                                 .await?;
                             }
@@ -702,11 +727,34 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
         }
     }
 
-    /// All splits finished backfilling.
+    /// When we should call `progress.finish()` to let blocking DDL return.
+    /// We report as soon as `SourceCachingUp`. Otherwise the DDL might be blocked forever until upstream messages come.
+    ///
+    /// Note: split migration (online scaling) is related with progress tracking.
+    /// - For foreground DDL, scaling is not allowed before progress is finished.
+    /// - For background DDL, scaling is skipped when progress is not finished, and can be triggered by recreating actors during recovery.
+    ///
+    /// See <https://github.com/risingwavelabs/risingwave/issues/18300> for more details.
+    fn should_report_finished(&self, states: &BackfillStates) -> bool {
+        states.values().all(|state| {
+            matches!(
+                state,
+                BackfillState::Finished | BackfillState::SourceCachingUp(_)
+            )
+        })
+    }
+
+    /// All splits entered `Finished` state.
     ///
     /// We check all splits for the source, including other actors' splits here, before going to the forward stage.
-    /// Otherwise if we break early, but after rescheduling, an unfinished split is migrated to
+    /// Otherwise if we `break` early, but after rescheduling, an unfinished split is migrated to
     /// this actor, we still need to backfill it.
+    ///
+    /// Note: at the beginning, the actor will only read the state written by itself.
+    /// It needs to _wait until it can read all actors' written data_.
+    /// i.e., wait for the first checkpoint has been available.
+    ///
+    /// See <https://github.com/risingwavelabs/risingwave/issues/18300> for more details.
     async fn backfill_finished(&self, states: &BackfillStates) -> StreamExecutorResult<bool> {
         Ok(states
             .values()
@@ -775,7 +823,6 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                     }
                     Some(backfill_state) => {
                         // Migrated split. Backfill if unfinished.
-                        // TODO: disallow online scaling during backfilling.
                         target_state.insert(split_id, backfill_state);
                     }
                 }

--- a/src/stream/src/executor/source/source_backfill_state_table.rs
+++ b/src/stream/src/executor/source/source_backfill_state_table.rs
@@ -76,6 +76,7 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
             };
             ret.push(state);
         }
+        tracing::trace!("scan SourceBackfill state table: {:?}", ret);
         Ok(ret)
     }
 

--- a/src/stream/src/from_proto/source_backfill.rs
+++ b/src/stream/src/from_proto/source_backfill.rs
@@ -72,6 +72,9 @@ impl ExecutorBuilder for SourceBackfillExecutorBuilder {
             source_desc_builder,
             state_table_handler,
         );
+        let progress = params
+            .local_barrier_manager
+            .register_create_mview_progress(params.actor_context.id);
 
         let exec = SourceBackfillExecutorInner::new(
             params.actor_context.clone(),
@@ -81,6 +84,7 @@ impl ExecutorBuilder for SourceBackfillExecutorBuilder {
             params.env.system_params_manager_ref().get_params(),
             backfill_state_table,
             node.rate_limit,
+            progress,
         );
         let [input]: [_; 1] = params.input.try_into().unwrap();
 

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -372,6 +372,9 @@ pub(super) struct PartialGraphManagedBarrierState {
     prev_barrier_table_ids: Option<(EpochPair, HashSet<TableId>)>,
 
     /// Record the progress updates of creating mviews for each epoch of concurrent checkpoints.
+    ///
+    /// This is updated by [`super::CreateMviewProgress::update`] and will be reported to meta
+    /// in [`BarrierCompleteResult`].
     pub(super) create_mview_progress: HashMap<u64, HashMap<ActorId, BackfillState>>,
 
     pub(super) state_store: StateStoreImpl,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Support blocking DDL for source #18338

Core changes:
1. Add `SourceScan` to `tracking_progress_actor_ids` of a MV. So a MV will not enter `Created` state until the `SourceBackfillExecutor`'s actor reported progress.
2. In `SourceBackfillExecutor`, the progress reporting is a dummy one: it simply reused MV's mechanism, and only uses `finish`.

---

A subtle case to consider: whether to report `finish` after entering `SourceCatchingUp` state, or after `Finished` state? 
- `Finished` might be more intuitive and safe. However, it may make a foreground DDL blocked forever until upstream messages come. (See state diagram in #18299. We will be in `SourceCatchingUp`.) It may seem strange: why with #18342 (end at high watermark), we still cannot enter `Finished` state? Or why no messages come from upstream when we already backfilled to high watermark?

    Here's a illustration: Assume there's no messages from upstream, and we reached `high_watermark`. Now we cannot distinguish whether upstream has reached `high_watermark`, so we enter `SourceCatchingUp` state. If it hasn't caught up, we can enter `Finished` when it catches up. If it's already at latest, we will not be able to transition state.  (#18299's point 4 mentioned that we might distinguish this situation if we can do `has_message_available`)
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JgO8A8bpio3B4YlQByok/fc83e8aa-a93f-4ffb-b54d-8cb63908ddf3.png)

- So it seems we'd better end at `SourceCatchingUp` to avoid blocking forever. It's also reasonable, since now we already exited backfill stream. But the problem is that after reporting `finish`, and the DDL returns, online scaling may happen now. But we need to handle it carefully (#18300).

    Note: for scaling, "backfill finished" == "progress reported finish". Not exactly the same as the loop code in the executor. So we can't use the old hack like scanning whole state table to delay `finished`. Now we do want to finish earlier! But need to make it scaling-safe.

    So the solution is to decouple 2 timings: 
    * **T1: "when scale is disallowed"** (also the time when DDL returns)
    * **T2: "when it's safe to scale"** (when we `scan` the state table, and exit loop. This PR used `try_wait_epoch` to fix the problem described in #18300)

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
