### PR TITLE
refactor(meta): only bail out on server-side error when registering worker node

### DIFF
--- a/src/error/src/tonic.rs
+++ b/src/error/src/tonic.rs
@@ -49,6 +49,9 @@ impl std::error::Error for ServerError {
     }
 
     fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        // Provide self so that `ErrorIsFromTonicServerImpl` can work.
+        request.provide_ref(self);
+        // Provide extra fields.
         self.extra.provide(request);
     }
 }
@@ -101,6 +104,21 @@ where
     /// The source chain is preserved by pairing with [`TonicStatusWrapper`].
     pub fn to_status_unnamed(&self, code: tonic::Code) -> tonic::Status {
         to_status(self, code, None)
+    }
+}
+
+#[easy_ext::ext(ErrorIsFromTonicServerImpl)]
+impl<T> T
+where
+    T: ?Sized + std::error::Error,
+{
+    /// Returns whether the error is from the implementation of a tonic server, i.e., created
+    /// with [`ToTonicStatus::to_status`].
+    ///
+    /// This does not count errors initiated from the library, typically connection issues.
+    /// As a result, this function can be used to decide whether an error should be retried.
+    pub fn is_from_tonic_server_impl(&self) -> bool {
+        std::error::request_ref::<ServerError>(self).is_some()
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In #18061 we made a list to decide whether an error is a "connection error" in terms of retrying of worker node registration. However, the list can be incomplete, causing some transient errors not to be retried.

Instead, this PR is an alternative implementation, which uses a list to decide whether an error is initiated by **us** in the gRPC server-side implementation (i.e., through `ToTonicStatus::to_status`). This can lead to more accurate results.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
