### PR TITLE
fix(pgwire): allow configuring tcp keepalive idle time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8470,6 +8470,7 @@ dependencies = [
  "risingwave_sqlparser",
  "serde",
  "serde_json",
+ "socket2 0.5.6",
  "tempfile",
  "thiserror",
  "thiserror-ext",

--- a/src/cmd_all/src/standalone.rs
+++ b/src/cmd_all/src/standalone.rs
@@ -498,6 +498,7 @@ mod test {
                     frontend_opts: Some(
                         FrontendOpts {
                             listen_addr: "0.0.0.0:4566",
+                            tcp_keepalive_idle_secs: 300,
                             advertise_addr: None,
                             meta_addr: List(
                                 [

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -30,6 +30,7 @@ risingwave_common = { workspace = true }
 risingwave_sqlparser = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+socket2 = "0.5"
 thiserror = "1"
 thiserror-ext = { workspace = true }
 tokio = { version = "0.2", package = "madsim-tokio", features = [

--- a/src/utils/pgwire/src/net.rs
+++ b/src/utils/pgwire/src/net.rs
@@ -82,6 +82,7 @@ impl Listener {
                 stream.set_nodelay(true)?;
                 // Set TCP keepalive to 5 minutes, which is less than the connection idle timeout of 350 seconds in AWS ELB.
                 // https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout
+                #[cfg(not(madsim))]
                 {
                     let r = socket2::SockRef::from(&stream);
                     let ka = socket2::TcpKeepalive::new().with_time(Duration::from_secs(300));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

It's common for an SQL statement not returning any data from the pgwire server for a long time (typically when executing DDL). If the connection is proxied through a load balancer, the LB may consider the connection idle and drop it unexpectedly.

To resolve this issue, we may set the tcp keepalive idle time to a lower value. Here we take a reference to the value in AWS ELB, which is 350 seconds. Note that this can be done in any place dealing with the connection, but doing it on the pgwire server eliminates the need for any additional configuration.

The value is configurable through CLI args and defaults to 300 seconds.


----

FYI, the default keepalive idle time is decided by the operating system, typically 2 hours.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
