### PR TITLE
fix(meta): correctly persist license key system param in SQL backend

### DIFF
--- a/src/common/src/system_param/reader.rs
+++ b/src/common/src/system_param/reader.rs
@@ -56,7 +56,7 @@ macro_rules! define_system_params_read_trait {
                         ParameterInfo {
                             name: stringify!($field),
                             mutable: $is_mutable,
-                            value: self.$field().to_string(),
+                            value: self.$field().to_string(), // use `to_string` to get displayable (maybe redacted) value
                             description: $doc,
                         },
                     )*

--- a/src/meta/src/manager/system_param/model.rs
+++ b/src/meta/src/manager/system_param/model.rs
@@ -35,7 +35,7 @@ pub trait SystemParamsModel: Sized {
 #[async_trait]
 impl SystemParamsModel for SystemParams {
     fn cf_name() -> String {
-        SYSTEM_PARAMS_CF_NAME.to_string()
+        SYSTEM_PARAMS_CF_NAME.to_owned()
     }
 
     /// Return error if there are missing or unrecognized fields.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Follow-up of #17936.

Previously the `new_value: String` returned by `set_system_param` is redacted for `license_key`, which will be further used to persist into the SQL backend. This is not expected. This PR fixes that and adds a unit test to clarify the semantics of the returned `String` type value.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
