### PR TITLE
feat(agg): support `aggregate:` prefixed scalar function in streaming agg

### DIFF
--- a/e2e_test/streaming/aggregate/wrap_scalar.slt
+++ b/e2e_test/streaming/aggregate/wrap_scalar.slt
@@ -1,0 +1,62 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t (a varchar, b int, c int);
+
+statement ok
+insert into t values ('aaa', 1, 1), ('bbb', 0, 2), ('ccc', 0, 5), ('ddd', 1, 4);
+
+statement ok
+create materialized view mv1 as select aggregate:array_sum(c) as res from t;
+
+statement ok
+create materialized view mv2 as select b, aggregate:array_max(c) as res from t group by b;
+
+statement ok
+create function myjoin(text[]) returns text language sql as $$ select array_join($1, ', '); $$;
+
+statement ok
+create materialized view mv3 as select b, aggregate:myjoin(a order by c) as res from t group by b;
+
+query I
+select * from mv1;
+----
+12
+
+query II
+select * from mv2 order by b;
+----
+0	5
+1	4
+
+query IT
+select * from mv3 order by b;
+----
+0	bbb, ccc
+1	aaa, ddd
+
+statement ok
+insert into t values ('x', 1, 2), ('y', 3, 6);
+
+query I
+select * from mv1;
+----
+20
+
+query II
+select * from mv2 order by b;
+----
+0	5
+1	4
+3	6
+
+query IT
+select * from mv3 order by b;
+----
+0	bbb, ccc
+1	aaa, x, ddd
+3	y
+
+statement ok
+drop table t cascade;

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -443,6 +443,24 @@ pub mod agg_kinds {
     }
     pub use single_value_state_iff_in_append_only;
 
+    /// [`AggKind`](super::AggKind)s that are implemented with a materialized input state.
+    #[macro_export]
+    macro_rules! materialized_input_state {
+        () => {
+            AggKind::Builtin(
+                PbAggKind::Min
+                    | PbAggKind::Max
+                    | PbAggKind::FirstValue
+                    | PbAggKind::LastValue
+                    | PbAggKind::StringAgg
+                    | PbAggKind::ArrayAgg
+                    | PbAggKind::JsonbAgg
+                    | PbAggKind::JsonbObjectAgg,
+            ) | AggKind::WrapScalar(_)
+        };
+    }
+    pub use materialized_input_state;
+
     /// Ordered-set aggregate functions.
     #[macro_export]
     macro_rules! ordered_set {

--- a/src/stream/src/executor/aggregation/minput.rs
+++ b/src/stream/src/executor/aggregation/minput.rs
@@ -136,7 +136,8 @@ impl MaterializedInputState {
                 | PbAggKind::ArrayAgg
                 | PbAggKind::JsonbAgg
                 | PbAggKind::JsonbObjectAgg,
-            ) => Box::new(GenericAggStateCache::new(
+            )
+            | AggKind::WrapScalar(_) => Box::new(GenericAggStateCache::new(
                 OrderedStateCache::new(),
                 agg_call.args.arg_types(),
             )),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After several previous PRs:

- https://github.com/risingwavelabs/risingwave/pull/18177
- https://github.com/risingwavelabs/risingwave/pull/18203

we can now easily support using `aggregate:` prefixed scalar function (including UDF) as streaming aggregate function. This resolves #16767.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

- Support `AGGREGATE:` prefixed scalar function in streaming aggregation