### PR TITLE
feat(dashboard): visualize average backpressure rather than spot backpressure

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -33,8 +33,10 @@ For example:
 
 ```bash
 ./risedev d
-sqllogictest -p 4566 -d dev './e2e_test/nexmark/create_tables.slt.part'
-sqllogictest -p 4566 -d dev './e2e_test/streaming/nexmark/create_views.slt.part'
+./risedev slt  e2e_test/nexmark/create_sources.slt.part
+./risedev psql -c 'CREATE TABLE dimension (v1 int);'
+./risedev psql -c 'CREATE MATERIALIZED VIEW mv AS SELECT auction.* FROM dimension join auction on auction.id-auction.id = dimension.v1;'
+./risedev psql -c 'INSERT INTO dimension select 0 from generate_series(1, 50);'
 ```
 
 Install dependencies and start the development server.

--- a/dashboard/lib/api/metric.ts
+++ b/dashboard/lib/api/metric.ts
@@ -113,15 +113,19 @@ function convertToBackPressureMetrics(
 }
 
 export function calculateCumulativeBp(
-    backPressureCumulative: BackPressureInfo[],
-    backPressureCurrent: BackPressureInfo[],
-    backPressureNew: BackPressureInfo[],
+  backPressureCumulative: BackPressureInfo[],
+  backPressureCurrent: BackPressureInfo[],
+  backPressureNew: BackPressureInfo[]
 ): BackPressureInfo[] {
   let mapCumulative = convertToMapAndAgg(backPressureCumulative)
   let mapCurrent = convertToMapAndAgg(backPressureCurrent)
   let mapNew = convertToMapAndAgg(backPressureNew)
   let mapResult = new Map<string, number>()
-  let keys = new Set([...mapCumulative.keys(), ...mapCurrent.keys(), ...mapNew.keys()])
+  let keys = new Set([
+    ...mapCumulative.keys(),
+    ...mapCurrent.keys(),
+    ...mapNew.keys(),
+  ])
   keys.forEach((key) => {
     let backpressureCumulativeValue = mapCumulative.get(key) || 0
     let backpressureCurrentValue = mapCurrent.get(key) || 0
@@ -145,17 +149,14 @@ export function calculateCumulativeBp(
 
 export function calculateBPRate(
   backPressureCumulative: BackPressureInfo[],
-  totalDurationNs: number,
+  totalDurationNs: number
 ): BackPressuresMetrics {
   let map = convertToMapAndAgg(backPressureCumulative)
   let result = new Map<string, number>()
   map.forEach((backpressureNs, key) => {
     let backpressureRateRatio = backpressureNs / totalDurationNs
     let backpressureRatePercent = backpressureRateRatio * 100
-    result.set(
-      key,
-      backpressureRatePercent
-    )
+    result.set(key, backpressureRatePercent)
   })
   return convertToBackPressureMetrics(convertFromMapAndAgg(result))
 }

--- a/dashboard/lib/api/metric.ts
+++ b/dashboard/lib/api/metric.ts
@@ -150,7 +150,6 @@ export function calculateBPRate(
   let map = convertToMapAndAgg(backPressureCumulative)
   let result = new Map<string, number>()
   map.forEach((backpressureNs, key) => {
-    console.log("backpressureNs", backpressureNs)
     let backpressureRateRatio = backpressureNs / totalDurationNs
     let backpressureRatePercent = backpressureRateRatio * 100
     result.set(

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -40,7 +40,7 @@ import useErrorToast from "../hook/useErrorToast"
 import useFetch from "../lib/api/fetch"
 import {
   BackPressureInfo,
-  calculateBPRate,
+  calculateBPRate, calculateCumulativeBp,
   fetchEmbeddedBackPressure,
   fetchPrometheusBackPressure,
 } from "../lib/api/metric"
@@ -54,7 +54,7 @@ interface DispatcherNode {
 }
 
 // Refresh interval (ms) for back pressure stats
-const INTERVAL = 5000
+const INTERVAL_MS = 5000
 
 /** Associated data of each plan node in the fragment graph, including the dispatchers. */
 export interface PlanNodeDatum {
@@ -187,6 +187,8 @@ const backPressureDataSources: BackPressureDataSource[] = [
 interface EmbeddedBackPressureInfo {
   previous: BackPressureInfo[]
   current: BackPressureInfo[]
+  totalBackpressureNs: BackPressureInfo[],
+  totalDurationNs: number,
 }
 
 export default function Streaming() {
@@ -293,7 +295,7 @@ export default function Streaming() {
   // Periodically fetch Prometheus back-pressure from Meta node
   const { response: promethusMetrics } = useFetch(
     fetchPrometheusBackPressure,
-    INTERVAL,
+    INTERVAL_MS,
     backPressureDataSource === "Prometheus"
   )
 
@@ -312,10 +314,14 @@ export default function Streaming() {
                 ? {
                     previous: prev.current,
                     current: newBP,
+                    totalBackpressureNs: calculateCumulativeBp(prev.totalBackpressureNs, prev.current, newBP),
+                    totalDurationNs: prev.totalDurationNs + INTERVAL_MS * 1000 * 1000,
                   }
                 : {
                     previous: newBP, // Use current value to show zero rate, but it's fine
                     current: newBP,
+                    totalBackpressureNs: [],
+                    totalDurationNs: 0,
                   }
             )
           },
@@ -324,7 +330,7 @@ export default function Streaming() {
             toast(e, "error")
           }
         )
-      }, INTERVAL)
+      }, INTERVAL_MS)
       return () => {
         clearInterval(interval)
       }
@@ -337,9 +343,8 @@ export default function Streaming() {
 
       if (backPressureDataSource === "Embedded" && embeddedBackPressureInfo) {
         const metrics = calculateBPRate(
-          embeddedBackPressureInfo.current,
-          embeddedBackPressureInfo.previous,
-          INTERVAL
+          embeddedBackPressureInfo.totalBackpressureNs,
+          embeddedBackPressureInfo.totalDurationNs,
         )
         for (const m of metrics.outputBufferBlockingDuration) {
           map.set(

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -40,7 +40,8 @@ import useErrorToast from "../hook/useErrorToast"
 import useFetch from "../lib/api/fetch"
 import {
   BackPressureInfo,
-  calculateBPRate, calculateCumulativeBp,
+  calculateBPRate,
+  calculateCumulativeBp,
   fetchEmbeddedBackPressure,
   fetchPrometheusBackPressure,
 } from "../lib/api/metric"
@@ -187,8 +188,8 @@ const backPressureDataSources: BackPressureDataSource[] = [
 interface EmbeddedBackPressureInfo {
   previous: BackPressureInfo[]
   current: BackPressureInfo[]
-  totalBackpressureNs: BackPressureInfo[],
-  totalDurationNs: number,
+  totalBackpressureNs: BackPressureInfo[]
+  totalDurationNs: number
 }
 
 export default function Streaming() {
@@ -314,8 +315,13 @@ export default function Streaming() {
                 ? {
                     previous: prev.current,
                     current: newBP,
-                    totalBackpressureNs: calculateCumulativeBp(prev.totalBackpressureNs, prev.current, newBP),
-                    totalDurationNs: prev.totalDurationNs + INTERVAL_MS * 1000 * 1000,
+                    totalBackpressureNs: calculateCumulativeBp(
+                      prev.totalBackpressureNs,
+                      prev.current,
+                      newBP
+                    ),
+                    totalDurationNs:
+                      prev.totalDurationNs + INTERVAL_MS * 1000 * 1000,
                   }
                 : {
                     previous: newBP, // Use current value to show zero rate, but it's fine
@@ -344,7 +350,7 @@ export default function Streaming() {
       if (backPressureDataSource === "Embedded" && embeddedBackPressureInfo) {
         const metrics = calculateBPRate(
           embeddedBackPressureInfo.totalBackpressureNs,
-          embeddedBackPressureInfo.totalDurationNs,
+          embeddedBackPressureInfo.totalDurationNs
         )
         for (const m of metrics.outputBufferBlockingDuration) {
           map.set(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See the demo: https://www.notion.so/risingwave-labs/Backpressure-Graph-improvements-a11b0c5c74d54202922acb071aca72a0?pvs=4

Currently dashboard calculates the backpressure with the following mechanism.
1. Poll the `actor_buffer_output_blocking_ns` metric from `meta` / `prometheus` at a fixed duration (5s).
2. After polling, get the difference between previous and current `blocking_duration`.
3. Then backpressure rate is calculated as:
  ```
  delta_blocking_duration / fixed_duration
  ```
4. This means if the blocking duration is a few minutes, it will show up on the graph for 5s, but in the subsequent epoch, it shows up `0`, since `actor_buffer_output_blocking_ns` will ONLY be incremented after the chunk has been yielded downstream.
5. It is very easy to miss as a result, and does not reflect the stuck state of the actor. This becomes worse if the stream job contains a large number of fragments.

We can just compute average BP to solve this problem. cr @fuyufjh.

Further PRs:
see: https://github.com/risingwavelabs/risingwave/issues/18176

## Other changes

I changed the suggested steps to run the dashboard in the readme, so there's actually some live workload running. Previously it's just a series of DDLs with no data running through it.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
