### PR TITLE
fix(log-store): fix incorrect lag caused by invalid initial read epoch

### DIFF
--- a/src/connector/src/sink/log_store.rs
+++ b/src/connector/src/sink/log_store.rs
@@ -26,7 +26,7 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::metrics::LabelGuardedIntCounter;
-use risingwave_common::util::epoch::{Epoch, EpochPair, INVALID_EPOCH};
+use risingwave_common::util::epoch::{EpochPair, INVALID_EPOCH};
 
 use crate::sink::SinkMetrics;
 

--- a/src/connector/src/sink/log_store.rs
+++ b/src/connector/src/sink/log_store.rs
@@ -26,7 +26,7 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::metrics::LabelGuardedIntCounter;
-use risingwave_common::util::epoch::{EpochPair, INVALID_EPOCH};
+use risingwave_common::util::epoch::{Epoch, EpochPair, INVALID_EPOCH};
 
 use crate::sink::SinkMetrics;
 

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -27,6 +27,7 @@ use risingwave_common::metrics::{
     RelabeledGuardedHistogramVec, RelabeledGuardedIntCounterVec,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
+use risingwave_common::util::epoch::Epoch;
 use risingwave_common::{
     register_guarded_gauge_vec_with_registry, register_guarded_histogram_vec_with_registry,
     register_guarded_int_counter_vec_with_registry, register_guarded_int_gauge_vec_with_registry,
@@ -1255,6 +1256,11 @@ impl StreamingMetrics {
         let log_store_first_write_epoch = self
             .log_store_first_write_epoch
             .with_guarded_label_values(&label_list);
+
+        let initial_epoch = Epoch::now().0;
+        log_store_first_write_epoch.set(initial_epoch as _);
+        log_store_latest_write_epoch.set(initial_epoch as _);
+        log_store_latest_read_epoch.set(initial_epoch as _);
 
         let log_store_write_rows = self
             .log_store_write_rows

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -1258,9 +1258,9 @@ impl StreamingMetrics {
             .with_guarded_label_values(&label_list);
 
         let initial_epoch = Epoch::now().0;
+        log_store_latest_read_epoch.set(initial_epoch as _);
         log_store_first_write_epoch.set(initial_epoch as _);
         log_store_latest_write_epoch.set(initial_epoch as _);
-        log_store_latest_read_epoch.set(initial_epoch as _);
 
         let log_store_write_rows = self
             .log_store_write_rows


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolve https://github.com/risingwavelabs/risingwave/issues/18224

The previous bug is because the latest read epoch is 0 when no data is read, and if the latest write epoch is set before collecting metrics, the subtraction between latest write epoch and latest read epoch will be huge, and cause false alerting on log store lag too large.

In this PR, we fix this by setting the initial read epoch to the current timestamp so that the initial log store lag will be small.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
