### PR TITLE
feat(connector): introduce azblob sink

### DIFF
--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -88,6 +88,7 @@ nexmark = { version = "0.2", features = ["serde"] }
 num-bigint = "0.4"
 opendal = { workspace = true, features = [
     "executors-tokio",
+    "services-azblob",
     "services-fs",
     "services-gcs",
     "services-memory",

--- a/src/connector/src/sink/file_sink/azblob.rs
+++ b/src/connector/src/sink/file_sink/azblob.rs
@@ -37,7 +37,7 @@ pub struct AzblobCommon {
     #[serde(rename = "azblob.credentials.account_key", default)]
     pub account_key: Option<String>,
     #[serde(rename = "azblob.endpoint_url")]
-    pub endpoint_url: Option<String>,
+    pub endpoint_url: String,
 }
 
 #[serde_as]
@@ -56,14 +56,11 @@ pub const AZBLOB_SINK: &str = "azblob";
 
 impl<S: OpendalSinkBackend> FileSink<S> {
     pub fn new_azblob_sink(config: AzblobConfig) -> Result<Operator> {
-        println!("这里");
         // Create azblob builder.
         let mut builder = Azblob::default();
         builder.container(&config.common.container_name);
 
-        if let Some(endpoint_url) = config.common.endpoint_url {
-            builder.endpoint(&endpoint_url);
-        }
+        builder.endpoint(&config.common.endpoint_url);
 
         if let Some(account_name) = config.common.account_name {
             builder.account_name(&account_name);

--- a/src/connector/src/sink/file_sink/azblob.rs
+++ b/src/connector/src/sink/file_sink/azblob.rs
@@ -1,0 +1,134 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::anyhow;
+use opendal::layers::{LoggingLayer, RetryLayer};
+use opendal::services::Azblob;
+use opendal::Operator;
+use serde::Deserialize;
+use serde_with::serde_as;
+use with_options::WithOptions;
+
+use super::opendal_sink::FileSink;
+use crate::sink::file_sink::opendal_sink::OpendalSinkBackend;
+use crate::sink::{Result, SinkError, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT};
+use crate::source::UnknownFields;
+#[derive(Deserialize, Debug, Clone, WithOptions)]
+pub struct AzblobCommon {
+    #[serde(rename = "azblob.container_name")]
+    pub container_name: String,
+    /// The directory where the sink file is located.
+    #[serde(rename = "azblob.path")]
+    pub path: String,
+    #[serde(rename = "azblob.credentials.account_name", default)]
+    pub account_name: Option<String>,
+    #[serde(rename = "azblob.credentials.account_key", default)]
+    pub account_key: Option<String>,
+    #[serde(rename = "azblob.endpoint_url")]
+    pub endpoint_url: Option<String>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, WithOptions)]
+pub struct AzblobConfig {
+    #[serde(flatten)]
+    pub common: AzblobCommon,
+
+    pub r#type: String, // accept "append-only"
+
+    #[serde(flatten)]
+    pub unknown_fields: HashMap<String, String>,
+}
+
+pub const AZBLOB_SINK: &str = "azblob";
+
+impl<S: OpendalSinkBackend> FileSink<S> {
+    pub fn new_azblob_sink(config: AzblobConfig) -> Result<Operator> {
+        println!("这里");
+        // Create azblob builder.
+        let mut builder = Azblob::default();
+        builder.container(&config.common.container_name);
+
+        if let Some(endpoint_url) = config.common.endpoint_url {
+            builder.endpoint(&endpoint_url);
+        }
+
+        if let Some(account_name) = config.common.account_name {
+            builder.account_name(&account_name);
+        } else {
+            tracing::warn!(
+                "account_name azblob is not set, container  {}",
+                config.common.container_name
+            );
+        }
+
+        if let Some(account_key) = config.common.account_key {
+            builder.account_key(&account_key);
+        } else {
+            tracing::warn!(
+                "account_key azblob is not set, container  {}",
+                config.common.container_name
+            );
+        }
+        let operator: Operator = Operator::new(builder)?
+            .layer(LoggingLayer::default())
+            .layer(RetryLayer::default())
+            .finish();
+
+        Ok(operator)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AzblobSink;
+
+impl UnknownFields for AzblobConfig {
+    fn unknown_fields(&self) -> HashMap<String, String> {
+        self.unknown_fields.clone()
+    }
+}
+
+impl OpendalSinkBackend for AzblobSink {
+    type Properties = AzblobConfig;
+
+    const SINK_NAME: &'static str = AZBLOB_SINK;
+
+    fn from_btreemap(btree_map: BTreeMap<String, String>) -> Result<Self::Properties> {
+        let config =
+            serde_json::from_value::<AzblobConfig>(serde_json::to_value(btree_map).unwrap())
+                .map_err(|e| SinkError::Config(anyhow!(e)))?;
+        if config.r#type != SINK_TYPE_APPEND_ONLY && config.r#type != SINK_TYPE_UPSERT {
+            return Err(SinkError::Config(anyhow!(
+                "`{}` must be {}, or {}",
+                SINK_TYPE_OPTION,
+                SINK_TYPE_APPEND_ONLY,
+                SINK_TYPE_UPSERT
+            )));
+        }
+        Ok(config)
+    }
+
+    fn new_operator(properties: AzblobConfig) -> Result<Operator> {
+        FileSink::<AzblobSink>::new_azblob_sink(properties)
+    }
+
+    fn get_path(properties: Self::Properties) -> String {
+        properties.common.path
+    }
+
+    fn get_engine_type() -> super::opendal_sink::EngineType {
+        super::opendal_sink::EngineType::Azblob
+    }
+}

--- a/src/connector/src/sink/file_sink/mod.rs
+++ b/src/connector/src/sink/file_sink/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod azblob;
 pub mod fs;
 pub mod gcs;
 pub mod opendal_sink;

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -86,6 +86,7 @@ pub enum EngineType {
     Gcs,
     S3,
     Fs,
+    Azblob,
 }
 
 impl<S: OpendalSinkBackend> Sink for FileSink<S> {
@@ -95,9 +96,9 @@ impl<S: OpendalSinkBackend> Sink for FileSink<S> {
     const SINK_NAME: &'static str = S::SINK_NAME;
 
     async fn validate(&self) -> Result<()> {
-        risingwave_common::license::Feature::FileSink
-            .check_available()
-            .map_err(|e| anyhow::anyhow!(e))?;
+        // risingwave_common::license::Feature::FileSink
+        //     .check_available()
+        //     .map_err(|e| anyhow::anyhow!(e))?;
         if !self.is_append_only {
             return Err(SinkError::Config(anyhow!(
                 "File sink only supports append-only mode at present. \

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -96,9 +96,9 @@ impl<S: OpendalSinkBackend> Sink for FileSink<S> {
     const SINK_NAME: &'static str = S::SINK_NAME;
 
     async fn validate(&self) -> Result<()> {
-        // risingwave_common::license::Feature::FileSink
-        //     .check_available()
-        //     .map_err(|e| anyhow::anyhow!(e))?;
+        risingwave_common::license::Feature::FileSink
+            .check_available()
+            .map_err(|e| anyhow::anyhow!(e))?;
         if !self.is_append_only {
             return Err(SinkError::Config(anyhow!(
                 "File sink only supports append-only mode at present. \

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -102,7 +102,10 @@ macro_rules! for_all_sinks {
                 { Doris, $crate::sink::doris::DorisSink },
                 { Starrocks, $crate::sink::starrocks::StarrocksSink },
                 { S3, $crate::sink::file_sink::opendal_sink::FileSink<$crate::sink::file_sink::s3::S3Sink>},
+
                 { Gcs, $crate::sink::file_sink::opendal_sink::FileSink<$crate::sink::file_sink::gcs::GcsSink>  },
+                { Azblob, $crate::sink::file_sink::opendal_sink::FileSink<$crate::sink::file_sink::azblob::AzblobSink>},
+
                 { Fs, $crate::sink::file_sink::opendal_sink::FileSink<FsSink>  },
                 { Snowflake, $crate::sink::snowflake::SnowflakeSink },
                 { DeltaLake, $crate::sink::deltalake::DeltaLakeSink },

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1,6 +1,29 @@
 # THIS FILE IS AUTO_GENERATED. DO NOT EDIT
 # UPDATE WITH: ./risedev generate-with-options
 
+AzblobConfig:
+  fields:
+  - name: azblob.container_name
+    field_type: String
+    required: true
+  - name: azblob.path
+    field_type: String
+    comments: The directory where the sink file is located.
+    required: true
+  - name: azblob.credentials.account_name
+    field_type: String
+    required: false
+    default: Default::default
+  - name: azblob.credentials.account_key
+    field_type: String
+    required: false
+    default: Default::default
+  - name: azblob.endpoint_url
+    field_type: String
+    required: true
+  - name: r#type
+    field_type: String
+    required: true
 BigQueryConfig:
   fields:
   - name: bigquery.local.path

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -869,6 +869,7 @@ fn bind_sink_format_desc(session: &SessionImpl, value: ConnectorSchema) -> Resul
 
 static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, Vec<Encode>>>> =
     LazyLock::new(|| {
+        use risingwave_connector::sink::file_sink::azblob::AzblobSink;
         use risingwave_connector::sink::file_sink::fs::FsSink;
         use risingwave_connector::sink::file_sink::gcs::GcsSink;
         use risingwave_connector::sink::file_sink::opendal_sink::FileSink;
@@ -894,6 +895,9 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
                     Format::Plain => vec![Encode::Parquet],
                 ),
                 FileSink::<GcsSink>::SINK_NAME => hashmap!(
+                    Format::Plain => vec![Encode::Parquet],
+                ),
+                FileSink::<AzblobSink>::SINK_NAME => hashmap!(
                     Format::Plain => vec![Encode::Parquet],
                 ),
                 FileSink::<FsSink>::SINK_NAME => hashmap!(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
As title, test passed locally.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

Please update the document, and this newly added sink is parallel with the GCS sink and S3 sink. For the Azure Blob sink fields, although the `account key` and `account name` are optional, they can only be left blank in one case: when the workload identity token is already configured (in other words, even cloud users need to configure these two fields). If you need assistance, please contact me.  cc@hengm3467 for scheduling this task.

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
