### PR TITLE
fix(source/nats): add missing `default` attribute for vectors

### DIFF
--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -126,8 +126,11 @@ pub struct NatsPropertiesConsumer {
     #[serde(rename = "consumer.filter_subject")]
     pub filter_subject: Option<String>,
 
-    #[serde(rename = "consumer.filter_subjects")]
-    #[serde(deserialize_with = "deserialize_optional_string_seq_from_string")]
+    #[serde(
+        rename = "consumer.filter_subjects",
+        default,
+        deserialize_with = "deserialize_optional_string_seq_from_string"
+    )]
     pub filter_subjects: Option<Vec<String>>,
 
     #[serde(rename = "consumer.replay_policy")]
@@ -178,8 +181,11 @@ pub struct NatsPropertiesConsumer {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub memory_storage: Option<bool>,
 
-    #[serde(rename = "consumer.backoff.sec")]
-    #[serde(deserialize_with = "deserialize_optional_u64_seq_from_string")]
+    #[serde(
+        rename = "consumer.backoff.sec",
+        default,
+        deserialize_with = "deserialize_optional_u64_seq_from_string"
+    )]
     pub backoff: Option<Vec<u64>>,
 }
 

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -537,6 +537,7 @@ NatsProperties:
   - name: consumer.filter_subjects
     field_type: Vec<String>
     required: false
+    default: Default::default
   - name: consumer.replay_policy
     field_type: String
     required: false
@@ -578,6 +579,7 @@ NatsProperties:
   - name: consumer.backoff.sec
     field_type: Vec<u64>
     required: false
+    default: Default::default
   - name: scan.startup.mode
     field_type: String
     required: false


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Currently, the `backoff` and `filter_subjects` fields are required due to a missing `default` attribute, causing source creation to fail when they are not defined.

However, these fields should are supposed to be optional and should allow the creation of the source to proceed, even if they are not defined. 

This PR adds the missing `default` attribute, which fixes the above issue.

Related to  https://github.com/risingwavelabs/risingwave/pull/17615

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
