### PR TITLE
feat(storage): remove shared buffer compaction grouped payload

### DIFF
--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -21,14 +21,13 @@ use std::sync::{Arc, LazyLock};
 use await_tree::InstrumentAwait;
 use bytes::Bytes;
 use foyer::CacheContext;
-use futures::future::{try_join, try_join_all};
+use futures::future::try_join;
 use futures::{stream, FutureExt, StreamExt, TryFutureExt};
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
-use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::{FullKey, FullKeyTracker, UserKey, EPOCH_LEN};
 use risingwave_hummock_sdk::key_range::KeyRange;
-use risingwave_hummock_sdk::{CompactionGroupId, EpochWithGap, LocalSstableInfo};
+use risingwave_hummock_sdk::{EpochWithGap, LocalSstableInfo};
 use risingwave_pb::hummock::compact_task;
 use thiserror_ext::AsReport;
 use tracing::{error, warn};
@@ -59,41 +58,20 @@ pub async fn compact(
     context: CompactorContext,
     sstable_object_id_manager: SstableObjectIdManagerRef,
     payload: Vec<ImmutableMemtable>,
-    compaction_group_index: Arc<HashMap<TableId, CompactionGroupId>>,
     filter_key_extractor_manager: FilterKeyExtractorManager,
 ) -> HummockResult<UploadTaskOutput> {
-    let mut grouped_payload: HashMap<CompactionGroupId, Vec<ImmutableMemtable>> = HashMap::new();
-    for imm in &payload {
-        let compaction_group_id = match compaction_group_index.get(&imm.table_id) {
-            // compaction group id is used only as a hint for grouping different data.
-            // If the compaction group id is not found for the table id, we can assign a
-            // default compaction group id for the batch.
-            //
-            // On meta side, when we commit a new epoch, it is acceptable that the
-            // compaction group id provided from CN does not match the latest compaction
-            // group config.
-            None => StaticCompactionGroupId::StateDefault as CompactionGroupId,
-            Some(group_id) => *group_id,
-        };
-        grouped_payload
-            .entry(compaction_group_id)
-            .or_default()
-            .push(imm.clone());
-    }
-
-    let mut new_value_futures = vec![];
-    for (id, group_payload) in grouped_payload {
-        new_value_futures.push(
-            compact_shared_buffer::<true>(
-                context.clone(),
-                sstable_object_id_manager.clone(),
-                filter_key_extractor_manager.clone(),
-                group_payload,
-            )
-            .map_ok(move |results| results.into_iter())
-            .instrument_await(format!("shared_buffer_compact_compaction_group {}", id)),
-        );
-    }
+    let new_value_payload = payload.clone();
+    let new_value_future = async {
+        compact_shared_buffer::<true>(
+            context.clone(),
+            sstable_object_id_manager.clone(),
+            filter_key_extractor_manager.clone(),
+            new_value_payload,
+        )
+        .map_ok(move |results| results.into_iter())
+        .instrument_await("shared_buffer_compact_new_value")
+        .await
+    };
 
     let old_value_payload = payload
         .into_iter()
@@ -106,8 +84,8 @@ pub async fn compact(
         } else {
             compact_shared_buffer::<false>(
                 context.clone(),
-                sstable_object_id_manager,
-                filter_key_extractor_manager,
+                sstable_object_id_manager.clone(),
+                filter_key_extractor_manager.clone(),
                 old_value_payload,
             )
             .await
@@ -115,10 +93,9 @@ pub async fn compact(
     };
 
     // Note that the output is reordered compared with input `payload`.
-    let (grouped_new_value_ssts, old_value_ssts) =
-        try_join(try_join_all(new_value_futures), old_value_future).await?;
+    let (new_value_ssts, old_value_ssts) = try_join(new_value_future, old_value_future).await?;
 
-    let new_value_ssts = grouped_new_value_ssts.into_iter().flatten().collect_vec();
+    let new_value_ssts = new_value_ssts.into_iter().collect_vec();
     Ok(UploadTaskOutput {
         new_value_ssts,
         old_value_ssts,

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -228,7 +228,6 @@ async fn flush_imms(
         compactor_context,
         sstable_object_id_manager,
         payload,
-        task_info.compaction_group_index,
         filter_key_extractor_manager,
     )
     .verbose_instrument_await("shared_buffer_compact")

--- a/src/storage/src/hummock/event_handler/uploader/mod.rs
+++ b/src/storage/src/hummock/event_handler/uploader/mod.rs
@@ -37,7 +37,7 @@ use risingwave_common::must_match;
 use risingwave_hummock_sdk::table_watermark::{
     TableWatermarks, VnodeWatermark, WatermarkDirection,
 };
-use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, LocalSstableInfo};
+use risingwave_hummock_sdk::{HummockEpoch, LocalSstableInfo};
 use task_manager::{TaskManager, UploadingTaskStatus};
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot;
@@ -88,7 +88,6 @@ pub struct UploadTaskInfo {
     pub task_size: usize,
     pub epochs: Vec<HummockEpoch>,
     pub imm_ids: HashMap<LocalInstanceId, Vec<ImmId>>,
-    pub compaction_group_index: Arc<HashMap<TableId, CompactionGroupId>>,
 }
 
 impl Display for UploadTaskInfo {
@@ -249,7 +248,6 @@ impl UploadingTask {
             task_size,
             epochs,
             imm_ids,
-            compaction_group_index: context.pinned_version.compaction_group_index(),
         };
         context
             .buffer_tracker

--- a/src/storage/src/hummock/local_version/pinned_version.rs
+++ b/src/storage/src/hummock/local_version/pinned_version.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::iter::empty;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -74,7 +74,6 @@ impl Drop for PinnedVersionGuard {
 #[derive(Clone)]
 pub struct PinnedVersion {
     version: Arc<HummockVersion>,
-    compaction_group_index: Arc<HashMap<TableId, CompactionGroupId>>,
     guard: Arc<PinnedVersionGuard>,
 }
 
@@ -84,20 +83,13 @@ impl PinnedVersion {
         pinned_version_manager_tx: UnboundedSender<PinVersionAction>,
     ) -> Self {
         let version_id = version.id;
-        let compaction_group_index = version.state_table_info.build_table_compaction_group_id();
-
         PinnedVersion {
             version: Arc::new(version),
-            compaction_group_index: Arc::new(compaction_group_index),
             guard: Arc::new(PinnedVersionGuard::new(
                 version_id,
                 pinned_version_manager_tx,
             )),
         }
-    }
-
-    pub(crate) fn compaction_group_index(&self) -> Arc<HashMap<TableId, CompactionGroupId>> {
-        self.compaction_group_index.clone()
     }
 
     pub fn new_pin_version(&self, version: HummockVersion) -> Self {
@@ -108,11 +100,9 @@ impl PinnedVersion {
             self.version.id
         );
         let version_id = version.id;
-        let compaction_group_index = version.state_table_info.build_table_compaction_group_id();
 
         PinnedVersion {
             version: Arc::new(version),
-            compaction_group_index: Arc::new(compaction_group_index),
             guard: Arc::new(PinnedVersionGuard::new(
                 version_id,
                 self.guard.pinned_version_manager_tx.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After https://github.com/risingwavelabs/risingwave/pull/18053, hummock can split CN submitted ssts based on table stats, so there is no longer the problem of multiple compaction groups being interfered with due to inaccurate sizes. 

So we can remove the logic of submitting ssts by compaction group on the CN side to reduce logic complexity and upload iops. This isn't a radical optimization , but I think it simplifies the logic on the CN side and is worth making as a separate change.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
