### PR TITLE
feat(risedev): prompt user with `argv[0]` instead of hard-coded `./risedev`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1244,7 +1244,7 @@ cat <<EOF > "${INSTALL_PATH}"
 #!/usr/bin/env bash
 set -e
 cd "$DIR"
-./risedev "\\$@"
+RISEDEV_CMD="\\$(basename \\"$0")" ./risedev "\\$@"
 EOF
 chmod +x "${INSTALL_PATH}"
 

--- a/risedev
+++ b/risedev
@@ -12,6 +12,12 @@ fi
 
 touch risedev-components.user.env
 
+# RISEDEV_CMD might be set if it is installed to the PATH.
+# Otherwise, we set it to the current script name.
+if [ -z "$RISEDEV_CMD" ]; then
+    export RISEDEV_CMD="$0"
+fi
+
 if [ $# -eq 0 ] || [ "$1" == "-h" ] || [ "$1" ==  "--help" ]; then
     cargo make --list-all-steps --hide-uninteresting
     exit 0

--- a/src/risedevtool/common.toml
+++ b/src/risedevtool/common.toml
@@ -35,7 +35,7 @@ condition = { env_not_set = [ "RISEDEV_CONFIGURED" ] }
 script = '''
 #!/usr/bin/env bash
 set -e
-echo "RiseDev is not configured, please run ./risedev configure"
+echo "RiseDev is not configured, please run ${RISEDEV_CMD} configure"
 exit 1
 '''
 

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -440,6 +440,8 @@ fn main() -> Result<()> {
     }
     manager.finish_all();
 
+    use risedev::util::stylized_risedev_subcmd as r;
+
     match task_result {
         Ok((stat, log_buffer)) => {
             println!("---- summary of startup time ----");
@@ -458,20 +460,11 @@ fn main() -> Result<()> {
 
             print!("{}", log_buffer);
 
-            println!(
-                "* You may find logs using {} command",
-                style("./risedev l").blue().bold()
-            );
+            println!("* You may find logs using {} command", r("l"));
 
-            println!(
-                "* Run {} to kill cluster.",
-                style("./risedev k").blue().bold()
-            );
+            println!("* Run {} to kill cluster.", r("k"));
 
-            println!(
-                "* Run {} to run `risedev` anywhere!",
-                style("./risedev install").blue().bold()
-            );
+            println!("* Run {} to run `risedev` anywhere!", r("install"));
 
             Ok(())
         }
@@ -484,20 +477,17 @@ fn main() -> Result<()> {
             println!();
             println!(
                 "* Use `{}` to enable new components, if they are missing.",
-                style("./risedev configure").blue().bold(),
+                r("configure")
             );
             println!(
                 "* Use `{}` to view logs, or visit `{}`",
-                style("./risedev l").blue().bold(),
+                r("l"),
                 env::var("PREFIX_LOG")?
             );
-            println!(
-                "* Run `{}` to clean up cluster.",
-                style("./risedev k").blue().bold()
-            );
+            println!("* Run `{}` to clean up cluster.", r("k"));
             println!(
                 "* Run `{}` to clean data, which might potentially fix the issue.",
-                style("./risedev clean-data").blue().bold()
+                r("clean-data")
             );
             println!("---");
             println!();

--- a/src/risedevtool/src/task/configure_tmux_service.rs
+++ b/src/risedevtool/src/task/configure_tmux_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{bail, Context, Result};
 use console::style;
 
+use crate::util::stylized_risedev_subcmd;
 use crate::{ExecuteContext, Task};
 
 pub struct ConfigureTmuxTask;
@@ -60,7 +61,7 @@ impl Task for ConfigureTmuxTask {
         if ctx.run_command(cmd).is_ok() {
             bail!(
                 "A previous cluster is already running. Please kill it first with {}.",
-                style("./risedev k").blue().bold()
+                stylized_risedev_subcmd("k"),
             );
         }
 

--- a/src/risedevtool/src/task/etcd_service.rs
+++ b/src/risedevtool/src/task/etcd_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
 
+use crate::util::stylized_risedev_subcmd;
 use crate::{EtcdConfig, Task};
 
 pub struct EtcdService {
@@ -102,7 +103,11 @@ impl Task for EtcdService {
 
         let path = Self::path()?;
         if !path.exists() {
-            return Err(anyhow!("etcd binary not found in {:?}\nDid you enable etcd feature in `./risedev configure`?", path));
+            return Err(anyhow!(
+                "etcd binary not found in {:?}\nDid you enable etcd feature in `{}`?",
+                path,
+                stylized_risedev_subcmd("configure")
+            ));
         }
 
         let mut cmd = Self::etcd()?;

--- a/src/risedevtool/src/task/grafana_service.rs
+++ b/src/risedevtool/src/task/grafana_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 
 use super::{ExecuteContext, Task};
+use crate::util::stylized_risedev_subcmd;
 use crate::{GrafanaConfig, GrafanaGen};
 
 pub struct GrafanaService {
@@ -102,7 +103,7 @@ impl Task for GrafanaService {
 
         let path = self.grafana_server_path()?;
         if !path.exists() {
-            return Err(anyhow!("grafana-server binary not found in {:?}\nDid you enable monitoring feature in `./risedev configure`?", path));
+            return Err(anyhow!("grafana-server binary not found in {:?}\nDid you enable monitoring feature in `{}`?", path, stylized_risedev_subcmd("configure")));
         }
 
         Self::write_config_files(

--- a/src/risedevtool/src/task/minio_service.rs
+++ b/src/risedevtool/src/task/minio_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 
 use super::{ExecuteContext, Task};
+use crate::util::stylized_risedev_subcmd;
 use crate::MinioConfig;
 
 pub struct MinioService {
@@ -91,7 +92,11 @@ impl Task for MinioService {
 
         let path = self.minio_path()?;
         if !path.exists() {
-            return Err(anyhow!("minio binary not found in {:?}\nDid you enable minio feature in `./risedev configure`?", path));
+            return Err(anyhow!(
+                "minio binary not found in {:?}\nDid you enable minio feature in `{}`?",
+                path,
+                stylized_risedev_subcmd("configure")
+            ));
         }
 
         let mut cmd = self.minio()?;

--- a/src/risedevtool/src/task/prometheus_service.rs
+++ b/src/risedevtool/src/task/prometheus_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 
 use super::{ExecuteContext, Task};
+use crate::util::stylized_risedev_subcmd;
 use crate::{PrometheusConfig, PrometheusGen};
 
 pub struct PrometheusService {
@@ -57,7 +58,11 @@ impl Task for PrometheusService {
 
         let path = self.prometheus_path()?;
         if !path.exists() {
-            return Err(anyhow!("prometheus binary not found in {:?}\nDid you enable monitoring feature in `./risedev configure`?", path));
+            return Err(anyhow!(
+                "prometheus binary not found in {:?}\nDid you enable monitoring feature in `{}`?",
+                path,
+                stylized_risedev_subcmd("configure")
+            ));
         }
 
         let prefix_config = env::var("PREFIX_CONFIG")?;

--- a/src/risedevtool/src/task/pubsub_service.rs
+++ b/src/risedevtool/src/task/pubsub_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 
 use super::{ExecuteContext, Task};
+use crate::util::stylized_risedev_subcmd;
 use crate::PubsubConfig;
 
 pub struct PubsubService {
@@ -49,7 +50,11 @@ impl Task for PubsubService {
 
         let path = self.gcloud_path()?;
         if !path.exists() {
-            return Err(anyhow!("gcloud binary not found in {:?}\nDid you enable pubsub-emulator feature in `./risedev configure`?", path));
+            return Err(anyhow!(
+                "gcloud binary not found in {:?}\nDid you enable pubsub-emulator feature in `{}`?",
+                path,
+                stylized_risedev_subcmd("configure")
+            ));
         }
 
         let mut cmd = self.gcloud()?;

--- a/src/risedevtool/src/task/redis_service.rs
+++ b/src/risedevtool/src/task/redis_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 
 use anyhow::{anyhow, Result};
 
+use crate::util::stylized_risedev_subcmd;
 use crate::{ExecuteContext, RedisConfig, Task};
 
 pub struct RedisService {
@@ -49,7 +50,11 @@ impl Task for RedisService {
         ctx.pb.set_message("starting");
         let path = self.redis_path()?;
         if !path.exists() {
-            return Err(anyhow!("Redis binary not found in {:?}\nDid you enable redis feature in `./risedev configure`?", path));
+            return Err(anyhow!(
+                "Redis binary not found in {:?}\nDid you enable redis feature in `{}`?",
+                path,
+                stylized_risedev_subcmd("configure")
+            ));
         }
 
         let mut cmd = self.redis()?;

--- a/src/risedevtool/src/task/tempo_service.rs
+++ b/src/risedevtool/src/task/tempo_service.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 
 use super::{ExecuteContext, Task};
+use crate::util::stylized_risedev_subcmd;
 use crate::{TempoConfig, TempoGen};
 
 pub struct TempoService {
@@ -63,7 +64,11 @@ impl Task for TempoService {
 
         let path = self.tempo_path()?;
         if !path.exists() {
-            return Err(anyhow!("tempo binary not found in {:?}\nDid you enable tracing feature in `./risedev configure`?", path));
+            return Err(anyhow!(
+                "tempo binary not found in {:?}\nDid you enable tracing feature in `{}`?",
+                path,
+                stylized_risedev_subcmd("configure")
+            ));
         }
 
         let prefix_config = env::var("PREFIX_CONFIG")?;

--- a/src/risedevtool/src/util.rs
+++ b/src/risedevtool/src/util.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
 use std::process::Command;
+use std::sync::LazyLock;
 
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
@@ -82,4 +84,22 @@ pub fn is_env_set(var: &str) -> bool {
 
 pub fn is_enable_backtrace() -> bool {
     !is_env_set("DISABLE_BACKTRACE")
+}
+
+pub fn risedev_cmd() -> &'static str {
+    static RISEDEV_CMD: LazyLock<String> = LazyLock::new(|| {
+        if let Ok(val) = std::env::var("RISEDEV_CMD") {
+            val
+        } else {
+            "./risedev".to_owned()
+        }
+    });
+
+    RISEDEV_CMD.as_str()
+}
+
+pub fn stylized_risedev_subcmd(subcmd: &str) -> impl Display {
+    console::style(format!("{} {}", risedev_cmd(), subcmd))
+        .blue()
+        .bold()
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Developers may install `risedev` to PATH with a custom name like `r+`. In this case, it would be better if we prompt users with the actual name of the executable.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
