### PR TITLE
feat: variable vnode count support in table distribution

### DIFF
--- a/src/batch/src/executor/join/distributed_lookup_join.rs
+++ b/src/batch/src/executor/join/distributed_lookup_join.rs
@@ -17,8 +17,9 @@ use std::mem::swap;
 
 use futures::pin_mut;
 use itertools::Itertools;
+use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
-use risingwave_common::hash::{HashKey, HashKeyDispatcher};
+use risingwave_common::hash::{HashKey, HashKeyDispatcher, VirtualNode};
 use risingwave_common::memory::MemoryContext;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
@@ -30,7 +31,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::common::BatchQueryEpoch;
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::{TableDistribution, TableIter};
+use risingwave_storage::table::TableIter;
 use risingwave_storage::{dispatch_state_store, StateStore};
 
 use crate::error::Result;
@@ -194,7 +195,8 @@ impl BoxedExecutorBuilder for DistributedLookupJoinExecutorBuilder {
             .collect();
 
         // Lookup Join always contains distribution key, so we don't need vnode bitmap
-        let vnodes = Some(TableDistribution::all_vnodes());
+        // TODO(var-vnode): use vnode count from table desc
+        let vnodes = Some(Bitmap::ones(VirtualNode::COUNT).into());
         dispatch_state_store!(source.context().state_store(), state_store, {
             let table = StorageTable::new_partial(state_store, column_ids, vnodes, table_desc);
             let inner_side_builder = InnerSideExecutorBuilder::new(

--- a/src/batch/src/executor/join/local_lookup_join.rs
+++ b/src/batch/src/executor/join/local_lookup_join.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 
 use anyhow::Context;
 use itertools::Itertools;
-use risingwave_common::bitmap::BitmapBuilder;
+use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::{ColumnDesc, Field, Schema};
 use risingwave_common::hash::table_distribution::TableDistribution;
 use risingwave_common::hash::{
@@ -408,12 +408,11 @@ impl BoxedExecutorBuilder for LocalLookupJoinExecutorBuilder {
             })
             .collect();
 
+        // TODO(var-vnode): use vnode count from table desc
+        let vnodes = Some(Bitmap::ones(VirtualNode::COUNT).into());
         let inner_side_builder = InnerSideExecutorBuilder {
             table_desc: table_desc.clone(),
-            table_distribution: TableDistribution::new_from_storage_table_desc(
-                Some(TableDistribution::all_vnodes()),
-                table_desc,
-            ),
+            table_distribution: TableDistribution::new_from_storage_table_desc(vnodes, table_desc),
             vnode_mapping,
             outer_side_key_types,
             inner_side_schema,

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -21,6 +21,7 @@ use prometheus::Histogram;
 use risingwave_common::array::DataChunk;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnId, Schema};
+use risingwave_common::hash::VirtualNode;
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
@@ -32,7 +33,6 @@ use risingwave_pb::plan_common::as_of::AsOfType;
 use risingwave_pb::plan_common::{as_of, PbAsOf, StorageTableDesc};
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::TableDistribution;
 use risingwave_storage::{dispatch_state_store, StateStore};
 
 use crate::error::{BatchError, Result};
@@ -210,7 +210,8 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             Some(vnodes) => Some(Bitmap::from(vnodes).into()),
             // This is possible for dml. vnode_bitmap is not filled by scheduler.
             // Or it's single distribution, e.g., distinct agg. We scan in a single executor.
-            None => Some(TableDistribution::all_vnodes()),
+            // TODO(var-vnode): use vnode count from table desc
+            None => Some(Bitmap::ones(VirtualNode::COUNT).into()),
         };
 
         let scan_ranges = {

--- a/src/common/src/hash/consistent_hash/bitmap.rs
+++ b/src/common/src/hash/consistent_hash/bitmap.rs
@@ -15,6 +15,7 @@
 use std::ops::RangeInclusive;
 
 use crate::bitmap::Bitmap;
+use crate::hash::table_distribution::SINGLETON_VNODE;
 use crate::hash::VirtualNode;
 
 /// An extension trait for `Bitmap` to support virtual node operations.
@@ -35,5 +36,18 @@ impl Bitmap {
     pub fn vnode_ranges(&self) -> impl Iterator<Item = RangeInclusive<VirtualNode>> + '_ {
         self.high_ranges()
             .map(|r| (VirtualNode::from_index(*r.start())..=VirtualNode::from_index(*r.end())))
+    }
+
+    /// Returns whether only the [`SINGLETON_VNODE`] is set in the bitmap.
+    ///
+    /// Note that this method returning `true` does not imply that the bitmap was created by
+    /// [`VnodeBitmapExt::singleton`], or that the bitmap has length 1.
+    pub fn is_singleton(&self) -> bool {
+        self.count_ones() == 1 && self.iter_vnodes().next().unwrap() == SINGLETON_VNODE
+    }
+
+    /// Creates a bitmap with length 1 and the single bit set.
+    pub fn singleton() -> Self {
+        Self::ones(1)
     }
 }

--- a/src/common/src/hash/consistent_hash/vnode.rs
+++ b/src/common/src/hash/consistent_hash/vnode.rs
@@ -115,6 +115,11 @@ impl VirtualNode {
 }
 
 impl VirtualNode {
+    pub const COUNT_FOR_TEST: usize = Self::COUNT;
+    pub const MAX_FOR_TEST: VirtualNode = Self::MAX;
+}
+
+impl VirtualNode {
     // `compute_chunk` is used to calculate the `VirtualNode` for the columns in the
     // chunk. When only one column is provided and its type is `Serial`, we consider the column to
     // be the one that contains RowId, and use a special method to skip the calculation of Hash

--- a/src/common/src/hash/table_distribution.rs
+++ b/src/common/src/hash/table_distribution.rs
@@ -24,9 +24,8 @@ use crate::hash::VirtualNode;
 use crate::row::Row;
 use crate::util::iter_util::ZipEqFast;
 
-/// For tables without distribution (singleton), the `DEFAULT_VNODE` is encoded.
-pub const DEFAULT_VNODE: VirtualNode = VirtualNode::ZERO;
-pub use DEFAULT_VNODE as SINGLETON_VNODE;
+/// For tables without distribution (singleton), the `SINGLETON_VNODE` is encoded.
+pub const SINGLETON_VNODE: VirtualNode = VirtualNode::ZERO;
 
 use super::VnodeBitmapExt;
 

--- a/src/common/src/hash/table_distribution.rs
+++ b/src/common/src/hash/table_distribution.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 use std::mem::replace;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use itertools::Itertools;
 use risingwave_pb::plan_common::StorageTableDesc;
-use tracing::warn;
 
 use crate::array::{Array, DataChunk, PrimitiveArray};
 use crate::bitmap::Bitmap;
@@ -35,10 +34,14 @@ use super::VnodeBitmapExt;
 enum ComputeVnode {
     Singleton,
     DistKeyIndices {
+        /// Virtual nodes that the table is partitioned into.
+        vnodes: Arc<Bitmap>,
         /// Indices of distribution key for computing vnode, based on the pk columns of the table.
         dist_key_in_pk_indices: Vec<usize>,
     },
     VnodeColumnIndex {
+        /// Virtual nodes that the table is partitioned into.
+        vnodes: Arc<Bitmap>,
         /// Index of vnode column.
         vnode_col_idx_in_pk: usize,
     },
@@ -49,9 +52,6 @@ enum ComputeVnode {
 pub struct TableDistribution {
     /// The way to compute vnode provided primary key
     compute_vnode: ComputeVnode,
-
-    /// Virtual nodes that the table is partitioned into.
-    vnodes: Arc<Bitmap>,
 }
 
 impl TableDistribution {
@@ -75,30 +75,19 @@ impl TableDistribution {
     ) -> Self {
         let compute_vnode = if let Some(vnode_col_idx_in_pk) = vnode_col_idx_in_pk {
             ComputeVnode::VnodeColumnIndex {
+                vnodes: vnodes.expect("vnodes must be `Some` as vnode column is set"),
                 vnode_col_idx_in_pk,
             }
         } else if !dist_key_in_pk_indices.is_empty() {
             ComputeVnode::DistKeyIndices {
+                vnodes: vnodes.expect("vnodes must be `Some` as dist key indices are set"),
                 dist_key_in_pk_indices,
             }
         } else {
             ComputeVnode::Singleton
         };
 
-        let vnodes = vnodes.unwrap_or_else(|| Bitmap::singleton().into());
-        if let ComputeVnode::Singleton = &compute_vnode {
-            if !vnodes.is_singleton() && !vnodes.all() {
-                warn!(
-                    ?vnodes,
-                    "singleton distribution get non-singleton vnode bitmap"
-                );
-            }
-        }
-
-        Self {
-            compute_vnode,
-            vnodes,
-        }
+        Self { compute_vnode }
     }
 
     pub fn is_singleton(&self) -> bool {
@@ -109,9 +98,9 @@ impl TableDistribution {
     pub fn all(dist_key_in_pk_indices: Vec<usize>, vnode_count: usize) -> Self {
         Self {
             compute_vnode: ComputeVnode::DistKeyIndices {
+                vnodes: Bitmap::ones(vnode_count).into(),
                 dist_key_in_pk_indices,
             },
-            vnodes: Bitmap::ones(vnode_count).into(),
         }
     }
 
@@ -119,20 +108,39 @@ impl TableDistribution {
     pub fn singleton() -> Self {
         Self {
             compute_vnode: ComputeVnode::Singleton,
-            vnodes: Bitmap::singleton().into(),
         }
     }
 
     pub fn update_vnode_bitmap(&mut self, new_vnodes: Arc<Bitmap>) -> Arc<Bitmap> {
-        if self.is_singleton() && !new_vnodes.is_singleton() {
-            warn!(?new_vnodes, "update vnode on singleton distribution");
+        match &mut self.compute_vnode {
+            ComputeVnode::Singleton => {
+                if !new_vnodes.is_singleton() {
+                    panic!(
+                        "update vnode bitmap on singleton distribution to non-singleton: {:?}",
+                        new_vnodes
+                    );
+                }
+                self.vnodes().clone() // not updated
+            }
+
+            ComputeVnode::DistKeyIndices { vnodes, .. }
+            | ComputeVnode::VnodeColumnIndex { vnodes, .. } => {
+                assert_eq!(vnodes.len(), new_vnodes.len());
+                replace(vnodes, new_vnodes)
+            }
         }
-        assert_eq!(self.vnodes.len(), new_vnodes.len());
-        replace(&mut self.vnodes, new_vnodes)
     }
 
+    /// Get vnode bitmap if distributed, or a dummy [`Bitmap::singleton()`] if singleton.
     pub fn vnodes(&self) -> &Arc<Bitmap> {
-        &self.vnodes
+        static SINGLETON_VNODES: LazyLock<Arc<Bitmap>> =
+            LazyLock::new(|| Bitmap::singleton().into());
+
+        match &self.compute_vnode {
+            ComputeVnode::DistKeyIndices { vnodes, .. } => vnodes,
+            ComputeVnode::VnodeColumnIndex { vnodes, .. } => vnodes,
+            ComputeVnode::Singleton => &*SINGLETON_VNODES,
+        }
     }
 
     /// Get vnode value with given primary key.
@@ -140,11 +148,13 @@ impl TableDistribution {
         match &self.compute_vnode {
             ComputeVnode::Singleton => SINGLETON_VNODE,
             ComputeVnode::DistKeyIndices {
+                vnodes,
                 dist_key_in_pk_indices,
-            } => compute_vnode(pk, dist_key_in_pk_indices, &self.vnodes),
+            } => compute_vnode(pk, dist_key_in_pk_indices, vnodes),
             ComputeVnode::VnodeColumnIndex {
+                vnodes,
                 vnode_col_idx_in_pk,
-            } => get_vnode_from_row(pk, *vnode_col_idx_in_pk, &self.vnodes),
+            } => get_vnode_from_row(pk, *vnode_col_idx_in_pk, vnodes),
         }
     }
 
@@ -152,22 +162,20 @@ impl TableDistribution {
         match &self.compute_vnode {
             ComputeVnode::Singleton => Some(SINGLETON_VNODE),
             ComputeVnode::DistKeyIndices {
+                vnodes,
                 dist_key_in_pk_indices,
             } => dist_key_in_pk_indices
                 .iter()
                 .all(|&d| d < pk_prefix.len())
-                .then(|| compute_vnode(pk_prefix, dist_key_in_pk_indices, &self.vnodes)),
+                .then(|| compute_vnode(pk_prefix, dist_key_in_pk_indices, vnodes)),
             ComputeVnode::VnodeColumnIndex {
+                vnodes,
                 vnode_col_idx_in_pk,
             } => {
                 if *vnode_col_idx_in_pk >= pk_prefix.len() {
                     None
                 } else {
-                    Some(get_vnode_from_row(
-                        pk_prefix,
-                        *vnode_col_idx_in_pk,
-                        &self.vnodes,
-                    ))
+                    Some(get_vnode_from_row(pk_prefix, *vnode_col_idx_in_pk, vnodes))
                 }
             }
         }
@@ -204,6 +212,7 @@ impl TableDistribution {
                 vec![SINGLETON_VNODE; chunk.capacity()]
             }
             ComputeVnode::DistKeyIndices {
+                vnodes,
                 dist_key_in_pk_indices,
             } => {
                 let dist_key_indices = dist_key_in_pk_indices
@@ -217,13 +226,14 @@ impl TableDistribution {
                     .map(|(vnode, vis)| {
                         // Ignore the invisible rows.
                         if vis {
-                            check_vnode_is_set(vnode, &self.vnodes);
+                            check_vnode_is_set(vnode, vnodes);
                         }
                         vnode
                     })
                     .collect()
             }
             ComputeVnode::VnodeColumnIndex {
+                vnodes,
                 vnode_col_idx_in_pk,
             } => {
                 let array: &PrimitiveArray<i16> =
@@ -236,7 +246,7 @@ impl TableDistribution {
                         let vnode = VirtualNode::from_scalar(vnode);
                         if vis {
                             assert!(exist);
-                            check_vnode_is_set(vnode, &self.vnodes);
+                            check_vnode_is_set(vnode, vnodes);
                         }
                         vnode
                     })

--- a/src/common/src/hash/table_distribution.rs
+++ b/src/common/src/hash/table_distribution.rs
@@ -75,7 +75,7 @@ impl TableDistribution {
     ) -> Self {
         let compute_vnode = if let Some(vnode_col_idx_in_pk) = vnode_col_idx_in_pk {
             ComputeVnode::VnodeColumnIndex {
-                vnodes: vnodes.expect("vnodes must be `Some` as vnode column is set"),
+                vnodes: vnodes.unwrap_or_else(|| Bitmap::singleton().into()),
                 vnode_col_idx_in_pk,
             }
         } else if !dist_key_in_pk_indices.is_empty() {
@@ -139,7 +139,7 @@ impl TableDistribution {
         match &self.compute_vnode {
             ComputeVnode::DistKeyIndices { vnodes, .. } => vnodes,
             ComputeVnode::VnodeColumnIndex { vnodes, .. } => vnodes,
-            ComputeVnode::Singleton => &*SINGLETON_VNODES,
+            ComputeVnode::Singleton => &SINGLETON_VNODES,
         }
     }
 

--- a/src/common/src/util/scan_range.rs
+++ b/src/common/src/util/scan_range.rs
@@ -159,7 +159,7 @@ mod tests {
         let pk = vec![1, 3, 2];
         let dist_key_idx_in_pk =
             crate::catalog::get_dist_key_in_pk_indices(&dist_key, &pk).unwrap();
-        let dist = TableDistribution::all(dist_key_idx_in_pk);
+        let dist = TableDistribution::all(dist_key_idx_in_pk, VirtualNode::COUNT_FOR_TEST);
 
         let mut scan_range = ScanRange::full_table_scan();
         assert!(scan_range.try_compute_vnode(&dist).is_none());
@@ -185,7 +185,7 @@ mod tests {
         let pk = vec![1, 3, 2];
         let dist_key_idx_in_pk =
             crate::catalog::get_dist_key_in_pk_indices(&dist_key, &pk).unwrap();
-        let dist = TableDistribution::all(dist_key_idx_in_pk);
+        let dist = TableDistribution::all(dist_key_idx_in_pk, VirtualNode::COUNT_FOR_TEST);
 
         let mut scan_range = ScanRange::full_table_scan();
         assert!(scan_range.try_compute_vnode(&dist).is_none());

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -1250,7 +1250,8 @@ fn derive_partitions(
     }
 
     let table_distribution = TableDistribution::new_from_storage_table_desc(
-        Some(TableDistribution::all_vnodes()),
+        // TODO(var-vnode): use vnode count from table desc
+        Some(Bitmap::ones(VirtualNode::COUNT).into()),
         &table_desc.try_to_protobuf()?,
     );
 

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -24,7 +24,6 @@ use futures::{pin_mut, StreamExt};
 use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{TableId, TableOption};
-use risingwave_common::hash::table_distribution::TableDistribution;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::{test_epoch, EpochExt, MAX_EPOCH};
 use risingwave_hummock_sdk::key::{prefixed_range_with_vnode, TableKeyRange};
@@ -1565,7 +1564,7 @@ async fn test_iter_log() {
             },
             table_option: Default::default(),
             is_replicated: false,
-            vnodes: TableDistribution::all_vnodes(),
+            vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
         })
         .await;
 
@@ -1580,7 +1579,7 @@ async fn test_iter_log() {
             },
             table_option: Default::default(),
             is_replicated: false,
-            vnodes: TableDistribution::all_vnodes(),
+            vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
         })
         .await;
     // flush for about 10 times per epoch

--- a/src/storage/src/hummock/iterator/change_log.rs
+++ b/src/storage/src/hummock/iterator/change_log.rs
@@ -527,8 +527,9 @@ mod tests {
 
     use bytes::Bytes;
     use itertools::Itertools;
+    use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::TableId;
-    use risingwave_common::hash::table_distribution::TableDistribution;
+    use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_hummock_sdk::key::{TableKey, UserKey};
     use risingwave_hummock_sdk::EpochWithGap;
@@ -699,7 +700,7 @@ mod tests {
                 },
                 table_option: Default::default(),
                 is_replicated: false,
-                vnodes: TableDistribution::all_vnodes(),
+                vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
             })
             .await;
         let logs = gen_test_data(epoch_count, 10000, 0.05, 0.2);

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -27,7 +27,7 @@ use risingwave_common::util::value_encoding::BasicSerde;
 use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
 use risingwave_storage::hummock::HummockStorage;
 use risingwave_storage::store::PrefetchOptions;
-use risingwave_storage::table::DEFAULT_VNODE;
+use risingwave_storage::table::SINGLETON_VNODE;
 
 use crate::common::table::state_table::{
     ReplicatedStateTable, StateTable, WatermarkCacheStateTable,
@@ -445,7 +445,7 @@ async fn test_state_table_iter_with_pk_range() {
         std::ops::Bound::Included(OwnedRow::new(vec![Some(4_i32.into())])),
     );
     let iter = state_table
-        .iter_with_vnode(DEFAULT_VNODE, &pk_range, Default::default())
+        .iter_with_vnode(SINGLETON_VNODE, &pk_range, Default::default())
         .await
         .unwrap();
     pin_mut!(iter);
@@ -470,7 +470,7 @@ async fn test_state_table_iter_with_pk_range() {
         std::ops::Bound::<row::Empty>::Unbounded,
     );
     let iter = state_table
-        .iter_with_vnode(DEFAULT_VNODE, &pk_range, Default::default())
+        .iter_with_vnode(SINGLETON_VNODE, &pk_range, Default::default())
         .await
         .unwrap();
     pin_mut!(iter);
@@ -1976,11 +1976,11 @@ async fn test_replicated_state_table_replication() {
             std::ops::Bound::Included(OwnedRow::new(vec![Some(2_i32.into())])),
         );
         let iter = state_table
-            .iter_with_vnode(DEFAULT_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(DEFAULT_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(iter);
@@ -2039,7 +2039,7 @@ async fn test_replicated_state_table_replication() {
         );
 
         let iter = state_table
-            .iter_with_vnode(DEFAULT_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
 
@@ -2048,7 +2048,7 @@ async fn test_replicated_state_table_replication() {
             std::ops::Bound::Unbounded,
         );
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(DEFAULT_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(iter);
@@ -2079,7 +2079,7 @@ async fn test_replicated_state_table_replication() {
         let range_bounds: (Bound<OwnedRow>, Bound<OwnedRow>) =
             (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded);
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(DEFAULT_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(replicated_iter);

--- a/src/stream/src/from_proto/mview.rs
+++ b/src/stream/src/from_proto/mview.rs
@@ -100,7 +100,7 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
         let table = node.get_table()?;
 
         // FIXME: Lookup is now implemented without cell-based table API and relies on all vnodes
-        // being `DEFAULT_VNODE`, so we need to make the Arrange a singleton.
+        // being `SINGLETON_VNODE`, so we need to make the Arrange a singleton.
         let vnodes = params.vnode_bitmap.map(Arc::new);
         let conflict_behavior =
             ConflictBehavior::from_protobuf(&table.handle_pk_conflict_behavior());

--- a/src/stream/src/from_proto/watermark_filter.rs
+++ b/src/stream/src/from_proto/watermark_filter.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use risingwave_common::catalog::{ColumnId, TableDesc};
 use risingwave_expr::expr::build_non_strict_from_prost;
 use risingwave_pb::stream_plan::WatermarkFilterNode;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
-use risingwave_storage::table::TableDistribution;
 
 use super::*;
 use crate::common::table::state_table::StateTable;
@@ -57,8 +55,7 @@ impl ExecutorBuilder for WatermarkFilterBuilder {
             .iter()
             .map(|i| ColumnId::new(*i as _))
             .collect_vec();
-        let other_vnodes =
-            Arc::new((!(*vnodes).clone()) & TableDistribution::all_vnodes_ref().deref());
+        let other_vnodes = Arc::new(!(*vnodes).clone());
         let global_watermark_table =
             StorageTable::new_partial(store.clone(), column_ids, Some(other_vnodes), &desc);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This is a progress towards #15900.

Specifically in the upcoming PRs, we aim to decrease the direct references on `VirtualNode::COUNT` within the codebase. The total vnode count will be provided as a parameter in the refactored functions, although it will remain hardcoded as `VirtualNode::COUNT` at the call-site. Eventually, it will be made user-facing.

This PR refactors the `TableDistribution`. Logic changes are:

- Will use bitmaps with all high bits and of length 1 for singleton table. Note that it's not 256 any more.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
