### PR TITLE
feat: variable vnode count support in vnode structure

### DIFF
--- a/src/batch/src/task/consistent_hash_shuffle_channel.rs
+++ b/src/batch/src/task/consistent_hash_shuffle_channel.rs
@@ -59,6 +59,7 @@ fn generate_hash_values(
             .iter()
             .map(|idx| *idx as usize)
             .collect::<Vec<_>>(),
+        consistent_hash_info.vmap.len(),
     );
 
     let hash_values = vnodes

--- a/src/common/src/hash/consistent_hash/vnode.rs
+++ b/src/common/src/hash/consistent_hash/vnode.rs
@@ -30,26 +30,44 @@ use crate::util::row_id::extract_vnode_id_from_row_id;
 pub struct VirtualNode(VirtualNodeInner);
 
 /// The internal representation of a virtual node id.
+///
+/// Note: not all bits of the inner representation are used.
 type VirtualNodeInner = u16;
-static_assertions::const_assert!(VirtualNodeInner::BITS >= VirtualNode::BITS as u32);
 
-impl From<Crc32HashCode> for VirtualNode {
-    fn from(hash_code: Crc32HashCode) -> Self {
+/// `vnode_count` must be provided to convert a hash code to a virtual node.
+///
+/// Use [`Crc32HashCodeToVnodeExt::to_vnode`] instead.
+impl !From<Crc32HashCode> for VirtualNode {}
+
+#[easy_ext::ext(Crc32HashCodeToVnodeExt)]
+impl Crc32HashCode {
+    fn to_vnode(self, vnode_count: usize) -> VirtualNode {
         // Take the least significant bits of the hash code.
         // TODO: should we use the most significant bits?
-        let inner = (hash_code.value() % Self::COUNT as u64) as VirtualNodeInner;
+        let inner = (self.value() % vnode_count as u64) as VirtualNodeInner;
         VirtualNode(inner)
     }
 }
 
 impl VirtualNode {
-    /// The number of bits used to represent a virtual node.
-    ///
-    /// Note: Not all bits of the inner representation are used. One should rely on this constant
-    /// to determine the count of virtual nodes.
-    pub const BITS: usize = 8;
     /// The total count of virtual nodes.
-    pub const COUNT: usize = 1 << Self::BITS;
+    // TODO(var-vnode): remove this and only keep `COUNT_FOR_TEST`
+    pub const COUNT: usize = 1 << 8;
+    /// The maximum value of the virtual node.
+    // TODO(var-vnode): remove this and only keep `MAX_FOR_TEST`
+    pub const MAX: VirtualNode = VirtualNode::from_index(Self::COUNT - 1);
+}
+
+impl VirtualNode {
+    /// The total count of virtual nodes, for testing purposes.
+    pub const COUNT_FOR_TEST: usize = Self::COUNT;
+    /// The maximum value of the virtual node, for testing purposes.
+    pub const MAX_FOR_TEST: VirtualNode = Self::MAX;
+}
+
+impl VirtualNode {
+    /// The maximum count of virtual nodes that fits in [`VirtualNodeInner`].
+    pub const MAX_COUNT: usize = 1 << VirtualNodeInner::BITS;
     /// The size of a virtual node in bytes, in memory or serialized representation.
     pub const SIZE: usize = std::mem::size_of::<Self>();
 }
@@ -58,8 +76,6 @@ impl VirtualNode {
 pub type AllVirtualNodeIter = std::iter::Map<std::ops::Range<usize>, fn(usize) -> VirtualNode>;
 
 impl VirtualNode {
-    /// The maximum value of the virtual node.
-    pub const MAX: VirtualNode = VirtualNode::from_index(Self::COUNT - 1);
     /// We may use `VirtualNode` as a datum in a stream, or store it as a column.
     /// Hence this reifies it as a RW datatype.
     pub const RW_TYPE: DataType = DataType::Int16;
@@ -68,7 +84,7 @@ impl VirtualNode {
 
     /// Creates a virtual node from the `usize` index.
     pub const fn from_index(index: usize) -> Self {
-        debug_assert!(index < Self::COUNT);
+        debug_assert!(index < Self::MAX_COUNT);
         Self(index as _)
     }
 
@@ -79,7 +95,6 @@ impl VirtualNode {
 
     /// Creates a virtual node from the given scalar representation. Used by `VNODE` expression.
     pub const fn from_scalar(scalar: i16) -> Self {
-        debug_assert!((scalar as usize) < Self::COUNT);
         Self(scalar as _)
     }
 
@@ -99,7 +114,6 @@ impl VirtualNode {
     /// Creates a virtual node from the given big-endian bytes representation.
     pub const fn from_be_bytes(bytes: [u8; Self::SIZE]) -> Self {
         let inner = VirtualNodeInner::from_be_bytes(bytes);
-        debug_assert!((inner as usize) < Self::COUNT);
         Self(inner)
     }
 
@@ -109,14 +123,9 @@ impl VirtualNode {
     }
 
     /// Iterates over all virtual nodes.
-    pub fn all() -> AllVirtualNodeIter {
-        (0..Self::COUNT).map(Self::from_index)
+    pub fn all(vnode_count: usize) -> AllVirtualNodeIter {
+        (0..vnode_count).map(Self::from_index)
     }
-}
-
-impl VirtualNode {
-    pub const COUNT_FOR_TEST: usize = Self::COUNT;
-    pub const MAX_FOR_TEST: VirtualNode = Self::MAX;
 }
 
 impl VirtualNode {
@@ -124,7 +133,11 @@ impl VirtualNode {
     // chunk. When only one column is provided and its type is `Serial`, we consider the column to
     // be the one that contains RowId, and use a special method to skip the calculation of Hash
     // and directly extract the `VirtualNode` from `RowId`.
-    pub fn compute_chunk(data_chunk: &DataChunk, keys: &[usize]) -> Vec<VirtualNode> {
+    pub fn compute_chunk(
+        data_chunk: &DataChunk,
+        keys: &[usize],
+        vnode_count: usize,
+    ) -> Vec<VirtualNode> {
         if let Ok(idx) = keys.iter().exactly_one()
             && let ArrayImpl::Serial(serial_array) = &**data_chunk.column_at(*idx)
         {
@@ -140,7 +153,7 @@ impl VirtualNode {
                         // This process doesn’t guarantee the order of rows, producing indeterminate results in some cases,
                         // such as when `distinct on` is used without an `order by`.
                         let (row, _) = data_chunk.row_at(idx);
-                        row.hash(Crc32FastBuilder).into()
+                        row.hash(Crc32FastBuilder).to_vnode(vnode_count)
                     }
                 })
                 .collect();
@@ -149,19 +162,29 @@ impl VirtualNode {
         data_chunk
             .get_hash_values(keys, Crc32FastBuilder)
             .into_iter()
-            .map(|hash| hash.into())
+            .map(|hash| hash.to_vnode(vnode_count))
             .collect()
+    }
+
+    /// Equivalent to [`Self::compute_chunk`] with [`VirtualNode::COUNT_FOR_TEST`] as the vnode count.
+    pub fn compute_chunk_for_test(data_chunk: &DataChunk, keys: &[usize]) -> Vec<VirtualNode> {
+        Self::compute_chunk(data_chunk, keys, Self::COUNT_FOR_TEST)
     }
 
     // `compute_row` is used to calculate the `VirtualNode` for the corresponding columns in a
     // `Row`. Similar to `compute_chunk`, it also contains special handling for serial columns.
-    pub fn compute_row(row: impl Row, indices: &[usize]) -> VirtualNode {
+    pub fn compute_row(row: impl Row, indices: &[usize], vnode_count: usize) -> VirtualNode {
         let project = row.project(indices);
         if let Ok(Some(ScalarRefImpl::Serial(s))) = project.iter().exactly_one().as_ref() {
             return extract_vnode_id_from_row_id(s.as_row_id());
         }
 
-        project.hash(Crc32FastBuilder).into()
+        project.hash(Crc32FastBuilder).to_vnode(vnode_count)
+    }
+
+    /// Equivalent to [`Self::compute_row`] with [`VirtualNode::COUNT_FOR_TEST`] as the vnode count.
+    pub fn compute_row_for_test(row: impl Row, indices: &[usize]) -> VirtualNode {
+        Self::compute_row(row, indices, Self::COUNT_FOR_TEST)
     }
 }
 
@@ -184,7 +207,7 @@ mod tests {
         );
 
         let chunk = DataChunk::from_pretty(chunk.as_str());
-        let vnodes = VirtualNode::compute_chunk(&chunk, &[0]);
+        let vnodes = VirtualNode::compute_chunk_for_test(&chunk, &[0]);
 
         assert_eq!(
             vnodes.as_slice(),
@@ -200,7 +223,7 @@ mod tests {
             Some(ScalarImpl::Int64(12345)),
         ]);
 
-        let vnode = VirtualNode::compute_row(&row, &[0]);
+        let vnode = VirtualNode::compute_row_for_test(&row, &[0]);
 
         assert_eq!(vnode, VirtualNode::from_index(100));
     }
@@ -221,7 +244,7 @@ mod tests {
         );
 
         let chunk = DataChunk::from_pretty(chunk.as_str());
-        let vnodes = VirtualNode::compute_chunk(&chunk, &[0]);
+        let vnodes = VirtualNode::compute_chunk_for_test(&chunk, &[0]);
 
         assert_eq!(
             vnodes.as_slice(),

--- a/src/common/src/hash/consistent_hash/vnode.rs
+++ b/src/common/src/hash/consistent_hash/vnode.rs
@@ -31,7 +31,7 @@ pub struct VirtualNode(VirtualNodeInner);
 
 /// The internal representation of a virtual node id.
 ///
-/// Note: not all bits of the inner representation are used.
+/// Note: not all bits of the inner representation might be used.
 type VirtualNodeInner = u16;
 
 /// `vnode_count` must be provided to convert a hash code to a virtual node.
@@ -41,6 +41,7 @@ impl !From<Crc32HashCode> for VirtualNode {}
 
 #[easy_ext::ext(Crc32HashCodeToVnodeExt)]
 impl Crc32HashCode {
+    /// Converts the hash code to a virtual node, based on the given total count of vnodes.
     fn to_vnode(self, vnode_count: usize) -> VirtualNode {
         // Take the least significant bits of the hash code.
         // TODO: should we use the most significant bits?

--- a/src/common/src/hash/table_distribution.rs
+++ b/src/common/src/hash/table_distribution.rs
@@ -184,7 +184,7 @@ impl TableDistribution {
 /// Get vnode value with `indices` on the given `row`.
 pub fn compute_vnode(row: impl Row, indices: &[usize], vnodes: &Bitmap) -> VirtualNode {
     assert!(!indices.is_empty());
-    let vnode = VirtualNode::compute_row(&row, indices);
+    let vnode = VirtualNode::compute_row(&row, indices, vnodes.len());
     check_vnode_is_set(vnode, vnodes);
 
     tracing::debug!(target: "events::storage::storage_table", "compute vnode: {:?} key {:?} => {}", row, indices, vnode);
@@ -219,7 +219,7 @@ impl TableDistribution {
                     .map(|idx| pk_indices[*idx])
                     .collect_vec();
 
-                VirtualNode::compute_chunk(chunk, &dist_key_indices)
+                VirtualNode::compute_chunk(chunk, &dist_key_indices, vnodes.len())
                     .into_iter()
                     .zip_eq_fast(chunk.visibility().iter())
                     .map(|(vnode, vis)| {

--- a/src/common/src/util/row_id.rs
+++ b/src/common/src/util/row_id.rs
@@ -52,6 +52,7 @@ pub struct RowIdGenerator {
 
 pub type RowId = i64;
 
+// TODO(var-vnode): how should we handle this for different virtual node counts?
 #[inline]
 pub fn extract_vnode_id_from_row_id(id: RowId) -> VirtualNode {
     let vnode_id = ((id >> VNODE_ID_SHIFT_BITS) & (VNODE_ID_UPPER_BOUND as i64 - 1)) as u32;

--- a/src/common/src/util/scan_range.rs
+++ b/src/common/src/util/scan_range.rs
@@ -173,7 +173,7 @@ mod tests {
             Some(ScalarImpl::from(514)),
         ]);
 
-        let vnode = VirtualNode::compute_row(&row, &[0, 1]);
+        let vnode = VirtualNode::compute_row_for_test(&row, &[0, 1]);
 
         assert_eq!(scan_range.try_compute_vnode(&dist), Some(vnode));
     }
@@ -203,7 +203,7 @@ mod tests {
             Some(ScalarImpl::from(114514)),
         ]);
 
-        let vnode = VirtualNode::compute_row(&row, &[2, 1]);
+        let vnode = VirtualNode::compute_row_for_test(&row, &[2, 1]);
 
         assert_eq!(scan_range.try_compute_vnode(&dist), Some(vnode));
     }

--- a/src/common/src/vnode_mapping/vnode_placement.rs
+++ b/src/common/src/vnode_mapping/vnode_placement.rs
@@ -123,7 +123,7 @@ pub fn place_vnode(
         }
         None => {
             // No hint is provided, assign all vnodes to `temp_pu`.
-            for vnode in VirtualNode::all() {
+            for vnode in VirtualNode::all(VirtualNode::COUNT) {
                 temp_slot.balance += 1;
                 temp_slot.builder.set(vnode.to_index(), true);
             }

--- a/src/expr/impl/src/scalar/vnode.rs
+++ b/src/expr/impl/src/scalar/vnode.rs
@@ -43,7 +43,8 @@ impl Expression for VnodeExpression {
     }
 
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let vnodes = VirtualNode::compute_chunk(input, &self.dist_key_indices);
+        // TODO(var-vnode): get vnode count from context
+        let vnodes = VirtualNode::compute_chunk(input, &self.dist_key_indices, VirtualNode::COUNT);
         let mut builder = I16ArrayBuilder::new(input.capacity());
         vnodes
             .into_iter()
@@ -52,8 +53,9 @@ impl Expression for VnodeExpression {
     }
 
     async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
+        // TODO(var-vnode): get vnode count from context
         Ok(Some(
-            VirtualNode::compute_row(input, &self.dist_key_indices)
+            VirtualNode::compute_row(input, &self.dist_key_indices, VirtualNode::COUNT)
                 .to_scalar()
                 .into(),
         ))

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -1411,7 +1411,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
 
     use itertools::Itertools;
-    use risingwave_common::hash::ActorMapping;
+    use risingwave_common::hash::{ActorMapping, VirtualNode};
     use risingwave_common::util::iter_util::ZipEqDebug;
     use risingwave_common::util::stream_graph_visitor::visit_stream_node;
     use risingwave_meta_model_v2::actor::ActorStatus;
@@ -1497,8 +1497,11 @@ mod tests {
             })
             .collect();
 
-        let actor_bitmaps =
-            ActorMapping::new_uniform((0..actor_count).map(|i| i as _)).to_bitmaps();
+        let actor_bitmaps = ActorMapping::new_uniform(
+            (0..actor_count).map(|i| i as _),
+            VirtualNode::COUNT_FOR_TEST,
+        )
+        .to_bitmaps();
 
         let pb_actors = (0..actor_count)
             .map(|actor_id| {
@@ -1610,8 +1613,11 @@ mod tests {
             })
             .collect();
 
-        let mut actor_bitmaps =
-            ActorMapping::new_uniform((0..actor_count).map(|i| i as _)).to_bitmaps();
+        let mut actor_bitmaps = ActorMapping::new_uniform(
+            (0..actor_count).map(|i| i as _),
+            VirtualNode::COUNT_FOR_TEST,
+        )
+        .to_bitmaps();
 
         let actors = (0..actor_count)
             .map(|actor_id| {

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -25,7 +25,7 @@ use either::Either;
 use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
-use risingwave_common::hash::{ActorMapping, WorkerSlotId, WorkerSlotMapping};
+use risingwave_common::hash::{ActorMapping, VirtualNode, WorkerSlotId, WorkerSlotMapping};
 use risingwave_common::{bail, hash};
 use risingwave_pb::common::{ActorInfo, WorkerNode};
 use risingwave_pb::meta::table_fragments::fragment::{
@@ -235,7 +235,8 @@ impl Scheduler {
         assert_eq!(scheduled_worker_slots.len(), parallelism);
 
         // Build the default hash mapping uniformly.
-        let default_hash_mapping = WorkerSlotMapping::build_from_ids(&scheduled_worker_slots);
+        let default_hash_mapping =
+            WorkerSlotMapping::build_from_ids(&scheduled_worker_slots, VirtualNode::COUNT);
 
         let single_scheduled = schedule_units_for_slots(&slots, 1, streaming_job_id)?;
         let default_single_worker_id = single_scheduled.keys().exactly_one().cloned().unwrap();

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -764,8 +764,7 @@ mod tests {
     use std::time::Duration;
 
     use futures::{Stream, TryStreamExt};
-    use risingwave_common::hash;
-    use risingwave_common::hash::{ActorMapping, WorkerSlotId};
+    use risingwave_common::hash::{self, ActorMapping, VirtualNode, WorkerSlotId};
     use risingwave_common::system_param::reader::SystemParamsRead;
     use risingwave_pb::common::{HostAddress, WorkerType};
     use risingwave_pb::meta::add_worker_node_request::Property;
@@ -1137,12 +1136,14 @@ mod tests {
     }
 
     fn make_mview_stream_actors(table_id: &TableId, count: usize) -> Vec<StreamActor> {
-        let mut actor_bitmaps: HashMap<_, _> =
-            ActorMapping::new_uniform((0..count).map(|i| i as hash::ActorId))
-                .to_bitmaps()
-                .into_iter()
-                .map(|(actor_id, bitmap)| (actor_id, bitmap.to_protobuf()))
-                .collect();
+        let mut actor_bitmaps: HashMap<_, _> = ActorMapping::new_uniform(
+            (0..count).map(|i| i as hash::ActorId),
+            VirtualNode::COUNT_FOR_TEST,
+        )
+        .to_bitmaps()
+        .into_iter()
+        .map(|(actor_id, bitmap)| (actor_id, bitmap.to_protobuf()))
+        .collect();
 
         (0..count)
             .map(|i| StreamActor {

--- a/src/stream/src/common/log_store_impl/kv_log_store/test_utils.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/test_utils.rs
@@ -143,7 +143,7 @@ pub(crate) fn gen_multi_vnode_stream_chunks<const MOD_COUNT: usize>(
         .collect_vec();
     let (ops, rows) = gen_sized_test_data(base, max_count);
     for (op, row) in zip_eq(ops, rows) {
-        let vnode = VirtualNode::compute_row(&row, &[TEST_SCHEMA_DIST_KEY_INDEX]);
+        let vnode = VirtualNode::compute_row_for_test(&row, &[TEST_SCHEMA_DIST_KEY_INDEX]);
         let (ops, builder) = &mut data_builder[vnode.to_index() % MOD_COUNT];
         ops.push(op);
         assert!(builder.append_one_row(row).is_none());
@@ -177,9 +177,9 @@ pub(crate) fn gen_test_log_store_table(pk_info: &'static KvLogStorePkInfo) -> Pb
 pub(crate) fn calculate_vnode_bitmap<'a>(
     test_data: impl Iterator<Item = (Op, RowRef<'a>)>,
 ) -> Bitmap {
-    let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT);
-    for vnode in
-        test_data.map(|(_, row)| VirtualNode::compute_row(row, &[TEST_SCHEMA_DIST_KEY_INDEX]))
+    let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+    for vnode in test_data
+        .map(|(_, row)| VirtualNode::compute_row_for_test(row, &[TEST_SCHEMA_DIST_KEY_INDEX]))
     {
         builder.set(vnode.to_index(), true);
     }

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -755,7 +755,8 @@ impl Dispatcher for HashDataDispatcher {
         let num_outputs = self.outputs.len();
 
         // get hash value of every line by its key
-        let vnodes = VirtualNode::compute_chunk(chunk.data_chunk(), &self.keys);
+        let vnode_count = self.hash_mapping.len();
+        let vnodes = VirtualNode::compute_chunk(chunk.data_chunk(), &self.keys, vnode_count);
 
         tracing::debug!(target: "events::stream::dispatch::hash", "\n{}\n keys {:?} => {:?}", chunk.to_pretty(), self.keys, vnodes);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This is a progress towards #15900.

This PR refactors the `VirtualNode` and `VnodeMapping`. Logic changes are:

- Derive vnode count from the input (like the length of a vnode mapping or bitmap), instead of using `VirtualNode::COUNT`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
