### PR TITLE
feat(sink): reimplement sink coordinator worker and support scale

### DIFF
--- a/proto/connector_service.proto
+++ b/proto/connector_service.proto
@@ -229,9 +229,15 @@ message CoordinateRequest {
     SinkMetadata metadata = 2;
   }
 
+  message UpdateVnodeBitmapRequest {
+    common.Buffer vnode_bitmap = 1;
+  }
+
   oneof msg {
     StartCoordinationRequest start_request = 1;
     CommitRequest commit_request = 2;
+    UpdateVnodeBitmapRequest update_vnode_request = 3;
+    bool stop = 4;
   }
 }
 

--- a/src/connector/src/sink/decouple_checkpoint_log_sink.rs
+++ b/src/connector/src/sink/decouple_checkpoint_log_sink.rs
@@ -65,7 +65,7 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSink
             EpochBegun { curr_epoch: u64 },
 
             /// Mark that the consumer has just received a barrier
-            BarrierReceived { prev_epoch: u64 },
+            BarrierReceived { prev_epoch: u64, committed: bool },
         }
 
         let mut state = LogConsumerState::Uninitialized;
@@ -75,15 +75,34 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSink
 
         loop {
             let (epoch, item): (u64, LogStoreReadItem) = log_reader.next_item().await?;
-            if let LogStoreReadItem::UpdateVnodeBitmap(_) = &item {
-                match &state {
-                    LogConsumerState::BarrierReceived { .. } => {}
+            if let LogStoreReadItem::UpdateVnodeBitmap(vnode_bitmap) = &item {
+                match &mut state {
+                    LogConsumerState::BarrierReceived {
+                        committed,
+                        prev_epoch,
+                    } => {
+                        if !*committed {
+                            // force commit on update vnode bitmap
+                            let start_time = Instant::now();
+                            sink_writer.barrier(true).await?;
+                            sink_metrics
+                                .sink_commit_duration_metrics
+                                .observe(start_time.elapsed().as_millis() as f64);
+                            log_reader.truncate(TruncateOffset::Barrier { epoch: *prev_epoch })?;
+                            current_checkpoint = 0;
+                            *committed = true;
+                        }
+                        sink_writer
+                            .update_vnode_bitmap(vnode_bitmap.clone())
+                            .await?;
+                    }
                     _ => unreachable!(
                         "update vnode bitmap can be accepted only right after \
                     barrier, but current state is {:?}",
                         state
                     ),
                 }
+                continue;
             }
             // begin_epoch when not previously began
             state = match state {
@@ -100,7 +119,7 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSink
                     );
                     LogConsumerState::EpochBegun { curr_epoch: epoch }
                 }
-                LogConsumerState::BarrierReceived { prev_epoch } => {
+                LogConsumerState::BarrierReceived { prev_epoch, .. } => {
                     assert!(
                         epoch > prev_epoch,
                         "new epoch {} should be greater than prev epoch {}",
@@ -123,7 +142,7 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSink
                         LogConsumerState::EpochBegun { curr_epoch } => curr_epoch,
                         _ => unreachable!("epoch must have begun before handling barrier"),
                     };
-                    if is_checkpoint {
+                    let committed = if is_checkpoint {
                         current_checkpoint += 1;
                         if current_checkpoint >= commit_checkpoint_interval.get() {
                             let start_time = Instant::now();
@@ -133,16 +152,22 @@ impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSink
                                 .observe(start_time.elapsed().as_millis() as f64);
                             log_reader.truncate(TruncateOffset::Barrier { epoch })?;
                             current_checkpoint = 0;
+                            true
                         } else {
                             sink_writer.barrier(false).await?;
+                            false
                         }
                     } else {
                         sink_writer.barrier(false).await?;
+                        false
+                    };
+                    state = LogConsumerState::BarrierReceived {
+                        prev_epoch,
+                        committed,
                     }
-                    state = LogConsumerState::BarrierReceived { prev_epoch }
                 }
-                LogStoreReadItem::UpdateVnodeBitmap(vnode_bitmap) => {
-                    sink_writer.update_vnode_bitmap(vnode_bitmap).await?;
+                LogStoreReadItem::UpdateVnodeBitmap(_) => {
+                    unreachable!("should have been handle earlier")
                 }
             }
         }

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -12,64 +12,191 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::future::{poll_fn, Future};
 use std::pin::pin;
+use std::task::Poll;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use futures::future::{select, Either};
-use futures::stream::FuturesUnordered;
-use futures::{StreamExt, TryStreamExt};
+use futures::pin_mut;
+use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
-use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
+use risingwave_common::hash::VirtualNode;
 use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::{build_sink, Sink, SinkCommitCoordinator, SinkParam};
-use risingwave_pb::connector_service::coordinate_request::CommitRequest;
-use risingwave_pb::connector_service::coordinate_response::{
-    CommitResponse, StartCoordinationResponse,
-};
-use risingwave_pb::connector_service::{
-    coordinate_request, coordinate_response, CoordinateRequest, CoordinateResponse, SinkMetadata,
-};
+use risingwave_pb::connector_service::SinkMetadata;
 use thiserror_ext::AsReport;
+use tokio::select;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::time::sleep;
 use tonic::Status;
 use tracing::{error, warn};
 
-use crate::manager::sink_coordination::{
-    NewSinkWriterRequest, SinkCoordinatorResponseSender, SinkWriterRequestStream,
-};
+use crate::manager::sink_coordination::handle::SinkWriterCoordinationHandle;
 
-macro_rules! send_await_with_err_check {
-    ($tx:expr, $msg:expr) => {
-        if $tx.send($msg).await.is_err() {
-            error!("unable to send msg");
+async fn run_future_with_periodic_fn<F: Future>(
+    future: F,
+    interval: Duration,
+    mut f: impl FnMut(),
+) -> F::Output {
+    pin_mut!(future);
+    loop {
+        match select(&mut future, pin!(sleep(interval))).await {
+            Either::Left((output, _)) => {
+                break output;
+            }
+            Either::Right(_) => f(),
         }
-    };
+    }
+}
+
+struct EpochCommitRequests {
+    epoch: u64,
+    metadatas: Vec<SinkMetadata>,
+    handle_ids: HashSet<usize>,
+    bitmap: Bitmap,
+}
+
+impl EpochCommitRequests {
+    fn new(epoch: u64) -> Self {
+        Self {
+            epoch,
+            metadatas: vec![],
+            handle_ids: Default::default(),
+            bitmap: Bitmap::zeros(VirtualNode::COUNT),
+        }
+    }
+
+    fn add_new_request(
+        &mut self,
+        handle_id: usize,
+        metadata: SinkMetadata,
+        vnode_bitmap: Bitmap,
+    ) -> anyhow::Result<()> {
+        self.metadatas.push(metadata);
+        assert!(self.handle_ids.insert(handle_id));
+        let check_bitmap = (&self.bitmap) & &vnode_bitmap;
+        if check_bitmap.count_ones() > 0 {
+            return Err(anyhow!(
+                "duplicate vnode {:?} on epoch {}. request vnode: {:?}, prev vnode: {:?}",
+                check_bitmap.iter_ones().collect_vec(),
+                self.epoch,
+                vnode_bitmap,
+                self.bitmap
+            ));
+        }
+        self.bitmap |= &vnode_bitmap;
+        Ok(())
+    }
+
+    fn can_commit(&self) -> bool {
+        self.bitmap.count_ones() == VirtualNode::COUNT
+    }
+}
+
+struct CoordinationHandleManager {
+    param: SinkParam,
+    writer_handles: HashMap<usize, SinkWriterCoordinationHandle>,
+    next_handle_id: usize,
+    request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
+}
+
+impl CoordinationHandleManager {
+    fn ack_commit(
+        &mut self,
+        epoch: u64,
+        handle_ids: impl IntoIterator<Item = usize>,
+    ) -> anyhow::Result<()> {
+        for handle_id in handle_ids {
+            let handle = self.writer_handles.get_mut(&handle_id).ok_or_else(|| {
+                anyhow!(
+                    "fail to find handle for {} when ack commit on epoch {}",
+                    handle_id,
+                    epoch
+                )
+            })?;
+            handle.ack_commit(epoch).map_err(|_| {
+                anyhow!(
+                    "fail to ack commit on epoch {} for handle {}",
+                    epoch,
+                    handle_id
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    async fn next_commit_request_inner(
+        writer_handles: &mut HashMap<usize, SinkWriterCoordinationHandle>,
+    ) -> anyhow::Result<(usize, Bitmap, u64, SinkMetadata)> {
+        poll_fn(|cx| 'outer: loop {
+            for (handle_id, handle) in writer_handles.iter_mut() {
+                if let Poll::Ready(result) = handle.poll_next_commit_request(cx) {
+                    match result {
+                        Ok(Some((epoch, metadata))) => {
+                            return Poll::Ready(Ok((
+                                *handle_id,
+                                handle.vnode_bitmap().clone(),
+                                epoch,
+                                metadata,
+                            )));
+                        }
+                        Ok(None) => {
+                            let handle_id = *handle_id;
+                            writer_handles.remove(&handle_id);
+                            continue 'outer;
+                        }
+                        Err(e) => {
+                            return Poll::Ready(Err(e));
+                        }
+                    }
+                }
+            }
+            return Poll::Pending;
+        })
+        .await
+    }
+
+    async fn next_commit_request(&mut self) -> anyhow::Result<(usize, Bitmap, u64, SinkMetadata)> {
+        loop {
+            select! {
+                handle = self.request_rx.recv() => {
+                    let mut handle = handle.ok_or_else(|| anyhow!("end of writer request stream"))?;
+                    if handle.param() != &self.param {
+                        warn!(prev_param = ?self.param, new_param = ?handle.param(), "sink param mismatch");
+                    }
+                    handle.start()?;
+                    let handle_id = self.next_handle_id;
+                    self.next_handle_id += 1;
+                    self.writer_handles.insert(handle_id, handle);
+                }
+                result = Self::next_commit_request_inner(&mut self.writer_handles) => {
+                    break result;
+                }
+            }
+        }
+    }
 }
 
 pub struct CoordinatorWorker {
-    param: SinkParam,
-    request_streams: Vec<SinkWriterRequestStream>,
-    response_senders: Vec<SinkCoordinatorResponseSender>,
-    request_rx: UnboundedReceiver<NewSinkWriterRequest>,
+    handle_manager: CoordinationHandleManager,
+    pending_epochs: BTreeMap<u64, EpochCommitRequests>,
 }
 
 impl CoordinatorWorker {
     pub async fn run(
-        first_writer_request: NewSinkWriterRequest,
-        request_rx: UnboundedReceiver<NewSinkWriterRequest>,
+        param: SinkParam,
+        request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
     ) {
-        let sink = match build_sink(first_writer_request.param.clone()) {
+        let sink = match build_sink(param.clone()) {
             Ok(sink) => sink,
             Err(e) => {
                 error!(
                     error = %e.as_report(),
                     "unable to build sink with param {:?}",
-                    first_writer_request.param
-                );
-                send_await_with_err_check!(
-                    first_writer_request.response_tx,
-                    Err(Status::invalid_argument("failed to build sink"))
+                    param
                 );
                 return;
             }
@@ -81,247 +208,76 @@ impl CoordinatorWorker {
                     error!(
                         error = %e.as_report(),
                         "unable to build coordinator with param {:?}",
-                        first_writer_request.param
-                    );
-                    send_await_with_err_check!(
-                        first_writer_request.response_tx,
-                        Err(Status::invalid_argument("failed to build coordinator"))
+                        param
                     );
                     return;
                 }
             };
-            Self::execute_coordinator(first_writer_request, request_rx, coordinator).await
+            Self::execute_coordinator(param, request_rx, coordinator).await
         });
     }
 
     pub async fn execute_coordinator(
-        first_writer_request: NewSinkWriterRequest,
-        request_rx: UnboundedReceiver<NewSinkWriterRequest>,
+        param: SinkParam,
+        request_rx: UnboundedReceiver<SinkWriterCoordinationHandle>,
         coordinator: impl SinkCommitCoordinator,
     ) {
         let mut worker = CoordinatorWorker {
-            param: first_writer_request.param,
-            request_streams: vec![first_writer_request.request_stream],
-            response_senders: vec![first_writer_request.response_tx],
-            request_rx,
+            handle_manager: CoordinationHandleManager {
+                param,
+                writer_handles: HashMap::new(),
+                next_handle_id: 0,
+                request_rx,
+            },
+            pending_epochs: Default::default(),
         };
 
-        if let Err(e) = worker
-            .wait_for_writers(first_writer_request.vnode_bitmap)
-            .await
-        {
-            error!(error = %e.as_report(), "failed to wait for all writers");
-            worker
-                .send_to_all_sink_writers(|| {
-                    Err(Status::cancelled("failed to wait for all writers"))
-                })
-                .await;
-        }
-
-        worker.start_coordination(coordinator).await;
-    }
-
-    async fn send_to_all_sink_writers(
-        &mut self,
-        new_msg: impl Fn() -> Result<CoordinateResponse, Status>,
-    ) {
-        for sender in &self.response_senders {
-            send_await_with_err_check!(sender, new_msg());
-        }
-    }
-
-    async fn next_new_writer(&mut self) -> anyhow::Result<NewSinkWriterRequest> {
-        // TODO: add timeout log
-        match select(
-            pin!(self.request_rx.recv()),
-            pin!(FuturesUnordered::from_iter(
-                self.request_streams
-                    .iter_mut()
-                    .map(|stream| stream.try_next()),
-            )
-            .next()),
-        )
-        .await
-        {
-            Either::Left((Some(req), _)) => Ok(req),
-            Either::Left((None, _)) => Err(anyhow!("manager request stream reaches the end")),
-            Either::Right((Some(Ok(Some(request))), _)) => Err(anyhow!(
-                "get new request from sink writer before initialize: {:?}",
-                request
-            )),
-            Either::Right((Some(Ok(None)), _)) => Err(anyhow!(
-                "one sink writer stream reaches the end before initialize"
-            )),
-            Either::Right((Some(Err(e)), _)) => {
-                Err(anyhow!(e).context("unable to poll one sink writer stream"))
-            }
-            Either::Right((None, _)) => unreachable!("request_streams must not be empty"),
-        }
-    }
-
-    async fn wait_for_writers(&mut self, first_vnode_bitmap: Bitmap) -> anyhow::Result<()> {
-        let mut remaining_count = VirtualNode::COUNT;
-        let mut registered_vnode = HashSet::with_capacity(VirtualNode::COUNT);
-
-        for vnode in first_vnode_bitmap.iter_vnodes() {
-            remaining_count -= 1;
-            registered_vnode.insert(vnode);
-        }
-
-        while remaining_count > 0 {
-            let new_writer_request = self.next_new_writer().await?;
-            if self.param != new_writer_request.param {
-                // TODO: may return error.
-                warn!(
-                    "get different param {:?} while current param {:?}",
-                    new_writer_request.param, self.param
-                );
-            }
-            self.request_streams.push(new_writer_request.request_stream);
-            self.response_senders.push(new_writer_request.response_tx);
-
-            for vnode in new_writer_request.vnode_bitmap.iter_vnodes() {
-                if registered_vnode.contains(&vnode) {
-                    return Err(anyhow!(
-                        "get overlapped vnode: {}, current vnode {:?}",
-                        vnode,
-                        registered_vnode
-                    ));
-                }
-                registered_vnode.insert(vnode);
-                remaining_count -= 1;
-            }
-        }
-
-        self.send_to_all_sink_writers(|| {
-            Ok(CoordinateResponse {
-                msg: Some(coordinate_response::Msg::StartResponse(
-                    StartCoordinationResponse {},
-                )),
-            })
-        })
-        .await;
-        Ok(())
-    }
-
-    async fn collect_all_metadata(&mut self) -> anyhow::Result<(u64, Vec<SinkMetadata>)> {
-        let mut epoch = None;
-        let mut metadata_list = Vec::with_capacity(self.request_streams.len());
-        let mut uncollected_futures = FuturesUnordered::from_iter(
-            self.request_streams
-                .iter_mut()
-                .map(|stream| stream.try_next()),
-        );
-
-        loop {
-            match select(
-                pin!(self.request_rx.recv()),
-                pin!(uncollected_futures.next()),
-            )
-            .await
-            {
-                Either::Left((Some(new_request), _)) => {
-                    warn!("get new writer request while collecting metadata");
-                    send_await_with_err_check!(
-                        new_request.response_tx,
-                        Err(Status::already_exists(
-                            "coordinator already running, should not get new request"
-                        ))
-                    );
-                    continue;
-                }
-                Either::Left((None, _)) => {
-                    return Err(anyhow!(
-                        "coordinator get notified to stop while collecting metadata"
-                    ));
-                }
-                Either::Right((Some(next_result), _)) => match next_result {
-                    Ok(Some(CoordinateRequest {
-                        msg:
-                            Some(coordinate_request::Msg::CommitRequest(CommitRequest {
-                                epoch: request_epoch,
-                                metadata: Some(metadata),
-                            })),
-                    })) => {
-                        match &epoch {
-                            Some(epoch) => {
-                                if *epoch != request_epoch {
-                                    warn!(
-                                        "current epoch is {} but get request from {}",
-                                        epoch, request_epoch
-                                    );
-                                }
-                            }
-                            None => {
-                                epoch = Some(request_epoch);
-                            }
-                        }
-                        metadata_list.push(metadata);
-                    }
-                    Ok(Some(req)) => {
-                        return Err(anyhow!("expect commit request but get {:?}", req));
-                    }
-                    Ok(None) => {
-                        return Err(anyhow!(
-                            "sink writer input reaches the end while collecting metadata"
-                        ));
-                    }
-                    Err(e) => {
-                        return Err(
-                            anyhow!(e).context("failed to poll one of the writer request streams")
-                        );
-                    }
-                },
-                Either::Right((None, _)) => {
-                    break;
-                }
-            }
-        }
-        Ok((
-            epoch.expect("should not be empty when have at least one writer"),
-            metadata_list,
-        ))
-    }
-
-    async fn start_coordination(&mut self, mut coordinator: impl SinkCommitCoordinator) {
-        let result: Result<(), String> = try {
-            coordinator.init().await.map_err(|e| {
-                error!(error = %e.as_report(), "failed to initialize coordinator");
-                format!("failed to initialize coordinator: {:?}", e.as_report())
-            })?;
-            loop {
-                let (epoch, metadata_list) = self.collect_all_metadata().await.map_err(|e| {
-                    error!(error = %e.as_report(), "failed to collect all metadata");
-                    format!("failed to collect all metadata: {:?}", e.as_report())
-                })?;
-                // TODO: measure commit time
-                coordinator
-                    .commit(epoch, metadata_list)
-                    .await
-                    .map_err(|e| {
-                        error!(epoch, error = %e.as_report(), "failed to commit metadata of epoch");
-                        format!("failed to commit: {:?}", e.as_report())
-                    })?;
-
-                self.send_to_all_sink_writers(|| {
-                    Ok(CoordinateResponse {
-                        msg: Some(coordinate_response::Msg::CommitResponse(CommitResponse {
-                            epoch,
-                        })),
-                    })
-                })
-                .await;
-            }
-        };
-
-        if let Err(err_str) = result {
-            self.send_to_all_sink_writers(|| {
-                Err(Status::aborted(format!(
-                    "failed to run coordination: {}",
-                    err_str
+        if let Err(e) = worker.run_coordination(coordinator).await {
+            for handle in worker.handle_manager.writer_handles.into_values() {
+                handle.abort(Status::internal(format!(
+                    "failed to run coordination: {:?}",
+                    e.as_report()
                 )))
-            })
-            .await;
+            }
+        }
+    }
+
+    async fn run_coordination(
+        &mut self,
+        mut coordinator: impl SinkCommitCoordinator,
+    ) -> anyhow::Result<()> {
+        loop {
+            let (handle_id, vnode_bitmap, epoch, metadata) =
+                self.handle_manager.next_commit_request().await?;
+            self.pending_epochs
+                .entry(epoch)
+                .or_insert_with(|| EpochCommitRequests::new(epoch))
+                .add_new_request(handle_id, metadata, vnode_bitmap)?;
+            if self
+                .pending_epochs
+                .first_key_value()
+                .expect("non-empty")
+                .1
+                .can_commit()
+            {
+                let (epoch, requests) = self.pending_epochs.pop_first().expect("non-empty");
+                // TODO: measure commit time
+                let start_time = Instant::now();
+                run_future_with_periodic_fn(
+                    coordinator.commit(epoch, requests.metadatas),
+                    Duration::from_secs(5),
+                    || {
+                        warn!(
+                            elapsed = ?start_time.elapsed(),
+                            sink_id = self.handle_manager.param.sink_id.sink_id,
+                            "committing"
+                        );
+                    },
+                )
+                .await
+                .map_err(|e| anyhow!(e))?;
+                self.handle_manager.ack_commit(epoch, requests.handle_ids)?;
+            }
         }
     }
 }

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -246,6 +246,7 @@ impl CoordinatorWorker {
         &mut self,
         mut coordinator: impl SinkCommitCoordinator,
     ) -> anyhow::Result<()> {
+        coordinator.init().await?;
         loop {
             let (handle_id, vnode_bitmap, epoch, metadata) =
                 self.handle_manager.next_commit_request().await?;

--- a/src/meta/src/manager/sink_coordination/handle.rs
+++ b/src/meta/src/manager/sink_coordination/handle.rs
@@ -1,0 +1,139 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::pin;
+use std::task::{Context, Poll};
+
+use anyhow::anyhow;
+use futures::{Future, TryStreamExt};
+use risingwave_common::bitmap::Bitmap;
+use risingwave_connector::sink::SinkParam;
+use risingwave_pb::connector_service::coordinate_response::{
+    CommitResponse, StartCoordinationResponse,
+};
+use risingwave_pb::connector_service::{
+    coordinate_request, coordinate_response, CoordinateResponse, SinkMetadata,
+};
+use tonic::Status;
+
+use crate::manager::sink_coordination::{SinkCoordinatorResponseSender, SinkWriterRequestStream};
+
+pub(super) struct SinkWriterCoordinationHandle {
+    request_stream: SinkWriterRequestStream,
+    response_tx: SinkCoordinatorResponseSender,
+    param: SinkParam,
+    vnode_bitmap: Bitmap,
+    prev_epoch: Option<u64>,
+}
+
+impl SinkWriterCoordinationHandle {
+    pub(super) fn new(
+        request_stream: SinkWriterRequestStream,
+        response_tx: SinkCoordinatorResponseSender,
+        param: SinkParam,
+        vnode_bitmap: Bitmap,
+    ) -> Self {
+        Self {
+            request_stream,
+            response_tx,
+            param,
+            vnode_bitmap,
+            prev_epoch: None,
+        }
+    }
+
+    pub(super) fn param(&self) -> &SinkParam {
+        &self.param
+    }
+
+    pub(super) fn vnode_bitmap(&self) -> &Bitmap {
+        &self.vnode_bitmap
+    }
+
+    pub(super) fn start(&mut self) -> anyhow::Result<()> {
+        self.response_tx
+            .send(Ok(CoordinateResponse {
+                msg: Some(coordinate_response::Msg::StartResponse(
+                    StartCoordinationResponse {},
+                )),
+            }))
+            .map_err(|_| anyhow!("fail to send start response"))
+    }
+
+    pub(super) fn abort(self, status: Status) {
+        let _ = self.response_tx.send(Err(status));
+    }
+
+    pub(super) fn ack_commit(&mut self, epoch: u64) -> anyhow::Result<()> {
+        self.response_tx
+            .send(Ok(CoordinateResponse {
+                msg: Some(coordinate_response::Msg::CommitResponse(CommitResponse {
+                    epoch,
+                })),
+            }))
+            .map_err(|_| anyhow!("fail to send commit response of epoch {}", epoch))
+    }
+
+    pub(super) fn poll_next_commit_request(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<anyhow::Result<Option<(u64, SinkMetadata)>>> {
+        let future = self.next_commit_request();
+        let future = pin!(future);
+        future.poll(cx)
+    }
+
+    async fn next_commit_request(&mut self) -> anyhow::Result<Option<(u64, SinkMetadata)>> {
+        loop {
+            let request = self
+                .request_stream
+                .try_next()
+                .await?
+                .ok_or_else(|| anyhow!("end of request stream"))?;
+            match request.msg.ok_or_else(|| anyhow!("None msg in request"))? {
+                coordinate_request::Msg::StartRequest(_) => {
+                    return Err(anyhow!("should have started"));
+                }
+                coordinate_request::Msg::CommitRequest(request) => {
+                    if let Some(prev_epoch) = self.prev_epoch {
+                        if request.epoch < prev_epoch {
+                            return Err(anyhow!(
+                                "invalid commit epoch {}, prev_epoch {}",
+                                request.epoch,
+                                prev_epoch
+                            ));
+                        }
+                    }
+                    let Some(metadata) = request.metadata else {
+                        return Err(anyhow!("empty commit metadata"));
+                    };
+                    self.prev_epoch = Some(request.epoch);
+                    return Ok(Some((request.epoch, metadata)));
+                }
+                coordinate_request::Msg::UpdateVnodeRequest(request) => {
+                    let bitmap = Bitmap::from(
+                        &request
+                            .vnode_bitmap
+                            .ok_or_else(|| anyhow!("empty vnode bitmap"))?,
+                    );
+                    self.vnode_bitmap = bitmap;
+                    continue;
+                }
+                coordinate_request::Msg::Stop(_) => {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+}

--- a/src/meta/src/manager/sink_coordination/mod.rs
+++ b/src/meta/src/manager/sink_coordination/mod.rs
@@ -13,22 +13,14 @@
 // limitations under the License.
 
 mod coordinator_worker;
+mod handle;
 mod manager;
 
 use futures::stream::BoxStream;
 pub use manager::SinkCoordinatorManager;
-use risingwave_common::bitmap::Bitmap;
-use risingwave_connector::sink::SinkParam;
 use risingwave_pb::connector_service::{CoordinateRequest, CoordinateResponse};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 use tonic::Status;
 
 pub type SinkWriterRequestStream = BoxStream<'static, Result<CoordinateRequest, Status>>;
-pub type SinkCoordinatorResponseSender = Sender<Result<CoordinateResponse, Status>>;
-
-pub struct NewSinkWriterRequest {
-    pub request_stream: SinkWriterRequestStream,
-    pub response_tx: SinkCoordinatorResponseSender,
-    pub param: SinkParam,
-    pub vnode_bitmap: Bitmap,
-}
+pub type SinkCoordinatorResponseSender = UnboundedSender<Result<CoordinateResponse, Status>>;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Our sink coordinator worker determine whether all sink metadata of an epoch are collected by checking if all vnodes are collected. The coordinator worker handles epochs one by one. When receiving a commit request from one parallelism, it will blocking await on the commit request from all other parallelisms, and then commit all, and then wait for the next epoch. In the current implementation there won't be concurrent epoch. 

The current implementation works in normal case, but doesn't work in the case of scale out, because when scale out happens, the newly created parallelism may send a commit request of a later epoch before the existing parallelisms finish a previous epoch, and there may exist more than one epoch in this case. The current implementation will report an error when such case happens, and the scale out is actually achieved by triggering a log store rewind with such error.

In this PR, we reimplement the sink coordinator worker and support concurrent epochs by introducing an epoch queue. We add variant `update_vnode_bitmap` and `stop` in the sink coordination request so that each sink parallelism can send the relevant information to the coordinator worker.

We also change to force a commit on update vnode bitmap for sinks that decouple commit with checkpoint barrier.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
