### PR TITLE
fix(source): parse protobuf into expected struct/array (#18419) and its pre-req #18380

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9096,9 +9096,12 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a6a9143ae25c25fa7b6a48d6cc08b10785372060009c25140a4e7c340e95af"
 dependencies = [
+ "base64 0.22.0",
  "once_cell",
  "prost 0.13.1",
  "prost-types 0.13.1",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]

--- a/e2e_test/source_inline/kafka/protobuf/recover.slt
+++ b/e2e_test/source_inline/kafka/protobuf/recover.slt
@@ -1,0 +1,97 @@
+control substitution on
+
+system ok
+rpk topic create 'test-pb-struct'
+
+
+system ok
+jq -sR '{"schema":.,"schemaType":"PROTOBUF"}' << EOF | curl -X POST -H 'content-type: application/json' -d @- "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/test-pb-struct-value/versions"
+syntax = "proto3";
+package test;
+message User {
+  int32 id = 1;
+  Name name = 2;
+}
+message Name {
+  string first_name = 1;
+  string last_name = 2;
+}
+EOF
+
+
+# create a source with v1 schema
+statement ok
+create source s with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test-pb-struct')
+format plain encode protobuf (
+  schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}',
+  message = 'test.User');
+
+
+# register a v2 schema
+system ok
+jq -sR '{"schema":.,"schemaType":"PROTOBUF"}' << EOF | curl -X POST -H 'content-type: application/json' -d @- "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/test-pb-struct-value/versions"
+syntax = "proto3";
+package test;
+message User {
+  int32 id = 1;
+  Name name = 2;
+}
+message Name {
+  string first_name = 1;
+  string last_name = 2;
+  string middle_name = 3;
+}
+EOF
+
+
+# trigger recovery
+statement ok
+recover;
+
+
+sleep 2s
+
+
+# produce a v2 message
+statement ok
+create sink sk as select
+  1 as id,
+  row('Alan', 'Turing', 'Mathison')::struct<first_name varchar, last_name varchar, middle_name varchar> as name
+with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test-pb-struct')
+format plain encode protobuf (
+  schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}',
+  message = 'test.User');
+
+
+sleep 1s
+
+
+# reading as v1 shall not panic
+query IT
+select * from s;
+----
+1 (Alan,Turing)
+
+
+statement ok
+drop sink sk;
+
+
+statement ok
+drop source s;
+
+
+system ok
+curl -X DELETE "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/test-pb-struct-value"
+
+
+system ok
+curl -X DELETE "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/test-pb-struct-value?permanent=true"
+
+
+system ok
+rpk topic delete 'test-pb-struct'

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -101,7 +101,7 @@ pg_bigdecimal = { git = "https://github.com/risingwavelabs/rust-pg_bigdecimal", 
 postgres-openssl = "0.5.0"
 prometheus = { version = "0.13", features = ["process"] }
 prost = { workspace = true, features = ["no-recursion-limit"] }
-prost-reflect = "0.14"
+prost-reflect = { version = "0.14", features = ["serde"] }
 prost-types = "0.13"
 protobuf-native = "0.2.2"
 pulsar = { version = "6.3", default-features = false, features = [

--- a/src/connector/codec/src/decoder/mod.rs
+++ b/src/connector/codec/src/decoder/mod.rs
@@ -38,6 +38,9 @@ pub enum AccessError {
     #[error("Unsupported additional column `{name}`")]
     UnsupportedAdditionalColumn { name: String },
 
+    #[error("Fail to convert protobuf Any into jsonb: {0}")]
+    ProtobufAnyToJson(#[source] serde_json::Error),
+
     /// Errors that are not categorized into variants above.
     #[error("{message}")]
     Uncategorized { message: String },

--- a/src/connector/src/parser/unified/mod.rs
+++ b/src/connector/src/parser/unified/mod.rs
@@ -17,9 +17,7 @@
 use auto_impl::auto_impl;
 use risingwave_common::types::{DataType, DatumCow};
 use risingwave_connector_codec::decoder::avro::AvroAccess;
-pub use risingwave_connector_codec::decoder::{
-    bail_uncategorized, uncategorized, Access, AccessError, AccessResult,
-};
+pub use risingwave_connector_codec::decoder::{uncategorized, Access, AccessError, AccessResult};
 
 use self::bytes::BytesAccess;
 use self::json::JsonAccess;


### PR DESCRIPTION
Cherry picking #18419 and its pre-req #18380 onto branch release-2.0

The 2 commits can actually be sequentially cherry-picked cleanly without conflict by the automation, but I am melting them into 1 single cherry-pick to emphasize their tight relation.