### PR TITLE
refactor: maintain subscriptions in local barrier worker

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -9,14 +9,6 @@ import "stream_plan.proto";
 option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
 
-message BuildActorInfo {
-  stream_plan.StreamActor actor = 1;
-  message SubscriptionIds {
-    repeated uint32 subscription_ids = 1;
-  }
-  map<uint32, SubscriptionIds> related_subscriptions = 2;
-}
-
 message InjectBarrierRequest {
   string request_id = 1;
   stream_plan.Barrier barrier = 2;
@@ -35,7 +27,9 @@ message InjectBarrierRequest {
   repeated uint32 actor_ids_to_pre_sync_barrier_mutation = 7;
 
   repeated common.ActorInfo broadcast_info = 8;
-  repeated BuildActorInfo actors_to_build = 9;
+  repeated stream_plan.StreamActor actors_to_build = 9;
+  repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_add = 10;
+  repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_remove = 11;
 }
 
 message BarrierCompleteResponse {

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -68,6 +68,7 @@ message WaitEpochCommitResponse {
 message StreamingControlStreamRequest {
   message InitRequest {
     uint64 version_id = 1;
+    repeated stream_plan.SubscriptionUpstreamInfo subscriptions = 2;
   }
 
   message RemovePartialGraphRequest {

--- a/src/meta/src/barrier/creating_job/status.rs
+++ b/src/meta/src/barrier/creating_job/status.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
+use risingwave_pb::stream_plan::StreamActor;
 use risingwave_pb::stream_service::barrier_complete_response::CreateMviewProgress;
-use risingwave_pb::stream_service::BuildActorInfo;
 
 use crate::barrier::command::CommandContext;
 use crate::barrier::info::InflightGraphInfo;
@@ -43,7 +43,7 @@ pub(super) enum CreatingStreamingJobStatus {
         snapshot_backfill_actors: HashMap<WorkerId, HashSet<ActorId>>,
         /// Info of the first barrier: (`actors_to_create`, `mutation`)
         /// Take the mutation out when injecting the first barrier
-        initial_barrier_info: Option<(HashMap<WorkerId, Vec<BuildActorInfo>>, Mutation)>,
+        initial_barrier_info: Option<(HashMap<WorkerId, Vec<StreamActor>>, Mutation)>,
     },
     ConsumingLogStore {
         graph_info: InflightGraphInfo,
@@ -62,7 +62,7 @@ pub(super) struct CreatingJobInjectBarrierInfo {
     pub curr_epoch: TracedEpoch,
     pub prev_epoch: TracedEpoch,
     pub kind: BarrierKind,
-    pub new_actors: Option<HashMap<WorkerId, Vec<BuildActorInfo>>>,
+    pub new_actors: Option<HashMap<WorkerId, Vec<StreamActor>>>,
     pub mutation: Option<Mutation>,
 }
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -833,7 +833,7 @@ impl GlobalBarrierManager {
                         .on_new_worker_node_map(self.active_streaming_nodes.current());
                     self.checkpoint_control.creating_streaming_job_controls.values().for_each(|job| job.on_new_worker_node_map(self.active_streaming_nodes.current()));
                     if let ActiveStreamingWorkerChange::Add(node) | ActiveStreamingWorkerChange::Update(node) = changed_worker {
-                        self.control_stream_manager.add_worker(node).await;
+                        self.control_stream_manager.add_worker(node, &self.state.inflight_subscription_info).await;
                     }
                 }
 

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -28,13 +28,11 @@ use risingwave_common::util::tracing::TracingContext;
 use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::common::{ActorInfo, WorkerNode};
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
-use risingwave_pb::stream_plan::{Barrier, BarrierMutation};
-use risingwave_pb::stream_service::build_actor_info::SubscriptionIds;
+use risingwave_pb::stream_plan::{Barrier, BarrierMutation, StreamActor, SubscriptionUpstreamInfo};
 use risingwave_pb::stream_service::streaming_control_stream_request::RemovePartialGraphRequest;
 use risingwave_pb::stream_service::{
     streaming_control_stream_request, streaming_control_stream_response, BarrierCompleteResponse,
-    BuildActorInfo, InjectBarrierRequest, StreamingControlStreamRequest,
-    StreamingControlStreamResponse,
+    InjectBarrierRequest, StreamingControlStreamRequest, StreamingControlStreamResponse,
 };
 use rw_futures_util::pending_on_none;
 use thiserror_ext::AsReport;
@@ -266,53 +264,32 @@ impl ControlStreamManager {
         applied_graph_info: Option<&InflightGraphInfo>,
         actor_ids_to_pre_sync_mutation: HashMap<WorkerId, Vec<ActorId>>,
     ) -> MetaResult<HashSet<WorkerId>> {
+        let mutation = command_ctx.to_mutation();
+        let subscriptions_to_add = if let Some(Mutation::Add(add)) = &mutation {
+            add.subscriptions_to_add.clone()
+        } else {
+            vec![]
+        };
+        let subscriptions_to_remove = if let Some(Mutation::DropSubscriptions(drop)) = &mutation {
+            drop.info.clone()
+        } else {
+            vec![]
+        };
         self.inject_barrier(
             None,
-            command_ctx.to_mutation(),
+            mutation,
             (&command_ctx.curr_epoch, &command_ctx.prev_epoch),
             &command_ctx.kind,
             pre_applied_graph_info,
             applied_graph_info,
             actor_ids_to_pre_sync_mutation,
-            command_ctx
-                .command
-                .actors_to_create()
-                .map(|actors_to_create| {
-                    actors_to_create
-                        .into_iter()
-                        .map(|(worker_id, actors)| {
-                            (
-                                worker_id,
-                                actors
-                                    .into_iter()
-                                    .map(|actor| BuildActorInfo {
-                                        actor: Some(actor),
-                                        // TODO: consider subscriber of backfilling mv
-                                        related_subscriptions: command_ctx
-                                            .subscription_info
-                                            .mv_depended_subscriptions
-                                            .iter()
-                                            .map(|(table_id, subscriptions)| {
-                                                (
-                                                    table_id.table_id,
-                                                    SubscriptionIds {
-                                                        subscription_ids: subscriptions
-                                                            .keys()
-                                                            .cloned()
-                                                            .collect(),
-                                                    },
-                                                )
-                                            })
-                                            .collect(),
-                                    })
-                                    .collect_vec(),
-                            )
-                        })
-                        .collect()
-                }),
+            command_ctx.command.actors_to_create(),
+            subscriptions_to_add,
+            subscriptions_to_remove,
         )
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn inject_barrier(
         &mut self,
         creating_table_id: Option<TableId>,
@@ -322,7 +299,9 @@ impl ControlStreamManager {
         pre_applied_graph_info: &InflightGraphInfo,
         applied_graph_info: Option<&InflightGraphInfo>,
         actor_ids_to_pre_sync_mutation: HashMap<WorkerId, Vec<ActorId>>,
-        mut new_actors: Option<HashMap<WorkerId, Vec<BuildActorInfo>>>,
+        mut new_actors: Option<HashMap<WorkerId, Vec<StreamActor>>>,
+        subscriptions_to_add: Vec<SubscriptionUpstreamInfo>,
+        subscriptions_to_remove: Vec<SubscriptionUpstreamInfo>,
     ) -> MetaResult<HashSet<WorkerId>> {
         fail_point!("inject_barrier_err", |_| risingwave_common::bail!(
             "inject_barrier_err"
@@ -359,7 +338,7 @@ impl ControlStreamManager {
             .flatten()
             .flat_map(|(worker_id, actor_infos)| {
                 actor_infos.iter().map(|actor_info| ActorInfo {
-                    actor_id: actor_info.actor.as_ref().unwrap().actor_id,
+                    actor_id: actor_info.actor_id,
                     host: self
                         .nodes
                         .get(worker_id)
@@ -424,6 +403,8 @@ impl ControlStreamManager {
                                             .flatten()
                                             .flatten()
                                             .collect(),
+                                        subscriptions_to_add: subscriptions_to_add.clone(),
+                                        subscriptions_to_remove: subscriptions_to_remove.clone(),
                                     },
                                 ),
                             ),

--- a/src/meta/src/barrier/state.rs
+++ b/src/meta/src/barrier/state.rs
@@ -28,7 +28,7 @@ pub struct BarrierManagerState {
     /// Inflight running actors info.
     pub(crate) inflight_graph_info: InflightGraphInfo,
 
-    inflight_subscription_info: InflightSubscriptionInfo,
+    pub(crate) inflight_subscription_info: InflightSubscriptionInfo,
 
     /// Whether the cluster is paused and the reason.
     paused_reason: Option<PausedReason>,

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -38,7 +38,6 @@ use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use risingwave_pb::stream_plan::{
     DispatchStrategy, Dispatcher, DispatcherType, FragmentTypeFlag, StreamActor, StreamNode,
 };
-use risingwave_pb::stream_service::BuildActorInfo;
 use tokio::sync::{RwLock, RwLockReadGuard};
 
 use crate::barrier::Reschedule;
@@ -49,7 +48,7 @@ use crate::model::{
     TableParallelism,
 };
 use crate::storage::Transaction;
-use crate::stream::{to_build_actor_info, SplitAssignment, TableRevision};
+use crate::stream::{SplitAssignment, TableRevision};
 use crate::{MetaError, MetaResult};
 
 pub struct FragmentManagerCore {
@@ -965,20 +964,14 @@ impl FragmentManager {
     pub async fn all_node_actors(
         &self,
         include_inactive: bool,
-        subscriptions: &HashMap<TableId, HashMap<u32, u64>>,
-    ) -> HashMap<WorkerId, Vec<BuildActorInfo>> {
+    ) -> HashMap<WorkerId, Vec<StreamActor>> {
         let mut actor_maps = HashMap::new();
 
         let map = &self.core.read().await.table_fragments;
         for fragments in map.values() {
-            let table_id = fragments.table_id();
             for (node_id, actors) in fragments.worker_actors(include_inactive) {
                 let node_actors = actor_maps.entry(node_id).or_insert_with(Vec::new);
-                node_actors.extend(
-                    actors
-                        .into_iter()
-                        .map(|actor| to_build_actor_info(actor, subscriptions, table_id)),
-                );
+                node_actors.extend(actors);
             }
         }
 

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -26,7 +26,6 @@ use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, WorkerNode,
 use risingwave_pb::meta::add_worker_node_request::Property as AddNodeProperty;
 use risingwave_pb::meta::table_fragments::{ActorStatus, Fragment, PbFragment};
 use risingwave_pb::stream_plan::{PbDispatchStrategy, StreamActor};
-use risingwave_pb::stream_service::BuildActorInfo;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::oneshot;
 use tokio::time::{sleep, Instant};
@@ -42,7 +41,7 @@ use crate::manager::{
 use crate::model::{
     ActorId, ClusterId, FragmentId, MetadataModel, TableFragments, TableParallelism,
 };
-use crate::stream::{to_build_actor_info, SplitAssignment};
+use crate::stream::SplitAssignment;
 use crate::telemetry::MetaTelemetryJobDesc;
 use crate::{MetaError, MetaResult};
 
@@ -760,26 +759,19 @@ impl MetadataManager {
     pub async fn all_node_actors(
         &self,
         include_inactive: bool,
-        subscriptions: &HashMap<TableId, HashMap<u32, u64>>,
-    ) -> MetaResult<HashMap<WorkerId, Vec<BuildActorInfo>>> {
+    ) -> MetaResult<HashMap<WorkerId, Vec<StreamActor>>> {
         match &self {
-            MetadataManager::V1(mgr) => Ok(mgr
-                .fragment_manager
-                .all_node_actors(include_inactive, subscriptions)
-                .await),
+            MetadataManager::V1(mgr) => {
+                Ok(mgr.fragment_manager.all_node_actors(include_inactive).await)
+            }
             MetadataManager::V2(mgr) => {
                 let table_fragments = mgr.catalog_controller.table_fragments().await?;
                 let mut actor_maps = HashMap::new();
                 for (_, fragments) in table_fragments {
                     let tf = TableFragments::from_protobuf(fragments);
-                    let table_id = tf.table_id();
                     for (node_id, actors) in tf.worker_actors(include_inactive) {
                         let node_actors = actor_maps.entry(node_id).or_insert_with(Vec::new);
-                        node_actors.extend(
-                            actors
-                                .into_iter()
-                                .map(|actor| to_build_actor_info(actor, subscriptions, table_id)),
-                        )
+                        node_actors.extend(actors)
                     }
                 }
                 Ok(actor_maps)

--- a/src/meta/src/stream/mod.rs
+++ b/src/meta/src/stream/mod.rs
@@ -21,36 +21,8 @@ mod stream_manager;
 mod test_fragmenter;
 mod test_scale;
 
-use std::collections::HashMap;
-
-use risingwave_common::catalog::TableId;
-use risingwave_pb::stream_plan::StreamActor;
-use risingwave_pb::stream_service::build_actor_info::SubscriptionIds;
-use risingwave_pb::stream_service::BuildActorInfo;
 pub use scale::*;
 pub use sink::*;
 pub use source_manager::*;
 pub use stream_graph::*;
 pub use stream_manager::*;
-
-pub(crate) fn to_build_actor_info(
-    actor: StreamActor,
-    subscriptions: &HashMap<TableId, HashMap<u32, u64>>,
-    subscription_depend_table_id: TableId,
-) -> BuildActorInfo {
-    BuildActorInfo {
-        actor: Some(actor),
-        related_subscriptions: subscriptions
-            .get(&subscription_depend_table_id)
-            .into_iter()
-            .map(|subscriptions| {
-                (
-                    subscription_depend_table_id.table_id,
-                    SubscriptionIds {
-                        subscription_ids: subscriptions.keys().cloned().collect(),
-                    },
-                )
-            })
-            .collect(),
-    }
-}

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -846,7 +846,6 @@ mod tests {
                                 let mut guard = inner.actor_streams.lock().unwrap();
                                 let mut actor_ids = inner.actor_ids.lock().unwrap();
                                 for actor in req.actors_to_build {
-                                    let actor = actor.actor.as_ref().unwrap();
                                     assert!(actor_ids.insert(actor.actor_id));
                                     guard.insert(actor.get_actor_id(), actor.clone());
                                 }

--- a/src/rpc_client/src/stream_client.rs
+++ b/src/rpc_client/src/stream_client.rs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::TryStreamExt;
+use risingwave_common::catalog::TableId;
 use risingwave_common::config::MAX_CONNECTION_WINDOW_SIZE;
 use risingwave_common::monitor::{EndpointExt, TcpConfig};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_hummock_sdk::HummockVersionId;
+use risingwave_pb::stream_plan::SubscriptionUpstreamInfo;
 use risingwave_pb::stream_service::stream_service_client::StreamServiceClient;
 use risingwave_pb::stream_service::streaming_control_stream_request::InitRequest;
 use risingwave_pb::stream_service::streaming_control_stream_response::InitResponse;
@@ -86,11 +89,23 @@ impl StreamClient {
     pub async fn start_streaming_control(
         &self,
         version_id: HummockVersionId,
+        mv_depended_subscriptions: &HashMap<TableId, HashMap<u32, u64>>,
     ) -> Result<StreamingControlHandle> {
         let first_request = StreamingControlStreamRequest {
             request: Some(streaming_control_stream_request::Request::Init(
                 InitRequest {
                     version_id: version_id.to_u64(),
+                    subscriptions: mv_depended_subscriptions
+                        .iter()
+                        .flat_map(|(table_id, subscriptions)| {
+                            subscriptions
+                                .keys()
+                                .map(|subscriber_id| SubscriptionUpstreamInfo {
+                                    subscriber_id: *subscriber_id,
+                                    upstream_mv_table_id: table_id.table_id,
+                                })
+                        })
+                        .collect(),
                 },
             )),
         };

--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -56,7 +56,7 @@ pub struct ActorContext {
     /// This is the number of dispatchers when the actor is created. It will not be updated during runtime when new downstreams are added.
     pub initial_dispatch_num: usize,
     // mv_table_id to subscription id
-    pub related_subscriptions: HashMap<TableId, HashSet<u32>>,
+    pub related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
 
     // Meta client. currently used for auto schema change. `None` for test only
     pub meta_client: Option<MetaClient>,
@@ -78,7 +78,7 @@ impl ActorContext {
             streaming_metrics: Arc::new(StreamingMetrics::unused()),
             // Set 1 for test to enable sanity check on table
             initial_dispatch_num: 1,
-            related_subscriptions: HashMap::new(),
+            related_subscriptions: HashMap::new().into(),
             meta_client: None,
             streaming_config: Arc::new(StreamingConfig::default()),
         })
@@ -89,7 +89,7 @@ impl ActorContext {
         total_mem_val: Arc<TrAdder<i64>>,
         streaming_metrics: Arc<StreamingMetrics>,
         initial_dispatch_num: usize,
-        related_subscriptions: HashMap<TableId, HashSet<u32>>,
+        related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
         meta_client: Option<MetaClient>,
         streaming_config: Arc<StreamingConfig>,
     ) -> ActorContextRef {

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
 use std::future::pending;
 use std::sync::Arc;
@@ -46,7 +46,6 @@ mod progress;
 mod tests;
 
 pub use progress::CreateMviewProgressReporter;
-use risingwave_common::catalog::TableId;
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::runtime::BackgroundShutdownRuntime;
 use risingwave_hummock_sdk::table_stats::to_prost_table_stats_map;
@@ -57,7 +56,7 @@ use risingwave_pb::stream_service::streaming_control_stream_response::{
     InitResponse, ShutdownResponse,
 };
 use risingwave_pb::stream_service::{
-    streaming_control_stream_response, BarrierCompleteResponse, BuildActorInfo,
+    streaming_control_stream_response, BarrierCompleteResponse, InjectBarrierRequest,
     StreamingControlStreamRequest, StreamingControlStreamResponse,
 };
 
@@ -383,20 +382,8 @@ impl LocalBarrierWorker {
         match request.request.expect("should not be empty") {
             Request::InjectBarrier(req) => {
                 let barrier = Barrier::from_protobuf(req.get_barrier().unwrap())?;
-                self.update_actor_info(req.broadcast_info)?;
-                self.send_barrier(
-                    &barrier,
-                    req.actors_to_build,
-                    req.actor_ids_to_collect.into_iter().collect(),
-                    req.table_ids_to_sync
-                        .into_iter()
-                        .map(TableId::new)
-                        .collect(),
-                    PartialGraphId::new(req.partial_graph_id),
-                    req.actor_ids_to_pre_sync_barrier_mutation
-                        .into_iter()
-                        .collect(),
-                )?;
+                self.update_actor_info(req.broadcast_info.iter().cloned())?;
+                self.send_barrier(&barrier, req)?;
                 Ok(())
             }
             Request::RemovePartialGraph(req) => {
@@ -554,11 +541,7 @@ impl LocalBarrierWorker {
     fn send_barrier(
         &mut self,
         barrier: &Barrier,
-        to_build: Vec<BuildActorInfo>,
-        to_collect: HashSet<ActorId>,
-        table_ids: HashSet<TableId>,
-        partial_graph_id: PartialGraphId,
-        actor_ids_to_pre_sync_barrier: HashSet<ActorId>,
+        request: InjectBarrierRequest,
     ) -> StreamResult<()> {
         if barrier.kind == BarrierKind::Initial {
             self.actor_manager
@@ -569,10 +552,10 @@ impl LocalBarrierWorker {
             target: "events::stream::barrier::manager::send",
             "send barrier {:?}, actor_ids_to_collect = {:?}",
             barrier,
-            to_collect
+            request.actor_ids_to_collect
         );
 
-        for actor_id in &to_collect {
+        for actor_id in &request.actor_ids_to_collect {
             if self.failure_actors.contains_key(actor_id) {
                 // The failure actors could exit before the barrier is issued, while their
                 // up-downstream actors could be stuck somehow. Return error directly to trigger the
@@ -585,14 +568,7 @@ impl LocalBarrierWorker {
             }
         }
 
-        self.state.transform_to_issued(
-            barrier,
-            to_build,
-            to_collect,
-            table_ids,
-            partial_graph_id,
-            actor_ids_to_pre_sync_barrier,
-        )?;
+        self.state.transform_to_issued(barrier, request)?;
         Ok(())
     }
 
@@ -1004,6 +980,8 @@ pub(crate) mod barrier_test_utils {
                             actor_ids_to_pre_sync_barrier_mutation: vec![],
                             broadcast_info: vec![],
                             actors_to_build: vec![],
+                            subscriptions_to_add: vec![],
+                            subscriptions_to_remove: vec![],
                         },
                     )),
                 }))

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -342,6 +342,7 @@ impl LocalBarrierWorker {
                             LocalActorOperation::NewControlStream { handle, init_request  } => {
                                 self.control_stream_handle.reset_stream_with_err(Status::internal("control stream has been reset to a new one"));
                                 self.reset(HummockVersionId::new(init_request.version_id)).await;
+                                self.state.add_subscriptions(init_request.subscriptions);
                                 self.control_stream_handle = handle;
                                 self.control_stream_handle.send_response(StreamingControlStreamResponse {
                                     response: Some(streaming_control_stream_response::Response::Init(InitResponse {}))
@@ -942,7 +943,10 @@ pub(crate) mod barrier_test_utils {
                     response_tx,
                     UnboundedReceiverStream::new(request_rx).boxed(),
                 ),
-                init_request: InitRequest { version_id: 0 },
+                init_request: InitRequest {
+                    version_id: 0,
+                    subscriptions: vec![],
+                },
             });
 
             assert_matches!(

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -635,6 +635,9 @@ impl ManagedBarrierState {
                 .or_default()
                 .insert(subscription_to_add.subscriber_id)
             {
+                if cfg!(debug_assertions) {
+                    panic!("add an existing subscription: {:?}", subscription_to_add);
+                }
                 warn!(?subscription_to_add, "add an existing subscription");
             }
         }
@@ -642,6 +645,12 @@ impl ManagedBarrierState {
             let upstream_table_id = TableId::new(subscription_to_remove.upstream_mv_table_id);
             let Some(subscribers) = self.mv_depended_subscriptions.get_mut(&upstream_table_id)
             else {
+                if cfg!(debug_assertions) {
+                    panic!(
+                        "unable to find upstream mv table to remove: {:?}",
+                        subscription_to_remove
+                    );
+                }
                 warn!(
                     ?subscription_to_remove,
                     "unable to find upstream mv table to remove"
@@ -649,6 +658,12 @@ impl ManagedBarrierState {
                 continue;
             };
             if !subscribers.remove(&subscription_to_remove.subscriber_id) {
+                if cfg!(debug_assertions) {
+                    panic!(
+                        "unable to find subscriber to remove: {:?}",
+                        subscription_to_remove
+                    );
+                }
                 warn!(
                     ?subscription_to_remove,
                     "unable to find subscriber to remove"

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::assert_matches::assert_matches;
+use std::cell::LazyCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::future::{pending, poll_fn, Future};
@@ -31,7 +32,6 @@ use risingwave_common::must_match;
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_hummock_sdk::SyncResult;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
-use risingwave_pb::stream_service::BuildActorInfo;
 use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc;
@@ -141,6 +141,7 @@ mod await_epoch_completed_future {
 }
 
 use await_epoch_completed_future::*;
+use risingwave_pb::stream_service::InjectBarrierRequest;
 
 fn sync_epoch<S: StateStore>(
     state_store: &S,
@@ -482,6 +483,8 @@ pub(crate) struct ManagedBarrierState {
 
     pub(super) graph_states: HashMap<PartialGraphId, PartialGraphManagedBarrierState>,
 
+    mv_depended_subscriptions: HashMap<TableId, HashSet<u32>>,
+
     actor_manager: Arc<StreamActorManager>,
 
     current_shared_context: Arc<SharedContext>,
@@ -496,6 +499,7 @@ impl ManagedBarrierState {
         Self {
             actor_states: Default::default(),
             graph_states: Default::default(),
+            mv_depended_subscriptions: Default::default(),
             actor_manager,
             current_shared_context,
         }
@@ -622,12 +626,39 @@ impl ManagedBarrierState {
     pub(super) fn transform_to_issued(
         &mut self,
         barrier: &Barrier,
-        actors_to_build: Vec<BuildActorInfo>,
-        actor_ids_to_collect: HashSet<ActorId>,
-        table_ids: HashSet<TableId>,
-        partial_graph_id: PartialGraphId,
-        actor_ids_to_pre_sync_barrier: HashSet<ActorId>,
+        request: InjectBarrierRequest,
     ) -> StreamResult<()> {
+        for subscription_to_add in request.subscriptions_to_add {
+            if !self
+                .mv_depended_subscriptions
+                .entry(TableId::new(subscription_to_add.upstream_mv_table_id))
+                .or_default()
+                .insert(subscription_to_add.subscriber_id)
+            {
+                warn!(?subscription_to_add, "add an existing subscription");
+            }
+        }
+        for subscription_to_remove in request.subscriptions_to_remove {
+            let upstream_table_id = TableId::new(subscription_to_remove.upstream_mv_table_id);
+            let Some(subscribers) = self.mv_depended_subscriptions.get_mut(&upstream_table_id)
+            else {
+                warn!(
+                    ?subscription_to_remove,
+                    "unable to find upstream mv table to remove"
+                );
+                continue;
+            };
+            if !subscribers.remove(&subscription_to_remove.subscriber_id) {
+                warn!(
+                    ?subscription_to_remove,
+                    "unable to find subscriber to remove"
+                );
+            }
+            if subscribers.is_empty() {
+                self.mv_depended_subscriptions.remove(&upstream_table_id);
+            }
+        }
+        let partial_graph_id = PartialGraphId::new(request.partial_graph_id);
         let actor_to_stop = barrier.all_stop_actors();
         let is_stop_actor = |actor_id| {
             actor_to_stop
@@ -645,17 +676,24 @@ impl ManagedBarrierState {
                 )
             });
 
-        graph_state.transform_to_issued(barrier, actor_ids_to_collect.clone(), table_ids);
+        graph_state.transform_to_issued(
+            barrier,
+            request.actor_ids_to_collect.iter().cloned(),
+            HashSet::from_iter(request.table_ids_to_sync.iter().cloned().map(TableId::new)),
+        );
 
         let mut new_actors = HashSet::new();
-        for actor in actors_to_build {
-            let actor_id = actor.actor.as_ref().unwrap().actor_id;
+        let subscriptions = LazyCell::new(|| Arc::new(self.mv_depended_subscriptions.clone()));
+        for actor in request.actors_to_build {
+            let actor_id = actor.actor_id;
             assert!(!is_stop_actor(actor_id));
             assert!(new_actors.insert(actor_id));
-            assert!(actor_ids_to_collect.contains(&actor_id));
-            let (join_handle, monitor_join_handle) = self
-                .actor_manager
-                .spawn_actor(actor, self.current_shared_context.clone());
+            assert!(request.actor_ids_to_collect.contains(&actor_id));
+            let (join_handle, monitor_join_handle) = self.actor_manager.spawn_actor(
+                actor,
+                (*subscriptions).clone(),
+                self.current_shared_context.clone(),
+            );
             assert!(self
                 .actor_states
                 .try_insert(
@@ -673,7 +711,7 @@ impl ManagedBarrierState {
 
         // Spawn a trivial join handle to be compatible with the unit test
         if cfg!(test) {
-            for actor_id in &actor_ids_to_collect {
+            for actor_id in &request.actor_ids_to_collect {
                 if !self.actor_states.contains_key(actor_id) {
                     let join_handle = self.actor_manager.runtime.spawn(async { pending().await });
                     assert!(self
@@ -696,27 +734,30 @@ impl ManagedBarrierState {
 
         // Note: it's important to issue barrier to actor after issuing to graph to ensure that
         // we call `start_epoch` on the graph before the actors receive the barrier
-        for actor_id in &actor_ids_to_collect {
+        for actor_id in &request.actor_ids_to_collect {
             if new_actors.contains(actor_id) {
                 continue;
             }
             self.actor_states
                 .get_mut(actor_id)
                 .unwrap_or_else(|| {
-                    panic!("should exist: {} {:?}", actor_id, actor_ids_to_collect);
+                    panic!(
+                        "should exist: {} {:?}",
+                        actor_id, request.actor_ids_to_collect
+                    );
                 })
                 .issue_barrier(partial_graph_id, barrier, is_stop_actor(*actor_id))?;
         }
 
         if partial_graph_id.is_global_graph() {
-            for actor_id in actor_ids_to_pre_sync_barrier {
+            for actor_id in request.actor_ids_to_pre_sync_barrier_mutation {
                 self.actor_states
                     .get_mut(&actor_id)
                     .expect("should exist")
                     .sync_barrier(barrier);
             }
         } else {
-            assert!(actor_ids_to_pre_sync_barrier.is_empty());
+            assert!(request.actor_ids_to_pre_sync_barrier_mutation.is_empty());
         }
         Ok(())
     }
@@ -898,7 +939,7 @@ impl PartialGraphManagedBarrierState {
     pub(super) fn transform_to_issued(
         &mut self,
         barrier: &Barrier,
-        actor_ids_to_collect: HashSet<ActorId>,
+        actor_ids_to_collect: impl IntoIterator<Item = ActorId>,
         table_ids: HashSet<TableId>,
     ) {
         let timer = self

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use core::time::Duration;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -32,10 +32,10 @@ use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::StreamNode;
+use risingwave_pb::stream_plan::{StreamActor, StreamNode};
 use risingwave_pb::stream_service::streaming_control_stream_request::InitRequest;
 use risingwave_pb::stream_service::{
-    BuildActorInfo, StreamingControlStreamRequest, StreamingControlStreamResponse,
+    StreamingControlStreamRequest, StreamingControlStreamResponse,
 };
 use risingwave_storage::monitor::HummockTraceFutureExt;
 use risingwave_storage::{dispatch_state_store, StateStore};
@@ -444,15 +444,11 @@ impl StreamActorManager {
 
     async fn create_actor(
         self: Arc<Self>,
-        actor: BuildActorInfo,
+        actor: StreamActor,
         shared_context: Arc<SharedContext>,
+        related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
     ) -> StreamResult<Actor<DispatchExecutor>> {
         {
-            let BuildActorInfo {
-                actor,
-                related_subscriptions,
-            } = actor;
-            let actor = actor.unwrap();
             let actor_id = actor.actor_id;
             let streaming_config = self.env.config().clone();
             let actor_context = ActorContext::create(
@@ -460,15 +456,7 @@ impl StreamActorManager {
                 self.env.total_mem_usage(),
                 self.streaming_metrics.clone(),
                 actor.dispatcher.len(),
-                related_subscriptions
-                    .into_iter()
-                    .map(|(table_id, subscription_ids)| {
-                        (
-                            TableId::new(table_id),
-                            HashSet::from_iter(subscription_ids.subscription_ids),
-                        )
-                    })
-                    .collect(),
+                related_subscriptions,
                 self.env.meta_client().clone(),
                 streaming_config,
             );
@@ -512,19 +500,20 @@ impl StreamActorManager {
 impl StreamActorManager {
     pub(super) fn spawn_actor(
         self: &Arc<Self>,
-        actor: BuildActorInfo,
+        actor: StreamActor,
+        related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
         current_shared_context: Arc<SharedContext>,
     ) -> (JoinHandle<()>, Option<JoinHandle<()>>) {
         {
             let monitor = tokio_metrics::TaskMonitor::new();
-            let stream_actor_ref = actor.actor.as_ref().unwrap();
+            let stream_actor_ref = &actor;
             let actor_id = stream_actor_ref.actor_id;
             let handle = {
                 let trace_span =
                     format!("Actor {actor_id}: `{}`", stream_actor_ref.mview_definition);
                 let barrier_manager = current_shared_context.local_barrier_manager.clone();
                 // wrap the future of `create_actor` with `boxed` to avoid stack overflow
-                let actor = self.clone().create_actor(actor, current_shared_context).boxed().and_then(|actor| actor.run()).map(move |result| {
+                let actor = self.clone().create_actor(actor, current_shared_context, related_subscriptions).boxed().and_then(|actor| actor.run()).map(move |result| {
                     if let Err(err) = result {
                         // TODO: check error type and panic if it's unexpected.
                         // Intentionally use `?` on the report to also include the backtrace.
@@ -602,7 +591,10 @@ impl StreamActorManager {
 impl LocalBarrierWorker {
     /// This function could only be called once during the lifecycle of `LocalStreamManager` for
     /// now.
-    pub fn update_actor_info(&self, new_actor_infos: Vec<ActorInfo>) -> StreamResult<()> {
+    pub fn update_actor_info(
+        &self,
+        new_actor_infos: impl Iterator<Item = ActorInfo>,
+    ) -> StreamResult<()> {
         let mut actor_infos = self.current_shared_context.actor_infos.write();
         for actor in new_actor_infos {
             if let Some(prev_actor) = actor_infos.get(&actor.get_actor_id())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously when build actor and inject barrier are not done together, we have to include the barrier information together with the `StreamActor` to a combined `BuildActorInfo` when we build the actor. After we change to build actor when inject barrier in https://github.com/risingwavelabs/risingwave/pull/18270, we are able to get the subscription information from local barrier worker.

Therefore, in this PR, we won't generate the actor subscription info on meta node to generate the `BuildActorInfo`, but instead include only the `StreamActor` in the `InjectBarrierRequest`. Meanwhile, we incrementally maintain the global subscription info in the local barrier worker so that we can pass the subscription info when we build actors.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
