### PR TITLE
fix: dup split assignment in source

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -524,14 +524,8 @@ impl Command {
                 }
 
                 Command::SourceSplitAssignment(change) => {
-                    let mut checked_assignment = change.clone();
-                    checked_assignment
-                        .iter_mut()
-                        .for_each(|(_, assignment)| validate_assignment(assignment));
-
                     let mut diff = HashMap::new();
-
-                    for actor_splits in checked_assignment.values() {
+                    for actor_splits in change.values() {
                         diff.extend(actor_splits.clone());
                     }
 
@@ -583,7 +577,11 @@ impl Command {
                     let mut checked_split_assignment = split_assignment.clone();
                     checked_split_assignment
                         .iter_mut()
-                        .for_each(|(_, assignment)| validate_assignment(assignment));
+                        .for_each(|(_, assignment)| {
+                            // No related actor running before, we don't need to check the mutation
+                            // should be wrapped with pause.
+                            validate_assignment(assignment);
+                        });
                     let actor_splits = checked_split_assignment
                         .values()
                         .flat_map(build_actor_connector_splits)
@@ -791,7 +789,8 @@ impl Command {
 
                     for reschedule in reschedules.values() {
                         let mut checked_assignment = reschedule.actor_splits.clone();
-                        validate_assignment(&mut checked_assignment);
+                        // Update mutation always wrapped by Pause and Resume mutation. no further action needed.
+                        _ = validate_assignment(&mut checked_assignment);
 
                         for (actor_id, splits) in &checked_assignment {
                             actor_splits.insert(

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -588,7 +588,9 @@ where
     )
 }
 
-pub fn validate_assignment(assignment: &mut HashMap<ActorId, Vec<SplitImpl>>) {
+pub fn validate_assignment(assignment: &mut HashMap<ActorId, Vec<SplitImpl>>) -> bool {
+    let mut dup_assignment_found_flag = false;
+
     // check if one split is assign to multiple actors
     let mut split_to_actor = HashMap::new();
     for (actor_id, splits) in &mut *assignment {
@@ -603,6 +605,7 @@ pub fn validate_assignment(assignment: &mut HashMap<ActorId, Vec<SplitImpl>>) {
     for (split_id, actor_ids) in &mut split_to_actor {
         if actor_ids.len() > 1 {
             tracing::warn!(split_id = ?split_id, actor_ids = ?actor_ids, "split is assigned to multiple actors");
+            dup_assignment_found_flag = true;
         }
         // keep the first actor and remove the rest from the assignment
         for actor_id in actor_ids.iter().skip(1) {
@@ -612,6 +615,8 @@ pub fn validate_assignment(assignment: &mut HashMap<ActorId, Vec<SplitImpl>>) {
                 .retain(|split| split.id() != *split_id);
         }
     }
+
+    dup_assignment_found_flag
 }
 
 fn align_backfill_splits(
@@ -1136,15 +1141,28 @@ impl SourceManager {
     /// The command will first updates `SourceExecutor`'s splits, and finally calls `Self::apply_source_change`
     /// to update states in `SourceManager`.
     async fn tick(&self) -> MetaResult<()> {
-        let split_assignment = {
+        let mut split_assignment = {
             let core_guard = self.core.lock().await;
             core_guard.reassign_splits().await?
         };
 
+        let dup_assignment_flag = split_assignment
+            .iter_mut()
+            .map(|(_, assignment)| validate_assignment(assignment))
+            .reduce(|a, b| a && b)
+            .unwrap_or(false);
+
         if !split_assignment.is_empty() {
             let command = Command::SourceSplitAssignment(split_assignment);
             tracing::info!(command = ?command, "pushing down split assignment command");
-            self.barrier_scheduler.run_command(command).await?;
+            if dup_assignment_flag {
+                tracing::warn!("duplicate split assignment found, wrap with pause and resume");
+                self.barrier_scheduler
+                    .run_config_change_command_with_pause(command)
+                    .await?;
+            } else {
+                self.barrier_scheduler.run_command(command).await?;
+            }
         }
 
         Ok(())
@@ -1353,10 +1371,12 @@ mod tests {
             1 => test_assignment,
         };
 
-        fragment_assignment.iter_mut().for_each(|(_, assignment)| {
-            validate_assignment(assignment);
-        });
-
+        let dup_assignment_flag = fragment_assignment
+            .iter_mut()
+            .map(|(_, assignment)| validate_assignment(assignment))
+            .reduce(|a, b| a && b)
+            .unwrap_or(false);
+        assert_eq!(dup_assignment_flag, true);
         {
             let mut split_to_actor = HashMap::new();
             for actor_to_splits in fragment_assignment.values() {

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -594,12 +594,12 @@ pub fn validate_assignment(assignment: &mut HashMap<ActorId, Vec<SplitImpl>>) ->
     // check if one split is assign to multiple actors
     let mut split_to_actor = HashMap::new();
     for (actor_id, splits) in &mut *assignment {
-        let _ = splits.iter().map(|split| {
+        for split in splits {
             split_to_actor
                 .entry(split.id())
                 .or_insert_with(Vec::new)
-                .push(*actor_id)
-        });
+                .push(*actor_id);
+        }
     }
 
     for (split_id, actor_ids) in &mut split_to_actor {

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -1149,7 +1149,7 @@ impl SourceManager {
         let dup_assignment_flag = split_assignment
             .iter_mut()
             .map(|(_, assignment)| validate_assignment(assignment))
-            .reduce(|a, b| a && b)
+            .reduce(|a, b| a || b)
             .unwrap_or(false);
 
         if !split_assignment.is_empty() {
@@ -1374,9 +1374,9 @@ mod tests {
         let dup_assignment_flag = fragment_assignment
             .iter_mut()
             .map(|(_, assignment)| validate_assignment(assignment))
-            .reduce(|a, b| a && b)
+            .reduce(|a, b| a || b)
             .unwrap_or(false);
-        assert_eq!(dup_assignment_flag, true);
+        assert!(dup_assignment_flag);
         {
             let mut split_to_actor = HashMap::new();
             for actor_to_splits in fragment_assignment.values() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

prev #18134 (#18167, #18158) does not fix the case completely. 

In the prev fix, we check each mutation and removed the dup one from the assignment. But we have no way to know the prev assignment and it can cause the dup assignment as well. 

Giving a more concrete example here

`T0: actor_1(split_1, split_2), actor_2(split_3)`

and we have a dup assignment, the mutation looks like `{"actor_1"; ["split_1, split_2"], "actor_2": [split_2, split_3]}`, after the check impl, the mutation may look like `{"actor_1"; ["split_1], "actor_2": [split_2, split_3]}` as we **RANDOMLY** remove the dup split from the assignment. 

So actor_1 knows it should remove split_2 but it still needs to write the latest offset to the storage. But actor_2 ought to write split_2 with the initial offset to the storage to mark it as applying the change successfully. 
As a result, we get a dup write on the same key and same epoch panic in the compactor. 

This pr handles this case by wrapping the dup split detected split_change_mutation with pause/resume. Separating the two writes to different epoches.  

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
