### PR TITLE
fix: revert split assignment check

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -524,8 +524,14 @@ impl Command {
                 }
 
                 Command::SourceSplitAssignment(change) => {
+                    let mut checked_assignment = change.clone();
+                    checked_assignment
+                        .iter_mut()
+                        .for_each(|(_, assignment)| validate_assignment(assignment));
+
                     let mut diff = HashMap::new();
-                    for actor_splits in change.values() {
+
+                    for actor_splits in checked_assignment.values() {
                         diff.extend(actor_splits.clone());
                     }
 
@@ -577,11 +583,7 @@ impl Command {
                     let mut checked_split_assignment = split_assignment.clone();
                     checked_split_assignment
                         .iter_mut()
-                        .for_each(|(_, assignment)| {
-                            // No related actor running before, we don't need to check the mutation
-                            // should be wrapped with pause.
-                            validate_assignment(assignment);
-                        });
+                        .for_each(|(_, assignment)| validate_assignment(assignment));
                     let actor_splits = checked_split_assignment
                         .values()
                         .flat_map(build_actor_connector_splits)
@@ -789,8 +791,7 @@ impl Command {
 
                     for reschedule in reschedules.values() {
                         let mut checked_assignment = reschedule.actor_splits.clone();
-                        // Update mutation always wrapped by Pause and Resume mutation. no further action needed.
-                        _ = validate_assignment(&mut checked_assignment);
+                        validate_assignment(&mut checked_assignment);
 
                         for (actor_id, splits) in &checked_assignment {
                             actor_splits.insert(

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -588,32 +588,6 @@ where
     )
 }
 
-pub fn validate_assignment(assignment: &mut HashMap<ActorId, Vec<SplitImpl>>) {
-    // check if one split is assign to multiple actors
-    let mut split_to_actor = HashMap::new();
-    for (actor_id, splits) in &mut *assignment {
-        let _ = splits.iter().map(|split| {
-            split_to_actor
-                .entry(split.id())
-                .or_insert_with(Vec::new)
-                .push(*actor_id)
-        });
-    }
-
-    for (split_id, actor_ids) in &mut split_to_actor {
-        if actor_ids.len() > 1 {
-            tracing::warn!(split_id = ?split_id, actor_ids = ?actor_ids, "split is assigned to multiple actors");
-        }
-        // keep the first actor and remove the rest from the assignment
-        for actor_id in actor_ids.iter().skip(1) {
-            assignment
-                .get_mut(actor_id)
-                .unwrap()
-                .retain(|split| split.id() != *split_id);
-        }
-    }
-}
-
 fn align_backfill_splits(
     backfill_actors: impl IntoIterator<Item = (ActorId, Vec<ActorId>)>,
     upstream_assignment: &HashMap<ActorId, Vec<SplitImpl>>,
@@ -1205,14 +1179,11 @@ mod tests {
 
     use risingwave_common::types::JsonbVal;
     use risingwave_connector::error::ConnectorResult;
-    use risingwave_connector::source::test_source::TestSourceSplit;
-    use risingwave_connector::source::{SplitId, SplitImpl, SplitMetaData};
+    use risingwave_connector::source::{SplitId, SplitMetaData};
     use serde::{Deserialize, Serialize};
 
-    use super::validate_assignment;
     use crate::model::{ActorId, FragmentId};
     use crate::stream::source_manager::{reassign_splits, SplitDiffOptions};
-    use crate::stream::SplitAssignment;
 
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
     struct TestSplit {
@@ -1331,49 +1302,6 @@ mod tests {
         .unwrap();
 
         assert!(!diff.is_empty())
-    }
-
-    #[test]
-    fn test_validate_assignment() {
-        let mut fragment_assignment: SplitAssignment;
-        let test_assignment: HashMap<ActorId, Vec<SplitImpl>> = maplit::hashmap! {
-            0 => vec![SplitImpl::Test(
-                TestSourceSplit {id: "1".into(), properties: Default::default(), offset: Default::default()}
-            ), SplitImpl::Test(
-                TestSourceSplit {id: "2".into(), properties: Default::default(), offset: Default::default()}
-            )],
-            1 => vec![SplitImpl::Test(
-                TestSourceSplit {id: "3".into(), properties: Default::default(), offset: Default::default()}
-            )],
-            2 => vec![SplitImpl::Test(
-                TestSourceSplit {id: "1".into(), properties: Default::default(), offset: Default::default()}
-            )],
-        };
-        fragment_assignment = maplit::hashmap! {
-            1 => test_assignment,
-        };
-
-        fragment_assignment.iter_mut().for_each(|(_, assignment)| {
-            validate_assignment(assignment);
-        });
-
-        {
-            let mut split_to_actor = HashMap::new();
-            for actor_to_splits in fragment_assignment.values() {
-                for (actor_id, splits) in actor_to_splits {
-                    let _ = splits.iter().map(|split| {
-                        split_to_actor
-                            .entry(split.id())
-                            .or_insert_with(Vec::new)
-                            .push(*actor_id)
-                    });
-                }
-            }
-
-            for actor_ids in split_to_actor.values() {
-                assert_eq!(actor_ids.len(), 1);
-            }
-        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Revert #18541 and #18134. It turns out that the problem was not there. 

The issue was finally fixed by #18553.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
