### PR TITLE
fix(optimizer): correctly derive cardinality for group top-n

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/topn.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/topn.yaml
@@ -40,3 +40,4 @@
         rn <= 1;
   expected_outputs:
     - logical_plan
+    - optimized_logical_plan_for_batch

--- a/src/frontend/planner_test/tests/testdata/input/topn.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/topn.yaml
@@ -16,3 +16,27 @@
     SELECT * FROM t1_mv ORDER BY a DESC LIMIT 50 OFFSET 50;
   expected_outputs:
     - batch_plan
+- sql: |
+    WITH c1(k, v) AS (
+        VALUES
+            (1, 'foo'),
+            (2, 'bar')
+    ),
+    c2 AS (
+        SELECT
+            *,
+            row_number() over (
+                PARTITION by k
+                ORDER BY 1
+            ) AS rn
+        FROM
+            c1
+    )
+    SELECT
+        count(*)
+    FROM
+        c2
+    WHERE
+        rn <= 1;
+  expected_outputs:
+    - logical_plan

--- a/src/frontend/planner_test/tests/testdata/output/topn.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/topn.yaml
@@ -26,3 +26,41 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchLimit { limit: 100, offset: 0 }
         └─BatchScan { table: t1_mv, columns: [t1_mv.pk, t1_mv.a, t1_mv.b, t1_mv.c, t1_mv.d], limit: 100, distribution: SomeShard }
+- sql: |
+    WITH c1(k, v) AS (
+        VALUES
+            (1, 'foo'),
+            (2, 'bar')
+    ),
+    c2 AS (
+        SELECT
+            *,
+            row_number() over (
+                PARTITION by k
+                ORDER BY 1
+            ) AS rn
+        FROM
+            c1
+    )
+    SELECT
+        count(*)
+    FROM
+        c2
+    WHERE
+        rn <= 1;
+  logical_plan: |-
+    LogicalProject { exprs: [count] }
+    └─LogicalAgg { aggs: [count] }
+      └─LogicalProject { exprs: [] }
+        └─LogicalFilter { predicate: (row_number <= 1:Int32) }
+          └─LogicalShare { id: 5 }
+            └─LogicalProject { exprs: [*VALUES*_0.column_0, *VALUES*_0.column_1, row_number] }
+              └─LogicalOverWindow { window_functions: [row_number() OVER(PARTITION BY *VALUES*_0.column_0 ORDER BY 1:Int32 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+                └─LogicalProject { exprs: [*VALUES*_0.column_0, *VALUES*_0.column_1, 1:Int32] }
+                  └─LogicalShare { id: 1 }
+                    └─LogicalValues { rows: [[1:Int32, 'foo':Varchar], [2:Int32, 'bar':Varchar]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Varchar] } }
+  optimized_logical_plan_for_batch: |-
+    LogicalAgg { aggs: [count] }
+    └─LogicalTopN { order: [1:Int32 ASC], limit: 1, offset: 0, group_key: [*VALUES*_0.column_0] }
+      └─LogicalProject { exprs: [*VALUES*_0.column_0, 1:Int32] }
+        └─LogicalValues { rows: [[1:Int32], [2:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }

--- a/src/frontend/src/optimizer/plan_visitor/cardinality_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/cardinality_visitor.rs
@@ -109,12 +109,22 @@ impl PlanVisitor for CardinalityVisitor {
     fn visit_logical_top_n(&mut self, plan: &plan_node::LogicalTopN) -> Cardinality {
         let input = self.visit(plan.input());
 
-        match plan.limit_attr() {
+        let each_group = match plan.limit_attr() {
             TopNLimit::Simple(limit) => input.sub(plan.offset() as usize).min(limit as usize),
             TopNLimit::WithTies(limit) => {
                 assert_eq!(plan.offset(), 0, "ties with offset is not supported yet");
                 input.min((limit as usize)..)
             }
+        };
+
+        if plan.group_key().is_empty() {
+            each_group
+        } else {
+            let group_number = input.min(1..);
+            each_group
+                .mul(group_number)
+                // the output cardinality will never be more than the input, thus `.min(input)`
+                .min(input)
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously we forgot to check whether there's a group key, treating all `LogicalTopN` as plain top-n, leading to incorrect results. Before this PR, the newly-added test case produced an incorrect result of 1, because we mistakenly believed that the group top-n yielded a constant number of rows.

https://github.com/risingwavelabs/risingwave/blob/49f4ab8e1cd08ae59434462e1950b2e5d39cd39a/src/frontend/src/optimizer/rule/trivial_project_to_values_rule.rs#L33

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
