### PR TITLE
refactor(storage): use arc SstableInfo in HummockVersion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11073,6 +11073,7 @@ dependencies = [
  "easy-ext",
  "hex",
  "itertools 0.12.1",
+ "madsim-tokio",
  "parse-display",
  "prost 0.13.1",
  "risingwave_common",

--- a/src/ctl/src/cmd_impl/hummock/validate_version.rs
+++ b/src/ctl/src/cmd_impl/hummock/validate_version.rs
@@ -21,6 +21,7 @@ use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext;
 use risingwave_hummock_sdk::key::{FullKey, UserKey};
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
 use risingwave_hummock_sdk::{version_archive_dir, HummockSstableObjectId, HummockVersionId};
 use risingwave_object_store::object::ObjectStoreRef;
@@ -102,7 +103,7 @@ async fn print_user_key_in_version(
     for cg in version.levels.values() {
         for level in cg.l0.sub_levels.iter().rev().chain(cg.levels.iter()) {
             for sstable_info in &level.table_infos {
-                let key_range = &sstable_info.key_range;
+                let key_range = &sstable_info.key_range();
                 let left_user_key = FullKey::decode(&key_range.left);
                 let right_user_key = FullKey::decode(&key_range.right);
                 if left_user_key.user_key > *target_key || *target_key > right_user_key.user_key {
@@ -146,7 +147,11 @@ async fn print_user_key_in_sst(
             let date_time = DateTime::<Utc>::from(epoch.as_system_time());
             if is_first {
                 is_first = false;
-                println!("\t\tSST id: {}, object id: {}", sst.sst_id, sst.object_id);
+                println!(
+                    "\t\tSST id: {}, object id: {}",
+                    sst.sst_id(),
+                    sst.object_id()
+                );
             }
             println!("\t\t   key: {:?}, len={}", full_key, full_key.encoded_len());
             println!(

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_version.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_version.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use risingwave_common::types::{Fields, JsonbVal};
 use risingwave_frontend_macro::system_catalog;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::version::HummockVersion;
 use serde_json::json;
 
@@ -114,10 +115,10 @@ fn version_to_sstable_rows(version: HummockVersion) -> Vec<RwHummockSstable> {
     for cg in version.levels.into_values() {
         for level in cg.levels.into_iter().chain(cg.l0.sub_levels) {
             for sst in level.table_infos {
-                let key_range = sst.key_range;
+                let key_range = sst.key_range();
                 sstables.push(RwHummockSstable {
-                    sstable_id: sst.sst_id as _,
-                    object_id: sst.object_id as _,
+                    sstable_id: sst.sst_id() as _,
+                    object_id: sst.object_id() as _,
                     compaction_group_id: cg.group_id as _,
                     level_id: level.level_idx as _,
                     sub_level_id: (level.level_idx == 0).then_some(level.sub_level_id as _),
@@ -125,17 +126,17 @@ fn version_to_sstable_rows(version: HummockVersion) -> Vec<RwHummockSstable> {
                     key_range_left: key_range.left.to_vec(),
                     key_range_right: key_range.right.to_vec(),
                     right_exclusive: key_range.right_exclusive,
-                    file_size: sst.file_size as _,
-                    meta_offset: sst.meta_offset as _,
-                    stale_key_count: sst.stale_key_count as _,
-                    total_key_count: sst.total_key_count as _,
-                    min_epoch: sst.min_epoch as _,
-                    max_epoch: sst.max_epoch as _,
-                    uncompressed_file_size: sst.uncompressed_file_size as _,
-                    range_tombstone_count: sst.range_tombstone_count as _,
-                    bloom_filter_kind: sst.bloom_filter_kind as _,
-                    table_ids: json!(sst.table_ids).into(),
-                    sst_size: sst.sst_size as _,
+                    file_size: sst.file_size() as _,
+                    meta_offset: sst.meta_offset() as _,
+                    stale_key_count: sst.stale_key_count() as _,
+                    total_key_count: sst.total_key_count() as _,
+                    min_epoch: sst.min_epoch() as _,
+                    max_epoch: sst.max_epoch() as _,
+                    uncompressed_file_size: sst.uncompressed_file_size() as _,
+                    range_tombstone_count: sst.range_tombstone_count() as _,
+                    bloom_filter_kind: sst.bloom_filter_kind() as _,
+                    table_ids: json!(sst.table_ids()).into(),
+                    sst_size: sst.sst_size() as _,
                 });
             }
         }

--- a/src/java_binding/src/hummock_iterator.rs
+++ b/src/java_binding/src/hummock_iterator.rs
@@ -25,7 +25,7 @@ use risingwave_common::row::OwnedRow;
 use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_common::util::value_encoding::{BasicSerde, EitherSerde, ValueRowDeserializer};
 use risingwave_hummock_sdk::key::{prefixed_range_with_vnode, TableKeyRange};
-use risingwave_hummock_sdk::version::HummockVersion;
+use risingwave_hummock_sdk::sstable_info_ref::HummockVersionType;
 use risingwave_jni_core::HummockJavaBindingIterator;
 use risingwave_object_store::object::build_remote_object_store;
 use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
@@ -141,7 +141,7 @@ pub(crate) async fn new_hummock_java_binding_iter(
         let mut streams = Vec::with_capacity(read_plan.vnode_ids.len());
         let key_range = read_plan.key_range.unwrap();
         let pin_version = PinnedVersion::new(
-            HummockVersion::from_rpc_protobuf(&read_plan.version.unwrap()),
+            HummockVersionType::from_rpc_protobuf(&read_plan.version.unwrap()),
             unbounded_channel().0,
         );
         let table_id = read_plan.table_id.into();

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -28,6 +28,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use picker::{LevelCompactionPicker, TierCompactionPicker};
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId};
@@ -179,7 +180,7 @@ impl CompactStatus {
         let exist_table_ids = HashSet::<u32>::from_iter(task.existing_table_ids.clone());
         task.input_ssts.iter().all(|level| {
             level.table_infos.iter().all(|sst| {
-                sst.table_ids
+                sst.table_ids()
                     .iter()
                     .all(|table_id| !exist_table_ids.contains(table_id))
             })

--- a/src/meta/src/hummock/compaction/overlap_strategy.rs
+++ b/src/meta/src/hummock/compaction/overlap_strategy.rs
@@ -19,6 +19,7 @@ use std::ops::Range;
 use itertools::Itertools;
 use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::KeyComparator;
 
 pub trait OverlapInfo: Debug {
@@ -85,14 +86,14 @@ impl OverlapInfo for RangeOverlapInfo {
         match self.target_range.as_ref() {
             Some(key_range) => {
                 let overlap_begin = others.partition_point(|table_status| {
-                    table_status.key_range.compare_right_with(&key_range.left)
+                    table_status.key_range().compare_right_with(&key_range.left)
                         == cmp::Ordering::Less
                 });
                 if overlap_begin >= others.len() {
                     return overlap_begin..overlap_begin;
                 }
                 let overlap_end = others.partition_point(|table_status| {
-                    key_range.compare_right_with(&table_status.key_range.left)
+                    key_range.compare_right_with(&table_status.key_range().left)
                         != cmp::Ordering::Less
                 });
                 overlap_begin..overlap_end
@@ -106,7 +107,7 @@ impl OverlapInfo for RangeOverlapInfo {
             Some(key_range) => {
                 let overlap_begin = others.partition_point(|table_status| {
                     KeyComparator::compare_encoded_full_key(
-                        &table_status.key_range.left,
+                        &table_status.key_range().left,
                         &key_range.left,
                     ) == cmp::Ordering::Less
                 });
@@ -115,7 +116,8 @@ impl OverlapInfo for RangeOverlapInfo {
                 }
                 let mut overlap_end = overlap_begin;
                 for table in &others[overlap_begin..] {
-                    if key_range.compare_right_with(&table.key_range.right) == cmp::Ordering::Less {
+                    if key_range.compare_right_with(&table.key_range().right) == cmp::Ordering::Less
+                    {
                         break;
                     }
                     overlap_end += 1;
@@ -127,7 +129,7 @@ impl OverlapInfo for RangeOverlapInfo {
     }
 
     fn update(&mut self, table: &SstableInfo) {
-        let other = &table.key_range;
+        let other = table.key_range();
         if let Some(range) = self.target_range.as_mut() {
             range.full_key_extend(other);
             return;
@@ -141,7 +143,7 @@ pub struct RangeOverlapStrategy {}
 
 impl OverlapStrategy for RangeOverlapStrategy {
     fn check_overlap(&self, a: &SstableInfo, b: &SstableInfo) -> bool {
-        check_table_overlap(&a.key_range, b)
+        check_table_overlap(a.key_range(), b)
     }
 
     fn create_overlap_info(&self) -> Box<dyn OverlapInfo> {
@@ -150,5 +152,5 @@ impl OverlapStrategy for RangeOverlapStrategy {
 }
 
 fn check_table_overlap(key_range: &KeyRange, table: &SstableInfo) -> bool {
-    key_range.sstable_overlap(&table.key_range)
+    key_range.sstable_overlap(table.key_range())
 }

--- a/src/meta/src/hummock/compaction/picker/compaction_task_validator.rs
+++ b/src/meta/src/hummock/compaction/picker/compaction_task_validator.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use risingwave_common::config::default::compaction_config;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_pb::hummock::CompactionConfig;
 
 use super::{CompactionInput, LocalPickerStatistic};
@@ -157,7 +158,7 @@ impl CompactionTaskValidationRule for IntraCompactionTaskValidationRule {
             let level_select_size = select_level
                 .table_infos
                 .iter()
-                .map(|sst| sst.sst_size)
+                .map(|sst| sst.sst_size())
                 .sum::<u64>();
 
             max_level_size = std::cmp::max(max_level_size, level_select_size);

--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use risingwave_common::config::default::compaction_config;
 use risingwave_hummock_sdk::level::{InputLevel, Levels, OverlappingLevel};
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::min_overlap_compaction_picker::NonOverlapSubLevelPicker;
@@ -191,7 +192,7 @@ impl IntraCompactionPicker {
                 for level_select_table in &input.sstable_infos {
                     let level_select_size = level_select_table
                         .iter()
-                        .map(|sst| sst.sst_size)
+                        .map(|sst| sst.sst_size())
                         .sum::<u64>();
 
                     max_level_size = std::cmp::max(max_level_size, level_select_size);
@@ -291,7 +292,7 @@ impl IntraCompactionPicker {
                 .check_multiple_overlap(&l0.sub_levels[idx].table_infos)
                 .is_empty());
 
-            let select_input_size = select_sst.sst_size;
+            let select_input_size = select_sst.sst_size();
             let input_levels = vec![
                 InputLevel {
                     level_idx: 0,
@@ -418,6 +419,7 @@ impl WholeLevelCompactionPicker {
 #[cfg(test)]
 pub mod tests {
     use risingwave_hummock_sdk::level::Level;
+    use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 
     use super::*;
     use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
@@ -611,9 +613,9 @@ pub mod tests {
                 3
             );
 
-            assert_eq!(4, ret.input_levels[0].table_infos[0].sst_id);
-            assert_eq!(3, ret.input_levels[1].table_infos[0].sst_id);
-            assert_eq!(1, ret.input_levels[2].table_infos[0].sst_id);
+            assert_eq!(4, ret.input_levels[0].table_infos[0].sst_id());
+            assert_eq!(3, ret.input_levels[1].table_infos[0].sst_id());
+            assert_eq!(1, ret.input_levels[2].table_infos[0].sst_id());
 
             // will pick sst [2, 6]
             let ret2 = picker
@@ -628,8 +630,8 @@ pub mod tests {
                 2
             );
 
-            assert_eq!(6, ret2.input_levels[0].table_infos[0].sst_id);
-            assert_eq!(2, ret2.input_levels[1].table_infos[0].sst_id);
+            assert_eq!(6, ret2.input_levels[0].table_infos[0].sst_id());
+            assert_eq!(2, ret2.input_levels[1].table_infos[0].sst_id());
         }
 
         {
@@ -682,9 +684,9 @@ pub mod tests {
                 3
             );
 
-            assert_eq!(11, ret.input_levels[0].table_infos[0].sst_id);
-            assert_eq!(9, ret.input_levels[1].table_infos[0].sst_id);
-            assert_eq!(7, ret.input_levels[2].table_infos[0].sst_id);
+            assert_eq!(11, ret.input_levels[0].table_infos[0].sst_id());
+            assert_eq!(9, ret.input_levels[1].table_infos[0].sst_id());
+            assert_eq!(7, ret.input_levels[2].table_infos[0].sst_id());
 
             let ret2 = picker
                 .pick_compaction(&levels, &levels_handler, &mut local_stats)
@@ -698,9 +700,9 @@ pub mod tests {
                 3
             );
 
-            assert_eq!(5, ret2.input_levels[0].table_infos[0].sst_id);
-            assert_eq!(10, ret2.input_levels[1].table_infos[0].sst_id);
-            assert_eq!(2, ret2.input_levels[2].table_infos[0].sst_id);
+            assert_eq!(5, ret2.input_levels[0].table_infos[0].sst_id());
+            assert_eq!(10, ret2.input_levels[1].table_infos[0].sst_id());
+            assert_eq!(2, ret2.input_levels[2].table_infos[0].sst_id());
         }
     }
 

--- a/src/meta/src/hummock/compaction/picker/trivial_move_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/trivial_move_compaction_picker.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use risingwave_hummock_sdk::level::InputLevel;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_pb::hummock::LevelType;
 
 use super::{CompactionInput, LocalPickerStatistic};
@@ -55,11 +56,11 @@ impl TrivialMovePicker {
     ) -> Option<SstableInfo> {
         let mut skip_by_pending = false;
         for sst in select_tables {
-            if sst.sst_size < self.sst_allowed_trivial_move_min_size {
+            if sst.sst_size() < self.sst_allowed_trivial_move_min_size {
                 continue;
             }
 
-            if level_handlers[self.level].is_pending_compact(&sst.sst_id) {
+            if level_handlers[self.level].is_pending_compact(&sst.sst_id()) {
                 skip_by_pending = true;
                 continue;
             }
@@ -90,7 +91,7 @@ impl TrivialMovePicker {
             self.pick_trivial_move_sst(select_tables, target_tables, level_handlers, stats)
         {
             return Some(CompactionInput {
-                select_input_size: trivial_move_sst.sst_size,
+                select_input_size: trivial_move_sst.sst_size(),
                 total_file_count: 1,
                 input_levels: vec![
                     InputLevel {

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -475,6 +475,7 @@ pub mod tests {
     use itertools::Itertools;
     use risingwave_common::constants::hummock::CompactionFilterFlag;
     use risingwave_hummock_sdk::level::Levels;
+    use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
     use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
     use risingwave_pb::hummock::compaction_config::CompactionMode;
 
@@ -528,7 +529,7 @@ pub mod tests {
         levels.levels[3].total_file_size = levels.levels[3]
             .table_infos
             .iter()
-            .map(|sst| sst.sst_size)
+            .map(|sst| sst.sst_size())
             .sum::<u64>();
 
         let ctx = selector.calculate_level_base_size(&levels);
@@ -555,7 +556,7 @@ pub mod tests {
         levels.levels[0].total_file_size = levels.levels[0]
             .table_infos
             .iter()
-            .map(|sst| sst.sst_size)
+            .map(|sst| sst.sst_size())
             .sum::<u64>();
 
         let ctx = selector.calculate_level_base_size(&levels);
@@ -673,7 +674,7 @@ pub mod tests {
             compaction.input.input_levels[0]
                 .table_infos
                 .iter()
-                .map(|sst| sst.sst_id)
+                .map(|sst| sst.sst_id())
                 .collect_vec(),
             vec![5]
         );
@@ -681,7 +682,7 @@ pub mod tests {
             compaction.input.input_levels[1]
                 .table_infos
                 .iter()
-                .map(|sst| sst.sst_id)
+                .map(|sst| sst.sst_id())
                 .collect_vec(),
             vec![10]
         );

--- a/src/meta/src/hummock/level_handler.rs
+++ b/src/meta/src/hummock/level_handler.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use risingwave_hummock_sdk::level::Level;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::{HummockCompactionTaskId, HummockSstableId};
 use risingwave_pb::hummock::level_handler::RunningCompactTask;
 
@@ -67,7 +68,7 @@ impl LevelHandler {
         level
             .table_infos
             .iter()
-            .any(|table| self.compacting_files.contains_key(&table.sst_id))
+            .any(|table| self.compacting_files.contains_key(&table.sst_id()))
     }
 
     pub fn is_level_all_pending_compact(&self, level: &Level) -> bool {
@@ -78,7 +79,7 @@ impl LevelHandler {
         level
             .table_infos
             .iter()
-            .all(|table| self.compacting_files.contains_key(&table.sst_id))
+            .all(|table| self.compacting_files.contains_key(&table.sst_id()))
     }
 
     pub fn add_pending_task<'a>(
@@ -91,9 +92,9 @@ impl LevelHandler {
         let mut table_ids = vec![];
         let mut total_file_size = 0;
         for sst in ssts {
-            self.compacting_files.insert(sst.sst_id, task_id);
-            total_file_size += sst.sst_size;
-            table_ids.push(sst.sst_id);
+            self.compacting_files.insert(sst.sst_id(), task_id);
+            total_file_size += sst.sst_size();
+            table_ids.push(sst.sst_id());
         }
 
         self.pending_tasks.push(RunningCompactTask {

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::Ordering;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::{
     object_size_map, summarize_group_deltas,
 };
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::hummock::hummock_version_checkpoint::{PbStaleObjects, StaleObjects};
@@ -162,7 +163,7 @@ impl HummockManager {
                     summary
                         .insert_table_infos
                         .iter()
-                        .map(|t| (t.object_id, t.file_size))
+                        .map(|t| (t.object_id(), t.file_size()))
                         .chain(
                             version_delta
                                 .change_log_delta
@@ -173,7 +174,7 @@ impl HummockManager {
                                         .new_value
                                         .iter()
                                         .chain(new_log.old_value.iter())
-                                        .map(|t| (t.object_id, t.file_size))
+                                        .map(|t| (t.object_id(), t.file_size()))
                                 }),
                         ),
                 );

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -20,6 +20,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::compact_task::ReportTask;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::TableGroupInfo;
 use risingwave_hummock_sdk::compaction_group::{StateTableId, StaticCompactionGroupId};
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::version::{GroupDelta, GroupDeltas};
 use risingwave_hummock_sdk::{can_concat, CompactionGroupId};
 use risingwave_pb::hummock::compact_task::TaskStatus;
@@ -146,10 +147,10 @@ impl HummockManager {
 
                 let left_last_sst = left_level.table_infos.last().unwrap().clone();
                 let right_first_sst = right_level.table_infos.first().unwrap().clone();
-                let left_sst_id = left_last_sst.sst_id;
-                let right_sst_id = right_first_sst.sst_id;
-                let left_obj_id = left_last_sst.object_id;
-                let right_obj_id = right_first_sst.object_id;
+                let left_sst_id = left_last_sst.sst_id();
+                let right_sst_id = right_first_sst.sst_id();
+                let left_obj_id = left_last_sst.object_id();
+                let right_obj_id = right_first_sst.object_id();
 
                 // Since the sst key_range within a group is legal, we only need to check the ssts adjacent to the two groups.
                 if !can_concat(&[left_last_sst, right_first_sst]) {

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -332,6 +332,7 @@ mod tests {
 
     use itertools::Itertools;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
+    use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
     use risingwave_hummock_sdk::HummockSstableObjectId;
     use risingwave_rpc_client::HummockMetaClient;
 
@@ -443,7 +444,7 @@ mod tests {
         let committed_object_ids = sst_infos
             .into_iter()
             .flatten()
-            .map(|s| s.object_id)
+            .map(|s| s.object_id())
             .sorted()
             .collect_vec();
         assert!(!committed_object_ids.is_empty());

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -28,6 +28,7 @@ use risingwave_hummock_sdk::change_log::build_table_change_log_delta;
 use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{
     HummockContextId, HummockEpoch, HummockSstableObjectId, HummockVersionId, LocalSstableInfo,
@@ -213,7 +214,7 @@ impl HummockMetaClient for MockHummockMetaClient {
         let sst_to_context = sync_result
             .uncommitted_ssts
             .iter()
-            .map(|LocalSstableInfo { sst_info, .. }| (sst_info.object_id, self.context_id))
+            .map(|LocalSstableInfo { sst_info, .. }| (sst_info.object_id(), self.context_id))
             .collect();
         let new_table_watermark = sync_result.table_watermarks;
         let table_change_log_table_ids = if is_log_store {

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -229,6 +229,7 @@ mod tests {
 
     use itertools::Itertools;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
+    use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
     use risingwave_hummock_sdk::HummockVersionId;
     use risingwave_pb::hummock::VacuumTask;
     use risingwave_rpc_client::HummockMetaClient;
@@ -290,7 +291,7 @@ mod tests {
                     .first()
                     .unwrap()
                     .iter()
-                    .map(|s| s.object_id)
+                    .map(|s| s.object_id())
                     .collect_vec(),
             })
             .await

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -339,8 +339,16 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
         b.to_async(FuturesExecutor).iter(|| {
             let sstable_store1 = sstable_store.clone();
             let sub_iters = vec![
-                ConcatIterator::new(level1.clone(), sstable_store.clone(), read_options.clone()),
-                ConcatIterator::new(level2.clone(), sstable_store.clone(), read_options.clone()),
+                ConcatIterator::new(
+                    level1.clone().into_iter().map(Into::into).collect(),
+                    sstable_store.clone(),
+                    read_options.clone(),
+                ),
+                ConcatIterator::new(
+                    level2.clone().into_iter().map(Into::into).collect(),
+                    sstable_store.clone(),
+                    read_options.clone(),
+                ),
             ];
             let iter = MergeIterator::for_compactor(sub_iters);
             async move { compact(iter, sstable_store1, None).await }

--- a/src/storage/benches/bench_multi_builder.rs
+++ b/src/storage/benches/bench_multi_builder.rs
@@ -25,7 +25,7 @@ use rand::random;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::{MetricLevel, ObjectStoreConfig};
 use risingwave_hummock_sdk::key::{FullKey, UserKey};
-use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoType;
 use risingwave_object_store::object::{
     InMemObjectStore, ObjectStore, ObjectStoreImpl, S3ObjectStore,
 };
@@ -105,7 +105,7 @@ fn test_user_key_of(idx: u64) -> UserKey<Vec<u8>> {
 
 async fn build_tables<F: SstableWriterFactory>(
     mut builder: CapacitySplitTableBuilder<LocalTableBuilderFactory<F>>,
-) -> Vec<SstableInfo> {
+) -> Vec<SstableInfoType> {
     for i in RANGE {
         builder
             .add_full_key_for_test(
@@ -122,7 +122,7 @@ async fn build_tables<F: SstableWriterFactory>(
         .await
         .unwrap()
         .into_iter()
-        .map(|info| info.sst_info)
+        .map(|info| info.sst_info.into())
         .collect()
 }
 

--- a/src/storage/benches/bench_table_watermarks.rs
+++ b/src/storage/benches/bench_table_watermarks.rs
@@ -24,10 +24,11 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
+use risingwave_hummock_sdk::sstable_info_ref::HummockVersionType;
 use risingwave_hummock_sdk::table_watermark::{
     TableWatermarks, TableWatermarksIndex, VnodeWatermark, WatermarkDirection,
 };
-use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionStateTableInfo};
+use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_pb::hummock::{PbHummockVersion, StateTableInfoDelta};
 use risingwave_storage::hummock::local_version::pinned_version::PinnedVersion;
@@ -109,14 +110,14 @@ fn gen_version(
     new_epoch_idx: usize,
     table_count: usize,
     vnode_part_count: usize,
-) -> HummockVersion {
+) -> HummockVersionType {
     let table_watermarks = Arc::new(gen_committed_table_watermarks(
         old_epoch_idx,
         new_epoch_idx,
         vnode_part_count,
     ));
     let committed_epoch = test_epoch(new_epoch_idx as _);
-    let mut version = HummockVersion::from_persisted_protobuf(&PbHummockVersion {
+    let mut version = HummockVersionType::from_persisted_protobuf(&PbHummockVersion {
         id: new_epoch_idx as _,
         max_committed_epoch: committed_epoch,
         ..Default::default()

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -25,6 +25,11 @@ risingwave_common_estimate_size = { workspace = true }
 risingwave_pb = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
+tokio = { version = "0.2", package = "madsim-tokio", features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+] }
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]

--- a/src/storage/hummock_sdk/src/level.rs
+++ b/src/storage/hummock_sdk/src/level.rs
@@ -224,16 +224,16 @@ pub struct LevelsCommon<T> {
 
 pub type Levels = LevelsCommon<SstableInfo>;
 
-impl Levels {
-    pub fn level0(&self) -> &OverlappingLevel {
+impl<T> LevelsCommon<T> {
+    pub fn level0(&self) -> &OverlappingLevelCommon<T> {
         &self.l0
     }
 
-    pub fn get_level(&self, level_idx: usize) -> &Level {
+    pub fn get_level(&self, level_idx: usize) -> &LevelCommon<T> {
         &self.levels[level_idx - 1]
     }
 
-    pub fn get_level_mut(&mut self, level_idx: usize) -> &mut Level {
+    pub fn get_level_mut(&mut self, level_idx: usize) -> &mut LevelCommon<T> {
         &mut self.levels[level_idx - 1]
     }
 

--- a/src/storage/hummock_sdk/src/sstable_info_ref.rs
+++ b/src/storage/hummock_sdk/src/sstable_info_ref.rs
@@ -1,0 +1,177 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use risingwave_pb::hummock::{PbBloomFilterType, PbHummockVersion, PbSstableInfo};
+
+use crate::change_log::EpochNewChangeLogCommon;
+use crate::key_range::KeyRange;
+use crate::sstable_info::SstableInfo;
+use crate::version::{HummockVersion, HummockVersionCommon, HummockVersionDeltaCommon};
+
+pub type SstableInfoType = SstableInfoRef;
+pub type EpochNewChangeLogType = EpochNewChangeLogCommon<SstableInfoType>;
+pub type HummockVersionType = HummockVersionCommon<SstableInfoType>;
+pub type HummockVersionDeltaType = HummockVersionDeltaCommon<SstableInfoType>;
+
+pub trait SstableInfoReader {
+    fn object_id(&self) -> u64;
+    fn sst_id(&self) -> u64;
+    fn key_range(&self) -> &KeyRange;
+    fn file_size(&self) -> u64;
+    fn table_ids(&self) -> &[u32];
+    fn meta_offset(&self) -> u64;
+    fn stale_key_count(&self) -> u64;
+    fn total_key_count(&self) -> u64;
+    fn min_epoch(&self) -> u64;
+    fn max_epoch(&self) -> u64;
+    fn uncompressed_file_size(&self) -> u64;
+    fn range_tombstone_count(&self) -> u64;
+    fn bloom_filter_kind(&self) -> PbBloomFilterType;
+    fn sst_size(&self) -> u64;
+}
+
+pub trait SstableInfoWriter {
+    fn set_sst_id(&mut self, v: u64);
+    fn set_sst_size(&mut self, v: u64);
+    fn set_table_ids(&mut self, v: Vec<u32>);
+}
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct SstableInfoRef {
+    sstable_info: Arc<SstableInfo>,
+}
+
+impl From<&PbSstableInfo> for SstableInfoRef {
+    fn from(pb: &PbSstableInfo) -> Self {
+        // TODO: get arc from global manager
+        Self {
+            sstable_info: Arc::new(SstableInfo::from(pb)),
+        }
+    }
+}
+
+impl From<PbSstableInfo> for SstableInfoRef {
+    fn from(pb: PbSstableInfo) -> Self {
+        (&pb).into()
+    }
+}
+
+impl From<&SstableInfoRef> for PbSstableInfo {
+    fn from(v: &SstableInfoRef) -> Self {
+        (*v.sstable_info).clone().into()
+    }
+}
+
+impl From<SstableInfoRef> for PbSstableInfo {
+    fn from(v: SstableInfoRef) -> Self {
+        (&v).into()
+    }
+}
+
+/// Note that this conversion is inefficient. It should be used only in tests.
+impl From<HummockVersion> for HummockVersionCommon<SstableInfoRef> {
+    fn from(value: HummockVersion) -> Self {
+        let pb = PbHummockVersion::from(value);
+        HummockVersionCommon::from(&pb)
+    }
+}
+
+impl SstableInfoReader for SstableInfoRef {
+    fn object_id(&self) -> u64 {
+        self.sstable_info.object_id()
+    }
+
+    fn sst_id(&self) -> u64 {
+        self.sstable_info.sst_id()
+    }
+
+    fn key_range(&self) -> &KeyRange {
+        self.sstable_info.key_range()
+    }
+
+    fn file_size(&self) -> u64 {
+        self.sstable_info.file_size()
+    }
+
+    fn table_ids(&self) -> &[u32] {
+        self.sstable_info.table_ids()
+    }
+
+    fn meta_offset(&self) -> u64 {
+        self.sstable_info.meta_offset()
+    }
+
+    fn stale_key_count(&self) -> u64 {
+        self.sstable_info.stale_key_count()
+    }
+
+    fn total_key_count(&self) -> u64 {
+        self.sstable_info.total_key_count()
+    }
+
+    fn min_epoch(&self) -> u64 {
+        self.sstable_info.min_epoch()
+    }
+
+    fn max_epoch(&self) -> u64 {
+        self.sstable_info.max_epoch()
+    }
+
+    fn uncompressed_file_size(&self) -> u64 {
+        self.sstable_info.uncompressed_file_size()
+    }
+
+    fn range_tombstone_count(&self) -> u64 {
+        self.sstable_info.range_tombstone_count()
+    }
+
+    fn bloom_filter_kind(&self) -> PbBloomFilterType {
+        self.sstable_info.bloom_filter_kind()
+    }
+
+    fn sst_size(&self) -> u64 {
+        self.sstable_info.sst_size()
+    }
+}
+
+/// Note that these setters are inefficient. Use a builder instead if necessary.
+impl SstableInfoWriter for SstableInfoRef {
+    fn set_sst_id(&mut self, v: u64) {
+        let mut origin = (*self.sstable_info).clone();
+        origin.set_sst_id(v);
+        self.sstable_info = Arc::new(origin);
+    }
+
+    fn set_sst_size(&mut self, v: u64) {
+        let mut origin = (*self.sstable_info).clone();
+        origin.set_sst_size(v);
+        self.sstable_info = Arc::new(origin);
+    }
+
+    fn set_table_ids(&mut self, v: Vec<u32>) {
+        let mut origin = (*self.sstable_info).clone();
+        origin.set_table_ids(v);
+        self.sstable_info = Arc::new(origin);
+    }
+}
+
+impl From<SstableInfo> for SstableInfoRef {
+    fn from(sst: SstableInfo) -> Self {
+        Self {
+            sstable_info: Arc::new(sst),
+        }
+    }
+}

--- a/src/storage/hummock_sdk/src/time_travel.rs
+++ b/src/storage/hummock_sdk/src/time_travel.rs
@@ -21,6 +21,7 @@ use risingwave_pb::hummock::{PbEpochNewChangeLog, PbSstableInfo};
 use crate::change_log::{TableChangeLog, TableChangeLogCommon};
 use crate::level::Level;
 use crate::sstable_info::SstableInfo;
+use crate::sstable_info_ref::SstableInfoReader;
 use crate::version::{
     HummockVersion, HummockVersionCommon, HummockVersionDelta, HummockVersionDeltaCommon,
 };
@@ -74,7 +75,7 @@ fn refill_sstable_info(
     sst_id_to_info: &HashMap<HummockSstableId, SstableInfo>,
 ) {
     *sstable_info = sst_id_to_info
-        .get(&sstable_info.sst_id)
+        .get(&sstable_info.sst_id())
         .unwrap_or_else(|| panic!("SstableInfo should exist"))
         .clone();
 }

--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -26,6 +26,7 @@ use risingwave_common::util::epoch::{test_epoch, EpochExt};
 use risingwave_hummock_sdk::key::{key_with_epoch, map_table_key_range};
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::LocalSstableInfo;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_storage::hummock::event_handler::TEST_LOCAL_INSTANCE_ID;
@@ -240,8 +241,8 @@ async fn test_read_version_basic() {
 
         let staging_ssts = staging_sst_iter.cloned().collect_vec();
         assert_eq!(2, staging_ssts.len());
-        assert_eq!(1, staging_ssts[0].object_id);
-        assert_eq!(2, staging_ssts[1].object_id);
+        assert_eq!(1, staging_ssts[0].object_id());
+        assert_eq!(2, staging_ssts[1].object_id());
     }
 
     {
@@ -264,7 +265,7 @@ async fn test_read_version_basic() {
 
         let staging_ssts = staging_sst_iter.cloned().collect_vec();
         assert_eq!(1, staging_ssts.len());
-        assert_eq!(2, staging_ssts[0].object_id);
+        assert_eq!(2, staging_ssts[0].object_id());
     }
 }
 

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -31,6 +31,7 @@ use risingwave_hummock_sdk::key::{
     gen_key_from_bytes, prefixed_range_with_vnode, FullKey, TableKey, UserKey, TABLE_PREFIX_LEN,
 };
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::table_stats::TableStats;
 use risingwave_hummock_sdk::table_watermark::{
     TableWatermarksIndex, VnodeWatermark, WatermarkDirection,
@@ -2567,10 +2568,10 @@ async fn test_commit_multi_epoch() {
             manager
                 .commit_epoch(CommitEpochInfo {
                     new_table_watermarks: Default::default(),
-                    sst_to_context: context_id_map(&[sst.object_id]),
+                    sst_to_context: context_id_map(&[sst.object_id()]),
                     sstables: vec![LocalSstableInfo {
                         table_stats: sst
-                            .table_ids
+                            .table_ids()
                             .iter()
                             .map(|&table_id| {
                                 (
@@ -2628,7 +2629,10 @@ async fn test_commit_multi_epoch() {
         let sub_level = &sub_levels[0];
         assert_eq!(sub_level.sub_level_id, epoch1);
         assert_eq!(sub_level.table_infos.len(), 1);
-        assert_eq!(sub_level.table_infos[0].object_id, sst1_epoch1.object_id);
+        assert_eq!(
+            sub_level.table_infos[0].object_id(),
+            sst1_epoch1.object_id()
+        );
 
         assert_eq!(version.visible_table_committed_epoch(), epoch1);
 
@@ -2677,11 +2681,17 @@ async fn test_commit_multi_epoch() {
         let sub_level = &sub_levels[0];
         assert_eq!(sub_level.sub_level_id, epoch1);
         assert_eq!(sub_level.table_infos.len(), 1);
-        assert_eq!(sub_level.table_infos[0].object_id, sst1_epoch1.object_id);
+        assert_eq!(
+            sub_level.table_infos[0].object_id(),
+            sst1_epoch1.object_id()
+        );
         let sub_level = &sub_levels[1];
         assert_eq!(sub_level.sub_level_id, epoch2);
         assert_eq!(sub_level.table_infos.len(), 1);
-        assert_eq!(sub_level.table_infos[0].object_id, sst1_epoch2.object_id);
+        assert_eq!(
+            sub_level.table_infos[0].object_id(),
+            sst1_epoch2.object_id()
+        );
 
         assert_eq!(version.visible_table_committed_epoch(), epoch2);
 
@@ -2732,7 +2742,10 @@ async fn test_commit_multi_epoch() {
         let sub_level1 = &sub_levels[0];
         assert_eq!(sub_level1.sub_level_id, epoch1);
         assert_eq!(sub_level1.table_infos.len(), 1);
-        assert_eq!(sub_level1.table_infos[0].object_id, sst2_epoch1.object_id);
+        assert_eq!(
+            sub_level1.table_infos[0].object_id(),
+            sst2_epoch1.object_id()
+        );
 
         assert_eq!(version.visible_table_committed_epoch(), epoch2);
 
@@ -2770,11 +2783,17 @@ async fn test_commit_multi_epoch() {
         let sub_level1 = &sub_levels[0];
         assert_eq!(sub_level1.sub_level_id, epoch1);
         assert_eq!(sub_level1.table_infos.len(), 1);
-        assert_eq!(sub_level1.table_infos[0].object_id, sst2_epoch1.object_id);
+        assert_eq!(
+            sub_level1.table_infos[0].object_id(),
+            sst2_epoch1.object_id()
+        );
         let sub_level2 = &sub_levels[1];
         assert_eq!(sub_level2.sub_level_id, epoch2);
         assert_eq!(sub_level2.table_infos.len(), 1);
-        assert_eq!(sub_level2.table_infos[0].object_id, sst2_epoch2.object_id);
+        assert_eq!(
+            sub_level2.table_infos[0].object_id(),
+            sst2_epoch2.object_id()
+        );
 
         assert_eq!(version.visible_table_committed_epoch(), epoch2);
 
@@ -2814,15 +2833,24 @@ async fn test_commit_multi_epoch() {
         let sub_level1 = &sub_levels[0];
         assert_eq!(sub_level1.sub_level_id, epoch1);
         assert_eq!(sub_level1.table_infos.len(), 1);
-        assert_eq!(sub_level1.table_infos[0].object_id, sst1_epoch1.object_id);
+        assert_eq!(
+            sub_level1.table_infos[0].object_id(),
+            sst1_epoch1.object_id()
+        );
         let sub_level2 = &sub_levels[1];
         assert_eq!(sub_level2.sub_level_id, epoch2);
         assert_eq!(sub_level2.table_infos.len(), 1);
-        assert_eq!(sub_level2.table_infos[0].object_id, sst1_epoch2.object_id);
+        assert_eq!(
+            sub_level2.table_infos[0].object_id(),
+            sst1_epoch2.object_id()
+        );
         let sub_level3 = &sub_levels[2];
         assert_eq!(sub_level3.sub_level_id, epoch3);
         assert_eq!(sub_level3.table_infos.len(), 1);
-        assert_eq!(sub_level3.table_infos[0].object_id, sst_epoch3.object_id);
+        assert_eq!(
+            sub_level3.table_infos[0].object_id(),
+            sst_epoch3.object_id()
+        );
 
         let new_cg = version.levels.get(&new_cg_id).unwrap();
         let sub_levels = &new_cg.l0.sub_levels;
@@ -2830,15 +2858,24 @@ async fn test_commit_multi_epoch() {
         let sub_level1 = &sub_levels[0];
         assert_eq!(sub_level1.sub_level_id, epoch1);
         assert_eq!(sub_level1.table_infos.len(), 1);
-        assert_eq!(sub_level1.table_infos[0].object_id, sst2_epoch1.object_id);
+        assert_eq!(
+            sub_level1.table_infos[0].object_id(),
+            sst2_epoch1.object_id()
+        );
         let sub_level2 = &sub_levels[1];
         assert_eq!(sub_level2.sub_level_id, epoch2);
         assert_eq!(sub_level2.table_infos.len(), 1);
-        assert_eq!(sub_level2.table_infos[0].object_id, sst2_epoch2.object_id);
+        assert_eq!(
+            sub_level2.table_infos[0].object_id(),
+            sst2_epoch2.object_id()
+        );
         let sub_level3 = &sub_levels[1];
         assert_eq!(sub_level3.sub_level_id, epoch2);
         assert_eq!(sub_level3.table_infos.len(), 1);
-        assert_eq!(sub_level3.table_infos[0].object_id, sst2_epoch2.object_id);
+        assert_eq!(
+            sub_level3.table_infos[0].object_id(),
+            sst2_epoch2.object_id()
+        );
 
         assert_eq!(version.visible_table_committed_epoch(), epoch3);
 

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -27,6 +27,7 @@ use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::{test_epoch, EpochExt, MAX_EPOCH};
 use risingwave_hummock_sdk::key::{prefixed_range_with_vnode, TableKeyRange};
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::{
     HummockReadEpoch, HummockSstableObjectId, LocalSstableInfo, SyncResult,
 };
@@ -1333,7 +1334,7 @@ async fn test_gc_watermark_and_clear_shared_buffer() {
         sync_result
             .uncommitted_ssts
             .iter()
-            .map(|LocalSstableInfo { sst_info, .. }| sst_info.object_id)
+            .map(|LocalSstableInfo { sst_info, .. }| sst_info.object_id())
             .min()
             .unwrap()
     };

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -24,6 +24,7 @@ use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::{next_key, user_key};
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::table_stats::to_prost_table_stats_map;
 use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_meta::hummock::compaction::compaction_config::CompactionConfigBuilder;
@@ -441,10 +442,10 @@ async fn test_syncpoints_get_in_delete_range_boundary() {
         .get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into())
         .levels[4];
     assert_eq!(base_level.table_infos.len(), 3);
-    assert!(base_level.table_infos[0].key_range.right_exclusive);
+    assert!(base_level.table_infos[0].key_range().right_exclusive);
     assert_eq!(
-        user_key(&base_level.table_infos[0].key_range.right),
-        user_key(&base_level.table_infos[1].key_range.left),
+        user_key(&base_level.table_infos[0].key_range().right),
+        user_key(&base_level.table_infos[1].key_range().left),
     );
     storage.wait_version(version).await;
     let read_options = ReadOptions {

--- a/src/storage/src/hummock/backup_reader.rs
+++ b/src/storage/src/hummock/backup_reader.rs
@@ -289,7 +289,10 @@ impl BackupReader {
 
 fn build_version_holder<S: Metadata>(s: MetaSnapshot<S>) -> VersionHolder {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    (PinnedVersion::new(s.metadata.hummock_version(), tx), rx)
+    (
+        PinnedVersion::new(s.metadata.hummock_version().into(), tx),
+        rx,
+    )
 }
 
 impl From<BackupError> for StorageError {

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -27,6 +27,7 @@ use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::table_stats::TableStats;
 use risingwave_hummock_sdk::{can_concat, compact_task_to_string, EpochWithGap, LocalSstableInfo};
 
@@ -110,7 +111,7 @@ impl BlockStreamIterator {
         let block_stream = self
             .sstable_store
             .get_stream_for_blocks(
-                self.sstable_info.object_id,
+                self.sstable_info.object_id(),
                 &self.sstable.meta.block_metas[self.next_block_index..],
             )
             .verbose_instrument_await("stream_iter_get_stream")
@@ -163,10 +164,10 @@ impl BlockStreamIterator {
                         self.io_retry_times,
                         format!(
                             "object_id={}, sst_id={}, meta_offset={}, table_ids={:?}",
-                            self.sstable_info.object_id,
-                            self.sstable_info.sst_id,
-                            self.sstable_info.meta_offset,
-                            self.sstable_info.table_ids
+                            self.sstable_info.object_id(),
+                            self.sstable_info.sst_id(),
+                            self.sstable_info.meta_offset(),
+                            self.sstable_info.table_ids()
                         )
                     );
                 }
@@ -578,10 +579,10 @@ impl CompactorRunner {
         }
         let mut total_read_bytes = 0;
         for sst in &self.left.sstables {
-            total_read_bytes += sst.sst_size;
+            total_read_bytes += sst.sst_size();
         }
         for sst in &self.right.sstables {
-            total_read_bytes += sst.sst_size;
+            total_read_bytes += sst.sst_size();
         }
         self.metrics
             .compact_fast_runner_bytes

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -52,6 +52,7 @@ pub use context::{
 use futures::{pin_mut, StreamExt};
 pub use iterator::{ConcatSstableIterator, SstableStreamIterator};
 use more_asserts::assert_ge;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoReader;
 use risingwave_hummock_sdk::table_stats::{to_prost_table_stats_map, TableStatsMap};
 use risingwave_hummock_sdk::{compact_task_to_string, HummockCompactionTaskId, LocalSstableInfo};
 use risingwave_pb::hummock::compact_task::TaskStatus;
@@ -189,7 +190,7 @@ impl Compactor {
 
         debug_assert!(split_table_outputs
             .iter()
-            .all(|table_info| table_info.sst_info.table_ids.is_sorted()));
+            .all(|table_info| table_info.sst_info.table_ids().is_sorted()));
 
         if task_id.is_some() {
             // skip shared buffer compaction

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -942,7 +942,7 @@ mod tests {
     use risingwave_common::bitmap::BitmapBuilder;
     use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::{test_epoch, EpochExt};
-    use risingwave_hummock_sdk::version::HummockVersion;
+    use risingwave_hummock_sdk::sstable_info_ref::HummockVersionType;
     use risingwave_pb::hummock::PbHummockVersion;
     use tokio::spawn;
     use tokio::sync::mpsc::unbounded_channel;
@@ -967,7 +967,7 @@ mod tests {
         let mut make_new_version = |max_committed_epoch| {
             let id = next_version_id;
             next_version_id += 1;
-            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+            HummockVersionType::from_rpc_protobuf(&PbHummockVersion {
                 id,
                 max_committed_epoch,
                 ..Default::default()
@@ -1102,7 +1102,7 @@ mod tests {
         let epoch0 = test_epoch(233);
 
         let initial_version = PinnedVersion::new(
-            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+            HummockVersionType::from_rpc_protobuf(&PbHummockVersion {
                 id: 1,
                 max_committed_epoch: epoch0,
                 ..Default::default()

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -32,7 +32,8 @@ pub mod refiller;
 pub mod uploader;
 
 pub use hummock_event_handler::HummockEventHandler;
-use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoType;
+use risingwave_hummock_sdk::version::{HummockVersionCommon, HummockVersionDeltaCommon};
 
 use super::store::version::HummockReadVersion;
 use crate::hummock::event_handler::hummock_event_handler::HummockEventSender;
@@ -47,8 +48,8 @@ pub struct BufferWriteRequest {
 
 #[derive(Debug)]
 pub enum HummockVersionUpdate {
-    VersionDeltas(Vec<HummockVersionDelta>),
-    PinnedVersion(Box<HummockVersion>),
+    VersionDeltas(Vec<HummockVersionDeltaCommon<SstableInfoType>>),
+    PinnedVersion(Box<HummockVersionCommon<SstableInfoType>>),
 }
 
 pub enum HummockEvent {

--- a/src/storage/src/hummock/event_handler/uploader/test_utils.rs
+++ b/src/storage/src/hummock/event_handler/uploader/test_utils.rs
@@ -33,7 +33,7 @@ use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::{FullKey, TableKey};
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
-use risingwave_hummock_sdk::version::HummockVersion;
+use risingwave_hummock_sdk::sstable_info_ref::HummockVersionType;
 use risingwave_hummock_sdk::{HummockEpoch, LocalSstableInfo};
 use risingwave_pb::hummock::{PbHummockVersion, StateTableInfoDelta};
 use spin::Mutex;
@@ -88,8 +88,8 @@ impl HummockUploader {
     }
 }
 
-pub(super) fn test_hummock_version(epoch: HummockEpoch) -> HummockVersion {
-    let mut version = HummockVersion::from_persisted_protobuf(&PbHummockVersion {
+pub(super) fn test_hummock_version(epoch: HummockEpoch) -> HummockVersionType {
+    let mut version = HummockVersionType::from_persisted_protobuf(&PbHummockVersion {
         id: epoch,
         max_committed_epoch: epoch,
         ..Default::default()

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -23,6 +23,7 @@ use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_hummock_sdk::key::{prefix_slice_with_vnode, FullKey, TableKey, UserKey};
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoType;
 use risingwave_hummock_sdk::{EpochWithGap, HummockEpoch, HummockSstableObjectId};
 use risingwave_object_store::object::{
     InMemObjectStore, ObjectStore, ObjectStoreImpl, ObjectStoreRef,
@@ -162,7 +163,7 @@ pub async fn gen_iterator_test_sstable_info(
     idx_mapping: impl Fn(usize) -> usize,
     sstable_store: SstableStoreRef,
     total: usize,
-) -> SstableInfo {
+) -> SstableInfoType {
     gen_test_sstable_info(
         opts,
         object_id,
@@ -175,6 +176,7 @@ pub async fn gen_iterator_test_sstable_info(
         sstable_store,
     )
     .await
+    .into()
 }
 
 /// Generates a test table used in almost all table-related tests. Developers may verify the

--- a/src/storage/src/hummock/local_version/recent_versions.rs
+++ b/src/storage/src/hummock/local_version/recent_versions.rs
@@ -191,7 +191,7 @@ mod tests {
     use std::collections::HashMap;
 
     use risingwave_common::catalog::TableId;
-    use risingwave_hummock_sdk::version::HummockVersion;
+    use risingwave_hummock_sdk::sstable_info_ref::HummockVersionType;
     use risingwave_pb::hummock::{PbHummockVersion, StateTableInfo};
     use tokio::sync::mpsc::unbounded_channel;
 
@@ -206,7 +206,7 @@ mod tests {
         table_committed_epoch: impl IntoIterator<Item = (TableId, u64)>,
     ) -> PinnedVersion {
         PinnedVersion::new(
-            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+            HummockVersionType::from_rpc_protobuf(&PbHummockVersion {
                 id: version_id,
                 state_table_info: HashMap::from_iter(table_committed_epoch.into_iter().map(
                     |(table_id, committed_epoch)| {

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use risingwave_common_service::ObserverState;
-use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
+use risingwave_hummock_sdk::sstable_info_ref::{HummockVersionDeltaType, HummockVersionType};
 use risingwave_hummock_trace::TraceSpan;
 use risingwave_pb::catalog::Table;
 use risingwave_pb::meta::relation::RelationInfo;
@@ -77,7 +77,7 @@ impl ObserverState for HummockObserverNode {
                         hummock_version_deltas
                             .version_deltas
                             .iter()
-                            .map(HummockVersionDelta::from_rpc_protobuf)
+                            .map(HummockVersionDeltaType::from_rpc_protobuf)
                             .collect(),
                     ))
                     .inspect_err(|e| {
@@ -124,7 +124,7 @@ impl ObserverState for HummockObserverNode {
         let _ = self
             .version_update_sender
             .send(HummockVersionUpdate::PinnedVersion(Box::new(
-                HummockVersion::from_rpc_protobuf(
+                HummockVersionType::from_rpc_protobuf(
                     &snapshot
                         .hummock_version
                         .expect("should get hummock version"),

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -24,7 +24,7 @@ use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::MAX_SPILL_TIMES;
 use risingwave_hummock_sdk::key::{is_empty_key_range, vnode_range, TableKey, TableKeyRange};
-use risingwave_hummock_sdk::sstable_info::SstableInfo;
+use risingwave_hummock_sdk::sstable_info_ref::SstableInfoType;
 use risingwave_hummock_sdk::{EpochWithGap, HummockEpoch};
 use tracing::{warn, Instrument};
 
@@ -888,7 +888,7 @@ impl IteratorFactory for ForwardIteratorFactory {
 
     fn add_concat_sst_iter(
         &mut self,
-        tables: Vec<SstableInfo>,
+        tables: Vec<SstableInfoType>,
         sstable_store: SstableStoreRef,
         read_options: Arc<SstableIteratorReadOptions>,
     ) {
@@ -957,7 +957,7 @@ impl IteratorFactory for BackwardIteratorFactory {
 
     fn add_concat_sst_iter(
         &mut self,
-        mut tables: Vec<SstableInfo>,
+        mut tables: Vec<SstableInfoType>,
         sstable_store: SstableStoreRef,
         read_options: Arc<SstableIteratorReadOptions>,
     ) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Given that compute node now will retain many recent hummock versions, to reduce its memory footprint, this PR stores and reuses `Arc<SstableInfo>` instead of `SstableInfo` in `HummockVersion` for compute node.

Two major changes:
- make relevant methods compatible with both `Arc<SstableInfo>` and `SstableInfo`.
- add a `SstableInfoCache` in `HummockObserverNode`, where `PbHummockVersion` and `PbHummockVersionDelta` are converted to types, i.e. `HummockVersion<Arc<SstableInfo>>`. `Arc<SstableInfo>` is retrieved from the cache whenever feasible.

Please find more details about how the `Arc<SstableInfo>` is cached and shared in `impl From<&PbSstableInfo> for SstableInfoRef` in `sstable_info_ref.rs`.

~~This PR is part1 of the refactor, aiming to adapt the related methods to be compatible with both `Arc<SstableInfo>` and `SstableInfo`.  After this PR, the `HummockVersion` in compute node will use `Arc<SstableInfo>`. However these `Arc<SstableInfo>` is not reused across `HummockVersion`, i.e. the memory footprint is not reduced yet. It'll be done in another PR after this one.~~

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
