### PR TITLE
refactor(meta): remove BarrierInfo and reduce pause and resume log output

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -160,17 +160,11 @@ enum PausedReason {
 
 message PauseRequest {}
 
-message PauseResponse {
-  optional PausedReason prev = 1;
-  optional PausedReason curr = 2;
-}
+message PauseResponse {}
 
 message ResumeRequest {}
 
-message ResumeResponse {
-  optional PausedReason prev = 1;
-  optional PausedReason curr = 2;
-}
+message ResumeResponse {}
 
 message CancelCreatingJobsRequest {
   message CreatingJobInfo {

--- a/src/ctl/src/cmd_impl/meta/pause_resume.rs
+++ b/src/ctl/src/cmd_impl/meta/pause_resume.rs
@@ -16,7 +16,7 @@ use risingwave_pb::meta::PausedReason;
 
 use crate::CtlContext;
 
-fn desc(reason: PausedReason) -> &'static str {
+pub fn desc(reason: PausedReason) -> &'static str {
     // Method on optional enums derived from `prost` will use `Unspecified` if unset. So we treat
     // `Unspecified` as not paused here.
     match reason {
@@ -29,13 +29,9 @@ fn desc(reason: PausedReason) -> &'static str {
 pub async fn pause(context: &CtlContext) -> anyhow::Result<()> {
     let meta_client = context.meta_client().await?;
 
-    let response = meta_client.pause().await?;
+    meta_client.pause().await?;
 
-    println!(
-        "Done.\nPrevious: {}\nCurrent: {}",
-        desc(response.prev()),
-        desc(response.curr())
-    );
+    println!("Done.");
 
     Ok(())
 }
@@ -43,13 +39,9 @@ pub async fn pause(context: &CtlContext) -> anyhow::Result<()> {
 pub async fn resume(context: &CtlContext) -> anyhow::Result<()> {
     let meta_client = context.meta_client().await?;
 
-    let response = meta_client.resume().await?;
+    meta_client.resume().await?;
 
-    println!(
-        "Done.\nPrevious: {}\nCurrent: {}",
-        desc(response.prev()),
-        desc(response.curr())
-    );
+    println!("Done.");
 
     Ok(())
 }

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -78,26 +78,18 @@ impl StreamManagerService for StreamServiceImpl {
 
     #[cfg_attr(coverage, coverage(off))]
     async fn pause(&self, _: Request<PauseRequest>) -> Result<Response<PauseResponse>, Status> {
-        let i = self
-            .barrier_scheduler
+        self.barrier_scheduler
             .run_command(Command::pause(PausedReason::Manual))
             .await?;
-        Ok(Response::new(PauseResponse {
-            prev: i.prev_paused_reason.map(Into::into),
-            curr: i.curr_paused_reason.map(Into::into),
-        }))
+        Ok(Response::new(PauseResponse {}))
     }
 
     #[cfg_attr(coverage, coverage(off))]
     async fn resume(&self, _: Request<ResumeRequest>) -> Result<Response<ResumeResponse>, Status> {
-        let i = self
-            .barrier_scheduler
+        self.barrier_scheduler
             .run_command(Command::resume(PausedReason::Manual))
             .await?;
-        Ok(Response::new(ResumeResponse {
-            prev: i.prev_paused_reason.map(Into::into),
-            curr: i.curr_paused_reason.map(Into::into),
-        }))
+        Ok(Response::new(ResumeResponse {}))
     }
 
     #[cfg_attr(coverage, coverage(off))]

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -54,7 +54,6 @@ use self::command::CommandContext;
 use self::notifier::Notifier;
 use crate::barrier::creating_job::CreatingStreamingJobControl;
 use crate::barrier::info::InflightGraphInfo;
-use crate::barrier::notifier::BarrierInfo;
 use crate::barrier::progress::{CreateMviewProgressTracker, TrackingCommand, TrackingJob};
 use crate::barrier::rpc::{merge_node_rpc_errors, ControlStreamManager};
 use crate::barrier::state::BarrierManagerState;
@@ -1075,16 +1074,9 @@ impl GlobalBarrierManager {
         };
 
         // Notify about the injection.
-        let prev_paused_reason = self.state.paused_reason();
         let curr_paused_reason = command_ctx.next_paused_reason();
 
-        let info = BarrierInfo {
-            prev_epoch: prev_epoch.value(),
-            curr_epoch: curr_epoch.value(),
-            prev_paused_reason,
-            curr_paused_reason,
-        };
-        notifiers.iter_mut().for_each(|n| n.notify_started(info));
+        notifiers.iter_mut().for_each(|n| n.notify_started());
 
         // Update the paused state after the barrier is injected.
         self.state.set_paused_reason(curr_paused_reason);

--- a/src/meta/src/barrier/notifier.rs
+++ b/src/meta/src/barrier/notifier.rs
@@ -12,27 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::util::epoch::Epoch;
-use risingwave_pb::meta::PausedReason;
 use tokio::sync::oneshot;
 
 use crate::{MetaError, MetaResult};
-
-/// The barrier info sent back to the caller when a barrier is injected.
-#[derive(Debug, Clone, Copy)]
-pub struct BarrierInfo {
-    pub prev_epoch: Epoch,
-    pub curr_epoch: Epoch,
-
-    pub prev_paused_reason: Option<PausedReason>,
-    pub curr_paused_reason: Option<PausedReason>,
-}
 
 /// Used for notifying the status of a scheduled command/barrier.
 #[derive(Debug, Default)]
 pub(crate) struct Notifier {
     /// Get notified when scheduled barrier has started to be handled.
-    pub started: Option<oneshot::Sender<MetaResult<BarrierInfo>>>,
+    pub started: Option<oneshot::Sender<MetaResult<()>>>,
 
     /// Get notified when scheduled barrier is collected or failed.
     pub collected: Option<oneshot::Sender<MetaResult<()>>>,
@@ -40,9 +28,9 @@ pub(crate) struct Notifier {
 
 impl Notifier {
     /// Notify when we have injected a barrier to compute nodes.
-    pub fn notify_started(&mut self, info: BarrierInfo) {
+    pub fn notify_started(&mut self) {
         if let Some(tx) = self.started.take() {
-            tx.send(Ok(info)).ok();
+            tx.send(Ok(())).ok();
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously in global barrier manager, we call `notify_started` providing with `BarrierInfo`. The `BarrierInfo` is ultimately used in the `println!` of `resume` and `pause` command of `risectl`.

In a future development, we may change to skip some commands when the cluster is empty (no streaming job) so that we won't call `commit_epoch` to hummock with empty table id list. In this case, we are be able to generate this `BarrierInfo` for these skipped command. Therefore, in this PR, we change to not providing `BarrierInfo` for `notify_started`, in the cost of reducing the log output of `pause` and `resume` for `risectl`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
