### PR TITLE
fix(scale): Fixed propagation issue with low level no shuffle scale in the sql backend 

### DIFF
--- a/src/meta/src/controller/scale.rs
+++ b/src/meta/src/controller/scale.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use itertools::Itertools;
 use risingwave_meta_model_migration::{
     Alias, CommonTableExpression, Expr, IntoColumnRef, QueryStatementBuilder, SelectStatement,
     UnionType, WithClause, WithQuery,
@@ -230,7 +231,14 @@ impl CatalogController {
         // NO_SHUFFLE related multi-layer downstream fragments
         let no_shuffle_related_downstream_fragment_ids = resolve_no_shuffle_query(
             txn,
-            construct_no_shuffle_downstream_traverse_query(fragment_ids.clone()),
+            construct_no_shuffle_downstream_traverse_query(
+                no_shuffle_related_upstream_fragment_ids
+                    .iter()
+                    .map(|(src, _, _)| *src)
+                    .chain(fragment_ids.iter().cloned())
+                    .unique()
+                    .collect(),
+            ),
         )
         .await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When scaling, after finding the root with no shuffle, the working set should traverse downwards from the root fragment rather than from the initial fragment.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
