### PR TITLE
fix(scale): Remove the wrong assert for broadcast dispatcher in the scaling post apply stage

### DIFF
--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1631,13 +1631,12 @@ impl CatalogController {
 
                     let mut dispatcher = dispatcher.into_active_model();
 
+                    // Only hash dispatcher needs mapping
                     if dispatcher.dispatcher_type.as_ref() == &DispatcherType::Hash {
                         dispatcher.hash_mapping =
                             Set(upstream_dispatcher_mapping.as_ref().map(|m| {
                                 risingwave_meta_model_v2::ActorMapping::from(&m.to_protobuf())
                             }));
-                    } else {
-                        debug_assert!(upstream_dispatcher_mapping.is_none());
                     }
 
                     let mut new_downstream_actor_ids =


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

A Fragment may be pointed to by multiple types of dispatchers, so the `upstream_dispatcher_mapping` of the fragment should only take effect for hash mapping, which means there could be cases like broadcast dispatcher that don't require mapping updates.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
