### PR TITLE
refactor(meta): reduce time travel hummock version size

### DIFF
--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -330,6 +330,7 @@ impl HummockManager {
             .order_by_asc(hummock_time_travel_delta::Column::VersionId)
             .all(&sql_store.conn)
             .await?;
+        // SstableInfo in actual_version is incomplete before refill_version.
         let mut actual_version = replay_archive(
             replay_version.version.to_protobuf(),
             deltas.into_iter().map(|d| d.version_delta.to_protobuf()),
@@ -363,7 +364,7 @@ impl HummockManager {
                 query_epoch, actual_version_id,
             ))));
         }
-        refill_version(&mut actual_version, &sst_id_to_info);
+        refill_version(&mut actual_version, &sst_id_to_info, table_id);
         Ok(actual_version)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As time travel version is always retrieved for a specific table, its size can be minimized by only retaining `SstableInfo` relevant to this table.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
