### PR TITLE
fix(nats): align offset and property fields between NATS and others for better ux and dx

### DIFF
--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -674,7 +674,7 @@ impl NatsCommon {
                 }
             }
             NatsOffset::Timestamp(v) => DeliverPolicy::ByStartTime {
-                start_time: OffsetDateTime::from_unix_timestamp_nanos(v * 1_000_000)
+                start_time: OffsetDateTime::from_unix_timestamp_nanos(v as i128 * 1_000_000)
                     .context("invalid timestamp for nats offset")?,
             },
             NatsOffset::None => DeliverPolicy::All,

--- a/src/connector/src/source/kinesis/mod.rs
+++ b/src/connector/src/source/kinesis/mod.rs
@@ -40,7 +40,7 @@ pub struct KinesisProperties {
 
     #[serde(rename = "scan.startup.timestamp.millis")]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    pub timestamp_offset: Option<i64>,
+    pub start_timestamp_millis: Option<i64>,
 
     #[serde(flatten)]
     pub common: KinesisCommon,
@@ -80,6 +80,6 @@ mod test {
 
         let kinesis_props: KinesisProperties =
             serde_json::from_value(serde_json::to_value(props).unwrap()).unwrap();
-        assert_eq!(kinesis_props.timestamp_offset, Some(123456789));
+        assert_eq!(kinesis_props.start_timestamp_millis, Some(123456789));
     }
 }

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -74,14 +74,14 @@ impl SplitReader for KinesisSplitReader {
                     "earliest" => KinesisOffset::Earliest,
                     "latest" => KinesisOffset::Latest,
                     "timestamp" => {
-                        if let Some(ts) = &properties.timestamp_offset {
+                        if let Some(ts) = &properties.start_timestamp_millis {
                             KinesisOffset::Timestamp(*ts)
                         } else {
                             bail!("scan.startup.timestamp.millis is required");
                         }
                     }
                     _ => {
-                        bail!("invalid scan_startup_mode, accept earliest/latest/timestamp")
+                        bail!("invalid scan.startup.mode, accept earliest/latest/timestamp")
                     }
                 },
             },
@@ -89,7 +89,7 @@ impl SplitReader for KinesisSplitReader {
         };
 
         if !matches!(next_offset, KinesisOffset::Timestamp(_))
-            && properties.timestamp_offset.is_some()
+            && properties.start_timestamp_millis.is_some()
         {
             // cannot bail! here because all new split readers will fail to start if user set 'scan.startup.mode' to 'timestamp'
             tracing::warn!("scan.startup.mode needs to be set to 'timestamp' if you want to start with a specific timestamp, starting shard {} from the beginning",
@@ -356,7 +356,7 @@ mod tests {
             },
 
             scan_startup_mode: None,
-            timestamp_offset: None,
+            start_timestamp_millis: None,
 
             unknown_fields: Default::default(),
         };

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -60,6 +60,7 @@ impl ReplayPolicyWrapper {
     }
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct NatsProperties {
     #[serde(flatten)]
@@ -75,7 +76,8 @@ pub struct NatsProperties {
         rename = "scan.startup.timestamp.millis",
         alias = "scan.startup.timestamp_millis"
     )]
-    pub start_time: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub start_timestamp_millis: Option<i64>,
 
     #[serde(rename = "stream")]
     pub stream: String,

--- a/src/connector/src/source/nats/split.rs
+++ b/src/connector/src/source/nats/split.rs
@@ -23,7 +23,7 @@ pub enum NatsOffset {
     Earliest,
     Latest,
     SequenceNumber(String),
-    Timestamp(i128),
+    Timestamp(i64),
     None,
 }
 

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -636,7 +636,7 @@ NatsProperties:
     field_type: String
     required: false
   - name: scan.startup.timestamp.millis
-    field_type: String
+    field_type: i64
     required: false
     alias:
     - scan.startup.timestamp_millis


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Seems we now prefer the following style of connector properties:

```
scan.startup.mode='timestamp',
scan.startup.timestamp.millis='123456'
```

This PR refines the NATS source connector to align with this style.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

https://github.com/risingwavelabs/risingwave-docs/pull/2643

