### PR TITLE
fix(meta): fix query for `running_fragment_parallelisms` in postgres backend

### DIFF
--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::hash::{VnodeCountCompat, WorkerSlotId};
 use risingwave_common::util::stream_graph_visitor::visit_stream_node;
+use risingwave_meta_model_migration::{Alias, SelectStatement};
 use risingwave_meta_model_v2::actor::ActorStatus;
 use risingwave_meta_model_v2::fragment::DistributionType;
 use risingwave_meta_model_v2::prelude::{Actor, ActorDispatcher, Fragment, Sink, StreamingJob};
@@ -48,7 +49,7 @@ use sea_orm::sea_query::Expr;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
     ColumnTrait, DbErr, EntityTrait, JoinType, ModelTrait, PaginatorTrait, QueryFilter,
-    QuerySelect, RelationTrait, TransactionTrait, Value,
+    QuerySelect, RelationTrait, SelectGetableTuple, Selector, TransactionTrait, Value,
 };
 
 use crate::controller::catalog::{CatalogController, CatalogControllerInner};
@@ -480,21 +481,40 @@ impl CatalogController {
     ) -> MetaResult<HashMap<FragmentId, FragmentParallelismInfo>> {
         let inner = self.inner.read().await;
 
-        let mut select = Actor::find()
-            .select_only()
+        let query_alias = Alias::new("fragment_actor_count");
+        let count_alias = Alias::new("count");
+
+        let mut query = SelectStatement::new()
             .column(actor::Column::FragmentId)
-            .column_as(actor::Column::ActorId.count(), "count")
-            .group_by(actor::Column::FragmentId);
+            .expr_as(actor::Column::ActorId.count(), count_alias.clone())
+            .from(Actor)
+            .group_by_col(actor::Column::FragmentId)
+            .to_owned();
+
         if let Some(id_filter) = id_filter {
-            select = select.having(actor::Column::FragmentId.is_in(id_filter));
+            query.cond_having(actor::Column::FragmentId.is_in(id_filter));
         }
-        select = select
-            .join(JoinType::InnerJoin, actor::Relation::Fragment.def())
+
+        let outer = SelectStatement::new()
+            .column((Fragment, fragment::Column::FragmentId))
+            .column(count_alias)
             .column(fragment::Column::DistributionType)
-            .column(fragment::Column::VnodeCount);
+            .column(fragment::Column::VnodeCount)
+            .from_subquery(query.to_owned(), query_alias.clone())
+            .inner_join(
+                Fragment,
+                Expr::col((query_alias, actor::Column::FragmentId))
+                    .equals((Fragment, fragment::Column::FragmentId)),
+            )
+            .to_owned();
 
         let fragment_parallelisms: Vec<(FragmentId, i64, DistributionType, i32)> =
-            select.into_tuple().all(&inner.db).await?;
+            Selector::<SelectGetableTuple<(FragmentId, i64, DistributionType, i32)>>::into_tuple(
+                outer.to_owned(),
+            )
+            .all(&inner.db)
+            .await?;
+
         Ok(fragment_parallelisms
             .into_iter()
             .map(|(fragment_id, count, distribution_type, vnode_count)| {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The previous query in #18515 works for SQLite but will be rejected by PostgreSQL. Rewritten with `sea-query`. Tested locally.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
