### PR TITLE
fix: better error message for `./risedev d` timeout

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -713,7 +713,7 @@ ${TMUX} list-windows -F "#{window_name} #{pane_id}" \
 | xargs -I {} ${TMUX} send-keys -t {} C-c
 
 # Stop docker components
-containers=$(docker ps -a -q -f name=risedev- 2>/dev/null) || true
+containers=$(docker ps -q -f name='risedev|risingwave'- 2>/dev/null) || true
 if [[ -n ${containers} ]]; then
   echo "Stopping docker components..."
   docker stop ${containers}

--- a/src/risedevtool/src/wait.rs
+++ b/src/risedevtool/src/wait.rs
@@ -100,7 +100,10 @@ pub fn wait_tcp_available(
 
         if let Some(ref timeout) = timeout {
             if std::time::Instant::now() - start_time >= *timeout {
-                return Err(anyhow!("failed to wait for closing"));
+                return Err(anyhow!(
+                    "Failed to wait for port closing on {}. The port may still be in use by another process or application. Please ensure the port is not being used elsewhere and try again.",
+                    server
+                ));
             }
         }
 


### PR DESCRIPTION
For the reason when use `./risedev d` failed to start, when the server and port is in used the error only shows `failed to wait for closing` This patch make the message better. Also make docker kill the containers named risingwave(which started by docker-compose.

when start docker-compose

```cli
cd risingwave/integration_tests/ad-ctr
docker compose up -d
```
then forget to close the docker container by `compose down`
./risedev d  error message only `failed to wait for closing` this path make the error message better
also fix the `./risedev k` only kill the container named `risedev` this patch add `risingwave` name to
`./risedev k` to make it easy to use

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
