### PR TITLE
feat: ensure number of tokio worker threads to be at least 4

### DIFF
--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -37,6 +37,8 @@ mod prof;
 use prof::*;
 use tokio::signal::unix::SignalKind;
 
+const MIN_WORKER_THREADS: usize = 4;
+
 /// Start RisingWave components with configs from environment variable.
 ///
 /// # Shutdown on Ctrl-C
@@ -77,6 +79,21 @@ where
     // `TOKIO` will be read by tokio. Duplicate `RW` for compatibility.
     if let Some(worker_threads) = std::env::var_os("RW_WORKER_THREADS") {
         std::env::set_var("TOKIO_WORKER_THREADS", worker_threads);
+    }
+
+    // Set the default number of worker threads to be at least `MIN_WORKER_THREADS`.
+    let worker_threads = match std::env::var("TOKIO_WORKER_THREADS") {
+        Ok(v) => v
+            .parse::<usize>()
+            .expect("Failed to parse TOKIO_WORKER_THREADS"),
+        Err(std::env::VarError::NotPresent) => std::thread::available_parallelism()
+            .expect("Failed to get available parallelism")
+            .get(),
+        Err(_) => panic!("Failed to parse TOKIO_WORKER_THREADS"),
+    };
+    if worker_threads < MIN_WORKER_THREADS {
+        tracing::warn!("the default number of worker threads ({worker_threads}) is too small, which may lead to issues, increasing to {MIN_WORKER_THREADS}");
+        std::env::set_var("TOKIO_WORKER_THREADS", MIN_WORKER_THREADS.to_string());
     }
 
     if let Ok(enable_deadlock_detection) = std::env::var("RW_DEADLOCK_DETECTION") {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See https://github.com/risingwavelabs/risingwave/issues/16693 and https://github.com/risingwavelabs/risingwave-operator/pull/663 for backgrounds.

Also enforce this in kernel, in case users are not deploying RisingWave with the operator (encountered by one customer recently).

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
