### PR TITLE
fix(meta): avoid removing control stream node when failed to send request

### DIFF
--- a/ci/scripts/deterministic-it-test.sh
+++ b/ci/scripts/deterministic-it-test.sh
@@ -19,7 +19,7 @@ mv target/ci-sim target/sim
 TEST_PATTERN="$@"
 
 echo "--- Run integration tests in deterministic simulation mode"
-seq "$TEST_NUM" | parallel "MADSIM_TEST_SEED={} NEXTEST_PROFILE=ci-sim \
+seq 24 24 | parallel "MADSIM_TEST_SEED={} NEXTEST_PROFILE=ci-sim \
  cargo nextest run \
  --no-fail-fast \
  --cargo-metadata target/nextest/cargo-metadata.json \

--- a/ci/scripts/deterministic-it-test.sh
+++ b/ci/scripts/deterministic-it-test.sh
@@ -19,7 +19,7 @@ mv target/ci-sim target/sim
 TEST_PATTERN="$@"
 
 echo "--- Run integration tests in deterministic simulation mode"
-seq 24 24 | parallel "MADSIM_TEST_SEED={} NEXTEST_PROFILE=ci-sim \
+seq "$TEST_NUM" | parallel "MADSIM_TEST_SEED={} NEXTEST_PROFILE=ci-sim \
  cargo nextest run \
  --no-fail-fast \
  --cargo-metadata target/nextest/cargo-metadata.json \

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -880,9 +880,11 @@ impl GlobalBarrierManager {
                                 assert_matches!(output.command_ctx.kind, BarrierKind::Barrier);
                                 self.scheduled_barriers.force_checkpoint_in_next_barrier();
                             }
-                            self.control_stream_manager.remove_partial_graph(
-                                output.table_ids_to_finish.iter().map(|table_id| table_id.table_id).collect()
-                            );
+                            if !output.table_ids_to_finish.is_empty() {
+                                self.control_stream_manager.remove_partial_graph(
+                                    output.table_ids_to_finish.iter().map(|table_id| table_id.table_id).collect()
+                                );
+                            }
                         }
                         Ok(None) => {}
                         Err(e) => {

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -236,10 +236,12 @@ impl ControlStreamManager {
                 Err(err) => Err(err),
             };
             if let Err(err) = &result {
-                let node = self
-                    .nodes
-                    .remove(&worker_id)
-                    .expect("should exist when get shutdown resp");
+                let node = self.nodes.remove(&worker_id).unwrap_or_else(|| {
+                    panic!(
+                        "should exist when get shutdown resp: {} {:?}",
+                        worker_id, err
+                    );
+                });
                 warn!(node = ?node.worker, err = %err.as_report(), "get error from response stream");
             }
             (worker_id, result)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix recovery test panic.

In `ControlStreamManager`, we always maintain that workers in field `nodes` are consistent to workers in `response_streams`. However, in method `remove_partial_graph`, we use `retain` when trying to send request, and will remove the node when failing to send the request, but we didn't remove the corresponding stream in `response_streams`, which causes inconsistency and causes subsequent panics. In this PR, we fix this inconsistency by storing the response_stream together with the request sender in the `ControlStreamNode`. Previously we have to introduce a `FutureUnordered` to concurrently poll the several response streams. In this PR, we change to implement the concurrent poll logic on our own by `poll_fn`, so that we don't need to separate the request sender and response stream.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
