### PR TITLE
fix(expr): cast untyped `start` and `step` when inferring type for `generate_series`

### DIFF
--- a/e2e_test/batch/basic/generate_series.slt.part
+++ b/e2e_test/batch/basic/generate_series.slt.part
@@ -148,3 +148,22 @@ SELECT * FROM generate_series(0::numeric,10::numeric,'nan'::numeric);
 
 statement error start value cannot be infinity
 SELECT * FROM generate_series('-infinity'::numeric,'infinity'::numeric,'nan'::numeric);
+
+# ------
+# generate_series(timestamptz, timestamptz, interval) is not supported in batch mode
+
+statement error Unsupported function
+select * from generate_series(
+  '2024-06-21 17:36:00'::timestamptz,
+  now(),
+  interval '1 hour'
+);
+
+statement error Unsupported function
+select * from generate_series(
+  '2024-06-21 17:36:00',
+  now(),
+  '1 hour'
+);
+
+# ------

--- a/src/frontend/planner_test/tests/testdata/input/generate_series_with_now.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/generate_series_with_now.yaml
@@ -10,6 +10,16 @@
     - stream_plan
 - sql: |
     select * from generate_series(
+      '2024-06-21 17:36:00',
+      now(),
+      '1 hour'
+    );
+  expected_outputs:
+    - logical_plan
+    - optimized_logical_plan_for_stream
+    - stream_plan
+- sql: |
+    select * from generate_series(
       '2024-06-21 17:36:00'::timestamp, -- `timestamp` type is not supported
       now(),
       interval '1 hour'

--- a/src/frontend/planner_test/tests/testdata/output/generate_series_with_now.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/generate_series_with_now.yaml
@@ -14,6 +14,19 @@
     └─StreamNow { output: [ts] }
 - sql: |
     select * from generate_series(
+      '2024-06-21 17:36:00',
+      now(),
+      '1 hour'
+    );
+  logical_plan: |-
+    LogicalProject { exprs: [generate_series] }
+    └─LogicalTableFunction { table_function: GenerateSeries('2024-06-21 17:36:00':Varchar::Timestamptz, Now, '01:00:00':Interval) }
+  optimized_logical_plan_for_stream: 'LogicalNow { output: [ts] }'
+  stream_plan: |-
+    StreamMaterialize { columns: [generate_series], stream_key: [generate_series], pk_columns: [generate_series], pk_conflict: NoCheck, watermark_columns: [generate_series] }
+    └─StreamNow { output: [ts] }
+- sql: |
+    select * from generate_series(
       '2024-06-21 17:36:00'::timestamp, -- `timestamp` type is not supported
       now(),
       interval '1 hour'


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #18729.

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
