### PR TITLE
fix(meta): rename `--license-key-file` to `--license-key-path`

### DIFF
--- a/src/cmd_all/src/standalone.rs
+++ b/src/cmd_all/src/standalone.rs
@@ -468,7 +468,7 @@ mod test {
                             dangerous_max_idle_secs: None,
                             connector_rpc_endpoint: None,
                             license_key: None,
-                            license_key_file: None,
+                            license_key_path: None,
                             temp_secret_file_dir: "./meta/secrets/",
                         },
                     ),

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -195,7 +195,7 @@ pub struct MetaNodeOpts {
 
     /// The path of the license key file to be watched and hot-reloaded.
     #[clap(long, env = "RW_LICENSE_KEY_PATH")]
-    pub license_key_file: Option<PathBuf>,
+    pub license_key_path: Option<PathBuf>,
 
     /// 128-bit AES key for secret store in HEX format.
     #[educe(Debug(ignore))] // TODO: use newtype to redact debug impl
@@ -471,7 +471,7 @@ pub fn start(
                     .meta
                     .developer
                     .actor_cnt_per_worker_parallelism_soft_limit,
-                license_key_path: opts.license_key_file,
+                license_key_path: opts.license_key_path,
             },
             config.system.into_init_system_params(),
             Default::default(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The new argument introduced in https://github.com/risingwavelabs/risingwave/pull/18768 was mistakenly named `--license-key-file`, while the env var and internal names are `license_key_path`. This PR unifies the naming.

See also:
- https://github.com/risingwavelabs/risingwave/pull/18768#discussion_r1794983086
- https://github.com/risingwavelabs/risingwave-operator/pull/732

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
