### PR TITLE
refactor(meta): use in-memory sqlite for `Mem` meta backend

### DIFF
--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -182,7 +182,9 @@ pub fn map_single_node_opts_to_standalone_opts(opts: SingleNodeOpts) -> ParsedSt
     };
     if !meta_backend_is_set {
         if opts.in_memory {
-            meta_opts.backend = Some(MetaBackend::Mem);
+            meta_opts.backend = Some(MetaBackend::Sqlite);
+            meta_opts.sql_endpoint =
+                Some("meta_backend?mode=memory&cache=shared".to_owned().into());
         } else {
             meta_opts.backend = Some(MetaBackend::Sqlite);
             let meta_store_dir = format!("{}/meta_store", &store_directory);

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -271,10 +271,22 @@ pub fn start(
             },
             MetaBackend::Sqlite => MetaStoreBackend::Sql {
                 endpoint: format!(
-                    "sqlite://{}?mode=rwc",
+                    "sqlite://{}{}",
                     opts.sql_endpoint
+                        .as_ref()
                         .expect("sql endpoint is required")
+                        .expose_secret(),
+                    if opts
+                        .sql_endpoint
+                        .as_ref()
+                        .unwrap()
                         .expose_secret()
+                        .contains("mode=memory")
+                    {
+                        ""
+                    } else {
+                        "?mode=rwc"
+                    }
                 ),
             },
             MetaBackend::Postgres => MetaStoreBackend::Sql {

--- a/src/meta/src/backup_restore/utils.rs
+++ b/src/meta/src/backup_restore/utils.rs
@@ -66,7 +66,7 @@ pub async fn get_meta_store(opts: RestoreOpts) -> BackupResult<MetaStoreBackendI
             endpoint: opts.sql_endpoint,
         },
         MetaBackend::Sqlite => MetaStoreBackend::Sql {
-            endpoint: format!("sqlite://{}?mode=rwc", opts.sql_endpoint),
+            endpoint: format!("sqlite://{}", opts.sql_endpoint),
         },
         MetaBackend::Postgres => MetaStoreBackend::Sql {
             endpoint: format!(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

IGNORE ME

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
