### PR TITLE
fix(storage): fix sub level id for time travel

### DIFF
--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -149,18 +149,6 @@ impl<'a> HummockVersionTransaction<'a> {
 
         // Append SSTs to a new version.
         for (compaction_group_id, inserted_table_infos) in commit_sstables {
-            let l0_sub_level_id = new_version_delta
-                .latest_version()
-                .levels
-                .get(&compaction_group_id)
-                .and_then(|levels| {
-                    levels
-                        .l0
-                        .sub_levels
-                        .last()
-                        .map(|level| level.sub_level_id + 1)
-                })
-                .unwrap_or(committed_epoch);
             let group_deltas = &mut new_version_delta
                 .group_deltas
                 .entry(compaction_group_id)
@@ -168,7 +156,7 @@ impl<'a> HummockVersionTransaction<'a> {
                 .group_deltas;
             let group_delta = GroupDelta::IntraLevel(IntraLevelDelta::new(
                 0,
-                l0_sub_level_id,
+                0,
                 vec![], // default
                 inserted_table_infos,
                 0, // default

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -156,7 +156,7 @@ impl<'a> HummockVersionTransaction<'a> {
                 .group_deltas;
             let group_delta = GroupDelta::IntraLevel(IntraLevelDelta::new(
                 0,
-                0,
+                0, // l0_sub_level_id will be generated during apply_version_delta
                 vec![], // default
                 inserted_table_infos,
                 0, // default

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -156,7 +156,7 @@ impl<'a> HummockVersionTransaction<'a> {
                 .group_deltas;
             let group_delta = GroupDelta::IntraLevel(IntraLevelDelta::new(
                 0,
-                0, // l0_sub_level_id will be generated during apply_version_delta
+                0,      // l0_sub_level_id will be generated during apply_version_delta
                 vec![], // default
                 inserted_table_infos,
                 0, // default

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -660,10 +660,15 @@ impl HummockVersion {
                         || group_destroy.is_some(),
                     "no sst should be deleted when committing an epoch"
                 );
+                let mut next_l0_sub_level_id = levels
+                    .l0
+                    .sub_levels
+                    .last()
+                    .map(|level| level.sub_level_id + 1)
+                    .unwrap_or(1);
                 for group_delta in &group_deltas.group_deltas {
                     if let GroupDelta::IntraLevel(IntraLevelDelta {
                         level_idx,
-                        l0_sub_level_id,
                         inserted_table_infos,
                         ..
                     }) = group_delta
@@ -675,11 +680,12 @@ impl HummockVersion {
                         if !inserted_table_infos.is_empty() {
                             insert_new_sub_level(
                                 &mut levels.l0,
-                                *l0_sub_level_id,
+                                next_l0_sub_level_id,
                                 PbLevelType::Overlapping,
                                 inserted_table_infos.clone(),
                                 None,
                             );
+                            next_l0_sub_level_id += 1;
                         }
                     }
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Since sublevel ids no longer ensure a monotonically increasing order, and the time travel doesn't keep version delta of compaction, for time travel it's possible the newly inserted sub level id is smaller than the smallest one in the current version. For example:
1. The version has 3 sublevels [1, 2, 3].
2. The version is compacted to 0 sublevels [].
3. A new sublevel is inserted, [using committed_epoch as sub_level id](https://github.com/risingwavelabs/risingwave/blob/52f233186b73d60f6d150b5da57946c729537711/src/meta/src/hummock/manager/transaction.rs#L163). Say committed_epoch is 2, resulting sublevels [2].

The problem is time travel doesn't include the delta from step 2. So in step 3 it will be inserting sublevel 2 into sublevels [1, 2, 3], [which will be rejected](https://github.com/risingwavelabs/risingwave/blob/52f233186b73d60f6d150b5da57946c729537711/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs#L1304).

This PR fixes it by setting sub level id later in apply_version_delta, instead of persisting it in delta.

https://risingwave-labs.slack.com/archives/C05MQT5DFTP/p1728718540051539

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
