### PR TITLE
feat(mssql-cdc): add ssl support for sqlserver-cdc

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
@@ -58,6 +58,7 @@ public class DbzConnectorConfig {
 
     /* Sql Server configs */
     public static final String SQL_SERVER_SCHEMA_NAME = "schema.name";
+    public static final String SQL_SERVER_ENCRYPT = "database.encrypt";
 
     /* RisingWave configs */
     private static final String DBZ_CONFIG_FILE = "debezium.properties";

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/SqlServerValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/SqlServerValidator.java
@@ -50,8 +50,12 @@ public class SqlServerValidator extends DatabaseValidator implements AutoCloseab
         var dbName = userProps.get(DbzConnectorConfig.DB_NAME);
         var user = userProps.get(DbzConnectorConfig.USER);
         var password = userProps.get(DbzConnectorConfig.PASSWORD);
+        var encrypt =
+                Boolean.parseBoolean(
+                        userProps.getOrDefault(DbzConnectorConfig.SQL_SERVER_ENCRYPT, "false"));
 
         var jdbcUrl = ValidatorUtils.getJdbcUrl(SourceTypeE.SQL_SERVER, dbHost, dbPort, dbName);
+        jdbcUrl = jdbcUrl + ";encrypt=" + encrypt + ";trustServerCertificate=true";
         this.jdbcConnection = DriverManager.getConnection(jdbcUrl, user, password);
 
         this.dbName = dbName;

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/ValidatorUtils.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/ValidatorUtils.java
@@ -68,8 +68,7 @@ public final class ValidatorUtils {
                 return String.format("jdbc:postgresql://%s:%s/%s", host, port, database);
             case SQL_SERVER:
                 return String.format(
-                        "jdbc:sqlserver://%s:%s;databaseName=%s;encrypt=false",
-                        host, port, database);
+                        "jdbc:sqlserver://%s:%s;databaseName=%s", host, port, database);
             default:
                 throw ValidatorUtils.invalidArgument("Unknown source type: " + sourceType);
         }

--- a/java/connector-node/risingwave-connector-service/src/main/resources/sql_server.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/sql_server.properties
@@ -21,4 +21,5 @@ name=${hostname}:${port}:${database.name}.${schema.name}.${table.name:-RW_CDC_Sh
 # In sharing cdc mode, transaction metadata will be enabled in frontend.
 # For sql server, it's always false actually.
 provide.transaction.metadata=${transactional:-false}
-database.encrypt=false
+database.encrypt=${database.encrypt:-false}
+database.trustServerCertificate=true

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -243,6 +243,12 @@ pub struct ExternalTableConfig {
     #[serde(rename = "ssl.root.cert")]
     #[serde(alias = "debezium.database.sslrootcert")]
     pub ssl_root_cert: Option<String>,
+
+    /// `encrypt` specifies whether connect to SQL Server using SSL.
+    /// Choices include `true`, `false`.
+    /// This field is optional.
+    #[serde(rename = "database.encrypt", default = "Default::default")]
+    pub encrypt: String,
 }
 
 impl ExternalTableConfig {

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -245,8 +245,7 @@ pub struct ExternalTableConfig {
     pub ssl_root_cert: Option<String>,
 
     /// `encrypt` specifies whether connect to SQL Server using SSL.
-    /// Choices include `true`, `false`.
-    /// This field is optional.
+    /// Only "true" means using SSL. All other values are treated as "false".
     #[serde(rename = "database.encrypt", default = "Default::default")]
     pub encrypt: String,
 }

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -598,6 +598,7 @@ mod tests {
             table: "part".to_string(),
             ssl_mode: Default::default(),
             ssl_root_cert: None,
+            encrypt: "false",
         };
 
         let table = MySqlExternalTable::connect(config).await.unwrap();

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -598,7 +598,7 @@ mod tests {
             table: "part".to_string(),
             ssl_mode: Default::default(),
             ssl_root_cert: None,
-            encrypt: "false",
+            encrypt: "false".to_string(),
         };
 
         let table = MySqlExternalTable::connect(config).await.unwrap();

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -540,6 +540,7 @@ mod tests {
             table: "mytest".to_string(),
             ssl_mode: Default::default(),
             ssl_root_cert: None,
+            encrypt: "false",
         };
 
         let table = PostgresExternalTable::connect(config).await.unwrap();

--- a/src/connector/src/source/cdc/external/postgres.rs
+++ b/src/connector/src/source/cdc/external/postgres.rs
@@ -540,7 +540,7 @@ mod tests {
             table: "mytest".to_string(),
             ssl_mode: Default::default(),
             ssl_root_cert: None,
-            encrypt: "false",
+            encrypt: "false".to_string(),
         };
 
         let table = PostgresExternalTable::connect(config).await.unwrap();

--- a/src/connector/src/source/cdc/external/sql_server.rs
+++ b/src/connector/src/source/cdc/external/sql_server.rs
@@ -90,8 +90,10 @@ impl SqlServerExternalTable {
             &config.username,
             &config.password,
         ));
-        // TODO(kexiang): add ssl support
         // TODO(kexiang): use trust_cert_ca, trust_cert is not secure
+        if config.encrypt == "true" {
+            client_config.encryption(tiberius::EncryptionLevel::Required);
+        }
         client_config.trust_cert();
 
         let mut client = SqlServerClient::new_with_config(client_config).await?;
@@ -282,8 +284,10 @@ impl SqlServerExternalTableReader {
             &config.username,
             &config.password,
         ));
-        // TODO(kexiang): add ssl support
         // TODO(kexiang): use trust_cert_ca, trust_cert is not secure
+        if config.encrypt == "true" {
+            client_config.encryption(tiberius::EncryptionLevel::Required);
+        }
         client_config.trust_cert();
 
         let client = SqlServerClient::new_with_config(client_config).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

At https://github.com/risingwavelabs/risingwave-docs/blob/38a20f52702649437c5d5eb62dd41551da230f69/docs/guides/ingest-from-sqlserver-cdc.md?plain=1#L118,
please add one more line
```
| database.encrypt | Optional. Specify whether you want to enable SSL encryption. Currently, `trustServerCertificate` is enabled, regardless of the value of `database.encrypt`. |
```
