### PR TITLE
refactor(meta): reorganize global barrier manager field

### DIFF
--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -25,6 +25,7 @@ use risingwave_common::telemetry::manager::TelemetryManager;
 use risingwave_common::telemetry::{report_scarf_enabled, report_to_scarf, telemetry_env_enabled};
 use risingwave_common::util::tokio_util::sync::CancellationToken;
 use risingwave_common_service::{MetricsManager, TracingExtractLayer};
+use risingwave_meta::barrier::GlobalBarrierManager;
 use risingwave_meta::controller::catalog::CatalogController;
 use risingwave_meta::controller::cluster::ClusterController;
 use risingwave_meta::controller::IN_MEMORY_STORE;
@@ -80,7 +81,7 @@ use thiserror_ext::AsReport;
 use tokio::sync::watch;
 
 use crate::backup_restore::BackupManager;
-use crate::barrier::{BarrierScheduler, GlobalBarrierManager};
+use crate::barrier::BarrierScheduler;
 use crate::controller::system_param::SystemParamsController;
 use crate::controller::SqlMetaStore;
 use crate::hummock::HummockManager;
@@ -489,7 +490,7 @@ pub async fn start_service_as_election_leader(
         env.clone(),
     ));
 
-    let barrier_manager = GlobalBarrierManager::new(
+    let (barrier_manager, join_handle, shutdown_rx) = GlobalBarrierManager::start(
         scheduled_barriers,
         env.clone(),
         metadata_manager.clone(),
@@ -500,6 +501,7 @@ pub async fn start_service_as_election_leader(
         scale_controller.clone(),
     )
     .await;
+    sub_tasks.push((join_handle, shutdown_rx));
 
     {
         let source_manager = source_manager.clone();
@@ -545,7 +547,7 @@ pub async fn start_service_as_election_leader(
         metadata_manager.clone(),
         stream_manager.clone(),
         source_manager.clone(),
-        barrier_manager.context().clone(),
+        barrier_manager.clone(),
         sink_manager.clone(),
         meta_metrics.clone(),
     )
@@ -557,12 +559,11 @@ pub async fn start_service_as_election_leader(
         metadata_manager.clone(),
         source_manager,
         stream_manager.clone(),
-        barrier_manager.context().clone(),
+        barrier_manager.clone(),
         scale_controller.clone(),
     );
 
-    let cluster_srv =
-        ClusterServiceImpl::new(metadata_manager.clone(), barrier_manager.context().clone());
+    let cluster_srv = ClusterServiceImpl::new(metadata_manager.clone(), barrier_manager.clone());
     let stream_srv = StreamServiceImpl::new(
         env.clone(),
         barrier_scheduler.clone(),
@@ -629,12 +630,11 @@ pub async fn start_service_as_election_leader(
         .await,
     );
 
-    if cfg!(not(test)) {
+    {
         sub_tasks.push(ClusterController::start_heartbeat_checker(
             metadata_manager.cluster_controller.clone(),
             Duration::from_secs(1),
         ));
-        sub_tasks.push(GlobalBarrierManager::start(barrier_manager));
 
         if !env.opts.disable_automatic_parallelism_control {
             sub_tasks.push(stream_manager.start_auto_parallelism_monitor());

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -41,8 +41,7 @@ use risingwave_pb::stream_service::WaitEpochCommitRequest;
 use tracing::warn;
 
 use super::info::{CommandFragmentChanges, InflightGraphInfo};
-use crate::barrier::state::BarrierInfo;
-use crate::barrier::{GlobalBarrierManagerContext, InflightSubscriptionInfo};
+use crate::barrier::{BarrierInfo, GlobalBarrierWorkerContext, InflightSubscriptionInfo};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::{DdlType, StreamingJob};
 use crate::model::{ActorId, DispatcherId, FragmentId, TableFragments, TableParallelism};
@@ -206,7 +205,7 @@ pub enum CreateStreamingJobType {
     SnapshotBackfill(SnapshotBackfillInfo),
 }
 
-/// [`Command`] is the input of [`crate::barrier::GlobalBarrierManager`]. For different commands,
+/// [`Command`] is the input of [`crate::barrier::GlobalBarrierWorker`]. For different commands,
 /// it will build different barriers to send, and may do different stuffs after the barrier is
 /// collected.
 #[derive(Debug, Clone, strum::Display)]
@@ -927,7 +926,7 @@ impl Command {
 impl CommandContext {
     pub async fn wait_epoch_commit(
         &self,
-        barrier_manager_context: &GlobalBarrierManagerContext,
+        barrier_manager_context: &GlobalBarrierWorkerContext,
     ) -> MetaResult<()> {
         let table_id = self.table_ids_to_commit.iter().next().cloned();
         // try wait epoch on an existing random table id
@@ -957,7 +956,7 @@ impl CommandContext {
     /// the given command.
     pub async fn post_collect(
         &self,
-        barrier_manager_context: &GlobalBarrierManagerContext,
+        barrier_manager_context: &GlobalBarrierWorkerContext,
     ) -> MetaResult<()> {
         match &self.command {
             Command::Plain(_) => {}

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -941,7 +941,7 @@ impl CommandContext {
                 .get(worker_node)
                 .await?;
             let request = WaitEpochCommitRequest {
-                epoch: self.barrier_info.prev_epoch.value().0,
+                epoch: self.barrier_info.prev_epoch(),
                 table_id: table_id.table_id,
             };
             client.wait_epoch_commit(request).await

--- a/src/meta/src/barrier/creating_job/mod.rs
+++ b/src/meta/src/barrier/creating_job/mod.rs
@@ -187,7 +187,7 @@ impl CreatingStreamingJobControl {
             vec![],
         )?;
         barrier_control.enqueue_epoch(
-            barrier_info.prev_epoch.value().0,
+            barrier_info.prev_epoch(),
             node_to_collect,
             barrier_info.kind.is_checkpoint(),
         );
@@ -210,7 +210,7 @@ impl CreatingStreamingJobControl {
         if start_consume_upstream {
             info!(
                 table_id = self.info.table_fragments.table_id().table_id,
-                prev_epoch = barrier_info.prev_epoch.value().0,
+                prev_epoch = barrier_info.prev_epoch(),
                 "start consuming upstream"
             );
         }

--- a/src/meta/src/barrier/creating_job/mod.rs
+++ b/src/meta/src/barrier/creating_job/mod.rs
@@ -36,8 +36,7 @@ use crate::barrier::creating_job::status::{
 use crate::barrier::info::InflightGraphInfo;
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::barrier::rpc::ControlStreamManager;
-use crate::barrier::state::BarrierInfo;
-use crate::barrier::{Command, CreateStreamingJobCommandInfo, SnapshotBackfillInfo};
+use crate::barrier::{BarrierInfo, Command, CreateStreamingJobCommandInfo, SnapshotBackfillInfo};
 use crate::rpc::metrics::MetaMetrics;
 use crate::MetaResult;
 

--- a/src/meta/src/barrier/creating_job/status.rs
+++ b/src/meta/src/barrier/creating_job/status.rs
@@ -228,7 +228,7 @@ impl CreatingStreamingJobStatus {
                 ))
             }
             CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
-                let prev_epoch = barrier_info.prev_epoch.value().0;
+                let prev_epoch = barrier_info.prev_epoch();
                 if start_consume_upstream {
                     assert!(barrier_info.kind.is_checkpoint());
                     *self = CreatingStreamingJobStatus::Finishing(prev_epoch);

--- a/src/meta/src/barrier/creating_job/status.rs
+++ b/src/meta/src/barrier/creating_job/status.rs
@@ -15,7 +15,6 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::mem::take;
-use std::sync::Arc;
 
 use risingwave_common::hash::ActorId;
 use risingwave_common::util::epoch::Epoch;
@@ -28,8 +27,8 @@ use risingwave_pb::stream_service::barrier_complete_response::{
 };
 use tracing::warn;
 
-use crate::barrier::command::CommandContext;
 use crate::barrier::progress::CreateMviewProgressTracker;
+use crate::barrier::state::BarrierInfo;
 use crate::barrier::{BarrierKind, TracedEpoch};
 
 #[derive(Debug)]
@@ -103,7 +102,7 @@ pub(super) enum CreatingStreamingJobStatus {
     /// the snapshot has been fully consumed after `update_progress`.
     ConsumingSnapshot {
         prev_epoch_fake_physical_time: u64,
-        pending_upstream_barriers: Vec<(TracedEpoch, TracedEpoch, BarrierKind)>,
+        pending_upstream_barriers: Vec<BarrierInfo>,
         version_stats: HummockVersionStats,
         create_mview_tracker: CreateMviewProgressTracker,
         snapshot_backfill_actors: HashSet<ActorId>,
@@ -127,9 +126,7 @@ pub(super) enum CreatingStreamingJobStatus {
 }
 
 pub(super) struct CreatingJobInjectBarrierInfo {
-    pub curr_epoch: TracedEpoch,
-    pub prev_epoch: TracedEpoch,
-    pub kind: BarrierKind,
+    pub barrier_info: BarrierInfo,
     pub new_actors: Option<HashMap<WorkerId, Vec<StreamActor>>>,
     pub mutation: Option<Mutation>,
 }
@@ -166,22 +163,22 @@ impl CreatingStreamingJobStatus {
 
                     let prev_epoch = Epoch::from_physical_time(*prev_epoch_fake_physical_time);
                     let barriers_to_inject: Vec<_> = [CreatingJobInjectBarrierInfo {
-                        curr_epoch: TracedEpoch::new(Epoch(*backfill_epoch)),
-                        prev_epoch: TracedEpoch::new(prev_epoch),
-                        kind: BarrierKind::Checkpoint(take(pending_non_checkpoint_barriers)),
+                        barrier_info: BarrierInfo {
+                            curr_epoch: TracedEpoch::new(Epoch(*backfill_epoch)),
+                            prev_epoch: TracedEpoch::new(prev_epoch),
+                            kind: BarrierKind::Checkpoint(take(pending_non_checkpoint_barriers)),
+                        },
                         new_actors,
                         mutation,
                     }]
                     .into_iter()
-                    .chain(pending_upstream_barriers.drain(..).map(
-                        |(prev_epoch, curr_epoch, kind)| CreatingJobInjectBarrierInfo {
-                            curr_epoch,
-                            prev_epoch,
-                            kind,
+                    .chain(pending_upstream_barriers.drain(..).map(|barrier_info| {
+                        CreatingJobInjectBarrierInfo {
+                            barrier_info,
                             new_actors: None,
                             mutation: None,
-                        },
-                    ))
+                        }
+                    }))
                     .collect();
 
                     *self = CreatingStreamingJobStatus::ConsumingLogStore {
@@ -208,7 +205,7 @@ impl CreatingStreamingJobStatus {
 
     pub(super) fn on_new_upstream_epoch(
         &mut self,
-        command_ctx: &Arc<CommandContext>,
+        barrier_info: &BarrierInfo,
         start_consume_upstream: bool,
     ) -> Option<CreatingJobInjectBarrierInfo> {
         match self {
@@ -223,28 +220,22 @@ impl CreatingStreamingJobStatus {
                     !start_consume_upstream,
                     "should not start consuming upstream for a job that are consuming snapshot"
                 );
-                pending_upstream_barriers.push((
-                    command_ctx.prev_epoch.clone(),
-                    command_ctx.curr_epoch.clone(),
-                    command_ctx.kind.clone(),
-                ));
+                pending_upstream_barriers.push(barrier_info.clone());
                 Some(CreatingStreamingJobStatus::new_fake_barrier(
                     prev_epoch_fake_physical_time,
                     pending_non_checkpoint_barriers,
                     initial_barrier_info,
-                    command_ctx.kind.is_checkpoint(),
+                    barrier_info.kind.is_checkpoint(),
                 ))
             }
             CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
-                let prev_epoch = command_ctx.prev_epoch.value().0;
+                let prev_epoch = barrier_info.prev_epoch.value().0;
                 if start_consume_upstream {
-                    assert!(command_ctx.kind.is_checkpoint());
+                    assert!(barrier_info.kind.is_checkpoint());
                     *self = CreatingStreamingJobStatus::Finishing(prev_epoch);
                 }
                 Some(CreatingJobInjectBarrierInfo {
-                    curr_epoch: command_ctx.curr_epoch.clone(),
-                    prev_epoch: command_ctx.prev_epoch.clone(),
-                    kind: command_ctx.kind.clone(),
+                    barrier_info: barrier_info.clone(),
                     new_actors: None,
                     mutation: None,
                 })
@@ -285,9 +276,11 @@ impl CreatingStreamingJobStatus {
                         Default::default()
                     };
                 CreatingJobInjectBarrierInfo {
-                    curr_epoch,
-                    prev_epoch,
-                    kind,
+                    barrier_info: BarrierInfo {
+                        prev_epoch,
+                        curr_epoch,
+                        kind,
+                    },
                     new_actors,
                     mutation,
                 }

--- a/src/meta/src/barrier/creating_job/status.rs
+++ b/src/meta/src/barrier/creating_job/status.rs
@@ -28,8 +28,7 @@ use risingwave_pb::stream_service::barrier_complete_response::{
 use tracing::warn;
 
 use crate::barrier::progress::CreateMviewProgressTracker;
-use crate::barrier::state::BarrierInfo;
-use crate::barrier::{BarrierKind, TracedEpoch};
+use crate::barrier::{BarrierInfo, BarrierKind, TracedEpoch};
 
 #[derive(Debug)]
 pub(super) struct CreateMviewLogStoreProgressTracker {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -30,6 +30,12 @@ pub(super) struct BarrierInfo {
     pub kind: BarrierKind,
 }
 
+impl BarrierInfo {
+    pub(super) fn prev_epoch(&self) -> u64 {
+        self.prev_epoch.value().0
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum CommandFragmentChanges {
     NewFragment(InflightFragmentInfo),

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -19,9 +19,16 @@ use risingwave_meta_model::WorkerId;
 use risingwave_pb::common::WorkerNode;
 use tracing::warn;
 
-use crate::barrier::Command;
+use crate::barrier::{BarrierKind, Command, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::model::{ActorId, FragmentId};
+
+#[derive(Debug, Clone)]
+pub(super) struct BarrierInfo {
+    pub prev_epoch: TracedEpoch,
+    pub curr_epoch: TracedEpoch,
+    pub kind: BarrierKind,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) enum CommandFragmentChanges {
@@ -40,7 +47,7 @@ pub struct InflightSubscriptionInfo {
 }
 
 /// [`InflightGraphInfo`] resolves the actor info read from meta store for
-/// [`crate::barrier::GlobalBarrierManager`].
+/// [`crate::barrier::GlobalBarrierWorker`].
 #[derive(Default, Clone, Debug)]
 pub struct InflightGraphInfo {
     /// `node_id` => actors

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -363,7 +363,7 @@ impl CreateMviewProgressTracker {
             // for checkpoint, we should also clear it.
             self.cancel_command(table_id);
         }
-        if command_ctx.kind.is_checkpoint() {
+        if command_ctx.barrier_info.kind.is_checkpoint() {
             self.take_finished_jobs()
         } else {
             vec![]

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -333,10 +333,10 @@ impl GlobalBarrierWorker {
                         debug!(?node_to_collect, "inject initial barrier");
                         while !node_to_collect.is_empty() {
                             let (worker_id, result) = control_stream_manager
-                                .next_complete_barrier_response()
+                                .next_collect_barrier_response()
                                 .await;
                             let resp = result?;
-                            assert_eq!(resp.epoch, barrier_info.prev_epoch.value().0);
+                            assert_eq!(resp.epoch, barrier_info.prev_epoch());
                             assert!(node_to_collect.remove(&worker_id));
                         }
                         debug!("collected initial barrier");

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -44,9 +44,8 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use super::{Command, GlobalBarrierManagerContext, InflightSubscriptionInfo};
-use crate::barrier::info::InflightGraphInfo;
-use crate::barrier::state::BarrierInfo;
+use super::{Command, GlobalBarrierWorkerContext, InflightSubscriptionInfo};
+use crate::barrier::info::{BarrierInfo, InflightGraphInfo};
 use crate::{MetaError, MetaResult};
 
 const COLLECT_ERROR_TIMEOUT: Duration = Duration::from_secs(3);
@@ -57,12 +56,12 @@ struct ControlStreamNode {
 }
 
 pub(super) struct ControlStreamManager {
-    context: GlobalBarrierManagerContext,
+    context: GlobalBarrierWorkerContext,
     nodes: HashMap<WorkerId, ControlStreamNode>,
 }
 
 impl ControlStreamManager {
-    pub(super) fn new(context: GlobalBarrierManagerContext) -> Self {
+    pub(super) fn new(context: GlobalBarrierWorkerContext) -> Self {
         Self {
             context,
             nodes: Default::default(),
@@ -436,7 +435,7 @@ impl ControlStreamManager {
     }
 }
 
-impl GlobalBarrierManagerContext {
+impl GlobalBarrierWorkerContext {
     async fn new_control_stream_node(
         &self,
         node: WorkerNode,

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -203,7 +203,7 @@ impl ControlStreamManager {
         Some((worker_id, result))
     }
 
-    pub(super) async fn next_complete_barrier_response(
+    pub(super) async fn next_collect_barrier_response(
         &mut self,
     ) -> (WorkerId, MetaResult<BarrierCompleteResponse>) {
         use streaming_control_stream_response::Response;
@@ -352,7 +352,7 @@ impl ControlStreamManager {
                     let barrier = Barrier {
                         epoch: Some(risingwave_pb::data::Epoch {
                             curr: barrier_info.curr_epoch.value().0,
-                            prev: barrier_info.prev_epoch.value().0,
+                            prev: barrier_info.prev_epoch(),
                         }),
                         mutation: mutation.clone().map(|_| BarrierMutation { mutation }),
                         tracing_context: TracingContext::from_span(barrier_info.curr_epoch.span())
@@ -402,7 +402,7 @@ impl ControlStreamManager {
                 // Record failure in event log.
                 use risingwave_pb::meta::event_log;
                 let event = event_log::EventInjectBarrierFail {
-                    prev_epoch: barrier_info.prev_epoch.value().0,
+                    prev_epoch: barrier_info.prev_epoch(),
                     cur_epoch: barrier_info.curr_epoch.value().0,
                     error: e.to_report_string(),
                 };
@@ -460,7 +460,7 @@ impl GlobalBarrierWorkerContext {
         // Record failure in event log.
         use risingwave_pb::meta::event_log;
         let event = event_log::EventCollectBarrierFail {
-            prev_epoch: barrier_info.prev_epoch.value().0,
+            prev_epoch: barrier_info.prev_epoch(),
             cur_epoch: barrier_info.curr_epoch.value().0,
             error: error.to_report_string(),
         };

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -330,7 +330,7 @@ impl BarrierScheduler {
 }
 
 /// The receiver side of the barrier scheduling queue.
-/// Held by the [`super::GlobalBarrierManager`] to execute these commands.
+/// Held by the [`super::GlobalBarrierWorker`] to execute these commands.
 pub struct ScheduledBarriers {
     min_interval: Option<Interval>,
 

--- a/src/meta/src/barrier/state.rs
+++ b/src/meta/src/barrier/state.rs
@@ -73,7 +73,7 @@ impl BarrierWorkerState {
         self.in_flight_prev_epoch.as_ref()
     }
 
-    /// Returns the epoch pair for the next barrier, and updates the state.
+    /// Returns the `BarrierInfo` for the next barrier, and updates the state.
     pub fn next_barrier_info(
         &mut self,
         command: &Command,

--- a/src/meta/src/barrier/state.rs
+++ b/src/meta/src/barrier/state.rs
@@ -19,18 +19,11 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::meta::PausedReason;
 
-use crate::barrier::info::{InflightGraphInfo, InflightSubscriptionInfo};
+use crate::barrier::info::{BarrierInfo, InflightGraphInfo, InflightSubscriptionInfo};
 use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
 
-#[derive(Debug, Clone)]
-pub struct BarrierInfo {
-    pub prev_epoch: TracedEpoch,
-    pub curr_epoch: TracedEpoch,
-    pub kind: BarrierKind,
-}
-
-/// `BarrierManagerState` defines the necessary state of `GlobalBarrierManager`.
-pub struct BarrierManagerState {
+/// The latest state of `GlobalBarrierWorker` after injecting the latest barrier.
+pub(super) struct BarrierWorkerState {
     /// The last sent `prev_epoch`
     ///
     /// There's no need to persist this field. On recovery, we will restore this from the latest
@@ -49,7 +42,7 @@ pub struct BarrierManagerState {
     paused_reason: Option<PausedReason>,
 }
 
-impl BarrierManagerState {
+impl BarrierWorkerState {
     pub fn new(
         in_flight_prev_epoch: Option<TracedEpoch>,
         inflight_graph_info: InflightGraphInfo,

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -355,12 +355,7 @@ impl DdlController {
         let notification_version = tokio::spawn(fut).await.map_err(|e| anyhow!(e))??;
         Ok(Some(WaitVersion {
             catalog_version: notification_version,
-            hummock_version_id: self
-                .barrier_manager
-                .hummock_manager()
-                .get_version_id()
-                .await
-                .to_u64(),
+            hummock_version_id: self.barrier_manager.get_hummock_version_id().await.to_u64(),
         }))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR includes some general refactors on the global barrier manager.

First, currently we have `GlobalBarrierManager` and `GlobalBarrierManagerContext`. `GlobalBarrierManager` is actually a owned worker that works in a loop to handle different async barrier event, and `GlobalBarrierManagerContext` holds some shared structs and is used by both the `GlobalBarrierManager` worker and other external usages (e.g. DdlController and etc). In this PR, the `GlobalBarrierManager` worker is renamed to `GlobalBarrierWorker`, and `GlobalBarrierManagerContext` is renamed to `GlobalBarrierWorkerContext`, and will be used by only `GlobalBarrierWorker`. The external usages will only use a new `GlobalBarrierManager`, which contains only the fields used by the external usages. With this refactor, only the `GlobalBarrierManager` has the `pub` visibility, and the `GlobalBarrierWorker` and the `GlobalBarrierWorkerContext` will only be visible within the crate.

Second, in the code of barrier manager, the tuple `(prev_epoch, curr_epoch, barrier_kind)` appears together in many codes. In this PR, we extract them to a new struct `BarrierInfo` that holds the 3 fields, and some related code can be less verbose.

Third, the `BarrierWorkerState` will be moved from `GlobalBarrierWorker` to `CheckpointControl`, and the logic of `handle_new_barrier` in `GlobalBarrierWorker` is narrowed down to only within `CheckpointControl`, so that it becomes a method of `CheckpointControl` only. Besides, previously in `GlobalBarrierWorker`, we have a separate field `pending_non_checkpoint_barriers`, which tracks the inflight non-checkpoint barrier before the next checkpoint barrier. In this PR, the field is moved to `BarrierWorkerState`, and we introduce a method `next_barrier_info` to generate a `BarrierInfo` of the next barrier in a single method call. In `handle_new_barrier`, the `BarrierWorkerState` becomes immutable after `apply_command`.

Fourth, the `CompletingTask` is moved out of `CheckpointControl` to `GlobalBarrierWorker`, which decouples the logical `CheckpointControl` from the physical join handle that calls `commit_epoch`. In the future PR that supports database isolation, we will have a `CheckpointControl` per database, but still a single global `CompletingTask`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
