### PR TITLE
fix(sqlparser): keyword after `char` shall not be consumed on error

### DIFF
--- a/src/sqlparser/src/parser_v2/data_type.rs
+++ b/src/sqlparser/src/parser_v2/data_type.rs
@@ -208,10 +208,10 @@ fn keyword_datatype<S: TokenStream>(input: &mut StatefulStream<S>) -> PResult<Da
         Keyword::INT | Keyword::INTEGER => empty.value(DataType::Int),
         Keyword::BIGINT => empty.value(DataType::BigInt),
         Keyword::STRING | Keyword::VARCHAR => empty.value(DataType::Varchar),
-        Keyword::CHAR | Keyword::CHARACTER => dispatch! {keyword;
-            Keyword::VARYING => empty.value(DataType::Varchar),
-            _ => opt(precision_in_range(..)).map(DataType::Char),
-        },
+        Keyword::CHAR | Keyword::CHARACTER => alt((
+            Keyword::VARYING.value(DataType::Varchar),
+            opt(precision_in_range(..)).map(DataType::Char),
+        )),
         Keyword::UUID => empty.value(DataType::Uuid),
         Keyword::DATE => empty.value(DataType::Date),
         Keyword::TIMESTAMP => with_time_zone().map(DataType::Timestamp),

--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -13,6 +13,8 @@
   formatted_ast: 'CreateSchema { schema_name: ObjectName([Ident { value: "t", quote_style: None }]), if_not_exists: true, user_specified: None }'
 - input: CREATE OR REPLACE TABLE t (a INT)
   formatted_sql: CREATE OR REPLACE TABLE t (a INT)
+- input: CREATE OR REPLACE TABLE t (a CHAR AS)
+  formatted_sql: CREATE OR REPLACE TABLE t (a CHAR)
 - input: CREATE TABLE t (a INT, b INT) AS SELECT 1 AS b, 2 AS a
   formatted_sql: CREATE TABLE t (a INT, b INT) AS SELECT 1 AS b, 2 AS a
 - input: CREATE SOURCE src

--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -14,7 +14,10 @@
 - input: CREATE OR REPLACE TABLE t (a INT)
   formatted_sql: CREATE OR REPLACE TABLE t (a INT)
 - input: CREATE OR REPLACE TABLE t (a CHAR AS)
-  formatted_sql: CREATE OR REPLACE TABLE t (a CHAR)
+  error_msg: |-
+    sql parser error: expected an expression, found: )
+    LINE 1: CREATE OR REPLACE TABLE t (a CHAR AS)
+                                                ^
 - input: CREATE TABLE t (a INT, b INT) AS SELECT 1 AS b, 2 AS a
   formatted_sql: CREATE TABLE t (a INT, b INT) AS SELECT 1 AS b, 2 AS a
 - input: CREATE SOURCE src


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When parsing `CHARACTER VARYING` the current sqlparser consumes the 2nd keyword unconditionally, leading to `CHARACTER AS` accepted as `char` unexpectedly.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
