### PR TITLE
refactor(meta): clarify the completeness of internal table catalogs

### DIFF
--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -160,7 +160,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_table(&mut self, id: TableId) {
-        let table_ref = self.table_by_id.remove(&id).unwrap();
+        let Some(table_ref) = self.table_by_id.remove(&id) else {
+            tracing::warn!(?id, "table to drop not found, cleaning up?");
+            return;
+        };
+
         self.table_by_name.remove(&table_ref.name).unwrap();
         self.indexes_by_table_id.remove(&table_ref.id);
     }
@@ -190,7 +194,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_index(&mut self, id: IndexId) {
-        let index_ref = self.index_by_id.remove(&id).unwrap();
+        let Some(index_ref) = self.index_by_id.remove(&id) else {
+            tracing::warn!(?id, "index to drop not found, cleaning up?");
+            return;
+        };
+
         self.index_by_name.remove(&index_ref.name).unwrap();
         match self.indexes_by_table_id.entry(index_ref.primary_table.id) {
             Occupied(mut entry) => {
@@ -225,7 +233,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_source(&mut self, id: SourceId) {
-        let source_ref = self.source_by_id.remove(&id).unwrap();
+        let Some(source_ref) = self.source_by_id.remove(&id) else {
+            tracing::warn!(?id, "source to drop not found, cleaning up?");
+            return;
+        };
+
         self.source_by_name.remove(&source_ref.name).unwrap();
         if let Some(connection_id) = source_ref.connection_id {
             if let Occupied(mut e) = self.connection_source_ref.entry(connection_id) {
@@ -274,7 +286,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_sink(&mut self, id: SinkId) {
-        let sink_ref = self.sink_by_id.remove(&id).unwrap();
+        let Some(sink_ref) = self.sink_by_id.remove(&id) else {
+            tracing::warn!(?id, "sink to drop not found, cleaning up?");
+            return;
+        };
+
         self.sink_by_name.remove(&sink_ref.name).unwrap();
         if let Some(connection_id) = sink_ref.connection_id {
             if let Occupied(mut e) = self.connection_sink_ref.entry(connection_id.0) {
@@ -318,7 +334,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_subscription(&mut self, id: SubscriptionId) {
-        let subscription_ref = self.subscription_by_id.remove(&id).unwrap();
+        let Some(subscription_ref) = self.subscription_by_id.remove(&id) else {
+            tracing::warn!(?id, "subscription to drop not found, cleaning up?");
+            return;
+        };
+
         self.subscription_by_name
             .remove(&subscription_ref.name)
             .unwrap();
@@ -354,7 +374,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_view(&mut self, id: ViewId) {
-        let view_ref = self.view_by_id.remove(&id).unwrap();
+        let Some(view_ref) = self.view_by_id.remove(&id) else {
+            tracing::warn!(?id, "view to drop not found, cleaning up?");
+            return;
+        };
+
         self.view_by_name.remove(&view_ref.name).unwrap();
     }
 
@@ -411,10 +435,10 @@ impl SchemaCatalog {
     }
 
     pub fn drop_function(&mut self, id: FunctionId) {
-        let function_ref = self
-            .function_by_id
-            .remove(&id)
-            .expect("function not found by id");
+        let Some(function_ref) = self.function_by_id.remove(&id) else {
+            tracing::warn!(?id, "function to drop not found, cleaning up?");
+            return;
+        };
 
         self.function_registry
             .remove(Self::get_func_sign(&function_ref))
@@ -483,10 +507,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_connection(&mut self, connection_id: ConnectionId) {
-        let connection_ref = self
-            .connection_by_id
-            .remove(&connection_id)
-            .expect("connection not found by id");
+        let Some(connection_ref) = self.connection_by_id.remove(&connection_id) else {
+            tracing::warn!(?connection_id, "connection to drop not found, cleaning up?");
+            return;
+        };
+
         self.connection_by_name
             .remove(&connection_ref.name)
             .expect("connection not found by name");
@@ -523,10 +548,11 @@ impl SchemaCatalog {
     }
 
     pub fn drop_secret(&mut self, secret_id: SecretId) {
-        let secret_ref = self
-            .secret_by_id
-            .remove(&secret_id)
-            .expect("secret not found by id");
+        let Some(secret_ref) = self.secret_by_id.remove(&secret_id) else {
+            tracing::warn!(?secret_id, "secret to drop not found, cleaning up?");
+            return;
+        };
+
         self.secret_by_name
             .remove(&secret_ref.name)
             .expect("secret not found by name");

--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -160,11 +160,7 @@ impl SchemaCatalog {
     }
 
     pub fn drop_table(&mut self, id: TableId) {
-        let Some(table_ref) = self.table_by_id.remove(&id) else {
-            tracing::warn!(?id, "table to drop not found, cleaning up?");
-            return;
-        };
-
+        let table_ref = self.table_by_id.remove(&id).unwrap();
         self.table_by_name.remove(&table_ref.name).unwrap();
         self.indexes_by_table_id.remove(&table_ref.id);
     }
@@ -194,11 +190,7 @@ impl SchemaCatalog {
     }
 
     pub fn drop_index(&mut self, id: IndexId) {
-        let Some(index_ref) = self.index_by_id.remove(&id) else {
-            tracing::warn!(?id, "index to drop not found, cleaning up?");
-            return;
-        };
-
+        let index_ref = self.index_by_id.remove(&id).unwrap();
         self.index_by_name.remove(&index_ref.name).unwrap();
         match self.indexes_by_table_id.entry(index_ref.primary_table.id) {
             Occupied(mut entry) => {
@@ -233,11 +225,7 @@ impl SchemaCatalog {
     }
 
     pub fn drop_source(&mut self, id: SourceId) {
-        let Some(source_ref) = self.source_by_id.remove(&id) else {
-            tracing::warn!(?id, "source to drop not found, cleaning up?");
-            return;
-        };
-
+        let source_ref = self.source_by_id.remove(&id).unwrap();
         self.source_by_name.remove(&source_ref.name).unwrap();
         if let Some(connection_id) = source_ref.connection_id {
             if let Occupied(mut e) = self.connection_source_ref.entry(connection_id) {
@@ -286,11 +274,7 @@ impl SchemaCatalog {
     }
 
     pub fn drop_sink(&mut self, id: SinkId) {
-        let Some(sink_ref) = self.sink_by_id.remove(&id) else {
-            tracing::warn!(?id, "sink to drop not found, cleaning up?");
-            return;
-        };
-
+        let sink_ref = self.sink_by_id.remove(&id).unwrap();
         self.sink_by_name.remove(&sink_ref.name).unwrap();
         if let Some(connection_id) = sink_ref.connection_id {
             if let Occupied(mut e) = self.connection_sink_ref.entry(connection_id.0) {
@@ -334,11 +318,7 @@ impl SchemaCatalog {
     }
 
     pub fn drop_subscription(&mut self, id: SubscriptionId) {
-        let Some(subscription_ref) = self.subscription_by_id.remove(&id) else {
-            tracing::warn!(?id, "subscription to drop not found, cleaning up?");
-            return;
-        };
-
+        let subscription_ref = self.subscription_by_id.remove(&id).unwrap();
         self.subscription_by_name
             .remove(&subscription_ref.name)
             .unwrap();
@@ -374,11 +354,7 @@ impl SchemaCatalog {
     }
 
     pub fn drop_view(&mut self, id: ViewId) {
-        let Some(view_ref) = self.view_by_id.remove(&id) else {
-            tracing::warn!(?id, "view to drop not found, cleaning up?");
-            return;
-        };
-
+        let view_ref = self.view_by_id.remove(&id).unwrap();
         self.view_by_name.remove(&view_ref.name).unwrap();
     }
 
@@ -435,10 +411,10 @@ impl SchemaCatalog {
     }
 
     pub fn drop_function(&mut self, id: FunctionId) {
-        let Some(function_ref) = self.function_by_id.remove(&id) else {
-            tracing::warn!(?id, "function to drop not found, cleaning up?");
-            return;
-        };
+        let function_ref = self
+            .function_by_id
+            .remove(&id)
+            .expect("function not found by id");
 
         self.function_registry
             .remove(Self::get_func_sign(&function_ref))
@@ -507,11 +483,10 @@ impl SchemaCatalog {
     }
 
     pub fn drop_connection(&mut self, connection_id: ConnectionId) {
-        let Some(connection_ref) = self.connection_by_id.remove(&connection_id) else {
-            tracing::warn!(?connection_id, "connection to drop not found, cleaning up?");
-            return;
-        };
-
+        let connection_ref = self
+            .connection_by_id
+            .remove(&connection_id)
+            .expect("connection not found by id");
         self.connection_by_name
             .remove(&connection_ref.name)
             .expect("connection not found by name");
@@ -548,11 +523,10 @@ impl SchemaCatalog {
     }
 
     pub fn drop_secret(&mut self, secret_id: SecretId) {
-        let Some(secret_ref) = self.secret_by_id.remove(&secret_id) else {
-            tracing::warn!(?secret_id, "secret to drop not found, cleaning up?");
-            return;
-        };
-
+        let secret_ref = self
+            .secret_by_id
+            .remove(&secret_id)
+            .expect("secret not found by id");
         self.secret_by_name
             .remove(&secret_ref.name)
             .expect("secret not found by name");

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -245,6 +245,7 @@ impl FrontendObserverNode {
         let Some(info) = resp.info.as_ref() else {
             return;
         };
+        tracing::trace!(?info, "handle catalog notification");
 
         let mut catalog_guard = self.catalog.write();
         match info {

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -245,7 +245,7 @@ impl FrontendObserverNode {
         let Some(info) = resp.info.as_ref() else {
             return;
         };
-        tracing::trace!(?info, "handle catalog notification");
+        tracing::trace!(op = ?resp.operation(), ?info, "handle catalog notification");
 
         let mut catalog_guard = self.catalog.write();
         match info {

--- a/src/meta/src/controller/catalog.rs
+++ b/src/meta/src/controller/catalog.rs
@@ -66,10 +66,11 @@ use tracing::info;
 use super::utils::{check_subscription_name_duplicate, get_fragment_ids_by_jobs};
 use crate::controller::rename::{alter_relation_rename, alter_relation_rename_refs};
 use crate::controller::utils::{
-    build_relation_group_for_delete, check_connection_name_duplicate, check_database_name_duplicate,
-    check_function_signature_duplicate, check_relation_name_duplicate, check_schema_name_duplicate,
-    check_secret_name_duplicate, ensure_object_id, ensure_object_not_refer, ensure_schema_empty,
-    ensure_user_id, extract_external_table_name_from_definition, get_referring_objects,
+    build_relation_group_for_delete, check_connection_name_duplicate,
+    check_database_name_duplicate, check_function_signature_duplicate,
+    check_relation_name_duplicate, check_schema_name_duplicate, check_secret_name_duplicate,
+    ensure_object_id, ensure_object_not_refer, ensure_schema_empty, ensure_user_id,
+    extract_external_table_name_from_definition, get_referring_objects,
     get_referring_objects_cascade, get_user_privilege, list_user_info_by_ids,
     resolve_source_register_info_for_jobs, PartialObject,
 };

--- a/src/meta/src/controller/catalog.rs
+++ b/src/meta/src/controller/catalog.rs
@@ -66,7 +66,7 @@ use tracing::info;
 use super::utils::{check_subscription_name_duplicate, get_fragment_ids_by_jobs};
 use crate::controller::rename::{alter_relation_rename, alter_relation_rename_refs};
 use crate::controller::utils::{
-    build_relation_group, check_connection_name_duplicate, check_database_name_duplicate,
+    build_relation_group_for_delete, check_connection_name_duplicate, check_database_name_duplicate,
     check_function_signature_duplicate, check_relation_name_duplicate, check_schema_name_duplicate,
     check_secret_name_duplicate, ensure_object_id, ensure_object_not_refer, ensure_schema_empty,
     ensure_user_id, extract_external_table_name_from_definition, get_referring_objects,
@@ -891,7 +891,7 @@ impl CatalogController {
 
         txn.commit().await?;
 
-        let relation_group = build_relation_group(
+        let relation_group = build_relation_group_for_delete(
             dirty_mview_objs
                 .into_iter()
                 .chain(dirty_mview_internal_table_objs.into_iter())
@@ -2305,7 +2305,7 @@ impl CatalogController {
 
         // notify about them.
         self.notify_users_update(user_infos).await;
-        let relation_group = build_relation_group(to_drop_objects);
+        let relation_group = build_relation_group_for_delete(to_drop_objects);
 
         let version = self
             .notify_frontend(NotificationOperation::Delete, relation_group)

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -63,7 +63,7 @@ use crate::barrier::{ReplaceTablePlan, Reschedule};
 use crate::controller::catalog::CatalogController;
 use crate::controller::rename::ReplaceTableExprRewriter;
 use crate::controller::utils::{
-    build_relation_group, check_relation_name_duplicate, check_sink_into_table_cycle,
+    build_relation_group_for_delete, check_relation_name_duplicate, check_sink_into_table_cycle,
     ensure_object_id, ensure_user_id, get_fragment_actor_ids, get_fragment_mappings,
     rebuild_fragment_mapping_from_actors, PartialObject,
 };
@@ -575,7 +575,7 @@ impl CatalogController {
         txn.commit().await?;
 
         if !objs.is_empty() {
-            self.notify_frontend(Operation::Delete, build_relation_group(objs))
+            self.notify_frontend(Operation::Delete, build_relation_group_for_delete(objs))
                 .await;
         }
         Ok(true)

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -575,6 +575,10 @@ impl CatalogController {
         txn.commit().await?;
 
         if !objs.is_empty() {
+            // We **may** also have notified the frontend about these objects,
+            // so we need to notify the frontend to delete them here.
+            // The frontend will ignore the request if the object does not exist,
+            // so it's safe to always notify.
             self.notify_frontend(Operation::Delete, build_relation_group_for_delete(objs))
                 .await;
         }

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -1082,7 +1082,13 @@ where
     ))
 }
 
-pub(crate) fn build_relation_group(relation_objects: Vec<PartialObject>) -> NotificationInfo {
+/// Build a relation group for notifying the deletion of the given objects.
+///
+/// Note that only id fields are filled in the relation info, as the arguments are partial objects.
+/// As a result, the returned notification info should only be used for deletion.
+pub(crate) fn build_relation_group_for_delete(
+    relation_objects: Vec<PartialObject>,
+) -> NotificationInfo {
     let mut relations = vec![];
     for obj in relation_objects {
         match obj.obj_type {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -566,9 +566,10 @@ impl TableFragments {
         }
     }
 
-    /// Retrieve the internal tables map of the whole graph.
+    /// Retrieve the **complete** internal tables map of the whole graph.
     ///
-    /// See also [`crate::stream::StreamFragmentGraph::incomplete_internal_tables`].
+    /// Compared to [`crate::stream::StreamFragmentGraph::incomplete_internal_tables`],
+    /// the table catalogs returned here are complete, with all fields filled.
     pub fn internal_tables(&self) -> BTreeMap<u32, Table> {
         let mut tables = BTreeMap::new();
         for fragment in self.fragments.values() {

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1082,16 +1082,6 @@ impl DdlController {
             .await?;
 
         let streaming_job = &ctx.streaming_job;
-        let internal_tables = ctx.internal_tables();
-
-        // Now that all fields in `internal_tables` are initialized,
-        // we can notify frontend for these relations.
-        if streaming_job.is_materialized_view() {
-            self.metadata_manager
-                .catalog_controller
-                .pre_notify_internal_tables(&internal_tables)
-                .await?;
-        }
 
         match streaming_job {
             StreamingJob::Table(None, table, TableJobType::SharedCdcSource) => {

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -349,6 +349,9 @@ impl StreamFragmentGraph {
     ) -> MetaResult<Self> {
         let fragment_id_gen =
             GlobalFragmentIdGen::new(env.id_gen_manager(), proto.fragments.len() as u64);
+        // Note: in SQL backend, the ids generated here are fake and will be overwritten again
+        // with `refill_internal_table_ids` later.
+        // TODO: refactor the code to remove this step.
         let table_id_gen = GlobalTableIdGen::new(env.id_gen_manager(), proto.table_ids_cnt as u64);
 
         // Create nodes.
@@ -418,7 +421,13 @@ impl StreamFragmentGraph {
     }
 
     /// Retrieve the internal tables map of the whole graph.
-    pub fn internal_tables(&self) -> BTreeMap<u32, Table> {
+    ///
+    /// Note that some fields in the table catalogs are not filled during the current phase, e.g.,
+    /// `fragment_id`, `vnode_count`. They will be all filled after a `TableFragments` is built.
+    /// Be careful when using the returned values.
+    ///
+    /// See also [`crate::model::TableFragments::internal_tables`].
+    pub fn incomplete_internal_tables(&self) -> BTreeMap<u32, Table> {
         let mut tables = BTreeMap::new();
         for fragment in self.fragments.values() {
             for table in fragment.extract_internal_tables() {
@@ -431,6 +440,8 @@ impl StreamFragmentGraph {
         tables
     }
 
+    /// Refill the internal tables' `table_id`s according to the given map, typically obtained from
+    /// `create_internal_table_catalog`.
     pub fn refill_internal_table_ids(&mut self, table_id_map: HashMap<u32, u32>) {
         for fragment in self.fragments.values_mut() {
             stream_graph_visitor::visit_internal_tables(

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -420,7 +420,7 @@ impl StreamFragmentGraph {
         })
     }
 
-    /// Retrieve the internal tables map of the whole graph.
+    /// Retrieve the **incomplete** internal tables map of the whole graph.
     ///
     /// Note that some fields in the table catalogs are not filled during the current phase, e.g.,
     /// `fragment_id`, `vnode_count`. They will be all filled after a `TableFragments` is built.

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -448,7 +448,7 @@ async fn test_graph_builder() -> MetaResult<()> {
         time_zone: graph.ctx.as_ref().unwrap().timezone.clone(),
     };
     let fragment_graph = StreamFragmentGraph::new(&env, graph, &job)?;
-    let internal_tables = fragment_graph.internal_tables();
+    let internal_tables = fragment_graph.incomplete_internal_tables();
 
     let actor_graph_builder = ActorGraphBuilder::new(
         job.id(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When creating a streaming job, the internal tables directly scraped from the frontend's `StreamFragmentGraph` are incomplete, because several fields like `fragment_id` or `vnode_count` are not filled yet and will be determined later.

~~Previously, we notified the frontend nodes with these catalogs but did not update them afterward. This will cause problems since variable vnode count support is introduced, as the vnode count of a table is a significant property when scheduling a batch scan over it.~~

~~This PR changes to notify the internal table catalogs only after a `TableFragments` is build, where all information is final and complete.~~

This PR revises the documentation, comments, and naming of related snippets to clarify the completeness of internal table catalogs during various phases of creating a streaming job.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
