### PR TITLE
perf(over window): skip remaining affected rows when rank is not changed

### DIFF
--- a/src/expr/core/src/window_function/kind.rs
+++ b/src/expr/core/src/window_function/kind.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyhow::Context;
+use enum_as_inner::EnumAsInner;
 use parse_display::{Display, FromStr};
 use risingwave_common::bail;
 
@@ -20,7 +21,7 @@ use crate::aggregate::AggType;
 use crate::Result;
 
 /// Kind of window functions.
-#[derive(Debug, Display, FromStr /* for builtin */, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Display, FromStr /* for builtin */, Clone, PartialEq, Eq, Hash, EnumAsInner)]
 #[display(style = "snake_case")]
 pub enum WindowFuncKind {
     // General-purpose window functions.
@@ -64,7 +65,7 @@ impl WindowFuncKind {
 }
 
 impl WindowFuncKind {
-    pub fn is_rank(&self) -> bool {
+    pub fn is_numbering(&self) -> bool {
         matches!(self, Self::RowNumber | Self::Rank | Self::DenseRank)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -278,7 +278,7 @@ impl LogicalOverWindow {
         let rewritten_selected_items = over_window_builder.rewrite_selected_items(select_exprs)?;
 
         for window_func in &window_functions {
-            if window_func.kind.is_rank() && window_func.order_by.sort_exprs.is_empty() {
+            if window_func.kind.is_numbering() && window_func.order_by.sort_exprs.is_empty() {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
                     "window rank function without order by: {:?}",
                     window_func

--- a/src/frontend/src/optimizer/rule/over_window_split_rule.rs
+++ b/src/frontend/src/optimizer/rule/over_window_split_rule.rs
@@ -36,7 +36,7 @@ impl Rule for OverWindowSplitRule {
             .iter()
             .enumerate()
             .map(|(idx, func)| {
-                let func_seq = if func.kind.is_rank() {
+                let func_seq = if func.kind.is_numbering() {
                     rank_func_seq += 1;
                     rank_func_seq
                 } else {

--- a/src/frontend/src/optimizer/rule/over_window_to_topn_rule.rs
+++ b/src/frontend/src/optimizer/rule/over_window_to_topn_rule.rs
@@ -70,7 +70,7 @@ impl Rule for OverWindowToTopNRule {
             return None;
         }
         let window_func = &over_window.window_functions()[0];
-        if !window_func.kind.is_rank() {
+        if !window_func.kind.is_numbering() {
             // Only rank functions can be converted to TopN.
             return None;
         }

--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -152,7 +152,11 @@ pub(super) struct Calls {
     pub(super) end_is_unbounded: bool,
     /// Deduplicated indices of all arguments of all calls.
     pub(super) all_arg_indices: Vec<usize>,
-    pub(super) rank_funcs_only: bool,
+
+    // TODO(rc): The following flags are used to optimize for `row_number`, `rank` and `dense_rank`.
+    // We should try our best to remove these flags while maintaining the performance in the future.
+    pub(super) numbering_only: bool,
+    pub(super) has_rank: bool,
 }
 
 impl Calls {
@@ -181,7 +185,8 @@ impl Calls {
             .dedup()
             .collect();
 
-        let rank_funcs_only = calls.iter().all(|call| call.kind.is_rank());
+        let numbering_only = calls.iter().all(|call| call.kind.is_numbering());
+        let has_rank = calls.iter().any(|call| call.kind.is_rank());
 
         Self {
             calls,
@@ -190,7 +195,8 @@ impl Calls {
             start_is_unbounded,
             end_is_unbounded,
             all_arg_indices,
-            rank_funcs_only,
+            numbering_only,
+            has_rank,
         }
     }
 

--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -152,6 +152,7 @@ pub(super) struct Calls {
     pub(super) end_is_unbounded: bool,
     /// Deduplicated indices of all arguments of all calls.
     pub(super) all_arg_indices: Vec<usize>,
+    pub(super) rank_funcs_only: bool,
 }
 
 impl Calls {
@@ -180,6 +181,8 @@ impl Calls {
             .dedup()
             .collect();
 
+        let rank_funcs_only = calls.iter().all(|call| call.kind.is_rank());
+
         Self {
             calls,
             super_rows_frame_bounds,
@@ -187,6 +190,7 @@ impl Calls {
             start_is_unbounded,
             end_is_unbounded,
             all_arg_indices,
+            rank_funcs_only,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

For example:

```sql
rank() over (
  partition by ...
  order by val
)
```

Rows:

```
 row_id | val | rank
--------|-----|------
 100    | 2   | 1
 101    | 6   | 2
 102    | 7   | 3
 103    | 9   | 4
```

When changing `val` of row `101`, it will potenrially affect row `102` and `103`. Previously, no matter what the `val` is changed to, we will re-compute all outputs from row `101` to the end of the partition (row `103`). After this PR, if the output of row `102` is not changed, we will stop the re-computation.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
