### PR TITLE
feat: persist processed rows for SourceBackfill for SHOW JOBS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ e2e_test/iceberg/metastore_db
 **/*.sqlite
 **/*.sqlite-journal
 
-*.slt.temp
+*.slt*.temp
 
 .direnv/
 

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -23,10 +23,10 @@ sleep 2s
 system ok
 internal_table.mjs --name mv_before_produce --type sourcebackfill
 ----
-0,"""Finished"""
-1,"""Finished"""
-2,"""Finished"""
-3,"""Finished"""
+0,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
+1,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
+2,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
+3,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
 
 
 system ok
@@ -78,10 +78,10 @@ internal_table.mjs --name s0 --type source
 system ok
 internal_table.mjs --name mv_1 --type sourcebackfill
 ----
-0,"{""SourceCachingUp"": ""0""}"
-1,"{""SourceCachingUp"": ""0""}"
-2,"{""SourceCachingUp"": ""0""}"
-3,"{""SourceCachingUp"": ""0""}"
+0,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
+1,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
+2,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
+3,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
 
 
 # This does not affect the behavior for CREATE MATERIALIZED VIEW below. It also uses the shared source, and creates SourceBackfillExecutor.
@@ -176,10 +176,10 @@ internal_table.mjs --name s0 --type source
 system ok
 internal_table.mjs --name mv_1 --type sourcebackfill
 ----
-0,"""Finished"""
-1,"""Finished"""
-2,"""Finished"""
-3,"""Finished"""
+0,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
+1,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
+2,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
+3,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
 
 
 system ok

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -23,10 +23,10 @@ sleep 2s
 system ok
 internal_table.mjs --name mv_before_produce --type sourcebackfill
 ----
-0,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
-1,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
-2,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
-3,"{""num_consumed_rows"": 0, ""state"": ""Finished""}"
+0,"{""num_consumed_rows"": 0, ""state"": ""Finished"", ""target_offset"": null}"
+1,"{""num_consumed_rows"": 0, ""state"": ""Finished"", ""target_offset"": null}"
+2,"{""num_consumed_rows"": 0, ""state"": ""Finished"", ""target_offset"": null}"
+3,"{""num_consumed_rows"": 0, ""state"": ""Finished"", ""target_offset"": null}"
 
 
 system ok
@@ -34,6 +34,9 @@ cat << EOF | rpk topic produce shared_source -f "%p %v\n" -p 0
 0 {"v1": 1, "v2": "a"}
 1 {"v1": 2, "v2": "b"}
 2 {"v1": 3, "v2": "c"}
+2 {"v1": 3, "v2": "c"}
+3 {"v1": 4, "v2": "d"}
+3 {"v1": 4, "v2": "d"}
 3 {"v1": 4, "v2": "d"}
 EOF
 
@@ -78,10 +81,10 @@ internal_table.mjs --name s0 --type source
 system ok
 internal_table.mjs --name mv_1 --type sourcebackfill
 ----
-0,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
-1,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
-2,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
-3,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}}"
+0,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}, ""target_offset"": ""0""}"
+1,"{""num_consumed_rows"": 1, ""state"": {""SourceCachingUp"": ""0""}, ""target_offset"": ""0""}"
+2,"{""num_consumed_rows"": 2, ""state"": {""SourceCachingUp"": ""1""}, ""target_offset"": ""1""}"
+3,"{""num_consumed_rows"": 3, ""state"": {""SourceCachingUp"": ""2""}, ""target_offset"": ""2""}"
 
 
 # This does not affect the behavior for CREATE MATERIALIZED VIEW below. It also uses the shared source, and creates SourceBackfillExecutor.
@@ -96,26 +99,35 @@ sleep 2s
 query ?? rowsort
 select v1, v2 from s0;
 ----
-1 a
-2 b
-3 c
-4 d
+1	a
+2	b
+3	c
+3	c
+4	d
+4	d
+4	d
 
 query ?? rowsort
 select v1, v2 from mv_1;
 ----
-1 a
-2 b
-3 c
-4 d
+1	a
+2	b
+3	c
+3	c
+4	d
+4	d
+4	d
 
 query ?? rowsort
 select v1, v2 from mv_2;
 ----
-1 a
-2 b
-3 c
-4 d
+1	a
+2	b
+3	c
+3	c
+4	d
+4	d
+4	d
 
 system ok
 cat << EOF | rpk topic produce shared_source -f "%p %v\n" -p 0
@@ -133,33 +145,39 @@ internal_table.mjs --name s0 --type source
 ----
 0,"{""split_info"": {""partition"": 0, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 1,"{""split_info"": {""partition"": 1, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""partition"": 2, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""partition"": 3, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""partition"": 2, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""partition"": 3, ""start_offset"": 3, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 query ?? rowsort
 select v1, v2 from s0;
 ----
-1 a
-1 aa
-2 b
-2 bb
-3 c
-3 cc
-4 d
-4 dd
+1	a
+1	aa
+2	b
+2	bb
+3	c
+3	c
+3	cc
+4	d
+4	d
+4	d
+4	dd
 
 query ?? rowsort
 select v1, v2 from mv_1;
 ----
-1 a
-1 aa
-2 b
-2 bb
-3 c
-3 cc
-4 d
-4 dd
+1	a
+1	aa
+2	b
+2	bb
+3	c
+3	c
+3	cc
+4	d
+4	d
+4	d
+4	dd
 
 
 # start_offset changed to 1
@@ -168,18 +186,18 @@ internal_table.mjs --name s0 --type source
 ----
 0,"{""split_info"": {""partition"": 0, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 1,"{""split_info"": {""partition"": 1, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""partition"": 2, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""partition"": 3, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""partition"": 2, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""partition"": 3, ""start_offset"": 3, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 # Transition from SourceCachingUp to Finished after consuming one upstream message.
 system ok
 internal_table.mjs --name mv_1 --type sourcebackfill
 ----
-0,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
-1,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
-2,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
-3,"{""num_consumed_rows"": 2, ""state"": ""Finished""}"
+0,"{""num_consumed_rows"": 2, ""state"": ""Finished"", ""target_offset"": ""0""}"
+1,"{""num_consumed_rows"": 2, ""state"": ""Finished"", ""target_offset"": ""0""}"
+2,"{""num_consumed_rows"": 3, ""state"": ""Finished"", ""target_offset"": ""1""}"
+3,"{""num_consumed_rows"": 4, ""state"": ""Finished"", ""target_offset"": ""2""}"
 
 
 system ok
@@ -198,26 +216,26 @@ sleep 3s
 query ?? rowsort
 select v1, count(*) from s0 group by v1;
 ----
-1 12
-2 12
-3 12
-4 12
+1	12
+2	12
+3	13
+4	14
 
 query ?? rowsort
 select v1, count(*) from mv_1 group by v1;
 ----
-1 12
-2 12
-3 12
-4 12
+1	12
+2	12
+3	13
+4	14
 
 query ?? rowsort
 select v1, count(*) from mv_before_produce group by v1;
 ----
-1 12
-2 12
-3 12
-4 12
+1	12
+2	12
+3	13
+4	14
 
 
 # start_offset changed to 11
@@ -226,8 +244,8 @@ internal_table.mjs --name s0 --type source
 ----
 0,"{""split_info"": {""partition"": 0, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 1,"{""split_info"": {""partition"": 1, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""partition"": 2, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""partition"": 3, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""partition"": 2, ""start_offset"": 12, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""partition"": 3, ""start_offset"": 13, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 # # Note: the parallelism depends on the risedev profile.

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -609,11 +609,6 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                         break 'backfill_loop;
                                     }
                                 } else {
-                                    self.progress.update_for_source_backfill(
-                                        barrier.epoch,
-                                        backfill_stage.total_backfilled_rows(),
-                                    );
-                                    // yield barrier after reporting progress
                                     yield Message::Barrier(barrier);
                                 }
                             }

--- a/src/stream/src/executor/source/source_backfill_state_table.rs
+++ b/src/stream/src/executor/source/source_backfill_state_table.rs
@@ -23,7 +23,7 @@ use risingwave_connector::source::SplitId;
 use risingwave_pb::catalog::PbTable;
 use risingwave_storage::StateStore;
 
-use super::source_backfill_executor::{BackfillState, BackfillStates};
+use super::source_backfill_executor::{BackfillStateWithCnt, BackfillStates};
 use crate::common::table::state_table::StateTable;
 use crate::executor::error::StreamExecutorError;
 use crate::executor::StreamExecutorResult;
@@ -56,7 +56,7 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
     }
 
     /// XXX: we might get stale data for other actors' writes, but it's fine?
-    pub async fn scan(&self) -> StreamExecutorResult<Vec<BackfillState>> {
+    pub async fn scan(&self) -> StreamExecutorResult<Vec<BackfillStateWithCnt>> {
         let sub_range: &(Bound<OwnedRow>, Bound<OwnedRow>) = &(Bound::Unbounded, Bound::Unbounded);
 
         let state_table_iter = self
@@ -70,7 +70,7 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
             let row = item?.into_owned_row();
             let state = match row.datum_at(1) {
                 Some(ScalarRefImpl::Jsonb(jsonb_ref)) => {
-                    BackfillState::restore_from_json(jsonb_ref.to_owned_scalar())?
+                    BackfillStateWithCnt::restore_from_json(jsonb_ref.to_owned_scalar())?
                 }
                 _ => unreachable!(),
             };
@@ -80,7 +80,7 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
         Ok(ret)
     }
 
-    async fn set(&mut self, key: SplitId, state: BackfillState) -> StreamExecutorResult<()> {
+    async fn set(&mut self, key: SplitId, state: BackfillStateWithCnt) -> StreamExecutorResult<()> {
         let row = [
             Some(Self::string_to_scalar(key.as_ref())),
             Some(ScalarImpl::Jsonb(state.encode_to_json())),
@@ -126,13 +126,13 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
     pub async fn try_recover_from_state_store(
         &mut self,
         split_id: &SplitId,
-    ) -> StreamExecutorResult<Option<BackfillState>> {
+    ) -> StreamExecutorResult<Option<BackfillStateWithCnt>> {
         Ok(self
             .get(split_id)
             .await?
             .map(|row| match row.datum_at(1) {
                 Some(ScalarRefImpl::Jsonb(jsonb_ref)) => {
-                    BackfillState::restore_from_json(jsonb_ref.to_owned_scalar())
+                    BackfillStateWithCnt::restore_from_json(jsonb_ref.to_owned_scalar())
                 }
                 _ => unreachable!(),
             })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Follow up of #18925

If we don't persist, after recovery the progress will start from 0 again. 

However, TBH I'm a little hesitant about this change, since it is a little ugly. And we have to persist it just for SHOW JOBS.

---

This changes the state table representation, and should be a **breaking change**. But if we can get this into 2.1, then we don't need to consider compatibility.

---

Besides `SHOW JOBS`, this also benefits scanning from state table, making it more informative. (See diff on `slt`)

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
