### PR TITLE
fix(test): fix some flaky e2e source tests

### DIFF
--- a/e2e_test/source_inline/kafka/avro/glue.slt
+++ b/e2e_test/source_inline/kafka/avro/glue.slt
@@ -14,6 +14,8 @@ EOF
 statement ok
 ALTER SYSTEM SET license_key TO '';
 
+sleep 1s
+
 statement error
 create source t with (
   connector = 'kafka',

--- a/e2e_test/source_inline/kafka/temporary_kafka_batch.slt
+++ b/e2e_test/source_inline/kafka/temporary_kafka_batch.slt
@@ -71,6 +71,12 @@ t
 t
 t
 
+# ensure now() is larger
+sleep 1s
+
+statement ok
+flush;
+
 query B
 select _rw_kafka_timestamp < now() from s1
 ----


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- `temporary_kafka_batch.slt`: In #18894, we moved data generation from ci script (generate before tests) to `slt` (generate inline), which may cause the test fail.
- `glue.slt`: Alter license may not take effect immediately.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
