### PR TITLE
fix(frontend): allow `INCLUDE payload` without other columns

### DIFF
--- a/e2e_test/source_legacy/basic/kafka.slt
+++ b/e2e_test/source_legacy/basic/kafka.slt
@@ -497,6 +497,16 @@ WITH (
 ) FORMAT PLAIN ENCODE JSON
 
 statement ok
+CREATE TABLE test_include_payload_only
+INCLUDE payload
+WITH (
+    connector = 'kafka',
+    topic = 'kafka_1_partition_topic',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
+) FORMAT PLAIN ENCODE JSON
+
+statement ok
 flush;
 
 # Wait enough time to ensure SourceExecutor consumes all Kafka data.
@@ -907,6 +917,9 @@ drop table source_with_rdkafka_props;
 
 statement ok
 drop table debezium_ignore_key;
+
+statement ok
+drop table test_include_payload_only;
 
 statement ok
 drop table test_include_payload;

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -646,12 +646,6 @@ pub fn handle_addition_columns(
         ))));
     }
 
-    let latest_col_id: ColumnId = columns
-        .iter()
-        .map(|col| col.column_desc.column_id)
-        .max()
-        .unwrap(); // there must be at least one column in the column catalog
-
     while let Some(item) = additional_columns.pop() {
         check_additional_column_compatibility(&item, source_schema)?;
 
@@ -667,7 +661,7 @@ pub fn handle_addition_columns(
             );
         }
         let col = build_additional_column_desc(
-            latest_col_id.next(),
+            ColumnId::placeholder(),
             connector_name.as_str(),
             item.column_type.real_value().as_str(),
             item.column_alias.map(|alias| alias.real_value()),
@@ -720,12 +714,6 @@ pub(crate) fn bind_all_columns(
             return Err(RwError::from(NotSupported(
                 "Wildcard in user-defined schema is only allowed when there exists columns from external schema".to_string(),
                 "Remove the wildcard or use a source with external schema".to_string(),
-            )));
-        }
-        // FIXME(yuhao): cols_from_sql should be None is no `()` is given.
-        if cols_from_sql.is_empty() {
-            return Err(RwError::from(ProtocolError(
-                "Schema definition is required, either from SQL or schema registry.".to_string(),
             )));
         }
         let non_generated_sql_defined_columns = non_generated_sql_columns(col_defs_from_sql);
@@ -1547,6 +1535,13 @@ pub async fn bind_create_source_or_table_with_connector(
         &mut columns,
         false,
     )?;
+
+    if columns.is_empty() {
+        return Err(RwError::from(ProtocolError(
+            "Schema definition is required, either from SQL or schema registry.".to_string(),
+        )));
+    }
+
     // compatible with the behavior that add a hidden column `_rw_kafka_timestamp` to each message from Kafka source
     if is_create_source {
         // must behind `handle_addition_columns`


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Since #18437 we have supported `INCLUDE payload` to ingest the whole json payload as a single `jsonb` column:
```
create [source | table] my_source (
  foo varchar,
  bar int)
include payload as root
with (...)
format plain encode json;
```
However, when there is no need to extract `foo` or `bar`, an empty column list would result in the following error:
```
Schema definition is required, either from SQL or schema registry.
```

This PR enables such usage by moving the empty column list check after handling `INCLUDE` additional columns.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
