### PR TITLE
feat(dashboard): list streaming job from `streaming_job` table & show info

### DIFF
--- a/dashboard/components/Relations.tsx
+++ b/dashboard/components/Relations.tsx
@@ -35,7 +35,7 @@ import Title from "../components/Title"
 import useFetch from "../lib/api/fetch"
 import {
   Relation,
-  StreamingJob,
+  StreamingRelation,
   getDatabases,
   getSchemas,
   getUsers,
@@ -73,7 +73,7 @@ export const dependentsColumn: Column<Relation> = {
   ),
 }
 
-export const fragmentsColumn: Column<StreamingJob> = {
+export const fragmentsColumn: Column<StreamingRelation> = {
   name: "Fragments",
   width: 1,
   content: (r) => (

--- a/dashboard/lib/api/streaming.ts
+++ b/dashboard/lib/api/streaming.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { plainToInstance } from "class-transformer"
+import { Expose, plainToInstance } from "class-transformer"
 import _ from "lodash"
 import sortBy from "lodash/sortBy"
 import {
@@ -69,15 +69,18 @@ export interface Relation {
 }
 
 export class StreamingJob {
-  jobId!: number
-  objType!: string
+  @Expose({ name: "jobId" })
+  id!: number
+  @Expose({ name: "objType" })
+  _objType!: string
   name!: string
   jobStatus!: string
-  parallelism!: any
+  @Expose({ name: "parallelism" })
+  _parallelism!: any
   maxParallelism!: number
 
-  parallelismDisplay() {
-    const parallelism = this.parallelism
+  get parallelism() {
+    const parallelism = this._parallelism
     if (typeof parallelism === "string") {
       // `Adaptive`
       return parallelism
@@ -92,11 +95,11 @@ export class StreamingJob {
     }
   }
 
-  typeDisplay() {
-    if (this.objType == "Table") {
+  get type() {
+    if (this._objType == "Table") {
       return "Table / MV"
     } else {
-      return this.objType
+      return this._objType
     }
   }
 }
@@ -134,7 +137,7 @@ export async function getStreamingJobs() {
     StreamingJob,
     (await api.get("/streaming_jobs")) as any[]
   )
-  jobs = sortBy(jobs, (x) => x.jobId)
+  jobs = sortBy(jobs, (x) => x.id)
   return jobs
 }
 

--- a/dashboard/lib/api/streaming.ts
+++ b/dashboard/lib/api/streaming.ts
@@ -68,7 +68,7 @@ export interface Relation {
   databaseName?: string
 }
 
-export class StreamingJobInfo {
+export class StreamingJob {
   jobId!: number
   objType!: string
   name!: string
@@ -101,7 +101,7 @@ export class StreamingJobInfo {
   }
 }
 
-export interface StreamingJob extends Relation {
+export interface StreamingRelation extends Relation {
   dependentRelations: number[]
 }
 
@@ -124,14 +124,14 @@ export function relationTypeTitleCase(x: Relation) {
   return _.startCase(_.toLower(relationType(x)))
 }
 
-export function relationIsStreamingJob(x: Relation): x is StreamingJob {
+export function relationIsStreamingJob(x: Relation): x is StreamingRelation {
   const type = relationType(x)
   return type !== "UNKNOWN" && type !== "SOURCE" && type !== "INTERNAL"
 }
 
 export async function getStreamingJobs() {
   let jobs = plainToInstance(
-    StreamingJobInfo,
+    StreamingJob,
     (await api.get("/streaming_jobs")) as any[]
   )
   jobs = sortBy(jobs, (x) => x.jobId)

--- a/dashboard/lib/api/streaming.ts
+++ b/dashboard/lib/api/streaming.ts
@@ -53,14 +53,6 @@ export async function getRelationIdInfos(): Promise<RelationIdInfos> {
   return fragmentIds
 }
 
-export async function getFragments(): Promise<TableFragments[]> {
-  let fragmentList: TableFragments[] = (await api.get("/fragments2")).map(
-    TableFragments.fromJSON
-  )
-  fragmentList = sortBy(fragmentList, (x) => x.tableId)
-  return fragmentList
-}
-
 export interface Relation {
   id: number
   name: string
@@ -73,6 +65,27 @@ export interface Relation {
   ownerName?: string
   schemaName?: string
   databaseName?: string
+}
+
+export interface StreamingJobInfo {
+  jobId: number
+  objType: string
+  name: string
+  jobStatus: string
+  parallelism: any
+  maxParallelism: number
+}
+
+export function formatParallelism(parallelism: any) {
+  if (typeof parallelism === "string") {
+    return parallelism
+  } else if (typeof parallelism === "object") {
+    let key = Object.keys(parallelism)[0]
+    let value = parallelism[key]
+    return `${key} (${value})`
+  } else {
+    return JSON.stringify(parallelism)
+  }
 }
 
 export interface StreamingJob extends Relation {
@@ -104,13 +117,8 @@ export function relationIsStreamingJob(x: Relation): x is StreamingJob {
 }
 
 export async function getStreamingJobs() {
-  let jobs = _.concat<StreamingJob>(
-    await getMaterializedViews(),
-    await getTables(),
-    await getIndexes(),
-    await getSinks()
-  )
-  jobs = sortBy(jobs, (x) => x.id)
+  let jobs: StreamingJobInfo[] = await api.get("/streaming_jobs")
+  jobs = sortBy(jobs, (x) => x.jobId)
   return jobs
 }
 

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -17,6 +17,7 @@
         "@uidotdev/usehooks": "^2.4.1",
         "base64url": "^3.0.1",
         "bootstrap-icons": "^1.9.1",
+        "class-transformer": "^0.5.1",
         "d3": "^7.6.1",
         "d3-axis": "^3.0.0",
         "d3-dag": "^0.11.4",
@@ -35,6 +36,7 @@
         "react-json-view": "^1.21.3",
         "react-syntax-highlighter": "^15.5.0",
         "recharts": "^2.3.2",
+        "reflect-metadata": "^0.2.2",
         "styled-components": "5.3.0",
         "ts-proto": "^1.169.1"
       },
@@ -4134,6 +4136,11 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
       "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/classcat": {
       "version": "5.0.4",
@@ -9801,6 +9808,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -14811,6 +14823,11 @@
       "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
       "dev": true
     },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
     "classcat": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
@@ -18961,6 +18978,11 @@
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
         }
       }
+    },
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "reflect.getprototypeof": {
       "version": "1.0.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -24,6 +24,7 @@
     "@uidotdev/usehooks": "^2.4.1",
     "base64url": "^3.0.1",
     "bootstrap-icons": "^1.9.1",
+    "class-transformer": "^0.5.1",
     "d3": "^7.6.1",
     "d3-axis": "^3.0.0",
     "d3-dag": "^0.11.4",
@@ -42,6 +43,7 @@
     "react-json-view": "^1.21.3",
     "react-syntax-highlighter": "^15.5.0",
     "recharts": "^2.3.2",
+    "reflect-metadata": "^0.2.2",
     "styled-components": "5.3.0",
     "ts-proto": "^1.169.1"
   },

--- a/dashboard/pages/_app.tsx
+++ b/dashboard/pages/_app.tsx
@@ -15,6 +15,7 @@
  *
  */
 import "bootstrap-icons/font/bootstrap-icons.css"
+import "reflect-metadata"
 import "../styles/global.css"
 
 import { ChakraProvider } from "@chakra-ui/react"

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -24,7 +24,12 @@ import {
   HStack,
   Input,
   Select,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
   Text,
+  Tr,
   VStack,
 } from "@chakra-ui/react"
 import * as d3 from "d3"
@@ -45,6 +50,7 @@ import {
   fetchPrometheusBackPressure,
 } from "../lib/api/metric"
 import {
+  formatParallelism,
   getFragmentsByJobId,
   getRelationIdInfos,
   getStreamingJobs,
@@ -184,7 +190,7 @@ function buildFragmentDependencyAsEdges(
   return nodes
 }
 
-const SIDEBAR_WIDTH = 200
+const SIDEBAR_WIDTH = 225
 
 type BackPressureDataSource = "Embedded" | "Prometheus"
 const backPressureDataSources: BackPressureDataSource[] = [
@@ -202,23 +208,28 @@ interface EmbeddedBackPressureInfo {
 }
 
 export default function Streaming() {
-  const { response: relationList } = useFetch(getStreamingJobs)
+  const { response: streamingJobList } = useFetch(getStreamingJobs)
   const { response: relationIdInfos } = useFetch(getRelationIdInfos)
 
-  const [relationId, setRelationId] = useQueryState("id", parseAsInteger)
+  const [jobId, setJobId] = useQueryState("id", parseAsInteger)
   const [selectedFragmentId, setSelectedFragmentId] = useState<number>()
   const [tableFragments, setTableFragments] = useState<TableFragments>()
+
+  const job = useMemo(
+    () => streamingJobList?.find((j) => j.jobId === jobId),
+    [streamingJobList, jobId]
+  )
 
   const toast = useErrorToast()
 
   useEffect(() => {
-    if (relationId) {
+    if (jobId) {
       setTableFragments(undefined)
-      getFragmentsByJobId(relationId).then((tf) => {
+      getFragmentsByJobId(jobId).then((tf) => {
         setTableFragments(tf)
       })
     }
-  }, [relationId])
+  }, [jobId])
 
   const fragmentDependencyCallback = useCallback(() => {
     if (tableFragments) {
@@ -232,14 +243,14 @@ export default function Streaming() {
   }, [tableFragments])
 
   useEffect(() => {
-    if (relationList) {
-      if (!relationId) {
-        if (relationList.length > 0) {
-          setRelationId(relationList[0].id)
+    if (streamingJobList) {
+      if (!jobId) {
+        if (streamingJobList.length > 0) {
+          setJobId(streamingJobList[0].jobId)
         }
       }
     }
-  }, [relationId, relationList, setRelationId])
+  }, [jobId, streamingJobList, setJobId])
 
   // The table fragments of the selected fragment id
   const fragmentDependency = fragmentDependencyCallback()?.fragmentDep
@@ -276,7 +287,7 @@ export default function Streaming() {
         const fragmentIdToRelationId = map[relationId].map
         for (const fragmentId in fragmentIdToRelationId) {
           if (parseInt(fragmentId) == searchFragIdInt) {
-            setRelationId(parseInt(relationId))
+            setJobId(parseInt(relationId))
             setSelectedFragmentId(searchFragIdInt)
             return
           }
@@ -295,7 +306,7 @@ export default function Streaming() {
         for (const fragmentId in fragmentIdToRelationId) {
           let actorIds = fragmentIdToRelationId[fragmentId].ids
           if (actorIds.includes(searchActorIdInt)) {
-            setRelationId(parseInt(relationId))
+            setJobId(parseInt(relationId))
             setSelectedFragmentId(parseInt(fragmentId))
             return
           }
@@ -406,41 +417,68 @@ export default function Streaming() {
           height="full"
         >
           <FormControl>
-            <FormLabel>Relations</FormLabel>
+            <FormLabel>Streaming Jobs</FormLabel>
             <Input
               list="relationList"
               spellCheck={false}
               onChange={(event) => {
-                const id = relationList?.find(
+                const id = streamingJobList?.find(
                   (x) => x.name == event.target.value
-                )?.id
+                )?.jobId
                 if (id) {
-                  setRelationId(id)
+                  setJobId(id)
                 }
               }}
               placeholder="Search..."
               mb={2}
             ></Input>
             <datalist id="relationList">
-              {relationList &&
-                relationList.map((r) => (
-                  <option value={r.name} key={r.id}>
-                    ({r.id}) {r.name}
+              {streamingJobList &&
+                streamingJobList.map((r) => (
+                  <option value={r.name} key={r.jobId}>
+                    ({r.jobId}) {r.name}
                   </option>
                 ))}
             </datalist>
             <Select
-              value={relationId ?? undefined}
-              onChange={(event) => setRelationId(parseInt(event.target.value))}
+              value={jobId ?? undefined}
+              onChange={(event) => setJobId(parseInt(event.target.value))}
             >
-              {relationList &&
-                relationList.map((r) => (
-                  <option value={r.id} key={r.name}>
-                    ({r.id}) {r.name}
+              {streamingJobList &&
+                streamingJobList.map((r) => (
+                  <option value={r.jobId} key={r.name}>
+                    ({r.jobId}) {r.name}
                   </option>
                 ))}
             </Select>
           </FormControl>
+          {job && (
+            <FormControl>
+              <FormLabel>Information</FormLabel>
+              <TableContainer>
+                <Table size="sm">
+                  <Tbody>
+                    <Tr>
+                      <Td fontWeight="medium">Type</Td>
+                      <Td isNumeric>{job.objType}</Td>
+                    </Tr>
+                    <Tr>
+                      <Td fontWeight="medium">Status</Td>
+                      <Td isNumeric>{job.jobStatus}</Td>
+                    </Tr>
+                    <Tr>
+                      <Td fontWeight="medium">Max Parallelism</Td>
+                      <Td isNumeric>{job.maxParallelism}</Td>
+                    </Tr>
+                    <Tr>
+                      <Td fontWeight="medium">Parallelism</Td>
+                      <Td isNumeric>{formatParallelism(job.parallelism)}</Td>
+                    </Tr>
+                  </Tbody>
+                </Table>
+              </TableContainer>
+            </FormControl>
+          )}
           <FormControl>
             <FormLabel>Goto</FormLabel>
             <VStack spacing={2}>

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -50,7 +50,6 @@ import {
   fetchPrometheusBackPressure,
 } from "../lib/api/metric"
 import {
-  formatParallelism,
   getFragmentsByJobId,
   getRelationIdInfos,
   getStreamingJobs,
@@ -460,19 +459,21 @@ export default function Streaming() {
                   <Tbody>
                     <Tr>
                       <Td fontWeight="medium">Type</Td>
-                      <Td isNumeric>{job.objType}</Td>
+                      <Td isNumeric>{job.typeDisplay()}</Td>
                     </Tr>
                     <Tr>
                       <Td fontWeight="medium">Status</Td>
                       <Td isNumeric>{job.jobStatus}</Td>
                     </Tr>
                     <Tr>
-                      <Td fontWeight="medium">Max Parallelism</Td>
-                      <Td isNumeric>{job.maxParallelism}</Td>
+                      <Td fontWeight="medium">Parallelism</Td>
+                      <Td isNumeric>{job.parallelismDisplay()}</Td>
                     </Tr>
                     <Tr>
-                      <Td fontWeight="medium">Parallelism</Td>
-                      <Td isNumeric>{formatParallelism(job.parallelism)}</Td>
+                      <Td fontWeight="medium" paddingEnd={0}>
+                        Max Parallelism
+                      </Td>
+                      <Td isNumeric>{job.maxParallelism}</Td>
                     </Tr>
                   </Tbody>
                 </Table>

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -215,7 +215,7 @@ export default function Streaming() {
   const [tableFragments, setTableFragments] = useState<TableFragments>()
 
   const job = useMemo(
-    () => streamingJobList?.find((j) => j.jobId === jobId),
+    () => streamingJobList?.find((j) => j.id === jobId),
     [streamingJobList, jobId]
   )
 
@@ -245,7 +245,7 @@ export default function Streaming() {
     if (streamingJobList) {
       if (!jobId) {
         if (streamingJobList.length > 0) {
-          setJobId(streamingJobList[0].jobId)
+          setJobId(streamingJobList[0].id)
         }
       }
     }
@@ -423,7 +423,7 @@ export default function Streaming() {
               onChange={(event) => {
                 const id = streamingJobList?.find(
                   (x) => x.name == event.target.value
-                )?.jobId
+                )?.id
                 if (id) {
                   setJobId(id)
                 }
@@ -434,8 +434,8 @@ export default function Streaming() {
             <datalist id="relationList">
               {streamingJobList &&
                 streamingJobList.map((r) => (
-                  <option value={r.name} key={r.jobId}>
-                    ({r.jobId}) {r.name}
+                  <option value={r.name} key={r.id}>
+                    ({r.id}) {r.name}
                   </option>
                 ))}
             </datalist>
@@ -445,8 +445,8 @@ export default function Streaming() {
             >
               {streamingJobList &&
                 streamingJobList.map((r) => (
-                  <option value={r.jobId} key={r.name}>
-                    ({r.jobId}) {r.name}
+                  <option value={r.id} key={r.name}>
+                    ({r.id}) {r.name}
                   </option>
                 ))}
             </Select>
@@ -459,7 +459,7 @@ export default function Streaming() {
                   <Tbody>
                     <Tr>
                       <Td fontWeight="medium">Type</Td>
-                      <Td isNumeric>{job.typeDisplay()}</Td>
+                      <Td isNumeric>{job.type}</Td>
                     </Tr>
                     <Tr>
                       <Td fontWeight="medium">Status</Td>
@@ -467,7 +467,7 @@ export default function Streaming() {
                     </Tr>
                     <Tr>
                       <Td fontWeight="medium">Parallelism</Td>
-                      <Td isNumeric>{job.parallelismDisplay()}</Td>
+                      <Td isNumeric>{job.parallelism}</Td>
                     </Tr>
                     <Tr>
                       <Td fontWeight="medium" paddingEnd={0}>

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -18,6 +18,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
   },
   "include": [
     "next-env.d.ts",

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_connector::source::SplitMetaData;
+use risingwave_meta::controller::fragment::StreamingJobInfo;
 use risingwave_meta::manager::{LocalNotification, MetadataManager};
 use risingwave_meta::model;
 use risingwave_meta::model::ActorId;
@@ -222,27 +223,35 @@ impl StreamManagerService for StreamServiceImpl {
         &self,
         _request: Request<ListTableFragmentStatesRequest>,
     ) -> Result<Response<ListTableFragmentStatesResponse>, Status> {
-        let job_states = self
+        let job_infos = self
             .metadata_manager
             .catalog_controller
-            .list_streaming_job_states()
+            .list_streaming_job_infos()
             .await?;
-        let states = job_states
+        let states = job_infos
             .into_iter()
-            .map(|(table_id, state, parallelism, max_parallelism)| {
-                let parallelism = match parallelism {
-                    StreamingParallelism::Adaptive => model::TableParallelism::Adaptive,
-                    StreamingParallelism::Custom => model::TableParallelism::Custom,
-                    StreamingParallelism::Fixed(n) => model::TableParallelism::Fixed(n as _),
-                };
+            .map(
+                |StreamingJobInfo {
+                     job_id,
+                     job_status,
+                     parallelism,
+                     max_parallelism,
+                     ..
+                 }| {
+                    let parallelism = match parallelism {
+                        StreamingParallelism::Adaptive => model::TableParallelism::Adaptive,
+                        StreamingParallelism::Custom => model::TableParallelism::Custom,
+                        StreamingParallelism::Fixed(n) => model::TableParallelism::Fixed(n as _),
+                    };
 
-                list_table_fragment_states_response::TableFragmentState {
-                    table_id: table_id as _,
-                    state: PbState::from(state) as _,
-                    parallelism: Some(parallelism.into()),
-                    max_parallelism: max_parallelism as _,
-                }
-            })
+                    list_table_fragment_states_response::TableFragmentState {
+                        table_id: job_id as _,
+                        state: PbState::from(job_status) as _,
+                        parallelism: Some(parallelism.into()),
+                        max_parallelism: max_parallelism as _,
+                    }
+                },
+            )
             .collect_vec();
 
         Ok(Response::new(ListTableFragmentStatesResponse { states }))

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -718,7 +718,10 @@ impl CatalogController {
                     Expr::col((table::Entity, table::Column::Name)),
                     Expr::if_null(
                         Expr::col((source::Entity, source::Column::Name)),
-                        Expr::col((sink::Entity, sink::Column::Name)),
+                        Expr::if_null(
+                            Expr::col((sink::Entity, sink::Column::Name)),
+                            Expr::val("<unknown>"),
+                        ),
                     ),
                 ),
                 "name",

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -24,11 +24,12 @@ use risingwave_common::util::stream_graph_visitor::visit_stream_node;
 use risingwave_common::util::worker_util::WorkerNodeId;
 use risingwave_meta_model::actor::ActorStatus;
 use risingwave_meta_model::fragment::DistributionType;
+use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::prelude::{Actor, ActorDispatcher, Fragment, Sink, StreamingJob};
 use risingwave_meta_model::{
-    actor, actor_dispatcher, fragment, object, sink, streaming_job, ActorId, ActorUpstreamActors,
-    ConnectorSplits, DatabaseId, ExprContext, FragmentId, I32Array, JobStatus, ObjectId, SinkId,
-    SourceId, StreamNode, StreamingParallelism, TableId, VnodeBitmap, WorkerId,
+    actor, actor_dispatcher, fragment, object, sink, source, streaming_job, table, ActorId,
+    ActorUpstreamActors, ConnectorSplits, DatabaseId, ExprContext, FragmentId, I32Array, JobStatus,
+    ObjectId, SinkId, SourceId, StreamNode, StreamingParallelism, TableId, VnodeBitmap, WorkerId,
 };
 use risingwave_meta_model_migration::{Alias, SelectStatement};
 use risingwave_pb::common::PbActorLocation;
@@ -51,9 +52,10 @@ use risingwave_pb::stream_plan::{
 use sea_orm::sea_query::Expr;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ColumnTrait, DbErr, EntityTrait, JoinType, ModelTrait, PaginatorTrait, QueryFilter,
-    QuerySelect, RelationTrait, SelectGetableTuple, Selector, TransactionTrait, Value,
+    ColumnTrait, DbErr, EntityTrait, FromQueryResult, JoinType, ModelTrait, PaginatorTrait,
+    QueryFilter, QuerySelect, RelationTrait, SelectGetableTuple, Selector, TransactionTrait, Value,
 };
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::controller::catalog::{CatalogController, CatalogControllerInner};
@@ -77,6 +79,17 @@ pub struct FragmentParallelismInfo {
     pub distribution_type: FragmentDistributionType,
     pub actor_count: usize,
     pub vnode_count: usize,
+}
+
+#[derive(Clone, Debug, FromQueryResult, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")] // for dashboard
+pub struct StreamingJobInfo {
+    pub job_id: ObjectId,
+    pub obj_type: ObjectType,
+    pub name: String,
+    pub job_status: JobStatus,
+    pub parallelism: StreamingParallelism,
+    pub max_parallelism: i32,
 }
 
 impl CatalogControllerInner {
@@ -690,19 +703,32 @@ impl CatalogController {
         )
     }
 
-    pub async fn list_streaming_job_states(
-        &self,
-    ) -> MetaResult<Vec<(ObjectId, JobStatus, StreamingParallelism, i32)>> {
+    pub async fn list_streaming_job_infos(&self) -> MetaResult<Vec<StreamingJobInfo>> {
         let inner = self.inner.read().await;
         let job_states = StreamingJob::find()
             .select_only()
+            .column(streaming_job::Column::JobId)
+            .join(JoinType::InnerJoin, streaming_job::Relation::Object.def())
+            .column(object::Column::ObjType)
+            .join(JoinType::LeftJoin, table::Relation::Object1.def().rev())
+            .join(JoinType::LeftJoin, source::Relation::Object.def().rev())
+            .join(JoinType::LeftJoin, sink::Relation::Object.def().rev())
+            .column_as(
+                Expr::if_null(
+                    Expr::col((table::Entity, table::Column::Name)),
+                    Expr::if_null(
+                        Expr::col((source::Entity, source::Column::Name)),
+                        Expr::col((sink::Entity, sink::Column::Name)),
+                    ),
+                ),
+                "name",
+            )
             .columns([
-                streaming_job::Column::JobId,
                 streaming_job::Column::JobStatus,
                 streaming_job::Column::Parallelism,
                 streaming_job::Column::MaxParallelism,
             ])
-            .into_tuple()
+            .into_model()
             .all(&inner.db)
             .await?;
         Ok(job_states)

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -76,6 +76,7 @@ pub(super) mod handlers {
     use thiserror_ext::AsReport;
 
     use super::*;
+    use crate::controller::fragment::StreamingJobInfo;
 
     pub struct DashboardError(anyhow::Error);
     pub type Result<T> = std::result::Result<T, DashboardError>;
@@ -191,20 +192,17 @@ pub(super) mod handlers {
         Ok(Json(views))
     }
 
-    pub async fn list_fragments(
+    pub async fn list_streaming_jobs(
         Extension(srv): Extension<Service>,
-    ) -> Result<Json<Vec<PbTableFragments>>> {
-        let table_fragments = srv
+    ) -> Result<Json<Vec<StreamingJobInfo>>> {
+        let streaming_jobs = srv
             .metadata_manager
             .catalog_controller
-            .table_fragments()
+            .list_streaming_job_infos()
             .await
-            .map_err(err)?
-            .values()
-            .cloned()
-            .collect_vec();
+            .map_err(err)?;
 
-        Ok(Json(table_fragments))
+        Ok(Json(streaming_jobs))
     }
 
     /// In the ddl backpressure graph, we want to compute the backpressure between relations.
@@ -508,7 +506,7 @@ impl DashboardService {
 
         let api_router = Router::new()
             .route("/clusters/:ty", get(list_clusters))
-            .route("/fragments2", get(list_fragments))
+            .route("/streaming_jobs", get(list_streaming_jobs))
             .route("/fragments/job_id/:job_id", get(list_fragments_by_job_id))
             .route("/relation_id_infos", get(get_relation_id_infos))
             .route(

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -581,7 +581,7 @@ impl MetadataManager {
 
     pub async fn count_streaming_job(&self) -> MetaResult<usize> {
         self.catalog_controller
-            .list_streaming_job_states()
+            .list_streaming_job_infos()
             .await
             .map(|x| x.len())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

List streaming jobs in dashboard by querying the `streaming_job` table in meta store, instead of querying different catalog tables separately. This gives more accurate results and extra info about streaming jobs.

<img width="193" alt="image" src="https://github.com/user-attachments/assets/7e601d90-dcd3-4725-9e1d-23566e004b68">
<img width="193" alt="image" src="https://github.com/user-attachments/assets/64069a70-ed91-436b-bbe4-36f2d7d5a69b">



## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
