### PR TITLE
fix(source): pause source correctly

### DIFF
--- a/src/stream/src/executor/source/fs_source_executor.rs
+++ b/src/stream/src/executor/source/fs_source_executor.rs
@@ -364,8 +364,10 @@ impl<S: StateStore> FsSourceExecutor<S> {
         let barrier_stream = barrier_to_message_stream(barrier_receiver).boxed();
         let mut stream =
             StreamReaderWithPause::<true, StreamChunk>::new(barrier_stream, source_chunk_reader);
+        let mut command_paused = false;
         if start_with_paused {
             stream.pause_stream();
+            command_paused = true;
         }
 
         yield Message::Barrier(barrier);
@@ -376,7 +378,6 @@ impl<S: StateStore> FsSourceExecutor<S> {
             self.system_params.load().barrier_interval_ms() as u128 * WAIT_BARRIER_MULTIPLE_TIMES;
         let mut last_barrier_time = Instant::now();
         let mut self_paused = false;
-        let mut command_paused = false;
 
         let source_output_row_count = self
             .metrics

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -406,6 +406,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
 
         type PausedReader = Option<impl Stream>;
         let mut paused_reader: PausedReader = None;
+        let mut command_paused = false;
 
         macro_rules! pause_reader {
             () => {
@@ -422,6 +423,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
 
         // If the first barrier requires us to pause on startup, pause the stream.
         if barrier.is_pause_on_startup() {
+            command_paused = true;
             pause_reader!();
         }
 
@@ -463,7 +465,6 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                 * WAIT_BARRIER_MULTIPLE_TIMES;
             let mut last_barrier_time = Instant::now();
             let mut self_paused = false;
-            let mut command_paused = false;
 
             // The main logic of the loop is in handle_upstream_row and handle_backfill_row.
             'backfill_loop: while let Some(either) = backfill_stream.next().await {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -550,6 +550,7 @@ impl<S: StateStore> SourceExecutor<S> {
 
                     if self_paused {
                         self_paused = false;
+                        // command_paused has a higher priority.
                         if !command_paused {
                             stream.resume_stream();
                         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Unlike other executor that only pause/resume based on command of barrier, the source executor additionally pauses/resumes based on [self_paused](https://github.com/risingwavelabs/risingwave/blob/main/src/stream/src/executor/source/source_executor.rs#L640). However, there's a corner case where this `self_paused` method will resume the source executor incorrectly:
1. A new stream job is created, resulting in 3 barriers: [pause, configchange, resume].
2. The source executor receives the first [pause] barrier. Somehow the following 2 barriers are delayed.
3. `self_paused` [pauses](https://github.com/risingwavelabs/risingwave/blob/main/src/stream/src/executor/source/source_executor.rs#L640) the source executor.
4. The source executor receives the [configchange] barrier, causing `self_paused` to [resume](https://github.com/risingwavelabs/risingwave/blob/e99ad679863f4c5c6fbcb605739b8a9fe1e3a02c/src/stream/src/executor/source/source_executor.rs#L551) the source executor, **incorrectly**. The source executor is expected to be resumed by the following [resume] barrier.

This PR fixes this issue.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
