### PR TITLE
feat(ci): run e2e tests against postgres/mysql backends on demand

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,3 +42,7 @@ labels:
 - label: "ci/run-e2e-single-node-tests"
   files:
   - "src\\/meta\\/.*.rs"
+
+- label: "ci/run-e2e-test-other-backends"
+  files:
+  - "src\\/meta\\/.*.rs"

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -113,6 +113,14 @@ services:
     volumes:
       - ..:/risingwave
 
+  pg-mysql-backend-test-env:
+    image: public.ecr.aws/w1p7b4n3/rw-build-env:v20240911
+    depends_on:
+      - mysql
+      - db
+    volumes:
+      - ..:/risingwave
+
   ci-flamegraph-env:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20240911
     # NOTE(kwannoel): This is used in order to permit

--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -64,6 +64,13 @@ cluster_stop() {
   else
     risedev ci-kill
   fi
+
+  # Clean up meta store database.
+  if [[ $mode == *"mysql-backend" ]]; then
+    mysql -h mysql -P 3306 -u root -p123456 -e "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
+  elif [[ $mode == *"pg-backend" ]]; then
+    PGPASSWORD=postgres psql -h db -p 5432 -U postgres -c "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
+  fi
 }
 
 download_and_prepare_rw "$profile" common

--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -52,7 +52,7 @@ cluster_start() {
     if [[ $mode == *"mysql-backend" ]]; then
       mysql -h mysql -P 3306 -u root -p123456 -e "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
     elif [[ $mode == *"pg-backend" ]]; then
-      PGPASSWORD=postgres psql -h db -p 5432 -U postgres -c "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
+      PGPASSWORD=postgres psql -h db -p 5432 -U postgres -c "DROP DATABASE IF EXISTS metadata;" -c "CREATE DATABASE metadata;"
     fi
 
     risedev ci-start "$mode"

--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -48,6 +48,13 @@ cluster_start() {
     # Give it a while to make sure the single-node is ready.
     sleep 10
   else
+    # Initialize backends.
+    if [[ $mode == *"mysql-backend" ]]; then
+      mysql -h mysql -P 3306 -u root -p123456 -e "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
+    elif [[ $mode == *"pg-backend" ]]; then
+      PGPASSWORD=postgres psql -h db -p 5432 -U postgres -c "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
+    fi
+
     risedev ci-start "$mode"
   fi
 }
@@ -63,13 +70,6 @@ cluster_stop() {
     stop_single_node
   else
     risedev ci-kill
-  fi
-
-  # Clean up meta store database.
-  if [[ $mode == *"mysql-backend" ]]; then
-    mysql -h mysql -P 3306 -u root -p123456 -e "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
-  elif [[ $mode == *"pg-backend" ]]; then
-    PGPASSWORD=postgres psql -h db -p 5432 -U postgres -c "DROP DATABASE IF EXISTS metadata; CREATE DATABASE metadata;"
   fi
 }
 

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -808,7 +808,7 @@ steps:
 
   - label: "end-to-end test (mysql backend)"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe-mysql-backend"
-    if: false
+    if: "false"
     # TODO: enable this when all bugs of mysql backend are addressed.
     # if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
     depends_on:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -790,6 +790,38 @@ steps:
     timeout_in_minutes: 30
     retry: *auto-retry
 
+  - label: "end-to-end test (parallel, postgres backend)"
+    command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe-pg-backend"
+    if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.1.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 30
+    retry: *auto-retry
+
+  - label: "end-to-end test (parallel, mysql backend)"
+    command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe-mysql-backend"
+    if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.1.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 30
+    retry: *auto-retry
+
   # FIXME(kwannoel): Let the github PR labeller label it, if sqlsmith source files has changes.
   - label: "fuzz test"
     command: "ci/scripts/pr-fuzz-test.sh -p ci-dev"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -799,7 +799,7 @@ steps:
       - "docslt"
     plugins:
       - docker-compose#v5.1.0:
-          run: rw-build-env
+          run: pg-mysql-backend-test-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
@@ -815,7 +815,7 @@ steps:
       - "docslt"
     plugins:
       - docker-compose#v5.1.0:
-          run: rw-build-env
+          run: pg-mysql-backend-test-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -790,7 +790,7 @@ steps:
     timeout_in_minutes: 30
     retry: *auto-retry
 
-  - label: "end-to-end test (parallel, postgres backend)"
+  - label: "end-to-end test (postgres backend)"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe-pg-backend"
     if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
     depends_on:
@@ -806,7 +806,7 @@ steps:
     timeout_in_minutes: 30
     retry: *auto-retry
 
-  - label: "end-to-end test (parallel, mysql backend)"
+  - label: "end-to-end test (mysql backend)"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe-mysql-backend"
     if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
     depends_on:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -808,7 +808,9 @@ steps:
 
   - label: "end-to-end test (mysql backend)"
     command: "ci/scripts/e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe-mysql-backend"
-    if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
+    if: false
+    # TODO: enable this when all bugs of mysql backend are addressed.
+    # if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
     depends_on:
       - "build"
       - "build-other"

--- a/risedev.yml
+++ b/risedev.yml
@@ -43,7 +43,7 @@ profile:
       # - use: grafana     # visualization
 
       - use: meta-node
-      #   - meta-backend: postgres
+        # meta-backend: postgres
       - use: compute-node
       - use: frontend
 
@@ -779,6 +779,122 @@ profile:
       - use: sqlite
       - use: meta-node
         meta-backend: sqlite
+      - use: compute-node
+        port: 5687
+        exporter-port: 1222
+        enable-tiered-cache: true
+        role: streaming
+        parallelism: 4
+      - use: compute-node
+        port: 5688
+        exporter-port: 1223
+        enable-tiered-cache: true
+        role: streaming
+        parallelism: 4
+      - use: compute-node
+        port: 5689
+        exporter-port: 1224
+        enable-tiered-cache: true
+        role: streaming
+        parallelism: 4
+      - use: compute-node
+        port: 5685
+        exporter-port: 1225
+        enable-tiered-cache: true
+        role: serving
+        parallelism: 4
+      - use: compute-node
+        port: 5686
+        exporter-port: 1226
+        enable-tiered-cache: true
+        role: serving
+        parallelism: 8
+      - use: frontend
+        port: 4565
+        exporter-port: 2222
+        health-check-port: 6786
+      - use: frontend
+        port: 4566
+        exporter-port: 2223
+        health-check-port: 6787
+      - use: frontend
+        port: 4567
+        exporter-port: 2224
+        health-check-port: 6788
+      - use: compactor
+
+  ci-3streaming-2serving-3fe-pg-backend:
+    config-path: src/config/ci.toml
+    steps:
+      - use: minio
+      - use: postgres
+        port: 5432
+        address: db
+        database: metadata
+        user: postgres
+        password: postgres
+        user-managed: true
+        application: metastore
+      - use: meta-node
+        meta-backend: postgres
+      - use: compute-node
+        port: 5687
+        exporter-port: 1222
+        enable-tiered-cache: true
+        role: streaming
+        parallelism: 4
+      - use: compute-node
+        port: 5688
+        exporter-port: 1223
+        enable-tiered-cache: true
+        role: streaming
+        parallelism: 4
+      - use: compute-node
+        port: 5689
+        exporter-port: 1224
+        enable-tiered-cache: true
+        role: streaming
+        parallelism: 4
+      - use: compute-node
+        port: 5685
+        exporter-port: 1225
+        enable-tiered-cache: true
+        role: serving
+        parallelism: 4
+      - use: compute-node
+        port: 5686
+        exporter-port: 1226
+        enable-tiered-cache: true
+        role: serving
+        parallelism: 8
+      - use: frontend
+        port: 4565
+        exporter-port: 2222
+        health-check-port: 6786
+      - use: frontend
+        port: 4566
+        exporter-port: 2223
+        health-check-port: 6787
+      - use: frontend
+        port: 4567
+        exporter-port: 2224
+        health-check-port: 6788
+      - use: compactor
+
+  ci-3streaming-2serving-3fe-mysql-backend:
+    config-path: src/config/ci.toml
+    steps:
+      - use: minio
+      - use: mysql
+        port: 3306
+        address: mysql
+        database: metadata
+        user: root
+        password: 123456
+        user-managed: true
+        application: metastore
+      - use: meta-node
+        meta-backend: mysql
       - use: compute-node
         port: 5687
         exporter-port: 1222


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When there's changes under `src/meta`, a new label `ci/run-e2e-test-other-backends` will be attached to the PR. Then, end-to-end tests against postgres/mysql meta backends will be triggered.

Developers can also manually attach the label to trigger the tests.

**NOTE**: This PR only enables Postgres backend, as I found several bugs blocking the tests under the MySQL backend. Will address them and enable it in next PRs.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
