### PR TITLE
chore(meta): bump sea-orm to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11692,6 +11692,7 @@ name = "risingwave_meta_model_migration"
 version = "2.2.0-alpha"
 dependencies = [
  "async-std",
+ "easy-ext",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,7 +3964,7 @@ dependencies = [
 name = "delta_btree_map"
 version = "2.2.0-alpha"
 dependencies = [
- "educe",
+ "educe 0.6.0",
  "enum-as-inner 0.6.0",
 ]
 
@@ -4487,6 +4487,18 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -10635,7 +10647,7 @@ dependencies = [
  "criterion",
  "darwin-libproc",
  "easy-ext",
- "educe",
+ "educe 0.6.0",
  "either",
  "enum-as-inner 0.6.0",
  "enumflags2",
@@ -10727,7 +10739,7 @@ name = "risingwave_common_estimate_size"
 version = "2.2.0-alpha"
 dependencies = [
  "bytes",
- "educe",
+ "educe 0.6.0",
  "ethnum",
  "fixedbitset 0.5.0",
  "jsonbb",
@@ -11042,7 +11054,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "rw_futures_util",
- "sea-schema 0.15.0",
+ "sea-schema",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11217,7 +11229,7 @@ dependencies = [
  "const-currying",
  "downcast-rs",
  "easy-ext",
- "educe",
+ "educe 0.6.0",
  "either",
  "enum-as-inner 0.6.0",
  "expect-test",
@@ -11260,7 +11272,7 @@ dependencies = [
  "chrono",
  "chrono-tz 0.10.0",
  "criterion",
- "educe",
+ "educe 0.6.0",
  "expect-test",
  "fancy-regex",
  "futures-async-stream",
@@ -11327,7 +11339,7 @@ dependencies = [
  "downcast-rs",
  "dyn-clone",
  "easy-ext",
- "educe",
+ "educe 0.6.0",
  "either",
  "enum-as-inner 0.6.0",
  "expect-test",
@@ -11579,7 +11591,7 @@ dependencies = [
  "comfy-table",
  "crepe",
  "easy-ext",
- "educe",
+ "educe 0.6.0",
  "either",
  "enum-as-inner 0.6.0",
  "expect-test",
@@ -11693,7 +11705,7 @@ version = "2.2.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
- "educe",
+ "educe 0.6.0",
  "either",
  "futures",
  "hex",
@@ -12118,7 +12130,7 @@ dependencies = [
  "cfg-if",
  "criterion",
  "delta_btree_map",
- "educe",
+ "educe 0.6.0",
  "either",
  "enum-as-inner 0.6.0",
  "expect-test",
@@ -12766,9 +12778,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.12.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8814e37dc25de54398ee62228323657520b7f29713b8e238649385dbe473ee0"
+checksum = "ea1fee0cf8528dbe6eda29d5798afc522a63b75e44c5b15721e6e64af9c7cc4b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -12779,12 +12791,12 @@ dependencies = [
  "ouroboros",
  "rust_decimal",
  "sea-orm-macros",
- "sea-query 0.30.7",
- "sea-query-binder 0.5.0",
+ "sea-query",
+ "sea-query-binder",
  "serde",
  "serde_json",
  "sqlx",
- "strum 0.25.0",
+ "strum 0.26.3",
  "thiserror",
  "time",
  "tracing",
@@ -12794,16 +12806,16 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-cli"
-version = "0.12.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620bc560062ae251b1366bde43b3f1508445cab5c2c8cbdb397034638ab1b357"
+checksum = "5f0b8869c75cf3fbb1bd860abb025033cd2e514c5f4fa43e792697cb1fe6c882"
 dependencies = [
  "chrono",
  "clap",
  "dotenvy",
  "glob",
  "regex",
- "sea-schema 0.14.2",
+ "sea-schema",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -12811,9 +12823,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e115c6b078e013aa963cc2d38c196c2c40b05f03d0ac872fe06b6e0d5265603"
+checksum = "8737b566799ed0444f278d13c300c4c6f1a91782f60ff5825a591852d5502030"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -12825,9 +12837,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-migration"
-version = "0.12.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8269bc6ff71afd6b78aa4333ac237a69eebd2cdb439036291e64fb4b8db23c"
+checksum = "216643749e26ce27ab6c51d3475f2692981d4a902d34455bcd322f412900df5c"
 dependencies = [
  "async-trait",
  "clap",
@@ -12835,20 +12847,20 @@ dependencies = [
  "futures",
  "sea-orm",
  "sea-orm-cli",
- "sea-schema 0.14.2",
+ "sea-schema",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "sea-query"
-version = "0.30.7"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4166a1e072292d46dc91f31617c2a1cdaf55a8be4b5c9f4bf2ba248e3ac4999b"
+checksum = "b4fd043b8117af233e221f73e3ea8dfbc8e8c3c928017c474296db45c649105c"
 dependencies = [
  "bigdecimal 0.3.1",
  "chrono",
- "derivative",
+ "educe 0.5.11",
  "inherent",
  "ordered-float 3.9.1",
  "rust_decimal",
@@ -12859,39 +12871,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-query"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5073b2cfed767511a57d18115f3b3d8bcb5690bf8c89518caec6cb22c0cd74"
-dependencies = [
- "inherent",
- "sea-query-derive",
-]
-
-[[package]]
-name = "sea-query-binder"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36bbb68df92e820e4d5aeb17b4acd5cc8b5d18b2c36a4dd6f4626aabfa7ab1b9"
-dependencies = [
- "bigdecimal 0.3.1",
- "chrono",
- "rust_decimal",
- "sea-query 0.30.7",
- "serde_json",
- "sqlx",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "sea-query-binder"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754965d4aee6145bec25d0898e5c931e6c22859789ce62fd85a42a15ed5a8ce3"
 dependencies = [
- "sea-query 0.31.0",
+ "bigdecimal 0.3.1",
+ "chrono",
+ "rust_decimal",
+ "sea-query",
+ "serde_json",
  "sqlx",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -12910,38 +12902,15 @@ dependencies = [
 
 [[package]]
 name = "sea-schema"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d148608012d25222442d1ebbfafd1228dbc5221baf4ec35596494e27a2394e"
-dependencies = [
- "futures",
- "sea-query 0.30.7",
- "sea-schema-derive 0.2.0",
-]
-
-[[package]]
-name = "sea-schema"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad52149fc81836ea7424c3425d8f6ed8ad448dd16d2e4f6a3907ba46f3f2fd78"
 dependencies = [
  "futures",
- "sea-query 0.31.0",
- "sea-query-binder 0.6.0",
- "sea-schema-derive 0.3.0",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
  "sqlx",
-]
-
-[[package]]
-name = "sea-schema-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f686050f76bffc4f635cda8aea6df5548666b830b52387e8bc7de11056d11e"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -13714,7 +13683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b6b8f606d3c4cdcaf2031c4320b79d7584e454b79562ba3d675f49701c160e"
 dependencies = [
  "async-trait",
- "educe",
+ "educe 0.6.0",
  "fs-err",
  "futures",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,12 +176,12 @@ parking_lot = { version = "0.12", features = [
     "arc_lock",
     "deadlock_detection",
 ] }
-sea-orm = { version = "0.12.15", features = [
-    "sqlx-mysql",
-    "sqlx-postgres",
-    "sqlx-sqlite",
+sea-orm = { version = "~1.0", features = [
+    "sqlx-all",
     "runtime-tokio-native-tls",
+    "with-uuid",
 ] }
+sea-orm-migration = "~1.0"
 sqlx = { version = "0.7.4", default-features = false, features = [
     "bigdecimal",
     "chrono",

--- a/src/meta/model/migration/Cargo.toml
+++ b/src/meta/model/migration/Cargo.toml
@@ -16,10 +16,7 @@ normal = ["workspace-hack"]
 [dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-
-[dependencies.sea-orm-migration]
-version = "0.12.14"
-features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite", "runtime-tokio-native-tls", "with-uuid"]

--- a/src/meta/model/migration/Cargo.toml
+++ b/src/meta/model/migration/Cargo.toml
@@ -15,6 +15,7 @@ normal = ["workspace-hack"]
 
 [dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
+easy-ext = "1"
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -24,6 +24,7 @@ mod m20240820_081248_add_time_travel_per_table_epoch;
 mod m20240911_083152_variable_vnode_count;
 mod m20241016_065621_hummock_gc_history;
 mod m20241025_062548_singleton_vnode_count;
+mod utils;
 
 pub struct Migrator;
 

--- a/src/meta/model/migration/src/m20230908_072257_init.rs
+++ b/src/meta/model/migration/src/m20230908_072257_init.rs
@@ -1,6 +1,7 @@
 use sea_orm_migration::prelude::{Index as MigrationIndex, Table as MigrationTable, *};
 
 use crate::sea_orm::{DatabaseBackend, DbBackend, Statement};
+use crate::utils::ColumnDefExt;
 use crate::{assert_not_has_tables, drop_tables};
 
 #[derive(DeriveMigrationName)]
@@ -140,7 +141,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(User::CanCreateDb).boolean().not_null())
                     .col(ColumnDef::new(User::CanCreateUser).boolean().not_null())
                     .col(ColumnDef::new(User::CanLogin).boolean().not_null())
-                    .col(ColumnDef::new(User::AuthInfo).blob())
+                    .col(ColumnDef::new(User::AuthInfo).rw_binary(manager))
                     .to_owned(),
             )
             .await?;
@@ -376,8 +377,16 @@ impl MigrationTrait for Migration {
                             .string()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(Fragment::StreamNode).blob().not_null())
-                    .col(ColumnDef::new(Fragment::VnodeMapping).blob().not_null())
+                    .col(
+                        ColumnDef::new(Fragment::StreamNode)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Fragment::VnodeMapping)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Fragment::StateTableIds).json_binary())
                     .col(ColumnDef::new(Fragment::UpstreamFragmentId).json_binary())
                     .foreign_key(
@@ -403,12 +412,16 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Actor::FragmentId).integer().not_null())
                     .col(ColumnDef::new(Actor::Status).string().not_null())
-                    .col(ColumnDef::new(Actor::Splits).blob())
+                    .col(ColumnDef::new(Actor::Splits).rw_binary(manager))
                     .col(ColumnDef::new(Actor::ParallelUnitId).integer().not_null())
                     .col(ColumnDef::new(Actor::WorkerId).integer().not_null())
                     .col(ColumnDef::new(Actor::UpstreamActorIds).json_binary())
-                    .col(ColumnDef::new(Actor::VnodeBitmap).blob())
-                    .col(ColumnDef::new(Actor::ExprContext).blob().not_null())
+                    .col(ColumnDef::new(Actor::VnodeBitmap).rw_binary(manager))
+                    .col(
+                        ColumnDef::new(Actor::ExprContext)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_actor_fragment_id")
@@ -450,7 +463,7 @@ impl MigrationTrait for Migration {
                             .json_binary()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(ActorDispatcher::HashMapping).blob())
+                    .col(ColumnDef::new(ActorDispatcher::HashMapping).rw_binary(manager))
                     .col(
                         ColumnDef::new(ActorDispatcher::DispatcherId)
                             .integer()
@@ -491,7 +504,11 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Connection::Name).string().not_null())
-                    .col(ColumnDef::new(Connection::Info).blob().not_null())
+                    .col(
+                        ColumnDef::new(Connection::Info)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_connection_object_id")
@@ -510,7 +527,11 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Source::SourceId).integer().primary_key())
                     .col(ColumnDef::new(Source::Name).string().not_null())
                     .col(ColumnDef::new(Source::RowIdIndex).integer())
-                    .col(ColumnDef::new(Source::Columns).blob().not_null())
+                    .col(
+                        ColumnDef::new(Source::Columns)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Source::PkColumnIds).json_binary().not_null())
                     .col(
                         ColumnDef::new(Source::WithProperties)
@@ -518,8 +539,12 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(Source::Definition).text().not_null())
-                    .col(ColumnDef::new(Source::SourceInfo).blob())
-                    .col(ColumnDef::new(Source::WatermarkDescs).blob().not_null())
+                    .col(ColumnDef::new(Source::SourceInfo).rw_binary(manager))
+                    .col(
+                        ColumnDef::new(Source::WatermarkDescs)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Source::OptionalAssociatedTableId).integer())
                     .col(ColumnDef::new(Source::ConnectionId).integer())
                     .col(ColumnDef::new(Source::Version).big_integer().not_null())
@@ -558,8 +583,8 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Table::OptionalAssociatedSourceId).integer())
                     .col(ColumnDef::new(Table::TableType).string().not_null())
                     .col(ColumnDef::new(Table::BelongsToJobId).integer())
-                    .col(ColumnDef::new(Table::Columns).blob().not_null())
-                    .col(ColumnDef::new(Table::Pk).blob().not_null())
+                    .col(ColumnDef::new(Table::Columns).rw_binary(manager).not_null())
+                    .col(ColumnDef::new(Table::Pk).rw_binary(manager).not_null())
                     .col(
                         ColumnDef::new(Table::DistributionKey)
                             .json_binary()
@@ -589,14 +614,14 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Table::DistKeyInPk).json_binary().not_null())
                     .col(ColumnDef::new(Table::DmlFragmentId).integer())
-                    .col(ColumnDef::new(Table::Cardinality).blob())
+                    .col(ColumnDef::new(Table::Cardinality).rw_binary(manager))
                     .col(
                         ColumnDef::new(Table::CleanedByWatermark)
                             .boolean()
                             .not_null(),
                     )
                     .col(ColumnDef::new(Table::Description).string())
-                    .col(ColumnDef::new(Table::Version).blob())
+                    .col(ColumnDef::new(Table::Version).rw_binary(manager))
                     .col(ColumnDef::new(Table::RetentionSeconds).integer())
                     .col(
                         ColumnDef::new(Table::IncomingSinks)
@@ -651,8 +676,8 @@ impl MigrationTrait for Migration {
                     .table(Sink::Table)
                     .col(ColumnDef::new(Sink::SinkId).integer().primary_key())
                     .col(ColumnDef::new(Sink::Name).string().not_null())
-                    .col(ColumnDef::new(Sink::Columns).blob().not_null())
-                    .col(ColumnDef::new(Sink::PlanPk).blob().not_null())
+                    .col(ColumnDef::new(Sink::Columns).rw_binary(manager).not_null())
+                    .col(ColumnDef::new(Sink::PlanPk).rw_binary(manager).not_null())
                     .col(
                         ColumnDef::new(Sink::DistributionKey)
                             .json_binary()
@@ -665,7 +690,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Sink::ConnectionId).integer())
                     .col(ColumnDef::new(Sink::DbName).string().not_null())
                     .col(ColumnDef::new(Sink::SinkFromName).string().not_null())
-                    .col(ColumnDef::new(Sink::SinkFormatDesc).blob())
+                    .col(ColumnDef::new(Sink::SinkFormatDesc).rw_binary(manager))
                     .col(ColumnDef::new(Sink::TargetTable).integer())
                     .foreign_key(
                         &mut ForeignKey::create()
@@ -700,7 +725,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(View::Name).string().not_null())
                     .col(ColumnDef::new(View::Properties).json_binary().not_null())
                     .col(ColumnDef::new(View::Definition).text().not_null())
-                    .col(ColumnDef::new(View::Columns).blob().not_null())
+                    .col(ColumnDef::new(View::Columns).rw_binary(manager).not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_view_object_id")
@@ -720,7 +745,11 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Index::Name).string().not_null())
                     .col(ColumnDef::new(Index::IndexTableId).integer().not_null())
                     .col(ColumnDef::new(Index::PrimaryTableId).integer().not_null())
-                    .col(ColumnDef::new(Index::IndexItems).blob().not_null())
+                    .col(
+                        ColumnDef::new(Index::IndexItems)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Index::IndexColumnsLen).integer().not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
@@ -756,8 +785,16 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Function::FunctionId).integer().primary_key())
                     .col(ColumnDef::new(Function::Name).string().not_null())
                     .col(ColumnDef::new(Function::ArgNames).string().not_null())
-                    .col(ColumnDef::new(Function::ArgTypes).blob().not_null())
-                    .col(ColumnDef::new(Function::ReturnType).blob().not_null())
+                    .col(
+                        ColumnDef::new(Function::ArgTypes)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Function::ReturnType)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Function::Language).string().not_null())
                     .col(ColumnDef::new(Function::Link).string())
                     .col(ColumnDef::new(Function::Identifier).string())

--- a/src/meta/model/migration/src/m20230908_072257_init.rs
+++ b/src/meta/model/migration/src/m20230908_072257_init.rs
@@ -140,7 +140,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(User::CanCreateDb).boolean().not_null())
                     .col(ColumnDef::new(User::CanCreateUser).boolean().not_null())
                     .col(ColumnDef::new(User::CanLogin).boolean().not_null())
-                    .col(ColumnDef::new(User::AuthInfo).binary())
+                    .col(ColumnDef::new(User::AuthInfo).blob())
                     .to_owned(),
             )
             .await?;
@@ -376,12 +376,8 @@ impl MigrationTrait for Migration {
                             .string()
                             .not_null(),
                     )
-                    .col(
-                        ColumnDef::new(Fragment::StreamNode)
-                            .blob(BlobSize::Long)
-                            .not_null(),
-                    )
-                    .col(ColumnDef::new(Fragment::VnodeMapping).binary().not_null())
+                    .col(ColumnDef::new(Fragment::StreamNode).blob().not_null())
+                    .col(ColumnDef::new(Fragment::VnodeMapping).blob().not_null())
                     .col(ColumnDef::new(Fragment::StateTableIds).json_binary())
                     .col(ColumnDef::new(Fragment::UpstreamFragmentId).json_binary())
                     .foreign_key(
@@ -407,12 +403,12 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Actor::FragmentId).integer().not_null())
                     .col(ColumnDef::new(Actor::Status).string().not_null())
-                    .col(ColumnDef::new(Actor::Splits).binary())
+                    .col(ColumnDef::new(Actor::Splits).blob())
                     .col(ColumnDef::new(Actor::ParallelUnitId).integer().not_null())
                     .col(ColumnDef::new(Actor::WorkerId).integer().not_null())
                     .col(ColumnDef::new(Actor::UpstreamActorIds).json_binary())
-                    .col(ColumnDef::new(Actor::VnodeBitmap).binary())
-                    .col(ColumnDef::new(Actor::ExprContext).binary().not_null())
+                    .col(ColumnDef::new(Actor::VnodeBitmap).blob())
+                    .col(ColumnDef::new(Actor::ExprContext).blob().not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_actor_fragment_id")
@@ -454,7 +450,7 @@ impl MigrationTrait for Migration {
                             .json_binary()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(ActorDispatcher::HashMapping).binary())
+                    .col(ColumnDef::new(ActorDispatcher::HashMapping).blob())
                     .col(
                         ColumnDef::new(ActorDispatcher::DispatcherId)
                             .integer()
@@ -495,7 +491,7 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Connection::Name).string().not_null())
-                    .col(ColumnDef::new(Connection::Info).binary().not_null())
+                    .col(ColumnDef::new(Connection::Info).blob().not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_connection_object_id")
@@ -514,7 +510,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Source::SourceId).integer().primary_key())
                     .col(ColumnDef::new(Source::Name).string().not_null())
                     .col(ColumnDef::new(Source::RowIdIndex).integer())
-                    .col(ColumnDef::new(Source::Columns).binary().not_null())
+                    .col(ColumnDef::new(Source::Columns).blob().not_null())
                     .col(ColumnDef::new(Source::PkColumnIds).json_binary().not_null())
                     .col(
                         ColumnDef::new(Source::WithProperties)
@@ -522,8 +518,8 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(Source::Definition).text().not_null())
-                    .col(ColumnDef::new(Source::SourceInfo).binary())
-                    .col(ColumnDef::new(Source::WatermarkDescs).binary().not_null())
+                    .col(ColumnDef::new(Source::SourceInfo).blob())
+                    .col(ColumnDef::new(Source::WatermarkDescs).blob().not_null())
                     .col(ColumnDef::new(Source::OptionalAssociatedTableId).integer())
                     .col(ColumnDef::new(Source::ConnectionId).integer())
                     .col(ColumnDef::new(Source::Version).big_integer().not_null())
@@ -562,8 +558,8 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Table::OptionalAssociatedSourceId).integer())
                     .col(ColumnDef::new(Table::TableType).string().not_null())
                     .col(ColumnDef::new(Table::BelongsToJobId).integer())
-                    .col(ColumnDef::new(Table::Columns).binary().not_null())
-                    .col(ColumnDef::new(Table::Pk).binary().not_null())
+                    .col(ColumnDef::new(Table::Columns).blob().not_null())
+                    .col(ColumnDef::new(Table::Pk).blob().not_null())
                     .col(
                         ColumnDef::new(Table::DistributionKey)
                             .json_binary()
@@ -593,14 +589,14 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Table::DistKeyInPk).json_binary().not_null())
                     .col(ColumnDef::new(Table::DmlFragmentId).integer())
-                    .col(ColumnDef::new(Table::Cardinality).binary())
+                    .col(ColumnDef::new(Table::Cardinality).blob())
                     .col(
                         ColumnDef::new(Table::CleanedByWatermark)
                             .boolean()
                             .not_null(),
                     )
                     .col(ColumnDef::new(Table::Description).string())
-                    .col(ColumnDef::new(Table::Version).binary())
+                    .col(ColumnDef::new(Table::Version).blob())
                     .col(ColumnDef::new(Table::RetentionSeconds).integer())
                     .col(
                         ColumnDef::new(Table::IncomingSinks)
@@ -655,8 +651,8 @@ impl MigrationTrait for Migration {
                     .table(Sink::Table)
                     .col(ColumnDef::new(Sink::SinkId).integer().primary_key())
                     .col(ColumnDef::new(Sink::Name).string().not_null())
-                    .col(ColumnDef::new(Sink::Columns).binary().not_null())
-                    .col(ColumnDef::new(Sink::PlanPk).binary().not_null())
+                    .col(ColumnDef::new(Sink::Columns).blob().not_null())
+                    .col(ColumnDef::new(Sink::PlanPk).blob().not_null())
                     .col(
                         ColumnDef::new(Sink::DistributionKey)
                             .json_binary()
@@ -669,7 +665,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Sink::ConnectionId).integer())
                     .col(ColumnDef::new(Sink::DbName).string().not_null())
                     .col(ColumnDef::new(Sink::SinkFromName).string().not_null())
-                    .col(ColumnDef::new(Sink::SinkFormatDesc).binary())
+                    .col(ColumnDef::new(Sink::SinkFormatDesc).blob())
                     .col(ColumnDef::new(Sink::TargetTable).integer())
                     .foreign_key(
                         &mut ForeignKey::create()
@@ -704,7 +700,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(View::Name).string().not_null())
                     .col(ColumnDef::new(View::Properties).json_binary().not_null())
                     .col(ColumnDef::new(View::Definition).text().not_null())
-                    .col(ColumnDef::new(View::Columns).binary().not_null())
+                    .col(ColumnDef::new(View::Columns).blob().not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_view_object_id")
@@ -724,7 +720,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Index::Name).string().not_null())
                     .col(ColumnDef::new(Index::IndexTableId).integer().not_null())
                     .col(ColumnDef::new(Index::PrimaryTableId).integer().not_null())
-                    .col(ColumnDef::new(Index::IndexItems).binary().not_null())
+                    .col(ColumnDef::new(Index::IndexItems).blob().not_null())
                     .col(ColumnDef::new(Index::IndexColumnsLen).integer().not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
@@ -760,8 +756,8 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Function::FunctionId).integer().primary_key())
                     .col(ColumnDef::new(Function::Name).string().not_null())
                     .col(ColumnDef::new(Function::ArgNames).string().not_null())
-                    .col(ColumnDef::new(Function::ArgTypes).binary().not_null())
-                    .col(ColumnDef::new(Function::ReturnType).binary().not_null())
+                    .col(ColumnDef::new(Function::ArgTypes).blob().not_null())
+                    .col(ColumnDef::new(Function::ReturnType).blob().not_null())
                     .col(ColumnDef::new(Function::Language).string().not_null())
                     .col(ColumnDef::new(Function::Link).string())
                     .col(ColumnDef::new(Function::Identifier).string())

--- a/src/meta/model/migration/src/m20231008_020431_hummock.rs
+++ b/src/meta/model/migration/src/m20231008_020431_hummock.rs
@@ -1,5 +1,6 @@
 use sea_orm_migration::prelude::*;
 
+use crate::utils::ColumnDefExt;
 use crate::{assert_not_has_tables, drop_tables};
 
 #[derive(DeriveMigrationName)]
@@ -30,7 +31,11 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(CompactionTask::Task).blob().not_null())
+                    .col(
+                        ColumnDef::new(CompactionTask::Task)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(CompactionTask::ContextId)
                             .integer()
@@ -50,7 +55,7 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(CompactionConfig::Config).blob())
+                    .col(ColumnDef::new(CompactionConfig::Config).rw_binary(manager))
                     .to_owned(),
             )
             .await?;
@@ -65,7 +70,7 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(CompactionStatus::Status).blob())
+                    .col(ColumnDef::new(CompactionStatus::Status).rw_binary(manager))
                     .to_owned(),
             )
             .await?;
@@ -138,7 +143,7 @@ impl MigrationTrait for Migration {
                             .boolean()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(HummockVersionDelta::FullVersionDelta).blob())
+                    .col(ColumnDef::new(HummockVersionDelta::FullVersionDelta).rw_binary(manager))
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20231008_020431_hummock.rs
+++ b/src/meta/model/migration/src/m20231008_020431_hummock.rs
@@ -30,11 +30,7 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(
-                        ColumnDef::new(CompactionTask::Task)
-                            .blob(BlobSize::Long)
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(CompactionTask::Task).blob().not_null())
                     .col(
                         ColumnDef::new(CompactionTask::ContextId)
                             .integer()
@@ -54,7 +50,7 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(CompactionConfig::Config).blob(BlobSize::Long))
+                    .col(ColumnDef::new(CompactionConfig::Config).blob())
                     .to_owned(),
             )
             .await?;
@@ -69,7 +65,7 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(CompactionStatus::Status).blob(BlobSize::Long))
+                    .col(ColumnDef::new(CompactionStatus::Status).blob())
                     .to_owned(),
             )
             .await?;
@@ -142,7 +138,7 @@ impl MigrationTrait for Migration {
                             .boolean()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(HummockVersionDelta::FullVersionDelta).blob(BlobSize::Long))
+                    .col(ColumnDef::new(HummockVersionDelta::FullVersionDelta).blob())
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240304_074901_subscription.rs
+++ b/src/meta/model/migration/src/m20240304_074901_subscription.rs
@@ -1,5 +1,6 @@
 use sea_orm_migration::prelude::{Table as MigrationTable, *};
 
+use crate::utils::ColumnDefExt;
 use crate::{assert_not_has_tables, drop_tables};
 
 #[derive(DeriveMigrationName)]
@@ -19,8 +20,16 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Subscription::Name).string().not_null())
-                    .col(ColumnDef::new(Subscription::Columns).blob().not_null())
-                    .col(ColumnDef::new(Subscription::PlanPk).blob().not_null())
+                    .col(
+                        ColumnDef::new(Subscription::Columns)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Subscription::PlanPk)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(Subscription::DistributionKey)
                             .json_binary()

--- a/src/meta/model/migration/src/m20240304_074901_subscription.rs
+++ b/src/meta/model/migration/src/m20240304_074901_subscription.rs
@@ -19,8 +19,8 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Subscription::Name).string().not_null())
-                    .col(ColumnDef::new(Subscription::Columns).binary().not_null())
-                    .col(ColumnDef::new(Subscription::PlanPk).binary().not_null())
+                    .col(ColumnDef::new(Subscription::Columns).blob().not_null())
+                    .col(ColumnDef::new(Subscription::PlanPk).blob().not_null())
                     .col(
                         ColumnDef::new(Subscription::DistributionKey)
                             .json_binary()

--- a/src/meta/model/migration/src/m20240506_112555_subscription_partial_ckpt.rs
+++ b/src/meta/model/migration/src/m20240506_112555_subscription_partial_ckpt.rs
@@ -1,6 +1,7 @@
 use sea_orm_migration::prelude::{Table as MigrationTable, *};
 
 use crate::drop_tables;
+use crate::utils::ColumnDefExt;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -67,8 +68,16 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Subscription::Name).string().not_null())
                     .col(ColumnDef::new(Subscription::Definition).string().not_null())
-                    .col(ColumnDef::new(Subscription::Columns).blob().not_null())
-                    .col(ColumnDef::new(Subscription::PlanPk).blob().not_null())
+                    .col(
+                        ColumnDef::new(Subscription::Columns)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Subscription::PlanPk)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(Subscription::DistributionKey)
                             .json_binary()

--- a/src/meta/model/migration/src/m20240506_112555_subscription_partial_ckpt.rs
+++ b/src/meta/model/migration/src/m20240506_112555_subscription_partial_ckpt.rs
@@ -67,8 +67,8 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Subscription::Name).string().not_null())
                     .col(ColumnDef::new(Subscription::Definition).string().not_null())
-                    .col(ColumnDef::new(Subscription::Columns).binary().not_null())
-                    .col(ColumnDef::new(Subscription::PlanPk).binary().not_null())
+                    .col(ColumnDef::new(Subscription::Columns).blob().not_null())
+                    .col(ColumnDef::new(Subscription::PlanPk).blob().not_null())
                     .col(
                         ColumnDef::new(Subscription::DistributionKey)
                             .json_binary()

--- a/src/meta/model/migration/src/m20240525_090457_secret.rs
+++ b/src/meta/model/migration/src/m20240525_090457_secret.rs
@@ -1,5 +1,6 @@
 use sea_orm_migration::prelude::{Table as MigrationTable, *};
 
+use crate::utils::ColumnDefExt;
 use crate::{assert_not_has_tables, drop_tables};
 
 #[derive(DeriveMigrationName)]
@@ -21,7 +22,7 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Secret::Name).string().not_null())
-                    .col(ColumnDef::new(Secret::Value).blob().not_null())
+                    .col(ColumnDef::new(Secret::Value).rw_binary(manager).not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_secret_object_id")
@@ -42,7 +43,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 MigrationTable::alter()
                     .table(Sink::Table)
-                    .add_column(ColumnDef::new(Sink::SecretRef).blob())
+                    .add_column(ColumnDef::new(Sink::SecretRef).rw_binary(manager))
                     .to_owned(),
             )
             .await?;
@@ -52,7 +53,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 MigrationTable::alter()
                     .table(Source::Table)
-                    .add_column(ColumnDef::new(Source::SecretRef).blob())
+                    .add_column(ColumnDef::new(Source::SecretRef).rw_binary(manager))
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240525_090457_secret.rs
+++ b/src/meta/model/migration/src/m20240525_090457_secret.rs
@@ -21,7 +21,7 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Secret::Name).string().not_null())
-                    .col(ColumnDef::new(Secret::Value).binary().not_null())
+                    .col(ColumnDef::new(Secret::Value).blob().not_null())
                     .foreign_key(
                         &mut ForeignKey::create()
                             .name("FK_secret_object_id")
@@ -42,7 +42,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 MigrationTable::alter()
                     .table(Sink::Table)
-                    .add_column(ColumnDef::new(Sink::SecretRef).binary())
+                    .add_column(ColumnDef::new(Sink::SecretRef).blob())
                     .to_owned(),
             )
             .await?;
@@ -52,7 +52,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 MigrationTable::alter()
                     .table(Source::Table)
-                    .add_column(ColumnDef::new(Source::SecretRef).binary())
+                    .add_column(ColumnDef::new(Source::SecretRef).blob())
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240617_070131_index_column_properties.rs
+++ b/src/meta/model/migration/src/m20240617_070131_index_column_properties.rs
@@ -10,7 +10,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Index::Table)
-                    .add_column(ColumnDef::new(Index::IndexColumnProperties).binary())
+                    .add_column(ColumnDef::new(Index::IndexColumnProperties).blob())
                     .to_owned(),
             )
             .await

--- a/src/meta/model/migration/src/m20240617_070131_index_column_properties.rs
+++ b/src/meta/model/migration/src/m20240617_070131_index_column_properties.rs
@@ -1,5 +1,7 @@
 use sea_orm_migration::prelude::*;
 
+use crate::utils::ColumnDefExt;
+
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
@@ -10,7 +12,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Index::Table)
-                    .add_column(ColumnDef::new(Index::IndexColumnProperties).blob())
+                    .add_column(ColumnDef::new(Index::IndexColumnProperties).rw_binary(manager))
                     .to_owned(),
             )
             .await

--- a/src/meta/model/migration/src/m20240617_071625_sink_into_table_column.rs
+++ b/src/meta/model/migration/src/m20240617_071625_sink_into_table_column.rs
@@ -1,5 +1,6 @@
 use sea_orm_migration::prelude::{Table as MigrationTable, *};
 
+use crate::utils::ColumnDefExt;
 use crate::SubQueryStatement::SelectStatement;
 
 #[derive(DeriveMigrationName)]
@@ -12,7 +13,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 MigrationTable::alter()
                     .table(Sink::Table)
-                    .add_column(ColumnDef::new(Sink::OriginalTargetColumns).blob())
+                    .add_column(ColumnDef::new(Sink::OriginalTargetColumns).rw_binary(manager))
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240617_071625_sink_into_table_column.rs
+++ b/src/meta/model/migration/src/m20240617_071625_sink_into_table_column.rs
@@ -12,7 +12,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 MigrationTable::alter()
                     .table(Sink::Table)
-                    .add_column(ColumnDef::new(Sink::OriginalTargetColumns).binary())
+                    .add_column(ColumnDef::new(Sink::OriginalTargetColumns).blob())
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240618_072634_function_compressed_binary.rs
+++ b/src/meta/model/migration/src/m20240618_072634_function_compressed_binary.rs
@@ -18,9 +18,7 @@ impl MigrationTrait for Migration {
                     .alter_table(
                         Table::alter()
                             .table(Function::Table)
-                            .modify_column(
-                                ColumnDef::new(Function::CompressedBinary).blob(BlobSize::Medium),
-                            )
+                            .modify_column(ColumnDef::new(Function::CompressedBinary).blob())
                             .to_owned(),
                     )
                     .await?;

--- a/src/meta/model/migration/src/m20240618_072634_function_compressed_binary.rs
+++ b/src/meta/model/migration/src/m20240618_072634_function_compressed_binary.rs
@@ -1,6 +1,7 @@
 use sea_orm_migration::prelude::*;
 
 use crate::sea_orm::{DatabaseBackend, DbBackend, Statement};
+use crate::utils::ColumnDefExt;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -18,7 +19,9 @@ impl MigrationTrait for Migration {
                     .alter_table(
                         Table::alter()
                             .table(Function::Table)
-                            .modify_column(ColumnDef::new(Function::CompressedBinary).blob())
+                            .modify_column(
+                                ColumnDef::new(Function::CompressedBinary).rw_binary(manager),
+                            )
                             .to_owned(),
                     )
                     .await?;

--- a/src/meta/model/migration/src/m20240630_131430_remove_parallel_unit.rs
+++ b/src/meta/model/migration/src/m20240630_131430_remove_parallel_unit.rs
@@ -75,7 +75,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Fragment::Table)
-                    .add_column(ColumnDef::new(Fragment::VnodeMapping).binary().not_null())
+                    .add_column(ColumnDef::new(Fragment::VnodeMapping).blob().not_null())
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240630_131430_remove_parallel_unit.rs
+++ b/src/meta/model/migration/src/m20240630_131430_remove_parallel_unit.rs
@@ -2,6 +2,7 @@ use sea_orm_migration::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::sea_orm::{FromJsonQueryResult, FromQueryResult, Statement};
+use crate::utils::ColumnDefExt;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -75,7 +76,11 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Fragment::Table)
-                    .add_column(ColumnDef::new(Fragment::VnodeMapping).blob().not_null())
+                    .add_column(
+                        ColumnDef::new(Fragment::VnodeMapping)
+                            .rw_binary(manager)
+                            .not_null(),
+                    )
                     .to_owned(),
             )
             .await?;

--- a/src/meta/model/migration/src/m20240701_060504_hummock_time_travel.rs
+++ b/src/meta/model/migration/src/m20240701_060504_hummock_time_travel.rs
@@ -1,6 +1,7 @@
 use sea_orm_migration::prelude::*;
 
 use crate::drop_tables;
+use crate::utils::ColumnDefExt;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -26,7 +27,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(HummockSstableInfo::SstableInfo)
-                            .blob()
+                            .rw_binary(manager)
                             .null(),
                     )
                     .to_owned(),
@@ -46,7 +47,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(HummockTimeTravelVersion::Version)
-                            .blob()
+                            .rw_binary(manager)
                             .null(),
                     )
                     .to_owned(),
@@ -66,7 +67,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(HummockTimeTravelDelta::VersionDelta)
-                            .blob()
+                            .rw_binary(manager)
                             .null(),
                     )
                     .to_owned(),

--- a/src/meta/model/migration/src/m20240701_060504_hummock_time_travel.rs
+++ b/src/meta/model/migration/src/m20240701_060504_hummock_time_travel.rs
@@ -26,7 +26,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(HummockSstableInfo::SstableInfo)
-                            .blob(BlobSize::Long)
+                            .blob()
                             .null(),
                     )
                     .to_owned(),
@@ -46,7 +46,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(HummockTimeTravelVersion::Version)
-                            .blob(BlobSize::Long)
+                            .blob()
                             .null(),
                     )
                     .to_owned(),
@@ -66,7 +66,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(HummockTimeTravelDelta::VersionDelta)
-                            .blob(BlobSize::Long)
+                            .blob()
                             .null(),
                     )
                     .to_owned(),

--- a/src/meta/model/migration/src/utils.rs
+++ b/src/meta/model/migration/src/utils.rs
@@ -4,6 +4,10 @@ use sea_orm_migration::prelude::*;
 #[easy_ext::ext(ColumnDefExt)]
 impl ColumnDef {
     /// Set column type as `longblob` for MySQL, `bytea` for Postgres, and `blob` for Sqlite.
+    ///
+    /// Should be preferred over [`binary`](ColumnDef::binary) or [`blob`](ColumnDef::blob) for large binary fields,
+    /// typically the fields wrapping protobuf or other serialized data. Otherwise, MySQL will return an error
+    /// when the length exceeds 65535 bytes.
     pub fn rw_binary(&mut self, manager: &SchemaManager) -> &mut Self {
         match manager.get_database_backend() {
             DatabaseBackend::MySql => self.custom(extension::mysql::MySqlType::LongBlob),

--- a/src/meta/model/migration/src/utils.rs
+++ b/src/meta/model/migration/src/utils.rs
@@ -1,0 +1,13 @@
+use sea_orm::DatabaseBackend;
+use sea_orm_migration::prelude::*;
+
+#[easy_ext::ext(ColumnDefExt)]
+impl ColumnDef {
+    /// Set column type as `longblob` for MySQL, `bytea` for Postgres, and `blob` for Sqlite.
+    pub fn rw_binary(&mut self, manager: &SchemaManager) -> &mut Self {
+        match manager.get_database_backend() {
+            DatabaseBackend::MySql => self.custom(extension::mysql::MySqlType::LongBlob),
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => self.blob(),
+        }
+    }
+}

--- a/src/meta/model/src/actor.rs
+++ b/src/meta/model/src/actor.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum ActorStatus {
     #[sea_orm(string_value = "INACTIVE")]
     Inactive,

--- a/src/meta/model/src/actor_dispatcher.rs
+++ b/src/meta/model/src/actor_dispatcher.rs
@@ -23,7 +23,7 @@ use crate::{ActorId, ActorMapping, FragmentId, I32Array};
 #[derive(
     Hash, Copy, Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
 )]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum DispatcherType {
     #[sea_orm(string_value = "HASH")]
     Hash,

--- a/src/meta/model/src/catalog_version.rs
+++ b/src/meta/model/src/catalog_version.rs
@@ -16,7 +16,7 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum VersionCategory {
     #[sea_orm(string_value = "NOTIFICATION")]
     Notification,

--- a/src/meta/model/src/fragment.rs
+++ b/src/meta/model/src/fragment.rs
@@ -33,7 +33,7 @@ pub struct Model {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum DistributionType {
     #[sea_orm(string_value = "SINGLE")]
     Single,

--- a/src/meta/model/src/function.rs
+++ b/src/meta/model/src/function.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DataType, DataTypeArray, FunctionId};
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum FunctionKind {
     #[sea_orm(string_value = "Scalar")]
     Scalar,

--- a/src/meta/model/src/lib.rs
+++ b/src/meta/model/src/lib.rs
@@ -93,7 +93,7 @@ pub type FragmentId = i32;
 pub type ActorId = i32;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum JobStatus {
     #[sea_orm(string_value = "INITIAL")]
     Initial,
@@ -125,7 +125,7 @@ impl From<JobStatus> for PbStreamJobState {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum CreateType {
     #[sea_orm(string_value = "BACKGROUND")]
     Background,

--- a/src/meta/model/src/object.rs
+++ b/src/meta/model/src/object.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DatabaseId, ObjectId, SchemaId, UserId};
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum ObjectType {
     #[sea_orm(string_value = "DATABASE")]
     Database,

--- a/src/meta/model/src/secret.rs
+++ b/src/meta/model/src/secret.rs
@@ -23,7 +23,6 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub secret_id: i32,
     pub name: String,
-    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
     pub value: Vec<u8>,
 }
 

--- a/src/meta/model/src/sink.rs
+++ b/src/meta/model/src/sink.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum SinkType {
     #[sea_orm(string_value = "APPEND_ONLY")]
     AppendOnly,

--- a/src/meta/model/src/table.rs
+++ b/src/meta/model/src/table.rs
@@ -29,7 +29,7 @@ use crate::{
 #[derive(
     Clone, Debug, PartialEq, Hash, Copy, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
 )]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum TableType {
     #[sea_orm(string_value = "TABLE")]
     Table,
@@ -65,7 +65,7 @@ impl From<PbTableType> for TableType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum HandleConflictBehavior {
     #[sea_orm(string_value = "OVERWRITE")]
     Overwrite,

--- a/src/meta/model/src/user_privilege.rs
+++ b/src/meta/model/src/user_privilege.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ObjectId, PrivilegeId, UserId};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum Action {
     #[sea_orm(string_value = "INSERT")]
     Insert,

--- a/src/meta/model/src/worker.rs
+++ b/src/meta/model/src/worker.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::{TransactionId, WorkerId};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum WorkerType {
     #[sea_orm(string_value = "FRONTEND")]
     Frontend,
@@ -61,7 +61,7 @@ impl From<WorkerType> for PbWorkerType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "String(None)")]
+#[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum WorkerStatus {
     #[sea_orm(string_value = "STARTING")]
     Starting,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Bump `sea-orm` to `1.0`, along with its dependencies.

The motivation is https://github.com/risingwavelabs/risingwave/pull/19156, where the necessary fix (https://github.com/SeaQL/sea-orm/pull/2244) is only included since `1.0`.

The only worth-noting breaking change is that, there is no longer a backend-agnostic method to specify `longblob` for MySQL, `blob` for SQLite, and `bytea` for Postgres simultaneously (https://github.com/SeaQL/sea-query/pull/743, a regression to me). As a workaround, add a helper method which dispatches the type based on the backend variant.

Although the latest version of `sea-orm` is `1.1`, we are not upgrading to it in this PR because it depends on a new major version of `sqlx`, for which we are maintaining our own forks to make it compatible with madsim. We may further bump it in following PRs.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
