### PR TITLE
perf(over window): O(1) impl for `delta_btree_map::CursorWithDelta::move_next `

### DIFF
--- a/src/utils/delta_btree_map/src/lib.rs
+++ b/src/utils/delta_btree_map/src/lib.rs
@@ -130,7 +130,7 @@ impl<'a, K: Ord, V> DeltaBTreeMap<'a, K, V> {
 ///
 /// A cursor always points at the gap of items in the map. For example:
 ///
-/// ```
+/// ```text
 /// | Foo | Bar |
 /// ^     ^     ^
 /// 1     2     3

--- a/src/utils/delta_btree_map/src/lib.rs
+++ b/src/utils/delta_btree_map/src/lib.rs
@@ -130,9 +130,11 @@ impl<'a, K: Ord, V> DeltaBTreeMap<'a, K, V> {
 ///
 /// A cursor always points at the gap of items in the map. For example:
 ///
-///     | Foo | Bar |
-///     ^     ^     ^
-///     1     2     3
+/// ```
+/// | Foo | Bar |
+/// ^     ^     ^
+/// 1     2     3
+/// ```
 ///
 /// The cursor can be at position 1, 2, or 3.
 /// If it's at position 1, `peek_prev` will return `None`, and `peek_next` will return `Foo`.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previous implementation of `CursorWithDelta` used a O(logN) algorithm in `move_next` and `move_prev`. This PR replace them with a O(1) algorithm utilizing `btree_map::Cursor`.

A local performance benchmark running a user-provided query showed a significant improvement.

Before:

<img width="1209" alt="rank before" src="https://github.com/user-attachments/assets/4bf4302a-b33a-4b55-8692-9776c7f63387">

After:

<img width="1205" alt="rank after" src="https://github.com/user-attachments/assets/f86a8746-d8dd-4085-ae9a-699e6118533a">

Average inflight barrier number dropped 30.7%, p99 barrier latency dropped 30%, source throughput increased 24.8%.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
