### PR TITLE
perf(over window): shortcut implementation for `first_value` and `last_value` in over window

### DIFF
--- a/src/expr/impl/src/window_function/buffer.rs
+++ b/src/expr/impl/src/window_function/buffer.rs
@@ -132,6 +132,27 @@ impl<W: WindowImpl> WindowBuffer<W> {
             .map(|Entry { value, .. }| value)
     }
 
+    /// Get the first value in the current window. Time complexity is O(1).
+    pub fn curr_window_first_value(&self) -> Option<&W::Value> {
+        self.curr_window_values().next()
+    }
+
+    /// Get the last value in the current window. Time complexity is O(1).
+    pub fn curr_window_last_value(&self) -> Option<&W::Value> {
+        let (left, right) = self.curr_window_ranges();
+        if !right.is_empty() {
+            self.buffer
+                .get(right.end - 1)
+                .map(|Entry { value, .. }| value)
+        } else if !left.is_empty() {
+            self.buffer
+                .get(left.end - 1)
+                .map(|Entry { value, .. }| value)
+        } else {
+            None
+        }
+    }
+
     /// Consume the delta of values comparing the current window to the previous window.
     /// The delta is not guaranteed to be sorted, especially when frame exclusion is not `NoOthers`.
     pub fn consume_curr_window_values_delta(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously we reuse batch aggregator for `first_value` and `last_value` in OverWindow, and this required an O(n) iteration through the "current window" when evaluating output for each row. This PR introduces shortcut implementations fro these two special aggregate types to avoid the need of O(n) iteration.

This also benefits `lag` and `lead` because they are implemented with `first_value` and `last_value` under the hood.

A rough benchmark with a dumb query based on nexmark source showed a 392% source throughput increase introduced by this PR, during the first 10 minutes after streaming job creation.

Query:

```sql
CREATE VIEW all_points AS
SELECT
    account,
    key,
    SUM(delta) AS points
FROM (
    SELECT
        ((bidder * 2654435761) # (bidder >> 16)) % 10000 as account,
        auction % 3 as key,
        price % 10 as delta
    FROM bid
)
GROUP BY account, key;

-- rank = row_number + first_value

set rw_streaming_over_window_cache_policy = full;
CREATE MATERIALIZED VIEW rn AS
SELECT
    account,
    key,
    points,
    ROW_NUMBER() OVER (
        PARTITION BY key
        ORDER BY points DESC
    ) AS rn
FROM all_points;

set rw_streaming_over_window_cache_policy = recent;
CREATE SINK mv AS
SELECT
    account,
    key,
    points,
    FIRST_VALUE(rn) OVER (
        PARTITION BY key
        ORDER BY points DESC
        RANGE BETWEEN CURRENT ROW AND CURRENT ROW
    ) AS rank
FROM rn
WITH ( connector = 'blackhole', type = 'append-only', force_append_only = 'true');
```

Before:

<img width="1150" alt="before" src="https://github.com/user-attachments/assets/9c1d8d40-37bf-49a7-b029-4ea2b3922c84">

After:

<img width="1155" alt="after" src="https://github.com/user-attachments/assets/6a8129b0-08c0-4381-b181-77990ee84f48">

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
