### PR TITLE
fix(meta): record delta for new compaction group

### DIFF
--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -466,7 +466,7 @@ fn replay_archive(
         let d = HummockVersionDelta::from_persisted_protobuf(&d);
         debug_assert!(
             !should_mark_next_time_travel_version_snapshot(&d),
-            "unexpect time travel delta {:?}",
+            "unexpected time travel delta {:?}",
             d
         );
         // Need to work around the assertion in `apply_version_delta`.

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -506,9 +506,9 @@ pub fn require_sql_meta_store_err() -> Error {
 /// Time travel delta replay only expect `NewL0SubLevel`. In all other cases, a new version snapshot should be created.
 pub fn should_mark_next_time_travel_version_snapshot(delta: &HummockVersionDelta) -> bool {
     delta.group_deltas.iter().any(|(_, deltas)| {
-        deltas.group_deltas.iter().any(|d| match d {
-            GroupDeltaCommon::NewL0SubLevel(_) => false,
-            _ => true,
-        })
+        deltas
+            .group_deltas
+            .iter()
+            .any(|d| !matches!(d, GroupDeltaCommon::NewL0SubLevel(_)))
     })
 }

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -17,14 +17,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use anyhow::anyhow;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
-use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::time_travel::{
     refill_version, IncompleteHummockVersion, IncompleteHummockVersionDelta,
 };
-use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
+use risingwave_hummock_sdk::version::{GroupDeltaCommon, HummockVersion, HummockVersionDelta};
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockEpoch, HummockSstableId, HummockSstableObjectId,
 };
@@ -45,14 +44,6 @@ use crate::hummock::HummockManager;
 
 /// Time travel.
 impl HummockManager {
-    pub(crate) async fn time_travel_enabled(&self) -> bool {
-        self.env
-            .system_params_reader()
-            .await
-            .time_travel_retention_ms()
-            > 0
-    }
-
     pub(crate) async fn init_time_travel_state(&self) -> Result<()> {
         let sql_store = self.env.meta_store_ref();
         let mut guard = self.versioning.write().await;
@@ -473,6 +464,11 @@ fn replay_archive(
     let mut last_version = HummockVersion::from_persisted_protobuf(&version);
     for d in deltas {
         let d = HummockVersionDelta::from_persisted_protobuf(&d);
+        debug_assert!(
+            !should_mark_next_time_travel_version_snapshot(&d),
+            "unexpect time travel delta {:?}",
+            d
+        );
         // Need to work around the assertion in `apply_version_delta`.
         // Because compaction deltas are not included in time travel archive.
         while last_version.id < d.prev_id {
@@ -505,4 +501,14 @@ fn should_ignore_group(root_group_id: CompactionGroupId) -> bool {
 
 pub fn require_sql_meta_store_err() -> Error {
     Error::TimeTravel(anyhow!("require SQL meta store"))
+}
+
+/// Time travel delta replay only expect `NewL0SubLevel`. In all other cases, a new version snapshot should be created.
+pub fn should_mark_next_time_travel_version_snapshot(delta: &HummockVersionDelta) -> bool {
+    delta.group_deltas.iter().any(|(_, deltas)| {
+        deltas.group_deltas.iter().any(|d| match d {
+            GroupDeltaCommon::NewL0SubLevel(_) => false,
+            _ => true,
+        })
+    })
 }

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -55,8 +55,6 @@ pub struct Versioning {
     pub time_travel_snapshot_interval_counter: u64,
     /// Used to avoid the attempts to rewrite the same SST to meta store
     pub last_time_travel_snapshot_sst_ids: HashSet<HummockSstableId>,
-    /// Whether time travel is enabled during last commit epoch.
-    pub time_travel_toggle_check: bool,
 
     // Persistent states below
     pub hummock_version_deltas: BTreeMap<HummockVersionId, HummockVersionDelta>,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

There's an optimization in time travel metadata: it will drop any delta log that doesn't add any SSTs. Because previously a new delta log from `commit_epoch` always belongs to either compaction group 2 or 3, which must exist.

However, during snapshot backfill it's possible that a delta log adds a new compaction group without adding any SSTs, e.g. it includes `GroupConstruct` but doesn't include any `NewL0SubLevel`.
This PR fixes the bug by enforcing a new version for time travel for the above new case, similar to how it is handled for delta logs generated by compaction.

This PR also removes useless `time_travel_toggle_check`, since time travel is always enabled.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
