### PR TITLE
Introducing RisingWave Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@
   >
     <img alt="YouTube" src="https://img.shields.io/youtube/channel/views/UCsHwdyBRxBpmkA5RRd0YNEA" />
   </a>
+  <a
+    href="https://gurubase.io/g/risingwave"
+    target="_blank"
+  >
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20RisingWave%20Guru-006BFF" />
+  </a>
 </div>
 
 RisingWave is a Postgres-compatible SQL database engineered to provide the <i><b>simplest</b></i> and <i><b>most cost-efficient</b></i> approach for <b>processing</b>, <b>analyzing</b>, and <b>managing</b> real-time event streaming data.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [RisingWave Guru](https://gurubase.io/g/risingwave) to Gurubase. RisingWave Guru uses the data from this repo and data from the [docs](https://docs.risingwave.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "RisingWave Guru", which highlights that RisingWave now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable RisingWave Guru in Gurubase, just let me know that's totally fine.
