### PR TITLE
refactor(agg): remove `state = "ref"` from `bool_and` + refactor `aggregate` macro

### DIFF
--- a/src/expr/impl/src/aggregate/bool_and.rs
+++ b/src/expr/impl/src/aggregate/bool_and.rs
@@ -48,7 +48,7 @@ use risingwave_expr::aggregate;
 /// statement ok
 /// drop table t;
 /// ```
-#[aggregate("bool_and(boolean) -> boolean", state = "ref")]
+#[aggregate("bool_and(boolean) -> boolean")]
 fn bool_and_append_only(state: bool, input: bool) -> bool {
     state && input
 }

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -829,18 +829,6 @@ impl FunctionAttr {
             let first_state = if self.init_state.is_some() {
                 // if `init_state` is specified, the state will never be None
                 quote! { unreachable!() }
-            } else if let Some(s) = &self.state
-                && s == "ref"
-            {
-                if self.args.is_empty() {
-                    return Err(Error::new(
-                        Span::call_site(),
-                        "`state` cannot be `ref` if there's no argument",
-                    ));
-                }
-
-                // for min/max/..., the first state is the first non-NULL value
-                quote! { Some(v0) }
             } else if let AggregateFnOrImpl::Impl(impl_) = user_fn
                 && impl_.create_state.is_some()
             {
@@ -849,11 +837,27 @@ impl FunctionAttr {
                     let state = self.function.create_state();
                     #next_state
                 }}
+            } else if let Some(state) = &self.state {
+                if state == "ref" {
+                    if self.args.is_empty() {
+                        return Err(Error::new(
+                            Span::call_site(),
+                            "`state` cannot be `ref` if there's no argument",
+                        ));
+                    }
+
+                    // for ref state, use the first non-NULL input as the initial state
+                    quote! { Some(v0) }
+                } else {
+                    // for state with specified data type, use the default value of the type
+                    quote! {{
+                        let state = #state_type::default();
+                        #next_state
+                    }}
+                }
             } else {
-                quote! {{
-                    let state = #state_type::default();
-                    #next_state
-                }}
+                // for the remaining cases, clone the first input as the initial state
+                quote! { Some(v0.clone().into()) }
             };
 
             match self.args.len() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously `aggregate` macro didn't correctly handle aggregates that require the first (non-NULL) input as its "first state". For example, for `bool_and`, the behaviors of with and without `state = "ref"` are different, of which the latter one produce wrong results. This PR refactors the state maintanence code generated by the `aggregate` macro, as a result, we can remove `state = "ref"` from append-only `bool_and` to align with `bool_or`, avoiding further confusion and maintanence error.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
