### PR TITLE
fix: background mview without backfilling should not tracked in barrier runtime info

### DIFF
--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -64,7 +64,6 @@ impl GlobalBarrierWorkerContextImpl {
         Ok(())
     }
 
-    // FIXME: didn't consider Values here
     async fn recover_background_mv_progress(
         &self,
     ) -> MetaResult<HashMap<TableId, (String, TableFragments)>> {
@@ -82,7 +81,7 @@ impl GlobalBarrierWorkerContextImpl {
                 .get_job_fragments_by_id(mview.table_id)
                 .await?;
             let table_fragments = TableFragments::from_protobuf(table_fragments);
-            if table_fragments.backfill_actor_ids().is_empty() {
+            if table_fragments.tracking_progress_actor_ids().is_empty() {
                 // If the backfill actors are empty, we can finish the job directly.
                 mgr.catalog_controller
                     .finish_streaming_job(mview.table_id, None)

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -82,7 +82,7 @@ impl GlobalBarrierWorkerContextImpl {
                 .await?;
             let table_fragments = TableFragments::from_protobuf(table_fragments);
             if table_fragments.tracking_progress_actor_ids().is_empty() {
-                // If the backfill actors are empty, we can finish the job directly.
+                // If there's no tracking actor in the mview, we can finish the job directly.
                 mgr.catalog_controller
                     .finish_streaming_job(mview.table_id, None)
                     .await?;

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -723,7 +723,7 @@ impl MetadataManager {
 }
 
 impl MetadataManager {
-    /// Wait for job finishing notification in `TrackingJob::pre_finish`.
+    /// Wait for job finishing notification in `TrackingJob::finish`.
     /// The progress is updated per barrier.
     pub(crate) async fn wait_streaming_job_finished(
         &self,

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -401,14 +401,6 @@ impl TableFragments {
             .cloned()
     }
 
-    /// Returns actors that contains backfill executors.
-    pub fn backfill_actor_ids(&self) -> HashSet<ActorId> {
-        Self::filter_actor_ids(self, |fragment_type_mask| {
-            (fragment_type_mask & FragmentTypeFlag::StreamScan as u32) != 0
-        })
-        .collect()
-    }
-
     pub fn snapshot_backfill_actor_ids(&self) -> HashSet<ActorId> {
         Self::filter_actor_ids(self, |mask| {
             (mask & FragmentTypeFlag::SnapshotBackfillStreamScan as u32) != 0


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixed a bug found in https://buildkite.com/risingwavelabs/main-cron/builds/3843#01931e2c-869a-4314-aa99-849e4747f72c, will open another PR to fix `release-2.0`.

As title, we need to complete the background materialized view without backfilling during recovery; otherwise, it will be logged in the barrier runtime information and remain unfinished because of the absence of progress reports from actors. Similar logic in normal creation:
https://github.com/risingwavelabs/risingwave/blob/3c2e81b53a8411451a5f999ca3313654d98c9586/src/meta/src/barrier/progress.rs#L511-L516
Furthermore, it should be noted that `Value` cannot be recovered and is not permitted in background mode.
https://github.com/risingwavelabs/risingwave/blob/58ecec217dab253284beac1419da878928e296e9/src/frontend/src/optimizer/plan_node/utils.rs#L394-L398


## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
