### PR TITLE
fix(test): incorrect flaky madsim initial sink parallelism

### DIFF
--- a/ci/scripts/deterministic-it-test.sh
+++ b/ci/scripts/deterministic-it-test.sh
@@ -22,7 +22,6 @@ echo "--- Run integration tests in deterministic simulation mode"
 seq "$TEST_NUM" | parallel "MADSIM_TEST_SEED={} NEXTEST_PROFILE=ci-sim \
  cargo nextest run \
  --no-fail-fast \
- --no-capture \
  --cargo-metadata target/nextest/cargo-metadata.json \
  --binaries-metadata target/nextest/binaries-metadata.json \
  $TEST_PATTERN 1>$LOGDIR/deterministic-it-test-{}.log 2>&1 && rm $LOGDIR/deterministic-it-test-{}.log"

--- a/ci/scripts/deterministic-it-test.sh
+++ b/ci/scripts/deterministic-it-test.sh
@@ -22,6 +22,7 @@ echo "--- Run integration tests in deterministic simulation mode"
 seq "$TEST_NUM" | parallel "MADSIM_TEST_SEED={} NEXTEST_PROFILE=ci-sim \
  cargo nextest run \
  --no-fail-fast \
+ --no-capture \
  --cargo-metadata target/nextest/cargo-metadata.json \
  --binaries-metadata target/nextest/binaries-metadata.json \
  $TEST_PATTERN 1>$LOGDIR/deterministic-it-test-{}.log 2>&1 && rm $LOGDIR/deterministic-it-test-{}.log"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -388,7 +388,7 @@ steps:
   # Ddl statements will randomly run with background_ddl.
   - label: "background_ddl, arrangement_backfill recovery test (madsim)"
     key: "background-ddl-arrangement-backfill-recovery-test-deterministic"
-    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.8 USE_ARRANGEMENT_BACKFILL=true timeout 65m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.8 USE_ARRANGEMENT_BACKFILL=true timeout 70m ci/scripts/deterministic-recovery-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -44,13 +44,7 @@ async fn basic_test_inner(is_decouple: bool) -> Result<()> {
     }
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-
-    if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow::anyhow!(
-            "incorrect initial parallelism: {} ",
-            test_sink.parallelism_counter.load(Relaxed)
-        ));
-    }
+    test_sink.wait_initial_parallelism(6).await?;
 
     let internal_tables = session.run("show internal tables").await?;
 

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -44,7 +44,13 @@ async fn basic_test_inner(is_decouple: bool) -> Result<()> {
     }
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-    assert_eq!(6, test_sink.parallelism_counter.load(Relaxed));
+
+    if test_sink.parallelism_counter.load(Relaxed) != 6 {
+        return Err(anyhow!(
+            "incorrect initial parallelism: {} ",
+            test_sink.parallelism_counter.load(Relaxed)
+        ));
+    }
 
     let internal_tables = session.run("show internal tables").await?;
 

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -46,7 +46,7 @@ async fn basic_test_inner(is_decouple: bool) -> Result<()> {
     session.run(CREATE_SINK).await?;
 
     if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow!(
+        return Err(anyhow::anyhow!(
             "incorrect initial parallelism: {} ",
             test_sink.parallelism_counter.load(Relaxed)
         ));

--- a/src/tests/simulation/tests/integration_tests/sink/err_isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/err_isolation.rs
@@ -40,7 +40,13 @@ async fn test_sink_decouple_err_isolation() -> Result<()> {
     session.run("set sink_decouple = true").await?;
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-    assert_eq!(6, test_sink.parallelism_counter.load(Relaxed));
+
+    if test_sink.parallelism_counter.load(Relaxed) != 6 {
+        return Err(anyhow!(
+            "incorrect initial parallelism: {} ",
+            test_sink.parallelism_counter.load(Relaxed)
+        ));
+    }
 
     test_sink.set_err_rate(0.002);
 
@@ -81,7 +87,13 @@ async fn test_sink_error_event_logs() -> Result<()> {
     session.run("set sink_decouple = true").await?;
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-    assert_eq!(6, test_sink.parallelism_counter.load(Relaxed));
+
+    if test_sink.parallelism_counter.load(Relaxed) != 6 {
+        return Err(anyhow!(
+            "incorrect initial parallelism: {} ",
+            test_sink.parallelism_counter.load(Relaxed)
+        ));
+    }
 
     test_sink.store.wait_for_err(1).await?;
 

--- a/src/tests/simulation/tests/integration_tests/sink/err_isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/err_isolation.rs
@@ -42,7 +42,7 @@ async fn test_sink_decouple_err_isolation() -> Result<()> {
     session.run(CREATE_SINK).await?;
 
     if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow!(
+        return Err(anyhow::anyhow!(
             "incorrect initial parallelism: {} ",
             test_sink.parallelism_counter.load(Relaxed)
         ));
@@ -89,7 +89,7 @@ async fn test_sink_error_event_logs() -> Result<()> {
     session.run(CREATE_SINK).await?;
 
     if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow!(
+        return Err(anyhow::anyhow!(
             "incorrect initial parallelism: {} ",
             test_sink.parallelism_counter.load(Relaxed)
         ));

--- a/src/tests/simulation/tests/integration_tests/sink/err_isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/err_isolation.rs
@@ -40,13 +40,7 @@ async fn test_sink_decouple_err_isolation() -> Result<()> {
     session.run("set sink_decouple = true").await?;
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-
-    if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow::anyhow!(
-            "incorrect initial parallelism: {} ",
-            test_sink.parallelism_counter.load(Relaxed)
-        ));
-    }
+    test_sink.wait_initial_parallelism(6).await?;
 
     test_sink.set_err_rate(0.002);
 
@@ -87,13 +81,7 @@ async fn test_sink_error_event_logs() -> Result<()> {
     session.run("set sink_decouple = true").await?;
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-
-    if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow::anyhow!(
-            "incorrect initial parallelism: {} ",
-            test_sink.parallelism_counter.load(Relaxed)
-        ));
-    }
+    test_sink.wait_initial_parallelism(6).await?;
 
     test_sink.store.wait_for_err(1).await?;
 

--- a/src/tests/simulation/tests/integration_tests/sink/recovery.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/recovery.rs
@@ -72,7 +72,7 @@ async fn recovery_test_inner(is_decouple: bool) -> Result<()> {
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
     if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow!(
+        return Err(anyhow::anyhow!(
             "incorrect initial parallelism: {} ",
             test_sink.parallelism_counter.load(Relaxed)
         ));

--- a/src/tests/simulation/tests/integration_tests/sink/recovery.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/recovery.rs
@@ -71,12 +71,7 @@ async fn recovery_test_inner(is_decouple: bool) -> Result<()> {
     }
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-    if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow::anyhow!(
-            "incorrect initial parallelism: {} ",
-            test_sink.parallelism_counter.load(Relaxed)
-        ));
-    }
+    test_sink.wait_initial_parallelism(6).await?;
 
     let count = test_source.id_list.len();
 

--- a/src/tests/simulation/tests/integration_tests/sink/recovery.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/recovery.rs
@@ -71,7 +71,12 @@ async fn recovery_test_inner(is_decouple: bool) -> Result<()> {
     }
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-    assert_eq!(6, test_sink.parallelism_counter.load(Relaxed));
+    if test_sink.parallelism_counter.load(Relaxed) != 6 {
+        return Err(anyhow!(
+            "incorrect initial parallelism: {} ",
+            test_sink.parallelism_counter.load(Relaxed)
+        ));
+    }
 
     let count = test_source.id_list.len();
 

--- a/src/tests/simulation/tests/integration_tests/sink/scale.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/scale.rs
@@ -75,7 +75,7 @@ async fn scale_test_inner(is_decouple: bool) -> Result<()> {
     session.run(CREATE_SINK).await?;
 
     if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow!(
+        return Err(anyhow::anyhow!(
             "incorrect initial parallelism: {} ",
             test_sink.parallelism_counter.load(Relaxed)
         ));

--- a/src/tests/simulation/tests/integration_tests/sink/scale.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/scale.rs
@@ -73,7 +73,13 @@ async fn scale_test_inner(is_decouple: bool) -> Result<()> {
     }
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-    assert_eq!(6, test_sink.parallelism_counter.load(Relaxed));
+
+    if test_sink.parallelism_counter.load(Relaxed) != 6 {
+        return Err(anyhow!(
+            "incorrect initial parallelism: {} ",
+            test_sink.parallelism_counter.load(Relaxed)
+        ));
+    }
 
     let mut sink_fragments = cluster
         .locate_fragments([identity_contains("Sink")])

--- a/src/tests/simulation/tests/integration_tests/sink/scale.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/scale.rs
@@ -73,13 +73,7 @@ async fn scale_test_inner(is_decouple: bool) -> Result<()> {
     }
     session.run(CREATE_SOURCE).await?;
     session.run(CREATE_SINK).await?;
-
-    if test_sink.parallelism_counter.load(Relaxed) != 6 {
-        return Err(anyhow::anyhow!(
-            "incorrect initial parallelism: {} ",
-            test_sink.parallelism_counter.load(Relaxed)
-        ));
-    }
+    test_sink.wait_initial_parallelism(6).await?;
 
     let mut sink_fragments = cluster
         .locate_fragments([identity_contains("Sink")])


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previous in sink decouple madsim test, we assume that the sink writer of all sink parallelisms should be created after the create sink SQL returns. However, when sink decouple is enabled, the sink writer will be created in the log reader side, which is decoupled from the upstream. Therefore, it may happen that when the create sink SQL returns, not all sink writer have been created, and some related tests become flaky. In this PR, we change to explicitly wait for all sink writer parallelisms to be created before proceeding to next step, and the flaky tests will be fixed.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
