### PR TITLE
refactor(optimizer): record error contexts when casting composite types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14299,9 +14299,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c19760dc47062bca5c1b3699b032111c93802d51ac47660db11b08afc6bad2"
+checksum = "ef4323942237f7cc071061f2c5f0db919e6053c2cdf58c6bc974883073429737"
 dependencies = [
  "thiserror 1.0.63",
  "thiserror-ext-derive",
@@ -14309,9 +14309,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext-derive"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667c8c48f68021098038115926c64d9950b0582062ae63f7d30638b1168daf03"
+checksum = "96541747c50e6c73e094737938f4f5dfaf50c48a31adff4197a3e2a481371674"
 dependencies = [
  "either",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ parquet = { version = "53.2", features = ["async"] }
 mysql_async = { version = "0.34", default-features = false, features = [
     "default",
 ] }
-thiserror-ext = "0.1.2"
+thiserror-ext = { version = "0.2.1", features = ["backtrace"] }
 tikv-jemalloc-ctl = { git = "https://github.com/risingwavelabs/jemallocator.git", rev = "64a2d9" }
 tikv-jemallocator = { git = "https://github.com/risingwavelabs/jemallocator.git", features = [
     "profiling",

--- a/e2e_test/batch/basic/dml_update.slt.part
+++ b/e2e_test/batch/basic/dml_update.slt.part
@@ -99,7 +99,7 @@ update t set (v1, v2) = (select '888.88', 999);
 db error: ERROR: Failed to run the query
 
 Caused by these errors (recent errors listed first):
-  1: cannot cast type "record" to "record" in Assign context
+  1: cannot cast type "record" to "record"
   2: cannot cast type "character varying" to "integer" in Assign context
 
 

--- a/e2e_test/batch/basic/dml_update.slt.part
+++ b/e2e_test/batch/basic/dml_update.slt.part
@@ -93,10 +93,15 @@ select * from t;
 889 999
 
 # Multiple assignments, to subquery with cast failure.
-# TODO: this currently shows `cannot cast type "record" to "record"` because we wrap the subquery result
-#       into a struct, which is not quite clear.
-statement error cannot cast type
+statement error
 update t set (v1, v2) = (select '888.88', 999);
+----
+db error: ERROR: Failed to run the query
+
+Caused by these errors (recent errors listed first):
+  1: cannot cast type "record" to "record" in Assign context
+  2: cannot cast type "character varying" to "integer" in Assign context
+
 
 # Multiple assignments, to subquery with mismatched column count.
 statement error number of columns does not match number of values

--- a/src/frontend/planner_test/tests/testdata/input/cast.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/cast.yaml
@@ -64,3 +64,20 @@
     select count(*) FILTER(WHERE 'y') from t;
   expected_outputs:
   - batch_plan
+- name: composite type cast error message (array)
+  sql: |
+    select '[]'::int[]::bytea[];
+  expected_outputs:
+  - binder_error
+- name: composite type cast error message (struct)
+  sql: |
+    create table t (v struct<a struct<b int>, c bool>);
+    select v::struct<d struct<e bytea>, f bool> from t;
+  expected_outputs:
+  - binder_error
+- name: composite type cast error message (map)
+  sql: |
+    create table t (v map(int, int));
+    select v::map(int, bytea) from t;
+  expected_outputs:
+  - binder_error

--- a/src/frontend/planner_test/tests/testdata/output/array.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/array.yaml
@@ -228,7 +228,7 @@
   sql: |
     create table t (v1 varchar[]);
     insert into t values ('{c,' || 'd}');
-  binder_error: 'Bind error: cannot cast type "character varying" to "character varying[]" in Assign context'
+  binder_error: cannot cast type "character varying" to "character varying[]" in Assign context
 - name: string to varchar[] in explicit context
   sql: |
     select ('{c,' || 'd}')::varchar[];

--- a/src/frontend/planner_test/tests/testdata/output/cast.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/cast.yaml
@@ -87,7 +87,7 @@
     Failed to bind expression: CAST(CAST('[]' AS INT[]) AS BYTEA[])
 
     Caused by these errors (recent errors listed first):
-      1: cannot cast type "integer[]" to "bytea[]" in Explicit context
+      1: cannot cast type "integer[]" to "bytea[]"
       2: cannot cast type "integer" to "bytea" in Explicit context
 - name: composite type cast error message (struct)
   sql: |
@@ -97,9 +97,11 @@
     Failed to bind expression: CAST(v AS STRUCT<d STRUCT<e BYTEA>, f BOOLEAN>)
 
     Caused by these errors (recent errors listed first):
-      1: cannot cast type "struct<a struct<b integer>, c boolean>" to "struct<d struct<e bytea>, f boolean>" in Explicit context
-      2: cannot cast type "struct<b integer>" to "struct<e bytea>" in Explicit context
-      3: cannot cast type "integer" to "bytea" in Explicit context
+      1: cannot cast type "struct<a struct<b integer>, c boolean>" to "struct<d struct<e bytea>, f boolean>"
+      2: cannot cast struct field "a" to struct field "d"
+      3: cannot cast type "struct<b integer>" to "struct<e bytea>"
+      4: cannot cast struct field "b" to struct field "e"
+      5: cannot cast type "integer" to "bytea" in Explicit context
 - name: composite type cast error message (map)
   sql: |
     create table t (v map(int, int));
@@ -108,7 +110,6 @@
     Failed to bind expression: CAST(v AS MAP(INT,BYTEA))
 
     Caused by these errors (recent errors listed first):
-      1: cannot cast type "map(integer,integer)" to "map(integer,bytea)" in Explicit context
-      2: cannot cast type "struct<key integer, value integer>[]" to "struct<key integer, value bytea>[]" in Explicit context
-      3: cannot cast type "struct<key integer, value integer>" to "struct<key integer, value bytea>" in Explicit context
-      4: cannot cast type "integer" to "bytea" in Explicit context
+      1: cannot cast type "map(integer,integer)" to "map(integer,bytea)"
+      2: cannot cast map value
+      3: cannot cast type "integer" to "bytea" in Explicit context

--- a/src/frontend/planner_test/tests/testdata/output/cast.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/cast.yaml
@@ -80,3 +80,35 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchSimpleAgg { aggs: [count] }
         └─BatchScan { table: t, columns: [], distribution: SomeShard }
+- name: composite type cast error message (array)
+  sql: |
+    select '[]'::int[]::bytea[];
+  binder_error: |
+    Failed to bind expression: CAST(CAST('[]' AS INT[]) AS BYTEA[])
+
+    Caused by these errors (recent errors listed first):
+      1: cannot cast type "integer[]" to "bytea[]" in Explicit context
+      2: cannot cast type "integer" to "bytea" in Explicit context
+- name: composite type cast error message (struct)
+  sql: |
+    create table t (v struct<a struct<b int>, c bool>);
+    select v::struct<d struct<e bytea>, f bool> from t;
+  binder_error: |
+    Failed to bind expression: CAST(v AS STRUCT<d STRUCT<e BYTEA>, f BOOLEAN>)
+
+    Caused by these errors (recent errors listed first):
+      1: cannot cast type "struct<a struct<b integer>, c boolean>" to "struct<d struct<e bytea>, f boolean>" in Explicit context
+      2: cannot cast type "struct<b integer>" to "struct<e bytea>" in Explicit context
+      3: cannot cast type "integer" to "bytea" in Explicit context
+- name: composite type cast error message (map)
+  sql: |
+    create table t (v map(int, int));
+    select v::map(int, bytea) from t;
+  binder_error: |
+    Failed to bind expression: CAST(v AS MAP(INT,BYTEA))
+
+    Caused by these errors (recent errors listed first):
+      1: cannot cast type "map(integer,integer)" to "map(integer,bytea)" in Explicit context
+      2: cannot cast type "struct<key integer, value integer>[]" to "struct<key integer, value bytea>[]" in Explicit context
+      3: cannot cast type "struct<key integer, value integer>" to "struct<key integer, value bytea>" in Explicit context
+      4: cannot cast type "integer" to "bytea" in Explicit context

--- a/src/frontend/planner_test/tests/testdata/output/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/expr.yaml
@@ -304,7 +304,7 @@
     Failed to bind expression: concat_ws(v1, 1.2)
 
     Caused by:
-      Bind error: cannot cast type "integer" to "character varying" in Implicit context
+      cannot cast type "integer" to "character varying" in Implicit context
 - sql: |
     create table t (v1 int);
     select concat_ws() from t;

--- a/src/frontend/planner_test/tests/testdata/output/struct_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/struct_query.yaml
@@ -421,7 +421,7 @@
 - sql: |
     CREATE TABLE a (c STRUCT<i STRUCT<a INTEGER>, j INTEGER>);
     INSERT INTO a VALUES (1);
-  binder_error: 'Bind error: cannot cast type "integer" to "struct<i struct<a integer>, j integer>" in Assign context'
+  binder_error: cannot cast type "integer" to "struct<i struct<a integer>, j integer>" in Assign context
 - name: test struct type alignment in CASE expression
   sql: |
     select CASE WHEN false THEN ROW(0, INTERVAL '1') WHEN true THEN ROW(1.1, INTERVAL '1') ELSE ROW(1, INTERVAL '1') END;

--- a/src/frontend/planner_test/tests/testdata/output/update.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/update.yaml
@@ -11,7 +11,7 @@
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = true;
-  binder_error: 'Bind error: cannot cast type "boolean" to "integer" in Assign context'
+  binder_error: cannot cast type "boolean" to "integer" in Assign context
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = v2 + 1;

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_cast.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_cast.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use itertools::Itertools;
 use risingwave_common::types::{DataType, Fields};
 use risingwave_frontend_macro::system_catalog;
 
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
-use crate::expr::cast_map_array;
+use crate::expr::CAST_TABLE;
 
 /// The catalog `pg_cast` stores data type conversion paths.
 /// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-cast.html`]
@@ -31,12 +32,11 @@ struct PgCast {
 
 #[system_catalog(table, "pg_catalog.pg_cast")]
 fn read_pg_cast(_: &SysCatalogReaderImpl) -> Vec<PgCast> {
-    let mut cast_array = cast_map_array();
-    cast_array.sort();
-    cast_array
+    CAST_TABLE
         .iter()
+        .sorted()
         .enumerate()
-        .map(|(idx, (src, target, ctx))| PgCast {
+        .map(|(idx, ((src, target), ctx))| PgCast {
             oid: idx as i32,
             castsource: DataType::try_from(*src).unwrap().to_oid(),
             casttarget: DataType::try_from(*target).unwrap().to_oid(),

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -26,6 +26,8 @@ use risingwave_rpc_client::error::{RpcError, TonicStatusWrapper};
 use thiserror::Error;
 use tokio::task::JoinError;
 
+use crate::expr::CastError;
+
 /// The error type for the frontend crate, acting as the top-level error type for the
 /// entire RisingWave project.
 // TODO(error-handling): this is migrated from the `common` crate, and there could
@@ -114,6 +116,12 @@ pub enum ErrorCode {
         #[backtrace]
         error: BoxedError,
     },
+    #[error(transparent)]
+    CastError(
+        #[from]
+        #[backtrace]
+        CastError,
+    ),
     #[error("Catalog error: {0}")]
     CatalogError(
         #[source]

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -437,6 +437,6 @@ pub type CastResult<T = ()> = Result<T, CastError>;
 // TODO(error-handling): shall we make it a new variant?
 impl From<CastError> for ErrorCode {
     fn from(value: CastError) -> Self {
-        ErrorCode::Uncategorized(value.into()).into()
+        ErrorCode::Uncategorized(value.into())
     }
 }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -17,7 +17,7 @@ use risingwave_common::catalog::Schema;
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::iter_util::ZipEqFast;
 use thiserror::Error;
-use thiserror_ext::{AsReport, Box, Macro};
+use thiserror_ext::{Box, Macro};
 
 use super::type_inference::cast;
 use super::{infer_some_all, infer_type, CastContext, Expr, ExprImpl, Literal};
@@ -434,9 +434,9 @@ pub struct CastErrorInner {
 
 pub type CastResult<T = ()> = Result<T, CastError>;
 
-// TODO(error-handling): do not use report string but directly make it a source of `ErrorCode`.
+// TODO(error-handling): shall we make it a new variant?
 impl From<CastError> for ErrorCode {
     fn from(value: CastError) -> Self {
-        ErrorCode::BindError(value.to_report_string())
+        ErrorCode::Uncategorized(value.into()).into()
     }
 }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -423,6 +423,7 @@ pub fn is_row_function(expr: &ExprImpl) -> bool {
     false
 }
 
+/// A stack of error messages for the cast operation.
 #[derive(Error, Debug, Box, Macro)]
 #[thiserror_ext(newtype(name = CastError), macro(path = "crate::expr::function_call"))]
 #[error("{message}")]
@@ -433,6 +434,7 @@ pub struct CastErrorInner {
 
 pub type CastResult<T = ()> = Result<T, CastError>;
 
+// TODO(error-handling): do not use report string but directly make it a source of `ErrorCode`.
 impl From<CastError> for ErrorCode {
     fn from(value: CastError) -> Self {
         ErrorCode::BindError(value.to_report_string())

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -14,12 +14,13 @@
 
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
+use risingwave_common::error::{bail, def_anyhow_newtype};
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::iter_util::ZipEqFast;
-use thiserror::Error;
 use thiserror_ext::AsReport;
 
-use super::{cast_ok, infer_some_all, infer_type, CastContext, Expr, ExprImpl, Literal};
+use super::type_inference::cast;
+use super::{infer_some_all, infer_type, CastContext, Expr, ExprImpl, Literal};
 use crate::error::{ErrorCode, Result as RwResult};
 use crate::expr::{ExprDisplay, ExprType, ExprVisitor, ImpureAnalyzer};
 
@@ -144,22 +145,23 @@ impl FunctionCall {
             // else when eager parsing fails, just proceed as normal.
             // Some callers are not ready to handle `'a'::int` error here.
         }
+
         let source = child.return_type();
         if source == target {
-            Ok(())
-        // Casting from unknown is allowed in all context. And PostgreSQL actually does the parsing
-        // in frontend.
-        } else if child.is_untyped() || cast_ok(&source, &target, allows) {
-            // Always Ok below. Safe to mutate `child`.
-            let owned = std::mem::replace(child, ExprImpl::literal_bool(false));
-            *child = Self::new_unchecked(ExprType::Cast, vec![owned], target).into();
-            Ok(())
-        } else {
-            Err(CastError(format!(
-                "cannot cast type \"{}\" to \"{}\" in {:?} context",
-                source, target, allows
-            )))
+            return Ok(());
         }
+
+        if child.is_untyped() {
+            // Casting from unknown is allowed in all context. And PostgreSQL actually does the parsing
+            // in frontend.
+        } else {
+            cast(&source, &target, allows)?;
+        }
+
+        // Always Ok below. Safe to mutate `child`.
+        let owned = std::mem::replace(child, ExprImpl::literal_bool(false));
+        *child = Self::new_unchecked(ExprType::Cast, vec![owned], target).into();
+        Ok(())
     }
 
     /// Cast a `ROW` expression to the target type. We intentionally disallow casting arbitrary
@@ -170,13 +172,13 @@ impl FunctionCall {
         target_type: DataType,
         allows: CastContext,
     ) -> Result<(), CastError> {
+        // Can only cast to a struct type.
         let DataType::Struct(t) = &target_type else {
-            return Err(CastError(format!(
-                "cannot cast type \"{}\" to \"{}\" in {:?} context",
-                func.return_type(),
+            bail!(
+                "cannot cast type \"{}\" to \"{}\"",
+                func.return_type(), // typically "record"
                 target_type,
-                allows
-            )));
+            );
         };
         match t.len().cmp(&func.inputs.len()) {
             std::cmp::Ordering::Equal => {
@@ -189,10 +191,8 @@ impl FunctionCall {
                 func.return_type = target_type;
                 Ok(())
             }
-            std::cmp::Ordering::Less => Err(CastError("Input has too few columns.".to_string())),
-            std::cmp::Ordering::Greater => {
-                Err(CastError("Input has too many columns.".to_string()))
-            }
+            std::cmp::Ordering::Less => bail!("input has too few columns"),
+            std::cmp::Ordering::Greater => bail!("input has too many columns"),
         }
     }
 
@@ -423,9 +423,10 @@ pub fn is_row_function(expr: &ExprImpl) -> bool {
     false
 }
 
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct CastError(pub(super) String);
+def_anyhow_newtype! {
+    pub CastError,
+}
+pub type CastResult<T = ()> = Result<T, CastError>;
 
 impl From<CastError> for ErrorCode {
     fn from(value: CastError) -> Self {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -14,7 +14,6 @@
 
 use enum_as_inner::EnumAsInner;
 use fixedbitset::FixedBitSet;
-use function_call::bail_cast_error;
 use futures::FutureExt;
 use paste::paste;
 use risingwave_common::array::ListValue;
@@ -67,10 +66,7 @@ pub use risingwave_pb::expr::expr_node::Type as ExprType;
 pub use session_timezone::{SessionTimezone, TimestamptzExprFinder};
 pub use subquery::{Subquery, SubqueryKind};
 pub use table_function::{TableFunction, TableFunctionType};
-pub use type_inference::{
-    align_types, cast_ok, cast_sigs, infer_some_all, infer_type, infer_type_name,
-    infer_type_with_sigmap, CastContext, CastSig, FuncSign, CAST_TABLE,
-};
+pub use type_inference::*;
 pub use user_defined_function::UserDefinedFunction;
 pub use utils::*;
 pub use window_function::WindowFunction;
@@ -1172,7 +1168,6 @@ use risingwave_common::bail;
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::OwnedRow;
 
-use self::function_call::CastError;
 use crate::binder::BoundSetExpr;
 use crate::utils::Condition;
 

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -14,6 +14,7 @@
 
 use enum_as_inner::EnumAsInner;
 use fixedbitset::FixedBitSet;
+use function_call::bail_cast_error;
 use futures::FutureExt;
 use paste::paste;
 use risingwave_common::array::ListValue;
@@ -300,7 +301,7 @@ impl ExprImpl {
             ))),
             DataType::Int32 => Ok(self),
             dt if dt.is_int() => Ok(self.cast_explicit(DataType::Int32)?),
-            _ => bail!("unsupported input type"),
+            _ => bail_cast_error!("unsupported input type"),
         }
     }
 

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -68,8 +68,8 @@ pub use session_timezone::{SessionTimezone, TimestamptzExprFinder};
 pub use subquery::{Subquery, SubqueryKind};
 pub use table_function::{TableFunction, TableFunctionType};
 pub use type_inference::{
-    align_types, cast_map_array, cast_ok, cast_sigs, infer_some_all, infer_type, infer_type_name,
-    infer_type_with_sigmap, CastContext, CastSig, FuncSign,
+    align_types, cast_ok, cast_sigs, infer_some_all, infer_type, infer_type_name,
+    infer_type_with_sigmap, CastContext, CastSig, FuncSign, CAST_TABLE,
 };
 pub use user_defined_function::UserDefinedFunction;
 pub use utils::*;

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -300,7 +300,7 @@ impl ExprImpl {
             ))),
             DataType::Int32 => Ok(self),
             dt if dt.is_int() => Ok(self.cast_explicit(DataType::Int32)?),
-            _ => Err(CastError("Unsupported input type".to_string())),
+            _ => bail!("unsupported input type"),
         }
     }
 

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -118,16 +118,16 @@ pub fn align_array_and_element(
 
 /// Returns `Ok` if `ok` is true, otherwise returns a placeholder [`CastError`] to be further
 /// wrapped with a more informative context in [`cast`].
-fn canmeh(ok: bool) -> CastResult {
+fn canbo(ok: bool) -> CastResult {
     if ok {
         Ok(())
     } else {
         bail_cast_error!()
     }
 }
-/// Equivalent to `canmeh(false)`.
+/// Equivalent to `canbo(false)`.
 fn cannot() -> CastResult {
-    canmeh(false)
+    canbo(false)
 }
 
 /// Checks whether casting from `source` to `target` is ok in `allows` context.
@@ -146,7 +146,7 @@ pub fn cast(source: &DataType, target: &DataType, allows: CastContext) -> Result
     } else if any!(is_map) {
         cast_map(source, target, allows)
     } else {
-        canmeh(cast_ok_base(source, target, allows))
+        canbo(cast_ok_base(source, target, allows))
     }
     .map_err(|inner| {
         // Only show "in .. context" once in the error source chain.
@@ -218,8 +218,8 @@ fn cast_struct(source: &DataType, target: &DataType, allows: CastContext) -> Cas
         // The automatic casts to string types are treated as assignment casts, while the automatic
         // casts from string types are explicit-only.
         // https://www.postgresql.org/docs/14/sql-createcast.html#id-1.9.3.58.7.4
-        (DataType::Varchar, DataType::Struct(_)) => canmeh(CastContext::Explicit <= allows),
-        (DataType::Struct(_), DataType::Varchar) => canmeh(CastContext::Assign <= allows),
+        (DataType::Varchar, DataType::Struct(_)) => canbo(CastContext::Explicit <= allows),
+        (DataType::Struct(_), DataType::Varchar) => canbo(CastContext::Assign <= allows),
         _ => cannot(),
     }
 }
@@ -232,8 +232,8 @@ fn cast_array(source: &DataType, target: &DataType, allows: CastContext) -> Cast
         // The automatic casts to string types are treated as assignment casts, while the automatic
         // casts from string types are explicit-only.
         // https://www.postgresql.org/docs/14/sql-createcast.html#id-1.9.3.58.7.4
-        (DataType::Varchar, DataType::List(_)) => canmeh(CastContext::Explicit <= allows),
-        (DataType::List(_), DataType::Varchar) => canmeh(CastContext::Assign <= allows),
+        (DataType::Varchar, DataType::List(_)) => canbo(CastContext::Explicit <= allows),
+        (DataType::List(_), DataType::Varchar) => canbo(CastContext::Assign <= allows),
         _ => cannot(),
     }
 }

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -18,6 +18,7 @@
 mod cast;
 mod func;
 pub use cast::{
-    align_types, cast, cast_ok, cast_ok_base, cast_sigs, CastContext, CastSig, CAST_TABLE,
+    align_types, bail_cast_error, cast, cast_error, cast_ok, cast_ok_base, cast_sigs, CastContext,
+    CastError, CastErrorInner, CastSig, CAST_TABLE,
 };
 pub use func::{infer_some_all, infer_type, infer_type_name, infer_type_with_sigmap, FuncSign};

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -18,6 +18,6 @@
 mod cast;
 mod func;
 pub use cast::{
-    align_types, cast_map_array, cast_ok, cast_ok_base, cast_sigs, CastContext, CastSig,
+    align_types, cast_map_array, cast_ok, cast, cast_ok_base, cast_sigs, CastContext, CastSig,
 };
 pub use func::{infer_some_all, infer_type, infer_type_name, infer_type_with_sigmap, FuncSign};

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -18,6 +18,6 @@
 mod cast;
 mod func;
 pub use cast::{
-    align_types, cast_map_array, cast_ok, cast, cast_ok_base, cast_sigs, CastContext, CastSig,
+    align_types, cast, cast_ok, cast_ok_base, cast_sigs, CastContext, CastSig, CAST_TABLE,
 };
 pub use func::{infer_some_all, infer_type, infer_type_name, infer_type_with_sigmap, FuncSign};


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Record contexts for error when recursively calling `cast` on composite types, to provide better error messages.

Preview:

https://github.com/risingwavelabs/risingwave/blob/fc4223348295f029a4d88d0d9f64b4de8a760ac8/src/frontend/planner_test/tests/testdata/output/cast.yaml#L92-L115

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
