### PR TITLE
feat(meta): decouple barrier collect and sync in global barrier manager

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -143,7 +143,7 @@ steps:
           files: "*-junit.xml"
           format: "junit"
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 13
+    timeout_in_minutes: 15
     retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory) (release)"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -565,7 +565,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -22,7 +22,7 @@ message InjectBarrierRequest {
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_remove = 11;
 }
 
-message BarrierCompleteResponse {
+message BarrierCollectResponse {
   message CreateMviewProgress {
     // Note: ideally we should use `executor_id`, but `actor_id` is ok-ish.
     // See <https://github.com/risingwavelabs/risingwave/issues/6236>.
@@ -34,9 +34,19 @@ message BarrierCompleteResponse {
     uint64 consumed_rows = 4;
     uint32 pending_barrier_num = 5;
   }
-  string request_id = 1;
-  common.Status status = 2;
+  uint64 partial_graph_id = 1;
+  // prev_epoch of barrier
+  uint64 epoch = 2;
   repeated CreateMviewProgress create_mview_progress = 3;
+}
+
+message BarrierCompleteRequest {
+  uint64 task_id = 1;
+  map<uint64, uint64> partial_graph_sync_epochs = 2;
+}
+
+message BarrierCompleteResponse {
+  uint64 task_id = 1;
   message LocalSstableInfo {
     reserved 1;
     reserved "compaction_group_id";
@@ -48,9 +58,6 @@ message BarrierCompleteResponse {
   uint32 worker_id = 5;
   map<uint32, hummock.TableWatermarks> table_watermarks = 6;
   repeated hummock.SstableInfo old_value_sstables = 7;
-  uint64 partial_graph_id = 8;
-  // prev_epoch of barrier
-  uint64 epoch = 9;
 }
 
 message WaitEpochCommitRequest {
@@ -85,6 +92,7 @@ message StreamingControlStreamRequest {
     InjectBarrierRequest inject_barrier = 2;
     RemovePartialGraphRequest remove_partial_graph = 3;
     CreatePartialGraphRequest create_partial_graph = 4;
+    BarrierCompleteRequest complete_barrier = 5;
   }
 }
 
@@ -96,6 +104,7 @@ message StreamingControlStreamResponse {
     InitResponse init = 1;
     BarrierCompleteResponse complete_barrier = 2;
     ShutdownResponse shutdown = 3;
+    BarrierCollectResponse collect_barrier = 4;
   }
 }
 

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -86,10 +86,16 @@ impl MonitorService for MonitorServiceImpl {
             Default::default()
         };
 
+        let mut barrier_traces_next_key = 0;
+        let barrier_traces_next_key = &mut barrier_traces_next_key;
         let barrier_traces = if let Some(reg) = self.stream_mgr.await_tree_reg() {
             reg.collect::<BarrierAwait>()
                 .into_iter()
-                .map(|(k, v)| (k.prev_epoch, v.to_string()))
+                .map(|(k, v)| {
+                    let key = *barrier_traces_next_key;
+                    *barrier_traces_next_key += 1;
+                    (key, format!("{:?}", (k.sync_graph_epochs, v.to_string())))
+                })
                 .collect()
         } else {
             Default::default()

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -31,7 +31,7 @@ use crate::barrier::checkpoint::creating_job::{CompleteJobType, CreatingStreamin
 use crate::barrier::checkpoint::state::BarrierWorkerState;
 use crate::barrier::command::CommandContext;
 use crate::barrier::complete_task::{
-    BarrierCompleteOutput, CompleteBarrierTask, CreatingJobCompleteBarrierTask,
+    BarrierCommitOutput, CompleteBarrierTask, CreatingJobCompleteBarrierTask,
     DatabaseCompleteBarrierTask,
 };
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
@@ -66,7 +66,7 @@ impl CheckpointControl {
 
     pub(crate) fn ack_completed(
         &mut self,
-        output: BarrierCompleteOutput,
+        output: BarrierCommitOutput,
         control_stream_manager: &mut ControlStreamManager,
     ) {
         self.hummock_version_stats = output.hummock_version_stats;

--- a/src/meta/src/barrier/checkpoint/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/status.rs
@@ -22,9 +22,7 @@ use risingwave_meta_model::WorkerId;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_plan::StreamActor;
-use risingwave_pb::stream_service::barrier_complete_response::{
-    CreateMviewProgress, PbCreateMviewProgress,
-};
+use risingwave_pb::stream_service::barrier_collect_response::PbCreateMviewProgress;
 use tracing::warn;
 
 use crate::barrier::progress::CreateMviewProgressTracker;
@@ -133,7 +131,7 @@ pub(super) struct CreatingJobInjectBarrierInfo {
 impl CreatingStreamingJobStatus {
     pub(super) fn update_progress(
         &mut self,
-        create_mview_progress: impl IntoIterator<Item = &CreateMviewProgress>,
+        create_mview_progress: impl IntoIterator<Item = &PbCreateMviewProgress>,
     ) -> Option<Vec<CreatingJobInjectBarrierInfo>> {
         match self {
             Self::ConsumingSnapshot {

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -22,8 +22,8 @@ use risingwave_meta_model::ObjectId;
 use risingwave_pb::catalog::CreateType;
 use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockVersionStats;
-use risingwave_pb::stream_service::barrier_complete_response::CreateMviewProgress;
-use risingwave_pb::stream_service::PbBarrierCompleteResponse;
+use risingwave_pb::stream_service::barrier_collect_response::PbCreateMviewProgress;
+use risingwave_pb::stream_service::PbBarrierCollectResponse;
 
 use crate::barrier::info::BarrierInfo;
 use crate::barrier::{
@@ -383,7 +383,7 @@ impl CreateMviewProgressTracker {
             &CreateStreamingJobCommandInfo,
             Option<&ReplaceStreamJobPlan>,
         )>,
-        create_mview_progress: impl IntoIterator<Item = &'a CreateMviewProgress>,
+        create_mview_progress: impl IntoIterator<Item = &'a PbCreateMviewProgress>,
         version_stats: &HummockVersionStats,
     ) {
         {
@@ -425,7 +425,7 @@ impl CreateMviewProgressTracker {
         &mut self,
         command: Option<&Command>,
         barrier_info: &BarrierInfo,
-        resps: impl IntoIterator<Item = &PbBarrierCompleteResponse>,
+        resps: impl IntoIterator<Item = &PbBarrierCollectResponse>,
         version_stats: &HummockVersionStats,
     ) -> Vec<TrackingJob> {
         let new_tracking_job_info =
@@ -593,7 +593,7 @@ impl CreateMviewProgressTracker {
     /// If all actors in this MV have finished, returns the command.
     pub fn update(
         &mut self,
-        progress: &CreateMviewProgress,
+        progress: &PbCreateMviewProgress,
         version_stats: &HummockVersionStats,
     ) -> Option<TrackingJob> {
         tracing::trace!(?progress, "update progress");

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -243,9 +243,9 @@ impl ControlStreamManager {
         let mut errors = vec![(worker_id, first_err)];
         #[cfg(not(madsim))]
         {
-            if !self.nodes.is_empty() {
+            {
                 let _ = timeout(COLLECT_ERROR_TIMEOUT, async {
-                    loop {
+                    while !self.nodes.is_empty() {
                         let (worker_id, result) = self.next_response().await;
                         if let Err(e) = result {
                             errors.push((worker_id, e));

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
@@ -22,25 +22,20 @@ use risingwave_hummock_sdk::table_watermark::{
     merge_multiple_new_table_watermarks, TableWatermarks,
 };
 use risingwave_hummock_sdk::{HummockSstableObjectId, LocalSstableInfo};
+use risingwave_meta_model::WorkerId;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 
-use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
+use crate::hummock::CommitEpochInfo;
 
-#[expect(clippy::type_complexity)]
 pub(super) fn collect_resp_info(
-    resps: Vec<BarrierCompleteResponse>,
-) -> (
-    HashMap<HummockSstableObjectId, u32>,
-    Vec<LocalSstableInfo>,
-    HashMap<TableId, TableWatermarks>,
-    Vec<SstableInfo>,
-) {
+    resps: HashMap<WorkerId, BarrierCompleteResponse>,
+) -> (CommitEpochInfo, Vec<SstableInfo>) {
     let mut sst_to_worker: HashMap<HummockSstableObjectId, u32> = HashMap::new();
     let mut synced_ssts: Vec<LocalSstableInfo> = vec![];
     let mut table_watermarks = Vec::with_capacity(resps.len());
     let mut old_value_ssts = Vec::with_capacity(resps.len());
 
-    for resp in resps {
+    for resp in resps.into_values() {
         let ssts_iter = resp.synced_sstables.into_iter().map(|local_sst| {
             let sst_info = local_sst.sst.expect("field not None");
             sst_to_worker.insert(sst_info.object_id, resp.worker_id);
@@ -56,51 +51,26 @@ pub(super) fn collect_resp_info(
     }
 
     (
-        sst_to_worker,
-        synced_ssts,
-        merge_multiple_new_table_watermarks(
-            table_watermarks
-                .into_iter()
-                .map(|watermarks| {
-                    watermarks
-                        .into_iter()
-                        .map(|(table_id, watermarks)| {
-                            (TableId::new(table_id), TableWatermarks::from(&watermarks))
-                        })
-                        .collect()
-                })
-                .collect_vec(),
-        ),
+        CommitEpochInfo {
+            sstables: synced_ssts,
+            new_table_watermarks: merge_multiple_new_table_watermarks(
+                table_watermarks
+                    .into_iter()
+                    .map(|watermarks| {
+                        watermarks
+                            .into_iter()
+                            .map(|(table_id, watermarks)| {
+                                (TableId::new(table_id), TableWatermarks::from(&watermarks))
+                            })
+                            .collect()
+                    })
+                    .collect_vec(),
+            ),
+            sst_to_context: sst_to_worker,
+            new_table_fragment_infos: vec![],
+            change_log_delta: Default::default(),
+            tables_to_commit: Default::default(),
+        },
         old_value_ssts,
     )
-}
-
-pub(super) fn collect_creating_job_commit_epoch_info(
-    commit_info: &mut CommitEpochInfo,
-    epoch: u64,
-    resps: Vec<BarrierCompleteResponse>,
-    tables_to_commit: impl Iterator<Item = TableId>,
-    is_first_time: bool,
-) {
-    let (sst_to_context, sstables, new_table_watermarks, old_value_sst) = collect_resp_info(resps);
-    assert!(old_value_sst.is_empty());
-    commit_info.sst_to_context.extend(sst_to_context);
-    commit_info.sstables.extend(sstables);
-    commit_info
-        .new_table_watermarks
-        .extend(new_table_watermarks);
-    let tables_to_commit: HashSet<_> = tables_to_commit.collect();
-    tables_to_commit.iter().for_each(|table_id| {
-        commit_info
-            .tables_to_commit
-            .try_insert(*table_id, epoch)
-            .expect("non duplicate");
-    });
-    if is_first_time {
-        commit_info
-            .new_table_fragment_infos
-            .push(NewTableFragmentInfo {
-                table_ids: tables_to_commit,
-            });
-    };
 }

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -90,7 +90,7 @@ pub(super) struct GlobalBarrierWorker<C> {
     /// Command that has been collected but is still completing.
     completing_tasks: CompletingTasks,
 
-    /// Command that has been completed but is still commiting.
+    /// Command that has been completed but is still committing.
     /// The join handle of the committing future is stored.
     committing_task: CommittingTask,
 

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -198,10 +198,7 @@ impl HummockMetaClient for MockHummockMetaClient {
             BTreeSet::new()
         };
         let table_change_log = build_table_change_log_delta(
-            sync_result
-                .old_value_ssts
-                .into_iter()
-                .map(|sst| sst.sst_info),
+            sync_result.old_value_ssts.iter().map(|sst| &sst.sst_info),
             sync_result.uncommitted_ssts.iter().map(|sst| &sst.sst_info),
             &vec![epoch],
             table_change_log_table_ids

--- a/src/storage/hummock_sdk/src/change_log.rs
+++ b/src/storage/hummock_sdk/src/change_log.rs
@@ -149,7 +149,7 @@ where
 }
 
 pub fn build_table_change_log_delta<'a>(
-    old_value_ssts: impl Iterator<Item = SstableInfo>,
+    old_value_ssts: impl Iterator<Item = &'a SstableInfo>,
     new_value_ssts: impl Iterator<Item = &'a SstableInfo>,
     epochs: &Vec<u64>,
     log_store_table_ids: impl Iterator<Item = (u32, u64)>,

--- a/src/stream/src/task/barrier_manager/progress.rs
+++ b/src/stream/src/task/barrier_manager/progress.rs
@@ -16,7 +16,7 @@ use std::assert_matches::assert_matches;
 use std::fmt::{Display, Formatter};
 
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_pb::stream_service::barrier_complete_response::PbCreateMviewProgress;
+use risingwave_pb::stream_service::barrier_collect_response::PbCreateMviewProgress;
 
 use super::LocalBarrierManager;
 use crate::task::barrier_manager::LocalBarrierEvent::ReportCreateProgress;

--- a/src/stream/src/task/barrier_manager/tests.rs
+++ b/src/stream/src/task/barrier_manager/tests.rs
@@ -69,7 +69,7 @@ async fn test_managed_barrier_collection() -> StreamResult<()> {
         let resp: StreamingControlStreamResponse = result.unwrap().unwrap();
         let resp = resp.response.unwrap();
         match resp {
-            streaming_control_stream_response::Response::CompleteBarrier(_complete_barrier) => {}
+            streaming_control_stream_response::Response::CollectBarrier(_) => {}
             _ => unreachable!(),
         }
     }));
@@ -151,7 +151,7 @@ async fn test_managed_barrier_collection_separately() -> StreamResult<()> {
         let resp: StreamingControlStreamResponse = result.unwrap().unwrap();
         let resp = resp.response.unwrap();
         match resp {
-            streaming_control_stream_response::Response::CompleteBarrier(_complete_barrier) => {}
+            streaming_control_stream_response::Response::CollectBarrier(_) => {}
             _ => unreachable!(),
         }
     }));
@@ -228,8 +228,8 @@ async fn test_late_register_barrier_sender() -> StreamResult<()> {
 
     let resp = test_env.response_rx.recv().await.unwrap().unwrap();
     match resp.response.unwrap() {
-        streaming_control_stream_response::Response::CompleteBarrier(complete_barrier) => {
-            assert_eq!(complete_barrier.epoch, barrier1.epoch.prev);
+        streaming_control_stream_response::Response::CollectBarrier(resp) => {
+            assert_eq!(resp.epoch, barrier1.epoch.prev);
         }
         _ => unreachable!(),
     }
@@ -240,8 +240,8 @@ async fn test_late_register_barrier_sender() -> StreamResult<()> {
         let resp: StreamingControlStreamResponse = result.unwrap().unwrap();
         let resp = resp.response.unwrap();
         match resp {
-            streaming_control_stream_response::Response::CompleteBarrier(complete_barrier) => {
-                assert_eq!(complete_barrier.epoch, barrier2.epoch.prev);
+            streaming_control_stream_response::Response::CollectBarrier(resp) => {
+                assert_eq!(resp.epoch, barrier2.epoch.prev);
             }
             _ => unreachable!(),
         }

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -40,7 +40,7 @@ pub type UpDownActorIds = (ActorId, ActorId);
 pub type UpDownFragmentIds = (FragmentId, FragmentId);
 
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
-struct PartialGraphId(u64);
+pub struct PartialGraphId(u64);
 
 impl PartialGraphId {
     fn new(id: u64) -> Self {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -75,14 +75,16 @@ pub type ActorHandle = JoinHandle<()>;
 pub type AtomicU64Ref = Arc<AtomicU64>;
 
 pub mod await_tree_key {
+    use crate::task::PartialGraphId;
+
     /// Await-tree key type for actors.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Actor(pub crate::task::ActorId);
 
     /// Await-tree key type for barriers.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct BarrierAwait {
-        pub prev_epoch: u64,
+        pub sync_graph_epochs: Vec<(PartialGraphId, u64)>,
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously in global barrier manager, barriers are handled in 2 phases. In phase 1, a barrier is injected to CNs, and waits for the `BarrierCompleteResponse` from the injected CNs. When the response is received, the barrier has been collected from all actors in the CN, and the epoch of the barrier has been synced and the SST files are included in the response. In phase 2, the SST files will be committed to hummock manager, and the barrier command will commit the change to fragment and catalog manager if there is any.

In partial checkpoint, barriers are injected to multiple partial graphs, and then multiple partial graphs can be synced and then committed together. Therefore, in this PR, we will decouple the barrier collection and sync in global barrier manager. In general, a barrier will have 3 phase, `collect`, `complete`, and `commit`. A barrier will be handled in the following steps:
1. The barrier is injected to CNs in multiple partial graphs and enters the `collect` phase to wait for the `BarrierCollectResponse`. The barrier injection and collection is independent in different partial graphs.
2. For all the partial graphs and epochs that have collected the `BarrierCollectResponse` from all CNs, the global barrier worker will generate a `CompleteBarrierTask` that includes them together. These partial graphs and epochs will enter the `complete` phase. `BarrierCompleteRequest` will be sent to CNs and wait for the responses. When CN receives the request, multiple partial graphs will be synced together.
3. When the `BarrierCompleteResponse` is received from all CNs, the partial graphs enters the `commit` phase and will be committed together to hummock, fragment manager and catalog manager.

Note:
* Non-checkpoint barriers only have `collect` phase, because it has nothing to do in the `complete` and `commit` phase.
* Basically, this PR divides the previous inject-collect barrier into the two `collect` and `complete` phase. The previous single `CompleteBarrierResponse` proto message will also be divided. The previous `create_mview_progress` is moved to the `CollectBarrierResponse`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
