### PR TITLE
refactor(meta): use correct type for the pb counterpart

### DIFF
--- a/src/storage/hummock_sdk/src/sstable_info.rs
+++ b/src/storage/hummock_sdk/src/sstable_info.rs
@@ -17,6 +17,8 @@ use std::mem::size_of;
 use risingwave_pb::hummock::{PbBloomFilterType, PbKeyRange, PbSstableInfo};
 
 use crate::key_range::KeyRange;
+use crate::version::{ObjectIdReader, SstableIdReader};
+use crate::{HummockSstableId, HummockSstableObjectId};
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct SstableInfo {
@@ -214,5 +216,17 @@ impl From<&SstableInfo> for PbSstableInfo {
 impl SstableInfo {
     pub fn remove_key_range(&mut self) {
         self.key_range = KeyRange::default();
+    }
+}
+
+impl SstableIdReader for SstableInfo {
+    fn sst_id(&self) -> HummockSstableId {
+        self.sst_id
+    }
+}
+
+impl ObjectIdReader for SstableInfo {
+    fn object_id(&self) -> HummockSstableObjectId {
+        self.object_id
     }
 }

--- a/src/storage/hummock_sdk/src/time_travel.rs
+++ b/src/storage/hummock_sdk/src/time_travel.rs
@@ -23,6 +23,7 @@ use crate::level::Level;
 use crate::sstable_info::SstableInfo;
 use crate::version::{
     HummockVersion, HummockVersionCommon, HummockVersionDelta, HummockVersionDeltaCommon,
+    ObjectIdReader, SstableIdReader,
 };
 use crate::{CompactionGroupId, HummockSstableId, HummockSstableObjectId};
 
@@ -170,6 +171,18 @@ impl From<(&HummockVersionDelta, &HashSet<CompactionGroupId>)> for IncompleteHum
 pub struct SstableIdInVersion {
     sst_id: HummockSstableId,
     object_id: HummockSstableObjectId,
+}
+
+impl SstableIdReader for SstableIdInVersion {
+    fn sst_id(&self) -> HummockSstableId {
+        self.sst_id
+    }
+}
+
+impl ObjectIdReader for SstableIdInVersion {
+    fn object_id(&self) -> HummockSstableObjectId {
+        self.object_id
+    }
 }
 
 impl From<&SstableIdInVersion> for PbSstableInfo {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Both `IncompleteHummockVersion` and `HummockVersion` use `PbHummockVersion` as the meta store type for persistence. 

In `time_travel.rs`, whenever reading `PbHummockVersion` from the meta store, the counterpart in-mem structs should be `IncompleteHummockVersion`. Because in time_travel metadata, only `sst_id` and `object_id` of a `SstableInfo` are stored in `PbHummockVersion`, while other fields are left to default.

However, currently in `time_travel.rs`, `HummockVersion` is incorrectly used instead of `IncompleteHummockVersion`. This generates an `SstableInfo` with correct `sst_id` and `object_id` fields, but other fields are incorrect. **It doesn't cause a correctness issue because other fields are not utilized in** `time_travel.rs`, for now.

To prevent potential future bugs, this PR ensures that `time_travel.rs` uses the `IncompleteHummockVersion` and `IncompleteHummockVersionDelta` correctly. Methods required by `time_travel.rs` are moved from `HummockVersion` to `HummockVersionCommon<T>`.

Since there's no correctness issue for now, this PR won't be cherry-picked to release 2.1.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
