### PR TITLE
refactor(common): consolidate `StructType` constructors (Part 1/2: trivial ones)

### DIFF
--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -290,10 +290,9 @@ mod tests {
         let store = MemoryStateStore::new();
 
         // Make struct field
-        let struct_field = Field::unnamed(DataType::new_struct(
-            vec![DataType::Int32, DataType::Int32, DataType::Int32],
-            vec![],
-        ));
+        let struct_field = Field::unnamed(
+            StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]).into(),
+        );
 
         // Schema for mock executor.
         let mut schema = schema_test_utils::ii();

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -851,10 +851,9 @@ mod tests {
     async fn test_encoding_for_struct_list() {
         let schema = Schema {
             fields: vec![
-                Field::unnamed(DataType::new_struct(
-                    vec![DataType::Varchar, DataType::Float32],
-                    vec![],
-                )),
+                Field::unnamed(
+                    StructType::unnamed(vec![DataType::Varchar, DataType::Float32]).into(),
+                ),
                 Field::unnamed(DataType::List(Box::new(DataType::Int64))),
             ],
         };

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -167,10 +167,7 @@ mod tests {
                 Some(ScalarImpl::Int64(3)),
             )),
             Box::new(LiteralExpression::new(
-                DataType::new_struct(
-                    vec![DataType::Int32, DataType::Int32, DataType::Int32],
-                    vec![],
-                ),
+                StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]).into(),
                 Some(ScalarImpl::Struct(value)),
             )) as BoxedExpression,
         ];
@@ -193,10 +190,7 @@ mod tests {
         assert_eq!(fields[2].data_type, DataType::Int64);
         assert_eq!(
             fields[3].data_type,
-            DataType::new_struct(
-                vec![DataType::Int32, DataType::Int32, DataType::Int32],
-                vec![],
-            )
+            StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]).into()
         );
 
         let mut stream = values_executor.execute();

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -663,19 +663,17 @@ mod tests {
         let fields = [
             DataType::Float32,
             DataType::Varchar,
-            DataType::new_struct(
-                vec![
-                    DataType::Float64,
-                    DataType::Varchar,
-                    DataType::Varchar,
-                    DataType::new_struct(vec![], vec![]),
-                ],
-                vec![],
-            ),
+            StructType::unnamed(vec![
+                DataType::Float64,
+                DataType::Varchar,
+                DataType::Varchar,
+                StructType::unnamed(vec![]).into(),
+            ])
+            .into(),
             DataType::Int64,
             DataType::Varchar,
             DataType::Int16,
-            DataType::new_struct(vec![], vec![]),
+            StructType::unnamed(vec![]).into(),
             DataType::Int32,
         ];
         let struct_ref = StructRef::ValueRef { val: &value };
@@ -747,7 +745,7 @@ mod tests {
                 ]),
                 vec![
                     DataType::Varchar,
-                    DataType::new_struct(vec![DataType::Varchar], vec![]),
+                    StructType::unnamed(vec![DataType::Varchar]).into(),
                 ],
                 Ordering::Greater,
             ),
@@ -762,7 +760,7 @@ mod tests {
                 ]),
                 vec![
                     DataType::Varchar,
-                    DataType::new_struct(vec![DataType::Varchar], vec![]),
+                    StructType::unnamed(vec![DataType::Varchar]).into(),
                 ],
                 Ordering::Equal,
             ),

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -484,6 +484,12 @@ impl DataType {
     }
 }
 
+impl From<StructType> for DataType {
+    fn from(value: StructType) -> Self {
+        Self::Struct(value)
+    }
+}
+
 impl From<DataType> for PbDataType {
     fn from(data_type: DataType) -> Self {
         data_type.to_protobuf()

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -1158,10 +1158,8 @@ mod tests {
 
     #[test]
     fn test_data_type_display() {
-        let d: DataType = DataType::new_struct(
-            vec![DataType::Int32, DataType::Varchar],
-            vec!["i".to_string(), "j".to_string()],
-        );
+        let d: DataType =
+            StructType::new(vec![("i", DataType::Int32), ("j", DataType::Varchar)]).into();
         assert_eq!(
             format!("{}", d),
             "struct<i integer, j character varying>".to_string()

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -409,10 +409,6 @@ impl DataType {
         Self::Struct(StructType::from_parts(field_names, fields))
     }
 
-    pub fn new_unnamed_struct(fields: Vec<DataType>) -> Self {
-        Self::Struct(StructType::unnamed(fields))
-    }
-
     pub fn as_struct(&self) -> &StructType {
         match self {
             DataType::Struct(t) => t,

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -579,7 +579,7 @@ mod tests {
     use super::*;
     use crate::array::{ListValue, StructValue};
     use crate::row::OwnedRow;
-    use crate::types::{DataType, Datum, ScalarImpl};
+    use crate::types::{DataType, Datum, ScalarImpl, StructType};
 
     #[test]
     fn test_order_type() {
@@ -720,7 +720,7 @@ mod tests {
                 DataType::Date,
                 DataType::Timestamp,
                 DataType::Time,
-                DataType::new_struct(vec![DataType::Int32, DataType::Float32], vec![]),
+                StructType::unnamed(vec![DataType::Int32, DataType::Float32]).into(),
                 DataType::List(Box::new(DataType::Int32)),
             ],
         );

--- a/src/connector/src/sink/formatter/debezium_json.rs
+++ b/src/connector/src/sink/formatter/debezium_json.rs
@@ -336,7 +336,7 @@ pub(crate) fn field_to_json(field: &Field) -> Value {
 #[cfg(test)]
 mod tests {
     use risingwave_common::test_prelude::StreamChunkTestExt;
-    use risingwave_common::types::DataType;
+    use risingwave_common::types::{DataType, StructType};
 
     use super::*;
     use crate::sink::utils::chunk_to_json;
@@ -373,10 +373,11 @@ mod tests {
                 type_name: "".into(),
             },
             Field {
-                data_type: DataType::new_struct(
-                    vec![DataType::Int32, DataType::Float32],
-                    vec!["v4".to_string(), "v5".to_string()],
-                ),
+                data_type: StructType::new(vec![
+                    ("v4", DataType::Int32),
+                    ("v5", DataType::Float32),
+                ])
+                .into(),
                 name: "v3".into(),
                 sub_fields: vec![
                     Field {

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -14,7 +14,9 @@
 
 use itertools::Itertools;
 use risingwave_common::bail_not_implemented;
-use risingwave_common::types::{DataType, DateTimeField, Decimal, Interval, MapType, ScalarImpl};
+use risingwave_common::types::{
+    DataType, DateTimeField, Decimal, Interval, MapType, ScalarImpl, StructType,
+};
 use risingwave_sqlparser::ast::{DateTimeField as AstDateTimeField, Expr, Value};
 use thiserror_ext::AsReport;
 
@@ -283,7 +285,7 @@ impl Binder {
             .map(|e| self.bind_expr_inner(e))
             .collect::<Result<Vec<ExprImpl>>>()?;
         let data_type =
-            DataType::new_unnamed_struct(exprs.iter().map(|e| e.return_type()).collect_vec());
+            StructType::unnamed(exprs.iter().map(|e| e.return_type()).collect_vec()).into();
         let expr: ExprImpl = FunctionCall::new_unchecked(ExprType::Row, exprs, data_type).into();
         Ok(expr)
     }

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -761,10 +761,11 @@ mod tests {
                     ColumnCatalog::row_id_column(),
                     ColumnCatalog {
                         column_desc: ColumnDesc {
-                            data_type: DataType::new_struct(
-                                vec![DataType::Varchar, DataType::Varchar],
-                                vec!["address".to_string(), "zipcode".to_string()]
-                            ),
+                            data_type: StructType::new(vec![
+                                ("address", DataType::Varchar),
+                                ("zipcode", DataType::Varchar)
+                            ],)
+                            .into(),
                             column_id: ColumnId::new(1),
                             name: "country".to_string(),
                             field_descs: vec![

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -148,7 +148,7 @@ fn value_encoding_to_literal(
 #[cfg(test)]
 mod tests {
     use risingwave_common::array::{ListValue, StructValue};
-    use risingwave_common::types::{DataType, Datum, ScalarImpl};
+    use risingwave_common::types::{DataType, Datum, ScalarImpl, StructType};
     use risingwave_common::util::value_encoding::DatumFromProtoExt;
     use risingwave_pb::expr::expr_node::RexNode;
 
@@ -166,10 +166,8 @@ mod tests {
         if let RexNode::Constant(prost) = node {
             let data2 = Datum::from_protobuf(
                 &prost,
-                &DataType::new_struct(
-                    vec![DataType::Varchar, DataType::Int32, DataType::Int32],
-                    vec![],
-                ),
+                &StructType::unnamed(vec![DataType::Varchar, DataType::Int32, DataType::Int32])
+                    .into(),
             )
             .unwrap()
             .unwrap();

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -272,7 +272,7 @@ pub mod tests {
     use risingwave_common::catalog::{
         DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROWID_PREFIX, RW_TIMESTAMP_COLUMN_NAME,
     };
-    use risingwave_common::types::DataType;
+    use risingwave_common::types::{DataType, StructType};
 
     use crate::catalog::root_catalog::SchemaPath;
     use crate::test_utils::{create_proto_file, LocalFrontend, PROTO_FILE_DATA};
@@ -314,16 +314,16 @@ pub mod tests {
             .map(|col| (col.name(), col.data_type().clone()))
             .collect::<HashMap<&str, DataType>>();
 
-        let city_type = DataType::new_struct(
-            vec![DataType::Varchar, DataType::Varchar],
-            vec!["address".to_string(), "zipcode".to_string()],
-        );
+        let city_type = StructType::new(vec![
+            ("address", DataType::Varchar),
+            ("zipcode", DataType::Varchar),
+        ])
+        .into();
         let expected_columns = maplit::hashmap! {
             ROWID_PREFIX => DataType::Serial,
-            "country" => DataType::new_struct(
-                 vec![DataType::Varchar,city_type,DataType::Varchar],
-                 vec!["address".to_string(), "city".to_string(), "zipcode".to_string()],
-            ),
+            "country" => StructType::new(
+                 vec![("address", DataType::Varchar),("city", city_type),("zipcode", DataType::Varchar)],
+            ).into(),
             RW_TIMESTAMP_COLUMN_NAME => DataType::Timestamptz,
         };
         assert_eq!(columns, expected_columns);

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -1780,7 +1780,7 @@ pub mod tests {
         CDC_SOURCE_COLUMN_NUM, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, OFFSET_COLUMN_NAME,
         ROWID_PREFIX, TABLE_NAME_COLUMN_NAME,
     };
-    use risingwave_common::types::DataType;
+    use risingwave_common::types::{DataType, StructType};
 
     use crate::catalog::root_catalog::SchemaPath;
     use crate::catalog::source_catalog::SourceCatalog;
@@ -1820,19 +1820,19 @@ pub mod tests {
 
         let columns = GET_COLUMN_FROM_CATALOG(source);
 
-        let city_type = DataType::new_struct(
-            vec![DataType::Varchar, DataType::Varchar],
-            vec!["address".to_string(), "zipcode".to_string()],
-        );
+        let city_type = StructType::new(vec![
+            ("address", DataType::Varchar),
+            ("zipcode", DataType::Varchar),
+        ])
+        .into();
         let expected_columns = maplit::hashmap! {
             ROWID_PREFIX => DataType::Serial,
             "id" => DataType::Int32,
             "zipcode" => DataType::Int64,
             "rate" => DataType::Float32,
-            "country" => DataType::new_struct(
-                vec![DataType::Varchar,city_type,DataType::Varchar],
-                vec!["address".to_string(), "city".to_string(), "zipcode".to_string()],
-            ),
+            "country" => StructType::new(
+                vec![("address", DataType::Varchar),("city", city_type),("zipcode", DataType::Varchar)],
+            ).into(),
         };
         assert_eq!(columns, expected_columns);
     }

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1454,7 +1454,7 @@ mod tests {
     use risingwave_common::catalog::{
         Field, DEFAULT_DATABASE_NAME, ROWID_PREFIX, RW_TIMESTAMP_COLUMN_NAME,
     };
-    use risingwave_common::types::DataType;
+    use risingwave_common::types::{DataType, StructType};
 
     use super::*;
     use crate::test_utils::{create_proto_file, LocalFrontend, PROTO_FILE_DATA};
@@ -1519,10 +1519,9 @@ mod tests {
         let expected_columns = maplit::hashmap! {
             ROWID_PREFIX => DataType::Serial,
             "v1" => DataType::Int16,
-            "v2" => DataType::new_struct(
-                vec![DataType::Int64,DataType::Float64,DataType::Float64],
-                vec!["v3".to_string(), "v4".to_string(), "v5".to_string()],
-            ),
+            "v2" => StructType::new(
+                vec![("v3", DataType::Int64),("v4", DataType::Float64),("v5", DataType::Float64)],
+            ).into(),
             RW_TIMESTAMP_COLUMN_NAME => DataType::Timestamptz,
         };
 

--- a/src/stream/src/executor/values.rs
+++ b/src/stream/src/executor/values.rs
@@ -173,10 +173,7 @@ mod tests {
                 Some(ScalarImpl::Int64(3)),
             )),
             Box::new(LiteralExpression::new(
-                DataType::new_struct(
-                    vec![DataType::Int32, DataType::Int32, DataType::Int32],
-                    vec![],
-                ),
+                StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]).into(),
                 Some(ScalarImpl::Struct(value)),
             )),
             Box::new(LiteralExpression::new(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Before:
* `Struct::new`
* `Struct::unnamed` (possibly via `DataType::new_unnamed_struct`)
* `Struct::from_parts` (via `DataType::new_struct`)

Goal:
* Deprecate `Struct::from_parts` in favor of `Struct::new` (done in Part 2/2)
* (minor) Avoid introducing unnecessary associated functions on `DataType` and interact with `StructType` directly.

Separated into 2 PRs so that we can focus on core changes in Part 2/2 #19570. This one is trivial and may distract people if squashed together with the latter part.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
