### PR TITLE
refactor(common): consolidate `StructType` constructors (Part 2/2)

### DIFF
--- a/src/common/src/array/arrow/arrow_impl.rs
+++ b/src/common/src/array/arrow/arrow_impl.rs
@@ -485,7 +485,7 @@ pub trait FromArrow {
             fields
                 .iter()
                 .map(|f| Ok((f.name().clone(), self.from_field(f)?)))
-                .try_collect::<_, _, ArrayError>()?,
+                .try_collect::<_, Vec<_>, ArrayError>()?,
         ))
     }
 

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -25,7 +25,7 @@ use risingwave_pb::plan_common::{
 
 use super::{row_id_column_desc, rw_timestamp_column_desc, USER_COLUMN_ID_OFFSET};
 use crate::catalog::{cdc_table_name_column_desc, offset_column_desc, Field, ROW_ID_COLUMN_ID};
-use crate::types::DataType;
+use crate::types::{DataType, StructType};
 use crate::util::value_encoding::DatumToProtoExt;
 
 /// Column ID is the unique identifier of a column in a table. Different from table ID, column ID is
@@ -270,10 +270,8 @@ impl ColumnDesc {
         type_name: &str,
         fields: Vec<ColumnDesc>,
     ) -> Self {
-        let data_type = DataType::new_struct(
-            fields.iter().map(|f| f.data_type.clone()).collect_vec(),
-            fields.iter().map(|f| f.name.clone()).collect_vec(),
-        );
+        let data_type =
+            StructType::new(fields.iter().map(|f| (&f.name, f.data_type.clone()))).into();
         Self {
             data_type,
             column_id: ColumnId::new(column_id),

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -71,15 +71,6 @@ impl StructType {
         }))
     }
 
-    pub(super) fn from_parts(field_names: Vec<String>, field_types: Vec<DataType>) -> Self {
-        // TODO: enable this assertion
-        // debug_assert!(field_names.len() == field_types.len());
-        Self(Arc::new(StructTypeInner {
-            field_types: field_types.into(),
-            field_names: field_names.into(),
-        }))
-    }
-
     /// Creates a struct type with unnamed fields.
     pub fn unnamed(fields: Vec<DataType>) -> Self {
         Self(Arc::new(StructTypeInner {

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -48,10 +48,11 @@ struct StructTypeInner {
 
 impl StructType {
     /// Creates a struct type with named fields.
-    pub fn new(named_fields: Vec<(impl Into<String>, DataType)>) -> Self {
-        let mut field_types = Vec::with_capacity(named_fields.len());
-        let mut field_names = Vec::with_capacity(named_fields.len());
-        for (name, ty) in named_fields {
+    pub fn new(named_fields: impl IntoIterator<Item = (impl Into<String>, DataType)>) -> Self {
+        let iter = named_fields.into_iter();
+        let mut field_types = Vec::with_capacity(iter.size_hint().0);
+        let mut field_names = Vec::with_capacity(iter.size_hint().0);
+        for (name, ty) in iter {
             field_names.push(name.into());
             field_types.push(ty);
         }

--- a/src/frontend/src/expr/subquery.rs
+++ b/src/frontend/src/expr/subquery.rs
@@ -97,9 +97,7 @@ impl Expr for Subquery {
                     StructType::unnamed(self.query.data_types())
                 } else {
                     StructType::new(
-                        (schema.fields().iter().cloned())
-                            .map(|f| (f.name, f.data_type))
-                            .collect(),
+                        (schema.fields().iter().cloned()).map(|f| (f.name, f.data_type)),
                     )
                 };
                 DataType::Struct(struct_type)

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -168,8 +168,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         DataType::Struct(StructType::new(
             STRUCT_FIELD_NAMES[0..num_fields]
                 .iter()
-                .map(|s| (s.to_string(), self.gen_data_type_inner(depth)))
-                .collect(),
+                .map(|s| (s.to_string(), self.gen_data_type_inner(depth))),
         ))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Before:
* `Struct::new`
* `Struct::unnamed` (possibly via `DataType::new_unnamed_struct`)
* `Struct::from_parts` (via `DataType::new_struct`)

Goal:
* Deprecate `Struct::from_parts` in favor of `Struct::new`
* (minor) Avoid introducing unnecessary associated functions on `DataType` and interact with `StructType` directly.

As we can see, most real callers (contrast to dummy / testing callers in Part 1/2 #19569) were iterating the same thing twice to obtain types and names separately (or `unzip`). Now they are doing it in one pass. Exceptions are where `zip_eq_fast` is used - namely `From<&PbDataType>` and `bind_update`. Effectively the `TODO: debug_assert!(field_names.len() == field_types.len());` in `from_parts` is now enforced by `zip_eq_fast`.

Single-iteration is not the primary goal though. By consolidating `from_parts` into `new`, it is easier for future refactoring: adding optional name for struct type.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
