### PR TITLE
feat(barrier): support database failure isolation (part 2, local)

### DIFF
--- a/e2e_test/error_ui/simple/recovery.slt
+++ b/e2e_test/error_ui/simple/recovery.slt
@@ -25,7 +25,7 @@ with error as (
     limit 1
 )
 select
-case when error like '%get error from control stream, in worker node %: %Actor % exited unexpectedly: Executor error: %Numeric out of range%' then 'ok'
+case when error like '%in worker node %: %Actor % exited unexpectedly: Executor error: %Numeric out of range%' then 'ok'
      else error
 end as result
 from error;

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -63,7 +63,7 @@ use risingwave_pb::stream_service::streaming_control_stream_response::{
 };
 use risingwave_pb::stream_service::{
     streaming_control_stream_response, BarrierCompleteResponse, InjectBarrierRequest,
-    StreamingControlStreamRequest, StreamingControlStreamResponse,
+    PbScoredError, StreamingControlStreamRequest, StreamingControlStreamResponse,
 };
 
 use crate::executor::exchange::permit::Receiver;
@@ -160,12 +160,15 @@ impl ControlStreamHandle {
     pub(super) fn ack_reset_database(
         &mut self,
         database_id: DatabaseId,
-        root_err: Option<StreamError>,
+        root_err: Option<ScoredStreamError>,
         reset_request_id: u32,
     ) {
         self.send_response(Response::ResetDatabase(ResetDatabaseResponse {
             database_id: database_id.database_id,
-            root_err: root_err.map(|err| err.to_report_string()),
+            root_err: root_err.map(|err| PbScoredError {
+                err_msg: err.error.to_report_string(),
+                score: err.score.0,
+            }),
             reset_request_id,
         }));
     }

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -405,7 +405,10 @@ impl LocalBarrierWorker {
                             self.on_epoch_completed(database_id, partial_graph_id, barrier.epoch.prev, result);
                         }
                         Err(err) => {
-                            self.on_database_failure(database_id, None, err, "failed to complete epoch");
+                            // TODO: may only report as database failure instead of reset the stream
+                            // when the HummockUploader support partial recovery. Currently the HummockUploader
+                            // enter `Err` state and stop working until a global recovery to clear the uploader.
+                            self.control_stream_handle.reset_stream_with_err(Status::internal(format!("failed to complete epoch: {} {} {:?} {:?}", database_id, partial_graph_id.0, barrier.epoch, err.as_report())));
                         }
                     }
                 },

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -328,12 +328,12 @@ impl LocalBarrierWorker {
                     (*database_id, {
                         match status {
                             DatabaseStatus::Running(state) => {
-                                ("running".to_string(), Some(state.to_debug_info()))
+                                ("running".to_owned(), Some(state.to_debug_info()))
                             }
                             DatabaseStatus::Suspended(state) => {
                                 (format!("suspended: {:?}", state.suspend_time), None)
                             }
-                            DatabaseStatus::Resetting(_) => ("resetting".to_string(), None),
+                            DatabaseStatus::Resetting(_) => ("resetting".to_owned(), None),
                             DatabaseStatus::Unspecified => {
                                 unreachable!()
                             }

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -19,7 +19,10 @@ use std::future::{pending, poll_fn, Future};
 use std::mem::replace;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Instant;
 
+use futures::stream::FuturesOrdered;
+use futures::FutureExt;
 use prometheus::HistogramTimer;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::util::epoch::EpochPair;
@@ -78,6 +81,7 @@ use risingwave_pb::stream_service::streaming_control_stream_request::{
 };
 use risingwave_pb::stream_service::InjectBarrierRequest;
 
+use crate::task::barrier_manager::await_epoch_completed_future::AwaitEpochCompletedFuture;
 use crate::task::barrier_manager::LocalBarrierEvent;
 
 pub(super) struct ManagedBarrierStateDebugInfo<'a> {
@@ -276,10 +280,6 @@ impl InflightActorState {
             self.inflight_barriers.is_empty() && self.is_stopping,
         )
     }
-
-    pub(super) fn is_running(&self) -> bool {
-        matches!(&self.status, InflightActorStatus::Running(_))
-    }
 }
 
 pub(super) struct PartialGraphManagedBarrierState {
@@ -335,8 +335,172 @@ impl PartialGraphManagedBarrierState {
     }
 }
 
+pub(crate) struct SuspendedDatabaseState {
+    pub(super) suspend_time: Instant,
+    inner: DatabaseManagedBarrierState,
+    failure: Option<(Option<ActorId>, StreamError)>,
+}
+
+impl SuspendedDatabaseState {
+    fn new(
+        state: DatabaseManagedBarrierState,
+        failure: Option<(Option<ActorId>, StreamError)>,
+        _completing_futures: Option<FuturesOrdered<AwaitEpochCompletedFuture>>, /* discard the completing futures */
+    ) -> Self {
+        state.abort_actors();
+        Self {
+            suspend_time: Instant::now(),
+            inner: state,
+            failure,
+        }
+    }
+
+    async fn reset(mut self) -> ResetDatabaseOutput {
+        let root_err = self.inner.try_find_root_actor_failure(self.failure).await;
+        self.inner.await_actors().await;
+        if let Some(hummock) = self.inner.actor_manager.env.state_store().as_hummock() {
+            hummock.clear_tables(self.inner.table_ids).await;
+        }
+        ResetDatabaseOutput {
+            root_err: root_err.error,
+        }
+    }
+}
+
+pub(crate) struct ResettingDatabaseState {
+    join_handle: JoinHandle<ResetDatabaseOutput>,
+    reset_request_id: u32,
+}
+
+pub(crate) struct ResetDatabaseOutput {
+    pub(crate) root_err: StreamError,
+}
+
+pub(crate) enum DatabaseStatus {
+    Running(DatabaseManagedBarrierState),
+    Suspended(SuspendedDatabaseState),
+    Resetting(ResettingDatabaseState),
+    /// temporary place holder
+    Unspecified,
+}
+
+impl DatabaseStatus {
+    pub(crate) async fn abort(&mut self) {
+        match self {
+            DatabaseStatus::Running(state) => {
+                state.abort_actors();
+                state.await_actors().await;
+            }
+            DatabaseStatus::Suspended(SuspendedDatabaseState { inner: state, .. }) => {
+                // has called `abort_actors` on `suspend` call
+                state.await_actors().await;
+            }
+            DatabaseStatus::Resetting(state) => {
+                (&mut state.join_handle)
+                    .await
+                    .expect("failed to join reset database join handle");
+            }
+            DatabaseStatus::Unspecified => {
+                unreachable!()
+            }
+        }
+    }
+
+    pub(crate) fn state_for_request(&mut self) -> Option<&mut DatabaseManagedBarrierState> {
+        match self {
+            DatabaseStatus::Running(state) => Some(state),
+            DatabaseStatus::Suspended(_) => None,
+            DatabaseStatus::Resetting(_) => {
+                unreachable!("should not receive further request during cleaning")
+            }
+            DatabaseStatus::Unspecified => {
+                unreachable!()
+            }
+        }
+    }
+
+    pub(super) fn poll_next_event(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ManagedBarrierStateEvent> {
+        match self {
+            DatabaseStatus::Running(state) => state.poll_next_event(cx),
+            DatabaseStatus::Suspended(_) => Poll::Pending,
+            DatabaseStatus::Resetting(state) => state.join_handle.poll_unpin(cx).map(|result| {
+                let output = result.expect("should be able to join");
+                ManagedBarrierStateEvent::DatabaseReset(output, state.reset_request_id)
+            }),
+            DatabaseStatus::Unspecified => {
+                unreachable!()
+            }
+        }
+    }
+
+    pub(super) fn suspend(
+        &mut self,
+        failed_actor: Option<ActorId>,
+        err: StreamError,
+        completing_futures: Option<FuturesOrdered<AwaitEpochCompletedFuture>>,
+    ) {
+        let state = must_match!(replace(self, DatabaseStatus::Unspecified), DatabaseStatus::Running(state) => state);
+        *self = DatabaseStatus::Suspended(SuspendedDatabaseState::new(
+            state,
+            Some((failed_actor, err)),
+            completing_futures,
+        ));
+    }
+
+    pub(super) fn start_reset(
+        &mut self,
+        database_id: DatabaseId,
+        completing_futures: Option<FuturesOrdered<AwaitEpochCompletedFuture>>,
+        reset_request_id: u32,
+    ) {
+        let join_handle = match replace(self, DatabaseStatus::Unspecified) {
+            DatabaseStatus::Running(state) => {
+                assert_eq!(database_id, state.database_id);
+                info!(
+                    database_id = database_id.database_id,
+                    reset_request_id, "start database reset from Running"
+                );
+                tokio::spawn(SuspendedDatabaseState::new(state, None, completing_futures).reset())
+            }
+            DatabaseStatus::Suspended(state) => {
+                assert!(
+                    completing_futures.is_none(),
+                    "should have been clear when suspended"
+                );
+                assert_eq!(database_id, state.inner.database_id);
+                info!(
+                    database_id = database_id.database_id,
+                    reset_request_id,
+                    suspend_elapsed = ?state.suspend_time.elapsed(),
+                    "start database reset after suspended"
+                );
+                tokio::spawn(state.reset())
+            }
+            DatabaseStatus::Resetting(state) => {
+                let prev_request_id = state.reset_request_id;
+                info!(
+                    database_id = database_id.database_id,
+                    reset_request_id, prev_request_id, "receive duplicate reset request"
+                );
+                assert!(reset_request_id > prev_request_id);
+                state.join_handle
+            }
+            DatabaseStatus::Unspecified => {
+                unreachable!()
+            }
+        };
+        *self = DatabaseStatus::Resetting(ResettingDatabaseState {
+            join_handle,
+            reset_request_id,
+        });
+    }
+}
+
 pub(crate) struct ManagedBarrierState {
-    pub(crate) databases: HashMap<DatabaseId, DatabaseManagedBarrierState>,
+    pub(crate) databases: HashMap<DatabaseId, DatabaseStatus>,
     pub(crate) current_shared_context: HashMap<DatabaseId, Arc<SharedContext>>,
 }
 
@@ -349,6 +513,7 @@ pub(super) enum ManagedBarrierStateEvent {
         actor_id: ActorId,
         err: StreamError,
     },
+    DatabaseReset(ResetDatabaseOutput, u32),
 }
 
 impl ManagedBarrierState {
@@ -363,11 +528,12 @@ impl ManagedBarrierState {
             assert!(!databases.contains_key(&database_id));
             let shared_context = Arc::new(SharedContext::new(database_id, &actor_manager.env));
             let state = DatabaseManagedBarrierState::new(
+                database_id,
                 actor_manager.clone(),
                 shared_context.clone(),
                 database.graphs,
             );
-            databases.insert(database_id, state);
+            databases.insert(database_id, DatabaseStatus::Running(state));
             current_shared_context.insert(database_id, shared_context);
         }
 
@@ -392,9 +558,12 @@ impl ManagedBarrierState {
 }
 
 pub(crate) struct DatabaseManagedBarrierState {
+    database_id: DatabaseId,
     pub(super) actor_states: HashMap<ActorId, InflightActorState>,
 
     pub(super) graph_states: HashMap<PartialGraphId, PartialGraphManagedBarrierState>,
+
+    table_ids: HashSet<TableId>,
 
     actor_manager: Arc<StreamActorManager>,
 
@@ -408,6 +577,7 @@ pub(crate) struct DatabaseManagedBarrierState {
 impl DatabaseManagedBarrierState {
     /// Create a barrier manager state. This will be called only once.
     pub(super) fn new(
+        database_id: DatabaseId,
         actor_manager: Arc<StreamActorManager>,
         current_shared_context: Arc<SharedContext>,
         initial_partial_graphs: Vec<InitialPartialGraph>,
@@ -415,6 +585,7 @@ impl DatabaseManagedBarrierState {
         let (local_barrier_manager, barrier_event_rx, actor_failure_rx) =
             LocalBarrierManager::new();
         Self {
+            database_id,
             actor_states: Default::default(),
             graph_states: initial_partial_graphs
                 .into_iter()
@@ -424,6 +595,7 @@ impl DatabaseManagedBarrierState {
                     (PartialGraphId::new(graph.partial_graph_id), state)
                 })
                 .collect(),
+            table_ids: Default::default(),
             actor_manager,
             current_shared_context,
             local_barrier_manager,
@@ -439,7 +611,7 @@ impl DatabaseManagedBarrierState {
         }
     }
 
-    pub(crate) async fn abort_actors(&mut self) {
+    fn abort_actors(&self) {
         for (actor_id, state) in &self.actor_states {
             tracing::debug!("force stopping actor {}", actor_id);
             state.join_handle.abort();
@@ -447,6 +619,9 @@ impl DatabaseManagedBarrierState {
                 monitor_task_handle.abort();
             }
         }
+    }
+
+    async fn await_actors(&mut self) {
         for (actor_id, state) in self.actor_states.drain() {
             tracing::debug!("join actor {}", actor_id);
             let result = state.join_handle.await;
@@ -568,10 +743,14 @@ impl DatabaseManagedBarrierState {
         graph_state.add_subscriptions(request.subscriptions_to_add);
         graph_state.remove_subscriptions(request.subscriptions_to_remove);
 
+        let table_ids =
+            HashSet::from_iter(request.table_ids_to_sync.iter().cloned().map(TableId::new));
+        self.table_ids.extend(table_ids.iter().cloned());
+
         graph_state.transform_to_issued(
             barrier,
             request.actor_ids_to_collect.iter().cloned(),
-            HashSet::from_iter(request.table_ids_to_sync.iter().cloned().map(TableId::new)),
+            table_ids,
         );
 
         let mut new_actors = HashSet::new();

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -371,7 +371,7 @@ pub(crate) struct ResettingDatabaseState {
 }
 
 pub(crate) struct ResetDatabaseOutput {
-    pub(crate) root_err: ScoredStreamError,
+    pub(crate) root_err: Option<ScoredStreamError>,
 }
 
 pub(crate) enum DatabaseStatus {

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -82,7 +82,7 @@ use risingwave_pb::stream_service::streaming_control_stream_request::{
 use risingwave_pb::stream_service::InjectBarrierRequest;
 
 use crate::task::barrier_manager::await_epoch_completed_future::AwaitEpochCompletedFuture;
-use crate::task::barrier_manager::LocalBarrierEvent;
+use crate::task::barrier_manager::{LocalBarrierEvent, ScoredStreamError};
 
 pub(super) struct ManagedBarrierStateDebugInfo<'a> {
     running_actors: BTreeSet<ActorId>,
@@ -361,9 +361,7 @@ impl SuspendedDatabaseState {
         if let Some(hummock) = self.inner.actor_manager.env.state_store().as_hummock() {
             hummock.clear_tables(self.inner.table_ids).await;
         }
-        ResetDatabaseOutput {
-            root_err: root_err.error,
-        }
+        ResetDatabaseOutput { root_err }
     }
 }
 
@@ -373,7 +371,7 @@ pub(crate) struct ResettingDatabaseState {
 }
 
 pub(crate) struct ResetDatabaseOutput {
-    pub(crate) root_err: StreamError,
+    pub(crate) root_err: ScoredStreamError,
 }
 
 pub(crate) enum DatabaseStatus {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -261,7 +261,7 @@ impl LocalBarrierWorker {
             self.state
                 .databases
                 .values_mut()
-                .map(|database| database.abort_actors()),
+                .map(|database| database.abort()),
         )
         .await;
         if let Some(m) = self.actor_manager.await_tree_reg.as_ref() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After https://github.com/risingwavelabs/risingwave/pull/19664. The local barrier manager part of database failure isolation.

Previously in `ManagedBarrierState`, all databases are in a `Running` status, as a `DatabaseManagedBarrierState`, because in case of any failure, we will wait for a global recovery. To support database failure isolation, besides the `Running` status, we will have the following statuses.

```
pub(crate) enum DatabaseStatus {
    Running(DatabaseManagedBarrierState),
    Suspended(SuspendedDatabaseState),
    Resetting(ResettingDatabaseState),
}
```

The lifecycle of a `DatabaseStatus` will be
1. Get created when the control stream is reset, or when handling `add_partial_graph` request. The status is at `Running`.
2. In case of actor failure, it will send to the meta global barrier manager with a `ReportDatabaseFailureResponse`, and enter the `Suspended`.
3. Wait for the `ResetDatabaseRequest` from the meta global barrier manager, and then enter `Resetting`, which spawns a task to clear all actors and clear hummock uploader state of the state tables. Note that we may enter the `Resetting`  directly from `Running` when the database reset is triggered by failure reported from other CNs.
4. After the task finishes, get the `DatabaseStatus` removed from `ManagedBarrierState`, and will be recreated by the subsequent `add_partial_graph` request from the meta global barrier manager.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
