### PR TITLE
fix(meta): avoid unnecessary alias after `rename` back

### DIFF
--- a/src/meta/src/controller/rename.rs
+++ b/src/meta/src/controller/rename.rs
@@ -193,6 +193,16 @@ impl QueryRewriter<'_> {
                         });
                     }
                     name.0[idx] = Ident::new_unchecked(self.to);
+
+                    // Strip out `a AS a` possibly from a previous rename
+                    if name.0.len() == 1
+                        && Some(TableAlias {
+                            name: name.0[0].clone(),
+                            columns: vec![],
+                        }) == *alias
+                    {
+                        *alias = None;
+                    }
                 }
             }
             TableFactor::Derived { subquery, .. } => self.visit_query(subquery),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Just noting down the request and a brutal fix. We shall try better ways before merging this, when it becomes a priority later.

Context:
> We compare our target MV definition (likely from dbt) and the response of `select definition from rw_materialized_views` in the database. If they differ, we spin-up a new MV with a different name, wait for it to backfill, then swap their names.
> The problem is this swapping process ends up with a different definition query than what we had originally.

Limitations:
* There can be other equivalent syntax leading to differences between `definition` and input from dbt. But at least this one source of discrepancy can be avoided.

cc @yezizp2012 

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
