### PR TITLE
feat(ci): more meta backend agnostic e2e tests in `main-cron`

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -31,27 +31,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # TODO: reuse the same mysql instance for connector test and meta store
-  #       after https://github.com/risingwavelabs/risingwave/issues/19783 addressed
-  mysql-meta:
-    image: mysql:8.0
-    command: --character-set-server=utf8 --collation-server=utf8_general_ci
-    ports:
-      - 3306
-    environment:
-      - MYSQL_ROOT_PASSWORD=123456
-      - MYSQL_USER=mysqluser
-      - MYSQL_PASSWORD=mysqlpw
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "mysqladmin ping -h 127.0.0.1 -u root -p123456"
-        ]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
   message_queue:
     image: "redpandadata/redpanda:latest"
     command:
@@ -93,7 +72,6 @@ services:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20241030
     depends_on:
       - mysql
-      - mysql-meta
       - sqlserver-server
       - db
       - message_queue
@@ -109,7 +87,6 @@ services:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20241030
     depends_on:
       - mysql
-      - mysql-meta
       - db
       - message_queue
       - schemaregistry
@@ -137,7 +114,7 @@ services:
   ci-standard-env:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20240911
     depends_on:
-      - mysql-meta
+      - mysql
       - db
     volumes:
       - ..:/risingwave

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -110,7 +110,8 @@ services:
     volumes:
       - ..:/risingwave
 
-  pg-mysql-backend-test-env:
+  # Standard environment for CI, including MySQL and Postgres for metadata.
+  ci-standard-env:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20240911
     depends_on:
       - mysql

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -31,6 +31,27 @@ services:
       timeout: 5s
       retries: 5
 
+  # TODO: reuse the same mysql instance for connector test and meta store
+  #       after https://github.com/risingwavelabs/risingwave/issues/19783 addressed
+  mysql-meta:
+    image: mysql:8.0
+    command: --character-set-server=utf8 --collation-server=utf8_general_ci
+    ports:
+      - 3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=123456
+      - MYSQL_USER=mysqluser
+      - MYSQL_PASSWORD=mysqlpw
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h 127.0.0.1 -u root -p123456"
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   message_queue:
     image: "redpandadata/redpanda:latest"
     command:
@@ -72,6 +93,7 @@ services:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20241030
     depends_on:
       - mysql
+      - mysql-meta
       - sqlserver-server
       - db
       - message_queue
@@ -87,6 +109,7 @@ services:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20241030
     depends_on:
       - mysql
+      - mysql-meta
       - db
       - message_queue
       - schemaregistry
@@ -114,7 +137,7 @@ services:
   ci-standard-env:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:v20240911
     depends_on:
-      - mysql
+      - mysql-meta
       - db
     volumes:
       - ..:/risingwave

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -95,7 +95,7 @@ steps:
 
   - group: "end-to-end test (release)"
     steps:
-    - label: "end-to-end test (release, {{matrix.backend}} backend)"
+    - label: "end-to-end test ({{matrix.backend}} backend)"
       key: "e2e-test-release"
       <<: *sql-backend
       command: "ci/scripts/cron-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
@@ -113,7 +113,7 @@ steps:
       timeout_in_minutes: 30
       retry: *auto-retry
 
-    - label: "slow end-to-end test (release, {{matrix.backend}} backend)"
+    - label: "slow end-to-end test ({{matrix.backend}} backend)"
       key: "slow-e2e-test-release"
       <<: *sql-backend
       command: "ci/scripts/slow-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
@@ -130,50 +130,28 @@ steps:
       timeout_in_minutes: 8
       retry: *auto-retry
 
-  - label: "meta backup test (release)"
-    key: "e2e-meta-backup-test-release"
-    command: "ci/scripts/run-meta-backup-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
-    if: |
-      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-meta-backup-test"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
-    depends_on:
-      - "build"
-      - "build-other"
-      - "docslt"
-    plugins:
-      - docker-compose#v5.5.0:
-          run: rw-build-env
-          config: ci/docker-compose.yml
-          mount-buildkite-agent: true
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 45
-    retry: *auto-retry
-
-  - label: "end-to-end test (parallel) (release)"
-    key: "e2e-test-release-parallel"
-    command: "ci/scripts/e2e-test-parallel.sh -p ci-release"
-    if: |
-      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-parallel-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/
-    depends_on:
-      - "build"
-      - "docslt"
-    plugins:
-      - seek-oss/aws-sm#v2.3.2:
-          env:
-            BUILDKITE_ANALYTICS_TOKEN: buildkite-build-analytics-sqllogictest-token
-      - docker-compose#v5.5.0:
-          run: rw-build-env
-          config: ci/docker-compose.yml
-          mount-buildkite-agent: true
-      - test-collector#v1.0.0:
-          files: "*-junit.xml"
-          format: "junit"
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 13
-    retry: *auto-retry
+    - label: "end-to-end test (parallel, {{matrix.backend}} backend)"
+      key: "e2e-test-release-parallel"
+      <<: *sql-backend
+      command: "ci/scripts/e2e-test-parallel.sh -p ci-release"
+      if: |
+        !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-parallel-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/
+      depends_on:
+        - "build"
+        - "docslt"
+      plugins:
+        - seek-oss/aws-sm#v2.3.1:
+            env:
+              BUILDKITE_ANALYTICS_TOKEN: buildkite-build-analytics-sqllogictest-token
+        - docker-compose#v5.5.0: *docker-compose-common
+        - test-collector#v1.0.0:
+            files: "*-junit.xml"
+            format: "junit"
+        - ./ci/plugins/upload-failure-logs
+      timeout_in_minutes: 13
+      retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory) (release)"
     key: "e2e-test-release-parallel-memory"
@@ -194,43 +172,45 @@ steps:
     timeout_in_minutes: 12
     retry: *auto-retry
 
-  - label: "end-to-end source test (release)"
-    key: "e2e-test-release-source"
-    command: "ci/scripts/e2e-source-test.sh -p ci-release"
-    if: |
-      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-source-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/
-    depends_on:
-      - "build"
-      - "build-other"
-    plugins:
-      - docker-compose#v5.5.0:
-          run: source-test-env
-          config: ci/docker-compose.yml
-          mount-buildkite-agent: true
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 15
-    retry: *auto-retry
+  - group: "end-to-end connector test (release)"
+    steps:
+    - label: "end-to-end source test ({{matrix.backend}} backend)"
+      key: "e2e-test-release-source"
+      <<: *sql-backend
+      command: "ci/scripts/e2e-source-test.sh -p ci-release"
+      if: |
+        !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-source-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/
+      depends_on:
+        - "build"
+        - "build-other"
+      plugins:
+        - docker-compose#v5.5.0:
+            <<: *docker-compose-common
+            run: source-test-env
+        - ./ci/plugins/upload-failure-logs
+      timeout_in_minutes: 15
+      retry: *auto-retry
 
-  - label: "end-to-end sink test (release)"
-    key: "e2e-test-release-sink"
-    command: "ci/scripts/e2e-sink-test.sh -p ci-release"
-    if: |
-      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-sink-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/
-    depends_on:
-      - "build"
-      - "build-other"
-    plugins:
-      - docker-compose#v5.5.0:
-          run: sink-test-env
-          config: ci/docker-compose.yml
-          mount-buildkite-agent: true
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 35
-    retry: *auto-retry
+    - label: "end-to-end sink test ({{matrix.backend}} backend)"
+      key: "e2e-test-release-sink"
+      <<: *sql-backend
+      command: "ci/scripts/e2e-sink-test.sh -p ci-release"
+      if: |
+        !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-sink-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/
+      depends_on:
+        - "build"
+        - "build-other"
+      plugins:
+        - docker-compose#v5.5.0:
+            <<: *docker-compose-common
+            run: sink-test-env
+        - ./ci/plugins/upload-failure-logs
+      timeout_in_minutes: 35
+      retry: *auto-retry
 
   - label: "fuzz test"
     key: "fuzz-test"
@@ -250,6 +230,26 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 20
+    retry: *auto-retry
+
+  - label: "meta backup test (release)"
+    key: "e2e-meta-backup-test-release"
+    command: "ci/scripts/run-meta-backup-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-meta-backup-test"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.5.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 45
     retry: *auto-retry
 
   # The timeout should be strictly more than timeout in `pull-request.yml`.

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -22,10 +22,11 @@ sql-backend: &sql-backend
           backend: "postgres"
           # PGPASSWORD=postgres psql -h db -p 5432 -U postgres -d rwmeta
           endpoint: "postgres://postgres:postgres@db:5432/rwmeta"
-      - with:
-          backend: "mysql"
-          # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
-          endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
+      # Temporarily disable tests for mysql backend as there are unresolved issues.
+      # - with:
+      #     backend: "mysql"
+      #     # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
+      #     endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
   env:
     RISEDEV_SQL_ENDPOINT: "{{matrix.endpoint}}"
 

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -24,8 +24,8 @@ sql-backend: &sql-backend
           endpoint: "postgres://postgres:postgres@db:5432/rwmeta"
       - with:
           backend: "mysql"
-          # mysql -h mysql -P 3306 -u root -p123456 -D rwmeta
-          endpoint: "mysql://root:123456@mysql:3306/rwmeta"
+          # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
+          endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
   env:
     RISEDEV_SQL_ENDPOINT: "{{matrix.endpoint}}"
 

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -142,7 +142,7 @@ steps:
         - "build"
         - "docslt"
       plugins:
-        - seek-oss/aws-sm#v2.3.1:
+        - seek-oss/aws-sm#v2.3.2:
             env:
               BUILDKITE_ANALYTICS_TOKEN: buildkite-build-analytics-sqllogictest-token
         - docker-compose#v5.5.0: *docker-compose-common

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -33,7 +33,7 @@ docker-compose-common: &docker-compose-common
     config: ci/docker-compose.yml
     mount-buildkite-agent: true
     propagate-environment: true
-    run: rw-build-env
+    run: ci-standard-env
 
 steps:
   - label: "build"
@@ -93,44 +93,42 @@ steps:
     timeout_in_minutes: 10
     retry: *auto-retry
 
-  - label: "end-to-end test (release, {{matrix.backend}} backend)"
-    key: "e2e-test-release"
-    <<: *sql-backend
-    command: "ci/scripts/cron-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
-    if: |
-      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-test"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
-    depends_on:
-      - "build"
-      - "build-other"
-      - "docslt"
-    plugins:
-      - docker-compose#v5.5.0:
-          <<: *docker-compose-common
-          run: pg-mysql-backend-test-env
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 30
-    retry: *auto-retry
+  - group: "end-to-end test (release)"
+    steps:
+    - label: "end-to-end test (release, {{matrix.backend}} backend)"
+      key: "e2e-test-release"
+      <<: *sql-backend
+      command: "ci/scripts/cron-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
+      if: |
+        !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-test"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+      depends_on:
+        - "build"
+        - "build-other"
+        - "docslt"
+      plugins:
+        - docker-compose#v5.5.0: *docker-compose-common
+        - ./ci/plugins/upload-failure-logs
+      timeout_in_minutes: 30
+      retry: *auto-retry
 
-  - label: "slow end-to-end test (release)"
-    key: "slow-e2e-test-release"
-    command: "ci/scripts/slow-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
-    if: |
-      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-slow-e2e-tests"
-      || build.env("CI_STEPS") =~ /(^|,)slow-e2e-tests?(,|$$)/
-    depends_on:
-      - "build"
-      - "build-other"
-    plugins:
-      - docker-compose#v5.5.0:
-          run: rw-build-env
-          config: ci/docker-compose.yml
-          mount-buildkite-agent: true
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 8
-    retry: *auto-retry
+    - label: "slow end-to-end test (release, {{matrix.backend}} backend)"
+      key: "slow-e2e-test-release"
+      <<: *sql-backend
+      command: "ci/scripts/slow-e2e-test.sh -p ci-release -m ci-3streaming-2serving-3fe"
+      if: |
+        !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-slow-e2e-tests"
+        || build.env("CI_STEPS") =~ /(^|,)slow-e2e-tests?(,|$$)/
+      depends_on:
+        - "build"
+        - "build-other"
+      plugins:
+        - docker-compose#v5.5.0: *docker-compose-common
+        - ./ci/plugins/upload-failure-logs
+      timeout_in_minutes: 8
+      retry: *auto-retry
 
   - label: "meta backup test (release)"
     key: "e2e-meta-backup-test-release"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -44,7 +44,7 @@ docker-compose-common: &docker-compose-common
     config: ci/docker-compose.yml
     mount-buildkite-agent: true
     propagate-environment: true
-    run: rw-build-env
+    run: ci-standard-env
 
 steps:
   - label: "check ci image rebuild"
@@ -840,9 +840,7 @@ steps:
       - "build-other"
       - "docslt"
     plugins:
-      - docker-compose#v5.5.0:
-          <<: *docker-compose-common
-          run: pg-mysql-backend-test-env
+      - docker-compose#v5.5.0: *docker-compose-common
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 32
     retry: *auto-retry

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -33,10 +33,11 @@ other-sql-backend: &other-sql-backend
           label: "postgres"
           # PGPASSWORD=postgres psql -h db -p 5432 -U postgres -d rwmeta
           endpoint: "postgres://postgres:postgres@db:5432/rwmeta"
-      - with:
-          label: "mysql"
-          # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
-          endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
+      # Temporarily disable tests for mysql backend as there are unresolved issues.
+      # - with:
+      #     label: "mysql"
+      #     # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
+      #     endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
   env:
     RISEDEV_SQL_ENDPOINT: "{{matrix.endpoint}}"
 

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -35,8 +35,8 @@ other-sql-backend: &other-sql-backend
           endpoint: "postgres://postgres:postgres@db:5432/rwmeta"
       - with:
           label: "mysql"
-          # mysql -h mysql -P 3306 -u root -p123456 -D rwmeta
-          endpoint: "mysql://root:123456@mysql:3306/rwmeta"
+          # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
+          endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
   env:
     RISEDEV_SQL_ENDPOINT: "{{matrix.endpoint}}"
 

--- a/risedev.yml
+++ b/risedev.yml
@@ -583,9 +583,8 @@ profile:
     config-path: src/config/ci.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222
@@ -605,9 +604,8 @@ profile:
     config-path: src/config/ci-longer-streaming-upload-timeout.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222
@@ -627,9 +625,8 @@ profile:
     config-path: src/config/ci-longer-streaming-upload-timeout.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222
@@ -653,9 +650,8 @@ profile:
       - use: minio
         api-requests-max: 30
         api-requests-deadline: 3s
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222
@@ -677,9 +673,8 @@ profile:
       - use: minio
         api-requests-max: 30
         api-requests-deadline: 2s
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222
@@ -701,9 +696,8 @@ profile:
     config-path: src/config/ci.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222
@@ -760,9 +754,8 @@ profile:
   ci-3cn-3fe-opendal-fs-backend:
     config-path: src/config/ci.toml
     steps:
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: opendal
         engine: fs
         bucket: "/tmp/rw_ci"
@@ -914,9 +907,8 @@ profile:
     config-path: src/config/ci.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
       - use: frontend
@@ -927,9 +919,8 @@ profile:
     config-path: src/config/ci-compaction-test.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
         total-memory-bytes: 17179869184
@@ -972,9 +963,8 @@ profile:
     config-path: src/config/ci-recovery.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
       - use: frontend
@@ -1034,9 +1024,8 @@ profile:
     config-path: "src/config/ci-backfill.toml"
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
       - use: frontend
       - use: compactor

--- a/risedev.yml
+++ b/risedev.yml
@@ -572,9 +572,8 @@ profile:
     config-path: src/config/ci.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
       - use: frontend
@@ -844,9 +843,8 @@ profile:
     config-path: src/config/ci.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
       - use: frontend
@@ -883,9 +881,8 @@ profile:
     config-path: src/config/ci-recovery.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
       - use: frontend
@@ -943,9 +940,8 @@ profile:
     config-path: src/config/ci-recovery.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         enable-tiered-cache: true
       - use: frontend
@@ -955,9 +951,8 @@ profile:
     config-path: src/config/ci-recovery.toml
     steps:
       - use: minio
-      - use: sqlite
       - use: meta-node
-        meta-backend: sqlite
+        meta-backend: env
       - use: compute-node
         port: 5687
         exporter-port: 1222

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -51,9 +51,10 @@ fn sql_endpoint_from_env() -> String {
             // Act as if `meta-backend: sqlite` is specified.
             // Not using a temporary file because we want to persist the data across restarts.
             let prefix_data = env::var("PREFIX_DATA").unwrap();
-            let path = PathBuf::from(&prefix_data)
-                .join("meta-backend-env-fallback-sqlite")
-                .join("metadata.db");
+            let dir = PathBuf::from(&prefix_data).join("meta-backend-env-fallback-sqlite");
+            fs_err::create_dir_all(&dir).unwrap();
+
+            let path = dir.join("metadata.db");
             let sqlite_endpoint = format!("sqlite://{}?mode=rwc", path.to_string_lossy());
             tracing::warn!(
                 "env RISEDEV_SQL_ENDPOINT not set, use fallback sqlite `{}`",

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -370,7 +370,9 @@ fn initialize_meta_store() -> Result<(), anyhow::Error> {
             // SQLite in-memory database does not need initialization.
         } else {
             let filename = options.get_filename();
-            fs_err::write(filename, b"").context("failed to empty SQLite file")?;
+            if std::fs::exists(filename)? {
+                fs_err::write(filename, b"").context("failed to empty SQLite file")?;
+            }
         }
 
         return Ok(());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Use `meta-backend: env` for all CI RiseDev profiles.
  * use a persisted SQLite database as a fallback when env var is not set, behaving as if `meta-backend: sqlite` is specified, ensuring compatibility with the behavior prior to this PR.

- Extend coverage for PG/MySQL meta backends on `main-cron` to
  * slow e2e test
  * parallel e2e test
  * e2e source test
  * e2e sink test

Note that although there are many other steps for specific connectors, I suppose it may not be necessary to cover them all, as the execution path on the meta node should not differ significantly.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
