### PR TITLE
fix: bypass cluster limits by default in debug build

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -58,6 +58,9 @@ type SessionConfigResult<T> = std::result::Result<T, SessionConfigError>;
 const DISABLE_BACKFILL_RATE_LIMIT: i32 = -1;
 const DISABLE_SOURCE_RATE_LIMIT: i32 = -1;
 
+/// Default to bypass cluster limits iff in debug mode.
+const BYPASS_CLUSTER_LIMITS: bool = cfg!(debug_assertions);
+
 #[serde_as]
 /// This is the Session Config of RisingWave.
 #[derive(Clone, Debug, Deserialize, Serialize, SessionConfig, ConfigDoc, PartialEq)]
@@ -306,7 +309,7 @@ pub struct SessionConfig {
     /// Bypass checks on cluster limits
     ///
     /// When enabled, `CREATE MATERIALIZED VIEW` will not fail if the cluster limit is hit.
-    #[parameter(default = false)]
+    #[parameter(default = BYPASS_CLUSTER_LIMITS)]
     bypass_cluster_limits: bool,
 
     /// The maximum number of parallelism a streaming query can use. Defaults to 256.

--- a/src/config/ci-sim.toml
+++ b/src/config/ci-sim.toml
@@ -7,7 +7,3 @@ max_concurrent_creating_streaming_jobs = 0
 
 [meta]
 meta_leader_lease_secs = 10
-
-[meta.developer]
-meta_actor_cnt_per_worker_parallelism_soft_limit = 65536
-meta_actor_cnt_per_worker_parallelism_hard_limit = 65536


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Otherwise we may encounter the limit exceeded error in CI.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
