### PR TITLE
feat(barrier): support database failure isolation (part 1, meta)

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -89,22 +89,44 @@ message StreamingControlStreamRequest {
     uint32 database_id = 2;
   }
 
+  message ResetDatabaseRequest {
+    uint32 database_id = 1;
+    uint32 reset_request_id = 2;
+  }
+
   oneof request {
     InitRequest init = 1;
     InjectBarrierRequest inject_barrier = 2;
     RemovePartialGraphRequest remove_partial_graph = 3;
     CreatePartialGraphRequest create_partial_graph = 4;
+    ResetDatabaseRequest reset_database = 5;
   }
+}
+
+message ScoredError {
+  string err_msg = 1;
+  int32 score = 2;
 }
 
 message StreamingControlStreamResponse {
   message InitResponse {}
   message ShutdownResponse {}
+  message ReportDatabaseFailureResponse {
+    uint32 database_id = 1;
+  }
+
+  message ResetDatabaseResponse {
+    uint32 database_id = 1;
+    optional ScoredError root_err = 2;
+    uint32 reset_request_id = 3;
+  }
 
   oneof response {
     InitResponse init = 1;
     BarrierCompleteResponse complete_barrier = 2;
     ShutdownResponse shutdown = 3;
+    ReportDatabaseFailureResponse report_database_failure = 4;
+    ResetDatabaseResponse reset_database = 5;
   }
 }
 

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -14,7 +14,9 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::future::{poll_fn, Future};
 use std::mem::take;
+use std::task::Poll;
 
 use anyhow::anyhow;
 use fail::fail_point;
@@ -24,10 +26,15 @@ use risingwave_meta_model::WorkerId;
 use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::meta::PausedReason;
+use risingwave_pb::stream_service::streaming_control_stream_response::ResetDatabaseResponse;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use tracing::{debug, warn};
 
 use crate::barrier::checkpoint::creating_job::{CompleteJobType, CreatingStreamingJobControl};
+use crate::barrier::checkpoint::recovery::{
+    DatabaseRecoveringState, DatabaseStatusAction, EnterInitializing, EnterRunning,
+    RecoveringStateAction,
+};
 use crate::barrier::checkpoint::state::BarrierWorkerState;
 use crate::barrier::command::CommandContext;
 use crate::barrier::complete_task::{BarrierCompleteOutput, CompleteBarrierTask};
@@ -47,17 +54,25 @@ use crate::{MetaError, MetaResult};
 
 #[derive(Default)]
 pub(crate) struct CheckpointControl {
-    databases: HashMap<DatabaseId, DatabaseCheckpointControl>,
-    hummock_version_stats: HummockVersionStats,
+    pub(super) databases: HashMap<DatabaseId, DatabaseCheckpointControlStatus>,
+    pub(super) hummock_version_stats: HummockVersionStats,
 }
 
 impl CheckpointControl {
     pub(crate) fn new(
-        databases: HashMap<DatabaseId, DatabaseCheckpointControl>,
+        databases: impl IntoIterator<Item = (DatabaseId, DatabaseCheckpointControl)>,
         hummock_version_stats: HummockVersionStats,
     ) -> Self {
         Self {
-            databases,
+            databases: databases
+                .into_iter()
+                .map(|(database_id, control)| {
+                    (
+                        database_id,
+                        DatabaseCheckpointControlStatus::Running(control),
+                    )
+                })
+                .collect(),
             hummock_version_stats,
         }
     }
@@ -68,6 +83,7 @@ impl CheckpointControl {
             self.databases
                 .get_mut(&database_id)
                 .expect("should exist")
+                .expect_running("should have wait for completing command before enter recovery")
                 .ack_completed(command_prev_epoch, creating_job_epochs);
         }
     }
@@ -78,6 +94,9 @@ impl CheckpointControl {
     ) -> Option<CompleteBarrierTask> {
         let mut task = None;
         for database in self.databases.values_mut() {
+            let Some(database) = database.running_state_mut() else {
+                continue;
+            };
             let context = context.as_mut().map(|(s, c)| (&mut **s, &mut **c));
             database.next_complete_barrier_task(&mut task, context, &self.hummock_version_stats);
         }
@@ -90,22 +109,35 @@ impl CheckpointControl {
         control_stream_manager: &mut ControlStreamManager,
     ) -> MetaResult<()> {
         let database_id = DatabaseId::new(resp.database_id);
-        self.databases
-            .get_mut(&database_id)
-            .expect("should exist")
-            .barrier_collected(resp, control_stream_manager)
+        let database_status = self.databases.get_mut(&database_id).expect("should exist");
+        match database_status {
+            DatabaseCheckpointControlStatus::Running(database) => {
+                database.barrier_collected(resp, control_stream_manager)
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => {
+                state.barrier_collected(resp);
+                Ok(())
+            }
+        }
     }
 
     pub(crate) fn can_inject_barrier(&self, in_flight_barrier_nums: usize) -> bool {
-        self.databases
-            .values()
-            .all(|database| database.can_inject_barrier(in_flight_barrier_nums))
+        self.databases.values().all(|database| {
+            database
+                .running_state()
+                .map(|database| database.can_inject_barrier(in_flight_barrier_nums))
+                .unwrap_or(true)
+        })
     }
 
     pub(crate) fn max_prev_epoch(&self) -> Option<TracedEpoch> {
         self.databases
             .values()
-            .map(|database| database.state.in_flight_prev_epoch())
+            .flat_map(|database| {
+                database
+                    .running_state()
+                    .map(|database| database.state.in_flight_prev_epoch())
+            })
             .max_by_key(|epoch| epoch.value())
             .cloned()
     }
@@ -126,7 +158,9 @@ impl CheckpointControl {
             let max_prev_epoch = self.max_prev_epoch();
             let (database, max_prev_epoch) = match self.databases.entry(database_id) {
                 Entry::Occupied(entry) => (
-                    entry.into_mut(),
+                    entry
+                        .into_mut()
+                        .expect_running("should not have command when not running"),
                     max_prev_epoch.expect("should exist when having some database"),
                 ),
                 Entry::Vacant(entry) => match &command {
@@ -147,7 +181,12 @@ impl CheckpointControl {
                             new_database.state.in_flight_prev_epoch().clone()
                         };
                         control_stream_manager.add_partial_graph(database_id, None)?;
-                        (entry.insert(new_database), max_prev_epoch)
+                        (
+                            entry
+                                .insert(DatabaseCheckpointControlStatus::Running(new_database))
+                                .expect_running("just initialized as running"),
+                            max_prev_epoch,
+                        )
                     }
                     Command::Flush
                     | Command::Pause(PausedReason::Manual)
@@ -177,6 +216,9 @@ impl CheckpointControl {
                 curr_epoch.clone(),
             )?;
             for database in self.databases.values_mut() {
+                let Some(database) = database.running_state_mut() else {
+                    continue;
+                };
                 if database.database_id == database_id {
                     continue;
                 }
@@ -192,11 +234,13 @@ impl CheckpointControl {
             }
         } else {
             let Some(max_prev_epoch) = self.max_prev_epoch() else {
-                assert!(self.databases.is_empty());
                 return Ok(());
             };
             let curr_epoch = max_prev_epoch.next();
             for database in self.databases.values_mut() {
+                let Some(database) = database.running_state_mut() else {
+                    continue;
+                };
                 database.handle_new_barrier(
                     None,
                     checkpoint,
@@ -214,12 +258,16 @@ impl CheckpointControl {
     pub(crate) fn update_barrier_nums_metrics(&self) {
         self.databases
             .values()
+            .flat_map(|database| database.running_state())
             .for_each(|database| database.update_barrier_nums_metrics());
     }
 
     pub(crate) fn gen_ddl_progress(&self) -> HashMap<u32, DdlProgress> {
         let mut progress = HashMap::new();
-        for database_checkpoint_control in self.databases.values() {
+        for status in self.databases.values() {
+            let Some(database_checkpoint_control) = status.running_state() else {
+                continue;
+            };
             // Progress of normal backfill
             progress.extend(
                 database_checkpoint_control
@@ -245,7 +293,16 @@ impl CheckpointControl {
     }
 
     pub(crate) fn is_failed_at_worker_err(&self, worker_id: WorkerId) -> bool {
-        for database_checkpoint_control in self.databases.values() {
+        for database_status in self.databases.values() {
+            let database_checkpoint_control = match database_status {
+                DatabaseCheckpointControlStatus::Running(control) => control,
+                DatabaseCheckpointControlStatus::Recovering(state) => {
+                    if state.remaining_workers().contains(&worker_id) {
+                        return true;
+                    }
+                    continue;
+                }
+            };
             let failed_barrier =
                 database_checkpoint_control.barrier_wait_collect_from_worker(worker_id as _);
             if failed_barrier.is_some()
@@ -265,27 +322,131 @@ impl CheckpointControl {
     }
 
     pub(crate) fn clear_on_err(&mut self, err: &MetaError) {
-        for (_, node) in self
-            .databases
-            .values_mut()
-            .flat_map(|database| take(&mut database.command_ctx_queue))
-        {
+        for (_, node) in self.databases.values_mut().flat_map(|status| {
+            status
+                .running_state_mut()
+                .map(|database| take(&mut database.command_ctx_queue))
+                .into_iter()
+                .flatten()
+        }) {
             for notifier in node.notifiers {
                 notifier.notify_failed(err.clone());
             }
             node.enqueue_time.observe_duration();
         }
-        self.databases
-            .values_mut()
-            .for_each(|database| database.create_mview_tracker.abort_all());
+        self.databases.values_mut().for_each(|database| {
+            if let Some(database) = database.running_state_mut() {
+                database.create_mview_tracker.abort_all()
+            }
+        });
     }
 
     pub(crate) fn subscriptions(
         &self,
     ) -> impl Iterator<Item = (DatabaseId, &InflightSubscriptionInfo)> + '_ {
-        self.databases.iter().map(|(database_id, database)| {
-            (*database_id, &database.state.inflight_subscription_info)
+        self.databases.iter().flat_map(|(database_id, database)| {
+            database
+                .checkpoint_control()
+                .map(|database| (*database_id, &database.state.inflight_subscription_info))
         })
+    }
+}
+
+pub(crate) enum CheckpointControlEvent<'a> {
+    EnteringInitializing(DatabaseStatusAction<'a, EnterInitializing>),
+    EnteringRunning(DatabaseStatusAction<'a, EnterRunning>),
+}
+
+impl CheckpointControl {
+    pub(crate) fn on_reset_database_resp(
+        &mut self,
+        worker_id: WorkerId,
+        resp: ResetDatabaseResponse,
+    ) {
+        let database_id = DatabaseId::new(resp.database_id);
+        match self.databases.get_mut(&database_id).expect("should exist") {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                unreachable!("should not receive reset database resp when running")
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => {
+                state.on_reset_database_resp(worker_id, resp)
+            }
+        }
+    }
+
+    pub(crate) fn next_event(
+        &mut self,
+    ) -> impl Future<Output = CheckpointControlEvent<'_>> + Send + '_ {
+        let mut this = Some(self);
+        poll_fn(move |cx| {
+            let Some(this_mut) = this.as_mut() else {
+                unreachable!("should not be polled after poll ready")
+            };
+            for (&database_id, database_status) in &mut this_mut.databases {
+                match database_status {
+                    DatabaseCheckpointControlStatus::Running(_) => {}
+                    DatabaseCheckpointControlStatus::Recovering(state) => {
+                        let poll_result = state.poll_next_event(cx);
+                        if let Poll::Ready(action) = poll_result {
+                            let this = this.take().expect("checked Some");
+                            return Poll::Ready(match action {
+                                RecoveringStateAction::EnterInitializing(reset_workers) => {
+                                    CheckpointControlEvent::EnteringInitializing(
+                                        this.new_database_status_action(
+                                            database_id,
+                                            EnterInitializing(reset_workers),
+                                        ),
+                                    )
+                                }
+                                RecoveringStateAction::EnterRunning => {
+                                    CheckpointControlEvent::EnteringRunning(
+                                        this.new_database_status_action(database_id, EnterRunning),
+                                    )
+                                }
+                            });
+                        }
+                    }
+                }
+            }
+            Poll::Pending
+        })
+    }
+}
+
+pub(crate) enum DatabaseCheckpointControlStatus {
+    Running(DatabaseCheckpointControl),
+    Recovering(DatabaseRecoveringState),
+}
+
+impl DatabaseCheckpointControlStatus {
+    fn running_state(&self) -> Option<&DatabaseCheckpointControl> {
+        match self {
+            DatabaseCheckpointControlStatus::Running(state) => Some(state),
+            DatabaseCheckpointControlStatus::Recovering(_) => None,
+        }
+    }
+
+    fn running_state_mut(&mut self) -> Option<&mut DatabaseCheckpointControl> {
+        match self {
+            DatabaseCheckpointControlStatus::Running(state) => Some(state),
+            DatabaseCheckpointControlStatus::Recovering(_) => None,
+        }
+    }
+
+    fn checkpoint_control(&self) -> Option<&DatabaseCheckpointControl> {
+        match self {
+            DatabaseCheckpointControlStatus::Running(control) => Some(control),
+            DatabaseCheckpointControlStatus::Recovering(state) => state.checkpoint_control(),
+        }
+    }
+
+    fn expect_running(&mut self, reason: &'static str) -> &mut DatabaseCheckpointControl {
+        match self {
+            DatabaseCheckpointControlStatus::Running(state) => state,
+            DatabaseCheckpointControlStatus::Recovering(_) => {
+                panic!("should be at running: {}", reason)
+            }
+        }
     }
 }
 

--- a/src/meta/src/barrier/checkpoint/mod.rs
+++ b/src/meta/src/barrier/checkpoint/mod.rs
@@ -14,7 +14,8 @@
 
 mod control;
 mod creating_job;
+mod recovery;
 mod state;
 
-pub(super) use control::{CheckpointControl, DatabaseCheckpointControl};
+pub(crate) use control::{CheckpointControl, CheckpointControlEvent, DatabaseCheckpointControl};
 pub(super) use state::BarrierWorkerState;

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -59,7 +59,7 @@ use crate::MetaResult;
 /// `Initializing`
 ///     - on `BarrierComplete`:
 ///         - mark the CN as collected
-///         - when all CNs ahve collected the response: enter Running
+///         - when all CNs have collected the response: enter Running
 ///     - on `ReportDatabaseFailure`
 ///         - increment the previously saved `reset_request_id`, and send `ResetDatabaseRequest` to all CNs
 ///         - enter `Resetting`

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -1,0 +1,434 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::mem::{replace, take};
+use std::task::{Context, Poll};
+
+use futures::FutureExt;
+use risingwave_common::catalog::DatabaseId;
+use risingwave_meta_model::WorkerId;
+use risingwave_pb::stream_service::streaming_control_stream_response::{
+    ReportDatabaseFailureResponse, ResetDatabaseResponse,
+};
+use risingwave_pb::stream_service::BarrierCompleteResponse;
+use thiserror_ext::AsReport;
+use tracing::{info, warn};
+
+use crate::barrier::checkpoint::control::DatabaseCheckpointControlStatus;
+use crate::barrier::checkpoint::{CheckpointControl, DatabaseCheckpointControl};
+use crate::barrier::complete_task::BarrierCompleteOutput;
+use crate::barrier::rpc::ControlStreamManager;
+use crate::barrier::worker::{
+    get_retry_backoff_strategy, RetryBackoffFuture, RetryBackoffStrategy,
+};
+use crate::barrier::DatabaseRuntimeInfoSnapshot;
+use crate::MetaResult;
+
+/// We can treat each database as a state machine of 3 states: `Running`, `Resetting` and `Initializing`.
+/// The state transition can be triggered when receiving 3 variants of response: `ReportDatabaseFailure`, `BarrierComplete`, `DatabaseReset`.
+/// The logic of state transition can be summarized as followed:
+///
+/// `Running`
+///     - on `ReportDatabaseFailure`
+///         - wait for the inflight B`arrierCompletingTask` to finish if there is any, mark the database as blocked in command queue
+///         - send `ResetDatabaseRequest` with `reset_request_id` as 0 to all CNs, and save `reset_request_id` and the set of nodes that need to collect response.
+///         - enter `Resetting` state.
+///     - on `BarrierComplete`: update the `DatabaseCheckpointControl`.
+///     - on `DatabaseReset`: unreachable
+/// `Resetting`
+///     - on `ReportDatabaseFailure` or `BarrierComplete`: ignore
+///     - on `DatabaseReset`:
+///         - if the `reset_request_id` in the response is less than the saved `reset_request_id`, ignore
+///         - otherwise, mark the CN as collected.
+///         - when all CNs have collected the response:
+///             - load the database runtime info from catalog manager and fragment manager
+///             - inject the initial barrier to CNs, save the set of nodes that need to collect response
+///             - enter `Initializing` state
+/// `Initializing`
+///     - on `BarrierComplete`:
+///         - mark the CN as collected
+///         - when all CNs ahve collected the response: enter Running
+///     - on `ReportDatabaseFailure`
+///         - increment the previously saved `reset_request_id`, and send `ResetDatabaseRequest` to all CNs
+///         - enter `Resetting`
+///     - on `DatabaseReset`: unreachable
+enum DatabaseRecoveringStage {
+    Resetting {
+        remaining_workers: HashSet<WorkerId>,
+        reset_workers: HashMap<WorkerId, ResetDatabaseResponse>,
+        reset_request_id: u32,
+        backoff_future: Option<RetryBackoffFuture>,
+    },
+    Initializing {
+        remaining_workers: HashSet<WorkerId>,
+        database: DatabaseCheckpointControl,
+        prev_epoch: u64,
+    },
+}
+
+pub(crate) struct DatabaseRecoveringState {
+    stage: DatabaseRecoveringStage,
+    next_reset_request_id: u32,
+    retry_backoff_strategy: RetryBackoffStrategy,
+}
+
+pub(super) enum RecoveringStateAction {
+    EnterInitializing(HashMap<WorkerId, ResetDatabaseResponse>),
+    EnterRunning,
+}
+
+impl DatabaseRecoveringState {
+    fn next_retry(&mut self) -> (RetryBackoffFuture, u32) {
+        let backoff_future = self
+            .retry_backoff_strategy
+            .next()
+            .expect("should not be empty");
+        let request_id = self.next_reset_request_id;
+        self.next_reset_request_id += 1;
+        (backoff_future, request_id)
+    }
+
+    pub(super) fn barrier_collected(&mut self, resp: BarrierCompleteResponse) {
+        match &mut self.stage {
+            DatabaseRecoveringStage::Resetting { .. } => {
+                // ignore the collected barrier on resetting or backoff
+            }
+            DatabaseRecoveringStage::Initializing {
+                remaining_workers,
+                prev_epoch,
+                ..
+            } => {
+                assert!(remaining_workers.remove(&(resp.worker_id as WorkerId)));
+                assert_eq!(resp.epoch, *prev_epoch);
+            }
+        }
+    }
+
+    pub(super) fn remaining_workers(&self) -> &HashSet<WorkerId> {
+        match &self.stage {
+            DatabaseRecoveringStage::Resetting {
+                remaining_workers, ..
+            }
+            | DatabaseRecoveringStage::Initializing {
+                remaining_workers, ..
+            } => remaining_workers,
+        }
+    }
+
+    pub(super) fn on_reset_database_resp(
+        &mut self,
+        worker_id: WorkerId,
+        resp: ResetDatabaseResponse,
+    ) {
+        match &mut self.stage {
+            DatabaseRecoveringStage::Resetting {
+                remaining_workers,
+                reset_workers,
+                reset_request_id,
+                ..
+            } => {
+                if resp.reset_request_id < *reset_request_id {
+                    info!(
+                        database_id = resp.database_id,
+                        worker_id,
+                        received_request_id = resp.reset_request_id,
+                        ongoing_request_id = reset_request_id,
+                        "ignore stale reset response"
+                    );
+                } else {
+                    assert_eq!(resp.reset_request_id, *reset_request_id);
+                    assert!(remaining_workers.remove(&worker_id));
+                    reset_workers
+                        .try_insert(worker_id, resp)
+                        .expect("non-duplicate");
+                }
+            }
+            DatabaseRecoveringStage::Initializing { .. } => {
+                unreachable!("all reset resp should have been received in Resetting")
+            }
+        }
+    }
+
+    pub(super) fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<RecoveringStateAction> {
+        match &mut self.stage {
+            DatabaseRecoveringStage::Resetting {
+                remaining_workers,
+                reset_workers,
+                backoff_future: backoff_future_option,
+                ..
+            } => {
+                let pass_backoff = if let Some(backoff_future) = backoff_future_option {
+                    if backoff_future.poll_unpin(cx).is_ready() {
+                        *backoff_future_option = None;
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    true
+                };
+                if pass_backoff && remaining_workers.is_empty() {
+                    return Poll::Ready(RecoveringStateAction::EnterInitializing(take(
+                        reset_workers,
+                    )));
+                }
+            }
+            DatabaseRecoveringStage::Initializing {
+                remaining_workers, ..
+            } => {
+                if remaining_workers.is_empty() {
+                    return Poll::Ready(RecoveringStateAction::EnterRunning);
+                }
+            }
+        }
+        Poll::Pending
+    }
+
+    pub(super) fn checkpoint_control(&self) -> Option<&DatabaseCheckpointControl> {
+        match &self.stage {
+            DatabaseRecoveringStage::Resetting { .. } => None,
+            DatabaseRecoveringStage::Initializing { database, .. } => Some(database),
+        }
+    }
+}
+
+pub(crate) struct DatabaseStatusAction<'a, A> {
+    control: &'a mut CheckpointControl,
+    database_id: DatabaseId,
+    pub(crate) action: A,
+}
+
+impl<A> DatabaseStatusAction<'_, A> {
+    pub(crate) fn database_id(&self) -> DatabaseId {
+        self.database_id
+    }
+}
+
+impl CheckpointControl {
+    pub(super) fn new_database_status_action<A>(
+        &mut self,
+        database_id: DatabaseId,
+        action: A,
+    ) -> DatabaseStatusAction<'_, A> {
+        DatabaseStatusAction {
+            control: self,
+            database_id,
+            action,
+        }
+    }
+}
+
+pub(crate) struct EnterReset;
+
+impl DatabaseStatusAction<'_, EnterReset> {
+    pub(crate) fn enter(
+        self,
+        barrier_complete_output: Option<BarrierCompleteOutput>,
+        control_stream_manager: &mut ControlStreamManager,
+    ) {
+        if let Some(output) = barrier_complete_output {
+            self.control.ack_completed(output);
+        }
+        let database_status = self
+            .control
+            .databases
+            .get_mut(&self.database_id)
+            .expect("should exist");
+        match database_status {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                let reset_request_id = 0;
+                let remaining_workers =
+                    control_stream_manager.reset_database(self.database_id, reset_request_id);
+                *database_status =
+                    DatabaseCheckpointControlStatus::Recovering(DatabaseRecoveringState {
+                        stage: DatabaseRecoveringStage::Resetting {
+                            remaining_workers,
+                            reset_workers: Default::default(),
+                            reset_request_id,
+                            backoff_future: None,
+                        },
+                        next_reset_request_id: reset_request_id + 1,
+                        retry_backoff_strategy: get_retry_backoff_strategy(),
+                    });
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => match state.stage {
+                DatabaseRecoveringStage::Resetting { .. } => {
+                    unreachable!("should not enter resetting again")
+                }
+                DatabaseRecoveringStage::Initializing { .. } => {
+                    let (backoff_future, reset_request_id) = state.next_retry();
+                    let remaining_workers =
+                        control_stream_manager.reset_database(self.database_id, reset_request_id);
+                    state.stage = DatabaseRecoveringStage::Resetting {
+                        remaining_workers,
+                        reset_workers: Default::default(),
+                        reset_request_id,
+                        backoff_future: Some(backoff_future),
+                    };
+                }
+            },
+        }
+    }
+}
+
+impl CheckpointControl {
+    pub(crate) fn on_report_failure(
+        &mut self,
+        resp: ReportDatabaseFailureResponse,
+        control_stream_manager: &mut ControlStreamManager,
+    ) -> Option<DatabaseStatusAction<'_, EnterReset>> {
+        let database_id = DatabaseId::new(resp.database_id);
+        let database_status = self.databases.get_mut(&database_id).expect("should exist");
+        match database_status {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                Some(self.new_database_status_action(database_id, EnterReset))
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => match state.stage {
+                DatabaseRecoveringStage::Resetting { .. } => {
+                    // ignore reported failure during resetting or backoff.
+                    None
+                }
+                DatabaseRecoveringStage::Initializing { .. } => {
+                    warn!(database_id = database_id.database_id, "");
+                    let (backoff_future, reset_request_id) = state.next_retry();
+                    let remaining_workers =
+                        control_stream_manager.reset_database(database_id, reset_request_id);
+                    state.stage = DatabaseRecoveringStage::Resetting {
+                        remaining_workers,
+                        reset_workers: Default::default(),
+                        reset_request_id,
+                        backoff_future: Some(backoff_future),
+                    };
+                    None
+                }
+            },
+        }
+    }
+}
+
+pub(crate) struct EnterInitializing(pub(crate) HashMap<WorkerId, ResetDatabaseResponse>);
+
+impl DatabaseStatusAction<'_, EnterInitializing> {
+    pub(crate) fn enter(
+        self,
+        runtime_info: DatabaseRuntimeInfoSnapshot,
+        control_stream_manager: &mut ControlStreamManager,
+    ) {
+        let database_status = self
+            .control
+            .databases
+            .get_mut(&self.database_id)
+            .expect("should exist");
+        let status = match database_status {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                unreachable!("should not enter initializing when running")
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => match state.stage {
+                DatabaseRecoveringStage::Initializing { .. } => {
+                    unreachable!("can only enter initializing when resetting")
+                }
+                DatabaseRecoveringStage::Resetting { .. } => state,
+            },
+        };
+        let DatabaseRuntimeInfoSnapshot {
+            database_fragment_info,
+            mut state_table_committed_epochs,
+            subscription_info,
+            mut stream_actors,
+            mut source_splits,
+            mut background_jobs,
+        } = runtime_info;
+        let result: MetaResult<_> = try {
+            control_stream_manager.add_partial_graph(self.database_id, None)?;
+            control_stream_manager.inject_database_initial_barrier(
+                self.database_id,
+                database_fragment_info,
+                &mut state_table_committed_epochs,
+                &mut stream_actors,
+                &mut source_splits,
+                &mut background_jobs,
+                subscription_info,
+                None,
+                &self.control.hummock_version_stats,
+            )?
+        };
+        match result {
+            Ok((remaining_workers, database, prev_epoch)) => {
+                status.stage = DatabaseRecoveringStage::Initializing {
+                    remaining_workers,
+                    database,
+                    prev_epoch,
+                };
+            }
+            Err(e) => {
+                warn!(database_id = self.database_id.database_id,e = ?e.as_report(), "failed to inject initial barrier");
+                let (backoff_future, reset_request_id) = status.next_retry();
+                let remaining_workers =
+                    control_stream_manager.reset_database(self.database_id, reset_request_id);
+                status.stage = DatabaseRecoveringStage::Resetting {
+                    remaining_workers,
+                    reset_workers: Default::default(),
+                    reset_request_id,
+                    backoff_future: Some(backoff_future),
+                };
+            }
+        }
+    }
+
+    pub(crate) fn remove(self) {
+        self.control
+            .databases
+            .remove(&self.database_id)
+            .expect("should exist");
+    }
+}
+
+pub(crate) struct EnterRunning;
+
+impl DatabaseStatusAction<'_, EnterRunning> {
+    pub(crate) fn enter(self) {
+        let database_status = self
+            .control
+            .databases
+            .get_mut(&self.database_id)
+            .expect("should exist");
+        match database_status {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                unreachable!("should not enter running again")
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => {
+                let temp_place_holder = DatabaseRecoveringStage::Resetting {
+                    remaining_workers: Default::default(),
+                    reset_workers: Default::default(),
+                    reset_request_id: 0,
+                    backoff_future: None,
+                };
+                match replace(&mut state.stage, temp_place_holder) {
+                    DatabaseRecoveringStage::Resetting { .. } => {
+                        unreachable!("can only enter running during initializing")
+                    }
+                    DatabaseRecoveringStage::Initializing {
+                        remaining_workers,
+                        database,
+                        ..
+                    } => {
+                        assert!(remaining_workers.is_empty());
+                        *database_status = DatabaseCheckpointControlStatus::Running(database);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -49,7 +49,9 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
         database_id: Option<DatabaseId>,
         recovery_reason: RecoveryReason,
     ) {
-        self.set_status(BarrierManagerStatus::Recovering(recovery_reason));
+        if database_id.is_none() {
+            self.set_status(BarrierManagerStatus::Recovering(recovery_reason));
+        }
 
         // Mark blocked and abort buffered schedules, they might be dirty already.
         self.scheduled_barriers
@@ -58,7 +60,9 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
 
     fn mark_ready(&self, database_id: Option<DatabaseId>) {
         self.scheduled_barriers.mark_ready(database_id);
-        self.set_status(BarrierManagerStatus::Running);
+        if database_id.is_none() {
+            self.set_status(BarrierManagerStatus::Running);
+        }
     }
 
     async fn post_collect_command<'a>(&'a self, command: &'a CommandContext) -> MetaResult<()> {

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -71,7 +71,6 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
 
     async fn reload_runtime_info(&self) -> MetaResult<BarrierWorkerRuntimeInfoSnapshot>;
 
-    #[expect(dead_code)]
     async fn reload_database_runtime_info(
         &self,
         database_id: DatabaseId,

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -275,7 +275,6 @@ impl GlobalBarrierWorkerContextImpl {
         }
     }
 
-    #[expect(dead_code)]
     pub(super) async fn reload_database_runtime_info_impl(
         &self,
         database_id: DatabaseId,

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -185,7 +185,6 @@ impl BarrierWorkerRuntimeInfoSnapshot {
     }
 }
 
-#[expect(dead_code)]
 #[derive(Debug)]
 struct DatabaseRuntimeInfoSnapshot {
     database_fragment_info: InflightDatabaseInfo,
@@ -197,7 +196,6 @@ struct DatabaseRuntimeInfoSnapshot {
 }
 
 impl DatabaseRuntimeInfoSnapshot {
-    #[expect(dead_code)]
     fn validate(
         &self,
         database_id: DatabaseId,

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -26,7 +26,7 @@ use futures::future::BoxFuture;
 use futures::stream::{BoxStream, FuturesOrdered};
 use futures::{FutureExt, StreamExt, TryFutureExt};
 use itertools::Itertools;
-use risingwave_common::error::tonic::extra::Score;
+use risingwave_common::error::tonic::extra::{Score, ScoredError};
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_service::barrier_complete_response::{
     PbCreateMviewProgress, PbLocalSstableInfo,
@@ -431,6 +431,9 @@ impl LocalBarrierWorker {
                     PartialGraphId::new(req.partial_graph_id),
                 );
                 Ok(())
+            }
+            Request::ResetDatabase(_) => {
+                unimplemented!("should not receive this request yet")
             }
             Request::Init(_) => {
                 unreachable!()
@@ -858,7 +861,7 @@ impl LocalBarrierWorker {
 
         once(first_err)
             .chain(later_errs.into_iter())
-            .map(|e| ScoredStreamError::new(e.clone()))
+            .map(|e| e.with_score())
             .max_by_key(|e| e.score)
             .expect("non-empty")
     }
@@ -979,33 +982,11 @@ impl LocalBarrierManager {
 }
 
 /// A [`StreamError`] with a score, used to find the root cause of actor failures.
-#[derive(Debug, Clone)]
-struct ScoredStreamError {
-    error: StreamError,
-    score: Score,
-}
+type ScoredStreamError = ScoredError<StreamError>;
 
-impl std::fmt::Display for ScoredStreamError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.error.fmt(f)
-    }
-}
-
-impl std::error::Error for ScoredStreamError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.error.source()
-    }
-
-    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
-        self.error.provide(request);
-        // HIGHLIGHT: Provide the score to make it retrievable from meta service.
-        request.provide_value(self.score);
-    }
-}
-
-impl ScoredStreamError {
+impl StreamError {
     /// Score the given error based on hard-coded rules.
-    fn new(error: StreamError) -> Self {
+    fn with_score(self) -> ScoredStreamError {
         // Explicitly list all error kinds here to notice developers to update this function when
         // there are changes in error kinds.
 
@@ -1052,8 +1033,8 @@ impl ScoredStreamError {
             }
         }
 
-        let score = Score(stream_error_score(&error));
-        Self { error, score }
+        let score = Score(stream_error_score(&self));
+        ScoredStreamError { error: self, score }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In this PR, we implement the logic of database failure isolation in meta global barrier manager part. 

We will add a new variant `ReportDatabaseFailureResponse` in `StreamingControlStreamResponse` to report the failure of single database. After receiving such response, instead of triggering a global recovery, we will only recover the streaming job of the failed database, and other databases won't be affected by this failure. Note that, the per-database recovery is only triggered by receiving a `ReportDatabaseFailureResponse` from CN, and when receiving an error from bidi-stream to any compute node will still trigger global recovery. However, in this PR we only implement the logic in the meta global barrier manager, and the CN local barrier manager will not send any `ReportDatabaseFailureResponse` yet. Therefore, the per-database recovery logic will not be triggered in this PR. It will be triggered only after https://github.com/risingwavelabs/risingwave/pull/19579, which implements the logic in CN local barrier manager, is merged.

Previously in `CheckpointControl`, we store the runtime info of each database in `DatabaseCheckpointControl`. In this PR, each database will be stored as `DatabaseCheckpointControlStatus`, which can be either `Running` or `Recovering`.
```
enum DatabaseCheckpointControlStatus {
    Running(DatabaseCheckpointControl),
    Recovering(DatabaseRecoveringState),
}
```

In `Recovery`, it has two stages, `Resetting` and `Initializing`. In the `Resetting` stage, it send `ResetDatabaseRequest` to all CNs, and wait for the `ResetDatabaseResponse` from all CNs. After receiving the `ResetDatabaseResponse` from all CNs, and will enter the `Initializing` stage. By now, we will have ensured that, any information of the reset database will not exist in any CN, and there won't be any inflight message of the database exist in the bidi-stream. In the `Initializing` stage, we will send initial barriers to all CNs to recreate the actors of the database. After we successfully collects the initial barrier from all CNs, the database is recovered and enter the normal `Running`.

We can treat each database as a state machine of 3 states: `Running`, `Resetting` and `Initializing`. The state transition can be triggered when receiving 3 variants of response: `ReportDatabaseFailure`, `BarrierComplete`, `DatabaseReset`. The logic of state transition can be summarized as followed:
- `Running`
  - on `ReportDatabaseFailure`
    - wait for the inflight `BarrierCompletingTask` to finish if there is any, mark the database as blocked in command queue
    - send `ResetDatabaseRequest` with `reset_request_id` as 0 to all CNs, and save `reset_request_id` and the set of nodes that need to collect response.
    - enter `Resetting`  state.
  - on `BarrierComplete`: update the `DatabaseCheckpointControl`.
  - on `DatabaseReset`: unreachable
- `Resetting`
  - on `ReportDatabaseFailure` or `BarrierComplete`: ignore
  - on `DatabaseReset`:
    -  if the `reset_request_id` in the response is less than the saved `reset_request_id`, ignore
    - otherwise, mark the CN as collected. 
    - when all CNs have collected the response:
      - load the database runtime info from catalog manager and fragment manager
      - inject the initial barrier to CNs, save the set of nodes that need to collect response
      - enter `Initializing` state
- `Initializing`
  - on `BarrierComplete`:
    - mark the CN as collected
    - when all CNs ahve collected the response: enter `Running`
  - on `ReportDatabaseFailure`
    - increment the previously saved `reset_request_id`, and send `ResetDatabaseRequest` to all CNs
    - enter `Resetting`
  - on `DatabaseReset`: unreachable

Note that we use the `reset_request_id` to handle the case of stale `ResetDatabaseResponse`, though in current state machine, there should not be stale `ResetDatabaseResponse`, because in `Resetting` state, we either enter `Initializing` when we collect the `ResetDatabaseResponse` from previously sent CNs, or get error and enter global recovery.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
