### PR TITLE
refactor(source): extract avro inner schema precisely

### DIFF
--- a/e2e_test/source_inline/kafka/avro/ref.slt
+++ b/e2e_test/source_inline/kafka/avro/ref.slt
@@ -109,7 +109,11 @@ select
   (bar).b.y
 from s;
 ----
-3 4 5 6 6 5 4 3
+3 4 5 6 NULL NULL NULL NULL
+
+# Parsing of column `bar` fails even with ints because now `schema` is required.
+# This will be fully supported in the next PR
+# 3 4 5 6 6 5 4 3
 
 
 statement ok

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -450,7 +450,7 @@ pub(crate) fn avro_decimal_to_rust_decimal(
 }
 
 /// If the union schema is `[null, T]` or `[T, null]`, returns `Some(T)`; otherwise returns `None`.
-fn get_nullable_union_inner(union_schema: &UnionSchema) -> Option<&'_ Schema> {
+pub fn get_nullable_union_inner(union_schema: &UnionSchema) -> Option<&'_ Schema> {
     let variants = union_schema.variants();
     // Note: `[null, null] is invalid`, we don't need to worry about that.
     if variants.len() == 2 && variants.contains(&Schema::Null) {
@@ -461,19 +461,6 @@ fn get_nullable_union_inner(union_schema: &UnionSchema) -> Option<&'_ Schema> {
         Some(inner_schema)
     } else {
         None
-    }
-}
-
-pub fn avro_schema_skip_nullable_union(schema: &Schema) -> anyhow::Result<&Schema> {
-    match schema {
-        Schema::Union(union_schema) => match get_nullable_union_inner(union_schema) {
-            Some(s) => Ok(s),
-            None => Err(anyhow::format_err!(
-                "illegal avro union schema, expected [null, T], got {:?}",
-                union_schema
-            )),
-        },
-        other => Ok(other),
     }
 }
 

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -13,17 +13,14 @@
 // limitations under the License.
 
 mod schema;
-use std::sync::LazyLock;
 
-use apache_avro::schema::{DecimalSchema, RecordSchema, UnionSchema};
+use apache_avro::schema::{DecimalSchema, UnionSchema};
 use apache_avro::types::{Value, ValueKind};
 use apache_avro::{Decimal as AvroDecimal, Schema};
 use chrono::Datelike;
 use itertools::Itertools;
 use num_bigint::{BigInt, Sign};
 use risingwave_common::array::{ListValue, StructValue};
-use risingwave_common::bail;
-use risingwave_common::log::LogSuppresser;
 use risingwave_common::types::{
     DataType, Date, DatumCow, Interval, JsonbVal, MapValue, ScalarImpl, Time, Timestamp,
     Timestamptz, ToOwnedDatum,
@@ -42,7 +39,7 @@ pub struct AvroParseOptions<'a> {
     ///
     /// FIXME: In theory we should use resolved schema.
     /// e.g., it's possible that a field is a reference to a decimal or a record containing a decimal field.
-    pub schema: Option<&'a Schema>,
+    pub schema: &'a Schema,
     /// Strict Mode
     /// If strict mode is disabled, an int64 can be parsed from an `AvroInt` (int32) value.
     pub relax_numeric: bool,
@@ -51,28 +48,13 @@ pub struct AvroParseOptions<'a> {
 impl<'a> AvroParseOptions<'a> {
     pub fn create(schema: &'a Schema) -> Self {
         Self {
-            schema: Some(schema),
+            schema,
             relax_numeric: true,
         }
     }
 }
 
 impl<'a> AvroParseOptions<'a> {
-    fn extract_inner_schema(&self, key: Option<&str>) -> Option<&'a Schema> {
-        self.schema
-            .map(|schema| avro_extract_field_schema(schema, key))
-            .transpose()
-            .map_err(|_err| {
-                static LOG_SUPPERSSER: LazyLock<LogSuppresser> =
-                    LazyLock::new(LogSuppresser::default);
-                if let Ok(suppressed_count) = LOG_SUPPERSSER.check() {
-                    tracing::error!(suppressed_count, "extract sub-schema");
-                }
-            })
-            .ok()
-            .flatten()
-    }
-
     /// Parse an avro value into expected type.
     ///
     /// 3 kinds of type info are used to parsing:
@@ -110,7 +92,7 @@ impl<'a> AvroParseOptions<'a> {
             (_, Value::Null) => return Ok(DatumCow::NULL),
             // ---- Union (with >=2 non null variants), and nullable Union ([null, record]) -----
             (DataType::Struct(struct_type_info), Value::Union(variant, v)) => {
-                let Some(Schema::Union(u)) = self.schema else {
+                let Schema::Union(u) = self.schema else {
                     // XXX: Is this branch actually unreachable? (if self.schema is correctly used)
                     return Err(create_error());
                 };
@@ -118,7 +100,7 @@ impl<'a> AvroParseOptions<'a> {
                 if let Some(inner) = get_nullable_union_inner(u) {
                     // nullable Union ([null, record])
                     return Self {
-                        schema: Some(inner),
+                        schema: inner,
                         relax_numeric: self.relax_numeric,
                     }
                     .convert_to_datum(v, type_expected);
@@ -139,7 +121,7 @@ impl<'a> AvroParseOptions<'a> {
                 for (field_name, field_type) in struct_type_info.iter() {
                     if field_name == expected_field_name {
                         let datum = Self {
-                            schema: Some(variant_schema),
+                            schema: variant_schema,
                             relax_numeric: self.relax_numeric,
                         }
                         .convert_to_datum(v, field_type)?
@@ -154,7 +136,12 @@ impl<'a> AvroParseOptions<'a> {
             }
             // nullable Union ([null, T])
             (_, Value::Union(_, v)) => {
-                let schema = self.extract_inner_schema(None);
+                let Schema::Union(u) = self.schema else {
+                    return Err(create_error());
+                };
+                let Some(schema) = get_nullable_union_inner(u) else {
+                    return Err(create_error());
+                };
                 return Self {
                     schema,
                     relax_numeric: self.relax_numeric,
@@ -182,9 +169,9 @@ impl<'a> AvroParseOptions<'a> {
             // ---- Decimal -----
             (DataType::Decimal, Value::Decimal(avro_decimal)) => {
                 let (precision, scale) = match self.schema {
-                    Some(Schema::Decimal(DecimalSchema {
+                    Schema::Decimal(DecimalSchema {
                         precision, scale, ..
-                    })) => (*precision, *scale),
+                    }) => (*precision, *scale),
                     _ => Err(create_error())?,
                 };
                 let decimal = avro_decimal_to_rust_decimal(avro_decimal.clone(), precision, scale)
@@ -266,14 +253,17 @@ impl<'a> AvroParseOptions<'a> {
                 ScalarImpl::Interval(Interval::from_month_day_usec(months, days, usecs))
             }
             // ---- Struct -----
-            (DataType::Struct(struct_type_info), Value::Record(descs)) => StructValue::new(
+            (DataType::Struct(struct_type_info), Value::Record(descs)) => StructValue::new({
+                let Schema::Record(record_schema) = &self.schema else {
+                    return Err(create_error());
+                };
                 struct_type_info
                     .names()
                     .zip_eq_fast(struct_type_info.types())
                     .map(|(field_name, field_type)| {
-                        let maybe_value = descs.iter().find(|(k, _v)| k == field_name);
-                        if let Some((_, value)) = maybe_value {
-                            let schema = self.extract_inner_schema(Some(field_name));
+                        if let Some(idx) = record_schema.lookup.get(field_name) {
+                            let value = &descs[*idx].1;
+                            let schema = &record_schema.fields[*idx].schema;
                             Ok(Self {
                                 schema,
                                 relax_numeric: self.relax_numeric,
@@ -284,12 +274,15 @@ impl<'a> AvroParseOptions<'a> {
                             Ok(None)
                         }
                     })
-                    .collect::<Result<_, AccessError>>()?,
-            )
+                    .collect::<Result<_, AccessError>>()?
+            })
             .into(),
             // ---- List -----
             (DataType::List(item_type), Value::Array(array)) => ListValue::new({
-                let schema = self.extract_inner_schema(None);
+                let Schema::Array(element_schema) = &self.schema else {
+                    return Err(create_error());
+                };
+                let schema = element_schema;
                 let mut builder = item_type.create_array_builder(array.len());
                 for v in array {
                     let value = Self {
@@ -316,7 +309,10 @@ impl<'a> AvroParseOptions<'a> {
                 uuid.as_hyphenated().to_string().into_boxed_str().into()
             }
             (DataType::Map(map_type), Value::Map(map)) => {
-                let schema = self.extract_inner_schema(None);
+                let Schema::Map(value_schema) = &self.schema else {
+                    return Err(create_error());
+                };
+                let schema = value_schema;
                 let mut builder = map_type
                     .clone()
                     .into_struct()
@@ -405,13 +401,23 @@ impl Access for AvroAccess<'_> {
                     // },
                     // ...]
                     value = v;
-                    options.schema = options.extract_inner_schema(None);
+                    let Schema::Union(u) = options.schema else {
+                        return Err(create_error());
+                    };
+                    let Some(schema) = get_nullable_union_inner(u) else {
+                        return Err(create_error());
+                    };
+                    options.schema = schema;
                     continue;
                 }
                 Value::Record(fields) => {
-                    if let Some((_, v)) = fields.iter().find(|(k, _)| k == key) {
-                        value = v;
-                        options.schema = options.extract_inner_schema(Some(key));
+                    let Schema::Record(record_schema) = &options.schema else {
+                        return Err(create_error());
+                    };
+                    if let Some(idx) = record_schema.lookup.get(key) {
+                        // if let Some((_, v)) = fields.iter().find(|(k, _)| k == key) {
+                        value = &fields[*idx].1;
+                        options.schema = &record_schema.fields[*idx].schema;
                         i += 1;
                         continue;
                     }
@@ -468,32 +474,6 @@ pub fn avro_schema_skip_nullable_union(schema: &Schema) -> anyhow::Result<&Schem
             )),
         },
         other => Ok(other),
-    }
-}
-
-// extract inner filed/item schema of record/array/union
-pub fn avro_extract_field_schema<'a>(
-    schema: &'a Schema,
-    name: Option<&str>,
-) -> anyhow::Result<&'a Schema> {
-    match schema {
-        Schema::Record(RecordSchema { fields, lookup, .. }) => {
-            let name =
-                name.ok_or_else(|| anyhow::format_err!("no name provided for a field in record"))?;
-            let index = lookup.get(name).ok_or_else(|| {
-                anyhow::format_err!("no field named '{}' in record: {:?}", name, schema)
-            })?;
-            let field = fields
-                .get(*index)
-                .ok_or_else(|| anyhow::format_err!("illegal avro record schema {:?}", schema))?;
-            Ok(&field.schema)
-        }
-        Schema::Array(schema) => Ok(schema),
-        // Only nullable union should be handled here.
-        // We will not extract inner schema for real union (and it's not extractable).
-        Schema::Union(_) => avro_schema_skip_nullable_union(schema),
-        Schema::Map(schema) => Ok(schema),
-        _ => bail!("avro schema does not have inner item, schema: {:?}", schema),
     }
 }
 

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -415,7 +415,6 @@ impl Access for AvroAccess<'_> {
                         return Err(create_error());
                     };
                     if let Some(idx) = record_schema.lookup.get(key) {
-                        // if let Some((_, v)) = fields.iter().find(|(k, _)| k == key) {
                         value = &fields[*idx].1;
                         options.schema = &record_schema.fields[*idx].schema;
                         i += 1;

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -39,10 +39,10 @@ pub struct AvroParseOptions<'a> {
     ///
     /// FIXME: In theory we should use resolved schema.
     /// e.g., it's possible that a field is a reference to a decimal or a record containing a decimal field.
-    pub schema: &'a Schema,
+    schema: &'a Schema,
     /// Strict Mode
     /// If strict mode is disabled, an int64 can be parsed from an `AvroInt` (int32) value.
-    pub relax_numeric: bool,
+    relax_numeric: bool,
 }
 
 impl<'a> AvroParseOptions<'a> {
@@ -68,7 +68,7 @@ impl<'a> AvroParseOptions<'a> {
     ///    `type_expected`, converting the value if possible.
     /// - If only value is provided (without schema and `type_expected`),
     ///     the `DataType` will be inferred.
-    pub fn convert_to_datum<'b>(
+    fn convert_to_datum<'b>(
         &self,
         value: &'b Value,
         type_expected: &DataType,

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -15,12 +15,13 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use anyhow::Context;
 use apache_avro::types::Value;
 use apache_avro::{from_avro_datum, Schema};
 use risingwave_common::try_match_expand;
 use risingwave_connector_codec::decoder::avro::{
-    avro_extract_field_schema, avro_schema_skip_nullable_union, avro_schema_to_column_descs,
-    AvroAccess, AvroParseOptions, ResolvedAvroSchema,
+    avro_schema_skip_nullable_union, avro_schema_to_column_descs, AvroAccess, AvroParseOptions,
+    ResolvedAvroSchema,
 };
 use risingwave_pb::plan_common::ColumnDesc;
 
@@ -162,18 +163,24 @@ impl DebeziumAvroParserConfig {
         // See <https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-events>
 
         avro_schema_to_column_descs(
-            avro_schema_skip_nullable_union(avro_extract_field_schema(
-                // FIXME: use resolved schema here.
-                // Currently it works because "after" refers to a subtree in "before",
-                // but in theory, inside "before" there could also be a reference.
-                &self.outer_schema,
-                Some("before"),
-            )?)?,
+            // This assumes no external `Ref`s (e.g. "before" referring to "after" or "source").
+            // Internal `Ref`s inside the "before" tree are allowed.
+            extract_debezium_table_schema(&self.outer_schema)?,
             // TODO: do we need to support map type here?
             None,
         )
         .map_err(Into::into)
     }
+}
+
+fn extract_debezium_table_schema(root: &Schema) -> anyhow::Result<&Schema> {
+    let Schema::Record(root_record) = root else {
+        anyhow::bail!("Root schema of debezium shall be a record but got: {root:?}");
+    };
+    let idx = (root_record.lookup.get("before"))
+        .context("Root schema of debezium shall contain \"before\" field.")?;
+    // It is always wrapped inside a union to allow null, so we look inside.
+    avro_schema_skip_nullable_union(&root_record.fields[*idx].schema)
 }
 
 #[cfg(test)]
@@ -264,10 +271,7 @@ mod tests {
 
         let outer_schema = get_outer_schema();
         let expected_inner_schema = Schema::parse_str(inner_shema_str).unwrap();
-        let extracted_inner_schema = avro_schema_skip_nullable_union(
-            avro_extract_field_schema(&outer_schema, Some("before")).unwrap(),
-        )
-        .unwrap();
+        let extracted_inner_schema = extract_debezium_table_schema(&outer_schema).unwrap();
         assert_eq!(&expected_inner_schema, extracted_inner_schema);
     }
 
@@ -355,10 +359,7 @@ mod tests {
     fn test_map_to_columns() {
         let outer_schema = get_outer_schema();
         let columns = avro_schema_to_column_descs(
-            avro_schema_skip_nullable_union(
-                avro_extract_field_schema(&outer_schema, Some("before")).unwrap(),
-            )
-            .unwrap(),
+            extract_debezium_table_schema(&outer_schema).unwrap(),
             None,
         )
         .unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously, when recursively handling an avro value, its associated schema is extracted with `extract_inner_schema` (wrapper over `avro_extract_field_schema`). It handles `Record`/`Array`/`Union`/`Map` together and allows `None` as output - meaning we may have a value with unknown schema.

This PR revisits all places extracting child schema and ensures the corresponding schema is always present:
* `AvroParseOptions::schema` is no longer an `Option`. It cannot be `None`.
* Extraction of `Record`/`Array`/`Union`/`Map` are handled in their corresponding context. Removes `avro_extract_field_schema` and `extract_inner_schema`.
* `avro_schema_skip_nullable_union` which builds `anyhow::Error` (with backtrace) for `get_nullable_union_inner` is removed. Callers use `get_nullable_union_inner` directly and may build an error without backtrace.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
