### PR TITLE
feat(snapshot-backfill): introduce state to snapshot backfill

### DIFF
--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -34,7 +34,7 @@ else
   RUNTIME_CLUSTER_PROFILE='ci-backfill-3cn-1fe-with-monitoring'
   MINIO_RATE_LIMIT_CLUSTER_PROFILE='ci-backfill-3cn-1fe-with-monitoring-and-minio-rate-limit'
 fi
-export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
+export RUST_LOG="info,risingwave_stream=info,risingwave_stream::executor::backfill=debug,risingwave_batch=info,risingwave_storage=info,risingwave_meta::barrier=debug" \
 
 run_sql_file() {
   psql -h localhost -p 4566 -d dev -U root -f "$@"
@@ -301,6 +301,11 @@ test_snapshot_backfill() {
 
   TEST_NAME=nexmark_q3 sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/check_data_equal.slt.part' &
   TEST_NAME=nexmark_q7 sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/check_data_equal.slt.part' &
+
+  wait
+
+  TEST_NAME=nexmark_q3 sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/scale.slt' &
+  TEST_NAME=nexmark_q7 sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/scale.slt' &
 
   wait
 

--- a/e2e_test/backfill/snapshot_backfill/scale.slt
+++ b/e2e_test/backfill/snapshot_backfill/scale.slt
@@ -1,0 +1,15 @@
+control substitution on
+
+statement ok
+alter materialized view ${TEST_NAME}_mv set parallelism to 1;
+
+sleep 3s
+
+include ./check_data_equal.slt.part
+
+statement ok
+alter materialized view ${TEST_NAME}_mv set parallelism to 4;
+
+sleep 3s
+
+include ./check_data_equal.slt.part

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -123,6 +123,8 @@ impl StreamTableScan {
 
     /// Build catalog for backfill state
     ///
+    /// When `stream_scan_type` is not `StreamScanType::SnapshotBackfill`:
+    ///
     /// Schema: | vnode | pk ... | `backfill_finished` | `row_count` |
     ///
     /// key:    | vnode |
@@ -153,9 +155,18 @@ impl StreamTableScan {
     /// the corresponding `no_shuffle_backfill`.
     /// However this is not high priority, since we are working on supporting arrangement backfill,
     /// which already has this capability.
+    ///
+    ///
+    /// When `stream_scan_type` is `StreamScanType::SnapshotBackfill`:
+    ///
+    /// Schema: | vnode | `epoch` | `row_count` | `is_epoch_finished` | pk ...
+    ///
+    /// key:    | vnode |
+    /// value:  | `epoch` | `row_count` | `is_epoch_finished` | pk ...
     pub fn build_backfill_state_catalog(
         &self,
         state: &mut BuildFragmentGraphState,
+        stream_scan_type: StreamScanType,
     ) -> TableCatalog {
         let mut catalog_builder = TableCatalogBuilder::default();
         let upstream_schema = &self.core.get_table_columns();
@@ -165,17 +176,46 @@ impl StreamTableScan {
         catalog_builder.add_column(&Field::with_name(VirtualNode::RW_TYPE, "vnode"));
         catalog_builder.add_order_column(0, OrderType::ascending());
 
-        // pk columns
-        for col_order in self.core.primary_key() {
-            let col = &upstream_schema[col_order.column_index];
-            catalog_builder.add_column(&Field::from(col));
+        match stream_scan_type {
+            StreamScanType::Chain
+            | StreamScanType::Rearrange
+            | StreamScanType::Backfill
+            | StreamScanType::UpstreamOnly
+            | StreamScanType::ArrangementBackfill => {
+                // pk columns
+                for col_order in self.core.primary_key() {
+                    let col = &upstream_schema[col_order.column_index];
+                    catalog_builder.add_column(&Field::from(col));
+                }
+
+                // `backfill_finished` column
+                catalog_builder
+                    .add_column(&Field::with_name(DataType::Boolean, "backfill_finished"));
+
+                // `row_count` column
+                catalog_builder.add_column(&Field::with_name(DataType::Int64, "row_count"));
+            }
+            StreamScanType::SnapshotBackfill => {
+                // `epoch` column
+                catalog_builder.add_column(&Field::with_name(DataType::Int64, "epoch"));
+
+                // `row_count` column
+                catalog_builder.add_column(&Field::with_name(DataType::Int64, "row_count"));
+
+                // `is_finished` column
+                catalog_builder
+                    .add_column(&Field::with_name(DataType::Boolean, "is_epoch_finished"));
+
+                // pk columns
+                for col_order in self.core.primary_key() {
+                    let col = &upstream_schema[col_order.column_index];
+                    catalog_builder.add_column(&Field::from(col));
+                }
+            }
+            StreamScanType::Unspecified => {
+                unreachable!()
+            }
         }
-
-        // `backfill_finished` column
-        catalog_builder.add_column(&Field::with_name(DataType::Boolean, "backfill_finished"));
-
-        // `row_count` column
-        catalog_builder.add_column(&Field::with_name(DataType::Int64, "row_count"));
 
         // Reuse the state store pk (vnode) as the vnode as well.
         catalog_builder.set_vnode_col_idx(0);
@@ -285,7 +325,7 @@ impl StreamTableScan {
         };
 
         let catalog = self
-            .build_backfill_state_catalog(state)
+            .build_backfill_state_catalog(state, self.stream_scan_type)
             .to_internal_table_prost();
 
         // For backfill, we first read pk + output_indices from upstream.

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -43,8 +43,9 @@ use risingwave_hummock_sdk::key::{
     TableKey, TableKeyRange,
 };
 use risingwave_hummock_sdk::table_watermark::{VnodeWatermark, WatermarkDirection};
+use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_pb::catalog::Table;
-use risingwave_storage::error::{ErrorKind, StorageError};
+use risingwave_storage::error::{ErrorKind, StorageError, StorageResult};
 use risingwave_storage::hummock::CachePolicy;
 use risingwave_storage::mem_table::MemTableError;
 use risingwave_storage::row_serde::find_columns_by_ids;
@@ -55,6 +56,7 @@ use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 use risingwave_storage::store::{
     InitOptions, LocalStateStore, NewLocalOptions, OpConsistencyLevel, PrefetchOptions,
     ReadLogOptions, ReadOptions, SealCurrentEpochOptions, StateStoreIter, StateStoreIterExt,
+    TryWaitEpochOptions,
 };
 use risingwave_storage::table::merge_sort::merge_sort;
 use risingwave_storage::table::{
@@ -181,6 +183,17 @@ where
     pub async fn init_epoch(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
         self.local_store.init(InitOptions::new(epoch)).await?;
         Ok(())
+    }
+
+    pub async fn try_wait_committed_epoch(&self, prev_epoch: u64) -> StorageResult<()> {
+        self.store
+            .try_wait_epoch(
+                HummockReadEpoch::Committed(prev_epoch),
+                TryWaitEpochOptions {
+                    table_id: self.table_id,
+                },
+            )
+            .await
     }
 
     pub fn state_store(&self) -> &S {

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -35,10 +35,11 @@ use risingwave_storage::StateStore;
 use tokio::select;
 use tokio::sync::mpsc::UnboundedReceiver;
 
+use crate::executor::backfill::snapshot_backfill::state::{BackfillState, EpochBackfillProgress};
 use crate::executor::backfill::snapshot_backfill::vnode_stream::VnodeStream;
 use crate::executor::backfill::utils::{create_builder, mapping_message};
 use crate::executor::monitor::StreamingMetrics;
-use crate::executor::prelude::{try_stream, StreamExt};
+use crate::executor::prelude::{try_stream, StateTable, StreamExt};
 use crate::executor::{
     expect_first_barrier, ActorContextRef, Barrier, BoxedMessageStream, DispatcherBarrier,
     DispatcherMessage, Execute, MergeExecutorInput, Message, StreamExecutorError,
@@ -49,6 +50,9 @@ use crate::task::CreateMviewProgressReporter;
 pub struct SnapshotBackfillExecutor<S: StateStore> {
     /// Upstream table
     upstream_table: StorageTable<S>,
+
+    /// Backfill progress table
+    progress_state_table: StateTable<S>,
 
     /// Upstream with the same schema with the upstream table.
     upstream: MergeExecutorInput,
@@ -73,6 +77,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         upstream_table: StorageTable<S>,
+        progress_state_table: StateTable<S>,
         upstream: MergeExecutorInput,
         output_indices: Vec<usize>,
         actor_ctx: ActorContextRef,
@@ -84,6 +89,14 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
         snapshot_epoch: Option<u64>,
     ) -> Self {
         assert_eq!(&upstream.info.schema, upstream_table.schema());
+        if upstream_table.pk_in_output_indices().is_none() {
+            panic!(
+                "storage table should include all pk columns in output: pk_indices: {:?}, output_indices: {:?}, schema: {:?}",
+                upstream_table.pk_indices(),
+                upstream_table.output_indices(),
+                upstream_table.schema()
+            )
+        };
         if !matches!(rate_limit, RateLimit::Disabled) {
             debug!(
                 ?rate_limit,
@@ -92,6 +105,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
         }
         Self {
             upstream_table,
+            progress_state_table,
             upstream,
             output_indices,
             progress,
@@ -133,9 +147,18 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
         };
         let first_recv_barrier_epoch = first_recv_barrier.epoch;
         yield Message::Barrier(first_recv_barrier);
+        let mut backfill_state = BackfillState::new(
+            self.progress_state_table,
+            first_recv_barrier_epoch,
+            self.upstream_table.pk_serializer().clone(),
+        )
+        .await?;
 
         let (mut barrier_epoch, mut need_report_finish) = {
             if should_backfill {
+                assert!(backfill_state
+                    .latest_progress()
+                    .all(|(_, progress)| progress.is_none()));
                 let table_id_str = format!("{}", self.upstream_table.table_id().table_id);
                 let actor_id_str = format!("{}", self.actor_ctx.id);
 
@@ -167,6 +190,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                             self.rate_limit,
                             &mut self.barrier_rx,
                             &mut self.progress,
+                            &mut backfill_state,
                             first_recv_barrier_epoch,
                         );
 
@@ -185,6 +209,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
 
                     let recv_barrier = self.barrier_rx.recv().await.expect("should exist");
                     assert_eq!(first_upstream_barrier.epoch, recv_barrier.epoch);
+                    backfill_state.commit(recv_barrier.epoch).await?;
                     yield Message::Barrier(recv_barrier);
                 }
 
@@ -222,7 +247,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                         // use `upstream_buffer.run_future` to poll upstream concurrently so that we won't have back-pressure
                         // on the upstream. Otherwise, in `batch_iter_log_with_pk_bounds`, we may wait upstream epoch to be committed,
                         // and the back-pressure may cause the upstream unable to consume the barrier and then cause deadlock.
-                        let stream = upstream_buffer
+                        let mut stream = upstream_buffer
                             .run_future(make_log_stream(
                                 &self.upstream_table,
                                 barrier_epoch.prev,
@@ -230,7 +255,6 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                                 self.chunk_size,
                             ))
                             .await?;
-                        pin_mut!(stream);
                         while let Some(chunk) =
                             upstream_buffer.run_future(stream.try_next()).await?
                         {
@@ -249,6 +273,14 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                             barrier.epoch,
                             upstream_buffer.barrier_count(),
                         );
+
+                        stream
+                            .for_vnode_pk_progress(|vnode, row_count, progress| {
+                                assert_eq!(progress, None);
+                                backfill_state.finish_epoch(vnode, barrier.epoch.prev, row_count);
+                            })
+                            .await?;
+                        backfill_state.commit(barrier.epoch).await?;
                         let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.actor_ctx.id);
                         yield Message::Barrier(barrier);
                         if update_vnode_bitmap.is_some() {
@@ -266,6 +298,22 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                 );
                 (barrier_epoch, true)
             } else {
+                backfill_state
+                    .latest_progress()
+                    .for_each(|(vnode, progress)| {
+                        let progress = progress.expect("should not be empty");
+                        assert_eq!(
+                            progress.epoch, first_upstream_barrier.epoch.prev,
+                            "vnode: {:?}",
+                            vnode
+                        );
+                        assert_eq!(
+                            progress.progress,
+                            EpochBackfillProgress::Consumed,
+                            "vnode: {:?}",
+                            vnode
+                        );
+                    });
                 info!(
                     table_id = self.upstream_table.table_id().table_id,
                     "skip backfill"
@@ -275,25 +323,58 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
             }
         };
         let mut upstream = self.upstream.into_executor(self.barrier_rx).execute();
+        let mut epoch_row_count = 0;
         // Phase 3: consume upstream
         while let Some(msg) = upstream.try_next().await? {
             match msg {
                 Message::Barrier(barrier) => {
                     assert_eq!(barrier.epoch.prev, barrier_epoch.curr);
+                    self.upstream_table
+                        .vnodes()
+                        .iter_vnodes()
+                        .for_each(|vnode| {
+                            // Note: the `epoch_row_count` is the accumulated row count of all vnodes of the current
+                            // executor.
+                            backfill_state.finish_epoch(vnode, barrier.epoch.prev, epoch_row_count);
+                        });
+                    epoch_row_count = 0;
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.actor_ctx.id);
                     barrier_epoch = barrier.epoch;
                     if need_report_finish {
                         need_report_finish = false;
                         self.progress.finish_consuming_log_store(barrier_epoch);
                     }
+                    backfill_state.commit(barrier.epoch).await?;
                     yield Message::Barrier(barrier);
                     if let Some(new_vnode_bitmap) = update_vnode_bitmap {
                         let _prev_vnode_bitmap = self
                             .upstream_table
                             .update_vnode_bitmap(new_vnode_bitmap.clone());
+                        backfill_state
+                            .update_vnode_bitmap(new_vnode_bitmap, barrier_epoch)
+                            .await?;
+                        backfill_state
+                            .latest_progress()
+                            .for_each(|(vnode, progress)| {
+                                let progress = progress.expect("should not be empty");
+                                assert_eq!(
+                                    progress.epoch, barrier_epoch.prev,
+                                    "vnode {:?} has unexpected progress epoch",
+                                    vnode
+                                );
+                                assert_eq!(
+                                    progress.progress,
+                                    EpochBackfillProgress::Consumed,
+                                    "vnode {:?} has unexpected progress",
+                                    vnode
+                                );
+                            });
                     }
                 }
                 msg => {
+                    if let Message::Chunk(chunk) = &msg {
+                        epoch_row_count += chunk.cardinality();
+                    }
                     yield msg;
                 }
             }
@@ -507,7 +588,11 @@ async fn make_log_stream(
     }))
     .await?;
     let builder = create_builder(RateLimit::Disabled, chunk_size, data_types.clone());
-    Ok(VnodeStream::new(vnode_streams, builder))
+    Ok(VnodeStream::new(
+        vnode_streams,
+        upstream_table.pk_in_output_indices().expect("should exist"),
+        builder,
+    ))
 }
 
 async fn make_snapshot_stream(
@@ -534,9 +619,14 @@ async fn make_snapshot_stream(
     }))
     .await?;
     let builder = create_builder(rate_limit, chunk_size, data_types.clone());
-    Ok(VnodeStream::new(vnode_streams, builder))
+    Ok(VnodeStream::new(
+        vnode_streams,
+        upstream_table.pk_in_output_indices().expect("should exist"),
+        builder,
+    ))
 }
 
+#[expect(clippy::too_many_arguments)]
 #[try_stream(ok = Message, error = StreamExecutorError)]
 async fn make_consume_snapshot_stream<'a, S: StateStore>(
     upstream_table: &'a StorageTable<S>,
@@ -545,6 +635,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
     rate_limit: RateLimit,
     barrier_rx: &'a mut UnboundedReceiver<Barrier>,
     progress: &'a mut CreateMviewProgressReporter,
+    backfill_state: &'a mut BackfillState<S>,
     first_recv_barrier_epoch: EpochPair,
 ) {
     let mut barrier_epoch = first_recv_barrier_epoch;
@@ -591,6 +682,26 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                 if barrier_epoch.curr >= snapshot_epoch {
                     return Err(anyhow!("should not receive barrier with epoch {barrier_epoch:?} later than snapshot epoch {snapshot_epoch}").into());
                 }
+                if let Some(chunk) = snapshot_stream.consume_builder() {
+                    count += chunk.cardinality();
+                    epoch_row_count += chunk.cardinality();
+                    yield Message::Chunk(chunk);
+                }
+                snapshot_stream
+                    .for_vnode_pk_progress(|vnode, row_count, pk_progress| {
+                        if let Some(pk) = pk_progress {
+                            backfill_state.update_epoch_progress(
+                                vnode,
+                                snapshot_epoch,
+                                row_count,
+                                pk,
+                            );
+                        } else {
+                            backfill_state.finish_epoch(vnode, snapshot_epoch, row_count);
+                        }
+                    })
+                    .await?;
+                backfill_state.commit(barrier.epoch).await?;
                 debug!(?barrier_epoch, count, epoch_row_count, "update progress");
                 progress.update(barrier_epoch, barrier_epoch.prev, count as _);
                 epoch_row_count = 0;
@@ -613,6 +724,13 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
     assert_eq!(barrier_to_report_finish.epoch.prev, barrier_epoch.curr);
     barrier_epoch = barrier_to_report_finish.epoch;
     info!(?barrier_epoch, count, "report finish");
+    snapshot_stream
+        .for_vnode_pk_progress(|vnode, row_count, pk_progress| {
+            assert_eq!(pk_progress, None);
+            backfill_state.finish_epoch(vnode, snapshot_epoch, row_count);
+        })
+        .await?;
+    backfill_state.commit(barrier_epoch).await?;
     progress.finish(barrier_epoch, count as _);
     yield Message::Barrier(barrier_to_report_finish);
 
@@ -621,6 +739,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
         let barrier = receive_next_barrier(barrier_rx).await?;
         assert_eq!(barrier.epoch.prev, barrier_epoch.curr);
         barrier_epoch = barrier.epoch;
+        backfill_state.commit(barrier.epoch).await?;
         yield Message::Barrier(barrier);
         if barrier_epoch.curr == snapshot_epoch {
             break;

--- a/src/stream/src/executor/backfill/snapshot_backfill/mod.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod executor;
+mod state;
 mod vnode_stream;
 
 pub use executor::SnapshotBackfillExecutor;

--- a/src/stream/src/executor/backfill/snapshot_backfill/state.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/state.rs
@@ -1,0 +1,399 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::mem::replace;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use futures::future::try_join_all;
+use futures::TryFutureExt;
+use risingwave_common::bitmap::Bitmap;
+use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
+use risingwave_common::must_match;
+use risingwave_common::row::{OwnedRow, Row, RowExt};
+use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::row_serde::OrderedRowSerde;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum EpochBackfillProgress {
+    Consuming { latest_pk: OwnedRow },
+    Consumed,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct VnodeBackfillProgress {
+    pub(super) epoch: u64,
+    pub(super) row_count: usize,
+    pub(super) progress: EpochBackfillProgress,
+}
+
+/// `vnode`, `epoch`, `row_count`, `is_finished`
+const EXTRA_COLUMN_TYPES: [DataType; 4] = [
+    DataType::Int16,
+    DataType::Int64,
+    DataType::Int64,
+    DataType::Boolean,
+];
+
+impl VnodeBackfillProgress {
+    fn validate_progress_table_schema(
+        progress_table_column_types: &[DataType],
+        upstream_pk_column_types: &[DataType],
+    ) -> StreamExecutorResult<()> {
+        if progress_table_column_types.len()
+            != EXTRA_COLUMN_TYPES.len() + upstream_pk_column_types.len()
+        {
+            return Err(anyhow!(
+                "progress table columns len not matched with the len derived from upstream table pk. progress table: {:?}, pk: {:?}",
+                progress_table_column_types,
+                upstream_pk_column_types)
+                .into()
+            );
+        }
+        for (expected_type, progress_table_type) in EXTRA_COLUMN_TYPES
+            .iter()
+            .chain(upstream_pk_column_types.iter())
+            .zip_eq_debug(progress_table_column_types.iter())
+        {
+            if expected_type != progress_table_type {
+                return Err(anyhow!(
+                    "progress table column not matched with upstream table schema: progress table: {:?}, pk: {:?}",
+                    progress_table_column_types,
+                    upstream_pk_column_types)
+                    .into()
+                );
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn from_row(row: &OwnedRow, pk_serde: &OrderedRowSerde) -> Self {
+        assert_eq!(
+            row.len(),
+            pk_serde.get_data_types().len() + EXTRA_COLUMN_TYPES.len() - 1, /* Pk of the progress state table (i.e. vnode column) not included */
+        );
+        let epoch = must_match!(&row[0], Some(ScalarImpl::Int64(epoch)) => {
+           *epoch as u64
+        });
+        let row_count = must_match!(&row[1], Some(ScalarImpl::Int64(row_count)) => {
+           *row_count as usize
+        });
+        let is_finished = must_match!(&row[2], Some(ScalarImpl::Bool(is_finished)) => {
+           *is_finished
+        });
+        Self {
+            epoch,
+            row_count,
+            progress: if !is_finished {
+                EpochBackfillProgress::Consuming {
+                    latest_pk: row.slice(EXTRA_COLUMN_TYPES.len()..).to_owned_row(),
+                }
+            } else {
+                row.slice(EXTRA_COLUMN_TYPES.len()..)
+                    .iter()
+                    .enumerate()
+                    .for_each(|(i, datum)| {
+                        if datum.is_some() {
+                            if cfg!(debug_assertions) {
+                                panic!("get non-empty pk row: {:?}", row);
+                            } else {
+                                warn!(
+                                    i,
+                                    row = ?row,
+                                    "get non-empty pk row. will be ignore"
+                                );
+                            }
+                        }
+                    });
+                EpochBackfillProgress::Consumed
+            },
+        }
+    }
+
+    fn build_row<'a>(
+        &'a self,
+        vnode: VirtualNode,
+        consumed_pk_rows: &'a OwnedRow,
+    ) -> impl Row + 'a {
+        let (is_finished, pk) = match &self.progress {
+            EpochBackfillProgress::Consuming { latest_pk } => {
+                assert_eq!(latest_pk.len(), consumed_pk_rows.len());
+                (false, latest_pk)
+            }
+            EpochBackfillProgress::Consumed => (true, consumed_pk_rows),
+        };
+        [
+            Some(ScalarImpl::Int16(vnode.to_scalar())),
+            Some(ScalarImpl::Int64(self.epoch as _)),
+            Some(ScalarImpl::Int64(self.row_count as _)),
+            Some(ScalarImpl::Bool(is_finished)),
+        ]
+        .chain(pk)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum VnodeBackfillState {
+    New(VnodeBackfillProgress),
+    Update {
+        latest: VnodeBackfillProgress,
+        committed: VnodeBackfillProgress,
+    },
+    Committed(VnodeBackfillProgress),
+}
+
+impl VnodeBackfillState {
+    fn update_inner(&mut self, latest_progress: VnodeBackfillProgress) {
+        let temp_place_holder = Self::temp_placeholder();
+        let prev_state = replace(self, temp_place_holder);
+        *self = match prev_state {
+            VnodeBackfillState::New(_) => VnodeBackfillState::New(latest_progress),
+            VnodeBackfillState::Update { committed, .. } => VnodeBackfillState::Update {
+                latest: latest_progress,
+                committed,
+            },
+            VnodeBackfillState::Committed(committed) => VnodeBackfillState::Update {
+                latest: latest_progress,
+                committed,
+            },
+        };
+    }
+
+    fn mark_committed(&mut self) {
+        *self = VnodeBackfillState::Committed(match replace(self, Self::temp_placeholder()) {
+            VnodeBackfillState::New(progress) => progress,
+            VnodeBackfillState::Update { latest, .. } => latest,
+            VnodeBackfillState::Committed(progress) => progress,
+        });
+    }
+
+    fn latest_progress(&self) -> &VnodeBackfillProgress {
+        match self {
+            VnodeBackfillState::New(progress) => progress,
+            VnodeBackfillState::Update { latest, .. } => latest,
+            VnodeBackfillState::Committed(progress) => progress,
+        }
+    }
+
+    fn temp_placeholder() -> Self {
+        Self::New(VnodeBackfillProgress {
+            epoch: 0,
+            row_count: 0,
+            progress: EpochBackfillProgress::Consumed,
+        })
+    }
+}
+
+use risingwave_common::util::epoch::EpochPair;
+use risingwave_common::util::iter_util::ZipEqDebug;
+use risingwave_storage::StateStore;
+
+use crate::executor::prelude::StateTable;
+use crate::executor::StreamExecutorResult;
+
+pub(super) struct BackfillState<S: StateStore> {
+    vnode_state: HashMap<VirtualNode, VnodeBackfillState>,
+    pk_serde: OrderedRowSerde,
+    consumed_pk_rows: OwnedRow,
+    state_table: StateTable<S>,
+}
+
+impl<S: StateStore> BackfillState<S> {
+    pub(super) async fn new(
+        mut state_table: StateTable<S>,
+        init_epoch: EpochPair,
+        pk_serde: OrderedRowSerde,
+    ) -> StreamExecutorResult<Self> {
+        VnodeBackfillProgress::validate_progress_table_schema(
+            state_table.get_data_types(),
+            pk_serde.get_data_types(),
+        )?;
+        state_table.init_epoch(init_epoch).await?;
+        let mut vnode_state = HashMap::new();
+        let committed_progress_row = Self::load_vnode_progress_row(&state_table).await?;
+        for (vnode, progress_row) in committed_progress_row {
+            let Some(progress_row) = progress_row else {
+                continue;
+            };
+            let progress = VnodeBackfillProgress::from_row(&progress_row, &pk_serde);
+            assert!(vnode_state
+                .insert(vnode, VnodeBackfillState::Committed(progress))
+                .is_none());
+        }
+        let consumed_pk_rows = OwnedRow::new(vec![None; pk_serde.get_data_types().len()]);
+        Ok(Self {
+            vnode_state,
+            pk_serde,
+            consumed_pk_rows,
+            state_table,
+        })
+    }
+
+    async fn load_vnode_progress_row(
+        state_table: &StateTable<S>,
+    ) -> StreamExecutorResult<Vec<(VirtualNode, Option<OwnedRow>)>> {
+        let rows = try_join_all(state_table.vnodes().iter_vnodes().map(|vnode| {
+            state_table
+                .get_row([vnode.to_datum()])
+                .map_ok(move |progress_row| (vnode, progress_row))
+        }))
+        .await?;
+        Ok(rows)
+    }
+
+    fn update_progress(&mut self, vnode: VirtualNode, progress: VnodeBackfillProgress) {
+        match self.vnode_state.entry(vnode) {
+            Entry::Occupied(entry) => {
+                let state = entry.into_mut();
+                let prev_progress = state.latest_progress();
+                if prev_progress == &progress {
+                    // ignore if no update
+                    return;
+                }
+                // sanity check
+                {
+                    match &prev_progress.progress {
+                        EpochBackfillProgress::Consuming { latest_pk: prev_pk } => {
+                            assert_eq!(prev_progress.epoch, progress.epoch);
+                            if let EpochBackfillProgress::Consuming { latest_pk: pk } =
+                                &progress.progress
+                            {
+                                assert_eq!(pk.len(), self.pk_serde.get_data_types().len());
+                                assert!(prev_progress.row_count <= progress.row_count);
+                                if cfg!(debug_assertions) {
+                                    let mut prev_buf = vec![];
+                                    self.pk_serde.serialize(prev_pk, &mut prev_buf);
+                                    let mut buf = vec![];
+                                    self.pk_serde.serialize(pk, &mut buf);
+                                    assert!(
+                                        buf > prev_buf,
+                                        "new pk progress: {:?} not exceed prev pk progress: {:?}",
+                                        pk,
+                                        prev_pk
+                                    );
+                                }
+                            }
+                        }
+                        EpochBackfillProgress::Consumed => {
+                            assert!(
+                                prev_progress.epoch < progress.epoch,
+                                "{:?} {:?}",
+                                prev_progress,
+                                progress
+                            );
+                        }
+                    }
+                }
+                state.update_inner(progress);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(VnodeBackfillState::New(progress));
+            }
+        }
+    }
+
+    pub(super) fn update_epoch_progress(
+        &mut self,
+        vnode: VirtualNode,
+        epoch: u64,
+        row_count: usize,
+        pk: OwnedRow,
+    ) {
+        self.update_progress(
+            vnode,
+            VnodeBackfillProgress {
+                epoch,
+                row_count,
+                progress: EpochBackfillProgress::Consuming { latest_pk: pk },
+            },
+        )
+    }
+
+    pub(super) fn finish_epoch(&mut self, vnode: VirtualNode, epoch: u64, row_count: usize) {
+        self.update_progress(
+            vnode,
+            VnodeBackfillProgress {
+                epoch,
+                row_count,
+                progress: EpochBackfillProgress::Consumed,
+            },
+        );
+    }
+
+    pub(super) fn latest_progress(
+        &self,
+    ) -> impl Iterator<Item = (VirtualNode, Option<&VnodeBackfillProgress>)> {
+        self.state_table.vnodes().iter_vnodes().map(|vnode| {
+            (
+                vnode,
+                self.vnode_state
+                    .get(&vnode)
+                    .map(VnodeBackfillState::latest_progress),
+            )
+        })
+    }
+
+    pub(super) async fn commit(&mut self, barrier_epoch: EpochPair) -> StreamExecutorResult<()> {
+        for (vnode, state) in &self.vnode_state {
+            match state {
+                VnodeBackfillState::New(progress) => {
+                    self.state_table
+                        .insert(progress.build_row(*vnode, &self.consumed_pk_rows));
+                }
+                VnodeBackfillState::Update { latest, committed } => {
+                    self.state_table.update(
+                        committed.build_row(*vnode, &self.consumed_pk_rows),
+                        latest.build_row(*vnode, &self.consumed_pk_rows),
+                    );
+                }
+                VnodeBackfillState::Committed(_) => {}
+            }
+        }
+        self.state_table.commit(barrier_epoch).await?;
+        self.vnode_state
+            .values_mut()
+            .for_each(VnodeBackfillState::mark_committed);
+        Ok(())
+    }
+
+    pub(super) async fn update_vnode_bitmap(
+        &mut self,
+        new_vnode_bitmap: Arc<Bitmap>,
+        barrier_epoch: EpochPair,
+    ) -> StreamExecutorResult<()> {
+        self.state_table
+            .try_wait_committed_epoch(barrier_epoch.prev)
+            .await?;
+        let (prev_vnode_bitmap, _) = self.state_table.update_vnode_bitmap(new_vnode_bitmap);
+        let committed_progress_rows = Self::load_vnode_progress_row(&self.state_table).await?;
+        let mut new_state = HashMap::new();
+        for (vnode, progress_row) in committed_progress_rows {
+            if let Some(progress_row) = progress_row {
+                let progress = VnodeBackfillProgress::from_row(&progress_row, &self.pk_serde);
+                assert!(new_state
+                    .insert(vnode, VnodeBackfillState::Committed(progress))
+                    .is_none());
+            }
+
+            if prev_vnode_bitmap.is_set(vnode.to_index()) {
+                // if the vnode exist previously, the new state should be the same as the previous one
+                assert_eq!(self.vnode_state.get(&vnode), new_state.get(&vnode));
+            }
+        }
+        self.vnode_state = new_state;
+        Ok(())
+    }
+}

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -47,6 +47,7 @@ use tokio::task::JoinHandle;
 use tonic::Status;
 
 use super::{unique_executor_id, unique_operator_id};
+use crate::common::table::state_table::StateTable;
 use crate::error::StreamResult;
 use crate::executor::exchange::permit::Receiver;
 use crate::executor::monitor::StreamingMetrics;
@@ -354,7 +355,7 @@ impl StreamActorManager {
     }
 
     #[expect(clippy::too_many_arguments)]
-    fn create_snapshot_backfill_node(
+    async fn create_snapshot_backfill_node(
         &self,
         stream_node: &StreamNode,
         node: &StreamScanNode,
@@ -394,10 +395,15 @@ impl StreamActorManager {
         let barrier_rx = local_barrier_manager.subscribe_barrier(actor_context.id);
 
         let upstream_table =
-            StorageTable::new_partial(state_store.clone(), column_ids, vnodes, table_desc);
+            StorageTable::new_partial(state_store.clone(), column_ids, vnodes.clone(), table_desc);
+
+        let state_table = node.get_state_table()?;
+        let state_table =
+            StateTable::from_table_catalog(state_table, state_store.clone(), vnodes).await;
 
         let executor = SnapshotBackfillExecutor::new(
             upstream_table,
+            state_table,
             upstream,
             output_indices,
             actor_context.clone(),
@@ -458,6 +464,7 @@ impl StreamActorManager {
                     local_barrier_manager,
                     store,
                 )
+                .await
             });
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In this PR, we will introduce state to track the progress of snapshot backfill. The progress state table will have the following schema
```
| vnode | `epoch` | `row_count` | `is_epoch_finished` | pk ...
```

* The pk of the state is `vnode`, which means we track the snapshot backfill progress in per-vnode way. 
* `epoch` is the epoch that the `vnode` is currently consuming on. We can assume that `epoch >= snapshot_epoch`. When `epoch == snapshot_epoch`, the `vnode` will be consuming the snapshot, and when `epoch > snapshot_epoch`, the `vnode` will be consuming the change log on `epoch`.
* `row_count` is the number of rows that we have consumed in this epoch. The `row_count` is measured in per-vnode manner.
* `is_epoch_finished` means whether the vnode has finished consuming the `epoch`.
* `pk...` is the current progress of consuming the epoch. When the fields only make sense when `is_epoch_finished` is `false`. Note that the `pk...` is the `pk` of the first unconsumed row, rather than the `pk` of the last consumed row, which is different to the one in arrangement backfill.

With the `VnodeStream` implemented in https://github.com/risingwavelabs/risingwave/pull/19936, we can get the current progress of each vnode before the stream is finished. When barrier is received, we can first drain the buffer, and then use `Peekable::peek` to get the first unconsumed row, and then save the `pk` to the backfill progress state.

In this PR, we only write the progress state, and only read the state for sanity check. In future PR, we will read the progress state to support recoverable snapshot backfill.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
