### PR TITLE
fix(file source): fix message offset of opendal source

### DIFF
--- a/src/connector/src/source/filesystem/opendal_source/opendal_reader.rs
+++ b/src/connector/src/source/filesystem/opendal_source/opendal_reader.rs
@@ -182,10 +182,16 @@ impl<Src: OpendalSource> OpendalReader<Src> {
             // note that the buffer contains the newline character
             debug_assert_eq!(n_read, line_buf.len());
 
+            // FIXME(rc): Here we have to use `offset + n_read`, i.e. the offset of the next line,
+            // as the *message offset*, because we check whether a file is finished by comparing the
+            // message offset with the file size in `FsFetchExecutor::into_stream`. However, we must
+            // understand that this message offset is not semantically consistent with the offset of
+            // other source connectors.
+            let msg_offset = (offset + n_read).to_string();
             batch.push(SourceMessage {
                 key: None,
                 payload: Some(std::mem::take(&mut line_buf).into_bytes()),
-                offset: offset.to_string(),
+                offset: msg_offset,
                 split_id: split.id(),
                 meta: SourceMeta::Empty,
             });

--- a/src/stream/src/executor/source/fetch_executor.rs
+++ b/src/stream/src/executor/source/fetch_executor.rs
@@ -386,6 +386,11 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                     }
                                     _ => unreachable!(),
                                 };
+                                // FIXME(rc): Here we compare `offset` with `fs_split.size` to determine
+                                // whether the file is finished, where the `offset` is the starting position
+                                // of the NEXT message line in the file. However, In other source connectors,
+                                // we use the word `offset` to represent the offset of the current message.
+                                // We have to be careful about this semantical inconsistency.
                                 if offset.parse::<usize>().unwrap() >= fs_split.size {
                                     splits_on_fetch -= 1;
                                     state_store_handler.delete(split_id).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

#19654 changed the `OpendalReader::stream_read_object` to yield lines instead of byte buffers, but there's a accidental change of the semantics of the `SourceMessage::offset` for file source, which caused main-cron to [fail](https://buildkite.com/risingwavelabs/main-cron/builds/4047#0193a700-f6c8-4059-b6b1-d272a0ce4e82).

The change is that, previously, when `OpendalReader::stream_read_object` yield `SourceMessage`s of byte buffers, the `offset` is the STARTIG position of the BYTES, and after `split_stream` which splits these bytes by new-line, the new `offset` will be set to the ENDING position of each LINE, which is also the STARTING position of the NEXT LINE. #19654 changed the reader, and the offset is changed to always representing the STARTING position of each LINE, hence causing the error.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
