### PR TITLE
refactor(batch): simplify batch executor builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10496,6 +10496,7 @@ dependencies = [
  "hytra",
  "iceberg",
  "itertools 0.13.0",
+ "linkme",
  "madsim-tokio",
  "madsim-tonic",
  "memcomparable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10496,7 +10496,6 @@ dependencies = [
  "hytra",
  "iceberg",
  "itertools 0.13.0",
- "linkme",
  "madsim-tokio",
  "madsim-tonic",
  "memcomparable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ clap = { version = "4", features = ["cargo", "derive", "env"] }
 deltalake = { version = "0.20.1", features = ["s3", "gcs", "datafusion"] }
 itertools = "0.13.0"
 jsonbb = "0.1.4"
+linkme = { version = "0.3", features = ["used_linker"] }
 lru = { git = "https://github.com/risingwavelabs/lru-rs.git", rev = "2682b85" }
 parquet = { version = "53.2", features = ["async"] }
 mysql_async = { version = "0.34", default-features = false, features = [

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -29,7 +29,6 @@ hashbrown = { workspace = true }
 hytra = "0.1.2"
 iceberg = { workspace = true }
 itertools = { workspace = true }
-linkme = { workspace = true }
 memcomparable = "0.2"
 mysql_async = { workspace = true }
 opendal = { workspace = true }

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -29,6 +29,7 @@ hashbrown = { workspace = true }
 hytra = "0.1.2"
 iceberg = { workspace = true }
 itertools = { workspace = true }
+linkme = { workspace = true }
 memcomparable = "0.2"
 mysql_async = { workspace = true }
 opendal = { workspace = true }

--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -31,7 +31,7 @@ pub struct LocalExchangeSource {
 impl LocalExchangeSource {
     pub fn create(
         output_id: TaskOutputId,
-        context: impl BatchTaskContext,
+        context: &dyn BatchTaskContext,
         task_id: TaskId,
     ) -> Result<Self> {
         let task_output = context.get_task_output(output_id)?;

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -28,7 +28,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// [`DeleteExecutor`] implements table deletion with values from its child executor.
 // Note: multiple `DELETE`s in a single epoch, or concurrent `DELETE`s may lead to conflicting
@@ -166,8 +165,8 @@ impl DeleteExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for DeleteExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -163,7 +163,6 @@ impl DeleteExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for DeleteExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/expand.rs
+++ b/src/batch/src/executor/expand.rs
@@ -89,7 +89,6 @@ impl ExpandExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for ExpandExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/expand.rs
+++ b/src/batch/src/executor/expand.rs
@@ -22,7 +22,6 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use super::{BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder};
 use crate::error::{BatchError, Result};
-use crate::task::BatchTaskContext;
 
 pub struct ExpandExecutor {
     column_subsets: Vec<Vec<usize>>,
@@ -92,8 +91,8 @@ impl ExpandExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ExpandExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let expand_node = try_match_expand!(

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -24,7 +24,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 pub struct FilterExecutor {
     expr: BoxedExpression,
@@ -78,8 +77,8 @@ impl FilterExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for FilterExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [input]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -75,7 +75,6 @@ impl FilterExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for FilterExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -147,7 +147,6 @@ impl CreateSource for DefaultCreateSource {
 
 pub struct GenericExchangeExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for GenericExchangeExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/group_top_n.rs
+++ b/src/batch/src/executor/group_top_n.rs
@@ -36,7 +36,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// Group Top-N Executor
 ///
@@ -92,8 +91,8 @@ impl HashKeyDispatcher for GroupTopNExecutorBuilder {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for GroupTopNExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/group_top_n.rs
+++ b/src/batch/src/executor/group_top_n.rs
@@ -89,7 +89,6 @@ impl HashKeyDispatcher for GroupTopNExecutorBuilder {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for GroupTopNExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -47,7 +47,7 @@ use crate::spill::spill_op::SpillBackend::Disk;
 use crate::spill::spill_op::{
     SpillBackend, SpillBuildHasher, SpillOp, DEFAULT_SPILL_PARTITION_NUM, SPILL_AT_LEAST_MEMORY,
 };
-use crate::task::{BatchTaskContext, ShutdownToken, TaskId};
+use crate::task::{ShutdownToken, TaskId};
 
 type AggHashMap<K, A> = hashbrown::HashMap<K, Vec<AggregateState>, PrecomputedBuildHasher, A>;
 
@@ -151,8 +151,8 @@ impl HashAggExecutorBuilder {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashAggExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -149,7 +149,6 @@ impl HashAggExecutorBuilder {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashAggExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -39,7 +39,6 @@ pub struct HopWindowExecutor {
     output_indices: Vec<usize>,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for HopWindowExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -27,7 +27,7 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
+
 pub struct HopWindowExecutor {
     child: BoxedExecutor,
     identity: String,
@@ -41,8 +41,8 @@ pub struct HopWindowExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for HopWindowExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/iceberg_scan.rs
+++ b/src/batch/src/executor/iceberg_scan.rs
@@ -40,7 +40,6 @@ use super::{BoxedExecutor, BoxedExecutorBuilder, ExecutorBuilder};
 use crate::error::BatchError;
 use crate::executor::{DataChunk, Executor};
 use crate::monitor::BatchMetrics;
-use crate::task::BatchTaskContext;
 
 static POSITION_DELETE_FILE_FILE_PATH_INDEX: usize = 0;
 static POSITION_DELETE_FILE_POS: usize = 1;
@@ -227,8 +226,8 @@ pub struct IcebergScanExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for IcebergScanExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> crate::error::Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/iceberg_scan.rs
+++ b/src/batch/src/executor/iceberg_scan.rs
@@ -224,7 +224,6 @@ impl IcebergScanExecutor {
 
 pub struct IcebergScanExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for IcebergScanExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -34,7 +34,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// [`InsertExecutor`] implements table insertion with values from its child executor.
 pub struct InsertExecutor {
@@ -210,8 +209,8 @@ impl InsertExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for InsertExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -207,7 +207,6 @@ impl InsertExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for InsertExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/join/distributed_lookup_join.rs
+++ b/src/batch/src/executor/join/distributed_lookup_join.rs
@@ -40,7 +40,7 @@ use crate::executor::{
     unix_timestamp_sec_to_epoch, AsOf, BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder,
     BufferChunkExecutor, Executor, ExecutorBuilder, LookupExecutorBuilder, LookupJoinBase,
 };
-use crate::task::{BatchTaskContext, ShutdownToken};
+use crate::task::ShutdownToken;
 
 /// Distributed Lookup Join Executor.
 /// High level Execution flow:
@@ -83,8 +83,8 @@ pub struct DistributedLookupJoinExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for DistributedLookupJoinExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [outer_side_input]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/join/distributed_lookup_join.rs
+++ b/src/batch/src/executor/join/distributed_lookup_join.rs
@@ -81,7 +81,6 @@ impl<K> DistributedLookupJoinExecutor<K> {
 
 pub struct DistributedLookupJoinExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for DistributedLookupJoinExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -2144,7 +2144,6 @@ impl DataChunkMutator {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashJoinExecutor<()> {
     async fn new_boxed_executor(
         context: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -47,7 +47,7 @@ use crate::spill::spill_op::SpillBackend::Disk;
 use crate::spill::spill_op::{
     SpillBackend, SpillBuildHasher, SpillOp, DEFAULT_SPILL_PARTITION_NUM, SPILL_AT_LEAST_MEMORY,
 };
-use crate::task::{BatchTaskContext, ShutdownToken};
+use crate::task::ShutdownToken;
 
 /// Hash Join Executor
 ///
@@ -2146,8 +2146,8 @@ impl DataChunkMutator {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashJoinExecutor<()> {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        context: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        context: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [left_child, right_child]: [_; 2] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/join/local_lookup_join.rs
+++ b/src/batch/src/executor/join/local_lookup_join.rs
@@ -288,7 +288,6 @@ impl<K> LocalLookupJoinExecutor<K> {
 
 pub struct LocalLookupJoinExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for LocalLookupJoinExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -153,7 +153,6 @@ impl NestedLoopJoinExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -33,7 +33,7 @@ use crate::executor::join::{concatenate, convert_row_to_chunk, JoinType};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::{BatchTaskContext, ShutdownToken};
+use crate::task::ShutdownToken;
 
 /// Nested loop join executor.
 ///
@@ -155,8 +155,8 @@ impl NestedLoopJoinExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [left_child, right_child]: [_; 2] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -25,7 +25,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// Limit executor.
 pub struct LimitExecutor {
@@ -40,8 +39,8 @@ pub struct LimitExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for LimitExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -37,7 +37,6 @@ pub struct LimitExecutor {
     identity: String,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for LimitExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/log_row_seq_scan.rs
+++ b/src/batch/src/executor/log_row_seq_scan.rs
@@ -36,7 +36,6 @@ use risingwave_storage::{dispatch_state_store, StateStore};
 use super::{BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder};
 use crate::error::{BatchError, Result};
 use crate::monitor::BatchMetrics;
-use crate::task::BatchTaskContext;
 
 pub struct LogRowSeqScanExecutor<S: StateStore> {
     chunk_size: usize,
@@ -89,8 +88,8 @@ pub struct LogStoreRowSeqScanExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for LogStoreRowSeqScanExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/log_row_seq_scan.rs
+++ b/src/batch/src/executor/log_row_seq_scan.rs
@@ -86,7 +86,6 @@ impl<S: StateStore> LogRowSeqScanExecutor<S> {
 
 pub struct LogStoreRowSeqScanExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for LogStoreRowSeqScanExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/max_one_row.rs
+++ b/src/batch/src/executor/max_one_row.rs
@@ -19,7 +19,6 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::error::{BatchError, Result};
 use crate::executor::{BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder};
-use crate::task::BatchTaskContext;
 
 pub struct MaxOneRowExecutor {
     child: BoxedExecutor,
@@ -30,8 +29,8 @@ pub struct MaxOneRowExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for MaxOneRowExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/max_one_row.rs
+++ b/src/batch/src/executor/max_one_row.rs
@@ -27,7 +27,6 @@ pub struct MaxOneRowExecutor {
     identity: String,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for MaxOneRowExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -29,12 +29,12 @@ use crate::executor::{
 };
 use crate::task::{BatchTaskContext, TaskId};
 
-pub type MergeSortExchangeExecutor<C> = MergeSortExchangeExecutorImpl<DefaultCreateSource, C>;
+pub type MergeSortExchangeExecutor = MergeSortExchangeExecutorImpl<DefaultCreateSource>;
 
 /// `MergeSortExchangeExecutor2` takes inputs from multiple sources and
 /// The outputs of all the sources have been sorted in the same way.
-pub struct MergeSortExchangeExecutorImpl<CS, C> {
-    context: C,
+pub struct MergeSortExchangeExecutorImpl<CS> {
+    context: Arc<dyn BatchTaskContext>,
     column_orders: Arc<Vec<ColumnOrder>>,
     proto_sources: Vec<PbExchangeSource>,
     /// Mock-able `CreateSource`.
@@ -47,10 +47,10 @@ pub struct MergeSortExchangeExecutorImpl<CS, C> {
     mem_ctx: MemoryContext,
 }
 
-impl<CS: 'static + Send + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorImpl<CS, C> {
+impl<CS: 'static + Send + CreateSource> MergeSortExchangeExecutorImpl<CS> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        context: C,
+        context: Arc<dyn BatchTaskContext>,
         column_orders: Arc<Vec<ColumnOrder>>,
         proto_sources: Vec<PbExchangeSource>,
         source_creators: Vec<CS>,
@@ -75,9 +75,7 @@ impl<CS: 'static + Send + CreateSource, C: BatchTaskContext> MergeSortExchangeEx
     }
 }
 
-impl<CS: 'static + Send + CreateSource, C: BatchTaskContext> Executor
-    for MergeSortExchangeExecutorImpl<CS, C>
-{
+impl<CS: 'static + Send + CreateSource> Executor for MergeSortExchangeExecutorImpl<CS> {
     fn schema(&self) -> &Schema {
         &self.schema
     }
@@ -93,13 +91,13 @@ impl<CS: 'static + Send + CreateSource, C: BatchTaskContext> Executor
 /// Everytime `execute` is called, it tries to produce a chunk of size
 /// `self.chunk_size`. It is possible that the chunk's size is smaller than the
 /// `self.chunk_size` as the executor runs out of input from `sources`.
-impl<CS: 'static + Send + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorImpl<CS, C> {
+impl<CS: 'static + Send + CreateSource> MergeSortExchangeExecutorImpl<CS> {
     #[try_stream(boxed, ok = DataChunk, error = BatchError)]
     async fn do_execute(self: Box<Self>) {
         let mut sources: Vec<BoxedExecutor> = vec![];
         for source_idx in 0..self.proto_sources.len() {
             let new_source = self.source_creators[source_idx]
-                .create_source(self.context.clone(), &self.proto_sources[source_idx])
+                .create_source(&*self.context, &self.proto_sources[source_idx])
                 .await?;
 
             sources.push(Box::new(WrapStreamExecutor::new(
@@ -128,8 +126,8 @@ pub struct MergeSortExchangeExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for MergeSortExchangeExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(
@@ -159,7 +157,7 @@ impl BoxedExecutorBuilder for MergeSortExchangeExecutorBuilder {
             .map(Field::from)
             .collect::<Vec<Field>>();
 
-        Ok(Box::new(MergeSortExchangeExecutor::<C>::new(
+        Ok(Box::new(MergeSortExchangeExecutor::new(
             source.context().clone(),
             column_orders,
             proto_sources,
@@ -209,10 +207,7 @@ mod tests {
             order_type: OrderType::ascending(),
         }]);
 
-        let executor = Box::new(MergeSortExchangeExecutorImpl::<
-            FakeCreateSource,
-            ComputeNodeContext,
-        >::new(
+        let executor = Box::new(MergeSortExchangeExecutorImpl::<FakeCreateSource>::new(
             ComputeNodeContext::for_test(),
             column_orders,
             proto_sources,

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -124,7 +124,6 @@ impl<CS: 'static + Send + CreateSource> MergeSortExchangeExecutorImpl<CS> {
 
 pub struct MergeSortExchangeExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for MergeSortExchangeExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/mysql_query.rs
+++ b/src/batch/src/executor/mysql_query.rs
@@ -25,7 +25,6 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::error::{BatchError, BatchExternalSystemError};
 use crate::executor::{BoxedExecutor, BoxedExecutorBuilder, DataChunk, Executor, ExecutorBuilder};
-use crate::task::BatchTaskContext;
 
 /// `MySqlQuery` executor. Runs a query against a `MySql` database.
 pub struct MySqlQueryExecutor {
@@ -146,8 +145,8 @@ pub struct MySqlQueryExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for MySqlQueryExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         _inputs: Vec<BoxedExecutor>,
     ) -> crate::error::Result<BoxedExecutor> {
         let mysql_query_node = try_match_expand!(

--- a/src/batch/src/executor/mysql_query.rs
+++ b/src/batch/src/executor/mysql_query.rs
@@ -143,7 +143,6 @@ impl MySqlQueryExecutor {
 
 pub struct MySqlQueryExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for MySqlQueryExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -75,7 +75,6 @@ impl Executor for SortExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -40,7 +40,6 @@ use crate::spill::spill_op::SpillBackend::Disk;
 use crate::spill::spill_op::{
     SpillBackend, SpillOp, DEFAULT_SPILL_PARTITION_NUM, SPILL_AT_LEAST_MEMORY,
 };
-use crate::task::BatchTaskContext;
 
 /// Sort Executor
 ///
@@ -78,8 +77,8 @@ impl Executor for SortExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/postgres_query.rs
+++ b/src/batch/src/executor/postgres_query.rs
@@ -173,7 +173,6 @@ impl PostgresQueryExecutor {
 
 pub struct PostgresQueryExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for PostgresQueryExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/postgres_query.rs
+++ b/src/batch/src/executor/postgres_query.rs
@@ -25,7 +25,6 @@ use tokio_postgres;
 
 use crate::error::BatchError;
 use crate::executor::{BoxedExecutor, BoxedExecutorBuilder, DataChunk, Executor, ExecutorBuilder};
-use crate::task::BatchTaskContext;
 
 /// `PostgresQuery` executor. Runs a query against a Postgres database.
 pub struct PostgresQueryExecutor {
@@ -176,8 +175,8 @@ pub struct PostgresQueryExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for PostgresQueryExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         _inputs: Vec<BoxedExecutor>,
     ) -> crate::error::Result<BoxedExecutor> {
         let postgres_query_node = try_match_expand!(

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -25,7 +25,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 pub struct ProjectExecutor {
     expr: Vec<BoxedExpression>,
@@ -75,8 +74,8 @@ impl ProjectExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -72,7 +72,6 @@ impl ProjectExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/project_set.rs
+++ b/src/batch/src/executor/project_set.rs
@@ -131,7 +131,6 @@ impl ProjectSetExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectSetExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/project_set.rs
+++ b/src/batch/src/executor/project_set.rs
@@ -30,7 +30,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 pub struct ProjectSetExecutor {
     select_list: Vec<ProjectSetSelectItem>,
@@ -134,8 +133,8 @@ impl ProjectSetExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectSetExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -191,7 +191,6 @@ impl<S: StateStore> RowSeqScanExecutor<S> {
 
 pub struct RowSeqScanExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -40,7 +40,6 @@ use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
 use crate::monitor::BatchMetrics;
-use crate::task::BatchTaskContext;
 
 /// Executor that scans data from row table
 pub struct RowSeqScanExecutor<S: StateStore> {
@@ -194,8 +193,8 @@ pub struct RowSeqScanExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/s3_file_scan.rs
+++ b/src/batch/src/executor/s3_file_scan.rs
@@ -100,7 +100,6 @@ impl S3FileScanExecutor {
 
 pub struct FileScanExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for FileScanExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/s3_file_scan.rs
+++ b/src/batch/src/executor/s3_file_scan.rs
@@ -22,7 +22,6 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::error::BatchError;
 use crate::executor::{BoxedExecutor, BoxedExecutorBuilder, DataChunk, Executor, ExecutorBuilder};
-use crate::task::BatchTaskContext;
 
 #[derive(PartialEq, Debug)]
 pub enum FileFormat {
@@ -103,8 +102,8 @@ pub struct FileScanExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for FileScanExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         _inputs: Vec<BoxedExecutor>,
     ) -> crate::error::Result<BoxedExecutor> {
         let file_scan_node = try_match_expand!(

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -28,7 +28,7 @@ use crate::executor::aggregation::build as build_agg;
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::{BatchTaskContext, ShutdownToken};
+use crate::task::ShutdownToken;
 
 /// `SortAggExecutor` implements the sort aggregate algorithm, which assumes
 /// that the input chunks has already been sorted by group columns.
@@ -49,8 +49,8 @@ pub struct SortAggExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortAggExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -47,7 +47,6 @@ pub struct SortAggExecutor {
     shutdown_rx: ShutdownToken,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortAggExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/sort_over_window.rs
+++ b/src/batch/src/executor/sort_over_window.rs
@@ -48,7 +48,6 @@ struct ExecutorInner {
     chunk_size: usize,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortOverWindowExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/sort_over_window.rs
+++ b/src/batch/src/executor/sort_over_window.rs
@@ -27,7 +27,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use super::{BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder};
 use crate::error::{BatchError, Result};
-use crate::task::{BatchTaskContext, ShutdownToken};
+use crate::task::ShutdownToken;
 
 /// [`SortOverWindowExecutor`] accepts input chunks sorted by partition key and order key, and
 /// outputs chunks with window function result columns.
@@ -50,8 +50,8 @@ struct ExecutorInner {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortOverWindowExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/source.rs
+++ b/src/batch/src/executor/source.rs
@@ -32,7 +32,6 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use super::Executor;
 use crate::error::{BatchError, Result};
 use crate::executor::{BoxedExecutor, BoxedExecutorBuilder, ExecutorBuilder};
-use crate::task::BatchTaskContext;
 
 pub struct SourceExecutor {
     source: SourceReader,
@@ -51,8 +50,8 @@ pub struct SourceExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SourceExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(inputs.is_empty(), "Source should not have input executor!");

--- a/src/batch/src/executor/source.rs
+++ b/src/batch/src/executor/source.rs
@@ -48,7 +48,6 @@ pub struct SourceExecutor {
     chunk_size: usize,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SourceExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/sys_row_seq_scan.rs
+++ b/src/batch/src/executor/sys_row_seq_scan.rs
@@ -22,7 +22,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 pub struct SysRowSeqScanExecutor {
     table_id: TableId,
@@ -55,8 +54,8 @@ pub struct SysRowSeqScanExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SysRowSeqScanExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/sys_row_seq_scan.rs
+++ b/src/batch/src/executor/sys_row_seq_scan.rs
@@ -52,7 +52,6 @@ impl SysRowSeqScanExecutor {
 
 pub struct SysRowSeqScanExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SysRowSeqScanExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/table_function.rs
+++ b/src/batch/src/executor/table_function.rs
@@ -67,7 +67,6 @@ pub struct TableFunctionExecutorBuilder {}
 
 impl TableFunctionExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for TableFunctionExecutorBuilder {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/table_function.rs
+++ b/src/batch/src/executor/table_function.rs
@@ -22,7 +22,6 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use super::{BoxedExecutor, BoxedExecutorBuilder};
 use crate::error::{BatchError, Result};
 use crate::executor::{BoxedDataChunkStream, Executor, ExecutorBuilder};
-use crate::task::BatchTaskContext;
 
 pub struct TableFunctionExecutor {
     schema: Schema,
@@ -70,8 +69,8 @@ impl TableFunctionExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for TableFunctionExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -277,7 +277,7 @@ impl FakeCreateSource {
 impl CreateSource for FakeCreateSource {
     async fn create_source(
         &self,
-        _: impl BatchTaskContext,
+        _: &dyn BatchTaskContext,
         _: &PbExchangeSource,
     ) -> Result<ExchangeSourceImpl> {
         Ok(ExchangeSourceImpl::Fake(self.fake_exchange_source.clone()))
@@ -343,8 +343,8 @@ pub struct BlockExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for BlockExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        _source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        _source: &ExecutorBuilder<'_>,
         _inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         Ok(Box::new(BlockExecutor {}))
@@ -380,8 +380,8 @@ pub struct BusyLoopExecutorBuilder {}
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for BusyLoopExecutorBuilder {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        _source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        _source: &ExecutorBuilder<'_>,
         _inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         Ok(Box::new(BusyLoopExecutor {}))

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -341,7 +341,6 @@ impl LookupExecutorBuilder for FakeInnerSideExecutorBuilder {
 
 pub struct BlockExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for BlockExecutorBuilder {
     async fn new_boxed_executor(
         _source: &ExecutorBuilder<'_>,
@@ -378,7 +377,6 @@ impl BlockExecutor {
 
 pub struct BusyLoopExecutorBuilder {}
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for BusyLoopExecutorBuilder {
     async fn new_boxed_executor(
         _source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/top_n.rs
+++ b/src/batch/src/executor/top_n.rs
@@ -30,7 +30,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// Top-N Executor
 ///
@@ -49,8 +48,8 @@ pub struct TopNExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for TopNExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/top_n.rs
+++ b/src/batch/src/executor/top_n.rs
@@ -46,7 +46,6 @@ pub struct TopNExecutor {
     mem_ctx: MemoryContext,
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for TopNExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/union.rs
+++ b/src/batch/src/executor/union.rs
@@ -62,7 +62,6 @@ impl UnionExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for UnionExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/union.rs
+++ b/src/batch/src/executor/union.rs
@@ -24,7 +24,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 pub struct UnionExecutor {
     inputs: Vec<BoxedExecutor>,
@@ -65,8 +64,8 @@ impl UnionExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for UnionExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let _union_node =

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -30,7 +30,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// [`UpdateExecutor`] implements table update with values from its child executor and given
 /// expressions.
@@ -219,8 +218,8 @@ impl UpdateExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for UpdateExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -216,7 +216,6 @@ impl UpdateExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for UpdateExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -26,7 +26,6 @@ use crate::error::{BatchError, Result};
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, Executor, ExecutorBuilder,
 };
-use crate::task::BatchTaskContext;
 
 /// [`ValuesExecutor`] implements Values executor.
 pub struct ValuesExecutor {
@@ -104,8 +103,8 @@ impl ValuesExecutor {
 
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ValuesExecutor {
-    async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<'_, C>,
+    async fn new_boxed_executor(
+        source: &ExecutorBuilder<'_>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(inputs.is_empty(), "ValuesExecutor should have no child!");

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -101,7 +101,6 @@ impl ValuesExecutor {
     }
 }
 
-#[async_trait::async_trait]
 impl BoxedExecutorBuilder for ValuesExecutor {
     async fn new_boxed_executor(
         source: &ExecutorBuilder<'_>,

--- a/src/batch/src/lib.rs
+++ b/src/batch/src/lib.rs
@@ -29,6 +29,7 @@
 #![feature(error_generic_member_access)]
 #![feature(map_try_insert)]
 #![feature(iter_from_coroutine)]
+#![feature(used_with_arg)]
 
 pub mod error;
 pub mod exchange_source;

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -74,7 +74,7 @@ impl TaskService for BatchServiceImpl {
                 task_id.as_ref().expect("no task id found"),
                 plan.expect("no plan found").clone(),
                 epoch.expect("no epoch found"),
-                ComputeNodeContext::new(self.env.clone()),
+                ComputeNodeContext::create(self.env.clone()),
                 state_reporter,
                 TracingContext::from_protobuf(&tracing_context),
                 expr_context.expect("no expression context found"),
@@ -140,7 +140,7 @@ impl BatchServiceImpl {
         let tracing_context = TracingContext::from_protobuf(&tracing_context);
         let expr_context = expr_context.expect("no expression context found");
 
-        let context = ComputeNodeContext::new(env.clone());
+        let context = ComputeNodeContext::create(env.clone());
         trace!(
             "local execute request: plan:{:?} with task id:{:?}",
             plan,

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -296,7 +296,7 @@ impl ShutdownToken {
 }
 
 /// `BatchTaskExecution` represents a single task execution.
-pub struct BatchTaskExecution<C> {
+pub struct BatchTaskExecution {
     /// Task id.
     task_id: TaskId,
 
@@ -313,7 +313,7 @@ pub struct BatchTaskExecution<C> {
     sender: ChanSenderImpl,
 
     /// Context for task execution
-    context: C,
+    context: Arc<dyn BatchTaskContext>,
 
     /// The execution failure.
     failure: Arc<Mutex<Option<Arc<BatchError>>>>,
@@ -328,11 +328,11 @@ pub struct BatchTaskExecution<C> {
     heartbeat_join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
-impl<C: BatchTaskContext> BatchTaskExecution<C> {
+impl BatchTaskExecution {
     pub fn new(
         prost_tid: &PbTaskId,
         plan: PlanFragment,
-        context: C,
+        context: Arc<dyn BatchTaskContext>,
         epoch: BatchQueryEpoch,
         runtime: Arc<BackgroundShutdownRuntime>,
     ) -> Result<Self> {
@@ -412,10 +412,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         // Clone `self` to make compiler happy because of the move block.
         let t_1 = self.clone();
         let this = self.clone();
-        async fn notify_panic<C: BatchTaskContext>(
-            this: &BatchTaskExecution<C>,
-            state_tx: Option<&mut StateReporter>,
-        ) {
+        async fn notify_panic(this: &BatchTaskExecution, state_tx: Option<&mut StateReporter>) {
             let err_str = "execution panic".into();
             if let Err(e) = this
                 .change_state_notify(TaskStatus::Failed, state_tx, Some(err_str))
@@ -669,7 +666,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
     }
 }
 
-impl<C> BatchTaskExecution<C> {
+impl BatchTaskExecution {
     pub(crate) fn set_heartbeat_join_handle(&self, join_handle: JoinHandle<()>) {
         *self.heartbeat_join_handle.lock() = Some(join_handle);
     }

--- a/src/expr/core/Cargo.toml
+++ b/src/expr/core/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3"
 futures-async-stream = { workspace = true }
 futures-util = "0.3"
 itertools = { workspace = true }
-linkme = { version = "0.3", features = ["used_linker"] }
+linkme = { workspace = true }
 num-traits = "0.2"
 parse-display = "0.10"
 paste = "1"

--- a/src/expr/impl/Cargo.toml
+++ b/src/expr/impl/Cargo.toml
@@ -48,7 +48,7 @@ hmac = "0.12"
 icelake = { workspace = true }
 itertools = { workspace = true }
 jsonbb = { workspace = true }
-linkme = { version = "0.3", features = ["used_linker"] }
+linkme = { workspace = true }
 md5 = "0.7"
 moka = { version = "0.12.0", features = ["sync"] }
 num-traits = "0.2"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -42,7 +42,7 @@ iceberg = { workspace = true }
 icelake = { workspace = true }
 itertools = { workspace = true }
 jsonbb = { workspace = true }
-linkme = { version = "0.3", features = ["used_linker"] }
+linkme = { workspace = true }
 maplit = "1"
 md5 = "0.7.0"
 memcomparable = "0.2"

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -100,7 +100,7 @@ impl LocalQueryExecution {
     pub async fn run_inner(self) {
         debug!(%self.query.query_id, self.sql, "Starting to run query");
 
-        let context = FrontendBatchTaskContext::new(self.session.clone());
+        let context = FrontendBatchTaskContext::create(self.session.clone());
 
         let task_id = TaskId {
             query_id: self.query.query_id.id.clone(),

--- a/src/frontend/src/scheduler/mod.rs
+++ b/src/frontend/src/scheduler/mod.rs
@@ -66,6 +66,6 @@ impl ExecutionContext {
     }
 
     pub fn to_batch_task_context(&self) -> Arc<dyn BatchTaskContext> {
-        FrontendBatchTaskContext::new(self.session.clone())
+        FrontendBatchTaskContext::create(self.session.clone())
     }
 }

--- a/src/frontend/src/scheduler/mod.rs
+++ b/src/frontend/src/scheduler/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::Stream;
+use risingwave_batch::task::BatchTaskContext;
 use risingwave_common::array::DataChunk;
 
 use crate::error::Result;
@@ -64,7 +65,7 @@ impl ExecutionContext {
         self.timeout
     }
 
-    pub fn to_batch_task_context(&self) -> FrontendBatchTaskContext {
+    pub fn to_batch_task_context(&self) -> Arc<dyn BatchTaskContext> {
         FrontendBatchTaskContext::new(self.session.clone())
     }
 }

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -39,13 +39,13 @@ pub struct FrontendBatchTaskContext {
 }
 
 impl FrontendBatchTaskContext {
-    pub fn new(session: Arc<SessionImpl>) -> Self {
+    pub fn create(session: Arc<SessionImpl>) -> Arc<dyn BatchTaskContext> {
         let mem_context =
             MemoryContext::new(Some(session.env().mem_context()), TrAdderAtomic::new(0));
-        Self {
+        Arc::new(Self {
             session,
             mem_context,
-        }
+        })
     }
 }
 

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -100,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute(".", "#[derive(prost_helpers::AnyPB)]")
         .type_attribute(
             "node_body",
-            "#[derive(::enum_as_inner::EnumAsInner, ::strum::Display)]",
+            "#[derive(::enum_as_inner::EnumAsInner, ::strum::Display, ::strum::EnumDiscriminants)]",
         )
         .type_attribute("rex_node", "#[derive(::enum_as_inner::EnumAsInner)]")
         .type_attribute(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Replace generic `C: BatchTaskContext` to `&dyn BatchTaskContext` to simplify signatures.
- Remove `async_trait` on `BoxedExecutorBuilder`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
