### PR TITLE
fix(source): resolve avro `Ref` during `access` without hack

### DIFF
--- a/e2e_test/source_inline/kafka/avro/ref.slt
+++ b/e2e_test/source_inline/kafka/avro/ref.slt
@@ -109,11 +109,102 @@ select
   (bar).b.y
 from s;
 ----
-3 4 5 6 NULL NULL NULL NULL
+3 4 5 6 6 5 4 3
 
-# Parsing of column `bar` fails even with ints because now `schema` is required.
-# This will be fully supported in the next PR
-# 3 4 5 6 6 5 4 3
+
+statement ok
+drop source s;
+
+
+system ok
+curl -X DELETE "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/avro-ref-value"
+
+
+system ok
+curl -X DELETE "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/avro-ref-value?permanent=true"
+
+
+system ok
+rpk topic delete 'avro-ref'
+
+
+system ok
+rpk topic create avro-ref
+
+
+system ok
+sr_register avro-ref-value AVRO <<EOF
+{
+  "type": "record",
+  "name": "Root",
+  "fields": [
+    {
+      "name": "foo",
+      "type": {
+        "type": "record",
+        "name": "Seg",
+        "fields": [
+          {
+            "name": "a",
+            "type": {
+              "type": "record",
+              "name": "Point",
+              "fields": [
+                {
+                  "name": "x",
+                  "type": {
+                    "type": "bytes",
+                    "logicalType": "decimal",
+                    "precision": 4,
+                    "scale": 2
+                  }
+                },
+                {
+                  "name": "y",
+                  "type": "int"
+                }
+              ]
+            }
+          },
+          {
+            "name": "b",
+            "type": "Point"
+          }
+        ]
+      }
+    },
+    {
+      "name": "bar",
+      "type": "Seg"
+    }
+  ]
+}
+EOF
+
+
+statement ok
+create source s WITH (${RISEDEV_KAFKA_WITH_OPTIONS_COMMON}, topic = 'avro-ref') FORMAT PLAIN ENCODE AVRO (schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}');
+
+
+system ok
+rpk topic produce avro-ref --schema-id=topic <<EOF
+{"foo":{"a":{"x":"\u0001\u002c","y":4},"b":{"x":"\u0001\u00f4","y":6}},"bar":{"a":{"x":"\u0002\u0058","y":5},"b":{"x":"\u0001\u0090","y":3}}}
+EOF
+
+
+query RIRIRIRI
+select
+  (foo).a.x,
+  (foo).a.y,
+  (foo).b.x,
+  (foo).b.y,
+  (bar).a.x,
+  (bar).a.y,
+  (bar).b.x,
+  (bar).b.y
+from s;
+----
+3.00 4 5.00 6 6.00 5 4.00 3
 
 
 statement ok

--- a/src/connector/codec/src/decoder/avro/mod.rs
+++ b/src/connector/codec/src/decoder/avro/mod.rs
@@ -14,7 +14,7 @@
 
 mod schema;
 
-use apache_avro::schema::{DecimalSchema, UnionSchema};
+use apache_avro::schema::{DecimalSchema, NamesRef, UnionSchema};
 use apache_avro::types::{Value, ValueKind};
 use apache_avro::{Decimal as AvroDecimal, Schema};
 use chrono::Datelike;
@@ -33,28 +33,39 @@ use super::{bail_uncategorized, uncategorized, Access, AccessError, AccessResult
 use crate::decoder::avro::schema::avro_schema_to_struct_field_name;
 
 #[derive(Clone)]
-/// Options for parsing an `AvroValue` into Datum, with an optional avro schema.
+/// Options for parsing an `AvroValue` into Datum, with a root avro schema.
 pub struct AvroParseOptions<'a> {
-    /// Currently, this schema is only used for decimal.
-    ///
-    /// FIXME: In theory we should use resolved schema.
-    /// e.g., it's possible that a field is a reference to a decimal or a record containing a decimal field.
-    schema: &'a Schema,
+    /// The avro schema at root level
+    root_schema: &'a Schema,
+    /// The immutable "global" context during recursive parsing
+    inner: AvroParseOptionsInner<'a>,
+}
+
+#[derive(Clone)]
+/// Options for parsing an `AvroValue` into Datum, with names resolved from root schema.
+struct AvroParseOptionsInner<'a> {
+    /// Mapping from type names to actual schema
+    refs: NamesRef<'a>,
     /// Strict Mode
     /// If strict mode is disabled, an int64 can be parsed from an `AvroInt` (int32) value.
     relax_numeric: bool,
 }
 
 impl<'a> AvroParseOptions<'a> {
-    pub fn create(schema: &'a Schema) -> Self {
+    pub fn create(root_schema: &'a Schema) -> Self {
+        let resolved = apache_avro::schema::ResolvedSchema::try_from(root_schema)
+            .expect("avro schema is self contained");
         Self {
-            schema,
-            relax_numeric: true,
+            root_schema,
+            inner: AvroParseOptionsInner {
+                refs: resolved.get_names().clone(),
+                relax_numeric: true,
+            },
         }
     }
 }
 
-impl<'a> AvroParseOptions<'a> {
+impl<'a> AvroParseOptionsInner<'a> {
     /// Parse an avro value into expected type.
     ///
     /// 3 kinds of type info are used to parsing:
@@ -70,6 +81,7 @@ impl<'a> AvroParseOptions<'a> {
     ///     the `DataType` will be inferred.
     fn convert_to_datum<'b>(
         &self,
+        schema: &'a Schema,
         value: &'b Value,
         type_expected: &DataType,
     ) -> AccessResult<DatumCow<'b>>
@@ -92,18 +104,14 @@ impl<'a> AvroParseOptions<'a> {
             (_, Value::Null) => return Ok(DatumCow::NULL),
             // ---- Union (with >=2 non null variants), and nullable Union ([null, record]) -----
             (DataType::Struct(struct_type_info), Value::Union(variant, v)) => {
-                let Schema::Union(u) = self.schema else {
+                let Schema::Union(u) = schema else {
                     // XXX: Is this branch actually unreachable? (if self.schema is correctly used)
                     return Err(create_error());
                 };
 
                 if let Some(inner) = get_nullable_union_inner(u) {
                     // nullable Union ([null, record])
-                    return Self {
-                        schema: inner,
-                        relax_numeric: self.relax_numeric,
-                    }
-                    .convert_to_datum(v, type_expected);
+                    return self.convert_to_datum(inner, v, type_expected);
                 }
                 let variant_schema = &u.variants()[*variant as usize];
 
@@ -120,12 +128,9 @@ impl<'a> AvroParseOptions<'a> {
                 let mut fields = Vec::with_capacity(struct_type_info.len());
                 for (field_name, field_type) in struct_type_info.iter() {
                     if field_name == expected_field_name {
-                        let datum = Self {
-                            schema: variant_schema,
-                            relax_numeric: self.relax_numeric,
-                        }
-                        .convert_to_datum(v, field_type)?
-                        .to_owned_datum();
+                        let datum = self
+                            .convert_to_datum(variant_schema, v, field_type)?
+                            .to_owned_datum();
 
                         fields.push(datum)
                     } else {
@@ -136,17 +141,13 @@ impl<'a> AvroParseOptions<'a> {
             }
             // nullable Union ([null, T])
             (_, Value::Union(_, v)) => {
-                let Schema::Union(u) = self.schema else {
+                let Schema::Union(u) = schema else {
                     return Err(create_error());
                 };
                 let Some(schema) = get_nullable_union_inner(u) else {
                     return Err(create_error());
                 };
-                return Self {
-                    schema,
-                    relax_numeric: self.relax_numeric,
-                }
-                .convert_to_datum(v, type_expected);
+                return self.convert_to_datum(schema, v, type_expected);
             }
             // ---- Boolean -----
             (DataType::Boolean, Value::Boolean(b)) => (*b).into(),
@@ -168,7 +169,7 @@ impl<'a> AvroParseOptions<'a> {
             (DataType::Float64, Value::Float(i)) => (*i as f64).into(),
             // ---- Decimal -----
             (DataType::Decimal, Value::Decimal(avro_decimal)) => {
-                let (precision, scale) = match self.schema {
+                let (precision, scale) = match schema {
                     Schema::Decimal(DecimalSchema {
                         precision, scale, ..
                     }) => (*precision, *scale),
@@ -254,7 +255,7 @@ impl<'a> AvroParseOptions<'a> {
             }
             // ---- Struct -----
             (DataType::Struct(struct_type_info), Value::Record(descs)) => StructValue::new({
-                let Schema::Record(record_schema) = &self.schema else {
+                let Schema::Record(record_schema) = schema else {
                     return Err(create_error());
                 };
                 struct_type_info
@@ -264,12 +265,9 @@ impl<'a> AvroParseOptions<'a> {
                         if let Some(idx) = record_schema.lookup.get(field_name) {
                             let value = &descs[*idx].1;
                             let schema = &record_schema.fields[*idx].schema;
-                            Ok(Self {
-                                schema,
-                                relax_numeric: self.relax_numeric,
-                            }
-                            .convert_to_datum(value, field_type)?
-                            .to_owned_datum())
+                            Ok(self
+                                .convert_to_datum(schema, value, field_type)?
+                                .to_owned_datum())
                         } else {
                             Ok(None)
                         }
@@ -279,17 +277,13 @@ impl<'a> AvroParseOptions<'a> {
             .into(),
             // ---- List -----
             (DataType::List(item_type), Value::Array(array)) => ListValue::new({
-                let Schema::Array(element_schema) = &self.schema else {
+                let Schema::Array(element_schema) = schema else {
                     return Err(create_error());
                 };
                 let schema = element_schema;
                 let mut builder = item_type.create_array_builder(array.len());
                 for v in array {
-                    let value = Self {
-                        schema,
-                        relax_numeric: self.relax_numeric,
-                    }
-                    .convert_to_datum(v, item_type)?;
+                    let value = self.convert_to_datum(schema, v, item_type)?;
                     builder.append(value);
                 }
                 builder.finish()
@@ -309,7 +303,7 @@ impl<'a> AvroParseOptions<'a> {
                 uuid.as_hyphenated().to_string().into_boxed_str().into()
             }
             (DataType::Map(map_type), Value::Map(map)) => {
-                let Schema::Map(value_schema) = &self.schema else {
+                let Schema::Map(value_schema) = schema else {
                     return Err(create_error());
                 };
                 let schema = value_schema;
@@ -325,12 +319,9 @@ impl<'a> AvroParseOptions<'a> {
                 // in tests. We might consider removing this, or make all MapValue sorted
                 // in the future.
                 for (k, v) in map.iter().sorted_by_key(|(k, _v)| *k) {
-                    let value_datum = Self {
-                        schema,
-                        relax_numeric: self.relax_numeric,
-                    }
-                    .convert_to_datum(v, map_type.value())?
-                    .to_owned_datum();
+                    let value_datum = self
+                        .convert_to_datum(schema, v, map_type.value())?
+                        .to_owned_datum();
                     builder.append(
                         StructValue::new(vec![Some(k.as_str().into()), value_datum])
                             .to_owned_datum(),
@@ -352,15 +343,18 @@ pub struct AvroAccess<'a> {
 }
 
 impl<'a> AvroAccess<'a> {
-    pub fn new(value: &'a Value, options: AvroParseOptions<'a>) -> Self {
-        Self { value, options }
+    pub fn new(root_value: &'a Value, options: AvroParseOptions<'a>) -> Self {
+        Self {
+            value: root_value,
+            options,
+        }
     }
 }
 
 impl Access for AvroAccess<'_> {
     fn access<'a>(&'a self, path: &[&str], type_expected: &DataType) -> AccessResult<DatumCow<'a>> {
         let mut value = self.value;
-        let mut options: AvroParseOptions<'_> = self.options.clone();
+        let mut schema = self.options.root_schema;
 
         debug_assert!(
             path.len() == 1
@@ -401,22 +395,22 @@ impl Access for AvroAccess<'_> {
                     // },
                     // ...]
                     value = v;
-                    let Schema::Union(u) = options.schema else {
+                    let Schema::Union(u) = schema else {
                         return Err(create_error());
                     };
-                    let Some(schema) = get_nullable_union_inner(u) else {
+                    let Some(s) = get_nullable_union_inner(u) else {
                         return Err(create_error());
                     };
-                    options.schema = schema;
+                    schema = s;
                     continue;
                 }
                 Value::Record(fields) => {
-                    let Schema::Record(record_schema) = &options.schema else {
+                    let Schema::Record(record_schema) = schema else {
                         return Err(create_error());
                     };
                     if let Some(idx) = record_schema.lookup.get(key) {
                         value = &fields[*idx].1;
-                        options.schema = &record_schema.fields[*idx].schema;
+                        schema = &record_schema.fields[*idx].schema;
                         i += 1;
                         continue;
                     }
@@ -426,7 +420,9 @@ impl Access for AvroAccess<'_> {
             Err(create_error())?;
         }
 
-        options.convert_to_datum(value, type_expected)
+        self.options
+            .inner
+            .convert_to_datum(schema, value, type_expected)
     }
 }
 
@@ -941,7 +937,8 @@ mod tests {
         shape: &DataType,
     ) -> anyhow::Result<Datum> {
         Ok(AvroParseOptions::create(value_schema)
-            .convert_to_datum(&value, shape)?
+            .inner
+            .convert_to_datum(value_schema, &value, shape)?
             .to_owned_datum())
     }
 
@@ -982,11 +979,7 @@ mod tests {
         .unwrap();
         let bytes = vec![0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f];
         let value = Value::Decimal(AvroDecimal::from(bytes));
-        let options = AvroParseOptions::create(&schema);
-        let resp = options
-            .convert_to_datum(&value, &DataType::Decimal)
-            .unwrap()
-            .to_owned_datum();
+        let resp = from_avro_value(value, &schema, &DataType::Decimal).unwrap();
         assert_eq!(
             resp,
             Some(ScalarImpl::Decimal(Decimal::Normalized(
@@ -1022,11 +1015,7 @@ mod tests {
             ("value".to_string(), Value::Bytes(vec![0x01, 0x02, 0x03])),
         ]);
 
-        let options = AvroParseOptions::create(&schema);
-        let resp = options
-            .convert_to_datum(&value, &DataType::Decimal)
-            .unwrap()
-            .to_owned_datum();
+        let resp = from_avro_value(value, &schema, &DataType::Decimal).unwrap();
         assert_eq!(resp, Some(ScalarImpl::Decimal(Decimal::from(66051))));
     }
 }

--- a/src/connector/codec/src/decoder/avro/schema.rs
+++ b/src/connector/codec/src/decoder/avro/schema.rs
@@ -35,18 +35,12 @@ use super::get_nullable_union_inner;
 pub struct ResolvedAvroSchema {
     /// Should be used for parsing bytes into Avro value
     pub original_schema: Arc<Schema>,
-    /// Should be used for type mapping from Avro value to RisingWave datum
-    pub resolved_schema: Schema,
 }
 
 impl ResolvedAvroSchema {
     pub fn create(schema: Arc<Schema>) -> AvroResult<Self> {
-        let resolver = ResolvedSchema::try_from(schema.as_ref())?;
-        // todo: to_resolved may cause stackoverflow if there's a loop in the schema
-        let resolved_schema = resolver.to_resolved(schema.as_ref())?;
         Ok(Self {
             original_schema: schema,
-            resolved_schema,
         })
     }
 }

--- a/src/connector/codec/tests/integration_tests/avro.rs
+++ b/src/connector/codec/tests/integration_tests/avro.rs
@@ -94,7 +94,7 @@ fn check(
     // manually implement some logic in AvroAccessBuilder, and some in PlainParser::parse_inner
     let mut data_str = vec![];
     for data in avro_data {
-        let parser = AvroParseOptions::create(&resolved_schema.resolved_schema);
+        let parser = AvroParseOptions::create(&resolved_schema.original_schema);
 
         match config.data_encoding {
             TestDataEncoding::Json => todo!(),

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -49,7 +49,7 @@ impl AccessBuilder for AvroAccessBuilder {
         self.value = self.parse_avro_value(&payload).await?;
         Ok(AccessImpl::Avro(AvroAccess::new(
             self.value.as_ref().unwrap(),
-            AvroParseOptions::create(&self.schema.resolved_schema),
+            AvroParseOptions::create(&self.schema.original_schema),
         )))
     }
 }

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -57,7 +57,7 @@ impl AccessBuilder for DebeziumAvroAccessBuilder {
             // Assumption: Key will not contain reference, so unresolved schema can work here.
             AvroParseOptions::create(match self.encoding_type {
                 EncodingType::Key => self.key_schema.as_mut().unwrap(),
-                EncodingType::Value => &self.schema.resolved_schema,
+                EncodingType::Value => &self.schema.original_schema,
             }),
         )))
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Sequel to #19601 and resolves #17020.

The recursive call is changed from `Self {schema: inner, relax_numeric: self.relax_numeric}.convert_to_datum(v, field_type)` into `self.convert_to_datum(inner, v, field_type)` so that
* The changing part `schema: inner` is passed as argument rather than keep reconstructing new `AvroParseOptions`.
* `self: AvroParseOptionsInner` captures the immutable "global" context: `relax_numeric: bool` and `refs: NamesRef<'a>`

On the use site, `self.schema` is changed to `self.lookup_ref(unresolved_schema)`. Note that introducing a new type to distinguish `resolved` from `unresolved` would not make it less error-prone for a careless developer - nothing prevents them from matching against unresolved `apache_avro::Schema` directly and ignoring `Schema::Ref`.

~~Full removal of `ResolvedAvroSchema` will be done in an immediate follow-up, to minimize the signature changes in this PR.~~ `ResolvedAvroSchema` will either be fully removed or repurposed to hold `HashMap<Name, Schema>` (an owned `NamesRef`) in a follow-up.

Same as #19601, this is intended to be part of v2.2 and NOT cherry-picked into earlier versions.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
