### PR TITLE
refactor(frontend): generate replace plan without relying on definition

### DIFF
--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -413,6 +413,10 @@ impl ColumnCatalog {
         !self.is_generated() && !self.is_rw_timestamp_column()
     }
 
+    pub fn can_drop(&self) -> bool {
+        !(self.is_hidden() || self.is_rw_sys_column())
+    }
+
     /// If the column is a generated column
     pub fn generated_expr(&self) -> Option<&ExprNode> {
         if let Some(GeneratedOrDefaultColumn::GeneratedColumn(desc)) =

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -728,7 +728,7 @@ pub struct CreateTableProps {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn gen_table_plan_inner(
+pub fn gen_table_plan_inner(
     context: OptimizerContextRef,
     schema_name: Option<String>,
     table_name: String,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Note: the diff can be outdated due to ongoing prerequisite refactoring.

We used to rely on the definition when re-planning the table for purposes like schema change or sink-into-table.  However, maintaining column definitions can be hard, especially for the schemas resolved from registry.

This PR is a attempt to generate replace plan without relying on persisted definition, but directly retrieve necessary info from the internal representation (`TableCatalog`).

To accomplish this, we need to refactor the procedure for generating a plan from a `CREATE TABLE` SQL statement, so that we can reuse as much code as possible when it comes to generating a plan from an existing `Table`.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
