### PR TITLE
fix(meta): skip unnecessary delta persistence

### DIFF
--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -484,6 +484,8 @@ impl HummockManager {
                 .on_conflict_do_nothing()
                 .exec(txn)
                 .await?;
+            // Return early to skip persisting delta.
+            return Ok(version_sst_ids);
         }
         let written = write_sstable_infos(
             delta.newly_added_sst_infos().filter(|s| {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

During commit_epoch for newly created table, a `GroupConstruct` delta is expected, which triggers [a false alarm](https://github.com/risingwavelabs/risingwave/blob/3cbc231b002eeef2e370ae15d067e4518b0f57dd/src/storage/hummock_sdk/src/time_travel.rs#L219). The alarm was added to assert only `NewL0SubLevel` delta was kept for time travel.

This PR resolves this issue by skipping delta contaning `GroupConstruct` for time travel, because for that delta a complete version snapshot is ensured to be created for time travel, based on `should_mark_next_time_travel_version_snapshot`. This redundant delta has never been used.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
