### PR TITLE
feat(storage): lazily remove instance data in uploader to avoid data loss

### DIFF
--- a/src/storage/src/hummock/event_handler/uploader/mod.rs
+++ b/src/storage/src/hummock/event_handler/uploader/mod.rs
@@ -927,7 +927,10 @@ impl UnsyncData {
                     }
                 }
                 assert!(
-                    table_unsync_data.instance_data.is_empty(),
+                    table_unsync_data
+                        .instance_data
+                        .values()
+                        .all(|instance| instance.is_destroyed),
                     "should be clear when dropping the read version instance"
                 );
             }

--- a/src/storage/src/hummock/event_handler/uploader/mod.rs
+++ b/src/storage/src/hummock/event_handler/uploader/mod.rs
@@ -933,6 +933,14 @@ impl UnsyncData {
                         .all(|instance| instance.is_destroyed),
                     "should be clear when dropping the read version instance"
                 );
+                for instance_id in table_unsync_data.instance_data.keys() {
+                    assert_eq!(
+                        *table_id,
+                        self.instance_table_id
+                            .remove(instance_id)
+                            .expect("should exist")
+                    );
+                }
             }
         }
         debug_assert!(self

--- a/src/storage/src/hummock/event_handler/uploader/task_manager.rs
+++ b/src/storage/src/hummock/event_handler/uploader/task_manager.rs
@@ -136,24 +136,6 @@ impl TaskManager {
         )
     }
 
-    pub(super) fn remove_table_spill_tasks(
-        &mut self,
-        table_id: TableId,
-        task_ids: impl Iterator<Item = UploadingTaskId>,
-    ) {
-        for task_id in task_ids {
-            let entry = self.tasks.get_mut(&task_id).expect("should exist");
-            let empty = must_match!(&mut entry.status, UploadingTaskStatus::Spilling(table_ids) => {
-                assert!(table_ids.remove(&table_id));
-                table_ids.is_empty()
-            });
-            if empty {
-                let task = self.tasks.remove(&task_id).expect("should exist").task;
-                task.join_handle.abort();
-            }
-        }
-    }
-
     pub(super) fn sync(
         &mut self,
         context: &UploaderContext,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Currently in uploader, when an local instance is destroyed, we will remove the instance from the uploader immediately, even if there is some unsync data in the instance. The logic works in current code, because an instance can be destroyed in 3 scenarios: drop streaming job, configuration change, and actor exit on error or recovery. When dropping streaming job, the table will be removed soon, and therefore the loss of data is invisible. In configuration change, before the barrier to drop actors, we will have a pause barrier to ensure that there is no data in between, so it works for configuration. 

However, when we support https://github.com/risingwavelabs/risingwave/issues/18312, there will not be a pause barrier, and then we may lose data if the sync is called later than the actor exits. So we need to fix it before implementing https://github.com/risingwavelabs/risingwave/issues/18312.

In this PR, we change to lazily remove the instance data. When the instance is destroyed, in uploader we only mark the instance as `destroyed`. The instance will later be destroyed when all the sealed epochs have been started syncing.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
