### PR TITLE
refactor(snapshot-backfill): extract common logic of consuming snapshot and log store

### DIFF
--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -232,8 +232,8 @@ impl DataChunkBuilder {
         self.buffered_count
     }
 
-    pub fn can_append(&self, count: usize) -> bool {
-        self.buffered_count + count <= self.batch_size
+    pub fn can_append_update(&self) -> bool {
+        self.buffered_count + 2 <= self.batch_size
     }
 
     pub fn num_columns(&self) -> usize {

--- a/src/stream/src/common/log_store_impl/kv_log_store/serde.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/serde.rs
@@ -598,7 +598,7 @@ impl<S: StateStoreReadIter> LogStoreRowOpStream<S> {
                     old_value,
                 } => {
                     read_info.read_update(row_read_size);
-                    if !data_chunk_builder.can_append(2) {
+                    if !data_chunk_builder.can_append_update() {
                         let ops = replace(&mut ops, Vec::with_capacity(chunk_size));
                         let chunk = data_chunk_builder.consume_all().expect("must not be empty");
                         yield (

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -490,6 +490,7 @@ async fn make_log_stream(
 ) -> StreamExecutorResult<VnodeStream<impl super::vnode_stream::BackfillRowStream>> {
     let data_types = upstream_table.schema().data_types();
     let start_pk = start_pk.as_ref();
+    // TODO: may avoid polling all vnodes concurrently at the same time but instead with a limit on concurrency.
     let vnode_streams = try_join_all(upstream_table.vnodes().iter_vnodes().map(move |vnode| {
         upstream_table
             .batch_iter_vnode_log(

--- a/src/stream/src/executor/backfill/snapshot_backfill/mod.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod executor;
+mod vnode_stream;
+
+pub use executor::SnapshotBackfillExecutor;

--- a/src/stream/src/executor/backfill/snapshot_backfill/vnode_stream.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/vnode_stream.rs
@@ -1,0 +1,198 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::mem::{replace, take};
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+use futures::stream::{FuturesUnordered, Peekable, StreamFuture};
+use futures::{Stream, StreamExt, TryStreamExt};
+use risingwave_common::array::{Op, StreamChunk};
+use risingwave_common::hash::VirtualNode;
+use risingwave_common::row::{OwnedRow, Row, RowExt};
+use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
+
+use crate::executor::StreamExecutorResult;
+
+pub(super) type BackfillRowItem = ((Op, OwnedRow), Option<(Op, OwnedRow)>);
+pub(super) trait BackfillRowStream =
+    Stream<Item = StreamExecutorResult<BackfillRowItem>> + Sized + 'static;
+
+struct StreamWithVnode<St> {
+    stream: St,
+    vnode: VirtualNode,
+}
+
+impl<St: Stream + Unpin> Stream for StreamWithVnode<St> {
+    type Item = St::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+}
+
+pub(super) struct VnodeStream<St: BackfillRowStream> {
+    #[expect(clippy::type_complexity)]
+    streams: FuturesUnordered<StreamFuture<StreamWithVnode<Pin<Box<Peekable<St>>>>>>,
+    finished_vnode: HashSet<VirtualNode>,
+    data_chunk_builder: DataChunkBuilder,
+    ops: Vec<Op>,
+}
+
+impl<St: BackfillRowStream> VnodeStream<St> {
+    pub(super) fn new(
+        vnode_streams: impl IntoIterator<Item = (VirtualNode, St)>,
+        data_chunk_builder: DataChunkBuilder,
+    ) -> Self {
+        assert!(data_chunk_builder.is_empty());
+        assert!(data_chunk_builder.batch_size() >= 2);
+        let streams =
+            FuturesUnordered::from_iter(vnode_streams.into_iter().map(|(vnode, stream)| {
+                StreamWithVnode {
+                    stream: Box::pin(stream.peekable()),
+                    vnode,
+                }
+                .into_future()
+            }));
+        let ops = Vec::with_capacity(data_chunk_builder.batch_size());
+        Self {
+            streams,
+            finished_vnode: HashSet::new(),
+            data_chunk_builder,
+            ops,
+        }
+    }
+}
+
+impl<St: BackfillRowStream> VnodeStream<St> {
+    fn poll_next_row(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<StreamExecutorResult<Option<BackfillRowItem>>> {
+        loop {
+            let ready_item = match ready!(self.streams.poll_next_unpin(cx)) {
+                None => Ok(None),
+                Some((None, stream)) => {
+                    assert!(self.finished_vnode.insert(stream.vnode));
+                    continue;
+                }
+                Some((Some(Ok(item)), stream)) => {
+                    self.streams.push(stream.into_future());
+                    Ok(Some(item))
+                }
+                Some((Some(Err(e)), _stream)) => Err(e),
+            };
+            break Poll::Ready(ready_item);
+        }
+    }
+
+    #[expect(dead_code)]
+    pub(super) fn consume_builder(&mut self) -> Option<StreamChunk> {
+        self.data_chunk_builder.consume_all().map(|chunk| {
+            let ops = replace(
+                &mut self.ops,
+                Vec::with_capacity(self.data_chunk_builder.batch_size()),
+            );
+            StreamChunk::from_parts(ops, chunk)
+        })
+    }
+
+    #[expect(dead_code)]
+    pub(super) async fn for_vnode_pk_progress(
+        &mut self,
+        pk_indices: &[usize],
+        mut on_vnode_progress: impl FnMut(VirtualNode, Option<OwnedRow>),
+    ) -> StreamExecutorResult<()> {
+        assert!(self.data_chunk_builder.is_empty());
+        for vnode in &self.finished_vnode {
+            on_vnode_progress(*vnode, None);
+        }
+        for vnode_stream in &mut self.streams {
+            let vnode_stream = vnode_stream.get_mut().expect("should exist");
+            match vnode_stream.stream.as_mut().peek().await {
+                Some(Ok(((_, row), extra))) => {
+                    let pk = row.project(pk_indices).to_owned_row();
+                    if cfg!(debug_assertions)
+                        && let Some((_, extra_row)) = extra
+                    {
+                        assert_eq!(pk, extra_row.project(pk_indices).to_owned_row());
+                    }
+                    on_vnode_progress(vnode_stream.vnode, Some(pk));
+                }
+                Some(Err(_)) => {
+                    return Err(vnode_stream
+                        .stream
+                        .try_next()
+                        .await
+                        .expect_err("checked Err"));
+                }
+                None => {
+                    on_vnode_progress(vnode_stream.vnode, None);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<St: BackfillRowStream> Stream for VnodeStream<St> {
+    type Item = StreamExecutorResult<StreamChunk>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let capacity = this.data_chunk_builder.batch_size();
+        loop {
+            match ready!(this.poll_next_row(cx)) {
+                Ok(Some(((op, row), extra))) => {
+                    let may_chunk = if let Some((extra_op, extra_row)) = extra {
+                        if this.data_chunk_builder.can_append(2) {
+                            this.ops.extend([op, extra_op]);
+                            assert!(this.data_chunk_builder.append_one_row(row).is_none());
+                            this.data_chunk_builder.append_one_row(extra_row)
+                        } else {
+                            let chunk = this
+                                .data_chunk_builder
+                                .consume_all()
+                                .expect("should be Some when not can_append");
+                            let ops = replace(&mut this.ops, Vec::with_capacity(capacity));
+                            this.ops.extend([op, extra_op]);
+                            assert!(this.data_chunk_builder.append_one_row(row).is_none());
+                            assert!(this.data_chunk_builder.append_one_row(extra_row).is_none());
+                            break Poll::Ready(Some(Ok(StreamChunk::from_parts(ops, chunk))));
+                        }
+                    } else {
+                        this.ops.push(op);
+                        this.data_chunk_builder.append_one_row(row)
+                    };
+                    if let Some(chunk) = may_chunk {
+                        let ops = replace(&mut this.ops, Vec::with_capacity(capacity));
+                        break Poll::Ready(Some(Ok(StreamChunk::from_parts(ops, chunk))));
+                    }
+                }
+                Ok(None) => {
+                    break if let Some(chunk) = this.data_chunk_builder.consume_all() {
+                        let ops = take(&mut this.ops);
+                        Poll::Ready(Some(Ok(StreamChunk::from_parts(ops, chunk))))
+                    } else {
+                        Poll::Ready(None)
+                    };
+                }
+                Err(e) => {
+                    break Poll::Ready(Some(Err(e)));
+                }
+            }
+        }
+    }
+}

--- a/src/stream/src/executor/backfill/snapshot_backfill/vnode_stream.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/vnode_stream.rs
@@ -91,6 +91,9 @@ impl<St: ChangeLogRowStream> VnodeStream<St> {
                     continue;
                 }
                 Some((Some(Ok(item)), stream)) => {
+                    // TODO: may avoid generating a `StreamFuture` for each row, because
+                    // `FuturesUnordered::push` involve memory allocation of `Arc`, and may
+                    // incur some unnecessary costs.
                     self.streams.push(stream.into_future());
                     Ok(Some(item))
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Part of https://github.com/risingwavelabs/risingwave/pull/19720.

For snapshot backfill, in the main branch and the future PR https://github.com/risingwavelabs/risingwave/pull/19720, the stage of consuming snapshot and consuming log store have the similar logic of consuming a stream of row with op and convert the stream into stream chunk. In this PR, we will extra the common logic and let them share the same code.

Previously, the row streams of multiple vnodes are combined in the stream returned from `StorageTable` method. In this PR we will change to combine the stream of multiple vnodes outside `StorageTable` with `FuturesUnordered`, so that we can access each vnode stream and get the progress of each vnode, which will be useful in https://github.com/risingwavelabs/risingwave/pull/19720.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
