### PR TITLE
feat(frontend): initially introduce table def sql purification

### DIFF
--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -1,10 +1,6 @@
 statement ok
 create table if not exists t3 (v1 int, v2 int, v3 int) append only;
 
-# Test definition purification for `CREATE TABLE AS`
-statement ok
-create table t3as as select v1 + 1 as vv1, v3 from t3;
-
 statement ok
 create materialized view mv3 as select sum(v1) as sum_v1 from t3;
 
@@ -98,17 +94,15 @@ pg_catalog
 public
 rw_catalog
 
-query T rowsort
+query T
 show tables;
 ----
 t3
-t3as
 
-query T rowsort
+query T
 show tables from public;
 ----
 t3
-t3as
 
 query T
 show tables from public like 't_';
@@ -150,11 +144,6 @@ query TT
 show create table t3;
 ----
 public.t3 CREATE TABLE t3 (v1 INT, v2 INT, v3 INT) APPEND ONLY
-
-query TT
-show create table t3as;
-----
-public.t3as	CREATE TABLE t3as (vv1 INT, v3 INT)
 
 query TT
 show create materialized view mv3;
@@ -206,9 +195,6 @@ drop sink sink3;
 
 statement ok
 drop table t3;
-
-statement ok
-drop table t3as;
 
 query TTTT
 describe pg_matviews;

--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -98,17 +98,17 @@ pg_catalog
 public
 rw_catalog
 
-query T
+query T rowsort
 show tables;
 ----
-t3as
 t3
+t3as
 
-query T
+query T rowsort
 show tables from public;
 ----
-t3as
 t3
+t3as
 
 query T
 show tables from public like 't_';

--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -1,6 +1,10 @@
 statement ok
 create table if not exists t3 (v1 int, v2 int, v3 int) append only;
 
+# Test definition purification for `CREATE TABLE AS`
+statement ok
+create table t3as as select v1 + 1 as vv1, v3 from t3;
+
 statement ok
 create materialized view mv3 as select sum(v1) as sum_v1 from t3;
 
@@ -97,11 +101,13 @@ rw_catalog
 query T
 show tables;
 ----
+t3as
 t3
 
 query T
 show tables from public;
 ----
+t3as
 t3
 
 query T
@@ -144,6 +150,11 @@ query TT
 show create table t3;
 ----
 public.t3 CREATE TABLE t3 (v1 INT, v2 INT, v3 INT) APPEND ONLY
+
+query TT
+show create table t3as;
+----
+public.t3as	CREATE TABLE t3as (vv1 INT, v3 INT)
 
 query TT
 show create materialized view mv3;
@@ -195,6 +206,9 @@ drop sink sink3;
 
 statement ok
 drop table t3;
+
+statement ok
+drop table t3as;
 
 query TTTT
 describe pg_matviews;

--- a/e2e_test/ddl/show_purify.slt
+++ b/e2e_test/ddl/show_purify.slt
@@ -1,0 +1,20 @@
+# Test definition purification for `CREATE TABLE AS`, mainly focusing on the data types.
+statement ok
+create table ctas as select
+    0::int as v0,
+    1::decimal as v1,
+    '2022-03-13 01:00:00'::timestamp as v2,
+    '2022-03-13 01:00:00Z'::timestamptz as v3,
+    array['foo', 'bar', 'null'] as v4,
+    (1, (2, 3))::STRUCT<i BIGINT, j STRUCT<a BIGINT, b VARCHAR>> as v5,
+    hex_to_int256('0x11') as v6,
+    map{'key1': 1, 'key2': 2, 'key3': 3} as v7
+;
+
+query TT
+show create table ctas;
+----
+public.ctas	CREATE TABLE ctas (v0 INT, v1 NUMERIC, v2 TIMESTAMP, v3 TIMESTAMP WITH TIME ZONE, v4 CHARACTER VARYING[], v5 STRUCT<i BIGINT, j STRUCT<a BIGINT, b CHARACTER VARYING>>, v6 rw_int256, v7 MAP(CHARACTER VARYING,INT))
+
+statement ok
+drop table ctas;

--- a/e2e_test/source_inline/kafka/avro/alter_table.slt
+++ b/e2e_test/source_inline/kafka/avro/alter_table.slt
@@ -28,6 +28,12 @@ FORMAT PLAIN ENCODE AVRO (
     schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
 );
 
+# Demonstrate purified definition
+query T
+SELECT SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name = 't';
+----
+CREATE TABLE t (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
+
 sleep 4s
 
 query ?
@@ -42,6 +48,12 @@ sr_register avro_alter_table_test-value AVRO <<< '{"type":"record","name":"Root"
 # Refresh table schema should succeed
 statement ok
 ALTER TABLE t REFRESH SCHEMA;
+
+# Demonstrate purified definition
+query T
+SELECT SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name = 't';
+----
+CREATE TABLE t (bar INT, foo CHARACTER VARYING, nested STRUCT<baz INT>, gen_col INT AS bar + 1)
 
 query ?
 select * from t

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -413,6 +413,12 @@ impl ColumnCatalog {
         !self.is_generated() && !self.is_rw_timestamp_column()
     }
 
+    /// Returns whether the column is defined by user within the column definition clause
+    /// in the `CREATE TABLE` statement.
+    pub fn is_user_defined(&self) -> bool {
+        !self.is_hidden() && !self.is_rw_sys_column() && !self.is_connector_additional_column()
+    }
+
     /// If the column is a generated column
     pub fn generated_expr(&self) -> Option<&ExprNode> {
         if let Some(GeneratedOrDefaultColumn::GeneratedColumn(desc)) =

--- a/src/frontend/src/catalog/mod.rs
+++ b/src/frontend/src/catalog/mod.rs
@@ -26,6 +26,7 @@ use thiserror::Error;
 
 use crate::error::{ErrorCode, Result, RwError};
 pub(crate) mod catalog_service;
+mod purify;
 
 pub(crate) mod connection_catalog;
 pub(crate) mod database_catalog;

--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2025 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -1,0 +1,130 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::bail;
+use risingwave_common::catalog::{ColumnCatalog, ColumnId};
+use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
+use risingwave_sqlparser::ast::*;
+
+use crate::error::Result;
+use crate::utils::data_type::DataTypeToAst as _;
+
+/// Try to restore missing column definitions and constraints in the persisted table definition,
+/// if the schema of the table is derived from external systems (like schema registry) or it's
+/// created by `CREATE TABLE AS`.
+///
+/// Returns error if restoring failed, or called on non-`TableType::Table`, or the persisted
+/// definition is invalid.
+pub fn try_purify_table_create_sql_ast(
+    mut base: Statement,
+    columns: &[ColumnCatalog],
+    row_id_index: Option<usize>,
+    pk_column_ids: &[ColumnId],
+) -> Result<Statement> {
+    let Statement::CreateTable {
+        columns: column_defs,
+        constraints,
+        wildcard_idx,
+        ..
+    } = &mut base
+    else {
+        bail!("expect `CREATE TABLE` statement, found: `{:?}`", base);
+    };
+
+    // Filter out columns that are not defined by users in SQL.
+    let defined_columns = columns.iter().filter(|c| c.is_user_defined());
+
+    // If all columns are defined...
+    // - either the schema is fully specified by the user,
+    // - the persisted definition is already purified.
+    // No need to proceed.
+    if !column_defs.is_empty() && wildcard_idx.is_none() {
+        let defined_columns_len = defined_columns.count();
+        if column_defs.len() != defined_columns_len {
+            bail /* unlikely */ !(
+                "column count mismatch: defined {} columns, but {} columns in the definition",
+                defined_columns_len,
+                column_defs.len()
+            );
+        }
+
+        return Ok(base);
+    }
+
+    // Schema inferred. Now derive the missing columns and constraints.
+    // First, remove the wildcard from the definition.
+    *wildcard_idx = None;
+
+    // Derive `ColumnDef` from `ColumnCatalog`.
+    let mut purified_column_defs = Vec::new();
+    for column in defined_columns {
+        // If the column is already defined in the persisted definition, keep it.
+        if let Some(existing) = column_defs
+            .iter()
+            .find(|c| c.name.real_value() == column.name())
+        {
+            purified_column_defs.push(existing.clone());
+            continue;
+        }
+
+        if let Some(c) = &column.column_desc.generated_or_default_column {
+            match c {
+                GeneratedOrDefaultColumn::GeneratedColumn(_) => {
+                    unreachable!("generated column must not be inferred");
+                }
+                GeneratedOrDefaultColumn::DefaultColumn(_) => {
+                    // TODO: convert `ExprNode` back to ast can be a bit tricky.
+                    // Fortunately, this case is rare as inferring default values is not
+                    // widely supported.
+                    bail /* unlikely */ !("purifying default value is not supported yet");
+                }
+            }
+        }
+
+        let column_def = ColumnDef {
+            name: column.name().into(),
+            data_type: Some(column.data_type().to_ast()?),
+            collation: None,
+            options: Vec::new(), // pk will be specified with table constraints
+        };
+        purified_column_defs.push(column_def);
+    }
+    *column_defs = purified_column_defs;
+
+    if row_id_index.is_none() {
+        // User-defined primary key.
+        let mut pk_columns = Vec::new();
+
+        for &id in pk_column_ids {
+            let column = columns.iter().find(|c| c.column_id() == id).unwrap();
+            if !column.is_user_defined() {
+                bail /* unlikely */ !(
+                    "primary key column \"{}\" is not user-defined",
+                    column.name()
+                );
+            }
+            pk_columns.push(column.name().into());
+        }
+
+        let pk_constraint = TableConstraint::Unique {
+            name: None,
+            columns: pk_columns,
+            is_primary: true,
+        };
+        // We don't support table constraints other than `PRIMARY KEY`, thus simply overwrite.
+        *constraints = vec![pk_constraint];
+    }
+
+    Ok(base)
+}

--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -122,7 +122,20 @@ pub fn try_purify_table_create_sql_ast(
             columns: pk_columns,
             is_primary: true,
         };
+
         // We don't support table constraints other than `PRIMARY KEY`, thus simply overwrite.
+        assert!(
+            constraints.len() <= 1
+                && constraints.iter().all(|c| matches!(
+                    c,
+                    TableConstraint::Unique {
+                        is_primary: true,
+                        ..
+                    }
+                )),
+            "unexpected table constraints: {constraints:?}",
+        );
+
         *constraints = vec![pk_constraint];
     }
 

--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -94,7 +94,7 @@ pub fn try_purify_table_create_sql_ast(
 
         let column_def = ColumnDef {
             name: column.name().into(),
-            data_type: Some(column.data_type().to_ast()?),
+            data_type: Some(column.data_type().to_ast()),
             collation: None,
             options: Vec::new(), // pk will be specified with table constraints
         };

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
@@ -50,7 +50,7 @@ fn read_rw_table_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwTable>> {
                 name: table.name().to_owned(),
                 schema_id: schema.id() as i32,
                 owner: table.owner as i32,
-                definition: table.create_sql(),
+                definition: table.create_sql_purified(),
                 append_only: table.append_only,
                 acl: get_acl_items(
                     &Object::TableId(table.id.table_id),

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -42,7 +42,7 @@ use crate::expr::ExprImpl;
 use crate::optimizer::property::Cardinality;
 use crate::session::current::notice_to_user;
 use crate::user::UserId;
-use crate::utils::data_type::to_ast_data_type;
+use crate::utils::data_type::DataTypeToAst;
 
 /// `TableCatalog` Includes full information about a table.
 ///
@@ -389,7 +389,7 @@ impl TableCatalog {
 
             let column_def = ColumnDef {
                 name: column.name().into(),
-                data_type: Some(to_ast_data_type(column.data_type())?),
+                data_type: Some(column.data_type().to_ast()?),
                 collation: None,
                 options: Vec::new(), // pk will be specified with table constraints
             };

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -15,7 +15,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{ColumnCatalog, Engine};

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -20,7 +20,6 @@ use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{ColumnCatalog, Engine};
 use risingwave_common::hash::VnodeCount;
-use risingwave_common::types::DataType;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::{bail, bail_not_implemented};
 use risingwave_connector::sink::catalog::SinkCatalog;
@@ -29,8 +28,7 @@ use risingwave_pb::ddl_service::TableJobType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{ProjectNode, StreamFragmentGraph};
 use risingwave_sqlparser::ast::{
-    AlterTableOperation, ColumnDef, ColumnOption, DataType as AstDataType, Ident, ObjectName,
-    Statement, StructField, TableConstraint,
+    AlterTableOperation, ColumnDef, ColumnOption, Ident, ObjectName, Statement, TableConstraint,
 };
 
 use super::create_source::schema_has_schema_registry;
@@ -44,6 +42,7 @@ use crate::expr::{Expr, ExprImpl, InputRef, Literal};
 use crate::handler::create_sink::{fetch_incoming_sinks, insert_merger_to_union_with_project};
 use crate::handler::create_table::bind_table_constraints;
 use crate::session::SessionImpl;
+use crate::utils::data_type::to_ast_data_type;
 use crate::{Binder, TableCatalog};
 
 /// Used in auto schema change process
@@ -111,43 +110,6 @@ pub async fn get_new_table_definition_for_cdc_table(
     *original_columns = new_column_defs;
 
     Ok((definition, original_catalog))
-}
-
-fn to_ast_data_type(ty: &DataType) -> Result<AstDataType> {
-    match ty {
-        DataType::Boolean => Ok(AstDataType::Boolean),
-        DataType::Int16 => Ok(AstDataType::SmallInt),
-        DataType::Int32 => Ok(AstDataType::Int),
-        DataType::Int64 => Ok(AstDataType::BigInt),
-        DataType::Float32 => Ok(AstDataType::Real),
-        DataType::Float64 => Ok(AstDataType::Double),
-        // TODO: handle precision and scale for decimal
-        DataType::Decimal => Ok(AstDataType::Decimal(None, None)),
-        DataType::Date => Ok(AstDataType::Date),
-        DataType::Varchar => Ok(AstDataType::Varchar),
-        DataType::Time => Ok(AstDataType::Time(false)),
-        DataType::Timestamp => Ok(AstDataType::Timestamp(false)),
-        DataType::Timestamptz => Ok(AstDataType::Timestamp(true)),
-        DataType::Interval => Ok(AstDataType::Interval),
-        DataType::Jsonb => Ok(AstDataType::Jsonb),
-        DataType::Bytea => Ok(AstDataType::Bytea),
-        DataType::List(item_ty) => Ok(AstDataType::Array(Box::new(to_ast_data_type(item_ty)?))),
-        DataType::Struct(fields) => {
-            let fields = fields
-                .iter()
-                .map(|(name, ty)| {
-                    Ok::<StructField, RwError>(StructField {
-                        name: name.into(),
-                        data_type: to_ast_data_type(ty)?,
-                    })
-                })
-                .try_collect()?;
-            Ok(AstDataType::Struct(fields))
-        }
-        DataType::Serial | DataType::Int256 | DataType::Map(_) => {
-            Err(anyhow!("unsupported data type: {:?}", ty).context("to_ast_data_type"))?
-        }
-    }
 }
 
 pub async fn get_replace_table_plan(

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -41,7 +41,7 @@ use crate::expr::{Expr, ExprImpl, InputRef, Literal};
 use crate::handler::create_sink::{fetch_incoming_sinks, insert_merger_to_union_with_project};
 use crate::handler::create_table::bind_table_constraints;
 use crate::session::SessionImpl;
-use crate::utils::data_type::to_ast_data_type;
+use crate::utils::data_type::DataTypeToAst;
 use crate::{Binder, TableCatalog};
 
 /// Used in auto schema change process
@@ -99,10 +99,10 @@ pub async fn get_new_table_definition_for_cdc_table(
         // if the column exists in the original catalog, use it to construct the column definition.
         // since we don't support altering the column type right now
         if let Some(original_col) = orig_column_catalog.get(new_col.name()) {
-            let ty = to_ast_data_type(original_col.data_type())?;
+            let ty = original_col.data_type().to_ast()?;
             new_column_defs.push(ColumnDef::new(original_col.name().into(), ty, None, vec![]));
         } else {
-            let ty = to_ast_data_type(new_col.data_type())?;
+            let ty = new_col.data_type().to_ast()?;
             new_column_defs.push(ColumnDef::new(new_col.name().into(), ty, None, vec![]));
         }
     }

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -99,10 +99,10 @@ pub async fn get_new_table_definition_for_cdc_table(
         // if the column exists in the original catalog, use it to construct the column definition.
         // since we don't support altering the column type right now
         if let Some(original_col) = orig_column_catalog.get(new_col.name()) {
-            let ty = original_col.data_type().to_ast()?;
+            let ty = original_col.data_type().to_ast();
             new_column_defs.push(ColumnDef::new(original_col.name().into(), ty, None, vec![]));
         } else {
-            let ty = new_col.data_type().to_ast()?;
+            let ty = new_col.data_type().to_ast();
             new_column_defs.push(ColumnDef::new(new_col.name().into(), ty, None, vec![]));
         }
     }

--- a/src/frontend/src/handler/create_table_as.rs
+++ b/src/frontend/src/handler/create_table_as.rs
@@ -112,7 +112,9 @@ pub async fn handle_create_as(
             vec![], // No watermark should be defined in for `CREATE TABLE AS`
             col_id_gen.into_version(),
             CreateTableProps {
-                definition: "".to_owned(), // TODO: empty definition means no schema change support
+                // Note: by providing and persisting an empty definition, querying the definition of the table
+                // will hit the purification logic, which will construct it based on the catalog.
+                definition: "".to_owned(),
                 append_only,
                 on_conflict: on_conflict.into(),
                 with_version_column,

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -649,7 +649,7 @@ pub fn handle_show_create_object(
                 .get_created_table_by_name(&object_name)
                 .filter(|t| t.is_user_table())
                 .ok_or_else(|| CatalogError::NotFound("table", name.to_string()))?;
-            table.table_purified_create_stmt()?.to_string()
+            table.create_sql_purified()
         }
         ShowCreateType::Sink => {
             let sink = schema

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -649,7 +649,7 @@ pub fn handle_show_create_object(
                 .get_created_table_by_name(&object_name)
                 .filter(|t| t.is_user_table())
                 .ok_or_else(|| CatalogError::NotFound("table", name.to_string()))?;
-            table.create_sql()
+            table.table_purified_create_stmt()?.to_string()
         }
         ShowCreateType::Sink => {
             let sink = schema

--- a/src/frontend/src/utils/data_type.rs
+++ b/src/frontend/src/utils/data_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2025 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/utils/data_type.rs
+++ b/src/frontend/src/utils/data_type.rs
@@ -1,47 +1,60 @@
-use anyhow::anyhow;
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::bail_not_implemented;
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{DataType as AstDataType, StructField};
 
 use crate::error::Result;
 
-pub fn to_ast_data_type(ty: &DataType) -> Result<AstDataType> {
-    match ty {
-        DataType::Boolean => Ok(AstDataType::Boolean),
-        DataType::Int16 => Ok(AstDataType::SmallInt),
-        DataType::Int32 => Ok(AstDataType::Int),
-        DataType::Int64 => Ok(AstDataType::BigInt),
-        DataType::Float32 => Ok(AstDataType::Real),
-        DataType::Float64 => Ok(AstDataType::Double),
-        // TODO: handle precision and scale for decimal
-        DataType::Decimal => Ok(AstDataType::Decimal(None, None)),
-        DataType::Date => Ok(AstDataType::Date),
-        DataType::Varchar => Ok(AstDataType::Varchar),
-        DataType::Time => Ok(AstDataType::Time(false)),
-        DataType::Timestamp => Ok(AstDataType::Timestamp(false)),
-        DataType::Timestamptz => Ok(AstDataType::Timestamp(true)),
-        DataType::Interval => Ok(AstDataType::Interval),
-        DataType::Jsonb => Ok(AstDataType::Jsonb),
-        DataType::Bytea => Ok(AstDataType::Bytea),
-        DataType::List(item_ty) => Ok(AstDataType::Array(Box::new(to_ast_data_type(item_ty)?))),
-        DataType::Struct(fields) => {
-            let fields = fields
-                .iter()
-                .map(|(name, ty)| {
-                    to_ast_data_type(ty).map(|ty| StructField {
-                        name: name.into(),
-                        data_type: ty,
+#[easy_ext::ext(DataTypeToAst)]
+impl DataType {
+    pub fn to_ast(&self) -> Result<AstDataType> {
+        match self {
+            DataType::Boolean => Ok(AstDataType::Boolean),
+            DataType::Int16 => Ok(AstDataType::SmallInt),
+            DataType::Int32 => Ok(AstDataType::Int),
+            DataType::Int64 => Ok(AstDataType::BigInt),
+            DataType::Float32 => Ok(AstDataType::Real),
+            DataType::Float64 => Ok(AstDataType::Double),
+            // TODO: handle precision and scale for decimal
+            DataType::Decimal => Ok(AstDataType::Decimal(None, None)),
+            DataType::Date => Ok(AstDataType::Date),
+            DataType::Varchar => Ok(AstDataType::Varchar),
+            DataType::Time => Ok(AstDataType::Time(false)),
+            DataType::Timestamp => Ok(AstDataType::Timestamp(false)),
+            DataType::Timestamptz => Ok(AstDataType::Timestamp(true)),
+            DataType::Interval => Ok(AstDataType::Interval),
+            DataType::Jsonb => Ok(AstDataType::Jsonb),
+            DataType::Bytea => Ok(AstDataType::Bytea),
+            DataType::List(item_ty) => Ok(AstDataType::Array(Box::new(item_ty.to_ast()?))),
+            DataType::Struct(fields) => {
+                let fields = fields
+                    .iter()
+                    .map(|(name, ty)| {
+                        ty.to_ast().map(|ty| StructField {
+                            name: name.into(),
+                            data_type: ty,
+                        })
                     })
-                    // Result::Ok(StructField {
-                    //     name: name.into(),
-                    //     data_type: to_ast_data_type(ty)?,
-                    // })
-                })
-                .try_collect()?;
-            Ok(AstDataType::Struct(fields))
-        }
-        DataType::Serial | DataType::Int256 | DataType::Map(_) => {
-            // TODO: support them
-            Err(anyhow!("unsupported data type: {:?}", ty).context("to_ast_data_type"))?
+                    .try_collect()?;
+                Ok(AstDataType::Struct(fields))
+            }
+            DataType::Serial | DataType::Int256 | DataType::Map(_) => {
+                // TODO: support them
+                bail_not_implemented!("convert data type {:?} back to AST", self);
+            }
         }
     }
 }

--- a/src/frontend/src/utils/data_type.rs
+++ b/src/frontend/src/utils/data_type.rs
@@ -1,0 +1,47 @@
+use anyhow::anyhow;
+use risingwave_common::types::DataType;
+use risingwave_sqlparser::ast::{DataType as AstDataType, StructField};
+
+use crate::error::Result;
+
+pub fn to_ast_data_type(ty: &DataType) -> Result<AstDataType> {
+    match ty {
+        DataType::Boolean => Ok(AstDataType::Boolean),
+        DataType::Int16 => Ok(AstDataType::SmallInt),
+        DataType::Int32 => Ok(AstDataType::Int),
+        DataType::Int64 => Ok(AstDataType::BigInt),
+        DataType::Float32 => Ok(AstDataType::Real),
+        DataType::Float64 => Ok(AstDataType::Double),
+        // TODO: handle precision and scale for decimal
+        DataType::Decimal => Ok(AstDataType::Decimal(None, None)),
+        DataType::Date => Ok(AstDataType::Date),
+        DataType::Varchar => Ok(AstDataType::Varchar),
+        DataType::Time => Ok(AstDataType::Time(false)),
+        DataType::Timestamp => Ok(AstDataType::Timestamp(false)),
+        DataType::Timestamptz => Ok(AstDataType::Timestamp(true)),
+        DataType::Interval => Ok(AstDataType::Interval),
+        DataType::Jsonb => Ok(AstDataType::Jsonb),
+        DataType::Bytea => Ok(AstDataType::Bytea),
+        DataType::List(item_ty) => Ok(AstDataType::Array(Box::new(to_ast_data_type(item_ty)?))),
+        DataType::Struct(fields) => {
+            let fields = fields
+                .iter()
+                .map(|(name, ty)| {
+                    to_ast_data_type(ty).map(|ty| StructField {
+                        name: name.into(),
+                        data_type: ty,
+                    })
+                    // Result::Ok(StructField {
+                    //     name: name.into(),
+                    //     data_type: to_ast_data_type(ty)?,
+                    // })
+                })
+                .try_collect()?;
+            Ok(AstDataType::Struct(fields))
+        }
+        DataType::Serial | DataType::Int256 | DataType::Map(_) => {
+            // TODO: support them
+            Err(anyhow!("unsupported data type: {:?}", ty).context("to_ast_data_type"))?
+        }
+    }
+}

--- a/src/frontend/src/utils/mod.rs
+++ b/src/frontend/src/utils/mod.rs
@@ -21,6 +21,7 @@ use std::sync::LazyLock;
 
 pub use column_index_mapping::*;
 mod condition;
+pub mod data_type;
 pub use condition::*;
 mod connected_components;
 pub(crate) use connected_components::*;

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3393,6 +3393,30 @@ impl Statement {
     pub fn to_redacted_string(&self, keywords: RedactSqlOptionKeywordsRef) -> String {
         REDACT_SQL_OPTION_KEYWORDS.sync_scope(keywords, || self.to_string())
     }
+
+    /// Create a new `CREATE TABLE` statement with the given `name` and empty fields.
+    pub fn default_create_table(name: ObjectName) -> Self {
+        Self::CreateTable {
+            name,
+            or_replace: false,
+            temporary: false,
+            if_not_exists: false,
+            columns: Vec::new(),
+            wildcard_idx: None,
+            constraints: Vec::new(),
+            with_options: Vec::new(),
+            format_encode: None,
+            source_watermarks: Vec::new(),
+            append_only: false,
+            on_conflict: None,
+            with_version_column: None,
+            query: None,
+            cdc_table_info: None,
+            include_column_options: Vec::new(),
+            webhook_info: None,
+            engine: Engine::Hummock,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

See #17472 for the background. This PR initially introduces SQL purification for table definition, and adopt it in `SHOW CREATE TABLE`. Further adoption (like for replacing table plan) will be done in future PRs, as they require additional work that is not directly relevant to the current scope to ensure a complete end-to-end implementation.

It turns out that we only need to restore the `ColumnDef` (specifically, the `DataType`, which is already contributed by @StrikeW). This makes the procedure much simpler than initially thought.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
