### PR TITLE
refactor(connector): use `pk IN (...)` instead of `AND/OR` in DELETE for pg sink

### DIFF
--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -537,13 +537,11 @@ fn create_insert_sql(schema: &Schema, table_name: &str, number_of_rows: usize) -
         .fields()
         .iter()
         .map(|field| field.name.clone())
-        .collect_vec()
         .join(", ");
     let parameters: String = (0..number_of_rows)
         .map(|i| {
             let row_parameters = (0..number_of_columns)
                 .map(|j| format!("${}", i * number_of_columns + j + 1))
-                .collect_vec()
                 .join(", ");
             format!("({row_parameters})")
         })
@@ -559,25 +557,28 @@ fn create_delete_sql(
     number_of_rows: usize,
 ) -> String {
     let number_of_pk = pk_indices.len();
+    let pk = {
+        let pk_symbols = pk_indices
+            .iter()
+            .map(|pk_index| &schema.fields()[*pk_index].name)
+            .join(", ");
+        format!("({})", pk_symbols)
+    };
     let parameters: String = (0..number_of_rows)
         .map(|i| {
-            let row_parameters: String = pk_indices
-                .iter()
-                .enumerate()
-                .map(|(j, pk_index)| {
+            let row_parameters: String = (0..pk_indices.len())
+                .map(|j| {
                     format!(
-                        "{} = ${}",
-                        schema.fields()[*pk_index].name,
+                        "${}",
                         i * number_of_pk + j + 1
                     )
                 })
-                .collect_vec()
-                .join(" AND ");
+                .join(", ");
             format!("({row_parameters})")
         })
         .collect_vec()
-        .join(" OR ");
-    format!("DELETE FROM {table_name} WHERE {parameters}")
+        .join(", ");
+    format!("DELETE FROM {table_name} WHERE {pk} in ({parameters})")
 }
 
 #[cfg(test)]
@@ -639,7 +640,13 @@ mod tests {
         let sql = create_delete_sql(&schema, table_name, &[1], 3);
         check(
             sql,
-            expect!["DELETE FROM test_table WHERE (b = $1) OR (b = $2) OR (b = $3)"],
+            expect!["DELETE FROM test_table WHERE (b) in (($1), ($2), ($3))"],
+        );
+        let table_name = "test_table";
+        let sql = create_delete_sql(&schema, table_name, &[0, 1], 3);
+        check(
+            sql,
+            expect!["DELETE FROM test_table WHERE (a, b) in (($1, $2), ($3, $4), ($5, $6))"],
         );
     }
 }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -567,12 +567,7 @@ fn create_delete_sql(
     let parameters: String = (0..number_of_rows)
         .map(|i| {
             let row_parameters: String = (0..pk_indices.len())
-                .map(|j| {
-                    format!(
-                        "${}",
-                        i * number_of_pk + j + 1
-                    )
-                })
+                .map(|j| format!("${}", i * number_of_pk + j + 1))
                 .join(", ");
             format!("({row_parameters})")
         })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Closes https://github.com/risingwavelabs/risingwave/issues/19913

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
