### PR TITLE
perf(storage): use VecDeque for TableChangeLog to avoid large clone on truncate

### DIFF
--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -15,6 +15,7 @@
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::iter::once;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -696,16 +697,10 @@ impl HummockVersion {
             match table_change_log.entry(*table_id) {
                 Entry::Occupied(entry) => {
                     let change_log = entry.into_mut();
-                    if let Some(prev_log) = change_log.0.last() {
-                        assert!(
-                            prev_log.epochs.last().expect("non-empty")
-                                < new_change_log.epochs.first().expect("non-empty")
-                        );
-                    }
-                    change_log.0.push(new_change_log.clone());
+                    change_log.add_change_log(new_change_log.clone());
                 }
                 Entry::Vacant(entry) => {
-                    entry.insert(TableChangeLogCommon(vec![new_change_log.clone()]));
+                    entry.insert(TableChangeLogCommon::new(once(new_change_log.clone())));
                 }
             };
         }
@@ -957,7 +952,7 @@ where
         self.get_combined_levels()
             .flat_map(|level| level.table_infos.iter())
             .chain(self.table_change_log.values().flat_map(|change_log| {
-                change_log.0.iter().flat_map(|epoch_change_log| {
+                change_log.iter().flat_map(|epoch_change_log| {
                     epoch_change_log
                         .old_value
                         .iter()
@@ -1364,7 +1359,7 @@ pub fn object_size_map(version: &HummockVersion) -> HashMap<HummockSstableObject
                 .flat_map(|level| level.table_infos.iter().map(|t| (t.object_id, t.file_size)))
         })
         .chain(version.table_change_log.values().flat_map(|c| {
-            c.0.iter().flat_map(|l| {
+            c.iter().flat_map(|l| {
                 l.old_value
                     .iter()
                     .chain(l.new_value.iter())

--- a/src/storage/hummock_sdk/src/frontend_version.rs
+++ b/src/storage/hummock_sdk/src/frontend_version.rs
@@ -44,17 +44,13 @@ impl FrontendHummockVersion {
                 .map(|(table_id, change_log)| {
                     (
                         *table_id,
-                        TableChangeLogCommon(
-                            change_log
-                                .0
-                                .iter()
-                                .map(|change_log| EpochNewChangeLogCommon {
-                                    new_value: vec![],
-                                    old_value: vec![],
-                                    epochs: change_log.epochs.clone(),
-                                })
-                                .collect(),
-                        ),
+                        TableChangeLogCommon::new(change_log.iter().map(|change_log| {
+                            EpochNewChangeLogCommon {
+                                new_value: vec![],
+                                old_value: vec![],
+                                epochs: change_log.epochs.clone(),
+                            }
+                        })),
                     )
                 })
                 .collect(),
@@ -76,7 +72,6 @@ impl FrontendHummockVersion {
                         table_id.table_id,
                         PbTableChangeLog {
                             change_logs: change_log
-                                .0
                                 .iter()
                                 .map(|change_log| PbEpochNewChangeLog {
                                     old_value: vec![],
@@ -102,17 +97,13 @@ impl FrontendHummockVersion {
                 .map(|(table_id, change_log)| {
                     (
                         TableId::new(table_id),
-                        TableChangeLogCommon(
-                            change_log
-                                .change_logs
-                                .into_iter()
-                                .map(|change_log| EpochNewChangeLogCommon {
-                                    new_value: vec![],
-                                    old_value: vec![],
-                                    epochs: change_log.epochs,
-                                })
-                                .collect(),
-                        ),
+                        TableChangeLogCommon::new(change_log.change_logs.into_iter().map(
+                            |change_log| EpochNewChangeLogCommon {
+                                new_value: vec![],
+                                old_value: vec![],
+                                epochs: change_log.epochs,
+                            },
+                        )),
                     )
                 })
                 .collect(),

--- a/src/storage/hummock_sdk/src/time_travel.rs
+++ b/src/storage/hummock_sdk/src/time_travel.rs
@@ -68,7 +68,7 @@ fn refill_table_change_log(
     table_change_log: &mut TableChangeLog,
     sst_id_to_info: &HashMap<HummockSstableId, SstableInfo>,
 ) {
-    for c in &mut table_change_log.0 {
+    for c in table_change_log.iter_mut() {
         for s in &mut c.old_value {
             refill_sstable_info(s, sst_id_to_info);
         }
@@ -113,7 +113,7 @@ impl From<(&HummockVersion, &HashSet<StateTableId>)> for IncompleteHummockVersio
                     if !time_travel_table_ids.contains(&table_id.table_id()) {
                         return None;
                     }
-                    debug_assert!(change_log.0.iter().all(|d| {
+                    debug_assert!(change_log.iter().all(|d| {
                         d.new_value.iter().chain(d.old_value.iter()).all(|s| {
                             s.table_ids
                                 .iter()
@@ -121,11 +121,12 @@ impl From<(&HummockVersion, &HashSet<StateTableId>)> for IncompleteHummockVersio
                         })
                     }));
                     let incomplete_table_change_log = change_log
-                        .0
                         .iter()
-                        .map(|e| PbEpochNewChangeLog::from(e).into())
-                        .collect();
-                    Some((*table_id, TableChangeLogCommon(incomplete_table_change_log)))
+                        .map(|e| PbEpochNewChangeLog::from(e).into());
+                    Some((
+                        *table_id,
+                        TableChangeLogCommon::new(incomplete_table_change_log),
+                    ))
                 })
                 .collect(),
             state_table_info: version.state_table_info.clone(),

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -275,7 +275,7 @@ impl HummockVersion {
                 .table_change_log
                 .values()
                 .map(|c| {
-                    c.0.iter()
+                    c.iter()
                         .map(|l| {
                             l.old_value
                                 .iter()

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -27,7 +27,6 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::MAX_SPILL_TIMES;
-use risingwave_hummock_sdk::change_log::EpochNewChangeLog;
 use risingwave_hummock_sdk::key::{
     bound_table_key_range, FullKey, TableKey, TableKeyRange, UserKey,
 };
@@ -994,10 +993,9 @@ impl HummockVersionReader {
         options: ReadLogOptions,
     ) -> HummockResult<ChangeLogIterator> {
         let change_log = if let Some(change_log) = version.table_change_log.get(&options.table_id) {
-            change_log.filter_epoch(epoch_range)
+            change_log.filter_epoch(epoch_range).collect_vec()
         } else {
-            static EMPTY_VEC: Vec<EpochNewChangeLog> = Vec::new();
-            &EMPTY_VEC[..]
+            Vec::new()
         };
         if let Some(max_epoch_change_log) = change_log.last() {
             let (_, max_epoch) = epoch_range;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

May alleviate the issue mentioned in https://github.com/risingwavelabs/risingwave/issues/19960.

Previously we use `Vec` to store all table change log. When applying version delta, we use `Vec::retain` to clean the stale change log. However, for subscription with large retention time, the `Vec` can be large, and the `Vec::retain` called in `truncate` will incur great cost. In this PR, we change to use `VecDeque` to store the change log, so that the cost of `truncate` will reduce from `O(N)` to `O(1)`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
