### PR TITLE
fix(meta): resolve deadlock caused by Hummock write stop

### DIFF
--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -238,7 +238,7 @@ impl CatalogController {
 
         txn.commit().await?;
 
-        // After catalog changes have been saved, synchronize them with Hummock.
+        // After catalog changes have been saved, may need to synchronize them with Hummock to resolve a corner case.
         tracing::debug!(?to_drop_state_table_ids, "May unregister from Hummock.");
         let tables_to_unregister_from_hummock = to_drop_state_table_ids
             .iter()

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -326,6 +326,10 @@ impl HummockManager {
             new_version_delta.removed_table_ids.insert(table_id);
         }
 
+        if modified_groups.is_empty() {
+            return Ok(());
+        }
+
         let groups_to_remove = modified_groups
             .into_iter()
             .filter_map(|(group_id, member_count)| {

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -186,7 +186,7 @@ impl HummockManager {
         if new_write_limits == cg_manager.write_limit {
             return false;
         }
-        tracing::debug!("Hummock stopped write is updated: {:#?}", new_write_limits);
+        tracing::debug!(?new_write_limits, "Hummock stopped write is updated.");
         trigger_write_stop_stats(&self.metrics, &new_write_limits);
         cg_manager.write_limit = new_write_limits;
         self.env

--- a/src/meta/src/hummock/manager/worker.rs
+++ b/src/meta/src/hummock/manager/worker.rs
@@ -125,7 +125,10 @@ impl HummockManager {
                     self.unregister_table_ids(table_ids.into_iter().map(Into::into))
                         .await
                         .unwrap_or_else(|e| {
-                            panic!("Failed to unregister table from Hummock {:?}.", e);
+                            panic!(
+                                "Failed to unregister table from Hummock {}.",
+                                e.as_report()
+                            );
                         });
                     self.try_update_write_limits(&write_limit_compaction_groups)
                         .await;

--- a/src/meta/src/hummock/manager/worker.rs
+++ b/src/meta/src/hummock/manager/worker.rs
@@ -125,10 +125,7 @@ impl HummockManager {
                     self.unregister_table_ids(table_ids.into_iter().map(Into::into))
                         .await
                         .unwrap_or_else(|e| {
-                            panic!(
-                                "Failed to unregister table from Hummock {}.",
-                                e.as_report()
-                            );
+                            panic!("Failed to unregister table from Hummock {}.", e.as_report());
                         });
                     self.try_update_write_limits(&write_limit_compaction_groups)
                         .await;

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -47,6 +47,7 @@ pub enum LocalNotification {
     SystemParamsChange(SystemParamsReader),
     FragmentMappingsUpsert(Vec<FragmentId>),
     FragmentMappingsDelete(Vec<FragmentId>),
+    MayUnregisterTablesFromHummock(Vec<u32>),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Before this PR, tables are unregistered from Hummock either after the drop-stream-job barrier succeeds or during recovery. However there is a corner case that can cause a deadlock situation:

1. The cluster encounters backpressure originating from Hummock. So the earliest barrier becomes stuck. It is expected to be resolved via Hummock compaction.
2. User drops the table. Meta removes the table from catalog immediately on receiving the drop command. But Hummock manager won't remove the table until the barrier finishes, which is stuck already.
3. At the moment, compaction task related to this dropped table will always fail due to the inconsistency between catalog and Hummock. So the backpressure will never recover. It's a deadlock situation. Neither the barrier or the compaction can make any progress.

This PR fixes it by ensuring Hummock unregister tables immediately after catalog has done so, **only if any of the dropped tables are causing Hummock write stop**. Note that during the period between the immediate unregistration of tables and the later actor dropping due to the mutation barrier, 
1. The actors related to the dropped tables will read incorrect data from Hummock. This is fine since those tables and their dependent tables will be eventually dropped anyway.
2. Consequenly compute nodes may panic due to consistency check failure. This is expected and the cluster will recover successfully after this.

related https://github.com/risingwavelabs/risingwave/issues/15144

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
