### PR TITLE
feat(frontend): lossy "purify" column default value

### DIFF
--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -109,7 +109,7 @@ pub fn try_purify_table_source_create_sql_ast(
                     matches!(
                         o.option,
                         ColumnOption::DefaultValue { .. }
-                            | ColumnOption::DefaultValuePersisted { .. }
+                            | ColumnOption::DefaultValueInternal { .. }
                     )
                 })
                 .at_most_one()
@@ -118,13 +118,13 @@ pub fn try_purify_table_source_create_sql_ast(
 
             let expr = default_value_option.and_then(|o| match o.option {
                 ColumnOption::DefaultValue(expr) => Some(expr),
-                ColumnOption::DefaultValuePersisted { expr, .. } => expr,
+                ColumnOption::DefaultValueInternal { expr, .. } => expr,
                 _ => unreachable!(),
             });
 
             column_def.options.push(ColumnOptionDef {
                 name: None,
-                option: ColumnOption::DefaultValuePersisted { persisted, expr },
+                option: ColumnOption::DefaultValueInternal { persisted, expr },
             });
         }
 

--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -117,18 +117,17 @@ pub fn try_purify_table_source_create_sql_ast(
             });
         }
 
-        // Remove primary key constraint from the column options. It will be specified with
-        // table constraints later.
-        column_def
-            .options
-            .retain(|o| !matches!(o.option, ColumnOption::Unique { is_primary: true }));
-
         purified_column_defs.push(column_def);
     }
     *column_defs = purified_column_defs;
 
-    if row_id_index.is_none() {
-        // User-defined primary key.
+    // Specify user-defined primary key in table constraints.
+    let has_pk_column_constraint = column_defs.iter().any(|c| {
+        c.options
+            .iter()
+            .any(|o| matches!(o.option, ColumnOption::Unique { is_primary: true }))
+    });
+    if !has_pk_column_constraint && row_id_index.is_none() {
         let mut pk_columns = Vec::new();
 
         for &id in pk_column_ids {

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -179,7 +179,7 @@ fn ensure_column_options_supported(c: &ColumnDef) -> Result<()> {
     for option_def in &c.options {
         match option_def.option {
             ColumnOption::GeneratedColumns(_) => {}
-            ColumnOption::DefaultColumns(_) => {}
+            ColumnOption::DefaultValue(_) => {}
             ColumnOption::Unique { is_primary: true } => {}
             _ => bail_not_implemented!("column constraints \"{}\"", option_def),
         }
@@ -352,7 +352,7 @@ pub fn bind_sql_column_constraints(
                     );
                     binder.set_clause(None);
                 }
-                ColumnOption::DefaultColumns(expr) => {
+                ColumnOption::DefaultValue(expr) => {
                     let idx = binder
                         .get_column_binding_index(table_name.clone(), &column.name.real_value())?;
                     let expr_impl = binder
@@ -1128,7 +1128,7 @@ pub(super) async fn handle_create_table_plan(
                 None => {
                     for column_def in &column_defs {
                         for option_def in &column_def.options {
-                            if let ColumnOption::DefaultColumns(_) = option_def.option {
+                            if let ColumnOption::DefaultValue(_) = option_def.option {
                                 return Err(ErrorCode::NotSupported(
                                             "Default value for columns defined on the table created from a CDC source".into(),
                                             "Remove the default value expression in the column definitions".into(),

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -181,7 +181,7 @@ fn ensure_column_options_supported(c: &ColumnDef) -> Result<()> {
         match option_def.option {
             ColumnOption::GeneratedColumns(_) => {}
             ColumnOption::DefaultValue(_) => {}
-            ColumnOption::DefaultValuePersisted { .. } => {}
+            ColumnOption::DefaultValueInternal { .. } => {}
             ColumnOption::Unique { is_primary: true } => {}
             _ => bail_not_implemented!("column constraints \"{}\"", option_def),
         }
@@ -390,7 +390,7 @@ pub fn bind_sql_column_constraints(
                         .into());
                     }
                 }
-                ColumnOption::DefaultValuePersisted { persisted, expr: _ } => {
+                ColumnOption::DefaultValueInternal { persisted, expr: _ } => {
                     // When a `DEFAULT INTERNAL` is used internally for schema change, the persisted value
                     // should already be set during purifcation. So if we encounter an empty value here, it
                     // means the user has specified it explicitly in the SQL statement, typically by
@@ -1148,7 +1148,7 @@ pub(super) async fn handle_create_table_plan(
                     for column_def in &column_defs {
                         for option_def in &column_def.options {
                             if let ColumnOption::DefaultValue(_)
-                            | ColumnOption::DefaultValuePersisted { .. } = option_def.option
+                            | ColumnOption::DefaultValueInternal { .. } = option_def.option
                             {
                                 return Err(ErrorCode::NotSupported(
                                             "Default value for columns defined on the table created from a CDC source".into(),

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -736,8 +736,13 @@ pub enum ColumnOption {
     NotNull,
     /// `DEFAULT <restricted-expr>`
     DefaultValue(Expr),
+    /// Default value from previous bound `DefaultColumnDesc`. Used internally
+    /// and will not be parsed from SQL.
     DefaultValuePersisted {
+        /// Protobuf encoded `DefaultColumnDesc`.
         persisted: Box<[u8]>,
+        /// Optional AST for unparsing. If `None`, the default value will be
+        /// shown as `DEFAULT ...`, which is for demonstrating and not valid.
         expr: Option<Expr>,
     },
     /// `{ PRIMARY KEY | UNIQUE }`

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -735,7 +735,7 @@ pub enum ColumnOption {
     /// `NOT NULL`
     NotNull,
     /// `DEFAULT <restricted-expr>`
-    DefaultColumns(Expr),
+    DefaultValue(Expr),
     /// `{ PRIMARY KEY | UNIQUE }`
     Unique { is_primary: bool },
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
@@ -765,7 +765,7 @@ impl fmt::Display for ColumnOption {
         match self {
             Null => write!(f, "NULL"),
             NotNull => write!(f, "NOT NULL"),
-            DefaultColumns(expr) => write!(f, "DEFAULT {}", expr),
+            DefaultValue(expr) => write!(f, "DEFAULT {}", expr),
             Unique { is_primary } => {
                 write!(f, "{}", if *is_primary { "PRIMARY KEY" } else { "UNIQUE" })
             }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -779,7 +779,7 @@ impl fmt::Display for ColumnOption {
                 if let Some(expr) = expr {
                     write!(f, "DEFAULT {}", expr)
                 } else {
-                    write!(f, "DEFAULT ...")
+                    write!(f, "DEFAULT INTERNAL")
                 }
             }
             Unique { is_primary } => {

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -736,6 +736,10 @@ pub enum ColumnOption {
     NotNull,
     /// `DEFAULT <restricted-expr>`
     DefaultValue(Expr),
+    DefaultValuePersisted {
+        persisted: Box<[u8]>,
+        expr: Option<Expr>,
+    },
     /// `{ PRIMARY KEY | UNIQUE }`
     Unique { is_primary: bool },
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
@@ -766,6 +770,13 @@ impl fmt::Display for ColumnOption {
             Null => write!(f, "NULL"),
             NotNull => write!(f, "NOT NULL"),
             DefaultValue(expr) => write!(f, "DEFAULT {}", expr),
+            DefaultValuePersisted { persisted: _, expr } => {
+                if let Some(expr) = expr {
+                    write!(f, "DEFAULT {}", expr)
+                } else {
+                    write!(f, "DEFAULT ...")
+                }
+            }
             Unique { is_primary } => {
                 write!(f, "{}", if *is_primary { "PRIMARY KEY" } else { "UNIQUE" })
             }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -737,12 +737,13 @@ pub enum ColumnOption {
     /// `DEFAULT <restricted-expr>`
     DefaultValue(Expr),
     /// Default value from previous bound `DefaultColumnDesc`. Used internally
-    /// and will not be parsed from SQL.
-    DefaultValuePersisted {
+    /// for schema change and should not be specified by users.
+    DefaultValueInternal {
         /// Protobuf encoded `DefaultColumnDesc`.
         persisted: Box<[u8]>,
         /// Optional AST for unparsing. If `None`, the default value will be
-        /// shown as `DEFAULT ...`, which is for demonstrating and not valid.
+        /// shown as `DEFAULT INTERNAL` which is for demonstrating and should
+        /// not be specified by users.
         expr: Option<Expr>,
     },
     /// `{ PRIMARY KEY | UNIQUE }`
@@ -775,7 +776,7 @@ impl fmt::Display for ColumnOption {
             Null => write!(f, "NULL"),
             NotNull => write!(f, "NOT NULL"),
             DefaultValue(expr) => write!(f, "DEFAULT {}", expr),
-            DefaultValuePersisted { persisted: _, expr } => {
+            DefaultValueInternal { persisted: _, expr } => {
                 if let Some(expr) = expr {
                     write!(f, "DEFAULT {}", expr)
                 } else {

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2795,7 +2795,7 @@ impl Parser<'_> {
             Ok(Some(ColumnOption::Null))
         } else if self.parse_keyword(Keyword::DEFAULT) {
             if self.parse_keyword(Keyword::INTERNAL) {
-                Ok(Some(ColumnOption::DefaultValuePersisted {
+                Ok(Some(ColumnOption::DefaultValueInternal {
                     // Placeholder. Will fill during definition purification for schema change.
                     persisted: Default::default(),
                     expr: None,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2794,7 +2794,15 @@ impl Parser<'_> {
         } else if self.parse_keyword(Keyword::NULL) {
             Ok(Some(ColumnOption::Null))
         } else if self.parse_keyword(Keyword::DEFAULT) {
-            Ok(Some(ColumnOption::DefaultValue(self.parse_expr()?)))
+            if self.parse_keyword(Keyword::INTERNAL) {
+                Ok(Some(ColumnOption::DefaultValuePersisted {
+                    // Placeholder. Will fill during definition purification for schema change.
+                    persisted: Default::default(),
+                    expr: None,
+                }))
+            } else {
+                Ok(Some(ColumnOption::DefaultValue(self.parse_expr()?)))
+            }
         } else if self.parse_keywords(&[Keyword::PRIMARY, Keyword::KEY]) {
             Ok(Some(ColumnOption::Unique { is_primary: true }))
         } else if self.parse_keyword(Keyword::UNIQUE) {

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2794,7 +2794,7 @@ impl Parser<'_> {
         } else if self.parse_keyword(Keyword::NULL) {
             Ok(Some(ColumnOption::Null))
         } else if self.parse_keyword(Keyword::DEFAULT) {
-            Ok(Some(ColumnOption::DefaultColumns(self.parse_expr()?)))
+            Ok(Some(ColumnOption::DefaultValue(self.parse_expr()?)))
         } else if self.parse_keywords(&[Keyword::PRIMARY, Keyword::KEY]) {
             Ok(Some(ColumnOption::Unique { is_primary: true }))
         } else if self.parse_keyword(Keyword::UNIQUE) {

--- a/src/sqlparser/tests/sqlparser_postgres.rs
+++ b/src/sqlparser/tests/sqlparser_postgres.rs
@@ -51,7 +51,7 @@ fn parse_create_table_with_defaults() {
                         None,
                         vec![ColumnOptionDef {
                             name: None,
-                            option: ColumnOption::DefaultColumns(verified_expr(
+                            option: ColumnOption::DefaultValue(verified_expr(
                                 "nextval(public.customer_customer_id_seq)"
                             ))
                         }],
@@ -100,7 +100,7 @@ fn parse_create_table_with_defaults() {
                         vec![
                             ColumnOptionDef {
                                 name: None,
-                                option: ColumnOption::DefaultColumns(Expr::Value(Value::Boolean(
+                                option: ColumnOption::DefaultValue(Expr::Value(Value::Boolean(
                                     true
                                 ))),
                             },
@@ -117,7 +117,7 @@ fn parse_create_table_with_defaults() {
                         vec![
                             ColumnOptionDef {
                                 name: None,
-                                option: ColumnOption::DefaultColumns(verified_expr(
+                                option: ColumnOption::DefaultValue(verified_expr(
                                     "CAST(now() AS TEXT)"
                                 ))
                             },
@@ -134,7 +134,7 @@ fn parse_create_table_with_defaults() {
                         vec![
                             ColumnOptionDef {
                                 name: None,
-                                option: ColumnOption::DefaultColumns(verified_expr("now()")),
+                                option: ColumnOption::DefaultValue(verified_expr("now()")),
                             },
                             ColumnOptionDef {
                                 name: None,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

In #19949 we mentioned that

> convert `ExprNode` back to ast can be a bit tricky.

which is the very missing piece of definition purification.

In this PR, we allow converting persisted `DefaultColumnDesc` back to `ast::ColumnOption::DefaultValue` losslessly, by simply storing the encoded value temporarily into the AST.

Apparently this is somehow hacky, as unparsing the AST back to SQL will still lose such information. However, this can still be beneficial for...

- reusing the purification code for `get_new_table_definition_for_cdc_table`
- resolv-ing https://github.com/risingwavelabs/risingwave/issues/17121 once we adopt the purified definition for replacing job

...as long as we believe that AST is the best intermediate representation for schema change.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
