### PR TITLE
fix(stream): avoid committing to in-memory state store in join benchmark

### DIFF
--- a/src/stream/benches/stream_hash_join_rt.rs
+++ b/src/stream/benches/stream_hash_join_rt.rs
@@ -34,7 +34,7 @@ risingwave_expr_impl::enable!();
 
 fn bench_hash_join(c: &mut Criterion) {
     let mut group = c.benchmark_group("benchmark_hash_join");
-    group.sample_size(10);
+    group.sample_size(100);
 
     let rt = Runtime::new().unwrap();
     for amp in [10_000, 20_000, 30_000, 40_000, 100_000, 200_000, 400_000] {

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -852,6 +852,12 @@ pub mod hash_join_executor {
             // Push a single record into tx_r, so 100K records to be matched are cached.
             let chunk = build_chunk(amp, 200_000);
             tx_r.push_chunk(chunk);
+
+            // Ensure that the chunk on the rhs is processed, before inserting a chunk
+            // into the lhs. This is to ensure that the rhs chunk is cached,
+            // and we don't get interleaving of chunks between lhs and rhs.
+            tx_l.push_barrier(test_epoch(2), false);
+            tx_r.push_barrier(test_epoch(2), false);
         }
 
         // Push a chunk of records into tx_l, matches 100K records in the build side.
@@ -874,6 +880,17 @@ pub mod hash_join_executor {
             }
             other => {
                 panic!("Expected a barrier, got {:?}", other);
+            }
+        }
+
+        if matches!(hash_join_workload, HashJoinWorkload::InCache) {
+            match stream.next().await {
+                Some(Ok(Message::Barrier(b))) => {
+                    assert_eq!(b.epoch.curr, test_epoch(2));
+                }
+                other => {
+                    panic!("Expected a barrier, got {:?}", other);
+                }
             }
         }
 

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -854,9 +854,6 @@ pub mod hash_join_executor {
             tx_r.push_chunk(chunk);
         }
 
-        tx_l.push_barrier(test_epoch(2), false);
-        tx_r.push_barrier(test_epoch(2), false);
-
         // Push a chunk of records into tx_l, matches 100K records in the build side.
         let chunk_size = match hash_join_workload {
             HashJoinWorkload::InCache => 64,
@@ -874,15 +871,6 @@ pub mod hash_join_executor {
         match stream.next().await {
             Some(Ok(Message::Barrier(b))) => {
                 assert_eq!(b.epoch.curr, test_epoch(1));
-            }
-            other => {
-                panic!("Expected a barrier, got {:?}", other);
-            }
-        }
-
-        match stream.next().await {
-            Some(Ok(Message::Barrier(b))) => {
-                assert_eq!(b.epoch.curr, test_epoch(2));
             }
             other => {
                 panic!("Expected a barrier, got {:?}", other);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

If we commit to state store, we will end up measuring the memory consumption of writing the amplified chunks to the in-memory state store.
In production, state store is on top of object storage / disk. The in-memory state store is only used in benchmark / tests. So we shouldn't benchmark the memory consumption.

Further, the amplified chunks are not written in a large batch typically. The scenario we care about is OOM from dimension table update. In such a scenario, the fact table side's memory consumption will be high due to reads from the update side, rather than writes.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
