### PR TITLE
feat(sink): Support updates rather than overrides for mongodb sink upsert

### DIFF
--- a/ci/scripts/e2e-mongodb-sink-test.sh
+++ b/ci/scripts/e2e-mongodb-sink-test.sh
@@ -66,6 +66,18 @@ if [ "$compound_pk_result" != "1" ]; then
     exit 1
 fi
 
+compound_pk_result=$(mongo mongodb://mongodb:27017 --eval 'db.getSiblingDB("demo").t4.find({ "_id": 1 }).toArray()' | tail -n 1)
+if [ "$compound_pk_result" != "[ { "_id" : 1, "v1" : 1, "v2" : 10, "v3" : 1, "v4" : 1 } ]" ]; then
+    echo "The upsert output is not as expected."
+    exit 1
+fi
+
+compound_pk_result=$(mongo mongodb://mongodb:27017 --eval 'db.getSiblingDB("demo").t4.find({ "_id": 1 }).toArray()' | tail -n 1)
+if [ "$compound_pk_result" != "[ { "_id" : 2, "v1" : 2, "v2" : 200, "v3" : 2, "v4" : 2 } ]" ]; then
+    echo "The upsert output is not as expected."
+    exit 1
+fi
+
 echo "Mongodb sink check passed"
 
 echo "--- Kill cluster"

--- a/ci/scripts/e2e-mongodb-sink-test.sh
+++ b/ci/scripts/e2e-mongodb-sink-test.sh
@@ -66,15 +66,17 @@ if [ "$compound_pk_result" != "1" ]; then
     exit 1
 fi
 
-compound_pk_result=$(mongo mongodb://mongodb:27017 --eval 'db.getSiblingDB("demo").t4.find({ "_id": 1 }).toArray()' | tail -n 1)
-if [ "$compound_pk_result" != "[ { "_id" : 1, "v1" : 1, "v2" : 10, "v3" : 1, "v4" : 1 } ]" ]; then
+update_id1_result=$(mongo mongodb://mongodb:27017 --eval 'db.getSiblingDB("demo").t4.find({ "_id": 1 }).toArray()' | tail -n 1)
+if [ "$update_id1_result" != "[ { \"_id\" : 1, \"v1\" : 1, \"v2\" : 10, \"v3\" : 1, \"v4\" : 1 } ]" ]; then
     echo "The upsert output is not as expected."
+    echo $update_id1_result
     exit 1
 fi
 
-compound_pk_result=$(mongo mongodb://mongodb:27017 --eval 'db.getSiblingDB("demo").t4.find({ "_id": 1 }).toArray()' | tail -n 1)
-if [ "$compound_pk_result" != "[ { "_id" : 2, "v1" : 2, "v2" : 200, "v3" : 2, "v4" : 2 } ]" ]; then
+update_id2_result=$(mongo mongodb://mongodb:27017 --eval 'db.getSiblingDB("demo").t4.find({ "_id": 2 }).toArray()' | tail -n 1)
+if [ "$update_id2_result" != "[ { \"_id\" : 2, \"v1\" : 2, \"v2\" : 200, \"v3\" : 2, \"v4\" : 2 } ]" ]; then
     echo "The upsert output is not as expected."
+    echo $update_id2_result
     exit 1
 fi
 

--- a/e2e_test/sink/mongodb_sink.slt
+++ b/e2e_test/sink/mongodb_sink.slt
@@ -87,6 +87,58 @@ delete from t3 where a = 1 and b = 2;
 statement ok
 insert into t3 values(1, 2, 'abc');
 
+
+statement ok
+create table t4(
+    v1 int,
+    v2 int,
+    v3 int,
+    v4 int,
+);
+
+statement ok
+create sink t4_sink from t4
+with (
+    connector='mongodb',
+    type = 'upsert',
+    mongodb.url = 'mongodb://mongodb:27017/?replicaSet=rs0',
+    collection.name = 'demo.t4',
+    mongodb.bulk_write.max_entries = '1024',
+    primary_key='v1'
+);
+
+statement ok
+insert into t4 values(1, 1, 1, 1),(2, 2, 2, 2);
+
+statement ok
+drop sink t4_sink;
+
+statement ok
+drop table t4;
+
+statement ok
+create table t5(
+    v1 int,
+    v2 int,
+);
+
+statement ok
+create sink t5_sink from t5
+with (
+    connector='mongodb',
+    type = 'upsert',
+    mongodb.url = 'mongodb://mongodb:27017/?replicaSet=rs0',
+    collection.name = 'demo.t4',
+    mongodb.bulk_write.max_entries = '1024',
+    primary_key='v1'
+);
+
+statement ok
+insert into t5 values(1, 10),(2, 20);
+
+statement ok
+update t5 set v2 = 200 where v1 = 2;
+
 statement ok
 FLUSH;
 
@@ -107,3 +159,9 @@ DROP SINK t3_sink;
 
 statement ok
 DROP TABLE t3;
+
+statement ok
+DROP SINK t5_sink;
+
+statement ok
+DROP TABLE t5;

--- a/e2e_test/sink/mongodb_sink.slt
+++ b/e2e_test/sink/mongodb_sink.slt
@@ -142,6 +142,8 @@ update t5 set v2 = 200 where v1 = 2;
 statement ok
 FLUSH;
 
+sleep 5s
+
 statement ok
 DROP SINK t1_sink;
 

--- a/e2e_test/sink/mongodb_sink.slt
+++ b/e2e_test/sink/mongodb_sink.slt
@@ -137,6 +137,9 @@ statement ok
 insert into t5 values(1, 10),(2, 20);
 
 statement ok
+FLUSH;
+
+statement ok
 update t5 set v2 = 200 where v1 = 2;
 
 statement ok

--- a/src/connector/src/sink/mongodb.rs
+++ b/src/connector/src/sink/mongodb.rs
@@ -530,7 +530,9 @@ impl UpsertCommandBuilder {
 
         self.updates.push(bson!( {
             "q": pk,
-            "u": row,
+            "u": bson!( {
+                "$set": row,
+            }),
             "upsert": true,
             "multi": false,
         }));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Before: 
If mongodb's data is 
```
id: 1
v1:1
v2:1
v3:1
```
our table is` v1,v2 (v1 is pk)`, we `insert 1,1`
mongodb's data will be 
```
id: 1
v1:1
v2:1
```
Or we `update v2 = 100 where v1 = 1`;
mongodb's data will be 
```
id: 1
v1:1
v2:100
```

After this pr: 
`insert 1,1` mongodb's data will be 
```
id: 1
v1:1
v2:1
v3:1
```

`update v2 = 100 where v1 = 1`; mongodb's data will be 
```
id: 1
v1:1
v2:100
v3:1
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
