### PR TITLE
feat(snapshot-backfill): measure accumulated row count for each vnode stream

### DIFF
--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -502,7 +502,7 @@ async fn make_log_stream(
             )
             .map_ok(move |stream| {
                 let stream = stream.map_err(Into::into);
-                (vnode, stream)
+                (vnode, stream, 0)
             })
     }))
     .await?;
@@ -529,7 +529,7 @@ async fn make_snapshot_stream(
             )
             .map_ok(move |stream| {
                 let stream = stream.map_ok(ChangeLogRow::Insert).map_err(Into::into);
-                (vnode, stream)
+                (vnode, stream, 0)
             })
     }))
     .await?;

--- a/src/stream/src/executor/backfill/snapshot_backfill/vnode_stream.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/vnode_stream.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::mem::{replace, take};
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
@@ -32,10 +32,11 @@ pub(super) trait ChangeLogRowStream =
     Stream<Item = StreamExecutorResult<ChangeLogRow>> + Sized + 'static;
 
 #[pin_project]
-struct StreamWithVnode<St> {
+struct StreamWithVnode<St: ChangeLogRowStream> {
     #[pin]
-    stream: St,
+    stream: Peekable<St>,
     vnode: VirtualNode,
+    row_count: usize,
 }
 
 impl<St: ChangeLogRowStream> Stream for StreamWithVnode<St> {
@@ -43,34 +44,52 @@ impl<St: ChangeLogRowStream> Stream for StreamWithVnode<St> {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        this.stream.poll_next(cx)
+        let poll_result = this.stream.poll_next(cx);
+        if let Poll::Ready(Some(Ok(change_log_row))) = &poll_result {
+            match change_log_row {
+                ChangeLogRow::Insert(_) | ChangeLogRow::Delete(_) => {
+                    *this.row_count += 1;
+                }
+                ChangeLogRow::Update { .. } => {
+                    *this.row_count += 2;
+                }
+            }
+        }
+        poll_result
     }
 }
 
-type ChangeLogRowVnodeStream<St> = Pin<Box<Peekable<StreamWithVnode<St>>>>;
+type ChangeLogRowVnodeStream<St> = Pin<Box<StreamWithVnode<St>>>;
 
 pub(super) struct VnodeStream<St: ChangeLogRowStream> {
     streams: FuturesUnordered<StreamFuture<ChangeLogRowVnodeStream<St>>>,
-    finished_vnode: HashSet<VirtualNode>,
+    finished_vnode: HashMap<VirtualNode, usize>,
     data_chunk_builder: DataChunkBuilder,
     ops: Vec<Op>,
 }
 
 impl<St: ChangeLogRowStream> VnodeStream<St> {
     pub(super) fn new(
-        vnode_streams: impl IntoIterator<Item = (VirtualNode, St)>,
+        vnode_streams: impl IntoIterator<Item = (VirtualNode, St, usize)>,
         data_chunk_builder: DataChunkBuilder,
     ) -> Self {
         assert!(data_chunk_builder.is_empty());
-        assert!(data_chunk_builder.batch_size() >= 2);
-        let streams =
-            FuturesUnordered::from_iter(vnode_streams.into_iter().map(|(vnode, stream)| {
-                Box::pin(StreamWithVnode { stream, vnode }.peekable()).into_future()
-            }));
+        assert!(data_chunk_builder.batch_size() > 2);
+        let streams = FuturesUnordered::from_iter(vnode_streams.into_iter().map(
+            |(vnode, stream, row_count)| {
+                let stream = stream.peekable();
+                Box::pin(StreamWithVnode {
+                    stream,
+                    vnode,
+                    row_count,
+                })
+                .into_future()
+            },
+        ));
         let ops = Vec::with_capacity(data_chunk_builder.batch_size());
         Self {
             streams,
-            finished_vnode: HashSet::new(),
+            finished_vnode: HashMap::new(),
             data_chunk_builder,
             ops,
         }
@@ -86,8 +105,9 @@ impl<St: ChangeLogRowStream> VnodeStream<St> {
             let ready_item = match ready!(self.streams.poll_next_unpin(cx)) {
                 None => Ok(None),
                 Some((None, stream)) => {
-                    let stream = stream.get_ref();
-                    assert!(self.finished_vnode.insert(stream.vnode));
+                    self.finished_vnode
+                        .try_insert(stream.vnode, stream.row_count)
+                        .expect("non-duplicate");
                     continue;
                 }
                 Some((Some(Ok(item)), stream)) => {
@@ -103,7 +123,7 @@ impl<St: ChangeLogRowStream> VnodeStream<St> {
         }
     }
 
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(super) fn consume_builder(&mut self) -> Option<StreamChunk> {
         self.data_chunk_builder.consume_all().map(|chunk| {
             let ops = replace(
@@ -114,19 +134,29 @@ impl<St: ChangeLogRowStream> VnodeStream<St> {
         })
     }
 
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(super) async fn for_vnode_pk_progress(
         &mut self,
         pk_indices: &[usize],
-        mut on_vnode_progress: impl FnMut(VirtualNode, Option<OwnedRow>),
+        mut on_vnode_progress: impl FnMut(VirtualNode, usize, Option<OwnedRow>),
     ) -> StreamExecutorResult<()> {
         assert!(self.data_chunk_builder.is_empty());
-        for vnode in &self.finished_vnode {
-            on_vnode_progress(*vnode, None);
+        for (vnode, row_count) in &self.finished_vnode {
+            on_vnode_progress(*vnode, *row_count, None);
         }
-        for vnode_stream in &mut self.streams {
-            let vnode_stream = vnode_stream.get_mut().expect("should exist");
-            match vnode_stream.as_mut().peek().await {
+        let streams = take(&mut self.streams);
+        // When the `VnodeStream` is polled, the `FuturesUnordered` will generate a special cx to poll the futures.
+        // The pending futures will be stored in a separate linked list and will not be polled until the special cx is awakened
+        // and move the awakened future from the linked list to a ready queue.
+        //
+        // However, here if we use `FuturesUnordered::iter_mut` to in place access the pending futures and call `peek` directly,
+        // the cx specially generated in `FuturedUnordered::poll_next` will be overwritten, and then even the peeked future is ready,
+        // it will not be moved to the ready queue, and the `FuturesUnordered` will be stuck forever.
+        //
+        // Therefore, to avoid this, we will take all stream futures out and push them back again, so that all futures will be in the ready queue.
+        for vnode_stream_future in streams {
+            let mut vnode_stream = vnode_stream_future.into_inner().expect("should exist");
+            match vnode_stream.as_mut().project().stream.peek().await {
                 Some(Ok(change_log_row)) => {
                     let row = match change_log_row {
                         ChangeLogRow::Insert(row) | ChangeLogRow::Delete(row) => row,
@@ -144,15 +174,17 @@ impl<St: ChangeLogRowStream> VnodeStream<St> {
                         }
                     };
                     let pk = row.project(pk_indices).to_owned_row();
-                    let vnode_stream = vnode_stream.get_ref();
-                    on_vnode_progress(vnode_stream.vnode, Some(pk));
+                    on_vnode_progress(vnode_stream.vnode, vnode_stream.row_count, Some(pk));
+                    self.streams.push(vnode_stream.into_future());
                 }
                 Some(Err(_)) => {
                     return Err(vnode_stream.try_next().await.expect_err("checked Err"));
                 }
                 None => {
-                    let vnode_stream = vnode_stream.get_ref();
-                    on_vnode_progress(vnode_stream.vnode, None);
+                    self.finished_vnode
+                        .try_insert(vnode_stream.vnode, vnode_stream.row_count)
+                        .expect("non-duplicate");
+                    on_vnode_progress(vnode_stream.vnode, vnode_stream.row_count, None);
                 }
             }
         }
@@ -228,5 +260,180 @@ impl<St: ChangeLogRowStream> Stream for VnodeStream<St> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::future::poll_fn;
+    use std::sync::LazyLock;
+    use std::task::Poll;
+
+    use anyhow::anyhow;
+    use futures::{pin_mut, Future, FutureExt};
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::row::OwnedRow;
+    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
+    use risingwave_storage::table::ChangeLogRow;
+    use tokio::sync::mpsc::unbounded_channel;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+    use tokio_stream::StreamExt;
+
+    use crate::executor::backfill::snapshot_backfill::vnode_stream::VnodeStream;
+
+    static DATA_TYPES: LazyLock<Vec<DataType>> = LazyLock::new(|| vec![DataType::Int64]);
+
+    fn test_row(index: i64) -> OwnedRow {
+        OwnedRow::new(vec![Some(ScalarImpl::Int64(index))])
+    }
+
+    impl<St: super::ChangeLogRowStream> VnodeStream<St> {
+        async fn assert_progress(
+            &mut self,
+            progress: impl IntoIterator<Item = (VirtualNode, usize, Option<OwnedRow>)>,
+        ) {
+            let expected_progress_map: HashMap<_, _> = progress
+                .into_iter()
+                .map(|(vnode, row_count, progress)| (vnode, (row_count, progress)))
+                .collect();
+            let mut progress_map = HashMap::new();
+            self.for_vnode_pk_progress(&[0], |vnode, row_count, progress| {
+                progress_map
+                    .try_insert(vnode, (row_count, progress))
+                    .unwrap();
+            })
+            .await
+            .unwrap();
+            assert_eq!(expected_progress_map, progress_map);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_basic() {
+        let [vnode1, vnode2] = [1, 2].map(VirtualNode::from_index);
+        let (tx1, rx1) = unbounded_channel();
+        let (tx2, rx2) = unbounded_channel();
+        let mut stream = VnodeStream::<UnboundedReceiverStream<_>>::new(
+            [
+                (vnode1, UnboundedReceiverStream::new(rx1), 10),
+                (vnode2, UnboundedReceiverStream::new(rx2), 0),
+            ]
+            .into_iter(),
+            DataChunkBuilder::new(DATA_TYPES.clone(), 3),
+        );
+        assert!(stream.next().now_or_never().is_none());
+        tx1.send(Ok(ChangeLogRow::Insert(test_row(0)))).unwrap();
+        assert!(stream.next().now_or_never().is_none());
+        tx2.send(Ok(ChangeLogRow::Insert(test_row(0)))).unwrap();
+        tx2.send(Ok(ChangeLogRow::Insert(test_row(1)))).unwrap();
+        assert_eq!(3, stream.next().await.unwrap().unwrap().cardinality());
+
+        let next_row = test_row(1);
+        {
+            let future =
+                stream.assert_progress([(vnode1, 11, Some(next_row.clone())), (vnode2, 2, None)]);
+            pin_mut!(future);
+            assert!((&mut future).now_or_never().is_none());
+            tx1.send(Ok(ChangeLogRow::Insert(next_row.clone())))
+                .unwrap();
+            assert!((&mut future).now_or_never().is_none());
+            drop(tx2);
+            future.await;
+        }
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(1, stream.consume_builder().unwrap().cardinality());
+        {
+            let future = stream.assert_progress([(vnode1, 12, None), (vnode2, 2, None)]);
+            pin_mut!(future);
+            assert!((&mut future).now_or_never().is_none());
+            drop(tx1);
+            future.await;
+        }
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let (tx, rx) = unbounded_channel();
+        let mut stream = VnodeStream::new(
+            [(VirtualNode::ZERO, UnboundedReceiverStream::new(rx), 0)].into_iter(),
+            DataChunkBuilder::new(DATA_TYPES.clone(), 3),
+        );
+        assert!(stream.next().now_or_never().is_none());
+        tx.send(Ok(ChangeLogRow::Insert(test_row(0)))).unwrap();
+        tx.send(Ok(ChangeLogRow::Insert(test_row(1)))).unwrap();
+        assert!(stream.next().now_or_never().is_none());
+        tx.send(Ok(ChangeLogRow::Update {
+            new_value: test_row(2),
+            old_value: test_row(3),
+        }))
+        .unwrap();
+        assert_eq!(2, stream.next().await.unwrap().unwrap().cardinality());
+        drop(tx);
+        assert_eq!(2, stream.next().await.unwrap().unwrap().cardinality());
+        assert!(stream.next().await.is_none());
+        stream.assert_progress([(VirtualNode::ZERO, 4, None)]).await;
+    }
+
+    #[tokio::test]
+    async fn test_empty() {
+        let mut stream = VnodeStream::<UnboundedReceiverStream<_>>::new(
+            [].into_iter(),
+            DataChunkBuilder::new(DATA_TYPES.clone(), 1024),
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_err() {
+        {
+            let (tx, rx) = unbounded_channel();
+            let mut stream = VnodeStream::new(
+                [(VirtualNode::ZERO, UnboundedReceiverStream::new(rx), 0)].into_iter(),
+                DataChunkBuilder::new(DATA_TYPES.clone(), 3),
+            );
+            assert!(stream.next().now_or_never().is_none());
+            tx.send(Err(anyhow!("err").into())).unwrap();
+            assert!(stream.next().await.unwrap().is_err());
+        }
+        {
+            let (tx, rx) = unbounded_channel();
+            let mut stream = VnodeStream::new(
+                [(VirtualNode::ZERO, UnboundedReceiverStream::new(rx), 0)].into_iter(),
+                DataChunkBuilder::new(DATA_TYPES.clone(), 3),
+            );
+            assert!(stream.next().now_or_never().is_none());
+            let future = stream.for_vnode_pk_progress(&[0], |_, _, _| unreachable!());
+            pin_mut!(future);
+            assert!((&mut future).now_or_never().is_none());
+            tx.send(Err(anyhow!("err").into())).unwrap();
+            assert!(future.await.is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_futures_unordered_peek() {
+        let (tx, rx) = unbounded_channel();
+        let mut stream = VnodeStream::new(
+            [(VirtualNode::ZERO, UnboundedReceiverStream::new(rx), 0)].into_iter(),
+            DataChunkBuilder::new(DATA_TYPES.clone(), 1024),
+        );
+        // poll the stream for once, and then the stream future inside it will be stored in the pending list.
+        assert!(stream.next().now_or_never().is_none());
+        let row = test_row(1);
+        {
+            let fut = stream.assert_progress([(VirtualNode::ZERO, 0, Some(row.clone()))]);
+            pin_mut!(fut);
+            assert!(poll_fn(|cx| Poll::Ready(fut.as_mut().poll(cx)))
+                .await
+                .is_pending());
+            tx.send(Ok(ChangeLogRow::Insert(row.clone()))).unwrap();
+            drop(tx);
+            fut.await;
+        }
+        let chunk = stream.next().await.unwrap().unwrap();
+        assert_eq!(chunk.capacity(), 1);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Part of https://github.com/risingwavelabs/risingwave/pull/19720

Measure the row count of each vnode stream, so that the row count can be saved in the state to be introduced in https://github.com/risingwavelabs/risingwave/pull/19720.

This PR will also fix a bug found in the CI https://github.com/risingwavelabs/risingwave/pull/19720. In short, the bug is caused by the use of `FuturesUnordered`. In `FuturesUnordered`, pending futures will be stored separately and will not be polled until a special cx generated in `FuturesUnordered::poll_next` is awakened. However, when we use `Peekable::peek` to peek the latest progress of the stream, the special cx will be overwritten when we poll the `Peek` future, and then even the future is ready after peeked, it is still not in the ready queue, and will not be polled and get stuck forever.

Tests are added to cover the bug.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
