### PR TITLE
refactor(streaming): remove `get_compacted_row` from `StateTable`

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -30,7 +30,7 @@ use risingwave_common::catalog::{
     get_dist_key_in_pk_indices, ColumnDesc, ColumnId, TableId, TableOption,
 };
 use risingwave_common::hash::{VirtualNode, VnodeBitmapExt, VnodeCountCompat};
-use risingwave_common::row::{self, once, CompactedRow, Once, OwnedRow, Row, RowExt};
+use risingwave_common::row::{self, once, Once, OwnedRow, Row, RowExt};
 use risingwave_common::types::{DataType, Datum, DefaultOrd, DefaultOrdered, ScalarImpl};
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::epoch::EpochPair;
@@ -658,25 +658,6 @@ where
             .get(serialized_pk, read_options)
             .await
             .map_err(Into::into)
-    }
-
-    /// Get a row in value-encoding format from state table.
-    pub async fn get_compacted_row(
-        &self,
-        pk: impl Row,
-    ) -> StreamExecutorResult<Option<CompactedRow>> {
-        if self.row_serde.kind().is_basic() {
-            // Basic serde is in value-encoding format, which is compatible with the compacted row.
-            self.get_encoded_row(pk)
-                .await
-                .map(|bytes| bytes.map(CompactedRow::new))
-        } else {
-            // For other encodings, we must first deserialize it into a `Row` first, then serialize
-            // it back into value-encoding format.
-            self.get_row(pk)
-                .await
-                .map(|row| row.map(CompactedRow::from))
-        }
     }
 
     /// Update the vnode bitmap of the state table, returns the previous vnode bitmap.

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -741,18 +741,19 @@ impl<SD: ValueRowSerde> MaterializeCache<SD> {
             }
             futures.push(async {
                 let key_row = table.pk_serde().deserialize(key).unwrap();
-                (key.to_vec(), table.get_compacted_row(&key_row).await)
+                let row = table.get_row(key_row).await?.map(CompactedRow::from);
+                StreamExecutorResult::Ok((key.to_vec(), row))
             });
         }
 
         let mut buffered = stream::iter(futures).buffer_unordered(10).fuse();
         while let Some(result) = buffered.next().await {
-            let (key, value) = result;
+            let (key, value) = result?;
             match conflict_behavior {
                 ConflictBehavior::Overwrite | ConflictBehavior::DoUpdateIfNotNull => {
-                    self.data.push(key, value?)
+                    self.data.push(key, value)
                 }
-                ConflictBehavior::IgnoreConflict => self.data.push(key, value?),
+                ConflictBehavior::IgnoreConflict => self.data.push(key, value),
                 _ => unreachable!(),
             };
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The point of `StateTable::get_compacted_row` is that, when a table is using value-encoding, we can save a roundtrip of parsing the encoded row bytes into an `OwnedRow` and serializing it back.

This function is currently used only by `MaterializeCache` when a state table has an on-conflict behavior set. However, in such cases, the state table must be a user `TABLE` that adopts column-aware encoding. As a result, the optimized branch is effectively dead.

In this PR, we remove this function and inline it to its only caller.

This shows us that there's no significant benefit to stick with value-encoding for its memory-efficiency , and we may adopt a better encoding for this (see https://github.com/risingwavelabs/risingwave/issues/20017 for more details).

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
