### PR TITLE
refactor(connector): make SplitEnumerator/Reader dyn

### DIFF
--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -14,7 +14,7 @@
 
 #[macro_export]
 macro_rules! for_all_classified_sources {
-    ($macro:path $(,$extra_args:tt)*) => {
+    ($macro:path $(, $extra_args:tt)*) => {
         $macro! {
             // cdc sources
             {
@@ -67,7 +67,7 @@ macro_rules! for_all_connections {
 #[macro_export]
 macro_rules! for_all_sources_inner {
     (
-        {$({ $cdc_source_type:ident }),* },
+        { $({ $cdc_source_type:ident }),* },
         { $({ $source_variant:ident, $prop_name:ty, $split:ty }),* },
         $macro:tt $(, $extra_args:tt)*
     ) => {
@@ -79,13 +79,14 @@ macro_rules! for_all_sources_inner {
                             [< $cdc_source_type Cdc >],
                             $crate::source::cdc::[< $cdc_source_type CdcProperties >],
                             $crate::source::cdc::DebeziumCdcSplit<$crate::source::cdc::$cdc_source_type>
-                        },
-                    )*
+                        }
+                    ),*
+                    ,
                     $(
                         { $source_variant, $prop_name, $split }
                     ),*
                 }
-                $(,$extra_args)*
+                $(, $extra_args)*
             }
         }
     };
@@ -98,22 +99,55 @@ macro_rules! for_all_sources {
     };
 }
 
+/// The invocation:
+/// ```ignore
+/// dispatch_source_enum_inner!(
+///     {
+///         {A1,B1,C1},
+///         {A2,B2,C2}
+///     },
+///     EnumType, enum_value, inner_ident, body
+/// );
+/// ```
+/// expands to:
+/// ```ignore
+/// match enum_value {
+///     EnumType::A1(inner_ident) => {
+///         #[allow(dead_code)]
+///         type PropType = B1;
+///         #[allow(dead_code)]
+///         type SplitType = C1;
+///         {
+///             body
+///         }
+///     }
+///     EnumType::A2(inner_ident) => {
+///         #[allow(dead_code)]
+///         type PropType = B2;
+///         #[allow(dead_code)]
+///         type SplitType = C2;
+///         {
+///             body
+///         }
+///     }
+/// }
+/// ```
 #[macro_export]
 macro_rules! dispatch_source_enum_inner {
     (
         {$({$source_variant:ident, $prop_name:ty, $split:ty }),*},
-        $enum_name:ident,
-        $impl:tt,
-        {$inner_name:ident, $prop_type_name:ident, $split_type_name:ident},
+        $enum_type:ident,
+        $enum_value:expr,
+        $inner_name:ident,
         $body:expr
     ) => {{
-        match $impl {
+        match $enum_value {
             $(
-                $enum_name::$source_variant($inner_name) => {
+                $enum_type::$source_variant($inner_name) => {
                     #[allow(dead_code)]
-                    type $prop_type_name = $prop_name;
+                    type PropType = $prop_name;
                     #[allow(dead_code)]
-                    type $split_type_name = $split;
+                    type SplitType = $split;
                     {
                         $body
                     }
@@ -123,10 +157,28 @@ macro_rules! dispatch_source_enum_inner {
     }}
 }
 
+/// Usage: `dispatch_source_enum!(EnumType, enum_value, inner_ident, body)`.
+///
+/// Inside `body`:
+/// - use `inner_ident` to represent the matched variant.
+/// - use `PropType` to represent the concrete property type.
+/// - use `SplitType` to represent the concrete split type.
+///
+/// Expands to:
+/// ```ignore
+/// match enum_value {
+///     EnumType::Variant1(inner_ident) => {
+///         body
+///     }
+///     ...
+/// }
+/// ```
+///
+/// Note: `inner_ident` must be passed as an argument due to macro hygiene.
 #[macro_export]
 macro_rules! dispatch_source_enum {
-    ($enum_name:ident, $impl:expr, $inner_name:tt, $body:expr) => {{
-        $crate::for_all_sources! {$crate::dispatch_source_enum_inner, $enum_name, { $impl }, $inner_name, $body}
+    ($enum_type:ident, $enum_value:expr, $inner_name:ident, $body:expr) => {{
+        $crate::for_all_sources! {$crate::dispatch_source_enum_inner, $enum_type, { $enum_value }, $inner_name, $body}
     }};
 }
 
@@ -167,11 +219,12 @@ macro_rules! match_source_name_str {
     }};
 }
 
+/// [`dispatch_source_enum`] with `SplitImpl` as the enum type.
 #[macro_export]
 macro_rules! dispatch_split_impl {
-    ($impl:expr, $inner_name:ident, $prop_type_name:ident, $body:expr) => {{
+    ($impl:expr, $inner_name:ident, $body:expr) => {{
         use $crate::source::SplitImpl;
-        $crate::dispatch_source_enum! {SplitImpl, { $impl }, {$inner_name, $prop_type_name, IgnoreSplitType}, $body}
+        $crate::dispatch_source_enum! {SplitImpl, { $impl }, $inner_name, $body}
     }};
 }
 
@@ -290,11 +343,12 @@ macro_rules! impl_split {
     }
 }
 
+/// [`dispatch_source_enum`] with `ConnectorProperties` as the enum type.
 #[macro_export]
 macro_rules! dispatch_source_prop {
-    ($impl:expr, $source_prop:tt, $body:expr) => {{
+    ($connector_properties:expr, $inner_ident:tt, $body:expr) => {{
         use $crate::source::ConnectorProperties;
-        $crate::dispatch_source_enum! {ConnectorProperties, { $impl }, {$source_prop, IgnorePropType, IgnoreSplitType}, {$body}}
+        $crate::dispatch_source_enum! {ConnectorProperties, { $connector_properties }, $inner_ident, {$body}}
     }};
 }
 

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -157,7 +157,7 @@ macro_rules! dispatch_source_enum_inner {
     }}
 }
 
-/// Usage: `dispatch_source_enum!(EnumType, enum_value, inner_ident, body)`.
+/// Usage: `dispatch_source_enum!(EnumType, enum_value, |inner_ident| body)`.
 ///
 /// Inside `body`:
 /// - use `inner_ident` to represent the matched variant.
@@ -177,7 +177,7 @@ macro_rules! dispatch_source_enum_inner {
 /// Note: `inner_ident` must be passed as an argument due to macro hygiene.
 #[macro_export]
 macro_rules! dispatch_source_enum {
-    ($enum_type:ident, $enum_value:expr, $inner_name:ident, $body:expr) => {{
+    ($enum_type:ident, $enum_value:expr, |$inner_name:ident| $body:expr) => {{
         $crate::for_all_sources! {$crate::dispatch_source_enum_inner, $enum_type, { $enum_value }, $inner_name, $body}
     }};
 }
@@ -222,9 +222,9 @@ macro_rules! match_source_name_str {
 /// [`dispatch_source_enum`] with `SplitImpl` as the enum type.
 #[macro_export]
 macro_rules! dispatch_split_impl {
-    ($impl:expr, $inner_name:ident, $body:expr) => {{
+    ($impl:expr, | $inner_name:ident | $body:expr) => {{
         use $crate::source::SplitImpl;
-        $crate::dispatch_source_enum! {SplitImpl, { $impl }, $inner_name, $body}
+        $crate::dispatch_source_enum! {SplitImpl, { $impl }, |$inner_name| $body}
     }};
 }
 
@@ -346,9 +346,9 @@ macro_rules! impl_split {
 /// [`dispatch_source_enum`] with `ConnectorProperties` as the enum type.
 #[macro_export]
 macro_rules! dispatch_source_prop {
-    ($connector_properties:expr, $inner_ident:tt, $body:expr) => {{
+    ($connector_properties:expr, |$inner_ident:ident| $body:expr) => {{
         use $crate::source::ConnectorProperties;
-        $crate::dispatch_source_enum! {ConnectorProperties, { $connector_properties }, $inner_ident, {$body}}
+        $crate::dispatch_source_enum! {ConnectorProperties, { $connector_properties }, |$inner_ident| {$body}}
     }};
 }
 

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -20,8 +20,9 @@ use async_trait::async_trait;
 use aws_sdk_s3::types::Object;
 use bytes::Bytes;
 use enum_as_inner::EnumAsInner;
+use futures::future::try_join_all;
 use futures::stream::BoxStream;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::bail;
@@ -31,6 +32,7 @@ use risingwave_common::types::{JsonbVal, Scalar};
 use risingwave_pb::catalog::{PbSource, PbStreamSourceInfo};
 use risingwave_pb::plan_common::ExternalTableDesc;
 use risingwave_pb::source::ConnectorSplit;
+use rw_futures_util::select_all;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use tokio::sync::mpsc;
@@ -87,6 +89,11 @@ pub trait SourceProperties: TryFromBTreeMap + Clone + WithOptions + std::fmt::De
 
     /// Load additional info from `ExternalTableDesc`. Currently only used by CDC.
     fn init_from_pb_cdc_table_desc(&mut self, _table_desc: &ExternalTableDesc) {}
+
+    // async fn create_split_enumerator(
+    //     self,
+    //     context: crate::source::SourceEnumeratorContextRef,
+    // ) -> Result<Self::SplitEnumerator>;
 }
 
 pub trait UnknownFields {
@@ -113,21 +120,77 @@ impl<P: DeserializeOwned + UnknownFields> TryFromBTreeMap for P {
     }
 }
 
-pub async fn create_split_reader<P: SourceProperties>(
+#[derive(Default)]
+pub struct CreateSplitReaderOpt {
+    pub support_multiple_splits: bool,
+    pub seek_to_latest: bool,
+}
+
+#[derive(Default)]
+pub struct CreateSplitReaderResult {
+    pub latest_splits: Option<Vec<SplitImpl>>,
+    pub backfill_info: HashMap<SplitId, BackfillInfo>,
+}
+
+pub async fn create_split_readers<P: SourceProperties>(
     prop: P,
     splits: Vec<SplitImpl>,
     parser_config: ParserConfig,
     source_ctx: SourceContextRef,
     columns: Option<Vec<Column>>,
-) -> Result<P::SplitReader> {
+    opt: CreateSplitReaderOpt,
+) -> Result<(BoxSourceChunkStream, CreateSplitReaderResult)> {
     let splits = splits.into_iter().map(P::Split::try_from).try_collect()?;
-    P::SplitReader::new(prop, splits, parser_config, source_ctx, columns).await
+    let mut res = CreateSplitReaderResult {
+        backfill_info: HashMap::new(),
+        latest_splits: None,
+    };
+    if opt.support_multiple_splits {
+        let mut reader = P::SplitReader::new(
+            prop.clone(),
+            splits,
+            parser_config.clone(),
+            source_ctx.clone(),
+            columns.clone(),
+        )
+        .await?;
+        if opt.seek_to_latest {
+            res.latest_splits = Some(reader.seek_to_latest().await?);
+        }
+        res.backfill_info = reader.backfill_info();
+        Ok((reader.into_stream().boxed(), res))
+    } else {
+        let mut readers = try_join_all(splits.into_iter().map(|split| {
+            // TODO: is this reader split across multiple threads...? Realistically, we want
+            // source_ctx to live in a single actor.
+            P::SplitReader::new(
+                prop.clone(),
+                vec![split],
+                parser_config.clone(),
+                source_ctx.clone(),
+                columns.clone(),
+            )
+        }))
+        .await?;
+        if opt.seek_to_latest {
+            let mut latest_splits = vec![];
+            for reader in &mut readers {
+                latest_splits.extend(reader.seek_to_latest().await?);
+            }
+            res.latest_splits = Some(latest_splits);
+        }
+        res.backfill_info = readers.iter().flat_map(|r| r.backfill_info()).collect();
+        Ok((
+            select_all(readers.into_iter().map(|r| r.into_stream())).boxed(),
+            res,
+        ))
+    }
 }
 
 /// [`SplitEnumerator`] fetches the split metadata from the external source service.
 /// NOTE: It runs in the meta server, so probably it should be moved to the `meta` crate.
 #[async_trait]
-pub trait SplitEnumerator: Sized {
+pub trait SplitEnumerator: Sized + Send {
     type Split: SplitMetaData + Send;
     type Properties;
 
@@ -138,6 +201,21 @@ pub trait SplitEnumerator: Sized {
 
 pub type SourceContextRef = Arc<SourceContext>;
 pub type SourceEnumeratorContextRef = Arc<SourceEnumeratorContext>;
+
+/// Dyn-compatible [`SplitEnumerator`].
+#[async_trait]
+pub trait AnySplitEnumerator: Send {
+    async fn list_splits(&mut self) -> Result<Vec<SplitImpl>>;
+}
+
+#[async_trait]
+impl<T: SplitEnumerator<Split: Into<SplitImpl>>> AnySplitEnumerator for T {
+    async fn list_splits(&mut self) -> Result<Vec<SplitImpl>> {
+        SplitEnumerator::list_splits(self)
+            .await
+            .map(|s| s.into_iter().map(|s| s.into()).collect())
+    }
+}
 
 /// The max size of a chunk yielded by source stream.
 pub const MAX_CHUNK_SIZE: usize = 1024;
@@ -498,6 +576,40 @@ impl ConnectorProperties {
             || matches!(self, ConnectorProperties::Gcs(_))
             || matches!(self, ConnectorProperties::Azblob(_))
     }
+
+    pub async fn create_split_enumerator(
+        self,
+        context: crate::source::base::SourceEnumeratorContextRef,
+    ) -> crate::error::ConnectorResult<Box<dyn AnySplitEnumerator>> {
+        let enumerator: Box<dyn AnySplitEnumerator> = dispatch_source_prop!(
+            self,
+            prop,
+            Box::new(<PropType as SourceProperties>::SplitEnumerator::new(*prop, context).await?)
+        );
+        Ok(enumerator)
+    }
+
+    pub async fn create_split_reader(
+        self,
+        splits: Vec<SplitImpl>,
+        parser_config: ParserConfig,
+        source_ctx: SourceContextRef,
+        columns: Option<Vec<Column>>,
+        mut opt: crate::source::CreateSplitReaderOpt,
+    ) -> Result<(BoxSourceChunkStream, crate::source::CreateSplitReaderResult)> {
+        opt.support_multiple_splits = self.support_multiple_splits();
+        tracing::debug!(
+            ?splits,
+            support_multiple_splits = opt.support_multiple_splits,
+            "spawning connector split reader",
+        );
+
+        dispatch_source_prop!(
+            self,
+            prop,
+            create_split_readers(*prop, splits, parser_config, source_ctx, columns, opt).await
+        )
+    }
 }
 
 for_all_sources!(impl_split);
@@ -505,9 +617,9 @@ for_all_connections!(impl_connection);
 
 impl From<&SplitImpl> for ConnectorSplit {
     fn from(split: &SplitImpl) -> Self {
-        dispatch_split_impl!(split, inner, SourcePropType, {
+        dispatch_split_impl!(split, inner, {
             ConnectorSplit {
-                split_type: String::from(SourcePropType::SOURCE_NAME),
+                split_type: String::from(PropType::SOURCE_NAME),
                 encoded_split: inner.encode_to_bytes().to_vec(),
             }
         })
@@ -564,7 +676,7 @@ impl SplitImpl {
 
 impl SplitMetaData for SplitImpl {
     fn id(&self) -> SplitId {
-        dispatch_split_impl!(self, inner, IgnoreType, inner.id())
+        dispatch_split_impl!(self, inner, inner.id())
     }
 
     fn encode_to_json(&self) -> JsonbVal {
@@ -587,31 +699,22 @@ impl SplitMetaData for SplitImpl {
     }
 
     fn update_offset(&mut self, last_seen_offset: String) -> Result<()> {
-        dispatch_split_impl!(
-            self,
-            inner,
-            IgnoreType,
-            inner.update_offset(last_seen_offset)
-        )
+        dispatch_split_impl!(self, inner, inner.update_offset(last_seen_offset))
     }
 }
 
 impl SplitImpl {
     pub fn get_type(&self) -> String {
-        dispatch_split_impl!(self, _ignored, PropType, {
-            PropType::SOURCE_NAME.to_owned()
-        })
+        dispatch_split_impl!(self, _inner, PropType::SOURCE_NAME.to_owned())
     }
 
     pub fn update_in_place(&mut self, last_seen_offset: String) -> Result<()> {
-        dispatch_split_impl!(self, inner, IgnoreType, {
-            inner.update_offset(last_seen_offset)?
-        });
+        dispatch_split_impl!(self, inner, inner.update_offset(last_seen_offset)?);
         Ok(())
     }
 
     pub fn encode_to_json_inner(&self) -> JsonbVal {
-        dispatch_split_impl!(self, inner, IgnoreType, inner.encode_to_json())
+        dispatch_split_impl!(self, inner, inner.encode_to_json())
     }
 }
 

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -89,11 +89,6 @@ pub trait SourceProperties: TryFromBTreeMap + Clone + WithOptions + std::fmt::De
 
     /// Load additional info from `ExternalTableDesc`. Currently only used by CDC.
     fn init_from_pb_cdc_table_desc(&mut self, _table_desc: &ExternalTableDesc) {}
-
-    // async fn create_split_enumerator(
-    //     self,
-    //     context: crate::source::SourceEnumeratorContextRef,
-    // ) -> Result<Self::SplitEnumerator>;
 }
 
 pub trait UnknownFields {

--- a/src/connector/src/source/filesystem/opendal_source/mod.rs
+++ b/src/connector/src/source/filesystem/opendal_source/mod.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashMap;
 
+pub use opendal_enumerator::OpendalEnumerator;
+
 pub mod azblob_source;
 pub mod gcs_source;
 pub mod posix_fs_source;
@@ -25,7 +27,6 @@ use with_options::WithOptions;
 pub mod opendal_enumerator;
 pub mod opendal_reader;
 
-use self::opendal_enumerator::OpendalEnumerator;
 use self::opendal_reader::OpendalReader;
 use super::file_common::CompressionFormat;
 pub use super::s3::S3PropertiesCommon;

--- a/src/connector/src/source/kinesis/mod.rs
+++ b/src/connector/src/source/kinesis/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod enumerator;
+pub use enumerator::client::KinesisSplitEnumerator;
 pub mod source;
 pub mod split;
 
@@ -24,7 +25,6 @@ pub use source::KinesisMeta;
 use with_options::WithOptions;
 
 use crate::connector_common::KinesisCommon;
-use crate::source::kinesis::enumerator::client::KinesisSplitEnumerator;
 use crate::source::kinesis::source::reader::KinesisSplitReader;
 use crate::source::kinesis::split::KinesisSplit;
 use crate::source::SourceProperties;

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -12,6 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod prelude {
+    // import all split enumerators
+    pub use crate::source::datagen::DatagenSplitEnumerator;
+    pub use crate::source::filesystem::opendal_source::OpendalEnumerator;
+    pub use crate::source::filesystem::S3SplitEnumerator;
+    pub use crate::source::google_pubsub::PubsubSplitEnumerator as GooglePubsubSplitEnumerator;
+    pub use crate::source::iceberg::IcebergSplitEnumerator;
+    pub use crate::source::kafka::KafkaSplitEnumerator;
+    pub use crate::source::kinesis::KinesisSplitEnumerator;
+    pub use crate::source::mqtt::MqttSplitEnumerator;
+    pub use crate::source::nats::NatsSplitEnumerator;
+    pub use crate::source::nexmark::NexmarkSplitEnumerator;
+    pub use crate::source::pulsar::PulsarSplitEnumerator;
+    pub use crate::source::test_source::TestSourceSplitEnumerator as TestSplitEnumerator;
+    pub type AzblobSplitEnumerator =
+        OpendalEnumerator<crate::source::filesystem::opendal_source::OpendalAzblob>;
+    pub type GcsSplitEnumerator =
+        OpendalEnumerator<crate::source::filesystem::opendal_source::OpendalGcs>;
+    pub type OpendalS3SplitEnumerator =
+        OpendalEnumerator<crate::source::filesystem::opendal_source::OpendalS3>;
+    pub type PosixFsSplitEnumerator =
+        OpendalEnumerator<crate::source::filesystem::opendal_source::OpendalPosixFs>;
+    pub use crate::source::cdc::enumerator::DebeziumSplitEnumerator;
+    pub type CitusCdcSplitEnumerator = DebeziumSplitEnumerator<crate::source::cdc::Citus>;
+    pub type MongodbCdcSplitEnumerator = DebeziumSplitEnumerator<crate::source::cdc::Mongodb>;
+    pub type PostgresCdcSplitEnumerator = DebeziumSplitEnumerator<crate::source::cdc::Postgres>;
+    pub type MysqlCdcSplitEnumerator = DebeziumSplitEnumerator<crate::source::cdc::Mysql>;
+    pub type SqlServerCdcSplitEnumerator = DebeziumSplitEnumerator<crate::source::cdc::SqlServer>;
+}
+
 pub mod base;
 pub mod cdc;
 pub mod data_gen_util;

--- a/src/connector/src/source/mqtt/mod.rs
+++ b/src/connector/src/source/mqtt/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod enumerator;
 pub mod source;
+pub use enumerator::MqttSplitEnumerator;
 pub mod split;
 
 use std::collections::HashMap;
@@ -25,7 +26,6 @@ use thiserror::Error;
 use with_options::WithOptions;
 
 use crate::connector_common::{MqttCommon, MqttQualityOfService};
-use crate::source::mqtt::enumerator::MqttSplitEnumerator;
 use crate::source::mqtt::source::{MqttSplit, MqttSplitReader};
 use crate::source::SourceProperties;
 

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod enumerator;
+pub use enumerator::NatsSplitEnumerator;
 pub mod source;
 pub mod split;
 
@@ -29,7 +30,6 @@ use with_options::WithOptions;
 
 use crate::connector_common::NatsCommon;
 use crate::error::{ConnectorError, ConnectorResult};
-use crate::source::nats::enumerator::NatsSplitEnumerator;
 use crate::source::nats::source::{NatsSplit, NatsSplitReader};
 use crate::source::SourceProperties;
 use crate::{

--- a/src/connector/src/source/reader/fs_reader.rs
+++ b/src/connector/src/source/reader/fs_reader.rs
@@ -24,10 +24,9 @@ use risingwave_common::catalog::ColumnId;
 use crate::error::ConnectorResult;
 use crate::parser::{CommonParserConfig, ParserConfig, SpecificParserConfig};
 use crate::source::{
-    create_split_reader, BoxSourceChunkStream, ConnectorProperties, ConnectorState,
-    SourceColumnDesc, SourceContext, SplitReader,
+    BoxSourceChunkStream, ConnectorProperties, ConnectorState, SourceColumnDesc, SourceContext,
 };
-use crate::{dispatch_source_prop, WithOptionsSecResolved};
+use crate::WithOptionsSecResolved;
 
 #[derive(Clone, Debug)]
 pub struct FsSourceReader {
@@ -92,11 +91,16 @@ impl FsSourceReader {
         let stream = match state {
             None => pending().boxed(),
             Some(splits) => {
-                dispatch_source_prop!(config, prop, {
-                    create_split_reader(*prop, splits, parser_config, source_ctx, None)
-                        .await?
-                        .into_stream()
-                })
+                config
+                    .create_split_reader(
+                        splits,
+                        parser_config,
+                        source_ctx,
+                        None,
+                        Default::default(),
+                    )
+                    .await?
+                    .0
             }
         };
         Ok(stream)

--- a/src/connector/src/source/reader/reader.rs
+++ b/src/connector/src/source/reader/reader.rs
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context;
 use async_nats::jetstream::consumer::AckPolicy;
-use futures::future::try_join_all;
 use futures::stream::pending;
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::ColumnId;
-use rw_futures_util::select_all;
 use thiserror_ext::AsReport as _;
 
 use crate::error::ConnectorResult;
@@ -36,11 +33,11 @@ use crate::source::filesystem::opendal_source::{
 };
 use crate::source::filesystem::{FsPageItem, OpendalFsSplit};
 use crate::source::{
-    create_split_reader, BackfillInfo, BoxSourceChunkStream, BoxTryStream, Column,
-    ConnectorProperties, ConnectorState, SourceColumnDesc, SourceContext, SplitId, SplitImpl,
-    SplitReader, WaitCheckpointTask,
+    BoxSourceChunkStream, BoxTryStream, Column, ConnectorProperties, ConnectorState,
+    CreateSplitReaderOpt, CreateSplitReaderResult, SourceColumnDesc, SourceContext,
+    WaitCheckpointTask,
 };
-use crate::{dispatch_source_prop, WithOptionsSecResolved};
+use crate::WithOptionsSecResolved;
 
 #[derive(Clone, Debug)]
 pub struct SourceReader {
@@ -144,72 +141,6 @@ impl SourceReader {
         })
     }
 
-    pub async fn build_stream_for_backfill(
-        &self,
-        state: ConnectorState,
-        column_ids: Vec<ColumnId>,
-        source_ctx: Arc<SourceContext>,
-    ) -> ConnectorResult<(BoxSourceChunkStream, HashMap<SplitId, BackfillInfo>)> {
-        let Some(splits) = state else {
-            return Ok((pending().boxed(), HashMap::new()));
-        };
-        let config = self.config.clone();
-        let columns = self.get_target_columns(column_ids)?;
-
-        let data_gen_columns = Some(
-            columns
-                .iter()
-                .map(|col| Column {
-                    name: col.name.clone(),
-                    data_type: col.data_type.clone(),
-                    is_visible: col.is_visible(),
-                })
-                .collect_vec(),
-        );
-
-        let parser_config = ParserConfig {
-            specific: self.parser_config.clone(),
-            common: CommonParserConfig {
-                rw_columns: columns,
-            },
-        };
-
-        let support_multiple_splits = config.support_multiple_splits();
-        dispatch_source_prop!(config, prop, {
-            let readers = if support_multiple_splits {
-                tracing::debug!(
-                    "spawning connector split reader for multiple splits {:?}",
-                    splits
-                );
-                let reader =
-                    create_split_reader(*prop, splits, parser_config, source_ctx, data_gen_columns)
-                        .await?;
-
-                vec![reader]
-            } else {
-                let to_reader_splits = splits.into_iter().map(|split| vec![split]);
-                try_join_all(to_reader_splits.into_iter().map(|splits| {
-                    tracing::debug!(?splits, "spawning connector split reader");
-                    let props = prop.clone();
-                    let data_gen_columns = data_gen_columns.clone();
-                    let parser_config = parser_config.clone();
-                    // TODO: is this reader split across multiple threads...? Realistically, we want
-                    // source_ctx to live in a single actor.
-                    let source_ctx = source_ctx.clone();
-                    create_split_reader(*props, splits, parser_config, source_ctx, data_gen_columns)
-                }))
-                .await?
-            };
-
-            let backfill_info = readers.iter().flat_map(|r| r.backfill_info()).collect();
-
-            Ok((
-                select_all(readers.into_iter().map(|r| r.into_stream())).boxed(),
-                backfill_info,
-            ))
-        })
-    }
-
     /// Build `SplitReader`s and then `BoxSourceChunkStream` from the given `ConnectorState` (`SplitImpl`s).
     ///
     /// If `seek_to_latest` is true, will also return the latest splits after seek.
@@ -219,9 +150,9 @@ impl SourceReader {
         column_ids: Vec<ColumnId>,
         source_ctx: Arc<SourceContext>,
         seek_to_latest: bool,
-    ) -> ConnectorResult<(BoxSourceChunkStream, Option<Vec<SplitImpl>>)> {
+    ) -> ConnectorResult<(BoxSourceChunkStream, CreateSplitReaderResult)> {
         let Some(splits) = state else {
-            return Ok((pending().boxed(), None));
+            return Ok((pending().boxed(), Default::default()));
         };
         let config = self.config.clone();
         let columns = self.get_target_columns(column_ids)?;
@@ -244,48 +175,18 @@ impl SourceReader {
             },
         };
 
-        let support_multiple_splits = config.support_multiple_splits();
-        dispatch_source_prop!(config, prop, {
-            let mut readers = if support_multiple_splits {
-                tracing::debug!(
-                    "spawning connector split reader for multiple splits {:?}",
-                    splits
-                );
-                let reader =
-                    create_split_reader(*prop, splits, parser_config, source_ctx, data_gen_columns)
-                        .await?;
-
-                vec![reader]
-            } else {
-                let to_reader_splits = splits.into_iter().map(|split| vec![split]);
-                try_join_all(to_reader_splits.into_iter().map(|splits| {
-                    tracing::debug!(?splits, "spawning connector split reader");
-                    let props = prop.clone();
-                    let data_gen_columns = data_gen_columns.clone();
-                    let parser_config = parser_config.clone();
-                    // TODO: is this reader split across multiple threads...? Realistically, we want
-                    // source_ctx to live in a single actor.
-                    let source_ctx = source_ctx.clone();
-                    create_split_reader(*props, splits, parser_config, source_ctx, data_gen_columns)
-                }))
-                .await?
-            };
-
-            let latest_splits = if seek_to_latest {
-                let mut latest_splits = Vec::new();
-                for reader in &mut readers {
-                    latest_splits.extend(reader.seek_to_latest().await?);
-                }
-                Some(latest_splits)
-            } else {
-                None
-            };
-
-            Ok((
-                select_all(readers.into_iter().map(|r| r.into_stream())).boxed(),
-                latest_splits,
-            ))
-        })
+        config
+            .create_split_reader(
+                splits,
+                parser_config,
+                source_ctx,
+                data_gen_columns,
+                CreateSplitReaderOpt {
+                    seek_to_latest,
+                    ..Default::default()
+                },
+            )
+            .await
     }
 }
 

--- a/src/meta/service/src/cloud_service.rs
+++ b/src/meta/service/src/cloud_service.rs
@@ -78,15 +78,9 @@ impl CloudService for CloudServiceImpl {
         };
         let props = props.unwrap();
 
-        async fn new_enumerator(
-            props: ConnectorProperties,
-        ) -> ConnectorResult<Box<dyn AnySplitEnumerator>> {
-            props
-                .create_split_enumerator(SourceEnumeratorContext::dummy().into())
-                .await
-        }
-
-        let enumerator = new_enumerator(props).await;
+        let enumerator = props
+            .create_split_enumerator(SourceEnumeratorContext::dummy().into())
+            .await;
         if let Err(e) = enumerator {
             return Ok(new_rwc_validate_fail_response(
                 ErrorType::KafkaInvalidProperties,

--- a/src/meta/service/src/cloud_service.rs
+++ b/src/meta/service/src/cloud_service.rs
@@ -17,10 +17,7 @@ use std::sync::LazyLock;
 
 use async_trait::async_trait;
 use regex::Regex;
-use risingwave_connector::error::ConnectorResult;
-use risingwave_connector::source::{
-    AnySplitEnumerator, ConnectorProperties, SourceEnumeratorContext,
-};
+use risingwave_connector::source::{ConnectorProperties, SourceEnumeratorContext};
 use risingwave_connector::WithOptionsSecResolved;
 use risingwave_pb::cloud_service::cloud_service_server::CloudService;
 use risingwave_pb::cloud_service::rw_cloud_validate_source_response::{Error, ErrorType};

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -31,10 +31,7 @@ use risingwave_common::util::stream_graph_visitor::{
 };
 use risingwave_common::{bail, bail_not_implemented, hash, must_match};
 use risingwave_connector::connector_common::validate_connection;
-use risingwave_connector::error::ConnectorError;
-use risingwave_connector::source::{
-    AnySplitEnumerator, ConnectorProperties, SourceEnumeratorContext,
-};
+use risingwave_connector::source::{ConnectorProperties, SourceEnumeratorContext};
 use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::{

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -664,7 +664,7 @@ impl DdlController {
                 props.init_from_pb_cdc_table_desc(cdc_table_desc);
 
                 // try creating a split enumerator to validate
-                let _enumerator = source_props
+                let _enumerator = props
                     .create_split_enumerator(SourceEnumeratorContext::dummy().into())
                     .await?;
                 tracing::debug!(?table.id, "validate cdc table success");

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -18,7 +18,6 @@ use std::borrow::BorrowMut;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
-use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -28,9 +27,9 @@ use risingwave_common::metrics::LabelGuardedIntGauge;
 use risingwave_connector::error::ConnectorResult;
 use risingwave_connector::source::{
     fill_adaptive_split, ConnectorProperties, SourceEnumeratorContext, SourceEnumeratorInfo,
-    SourceProperties, SplitEnumerator, SplitId, SplitImpl, SplitMetaData,
+    SplitId, SplitImpl, SplitMetaData,
 };
-use risingwave_connector::{dispatch_source_prop, WithOptionsSecResolved};
+use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::SourceId;
 use risingwave_pb::catalog::Source;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -309,14 +309,14 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
         // the executor can only know it's finished when data coming in.
         // For blocking DDL, this would be annoying.
 
-        let (stream, backfill_info) = source_desc
+        let (stream, res) = source_desc
             .source
-            .build_stream_for_backfill(Some(splits), column_ids, Arc::new(source_ctx))
+            .build_stream(Some(splits), column_ids, Arc::new(source_ctx), false)
             .await
             .map_err(StreamExecutorError::connector_error)?;
         Ok((
             apply_rate_limit(stream, self.rate_limit_rps).boxed(),
-            backfill_info,
+            res.backfill_info,
         ))
     }
 

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -129,7 +129,7 @@ impl<S: StateStore> SourceExecutor<S> {
         seek_to_latest: bool,
     ) -> StreamExecutorResult<(BoxSourceChunkStream, Option<Vec<SplitImpl>>)> {
         let (column_ids, source_ctx) = self.prepare_source_stream_build(source_desc);
-        let (stream, latest_splits) = source_desc
+        let (stream, res) = source_desc
             .source
             .build_stream(state, column_ids, Arc::new(source_ctx), seek_to_latest)
             .await
@@ -137,7 +137,7 @@ impl<S: StateStore> SourceExecutor<S> {
 
         Ok((
             apply_rate_limit(stream, self.rate_limit_rps).boxed(),
-            latest_splits,
+            res.latest_splits,
         ))
     }
 
@@ -554,7 +554,7 @@ impl<S: StateStore> SourceExecutor<S> {
                             false,  // not need to seek to latest since source state is initialized
                         )
                         .await {
-                        Ok((stream, latest_splits)) => Ok((stream, latest_splits)),
+                        Ok((stream, res)) => Ok((stream, res.latest_splits)),
                         Err(e) => {
                             tracing::warn!(error = %e.as_report(), "failed to build source stream, retrying...");
                             Err(e)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously we use `dispatch_source_prop` macro to dispatch a large enum, and use a generic function inside the macro. This PR moved these lines into method of `ConnectorProperties`, and make it return `dyn`. The traits are refactored to be `dyn-compatible` (aka object safe)

benefits:
- This is not IDE friendly, and hard to maintain. <img width="1002" alt="image" src="https://github.com/user-attachments/assets/a487fa2c-db09-402f-84a4-990e7b7ab02b" />
- (not sure) `dyn` may slightly compile faster than generics, because generics will lead to code bloat. And `async fn` compiles especially slow if the body is very large.
    - I did some preliminary benchmarks but didn't get a conclusion, since the results are too unstable.
    - One data is the difference in code size:  (2.3MB smaller)
```
Before:

 File  .text     Size                           Crate Name
 0.0%   0.1% 214.2KiB                      aws_sdk_s3 aws_sdk_s3::config::endpoint::internals::resolve_endpoint
 0.0%   0.0% 139.4KiB                         parquet brotli::enc::prior_eval::PriorEval<Alloc>::update_cost_base
 0.0%   0.0% 139.4KiB                         parquet brotli::enc::prior_eval::PriorEval<Alloc>::update_cost_base
 0.0%   0.0% 118.3KiB                 risingwave_meta risingwave_meta::manager::sink_coordination::coordinator_worker::CoordinatorWorker::...
 0.0%   0.0% 111.4KiB               risingwave_stream risingwave_connector::source::reader::reader::SourceReader::build_stream::{{closure}}
 0.0%   0.0% 111.4KiB      risingwave_batch_executors risingwave_connector::source::reader::reader::SourceReader::build_stream::{{closure}}
 0.0%   0.0% 101.7KiB                 risingwave_meta risingwave_meta::controller::scale::<impl risingwave_meta::controller::catalog::Cata...
 0.0%   0.0%  99.5KiB               risingwave_stream risingwave_connector::source::reader::reader::SourceReader::build_stream_for_backfil...
 0.0%   0.0%  86.5KiB               risingwave_stream risingwave_stream::executor::backfill::cdc::cdc_backfill::CdcBackfillExecutor<S>::ex...
 0.0%   0.0%  85.8KiB                 risingwave_meta risingwave_meta::stream::source_manager::worker::create_source_worker_async::{{closu...
 0.0%   0.0%  79.7KiB                          blake2 blake2::Blake2bVarCore::compress
 0.0%   0.0%  78.0KiB             risingwave_frontend risingwave_frontend::handler::handle::{{closure}}
 0.0%   0.0%  77.3KiB risingwave_meta_model_migration <risingwave_meta_model_migration::m20230908_072257_init::Migration as sea_orm_migrat...
 0.0%   0.0%  77.1KiB                         lz4_sys _LZ4_compress_fast_continue
 0.0%   0.0%  77.1KiB                       [Unknown] _prof_backtrace_impl
 0.0%   0.0%  75.6KiB               risingwave_stream risingwave_stream::executor::monitor::streaming_stats::StreamingMetrics::new
 0.0%   0.0%  72.2KiB                 risingwave_meta risingwave_meta::rpc::metrics::MetaMetrics::new
 0.0%   0.0%  71.8KiB                         lz4_sys _LZ4_compress_fast_extState_fastReset
 0.0%   0.0%  70.7KiB                          blake2 blake2::Blake2sVarCore::compress
 0.0%   0.0%  69.4KiB                          rustls rustls::msgs::ffdhe_groups::FfdheGroup::named_group
 0.0%   0.0%  63.7KiB                              h2 h2::codec::framed_read::decode_frame
 0.0%   0.0%  63.6KiB                              h2 h2::codec::framed_read::decode_frame
 0.0%   0.0%  63.2KiB                       sqlparser <sqlparser::ast::Statement as core::fmt::Display>::fmt
 0.0%   0.0%  62.5KiB         risingwave_meta_service <risingwave_meta_service::cloud_service::CloudServiceImpl as risingwave_pb::cloud_se...
 0.0%   0.0%  61.6KiB               tikv_jemalloc_sys __rjem_mallocx
 0.0%   0.0%  61.6KiB               tikv_jemalloc_sys __rjem_realloc
 0.0%   0.0%  61.3KiB               tikv_jemalloc_sys __rjem_calloc
 0.0%   0.0%  61.3KiB               tikv_jemalloc_sys __rjem_je_malloc_default
 0.0%   0.0%  61.0KiB                          blake3 _blake3_hash4_neon
 0.0%   0.0%  58.3KiB                       [Unknown] _rd_kafka_parse_Metadata0
 0.0%   0.0%  57.5KiB                      aws_sdk_s3 aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                     aws_sdk_sts aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                     aws_sdk_sso aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                 aws_sdk_ssooidc aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                    aws_sdk_glue aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                aws_sdk_dynamodb aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB           aws_sdk_emrserverless aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                 aws_sdk_kinesis aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  56.4KiB                       chrono_tz <chrono_tz::timezones::Tz as chrono_tz::timezone_impl::TimeSpans>::timespans
 0.0%   0.0%  56.0KiB               risingwave_stream risingwave_stream::executor::source::source_executor::SourceExecutor<S>::execute_wit...
 0.0%   0.0%  56.0KiB               risingwave_stream risingwave_stream::executor::source::source_executor::SourceExecutor<S>::execute_wit...
 0.0%   0.0%  55.8KiB               risingwave_stream risingwave_stream::executor::source::source_backfill_executor::SourceBackfillExecuto...
 0.0%   0.0%  53.0KiB                  risingwave_ctl <risingwave_ctl::HummockCommands as clap_builder::derive::Subcommand>::augment_subco...
 0.0%   0.0%  52.6KiB            datafusion_optimizer <datafusion_optimizer::simplify_expressions::expr_simplifier::Simplifier<S> as dataf...
 0.0%   0.0%  49.0KiB                      aws_sdk_s3 aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                     aws_sdk_sts aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                     aws_sdk_sso aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                 aws_sdk_ssooidc aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                    aws_sdk_glue aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                aws_sdk_dynamodb aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
30.7%  99.0% 361.7MiB                                 And 1767757 smaller methods. Use -n N to show more.
31.0% 100.0% 365.2MiB                                 .text section size, the file size is 1176.5MiB


After:


 File  .text     Size                           Crate Name
 0.0%   0.1% 214.2KiB                      aws_sdk_s3 aws_sdk_s3::config::endpoint::internals::resolve_endpoint
 0.0%   0.0% 139.4KiB                         parquet brotli::enc::prior_eval::PriorEval<Alloc>::update_cost_base
 0.0%   0.0% 139.4KiB                         parquet brotli::enc::prior_eval::PriorEval<Alloc>::update_cost_base
 0.0%   0.0% 118.3KiB                 risingwave_meta risingwave_meta::manager::sink_coordination::coordinator_worker::CoordinatorWorker::...
 0.0%   0.0% 101.7KiB                 risingwave_meta risingwave_meta::controller::scale::<impl risingwave_meta::controller::catalog::Cata...
 0.0%   0.0%  86.5KiB               risingwave_stream risingwave_stream::executor::backfill::cdc::cdc_backfill::CdcBackfillExecutor<S>::ex...
 0.0%   0.0%  79.7KiB                          blake2 blake2::Blake2bVarCore::compress
 0.0%   0.0%  78.0KiB             risingwave_frontend risingwave_frontend::handler::handle::{{closure}}
 0.0%   0.0%  77.3KiB risingwave_meta_model_migration <risingwave_meta_model_migration::m20230908_072257_init::Migration as sea_orm_migrat...
 0.0%   0.0%  77.1KiB                         lz4_sys _LZ4_compress_fast_continue
 0.0%   0.0%  77.1KiB                       [Unknown] _prof_backtrace_impl
 0.0%   0.0%  75.6KiB               risingwave_stream risingwave_stream::executor::monitor::streaming_stats::StreamingMetrics::new
 0.0%   0.0%  72.2KiB                 risingwave_meta risingwave_meta::rpc::metrics::MetaMetrics::new
 0.0%   0.0%  71.8KiB                         lz4_sys _LZ4_compress_fast_extState_fastReset
 0.0%   0.0%  70.7KiB                          blake2 blake2::Blake2sVarCore::compress
 0.0%   0.0%  69.4KiB                          rustls rustls::msgs::ffdhe_groups::FfdheGroup::named_group
 0.0%   0.0%  63.7KiB                              h2 h2::codec::framed_read::decode_frame
 0.0%   0.0%  63.6KiB                              h2 h2::codec::framed_read::decode_frame
 0.0%   0.0%  63.2KiB                       sqlparser <sqlparser::ast::Statement as core::fmt::Display>::fmt
 0.0%   0.0%  61.6KiB               tikv_jemalloc_sys __rjem_mallocx
 0.0%   0.0%  61.6KiB               tikv_jemalloc_sys __rjem_realloc
 0.0%   0.0%  61.3KiB               tikv_jemalloc_sys __rjem_calloc
 0.0%   0.0%  61.3KiB               tikv_jemalloc_sys __rjem_je_malloc_default
 0.0%   0.0%  61.0KiB                          blake3 _blake3_hash4_neon
 0.0%   0.0%  58.3KiB               risingwave_stream risingwave_stream::executor::source::source_backfill_executor::SourceBackfillExecuto...
 0.0%   0.0%  58.3KiB                       [Unknown] _rd_kafka_parse_Metadata0
 0.0%   0.0%  57.5KiB                      aws_sdk_s3 aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                     aws_sdk_sts aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                     aws_sdk_sso aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                 aws_sdk_ssooidc aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                    aws_sdk_glue aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                aws_sdk_dynamodb aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB           aws_sdk_emrserverless aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  57.5KiB                 aws_sdk_kinesis aws_smithy_runtime::client::orchestrator::try_op::{{closure}}::{{closure}}
 0.0%   0.0%  56.4KiB                       chrono_tz <chrono_tz::timezones::Tz as chrono_tz::timezone_impl::TimeSpans>::timespans
 0.0%   0.0%  56.1KiB               risingwave_stream risingwave_stream::executor::source::source_executor::SourceExecutor<S>::execute_wit...
 0.0%   0.0%  56.1KiB               risingwave_stream risingwave_stream::executor::source::source_executor::SourceExecutor<S>::execute_wit...
 0.0%   0.0%  53.0KiB                  risingwave_ctl <risingwave_ctl::HummockCommands as clap_builder::derive::Subcommand>::augment_subco...
 0.0%   0.0%  52.6KiB            datafusion_optimizer <datafusion_optimizer::simplify_expressions::expr_simplifier::Simplifier<S> as dataf...
 0.0%   0.0%  49.0KiB                      aws_sdk_s3 aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                     aws_sdk_sts aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                     aws_sdk_sso aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                 aws_sdk_ssooidc aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                    aws_sdk_glue aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                aws_sdk_dynamodb aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB           aws_sdk_emrserverless aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  49.0KiB                 aws_sdk_kinesis aws_smithy_runtime::client::orchestrator::try_attempt::{{closure}}::{{closure}}
 0.0%   0.0%  48.6KiB                      datafusion datafusion::physical_planner::DefaultPhysicalPlanner::map_logical_node_to_physical::...
 0.0%   0.0%  48.0KiB                              h2 h2::frame::headers::HeaderBlock::load::{{closure}}
 0.0%   0.0%  47.8KiB                              h2 h2::frame::headers::HeaderBlock::load::{{closure}}
30.8%  99.1% 359.6MiB                                 And 1755089 smaller methods. Use -n N to show more.
31.1% 100.0% 362.9MiB                                 .text section size, the file size is 1168.8MiB
```
- may also help https://github.com/risingwavelabs/risingwave/issues/16841
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
