### PR TITLE
fix(meta): work around sea-orm bug

### DIFF
--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -477,8 +477,8 @@ impl HummockManager {
             }
             hummock_gc_history::Entity::insert_many(batch)
                 .on_conflict(
-                    OnConflict::column(hummock_gc_history::Column::ObjectId)
-                        .do_nothing()
+                    OnConflict::new()
+                        .update_column(hummock_gc_history::Column::ObjectId)
                         .to_owned(),
                 )
                 .do_nothing()

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -431,8 +431,8 @@ impl HummockManager {
                 }
                 hummock_sstable_info::Entity::insert_many(batch)
                     .on_conflict(
-                        OnConflict::column(hummock_sstable_info::Column::SstId)
-                            .do_nothing()
+                        OnConflict::new()
+                            .update_column(hummock_sstable_info::Column::SstId)
                             .to_owned(),
                     )
                     .do_nothing()
@@ -485,8 +485,8 @@ impl HummockManager {
             };
             hummock_time_travel_version::Entity::insert(m)
                 .on_conflict(
-                    OnConflict::column(hummock_time_travel_version::Column::VersionId)
-                        .do_nothing()
+                    OnConflict::new()
+                        .update_column(hummock_time_travel_version::Column::VersionId)
                         .to_owned(),
                 )
                 .do_nothing()
@@ -517,8 +517,8 @@ impl HummockManager {
             };
             hummock_time_travel_delta::Entity::insert(m)
                 .on_conflict(
-                    OnConflict::column(hummock_time_travel_delta::Column::VersionId)
-                        .do_nothing()
+                    OnConflict::new()
+                        .update_column(hummock_time_travel_delta::Column::VersionId)
                         .to_owned(),
                 )
                 .do_nothing()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

[The SeaORM crate has a bug](https://github.com/SeaQL/sea-orm/issues/1790) that causes the meta node to panic when using MySQL as the meta store. Specifically, the `OnConflict do_nothing` doesn't work for MySQL.

The bug has been fixed in SeaORM of newer version. This PR provides a workaround for the bug instead of [upgrading the SeaORM version](https://github.com/risingwavelabs/risingwave/pull/19207).

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
