### PR TITLE
fix(storage): Remove logic for deleting objects in truncate_time_trav…

### DIFF
--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -108,18 +108,8 @@ impl HummockManager {
             txn.commit().await?;
             return Ok(());
         };
-        let (
-            latest_valid_version_id,
-            latest_valid_version_sst_ids,
-            latest_valid_version_object_ids,
-        ) = {
-            (
-                latest_valid_version.id,
-                latest_valid_version.get_sst_ids(),
-                latest_valid_version.get_object_ids(),
-            )
-        };
-        let mut object_ids_to_delete: HashSet<_> = HashSet::default();
+        let (latest_valid_version_id, latest_valid_version_sst_ids) =
+            { (latest_valid_version.id, latest_valid_version.get_sst_ids()) };
         let version_ids_to_delete: Vec<risingwave_meta_model::HummockVersionId> =
             hummock_time_travel_version::Entity::find()
                 .select_only()
@@ -163,8 +153,6 @@ impl HummockManager {
                 .filter(hummock_sstable_info::Column::SstId.is_in(sst_ids_to_delete))
                 .exec(&txn)
                 .await?;
-            let new_object_ids = delta_to_delete.newly_added_object_ids();
-            object_ids_to_delete.extend(&new_object_ids - &latest_valid_version_object_ids);
             tracing::debug!(
                 delta_id = delta_to_delete.id.to_u64(),
                 "delete {} rows from hummock_sstable_info",
@@ -194,18 +182,12 @@ impl HummockManager {
                 .filter(hummock_sstable_info::Column::SstId.is_in(sst_ids_to_delete))
                 .exec(&txn)
                 .await?;
-            let new_object_ids = prev_version.get_object_ids();
-            object_ids_to_delete.extend(&new_object_ids - &latest_valid_version_object_ids);
             tracing::debug!(
                 prev_version_id,
                 "delete {} rows from hummock_sstable_info",
                 res.rows_affected
             );
             next_version_sst_ids = sst_ids;
-        }
-        if !object_ids_to_delete.is_empty() {
-            self.gc_manager
-                .add_may_delete_object_ids(object_ids_to_delete.into_iter());
         }
 
         let res = hummock_time_travel_version::Entity::delete_many()


### PR DESCRIPTION
…el_metadata

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

A quick fix for `truncate_time_travel_metadata`.

Since time-travel only retains information from mv/table/index, truncate_time_travel_metadata incorrectly removes object.

See https://github.com/risingwavelabs/risingwave/pull/19694#issuecomment-2550205925

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
