### PR TITLE
feat(storage): refactor and support local state store flushed snapshot reader

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -37,6 +37,7 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(iter_from_coroutine)]
+#![feature(trait_upcasting)]
 
 pub mod hummock;
 pub mod memory;

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -821,6 +821,8 @@ impl<R: RangeKv> RangeKvLocalStateStore<R> {
 }
 
 impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
+    type FlushedSnapshotReader = RangeKvStateStore<R>;
+
     type Iter<'a> = impl StateStoreIter + 'a;
     type RevIter<'a> = impl StateStoreIter + 'a;
 
@@ -1055,6 +1057,10 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
     fn get_table_watermark(&self, _vnode: VirtualNode) -> Option<Bytes> {
         // TODO: may store the written table watermark and have a correct implementation
         None
+    }
+
+    fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
+        self.inner.clone()
     }
 }
 

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -239,6 +239,8 @@ impl<S: StateStoreReadLog> StateStoreReadLog for MonitoredStateStore<S> {
 }
 
 impl<S: LocalStateStore> LocalStateStore for MonitoredStateStore<S> {
+    type FlushedSnapshotReader = MonitoredStateStore<S::FlushedSnapshotReader>;
+
     type Iter<'a> = impl StateStoreIter + 'a;
     type RevIter<'a> = impl StateStoreIter + 'a;
 
@@ -325,6 +327,13 @@ impl<S: LocalStateStore> LocalStateStore for MonitoredStateStore<S> {
 
     fn get_table_watermark(&self, vnode: VirtualNode) -> Option<Bytes> {
         self.inner.get_table_watermark(vnode)
+    }
+
+    fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
+        MonitoredStateStore::new(
+            self.inner.new_flushed_snapshot_reader(),
+            self.storage_metrics.clone(),
+        )
     }
 }
 

--- a/src/storage/src/monitor/traced_store.rs
+++ b/src/storage/src/monitor/traced_store.rs
@@ -131,6 +131,9 @@ impl<S> TracedStateStore<S> {
 }
 
 impl<S: LocalStateStore> LocalStateStore for TracedStateStore<S> {
+    // Not trace the FlushedSnapshotReader
+    type FlushedSnapshotReader = S::FlushedSnapshotReader;
+
     type Iter<'a> = impl StateStoreIter + 'a;
     type RevIter<'a> = impl StateStoreIter + 'a;
 
@@ -259,6 +262,10 @@ impl<S: LocalStateStore> LocalStateStore for TracedStateStore<S> {
 
     fn get_table_watermark(&self, vnode: VirtualNode) -> Option<Bytes> {
         self.inner.get_table_watermark(vnode)
+    }
+
+    fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
+        self.inner.new_flushed_snapshot_reader()
     }
 }
 

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -82,6 +82,7 @@ impl StateStoreReadLog for PanicStateStore {
 }
 
 impl LocalStateStore for PanicStateStore {
+    type FlushedSnapshotReader = PanicStateStore;
     type Iter<'a> = PanicStateStoreIter<StateStoreKeyedRow>;
     type RevIter<'a> = PanicStateStoreIter<StateStoreKeyedRow>;
 
@@ -158,6 +159,10 @@ impl LocalStateStore for PanicStateStore {
 
     fn get_table_watermark(&self, _vnode: VirtualNode) -> Option<Bytes> {
         panic!("should not operate on the panic state store!");
+    }
+
+    fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
+        panic!()
     }
 }
 

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -392,6 +392,7 @@ pub trait StateStore: StateStoreRead + StateStoreReadLog + StaticSendSync + Clon
 /// written by itself. Each local state store is not `Clone`, and is owned by a streaming state
 /// table.
 pub trait LocalStateStore: StaticSendSync {
+    type FlushedSnapshotReader: StateStoreRead + Clone;
     type Iter<'a>: StateStoreIter + 'a;
     type RevIter<'a>: StateStoreIter + 'a;
 
@@ -419,6 +420,8 @@ pub trait LocalStateStore: StaticSendSync {
         key_range: TableKeyRange,
         read_options: ReadOptions,
     ) -> impl StorageFuture<'_, Self::RevIter<'_>>;
+
+    fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader;
 
     /// Get last persisted watermark for a given vnode.
     fn get_table_watermark(&self, vnode: VirtualNode) -> Option<Bytes>;

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -95,8 +95,8 @@ fn may_dynamic_dispatch(state_store: impl StateStore + AsHummock) -> impl StateS
     }
     #[cfg(debug_assertions)]
     {
-        use crate::store_impl::boxed_state_store::BoxDynamicDispatchedStateStore;
-        Box::new(state_store) as BoxDynamicDispatchedStateStore
+        use crate::store_impl::dyn_state_store::StateStorePointer;
+        StateStorePointer(Arc::new(state_store) as _)
     }
 }
 
@@ -404,6 +404,9 @@ pub mod verify {
     }
 
     impl<A: LocalStateStore, E: LocalStateStore> LocalStateStore for VerifyStateStore<A, E> {
+        type FlushedSnapshotReader =
+            VerifyStateStore<A::FlushedSnapshotReader, E::FlushedSnapshotReader>;
+
         type Iter<'a> = impl StateStoreIter + 'a;
         type RevIter<'a> = impl StateStoreIter + 'a;
 
@@ -543,6 +546,14 @@ pub mod verify {
                 assert_eq!(ret, expected.get_table_watermark(vnode));
             }
             ret
+        }
+
+        fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
+            VerifyStateStore {
+                actual: self.actual.new_flushed_snapshot_reader(),
+                expected: self.expected.as_ref().map(E::new_flushed_snapshot_reader),
+                _phantom: Default::default(),
+            }
         }
     }
 
@@ -787,13 +798,12 @@ impl AsHummock for SledStateStore {
 }
 
 #[cfg(debug_assertions)]
-mod boxed_state_store {
+mod dyn_state_store {
     use std::future::Future;
     use std::ops::{Deref, DerefMut};
     use std::sync::Arc;
 
     use bytes::Bytes;
-    use dyn_clone::{clone_trait_object, DynClone};
     use risingwave_common::bitmap::Bitmap;
     use risingwave_common::hash::VirtualNode;
     use risingwave_hummock_sdk::key::{TableKey, TableKeyRange};
@@ -806,19 +816,19 @@ mod boxed_state_store {
 
     #[expect(elided_named_lifetimes)] // false positive
     #[async_trait::async_trait]
-    pub trait DynamicDispatchedStateStoreIter<T: IterItem>: Send {
+    pub trait DynStateStoreIter<T: IterItem>: Send {
         async fn try_next(&mut self) -> StorageResult<Option<T::ItemRef<'_>>>;
     }
 
     #[expect(elided_named_lifetimes)] // false positive
     #[async_trait::async_trait]
-    impl<T: IterItem, I: StateStoreIter<T>> DynamicDispatchedStateStoreIter<T> for I {
+    impl<T: IterItem, I: StateStoreIter<T>> DynStateStoreIter<T> for I {
         async fn try_next(&mut self) -> StorageResult<Option<T::ItemRef<'_>>> {
             self.try_next().await
         }
     }
 
-    pub type BoxStateStoreIter<'a, T> = Box<dyn DynamicDispatchedStateStoreIter<T> + 'a>;
+    pub type BoxStateStoreIter<'a, T> = Box<dyn DynStateStoreIter<T> + 'a>;
     impl<'a, T: IterItem> StateStoreIter<T> for BoxStateStoreIter<'a, T> {
         fn try_next(
             &mut self,
@@ -833,7 +843,7 @@ mod boxed_state_store {
     pub type BoxStateStoreReadChangeLogIter = BoxStateStoreIter<'static, StateStoreReadLogItem>;
 
     #[async_trait::async_trait]
-    pub trait DynamicDispatchedStateStoreRead: StaticSendSync {
+    pub trait DynStateStoreRead: StaticSendSync {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
@@ -857,7 +867,7 @@ mod boxed_state_store {
     }
 
     #[async_trait::async_trait]
-    pub trait DynamicDispatchedStateStoreReadLog: StaticSendSync {
+    pub trait DynStateStoreReadLog: StaticSendSync {
         async fn next_epoch(&self, epoch: u64, options: NextEpochOptions) -> StorageResult<u64>;
         async fn iter_log(
             &self,
@@ -867,8 +877,10 @@ mod boxed_state_store {
         ) -> StorageResult<BoxStateStoreReadChangeLogIter>;
     }
 
+    pub type StateStoreReadDynRef = StateStorePointer<Arc<dyn DynStateStoreRead>>;
+
     #[async_trait::async_trait]
-    impl<S: StateStoreRead> DynamicDispatchedStateStoreRead for S {
+    impl<S: StateStoreRead> DynStateStoreRead for S {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
@@ -900,7 +912,7 @@ mod boxed_state_store {
     }
 
     #[async_trait::async_trait]
-    impl<S: StateStoreReadLog> DynamicDispatchedStateStoreReadLog for S {
+    impl<S: StateStoreReadLog> DynStateStoreReadLog for S {
         async fn next_epoch(&self, epoch: u64, options: NextEpochOptions) -> StorageResult<u64> {
             self.next_epoch(epoch, options).await
         }
@@ -920,7 +932,7 @@ mod boxed_state_store {
     // For LocalStateStore
     pub type BoxLocalStateStoreIterStream<'a> = BoxStateStoreIter<'a, StateStoreKeyedRow>;
     #[async_trait::async_trait]
-    pub trait DynamicDispatchedLocalStateStore: StaticSendSync {
+    pub trait DynLocalStateStore: StaticSendSync {
         async fn get(
             &self,
             key: TableKey<Bytes>,
@@ -940,6 +952,8 @@ mod boxed_state_store {
             key_range: TableKeyRange,
             read_options: ReadOptions,
         ) -> StorageResult<BoxLocalStateStoreIterStream<'_>>;
+
+        fn new_flushed_snapshot_reader(&self) -> StateStoreReadDynRef;
 
         fn insert(
             &mut self,
@@ -968,7 +982,7 @@ mod boxed_state_store {
     }
 
     #[async_trait::async_trait]
-    impl<S: LocalStateStore> DynamicDispatchedLocalStateStore for S {
+    impl<S: LocalStateStore> DynLocalStateStore for S {
         async fn get(
             &self,
             key: TableKey<Bytes>,
@@ -993,6 +1007,10 @@ mod boxed_state_store {
             read_options: ReadOptions,
         ) -> StorageResult<BoxLocalStateStoreIterStream<'_>> {
             Ok(Box::new(self.rev_iter(key_range, read_options).await?))
+        }
+
+        fn new_flushed_snapshot_reader(&self) -> StateStoreReadDynRef {
+            StateStorePointer(Arc::new(self.new_flushed_snapshot_reader()) as _)
         }
 
         fn insert(
@@ -1041,9 +1059,10 @@ mod boxed_state_store {
         }
     }
 
-    pub type BoxDynamicDispatchedLocalStateStore = Box<dyn DynamicDispatchedLocalStateStore>;
+    pub type BoxDynLocalStateStore = StateStorePointer<Box<dyn DynLocalStateStore>>;
 
-    impl LocalStateStore for BoxDynamicDispatchedLocalStateStore {
+    impl LocalStateStore for BoxDynLocalStateStore {
+        type FlushedSnapshotReader = StateStoreReadDynRef;
         type Iter<'a> = BoxLocalStateStoreIterStream<'a>;
         type RevIter<'a> = BoxLocalStateStoreIterStream<'a>;
 
@@ -1052,7 +1071,7 @@ mod boxed_state_store {
             key: TableKey<Bytes>,
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Option<Bytes>>> + Send + '_ {
-            self.deref().get(key, read_options)
+            (*self.0).get(key, read_options)
         }
 
         fn iter(
@@ -1060,7 +1079,7 @@ mod boxed_state_store {
             key_range: TableKeyRange,
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::Iter<'_>>> + Send + '_ {
-            self.deref().iter(key_range, read_options)
+            (*self.0).iter(key_range, read_options)
         }
 
         fn rev_iter(
@@ -1068,11 +1087,15 @@ mod boxed_state_store {
             key_range: TableKeyRange,
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::RevIter<'_>>> + Send + '_ {
-            self.deref().rev_iter(key_range, read_options)
+            (*self.0).rev_iter(key_range, read_options)
+        }
+
+        fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
+            (*self.0).new_flushed_snapshot_reader()
         }
 
         fn get_table_watermark(&self, vnode: VirtualNode) -> Option<Bytes> {
-            self.deref().get_table_watermark(vnode)
+            (*self.0).get_table_watermark(vnode)
         }
 
         fn insert(
@@ -1081,60 +1104,60 @@ mod boxed_state_store {
             new_val: Bytes,
             old_val: Option<Bytes>,
         ) -> StorageResult<()> {
-            self.deref_mut().insert(key, new_val, old_val)
+            (*self.0).insert(key, new_val, old_val)
         }
 
         fn delete(&mut self, key: TableKey<Bytes>, old_val: Bytes) -> StorageResult<()> {
-            self.deref_mut().delete(key, old_val)
+            (*self.0).delete(key, old_val)
         }
 
         fn flush(&mut self) -> impl Future<Output = StorageResult<usize>> + Send + '_ {
-            self.deref_mut().flush()
+            (*self.0).flush()
         }
 
         fn try_flush(&mut self) -> impl Future<Output = StorageResult<()>> + Send + '_ {
-            self.deref_mut().try_flush()
+            (*self.0).try_flush()
         }
 
         fn epoch(&self) -> u64 {
-            self.deref().epoch()
+            (*self.0).epoch()
         }
 
         fn is_dirty(&self) -> bool {
-            self.deref().is_dirty()
+            (*self.0).is_dirty()
         }
 
         fn init(
             &mut self,
             options: InitOptions,
         ) -> impl Future<Output = StorageResult<()>> + Send + '_ {
-            self.deref_mut().init(options)
+            (*self.0).init(options)
         }
 
         fn seal_current_epoch(&mut self, next_epoch: u64, opts: SealCurrentEpochOptions) {
-            self.deref_mut().seal_current_epoch(next_epoch, opts)
+            (*self.0).seal_current_epoch(next_epoch, opts)
         }
 
         fn update_vnode_bitmap(&mut self, vnodes: Arc<Bitmap>) -> Arc<Bitmap> {
-            self.deref_mut().update_vnode_bitmap(vnodes)
+            (*self.0).update_vnode_bitmap(vnodes)
         }
     }
 
     // For global StateStore
 
     #[async_trait::async_trait]
-    pub trait DynamicDispatchedStateStoreExt: StaticSendSync {
+    pub trait DynStateStoreExt: StaticSendSync {
         async fn try_wait_epoch(
             &self,
             epoch: HummockReadEpoch,
             options: TryWaitEpochOptions,
         ) -> StorageResult<()>;
 
-        async fn new_local(&self, option: NewLocalOptions) -> BoxDynamicDispatchedLocalStateStore;
+        async fn new_local(&self, option: NewLocalOptions) -> BoxDynLocalStateStore;
     }
 
     #[async_trait::async_trait]
-    impl<S: StateStore> DynamicDispatchedStateStoreExt for S {
+    impl<S: StateStore> DynStateStoreExt for S {
         async fn try_wait_epoch(
             &self,
             epoch: HummockReadEpoch,
@@ -1143,14 +1166,33 @@ mod boxed_state_store {
             self.try_wait_epoch(epoch, options).await
         }
 
-        async fn new_local(&self, option: NewLocalOptions) -> BoxDynamicDispatchedLocalStateStore {
-            Box::new(self.new_local(option).await)
+        async fn new_local(&self, option: NewLocalOptions) -> BoxDynLocalStateStore {
+            StateStorePointer(Box::new(self.new_local(option).await))
         }
     }
 
-    pub type BoxDynamicDispatchedStateStore = Box<dyn DynamicDispatchedStateStore>;
+    pub type StateStoreDynRef = StateStorePointer<Arc<dyn DynStateStore>>;
 
-    impl StateStoreRead for BoxDynamicDispatchedStateStore {
+    impl AsRef<dyn DynStateStoreRead> for dyn DynStateStore {
+        fn as_ref(&self) -> &dyn DynStateStoreRead {
+            self as _
+        }
+    }
+
+    impl AsRef<dyn DynStateStoreRead> for dyn DynStateStoreRead {
+        fn as_ref(&self) -> &dyn DynStateStoreRead {
+            self
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct StateStorePointer<P>(pub(crate) P);
+
+    impl<
+            S: AsRef<dyn DynStateStoreRead> + ?Sized + StaticSendSync,
+            P: Deref<Target = S> + StaticSendSync,
+        > StateStoreRead for StateStorePointer<P>
+    {
         type Iter = BoxStateStoreReadIter;
         type RevIter = BoxStateStoreReadIter;
 
@@ -1160,7 +1202,7 @@ mod boxed_state_store {
             epoch: u64,
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Option<StateStoreKeyedRow>>> + Send + '_ {
-            self.deref().get_keyed_row(key, epoch, read_options)
+            (*self.0).as_ref().get_keyed_row(key, epoch, read_options)
         }
 
         fn iter(
@@ -1169,7 +1211,7 @@ mod boxed_state_store {
             epoch: u64,
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::Iter>> + '_ {
-            self.deref().iter(key_range, epoch, read_options)
+            (*self.0).as_ref().iter(key_range, epoch, read_options)
         }
 
         fn rev_iter(
@@ -1178,15 +1220,15 @@ mod boxed_state_store {
             epoch: u64,
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::RevIter>> + '_ {
-            self.deref().rev_iter(key_range, epoch, read_options)
+            (*self.0).as_ref().rev_iter(key_range, epoch, read_options)
         }
     }
 
-    impl StateStoreReadLog for BoxDynamicDispatchedStateStore {
+    impl StateStoreReadLog for StateStoreDynRef {
         type ChangeLogIter = BoxStateStoreReadChangeLogIter;
 
         async fn next_epoch(&self, epoch: u64, options: NextEpochOptions) -> StorageResult<u64> {
-            self.deref().next_epoch(epoch, options).await
+            (*self.0).next_epoch(epoch, options).await
         }
 
         fn iter_log(
@@ -1195,53 +1237,42 @@ mod boxed_state_store {
             key_range: TableKeyRange,
             options: ReadLogOptions,
         ) -> impl Future<Output = StorageResult<Self::ChangeLogIter>> + Send + '_ {
-            self.deref().iter_log(epoch_range, key_range, options)
+            (*self.0).iter_log(epoch_range, key_range, options)
         }
     }
 
-    pub trait DynamicDispatchedStateStore:
-        DynClone
-        + DynamicDispatchedStateStoreRead
-        + DynamicDispatchedStateStoreReadLog
-        + DynamicDispatchedStateStoreExt
-        + AsHummock
+    pub trait DynStateStore:
+        DynStateStoreRead + DynStateStoreReadLog + DynStateStoreExt + AsHummock
     {
     }
 
-    clone_trait_object!(DynamicDispatchedStateStore);
-
-    impl AsHummock for BoxDynamicDispatchedStateStore {
+    impl AsHummock for StateStoreDynRef {
         fn as_hummock(&self) -> Option<&HummockStorage> {
-            self.deref().as_hummock()
+            (*self.0).as_hummock()
         }
     }
 
-    impl<
-            S: DynClone
-                + DynamicDispatchedStateStoreRead
-                + DynamicDispatchedStateStoreReadLog
-                + DynamicDispatchedStateStoreExt
-                + AsHummock,
-        > DynamicDispatchedStateStore for S
+    impl<S: DynStateStoreRead + DynStateStoreReadLog + DynStateStoreExt + AsHummock> DynStateStore
+        for S
     {
     }
 
-    impl StateStore for BoxDynamicDispatchedStateStore {
-        type Local = BoxDynamicDispatchedLocalStateStore;
+    impl StateStore for StateStoreDynRef {
+        type Local = BoxDynLocalStateStore;
 
         fn try_wait_epoch(
             &self,
             epoch: HummockReadEpoch,
             options: TryWaitEpochOptions,
         ) -> impl Future<Output = StorageResult<()>> + Send + '_ {
-            self.deref().try_wait_epoch(epoch, options)
+            (*self.0).try_wait_epoch(epoch, options)
         }
 
         fn new_local(
             &self,
             option: NewLocalOptions,
         ) -> impl Future<Output = Self::Local> + Send + '_ {
-            self.deref().new_local(option)
+            (*self.0).new_local(option)
         }
     }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
@@ -40,7 +40,7 @@ use risingwave_storage::hummock::CachePolicy;
 use risingwave_storage::store::{
     PrefetchOptions, ReadOptions, StateStoreKeyedRowRef, StateStoreRead,
 };
-use risingwave_storage::{StateStore, StateStoreIter};
+use risingwave_storage::StateStoreIter;
 use tokio::sync::watch;
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
@@ -117,7 +117,7 @@ impl RewindDelay {
     }
 }
 
-pub struct KvLogStoreReader<S: StateStore> {
+pub struct KvLogStoreReader<S: StateStoreRead> {
     table_id: TableId,
 
     state_store: S,
@@ -153,7 +153,7 @@ pub struct KvLogStoreReader<S: StateStore> {
     rewind_delay: RewindDelay,
 }
 
-impl<S: StateStore> KvLogStoreReader<S> {
+impl<S: StateStoreRead> KvLogStoreReader<S> {
     pub(crate) fn new(
         table_id: TableId,
         state_store: S,
@@ -338,7 +338,7 @@ impl<S: StateStoreRead, F: FnMut() -> bool + Send> StateStoreIter
     }
 }
 
-impl<S: StateStore> KvLogStoreReader<S> {
+impl<S: StateStoreRead + Clone> KvLogStoreReader<S> {
     fn read_persisted_log_store(
         &self,
         last_persisted_epoch: Option<u64>,
@@ -399,7 +399,7 @@ impl<S: StateStore> KvLogStoreReader<S> {
     }
 }
 
-impl<S: StateStore> LogReader for KvLogStoreReader<S> {
+impl<S: StateStoreRead + Clone> LogReader for KvLogStoreReader<S> {
     async fn init(&mut self) -> LogStoreResult<()> {
         let first_write_epoch = self.rx.init().await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously in the sink log store, for log reader, we use methods in `StateStore` to access the data flushed by log writer. Methods in `StateStore` will read all shards (aka HummockReadVersion) of the `table_id` on the same CN. However, since the log reader is always in the same SinkExecutor as  log writer, it actually only needs to read the shard that belongs to the writer, and using `StateStore` will unnecessarily read more unrelated data.

In this PR, we will add a new method `new_flushed_snapshot_reader` to `LocalStateStore`, whose return type is a new associated type `FlushedSnapshotReader` that should implement the `StateStoreRead` trait. 

```
pub trait LocalStateStore: StaticSendSync {
    type FlushedSnapshotReader: StateStoreRead + Clone;
   ...

    fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader;
}
```

The semantic of this new `FlushedSnapshotReader` is, it can read the uncommitted data written by the parent `LocalStateStore` as long as the data has been `flushe`ed by the parent `LocalStateStore`. Such `FlushedSnapshotReader` will only read the same shard as the local state store.

The KvLogStoreReader will change to use this `FlushedSnapshotReader` to read to avoid reading unnecessary data in other shards in the CN.



## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
