### PR TITLE
fix: telemetry init channel unsuccessful leads to panic

### DIFF
--- a/src/common/telemetry_event/src/lib.rs
+++ b/src/common/telemetry_event/src/lib.rs
@@ -46,6 +46,10 @@ pub fn get_telemetry_risingwave_cloud_uuid() -> Option<String> {
 }
 
 pub async fn do_telemetry_event_report(event_stash: &mut Vec<PbEventMessage>) {
+    if event_stash.is_empty() {
+        return;
+    }
+
     const TELEMETRY_EVENT_REPORT_TYPE: &str = "events"; // the batch report url
     let url = (TELEMETRY_REPORT_URL.to_owned() + "/" + TELEMETRY_EVENT_REPORT_TYPE).to_owned();
     let batch_message = PbBatchEventMessage {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

following #20000 

bug report in Slack: https://risingwave-community.slack.com/archives/C03BW71523T/p1736509111698569
and provided log file: https://risingwave-community.slack.com/files/U05J27L4A9L/F088411E1D1/rw.logs

see from the log that a line is `rw-standalone-compute risingwave_common::telemetry::report: Telemetry failed to set event reporting tx, event reporting will be disabled`. 

I am not sure why it cannot allocate a channel and has not been reproduced yet. Proposing adding a check before handling events related info

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
