### PR TITLE
refactor(storage): create new read snapshot to read for StateStore trait

### DIFF
--- a/src/batch/executors/src/executor/insert.rs
+++ b/src/batch/executors/src/executor/insert.rs
@@ -275,8 +275,9 @@ mod tests {
     use risingwave_common::types::StructType;
     use risingwave_dml::dml_manager::DmlManager;
     use risingwave_storage::hummock::CachePolicy;
+    use risingwave_storage::hummock::test_utils::*;
     use risingwave_storage::memory::MemoryStateStore;
-    use risingwave_storage::store::{ReadOptions, StateStoreReadExt};
+    use risingwave_storage::store::ReadOptions;
 
     use super::*;
     use crate::executor::test_utils::MockExecutor;

--- a/src/batch/src/executor/fast_insert.rs
+++ b/src/batch/src/executor/fast_insert.rs
@@ -163,8 +163,9 @@ mod tests {
     use risingwave_common::transaction::transaction_message::TxnMsg;
     use risingwave_common::types::JsonbVal;
     use risingwave_dml::dml_manager::DmlManager;
+    use risingwave_storage::hummock::test_utils::StateStoreReadTestExt;
     use risingwave_storage::memory::MemoryStateStore;
-    use risingwave_storage::store::{ReadOptions, StateStoreReadExt};
+    use risingwave_storage::store::ReadOptions;
     use serde_json::json;
 
     use super::*;

--- a/src/storage/hummock_test/benches/bench_hummock_iter.rs
+++ b/src/storage/hummock_test/benches/bench_hummock_iter.rs
@@ -28,7 +28,7 @@ use risingwave_hummock_test::test_utils::TestIngestBatch;
 use risingwave_meta::hummock::MockHummockMetaClient;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
-use risingwave_storage::hummock::test_utils::default_opts_for_test;
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::{CachePolicy, HummockStorage};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::*;

--- a/src/storage/hummock_test/src/bin/replay/replay_impl.rs
+++ b/src/storage/hummock_test/src/bin/replay/replay_impl.rs
@@ -33,9 +33,8 @@ use risingwave_pb::meta::subscribe_response::{Info, Operation as RespOperation};
 use risingwave_pb::meta::{SubscribeResponse, SubscribeType};
 use risingwave_storage::hummock::HummockStorage;
 use risingwave_storage::hummock::store::LocalHummockStorage;
-use risingwave_storage::store::{
-    LocalStateStore, StateStoreIterExt, StateStoreRead, to_owned_item,
-};
+use risingwave_storage::hummock::test_utils::*;
+use risingwave_storage::store::{LocalStateStore, StateStoreIterExt, to_owned_item};
 use risingwave_storage::{StateStore, StateStoreIter, StateStoreReadIter};
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -70,7 +70,7 @@ pub(crate) mod tests {
         PkPrefixSkipWatermarkIterator, PkPrefixSkipWatermarkState, UserIterator,
     };
     use risingwave_storage::hummock::sstable_store::SstableStoreRef;
-    use risingwave_storage::hummock::test_utils::gen_test_sstable_info;
+    use risingwave_storage::hummock::test_utils::*;
     use risingwave_storage::hummock::value::HummockValue;
     use risingwave_storage::hummock::{
         BlockedXor16FilterBuilder, CachePolicy, CompressionAlgorithm, FilterBuilder,

--- a/src/storage/hummock_test/src/failpoint_tests.rs
+++ b/src/storage/hummock_test/src/failpoint_tests.rs
@@ -27,12 +27,12 @@ use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::StateStore;
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
-use risingwave_storage::hummock::test_utils::{count_stream, default_opts_for_test};
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::{CachePolicy, HummockStorage};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::{
-    LocalStateStore, NewLocalOptions, PrefetchOptions, ReadOptions, StateStoreRead,
-    TryWaitEpochOptions, WriteOptions,
+    LocalStateStore, NewLocalOptions, PrefetchOptions, ReadOptions, TryWaitEpochOptions,
+    WriteOptions,
 };
 
 use crate::get_notification_client_for_test;

--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -36,7 +36,7 @@ use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::SharedBuffe
 use risingwave_storage::hummock::store::version::{
     HummockReadVersion, StagingData, StagingSstableInfo, VersionUpdate, read_filter_for_version,
 };
-use risingwave_storage::hummock::test_utils::gen_dummy_batch;
+use risingwave_storage::hummock::test_utils::*;
 
 use crate::test_utils::prepare_first_valid_version;
 

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -41,6 +41,7 @@ use risingwave_meta::hummock::{CommitEpochInfo, NewTableFragmentInfo};
 use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::hummock::local_version::pinned_version::PinnedVersion;
 use risingwave_storage::hummock::store::version::read_filter_for_version;
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::{CachePolicy, HummockStorage, LocalHummockStorage};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::*;

--- a/src/storage/hummock_test/src/snapshot_tests.rs
+++ b/src/storage/hummock_test/src/snapshot_tests.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 // Copyright 2025 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,8 @@ use std::collections::HashSet;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use std::collections::HashSet;
 use std::ops::Bound;
 use std::sync::Arc;
 
@@ -24,11 +25,12 @@ use risingwave_hummock_sdk::key::prefixed_range_with_vnode;
 use risingwave_meta::hummock::MockHummockMetaClient;
 use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::StateStore;
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::{CachePolicy, HummockStorage};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::{
     LocalStateStore, NewLocalOptions, PrefetchOptions, ReadOptions, SealCurrentEpochOptions,
-    StateStoreRead, TryWaitEpochOptions, WriteOptions,
+    TryWaitEpochOptions, WriteOptions,
 };
 
 use crate::local_state_store_test_utils::LocalStateStoreTestExt;

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -35,7 +35,7 @@ use risingwave_storage::hummock::iterator::change_log::test_utils::{
     apply_test_log_data, gen_test_data,
 };
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
-use risingwave_storage::hummock::test_utils::{count_stream, default_opts_for_test};
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::{CachePolicy, HummockStorage};
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::storage_value::StorageValue;

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -35,8 +35,9 @@ use risingwave_storage::StateStore;
 use risingwave_storage::compaction_catalog_manager::CompactionCatalogAgentRef;
 use risingwave_storage::hummock::compactor::CompactorContext;
 use risingwave_storage::hummock::compactor::compactor_runner::compact_with_agent;
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::{CachePolicy, GetObjectId, SstableObjectIdManager};
-use risingwave_storage::store::{LocalStateStore, NewLocalOptions, ReadOptions, StateStoreRead};
+use risingwave_storage::store::{LocalStateStore, NewLocalOptions, ReadOptions};
 use serial_test::serial;
 
 use super::compactor_tests::tests::get_hummock_storage;

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -40,7 +40,7 @@ use risingwave_storage::hummock::event_handler::HummockVersionUpdate;
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::local_version::pinned_version::PinnedVersion;
 use risingwave_storage::hummock::observer_manager::HummockObserverNode;
-use risingwave_storage::hummock::test_utils::default_opts_for_test;
+use risingwave_storage::hummock::test_utils::*;
 use risingwave_storage::hummock::write_limiter::WriteLimiter;
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::*;

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -246,7 +246,9 @@ impl HummockStorage {
 
         Ok(instance)
     }
+}
 
+impl HummockStorageReadSnapshot {
     /// Gets the value of a specified `key` in the table specified in `read_options`.
     /// The result is based on a snapshot corresponding to the given `epoch`.
     /// if `key` has consistent hash virtual node value, then such value is stored in `value_meta`
@@ -257,13 +259,12 @@ impl HummockStorage {
     async fn get_inner(
         &self,
         key: TableKey<Bytes>,
-        epoch: HummockEpoch,
         read_options: ReadOptions,
     ) -> StorageResult<Option<StateStoreKeyedRow>> {
         let key_range = (Bound::Included(key.clone()), Bound::Included(key.clone()));
 
         let (key_range, read_version_tuple) = self
-            .build_read_version_tuple(epoch, key_range, &read_options)
+            .build_read_version_tuple(self.raw_epoch, key_range, &read_options)
             .await?;
 
         if is_empty_key_range(&key_range) {
@@ -271,37 +272,41 @@ impl HummockStorage {
         }
 
         self.hummock_version_reader
-            .get(key, epoch, read_options, read_version_tuple)
+            .get(key, self.raw_epoch, read_options, read_version_tuple)
             .await
     }
 
     async fn iter_inner(
         &self,
         key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> StorageResult<HummockStorageIterator> {
         let (key_range, read_version_tuple) = self
-            .build_read_version_tuple(epoch, key_range, &read_options)
+            .build_read_version_tuple(self.raw_epoch, key_range, &read_options)
             .await?;
 
         self.hummock_version_reader
-            .iter(key_range, epoch, read_options, read_version_tuple)
+            .iter(key_range, self.raw_epoch, read_options, read_version_tuple)
             .await
     }
 
     async fn rev_iter_inner(
         &self,
         key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> StorageResult<HummockStorageRevIterator> {
         let (key_range, read_version_tuple) = self
-            .build_read_version_tuple(epoch, key_range, &read_options)
+            .build_read_version_tuple(self.raw_epoch, key_range, &read_options)
             .await?;
 
         self.hummock_version_reader
-            .rev_iter(key_range, epoch, read_options, read_version_tuple, None)
+            .rev_iter(
+                key_range,
+                self.raw_epoch,
+                read_options,
+                read_version_tuple,
+                None,
+            )
             .await
     }
 
@@ -335,13 +340,13 @@ impl HummockStorage {
         read_options: &ReadOptions,
     ) -> StorageResult<(TableKeyRange, ReadVersionTuple)> {
         if read_options.read_version_from_backup {
-            self.build_read_version_tuple_from_backup(epoch, read_options.table_id, key_range)
+            self.build_read_version_tuple_from_backup(epoch, self.table_id, key_range)
                 .await
         } else if read_options.read_committed {
-            self.build_read_version_tuple_from_committed(epoch, read_options.table_id, key_range)
+            self.build_read_version_tuple_from_committed(epoch, self.table_id, key_range)
                 .await
         } else {
-            self.build_read_version_tuple_from_all(epoch, read_options.table_id, key_range)
+            self.build_read_version_tuple_from_all(epoch, self.table_id, key_range)
         }
     }
 
@@ -484,7 +489,9 @@ impl HummockStorage {
 
         Ok(ret)
     }
+}
 
+impl HummockStorage {
     async fn new_local_inner(&self, option: NewLocalOptions) -> LocalHummockStorage {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.hummock_event_sender
@@ -590,23 +597,33 @@ impl HummockStorage {
     }
 }
 
-impl StateStoreRead for HummockStorage {
+#[derive(Clone)]
+pub struct HummockStorageReadSnapshot {
+    raw_epoch: u64,
+    table_id: TableId,
+    recent_versions: Arc<ArcSwap<RecentVersions>>,
+    hummock_version_reader: HummockVersionReader,
+    read_version_mapping: ReadOnlyReadVersionMapping,
+    backup_reader: BackupReaderRef,
+    hummock_meta_client: Arc<dyn HummockMetaClient>,
+    simple_time_travel_version_cache: Arc<SimpleTimeTravelVersionCache>,
+}
+
+impl StateStoreRead for HummockStorageReadSnapshot {
     type Iter = HummockStorageIterator;
     type RevIter = HummockStorageRevIterator;
 
     fn get_keyed_row(
         &self,
         key: TableKey<Bytes>,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> impl Future<Output = StorageResult<Option<StateStoreKeyedRow>>> + Send + '_ {
-        self.get_inner(key, epoch, read_options)
+        self.get_inner(key, read_options)
     }
 
     fn iter(
         &self,
         key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> impl Future<Output = StorageResult<Self::Iter>> + '_ {
         let (l_vnode_inclusive, r_vnode_exclusive) = vnode_range(&key_range);
@@ -615,15 +632,14 @@ impl StateStoreRead for HummockStorage {
             1,
             "read range {:?} for table {} iter contains more than one vnode",
             key_range,
-            read_options.table_id
+            self.table_id
         );
-        self.iter_inner(key_range, epoch, read_options)
+        self.iter_inner(key_range, read_options)
     }
 
     fn rev_iter(
         &self,
         key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> impl Future<Output = StorageResult<Self::RevIter>> + '_ {
         let (l_vnode_inclusive, r_vnode_exclusive) = vnode_range(&key_range);
@@ -632,9 +648,9 @@ impl StateStoreRead for HummockStorage {
             1,
             "read range {:?} for table {} iter contains more than one vnode",
             key_range,
-            read_options.table_id
+            self.table_id
         );
-        self.rev_iter_inner(key_range, epoch, read_options)
+        self.rev_iter_inner(key_range, read_options)
     }
 }
 
@@ -699,25 +715,18 @@ impl StateStoreReadLog for HummockStorage {
     }
 }
 
-impl StateStore for HummockStorage {
-    type Local = LocalHummockStorage;
-
+impl HummockStorage {
     /// Waits until the local hummock version contains the epoch. If `wait_epoch` is `Current`,
     /// we will only check whether it is le `sealed_epoch` and won't wait.
-    async fn try_wait_epoch(
+    async fn try_wait_epoch_impl(
         &self,
         wait_epoch: HummockReadEpoch,
-        options: TryWaitEpochOptions,
+        table_id: TableId,
     ) -> StorageResult<()> {
         match wait_epoch {
             HummockReadEpoch::Committed(wait_epoch) => {
                 assert!(!is_max_epoch(wait_epoch), "epoch should not be MAX EPOCH");
-                wait_for_epoch(
-                    &self.version_update_notifier_tx,
-                    wait_epoch,
-                    options.table_id,
-                )
-                .await?;
+                wait_for_epoch(&self.version_update_notifier_tx, wait_epoch, table_id).await?;
             }
             HummockReadEpoch::BatchQueryCommitted(wait_epoch, wait_version_id) => {
                 assert!(!is_max_epoch(wait_epoch), "epoch should not be MAX EPOCH");
@@ -727,7 +736,7 @@ impl StateStore for HummockStorage {
                     let latest_version = recent_versions.latest_version();
                     if latest_version.id >= wait_version_id
                         && let Some(committed_epoch) =
-                            latest_version.table_committed_epoch(options.table_id)
+                            latest_version.table_committed_epoch(table_id)
                         && committed_epoch >= wait_epoch
                     {
                         return Ok(());
@@ -739,15 +748,14 @@ impl StateStore for HummockStorage {
                         if wait_version_id > version.id() {
                             return Ok(false);
                         }
-                        let committed_epoch = version
-                            .table_committed_epoch(options.table_id)
-                            .ok_or_else(|| {
+                        let committed_epoch =
+                            version.table_committed_epoch(table_id).ok_or_else(|| {
                                 // In batch query, since we have ensured that the current version must be after the
                                 // `wait_version_id`, when seeing that the table_id not exist in the latest version,
                                 // the table must have been dropped.
                                 HummockError::wait_epoch(format!(
                                     "table id {} has been dropped",
-                                    options.table_id
+                                    table_id
                                 ))
                             })?;
                         Ok(committed_epoch >= wait_epoch)
@@ -765,9 +773,42 @@ impl StateStore for HummockStorage {
         };
         Ok(())
     }
+}
+
+impl StateStore for HummockStorage {
+    type Local = LocalHummockStorage;
+    type ReadSnapshot = HummockStorageReadSnapshot;
+
+    /// Waits until the local hummock version contains the epoch. If `wait_epoch` is `Current`,
+    /// we will only check whether it is le `sealed_epoch` and won't wait.
+    async fn try_wait_epoch(
+        &self,
+        wait_epoch: HummockReadEpoch,
+        options: TryWaitEpochOptions,
+    ) -> StorageResult<()> {
+        self.try_wait_epoch_impl(wait_epoch, options.table_id).await
+    }
 
     fn new_local(&self, option: NewLocalOptions) -> impl Future<Output = Self::Local> + Send + '_ {
         self.new_local_inner(option)
+    }
+
+    async fn new_read_snapshot(
+        &self,
+        epoch: HummockReadEpoch,
+        options: NewReadSnapshotOptions,
+    ) -> StorageResult<Self::ReadSnapshot> {
+        self.try_wait_epoch_impl(epoch, options.table_id).await?;
+        Ok(HummockStorageReadSnapshot {
+            raw_epoch: epoch.get_epoch(),
+            table_id: options.table_id,
+            recent_versions: self.recent_versions.clone(),
+            hummock_version_reader: self.hummock_version_reader.clone(),
+            read_version_mapping: self.read_version_mapping.clone(),
+            backup_reader: self.backup_reader.clone(),
+            hummock_meta_client: self.hummock_meta_client.clone(),
+            simple_time_travel_version_cache: self.simple_time_travel_version_cache.clone(),
+        })
     }
 }
 

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::hash::VirtualNode;
-use risingwave_common::util::epoch::{EpochPair, MAX_SPILL_TIMES};
+use risingwave_common::util::epoch::{EpochPair, MAX_EPOCH, MAX_SPILL_TIMES};
 use risingwave_hummock_sdk::EpochWithGap;
 use risingwave_hummock_sdk::key::{TableKey, TableKeyRange, is_empty_key_range, vnode_range};
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
@@ -106,7 +106,6 @@ impl LocalHummockFlushedSnapshotReader {
         hummock_version_reader: &HummockVersionReader,
         read_version: &HummockReadVersionRef,
         table_key: TableKey<Bytes>,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> StorageResult<Option<StateStoreKeyedRow>> {
         let table_key_range = (
@@ -114,26 +113,29 @@ impl LocalHummockFlushedSnapshotReader {
             Bound::Included(table_key.clone()),
         );
 
-        let (table_key_range, read_snapshot) =
-            read_filter_for_version(epoch, read_options.table_id, table_key_range, read_version)?;
+        let (table_key_range, read_snapshot) = read_filter_for_version(
+            MAX_EPOCH,
+            read_options.table_id,
+            table_key_range,
+            read_version,
+        )?;
 
         if is_empty_key_range(&table_key_range) {
             return Ok(None);
         }
 
         hummock_version_reader
-            .get(table_key, epoch, read_options, read_snapshot)
+            .get(table_key, MAX_EPOCH, read_options, read_snapshot)
             .await
     }
 
     async fn iter_flushed(
         &self,
         table_key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> StorageResult<HummockStorageIterator> {
         let (table_key_range, read_snapshot) = read_filter_for_version(
-            epoch,
+            MAX_EPOCH,
             read_options.table_id,
             table_key_range,
             &self.read_version,
@@ -142,18 +144,17 @@ impl LocalHummockFlushedSnapshotReader {
         let table_key_range = table_key_range;
 
         self.hummock_version_reader
-            .iter(table_key_range, epoch, read_options, read_snapshot)
+            .iter(table_key_range, MAX_EPOCH, read_options, read_snapshot)
             .await
     }
 
     async fn rev_iter_flushed(
         &self,
         table_key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> StorageResult<HummockStorageRevIterator> {
         let (table_key_range, read_snapshot) = read_filter_for_version(
-            epoch,
+            MAX_EPOCH,
             read_options.table_id,
             table_key_range,
             &self.read_version,
@@ -162,7 +163,13 @@ impl LocalHummockFlushedSnapshotReader {
         let table_key_range = table_key_range;
 
         self.hummock_version_reader
-            .rev_iter(table_key_range, epoch, read_options, read_snapshot, None)
+            .rev_iter(
+                table_key_range,
+                MAX_EPOCH,
+                read_options,
+                read_snapshot,
+                None,
+            )
             .await
     }
 }
@@ -247,7 +254,6 @@ impl StateStoreRead for LocalHummockFlushedSnapshotReader {
     fn get_keyed_row(
         &self,
         key: TableKey<Bytes>,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> impl Future<Output = StorageResult<Option<StateStoreKeyedRow>>> + Send + '_ {
         assert_eq!(self.table_id, read_options.table_id);
@@ -255,7 +261,6 @@ impl StateStoreRead for LocalHummockFlushedSnapshotReader {
             &self.hummock_version_reader,
             &self.read_version,
             key,
-            epoch,
             read_options,
         )
     }
@@ -263,20 +268,18 @@ impl StateStoreRead for LocalHummockFlushedSnapshotReader {
     fn iter(
         &self,
         key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> impl Future<Output = StorageResult<Self::Iter>> + '_ {
-        self.iter_flushed(key_range, epoch, read_options)
+        self.iter_flushed(key_range, read_options)
             .instrument(tracing::trace_span!("hummock_iter"))
     }
 
     fn rev_iter(
         &self,
         key_range: TableKeyRange,
-        epoch: u64,
         read_options: ReadOptions,
     ) -> impl Future<Output = StorageResult<Self::RevIter>> + '_ {
-        self.rev_iter_flushed(key_range, epoch, read_options)
+        self.rev_iter_flushed(key_range, read_options)
             .instrument(tracing::trace_span!("hummock_rev_iter"))
     }
 }
@@ -297,7 +300,6 @@ impl LocalStateStore for LocalHummockStorage {
                 &self.hummock_version_reader,
                 &self.read_version,
                 key,
-                self.epoch(),
                 read_options,
             )
             .await
@@ -395,7 +397,6 @@ impl LocalStateStore for LocalHummockStorage {
                             &key,
                             &value,
                             sanity_check_reader,
-                            self.epoch(),
                             self.table_id,
                             self.table_option,
                             &self.op_consistency_level,
@@ -413,7 +414,6 @@ impl LocalStateStore for LocalHummockStorage {
                             &key,
                             &old_value,
                             sanity_check_reader,
-                            self.epoch(),
                             self.table_id,
                             self.table_option,
                             &self.op_consistency_level,
@@ -432,7 +432,6 @@ impl LocalStateStore for LocalHummockStorage {
                             &old_value,
                             &new_value,
                             sanity_check_reader,
-                            self.epoch(),
                             self.table_id,
                             self.table_option,
                             &self.op_consistency_level,

--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -383,7 +383,6 @@ pub(crate) async fn do_insert_sanity_check(
     key: &TableKey<Bytes>,
     value: &Bytes,
     inner: &impl StateStoreRead,
-    epoch: u64,
     table_id: TableId,
     table_option: TableOption,
     op_consistency_level: &OpConsistencyLevel,
@@ -397,7 +396,7 @@ pub(crate) async fn do_insert_sanity_check(
         cache_policy: CachePolicy::Fill(CacheHint::Normal),
         ..Default::default()
     };
-    let stored_value = inner.get(key.clone(), epoch, read_options).await?;
+    let stored_value = inner.get(key.clone(), read_options).await?;
 
     if let Some(stored_value) = stored_value {
         return Err(Box::new(MemTableError::InconsistentOperation {
@@ -415,7 +414,6 @@ pub(crate) async fn do_delete_sanity_check(
     key: &TableKey<Bytes>,
     old_value: &Bytes,
     inner: &impl StateStoreRead,
-    epoch: u64,
     table_id: TableId,
     table_option: TableOption,
     op_consistency_level: &OpConsistencyLevel,
@@ -433,7 +431,7 @@ pub(crate) async fn do_delete_sanity_check(
         cache_policy: CachePolicy::Fill(CacheHint::Normal),
         ..Default::default()
     };
-    match inner.get(key.clone(), epoch, read_options).await? {
+    match inner.get(key.clone(), read_options).await? {
         None => Err(Box::new(MemTableError::InconsistentOperation {
             key: key.clone(),
             prev: KeyOp::Delete(Bytes::default()),
@@ -461,7 +459,6 @@ pub(crate) async fn do_update_sanity_check(
     old_value: &Bytes,
     new_value: &Bytes,
     inner: &impl StateStoreRead,
-    epoch: u64,
     table_id: TableId,
     table_option: TableOption,
     op_consistency_level: &OpConsistencyLevel,
@@ -480,7 +477,7 @@ pub(crate) async fn do_update_sanity_check(
         ..Default::default()
     };
 
-    match inner.get(key.clone(), epoch, read_options).await? {
+    match inner.get(key.clone(), read_options).await? {
         None => Err(Box::new(MemTableError::InconsistentOperation {
             key: key.clone(),
             prev: KeyOp::Delete(Bytes::default()),

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -14,7 +14,6 @@
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
-use std::future::Future;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, RangeBounds};
 use std::sync::{Arc, LazyLock};
@@ -25,7 +24,7 @@ use parking_lot::RwLock;
 use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
-use risingwave_common::util::epoch::EpochPair;
+use risingwave_common::util::epoch::{EpochPair, MAX_EPOCH};
 use risingwave_hummock_sdk::key::{
     FullKey, TableKey, TableKeyRange, UserKey, prefixed_range_with_vnode,
 };
@@ -671,20 +670,54 @@ impl<R: RangeKv> RangeKvStateStore<R> {
     }
 }
 
-impl<R: RangeKv> StateStoreRead for RangeKvStateStore<R> {
+#[derive(Clone)]
+pub struct RangeKvStateStoreReadSnapshot<R: RangeKv> {
+    inner: RangeKvStateStore<R>,
+    epoch: u64,
+    table_id: TableId,
+}
+
+impl<R: RangeKv> StateStoreRead for RangeKvStateStoreReadSnapshot<R> {
     type Iter = RangeKvStateStoreIter<R>;
     type RevIter = RangeKvStateStoreRevIter<R>;
 
-    #[allow(clippy::unused_async)]
     async fn get_keyed_row(
         &self,
         key: TableKey<Bytes>,
+        _read_options: ReadOptions,
+    ) -> StorageResult<Option<StateStoreKeyedRow>> {
+        self.inner
+            .get_keyed_row_impl(key, self.epoch, self.table_id)
+    }
+
+    async fn iter(
+        &self,
+        key_range: TableKeyRange,
+        _read_options: ReadOptions,
+    ) -> StorageResult<Self::Iter> {
+        self.inner.iter_impl(key_range, self.epoch, self.table_id)
+    }
+
+    async fn rev_iter(
+        &self,
+        key_range: TableKeyRange,
+        _read_options: ReadOptions,
+    ) -> StorageResult<Self::RevIter> {
+        self.inner
+            .rev_iter_impl(key_range, self.epoch, self.table_id)
+    }
+}
+
+impl<R: RangeKv> RangeKvStateStore<R> {
+    fn get_keyed_row_impl(
+        &self,
+        key: TableKey<Bytes>,
         epoch: u64,
-        read_options: ReadOptions,
+        table_id: TableId,
     ) -> StorageResult<Option<StateStoreKeyedRow>> {
         let range_bounds = (Bound::Included(key.clone()), Bound::Included(key));
         // We do not really care about vnodes here, so we just use the default value.
-        let res = self.scan(range_bounds, epoch, read_options.table_id, Some(1))?;
+        let res = self.scan(range_bounds, epoch, table_id, Some(1))?;
 
         Ok(match res.as_slice() {
             [] => None,
@@ -696,17 +729,16 @@ impl<R: RangeKv> StateStoreRead for RangeKvStateStore<R> {
         })
     }
 
-    #[allow(clippy::unused_async)]
-    async fn iter(
+    fn iter_impl(
         &self,
         key_range: TableKeyRange,
         epoch: u64,
-        read_options: ReadOptions,
-    ) -> StorageResult<Self::Iter> {
+        table_id: TableId,
+    ) -> StorageResult<RangeKvStateStoreIter<R>> {
         Ok(RangeKvStateStoreIter::new(
             batched_iter::Iter::new(
                 self.inner.clone(),
-                to_full_key_range(read_options.table_id, key_range),
+                to_full_key_range(table_id, key_range),
                 false,
             ),
             epoch,
@@ -714,17 +746,16 @@ impl<R: RangeKv> StateStoreRead for RangeKvStateStore<R> {
         ))
     }
 
-    #[allow(clippy::unused_async)]
-    async fn rev_iter(
+    fn rev_iter_impl(
         &self,
         key_range: TableKeyRange,
         epoch: u64,
-        read_options: ReadOptions,
-    ) -> StorageResult<Self::RevIter> {
+        table_id: TableId,
+    ) -> StorageResult<RangeKvStateStoreRevIter<R>> {
         Ok(RangeKvStateStoreRevIter::new(
             batched_iter::Iter::new(
                 self.inner.clone(),
-                to_full_key_range(read_options.table_id, key_range),
+                to_full_key_range(table_id, key_range),
                 true,
             ),
             epoch,
@@ -784,6 +815,18 @@ impl<R: RangeKv> StateStoreReadLog for RangeKvStateStore<R> {
 }
 
 impl<R: RangeKv> RangeKvStateStore<R> {
+    fn new_read_snapshot_impl(
+        &self,
+        epoch: u64,
+        table_id: TableId,
+    ) -> RangeKvStateStoreReadSnapshot<R> {
+        RangeKvStateStoreReadSnapshot {
+            inner: self.clone(),
+            epoch,
+            table_id,
+        }
+    }
+
     pub(crate) fn ingest_batch(
         &self,
         mut kv_pairs: Vec<(TableKey<Bytes>, StorageValue)>,
@@ -827,8 +870,8 @@ impl<R: RangeKv> RangeKvStateStore<R> {
 
 impl<R: RangeKv> StateStore for RangeKvStateStore<R> {
     type Local = RangeKvLocalStateStore<R>;
+    type ReadSnapshot = RangeKvStateStoreReadSnapshot<R>;
 
-    #[allow(clippy::unused_async)]
     async fn try_wait_epoch(
         &self,
         _epoch: HummockReadEpoch,
@@ -840,6 +883,14 @@ impl<R: RangeKv> StateStore for RangeKvStateStore<R> {
 
     async fn new_local(&self, option: NewLocalOptions) -> Self::Local {
         RangeKvLocalStateStore::new(self.clone(), option)
+    }
+
+    async fn new_read_snapshot(
+        &self,
+        epoch: HummockReadEpoch,
+        options: NewReadSnapshotOptions,
+    ) -> StorageResult<Self::ReadSnapshot> {
+        Ok(self.new_read_snapshot_impl(epoch.get_epoch(), options.table_id))
     }
 }
 
@@ -870,7 +921,7 @@ impl<R: RangeKv> RangeKvLocalStateStore<R> {
 }
 
 impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
-    type FlushedSnapshotReader = RangeKvStateStore<R>;
+    type FlushedSnapshotReader = RangeKvStateStoreReadSnapshot<R>;
 
     type Iter<'a> = impl StateStoreIter + 'a;
     type RevIter<'a> = impl StateStoreIter + 'a;
@@ -878,10 +929,13 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
     async fn get(
         &self,
         key: TableKey<Bytes>,
-        read_options: ReadOptions,
+        _read_options: ReadOptions,
     ) -> StorageResult<Option<Bytes>> {
         match self.mem_table.buffer.get(&key) {
-            None => self.inner.get(key, self.epoch(), read_options).await,
+            None => self
+                .inner
+                .get_keyed_row_impl(key, self.epoch(), self.table_id)
+                .map(|option| option.map(|(_, value)| value)),
             Some(op) => match op {
                 KeyOp::Insert(value) | KeyOp::Update((_, value)) => Ok(Some(value.clone())),
                 KeyOp::Delete(_) => Ok(None),
@@ -889,46 +943,38 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
         }
     }
 
-    #[allow(clippy::manual_async_fn)]
-    fn iter(
+    async fn iter(
         &self,
         key_range: TableKeyRange,
-        read_options: ReadOptions,
-    ) -> impl Future<Output = StorageResult<Self::Iter<'_>>> + Send + '_ {
-        async move {
-            let iter = self
-                .inner
-                .iter(key_range.clone(), self.epoch(), read_options)
-                .await?;
-            Ok(FromStreamStateStoreIter::new(Box::pin(merge_stream(
-                self.mem_table.iter(key_range),
-                iter.into_stream(to_owned_item),
-                self.table_id,
-                self.epoch(),
-                false,
-            ))))
-        }
+        _read_options: ReadOptions,
+    ) -> StorageResult<Self::Iter<'_>> {
+        let iter = self
+            .inner
+            .iter_impl(key_range.clone(), self.epoch(), self.table_id)?;
+        Ok(FromStreamStateStoreIter::new(Box::pin(merge_stream(
+            self.mem_table.iter(key_range),
+            iter.into_stream(to_owned_item),
+            self.table_id,
+            self.epoch(),
+            false,
+        ))))
     }
 
-    #[allow(clippy::manual_async_fn)]
-    fn rev_iter(
+    async fn rev_iter(
         &self,
         key_range: TableKeyRange,
-        read_options: ReadOptions,
-    ) -> impl Future<Output = StorageResult<Self::RevIter<'_>>> + Send + '_ {
-        async move {
-            let iter = self
-                .inner
-                .rev_iter(key_range.clone(), self.epoch(), read_options)
-                .await?;
-            Ok(FromStreamStateStoreIter::new(Box::pin(merge_stream(
-                self.mem_table.rev_iter(key_range),
-                iter.into_stream(to_owned_item),
-                self.table_id,
-                self.epoch(),
-                true,
-            ))))
-        }
+        _read_options: ReadOptions,
+    ) -> StorageResult<Self::RevIter<'_>> {
+        let iter = self
+            .inner
+            .rev_iter_impl(key_range.clone(), self.epoch(), self.table_id)?;
+        Ok(FromStreamStateStoreIter::new(Box::pin(merge_stream(
+            self.mem_table.rev_iter(key_range),
+            iter.into_stream(to_owned_item),
+            self.table_id,
+            self.epoch(),
+            true,
+        ))))
     }
 
     fn insert(
@@ -951,18 +997,22 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
     async fn flush(&mut self) -> StorageResult<usize> {
         let buffer = self.mem_table.drain().into_parts();
         let mut kv_pairs = Vec::with_capacity(buffer.len());
+        let sanity_check_read_snapshot = if sanity_check_enabled() {
+            Some(self.inner.new_read_snapshot_impl(MAX_EPOCH, self.table_id))
+        } else {
+            None
+        };
         for (key, key_op) in buffer {
             match key_op {
                 // Currently, some executors do not strictly comply with these semantics. As
                 // a workaround you may call disable the check by initializing the
                 // state store with `op_consistency_level=Inconsistent`.
                 KeyOp::Insert(value) => {
-                    if sanity_check_enabled() {
+                    if let Some(sanity_check_read_snapshot) = &sanity_check_read_snapshot {
                         do_insert_sanity_check(
                             &key,
                             &value,
-                            &self.inner,
-                            self.epoch(),
+                            sanity_check_read_snapshot,
                             self.table_id,
                             self.table_option,
                             &self.op_consistency_level,
@@ -972,12 +1022,11 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
                     kv_pairs.push((key, StorageValue::new_put(value)));
                 }
                 KeyOp::Delete(old_value) => {
-                    if sanity_check_enabled() {
+                    if let Some(sanity_check_read_snapshot) = &sanity_check_read_snapshot {
                         do_delete_sanity_check(
                             &key,
                             &old_value,
-                            &self.inner,
-                            self.epoch(),
+                            sanity_check_read_snapshot,
                             self.table_id,
                             self.table_option,
                             &self.op_consistency_level,
@@ -987,13 +1036,12 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
                     kv_pairs.push((key, StorageValue::new_delete()));
                 }
                 KeyOp::Update((old_value, new_value)) => {
-                    if sanity_check_enabled() {
+                    if let Some(sanity_check_read_snapshot) = &sanity_check_read_snapshot {
                         do_update_sanity_check(
                             &key,
                             &old_value,
                             &new_value,
-                            &self.inner,
-                            self.epoch(),
+                            sanity_check_read_snapshot,
                             self.table_id,
                             self.table_option,
                             &self.op_consistency_level,
@@ -1022,7 +1070,6 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
         self.mem_table.is_dirty()
     }
 
-    #[allow(clippy::unused_async)]
     async fn init(&mut self, options: InitOptions) -> StorageResult<()> {
         assert_eq!(
             self.epoch.replace(options.epoch),
@@ -1144,7 +1191,7 @@ impl<R: RangeKv> LocalStateStore for RangeKvLocalStateStore<R> {
     }
 
     fn new_flushed_snapshot_reader(&self) -> Self::FlushedSnapshotReader {
-        self.inner.clone()
+        self.inner.new_read_snapshot_impl(MAX_EPOCH, self.table_id)
     }
 }
 
@@ -1176,7 +1223,6 @@ impl<R: RangeKv> RangeKvStateStoreIter<R> {
 }
 
 impl<R: RangeKv> StateStoreIter for RangeKvStateStoreIter<R> {
-    #[allow(clippy::unused_async)]
     async fn try_next(&mut self) -> StorageResult<Option<StateStoreKeyedRowRef<'_>>> {
         self.next_inner()?;
         Ok(self
@@ -1234,7 +1280,6 @@ impl<R: RangeKv> RangeKvStateStoreRevIter<R> {
 }
 
 impl<R: RangeKv> StateStoreIter for RangeKvStateStoreRevIter<R> {
-    #[allow(clippy::unused_async)]
     async fn try_next(&mut self) -> StorageResult<Option<StateStoreKeyedRowRef<'_>>> {
         self.next_inner()?;
         Ok(self
@@ -1382,6 +1427,7 @@ mod tests {
     use crate::hummock::iterator::test_utils::{
         iterator_test_table_key_of, iterator_test_value_of,
     };
+    use crate::hummock::test_utils::StateStoreReadTestExt;
     use crate::memory::sled::SledStateStore;
 
     #[tokio::test]

--- a/src/storage/src/monitor/mod.rs
+++ b/src/storage/src/monitor/mod.rs
@@ -37,7 +37,7 @@ pub use risingwave_object_store::object::object_metrics::{
 
 // include only when hummock trace enabled
 #[cfg(all(not(madsim), feature = "hm-trace"))]
-mod traced_store;
+pub(crate) mod traced_store;
 
 pub trait HummockTraceFutureExt: Sized + Future {
     type TraceOutput;

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -37,7 +37,7 @@ impl StateStoreRead for PanicStateStore {
     async fn get_keyed_row(
         &self,
         _key: TableKey<Bytes>,
-        _epoch: u64,
+
         _read_options: ReadOptions,
     ) -> StorageResult<Option<StateStoreKeyedRow>> {
         panic!("should not read from the state store!");
@@ -47,7 +47,7 @@ impl StateStoreRead for PanicStateStore {
     async fn iter(
         &self,
         _key_range: TableKeyRange,
-        _epoch: u64,
+
         _read_options: ReadOptions,
     ) -> StorageResult<Self::Iter> {
         panic!("should not read from the state store!");
@@ -57,7 +57,7 @@ impl StateStoreRead for PanicStateStore {
     async fn rev_iter(
         &self,
         _key_range: TableKeyRange,
-        _epoch: u64,
+
         _read_options: ReadOptions,
     ) -> StorageResult<Self::RevIter> {
         panic!("should not read from the state store!");
@@ -148,7 +148,6 @@ impl LocalStateStore for PanicStateStore {
         panic!("should not operate on the panic state store!")
     }
 
-    #[allow(clippy::unused_async)]
     async fn try_flush(&mut self) -> StorageResult<()> {
         panic!("should not operate on the panic state store!");
     }
@@ -168,8 +167,8 @@ impl LocalStateStore for PanicStateStore {
 
 impl StateStore for PanicStateStore {
     type Local = Self;
+    type ReadSnapshot = Self;
 
-    #[allow(clippy::unused_async)]
     async fn try_wait_epoch(
         &self,
         _epoch: HummockReadEpoch,
@@ -178,9 +177,16 @@ impl StateStore for PanicStateStore {
         panic!("should not wait epoch from the panic state store!");
     }
 
-    #[allow(clippy::unused_async)]
     async fn new_local(&self, _option: NewLocalOptions) -> Self::Local {
         panic!("should not call new local from the panic state store");
+    }
+
+    async fn new_read_snapshot(
+        &self,
+        _epoch: HummockReadEpoch,
+        _options: NewReadSnapshotOptions,
+    ) -> StorageResult<Self::ReadSnapshot> {
+        panic!()
     }
 }
 

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -41,8 +41,8 @@ use crate::hummock::{
 use crate::memory::MemoryStateStore;
 use crate::memory::sled::SledStateStore;
 use crate::monitor::{
-    CompactorMetrics, HummockStateStoreMetrics, MonitoredStateStore as Monitored,
-    MonitoredStorageMetrics, ObjectStoreMetrics,
+    CompactorMetrics, HummockStateStoreMetrics, MonitoredStateStore, MonitoredStorageMetrics,
+    ObjectStoreMetrics,
 };
 use crate::opts::StorageOpts;
 
@@ -73,6 +73,43 @@ mod opaque_type {
 }
 pub use opaque_type::{HummockStorageType, MemoryStateStoreType, SledStateStoreType};
 use opaque_type::{hummock, in_memory, sled};
+
+#[cfg(feature = "hm-trace")]
+type Monitored<S> = MonitoredStateStore<crate::monitor::traced_store::TracedStateStore<S>>;
+
+#[cfg(not(feature = "hm-trace"))]
+type Monitored<S> = MonitoredStateStore<S>;
+
+fn monitored<S: StateStore>(
+    state_store: S,
+    storage_metrics: Arc<MonitoredStorageMetrics>,
+) -> Monitored<S> {
+    let inner = {
+        #[cfg(feature = "hm-trace")]
+        {
+            crate::monitor::traced_store::TracedStateStore::new_global(state_store)
+        }
+        #[cfg(not(feature = "hm-trace"))]
+        {
+            state_store
+        }
+    };
+    inner.monitored(storage_metrics)
+}
+
+fn inner<S>(state_store: &Monitored<S>) -> &S {
+    let inner = state_store.inner();
+    {
+        #[cfg(feature = "hm-trace")]
+        {
+            inner.inner()
+        }
+        #[cfg(not(feature = "hm-trace"))]
+        {
+            inner
+        }
+    }
+}
 
 /// The type erased [`StateStore`].
 #[derive(Clone, EnumAsInner)]
@@ -142,7 +179,7 @@ impl StateStoreImpl {
         storage_metrics: Arc<MonitoredStorageMetrics>,
     ) -> Self {
         // The specific type of MemoryStateStoreType in deducted here.
-        Self::MemoryStateStore(in_memory(state_store).monitored(storage_metrics))
+        Self::MemoryStateStore(monitored(in_memory(state_store), storage_metrics))
     }
 
     pub fn hummock(
@@ -150,14 +187,14 @@ impl StateStoreImpl {
         storage_metrics: Arc<MonitoredStorageMetrics>,
     ) -> Self {
         // The specific type of HummockStateStoreType in deducted here.
-        Self::HummockStateStore(hummock(state_store).monitored(storage_metrics))
+        Self::HummockStateStore(monitored(hummock(state_store), storage_metrics))
     }
 
     pub fn sled(
         state_store: SledStateStore,
         storage_metrics: Arc<MonitoredStorageMetrics>,
     ) -> Self {
-        Self::SledStateStore(sled(state_store).monitored(storage_metrics))
+        Self::SledStateStore(monitored(sled(state_store), storage_metrics))
     }
 
     pub fn shared_in_memory_store(storage_metrics: Arc<MonitoredStorageMetrics>) -> Self {
@@ -174,7 +211,7 @@ impl StateStoreImpl {
     pub fn as_hummock(&self) -> Option<&HummockStorage> {
         match self {
             StateStoreImpl::HummockStateStore(hummock) => {
-                Some(hummock.inner().as_hummock().expect("should be hummock"))
+                Some(inner(hummock).as_hummock().expect("should be hummock"))
             }
             _ => None,
         }
@@ -289,15 +326,15 @@ pub mod verify {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<Option<StateStoreKeyedRow>> {
             let actual = self
                 .actual
-                .get_keyed_row(key.clone(), epoch, read_options.clone())
+                .get_keyed_row(key.clone(), read_options.clone())
                 .await;
             if let Some(expected) = &self.expected {
-                let expected = expected.get_keyed_row(key, epoch, read_options).await;
+                let expected = expected.get_keyed_row(key, read_options).await;
                 assert_result_eq(&actual, &expected);
             }
             actual
@@ -309,16 +346,16 @@ pub mod verify {
         fn iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::Iter>> + '_ {
             async move {
                 let actual = self
                     .actual
-                    .iter(key_range.clone(), epoch, read_options.clone())
+                    .iter(key_range.clone(), read_options.clone())
                     .await?;
                 let expected = if let Some(expected) = &self.expected {
-                    Some(expected.iter(key_range, epoch, read_options).await?)
+                    Some(expected.iter(key_range, read_options).await?)
                 } else {
                     None
                 };
@@ -331,16 +368,16 @@ pub mod verify {
         fn rev_iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::RevIter>> + '_ {
             async move {
                 let actual = self
                     .actual
-                    .rev_iter(key_range.clone(), epoch, read_options.clone())
+                    .rev_iter(key_range.clone(), read_options.clone())
                     .await?;
                 let expected = if let Some(expected) = &self.expected {
-                    Some(expected.rev_iter(key_range, epoch, read_options).await?)
+                    Some(expected.rev_iter(key_range, read_options).await?)
                 } else {
                     None
                 };
@@ -566,6 +603,7 @@ pub mod verify {
 
     impl<A: StateStore, E: StateStore> StateStore for VerifyStateStore<A, E> {
         type Local = VerifyStateStore<A::Local, E::Local>;
+        type ReadSnapshot = VerifyStateStore<A::ReadSnapshot, E::ReadSnapshot>;
 
         fn try_wait_epoch(
             &self,
@@ -586,6 +624,23 @@ pub mod verify {
                 expected,
                 _phantom: PhantomData::<()>,
             }
+        }
+
+        async fn new_read_snapshot(
+            &self,
+            epoch: HummockReadEpoch,
+            options: NewReadSnapshotOptions,
+        ) -> StorageResult<Self::ReadSnapshot> {
+            let expected = if let Some(expected) = &self.expected {
+                Some(expected.new_read_snapshot(epoch, options).await?)
+            } else {
+                None
+            };
+            Ok(VerifyStateStore {
+                actual: self.actual.new_read_snapshot(epoch, options).await?,
+                expected,
+                _phantom: PhantomData::<()>,
+            })
         }
     }
 
@@ -872,21 +927,21 @@ mod dyn_state_store {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<Option<StateStoreKeyedRow>>;
 
         async fn iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<BoxStateStoreReadIter>;
 
         async fn rev_iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<BoxStateStoreReadIter>;
     }
@@ -909,30 +964,28 @@ mod dyn_state_store {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<Option<StateStoreKeyedRow>> {
-            self.get_keyed_row(key, epoch, read_options).await
+            self.get_keyed_row(key, read_options).await
         }
 
         async fn iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<BoxStateStoreReadIter> {
-            Ok(Box::new(self.iter(key_range, epoch, read_options).await?))
+            Ok(Box::new(self.iter(key_range, read_options).await?))
         }
 
         async fn rev_iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> StorageResult<BoxStateStoreReadIter> {
-            Ok(Box::new(
-                self.rev_iter(key_range, epoch, read_options).await?,
-            ))
+            Ok(Box::new(self.rev_iter(key_range, read_options).await?))
         }
     }
 
@@ -1179,6 +1232,11 @@ mod dyn_state_store {
         ) -> StorageResult<()>;
 
         async fn new_local(&self, option: NewLocalOptions) -> BoxDynLocalStateStore;
+        async fn new_read_snapshot(
+            &self,
+            epoch: HummockReadEpoch,
+            options: NewReadSnapshotOptions,
+        ) -> StorageResult<StateStoreReadDynRef>;
     }
 
     #[async_trait::async_trait]
@@ -1193,6 +1251,16 @@ mod dyn_state_store {
 
         async fn new_local(&self, option: NewLocalOptions) -> BoxDynLocalStateStore {
             StateStorePointer(Box::new(self.new_local(option).await))
+        }
+
+        async fn new_read_snapshot(
+            &self,
+            epoch: HummockReadEpoch,
+            options: NewReadSnapshotOptions,
+        ) -> StorageResult<StateStoreReadDynRef> {
+            Ok(StateStorePointer(Arc::new(
+                self.new_read_snapshot(epoch, options).await?,
+            )))
         }
     }
 
@@ -1210,7 +1278,6 @@ mod dyn_state_store {
         };
     }
 
-    state_store_pointer_dyn_as_ref!(Arc<dyn DynStateStore>, DynStateStoreRead);
     state_store_pointer_dyn_as_ref!(Arc<dyn DynStateStoreRead>, DynStateStoreRead);
 
     #[derive(Clone)]
@@ -1226,28 +1293,28 @@ mod dyn_state_store {
         fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Option<StateStoreKeyedRow>>> + Send + '_ {
-            self.as_ref().get_keyed_row(key, epoch, read_options)
+            self.as_ref().get_keyed_row(key, read_options)
         }
 
         fn iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::Iter>> + '_ {
-            self.as_ref().iter(key_range, epoch, read_options)
+            self.as_ref().iter(key_range, read_options)
         }
 
         fn rev_iter(
             &self,
             key_range: TableKeyRange,
-            epoch: u64,
+
             read_options: ReadOptions,
         ) -> impl Future<Output = StorageResult<Self::RevIter>> + '_ {
-            self.as_ref().rev_iter(key_range, epoch, read_options)
+            self.as_ref().rev_iter(key_range, read_options)
         }
     }
 
@@ -1268,10 +1335,7 @@ mod dyn_state_store {
         }
     }
 
-    pub trait DynStateStore:
-        DynStateStoreRead + DynStateStoreReadLog + DynStateStoreExt + AsHummock
-    {
-    }
+    pub trait DynStateStore: DynStateStoreReadLog + DynStateStoreExt + AsHummock {}
 
     impl AsHummock for StateStoreDynRef {
         fn as_hummock(&self) -> Option<&HummockStorage> {
@@ -1279,13 +1343,11 @@ mod dyn_state_store {
         }
     }
 
-    impl<S: DynStateStoreRead + DynStateStoreReadLog + DynStateStoreExt + AsHummock> DynStateStore
-        for S
-    {
-    }
+    impl<S: DynStateStoreReadLog + DynStateStoreExt + AsHummock> DynStateStore for S {}
 
     impl StateStore for StateStoreDynRef {
         type Local = BoxDynLocalStateStore;
+        type ReadSnapshot = StateStoreReadDynRef;
 
         fn try_wait_epoch(
             &self,
@@ -1300,6 +1362,14 @@ mod dyn_state_store {
             option: NewLocalOptions,
         ) -> impl Future<Output = Self::Local> + Send + '_ {
             (*self.0).new_local(option)
+        }
+
+        async fn new_read_snapshot(
+            &self,
+            epoch: HummockReadEpoch,
+            options: NewReadSnapshotOptions,
+        ) -> StorageResult<Self::ReadSnapshot> {
+            (*self.0).new_read_snapshot(epoch, options).await
         }
     }
 }

--- a/src/storage/src/table/batch_table/mod.rs
+++ b/src/storage/src/table/batch_table/mod.rs
@@ -50,8 +50,8 @@ use crate::row_serde::row_serde_util::{serialize_pk, serialize_pk_with_vnode};
 use crate::row_serde::value_serde::{ValueRowSerde, ValueRowSerdeNew};
 use crate::row_serde::{ColumnMapping, find_columns_by_ids};
 use crate::store::{
-    NextEpochOptions, PrefetchOptions, ReadLogOptions, ReadOptions, StateStoreIter,
-    StateStoreIterExt, TryWaitEpochOptions,
+    NewReadSnapshotOptions, NextEpochOptions, PrefetchOptions, ReadLogOptions, ReadOptions,
+    StateStoreIter, StateStoreIterExt, StateStoreRead, TryWaitEpochOptions,
 };
 use crate::table::merge_sort::NodePeek;
 use crate::table::{ChangeLogRow, KeyedRow, TableDistribution, TableIter};
@@ -370,7 +370,6 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
         pk: impl Row,
         wait_epoch: HummockReadEpoch,
     ) -> StorageResult<Option<OwnedRow>> {
-        let epoch = wait_epoch.get_epoch();
         let read_backup = matches!(wait_epoch, HummockReadEpoch::Backup(_));
         let read_committed = wait_epoch.is_read_committed();
         self.store
@@ -404,9 +403,17 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
             cache_policy: CachePolicy::Fill(CacheHint::Normal),
             ..Default::default()
         };
-        if let Some((full_key, value)) = self
+        let read_snapshot = self
             .store
-            .get_keyed_row(serialized_pk, epoch, read_options)
+            .new_read_snapshot(
+                wait_epoch,
+                NewReadSnapshotOptions {
+                    table_id: self.table_id,
+                },
+            )
+            .await?;
+        if let Some((full_key, value)) = read_snapshot
+            .get_keyed_row(serialized_pk, read_options)
             .await?
         {
             let row = self.row_serde.deserialize(&value)?;
@@ -612,9 +619,20 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
             None => self.distribution.vnodes().iter_vnodes().collect_vec(),
         };
 
+        let read_snapshot = self
+            .store
+            .new_read_snapshot(
+                wait_epoch,
+                NewReadSnapshotOptions {
+                    table_id: self.table_id,
+                },
+            )
+            .await?;
+
         build_vnode_stream(
             |vnode| {
                 self.iter_vnode_with_encoded_key_range(
+                    &read_snapshot,
                     prefix_hint.clone(),
                     (start_bound.as_ref(), end_bound.as_ref()),
                     wait_epoch,
@@ -624,6 +642,7 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
             },
             |vnode| {
                 self.iter_vnode_with_encoded_key_range(
+                    &read_snapshot,
                     prefix_hint.clone(),
                     (start_bound.as_ref(), end_bound.as_ref()),
                     wait_epoch,
@@ -639,6 +658,7 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
 
     async fn iter_vnode_with_encoded_key_range<K: CopyFromSlice>(
         &self,
+        read_snapshot: &S::ReadSnapshot,
         prefix_hint: Option<Bytes>,
         encoded_key_range: (Bound<&Bytes>, Bound<&Bytes>),
         wait_epoch: HummockReadEpoch,
@@ -672,8 +692,8 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
                     true => None,
                     false => Some(Arc::new(self.pk_serializer.clone())),
                 };
-                let iter = BatchTableInnerIterInner::<S, SD>::new(
-                    &self.store,
+                let iter = BatchTableInnerIterInner::new(
+                    read_snapshot,
                     self.mapping.clone(),
                     self.epoch_idx,
                     pk_serializer,
@@ -684,7 +704,6 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
                     self.row_serde.clone(),
                     table_key_range,
                     read_options,
-                    wait_epoch,
                 )
                 .await?
                 .into_stream::<K>();
@@ -904,8 +923,18 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
         } else {
             Unbounded
         };
+        let read_snapshot = self
+            .store
+            .new_read_snapshot(
+                epoch,
+                NewReadSnapshotOptions {
+                    table_id: self.table_id,
+                },
+            )
+            .await?;
         Ok(self
             .iter_vnode_with_encoded_key_range::<()>(
+                &read_snapshot,
                 None,
                 (start_bound.as_ref(), Unbounded),
                 epoch,
@@ -1021,9 +1050,9 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInner<S, SD> {
 }
 
 /// [`BatchTableInnerIterInner`] iterates on the storage table.
-struct BatchTableInnerIterInner<S: StateStore, SD: ValueRowSerde> {
+struct BatchTableInnerIterInner<SI: StateStoreIter, SD: ValueRowSerde> {
     /// An iterator that returns raw bytes from storage.
-    iter: S::Iter,
+    iter: SI,
 
     mapping: Arc<ColumnMapping>,
 
@@ -1047,10 +1076,10 @@ struct BatchTableInnerIterInner<S: StateStore, SD: ValueRowSerde> {
     output_row_in_key_indices: Vec<usize>,
 }
 
-impl<S: StateStore, SD: ValueRowSerde> BatchTableInnerIterInner<S, SD> {
+impl<SI: StateStoreIter, SD: ValueRowSerde> BatchTableInnerIterInner<SI, SD> {
     /// If `wait_epoch` is true, it will wait for the given epoch to be committed before iteration.
     #[allow(clippy::too_many_arguments)]
-    async fn new(
+    async fn new<S>(
         store: &S,
         mapping: Arc<ColumnMapping>,
         epoch_idx: Option<usize>,
@@ -1062,18 +1091,11 @@ impl<S: StateStore, SD: ValueRowSerde> BatchTableInnerIterInner<S, SD> {
         row_deserializer: Arc<SD>,
         table_key_range: TableKeyRange,
         read_options: ReadOptions,
-        epoch: HummockReadEpoch,
-    ) -> StorageResult<Self> {
-        let raw_epoch = epoch.get_epoch();
-        store
-            .try_wait_epoch(
-                epoch,
-                TryWaitEpochOptions {
-                    table_id: read_options.table_id,
-                },
-            )
-            .await?;
-        let iter = store.iter(table_key_range, raw_epoch, read_options).await?;
+    ) -> StorageResult<Self>
+    where
+        S: StateStoreRead<Iter = SI>,
+    {
+        let iter = store.iter(table_key_range, read_options).await?;
         let iter = Self {
             iter,
             mapping,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously we have two traits to read in storage, `LocalStateStore` and `StateStoreRead`. One difference in the two traits is that, for `StateStoreRead`, we have to specify the epoch to read on, while for `LocalStateStore`, since its read methods always read from the latest snapshot, we don't need to specify the epoch.

In https://github.com/risingwavelabs/risingwave/pull/20153, we introduce a new associated type `FlushedSnapshotReader`, which also reads data from the latest snapshot. However, since it implements the `StateStoreRead` trait, when we call its read methods, we still need to specify the epoch, which is actually unnecessary. Besides, it will be cleaner if we are able to make the read methods more unified in the trait definition.

Therefore, in this PR, we will remove the `epoch` parameter from the read methods of `StateStoreRead` trait. Instead, we add a new method `new_read_snapshot` to `StateStore`, whose return type is a new associated type `ReadSnapshot` that implements `StateStoreRead`. In the `new_read_snapshot` method, we specify the `epoch` and `table_id` to read. In the implementation of `HummockStorage` on `new_read_snapshot`, we also do `try_wait_epoch` on the epoch, so that the returned `ReadSnapshot` is ready to read.

Changes in the trait definition is as followed:
```
pub trait StateStoreRead: StaticSendSync {
    fn get(
        &self,
        key: TableKey<Bytes>,
        //  epoch: u64, // epoch is removed
        ...

    fn iter(
        &self,
        key_range: TableKeyRange,
        //  epoch: u64, // epoch is removed
        ...

    fn rev_iter(
        &self,
        key_range: TableKeyRange,
        //  epoch: u64, // epoch is removed
        ...
}

pub trait StateStore: StateStoreReadLog + StaticSendSync + Clone {
    type ReadSnapshot: StateStoreRead + Clone;

    fn new_read_snapshot(
        &self,
        epoch: HummockReadEpoch,
        options: NewReadSnapshotOptions,
    ) -> impl StorageFuture<'_, Self::ReadSnapshot>;
    ...
}
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
