### PR TITLE
feat(frontend): allow schema change & sink into a CTAS table

### DIFF
--- a/e2e_test/ddl/show_purify.slt
+++ b/e2e_test/ddl/show_purify.slt
@@ -17,4 +17,22 @@ show create table ctas;
 public.ctas	CREATE TABLE ctas (v0 INT, v1 NUMERIC, v2 TIMESTAMP, v3 TIMESTAMP WITH TIME ZONE, v4 CHARACTER VARYING[], v5 STRUCT<i BIGINT, j STRUCT<a BIGINT, b CHARACTER VARYING>>, v6 rw_int256, v7 MAP(CHARACTER VARYING,INT))
 
 statement ok
+alter table ctas add column v8 double;
+
+# Show that we can add or drop columns to the CTAS table.
+
+query TT
+show create table ctas;
+----
+public.ctas	CREATE TABLE ctas (v0 INT, v1 NUMERIC, v2 TIMESTAMP, v3 TIMESTAMP WITH TIME ZONE, v4 CHARACTER VARYING[], v5 STRUCT<i BIGINT, j STRUCT<a BIGINT, b CHARACTER VARYING>>, v6 rw_int256, v7 MAP(CHARACTER VARYING,INT), v8 DOUBLE)
+
+statement ok
+alter table ctas drop column v0;
+
+query TT
+show create table ctas;
+----
+public.ctas	CREATE TABLE ctas (v1 NUMERIC, v2 TIMESTAMP, v3 TIMESTAMP WITH TIME ZONE, v4 CHARACTER VARYING[], v5 STRUCT<i BIGINT, j STRUCT<a BIGINT, b CHARACTER VARYING>>, v6 rw_int256, v7 MAP(CHARACTER VARYING,INT), v8 DOUBLE)
+
+statement ok
 drop table ctas;

--- a/e2e_test/sink/sink_into_table/ctas.slt
+++ b/e2e_test/sink/sink_into_table/ctas.slt
@@ -1,0 +1,25 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table ctas as select 1 as v;
+
+query I rowsort
+select * from ctas;
+----
+1
+
+statement ok
+create sink sk into ctas as select 2 as v with (type = 'append-only');
+
+query I rowsort
+select * from ctas;
+----
+1
+2
+
+statement ok
+drop sink sk;
+
+statement ok
+drop table ctas;

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -502,9 +502,10 @@ impl TableCatalog {
         if let TableType::Table = self.table_type()
             && self.definition.is_empty()
         {
-            // Fix `CREATE TABLE AS`.
+            // Always fix definition for `CREATE TABLE AS`.
             self.create_sql_ast_purified()
         } else {
+            // Directly parse the persisted definition.
             self.create_sql_ast_raw()
         }
     }

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -299,7 +299,7 @@ impl TableCatalog {
                 let name = ast::ObjectName(vec![self.name.as_str().into()]);
                 ast::Statement::default_create_table(name)
             } else {
-                self.create_sql_ast_raw()?
+                self.create_sql_ast_from_persisted()?
             };
 
             match try_purify_table_source_create_sql_ast(
@@ -318,7 +318,7 @@ impl TableCatalog {
             }
         }
 
-        self.create_sql_ast_raw()
+        self.create_sql_ast_from_persisted()
     }
 }
 
@@ -506,11 +506,11 @@ impl TableCatalog {
             self.create_sql_ast_purified()
         } else {
             // Directly parse the persisted definition.
-            self.create_sql_ast_raw()
+            self.create_sql_ast_from_persisted()
         }
     }
 
-    fn create_sql_ast_raw(&self) -> Result<ast::Statement> {
+    fn create_sql_ast_from_persisted(&self) -> Result<ast::Statement> {
         Ok(Parser::parse_sql(&self.definition)
             .context("unable to parse definition sql")?
             .into_iter()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Allow performing schema changes (`ALTER TABLE ... [ADD | DROP] COLUMN`) on or create a sink into a table created by `CREATE TABLE AS` statement.

----

After #19949, we now have two different methods for retrieving the definition of a table: `create_sql` and `create_sql_purified`. Prior to this PR, `create_sql` always directly return the persisted definition string, while `create_sql_purified` will re-assemble a definition with all columns qualified based on the `TableCatalog`.

However, the definitions for CTAS tables are missing, causing `create_sql_ast` to always return an error. This seems pointless. So this PR makes `create_sql_ast` also run purification if (and only if) the definition is missing (indicating that it's a CTAS table). This enables replacing functionalities for CTAS table, including schema change and sink-into-table.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
