### PR TITLE
refactor(storage): unify state store trait get method

### DIFF
--- a/src/storage/hummock_test/src/bin/replay/replay_impl.rs
+++ b/src/storage/hummock_test/src/bin/replay/replay_impl.rs
@@ -34,7 +34,7 @@ use risingwave_pb::meta::{SubscribeResponse, SubscribeType};
 use risingwave_storage::hummock::HummockStorage;
 use risingwave_storage::hummock::store::LocalHummockStorage;
 use risingwave_storage::hummock::test_utils::*;
-use risingwave_storage::store::{LocalStateStore, StateStoreIterExt, to_owned_item};
+use risingwave_storage::store::*;
 use risingwave_storage::{StateStore, StateStoreIter, StateStoreReadIter};
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
@@ -248,12 +248,12 @@ impl LocalReplayRead for LocalReplayImpl {
         key: TracedBytes,
         read_options: TracedReadOptions,
     ) -> Result<Option<TracedBytes>> {
-        Ok(
-            LocalStateStore::get(&self.0, TableKey(key.into()), read_options.into())
-                .await
-                .unwrap()
-                .map(TracedBytes::from),
-        )
+        Ok(self
+            .0
+            .get(TableKey(key.into()), read_options.into())
+            .await
+            .unwrap()
+            .map(TracedBytes::from))
     }
 }
 

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -29,21 +29,21 @@ use crate::store::*;
 #[derive(Clone, Default)]
 pub struct PanicStateStore;
 
+impl StateStoreGet for PanicStateStore {
+    fn on_key_value<O: Send + 'static>(
+        &self,
+        _key: TableKey<Bytes>,
+        _read_options: ReadOptions,
+        _on_key_value_fn: impl KeyValueFn<O>,
+    ) -> impl StorageFuture<'_, Option<O>> {
+        async { panic!("should not read from PanicStateStore") }
+    }
+}
+
 impl StateStoreRead for PanicStateStore {
     type Iter = PanicStateStoreIter<StateStoreKeyedRow>;
     type RevIter = PanicStateStoreIter<StateStoreKeyedRow>;
 
-    #[allow(clippy::unused_async)]
-    async fn get_keyed_row(
-        &self,
-        _key: TableKey<Bytes>,
-
-        _read_options: ReadOptions,
-    ) -> StorageResult<Option<StateStoreKeyedRow>> {
-        panic!("should not read from the state store!");
-    }
-
-    #[allow(clippy::unused_async)]
     async fn iter(
         &self,
         _key_range: TableKeyRange,
@@ -53,7 +53,6 @@ impl StateStoreRead for PanicStateStore {
         panic!("should not read from the state store!");
     }
 
-    #[allow(clippy::unused_async)]
     async fn rev_iter(
         &self,
         _key_range: TableKeyRange,
@@ -86,16 +85,6 @@ impl LocalStateStore for PanicStateStore {
     type Iter<'a> = PanicStateStoreIter<StateStoreKeyedRow>;
     type RevIter<'a> = PanicStateStoreIter<StateStoreKeyedRow>;
 
-    #[allow(clippy::unused_async)]
-    async fn get(
-        &self,
-        _key: TableKey<Bytes>,
-        _read_options: ReadOptions,
-    ) -> StorageResult<Option<Bytes>> {
-        panic!("should not operate on the panic state store!");
-    }
-
-    #[allow(clippy::unused_async)]
     async fn iter(
         &self,
         _key_range: TableKeyRange,
@@ -104,7 +93,6 @@ impl LocalStateStore for PanicStateStore {
         panic!("should not operate on the panic state store!");
     }
 
-    #[allow(clippy::unused_async)]
     async fn rev_iter(
         &self,
         _key_range: TableKeyRange,
@@ -126,7 +114,6 @@ impl LocalStateStore for PanicStateStore {
         panic!("should not operate on the panic state store!");
     }
 
-    #[allow(clippy::unused_async)]
     async fn flush(&mut self) -> StorageResult<usize> {
         panic!("should not operate on the panic state store!");
     }
@@ -139,7 +126,6 @@ impl LocalStateStore for PanicStateStore {
         panic!("should not operate on the panic state store!");
     }
 
-    #[allow(clippy::unused_async)]
     async fn init(&mut self, _epoch: InitOptions) -> StorageResult<()> {
         panic!("should not operate on the panic state store!");
     }

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -281,7 +281,7 @@ pub mod verify {
     use risingwave_common::bitmap::Bitmap;
     use risingwave_common::hash::VirtualNode;
     use risingwave_hummock_sdk::HummockReadEpoch;
-    use risingwave_hummock_sdk::key::{TableKey, TableKeyRange};
+    use risingwave_hummock_sdk::key::{FullKey, TableKey, TableKeyRange};
     use tracing::log::warn;
 
     use crate::error::StorageResult;
@@ -289,6 +289,7 @@ pub mod verify {
     use crate::store::*;
     use crate::store_impl::AsHummock;
 
+    #[expect(dead_code)]
     fn assert_result_eq<Item: PartialEq + Debug, E>(
         first: &std::result::Result<Item, E>,
         second: &std::result::Result<Item, E>,
@@ -321,26 +322,44 @@ pub mod verify {
         }
     }
 
+    impl<A: StateStoreGet, E: StateStoreGet> StateStoreGet for VerifyStateStore<A, E> {
+        async fn on_key_value<O: Send + 'static>(
+            &self,
+            key: TableKey<Bytes>,
+            read_options: ReadOptions,
+            on_key_value_fn: impl KeyValueFn<O>,
+        ) -> StorageResult<Option<O>> {
+            let actual: Option<(FullKey<Bytes>, Bytes)> = self
+                .actual
+                .on_key_value(key.clone(), read_options.clone(), |key, value| {
+                    Ok((key.copy_into(), Bytes::copy_from_slice(value)))
+                })
+                .await?;
+            if let Some(expected) = &self.expected {
+                let expected: Option<(FullKey<Bytes>, Bytes)> = expected
+                    .on_key_value(key, read_options, |key, value| {
+                        Ok((key.copy_into(), Bytes::copy_from_slice(value)))
+                    })
+                    .await?;
+                assert_eq!(
+                    actual
+                        .as_ref()
+                        .map(|item| (item.0.epoch_with_gap.pure_epoch(), item)),
+                    expected
+                        .as_ref()
+                        .map(|item| (item.0.epoch_with_gap.pure_epoch(), item))
+                );
+            }
+
+            actual
+                .map(|(key, value)| on_key_value_fn(key.to_ref(), value.as_ref()))
+                .transpose()
+        }
+    }
+
     impl<A: StateStoreRead, E: StateStoreRead> StateStoreRead for VerifyStateStore<A, E> {
         type Iter = impl StateStoreReadIter;
         type RevIter = impl StateStoreReadIter;
-
-        async fn get_keyed_row(
-            &self,
-            key: TableKey<Bytes>,
-
-            read_options: ReadOptions,
-        ) -> StorageResult<Option<StateStoreKeyedRow>> {
-            let actual = self
-                .actual
-                .get_keyed_row(key.clone(), read_options.clone())
-                .await;
-            if let Some(expected) = &self.expected {
-                let expected = expected.get_keyed_row(key, read_options).await;
-                assert_result_eq(&actual, &expected);
-            }
-            actual
-        }
 
         // TODO: may avoid manual async fn when the bug of rust compiler is fixed. Currently it will
         // fail to compile.
@@ -455,19 +474,6 @@ pub mod verify {
 
         type Iter<'a> = impl StateStoreIter + 'a;
         type RevIter<'a> = impl StateStoreIter + 'a;
-
-        async fn get(
-            &self,
-            key: TableKey<Bytes>,
-            read_options: ReadOptions,
-        ) -> StorageResult<Option<Bytes>> {
-            let actual = self.actual.get(key.clone(), read_options.clone()).await;
-            if let Some(expected) = &self.expected {
-                let expected = expected.get(key, read_options).await;
-                assert_result_eq(&actual, &expected);
-            }
-            actual
-        }
 
         #[expect(clippy::manual_async_fn)]
         fn iter(
@@ -934,14 +940,16 @@ mod dyn_state_store {
     pub type BoxStateStoreReadChangeLogIter = BoxStateStoreIter<'static, StateStoreReadLogItem>;
 
     #[async_trait::async_trait]
-    pub trait DynStateStoreRead: StaticSendSync {
+    pub trait DynStateStoreGet: StaticSendSync {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
-
             read_options: ReadOptions,
         ) -> StorageResult<Option<StateStoreKeyedRow>>;
+    }
 
+    #[async_trait::async_trait]
+    pub trait DynStateStoreRead: DynStateStoreGet + StaticSendSync {
         async fn iter(
             &self,
             key_range: TableKeyRange,
@@ -971,16 +979,21 @@ mod dyn_state_store {
     pub type StateStoreReadDynRef = StateStorePointer<Arc<dyn DynStateStoreRead>>;
 
     #[async_trait::async_trait]
-    impl<S: StateStoreRead> DynStateStoreRead for S {
+    impl<S: StateStoreGet> DynStateStoreGet for S {
         async fn get_keyed_row(
             &self,
             key: TableKey<Bytes>,
-
             read_options: ReadOptions,
         ) -> StorageResult<Option<StateStoreKeyedRow>> {
-            self.get_keyed_row(key, read_options).await
+            self.on_key_value(key, read_options, move |key, value| {
+                Ok((key.copy_into(), Bytes::copy_from_slice(value)))
+            })
+            .await
         }
+    }
 
+    #[async_trait::async_trait]
+    impl<S: StateStoreRead> DynStateStoreRead for S {
         async fn iter(
             &self,
             key_range: TableKeyRange,
@@ -1021,13 +1034,7 @@ mod dyn_state_store {
     // For LocalStateStore
     pub type BoxLocalStateStoreIterStream<'a> = BoxStateStoreIter<'a, StateStoreKeyedRow>;
     #[async_trait::async_trait]
-    pub trait DynLocalStateStore: StaticSendSync {
-        async fn get(
-            &self,
-            key: TableKey<Bytes>,
-            read_options: ReadOptions,
-        ) -> StorageResult<Option<Bytes>>;
-
+    pub trait DynLocalStateStore: DynStateStoreGet + StaticSendSync {
         async fn iter(
             &self,
             key_range: TableKeyRange,
@@ -1070,14 +1077,6 @@ mod dyn_state_store {
 
     #[async_trait::async_trait]
     impl<S: LocalStateStore> DynLocalStateStore for S {
-        async fn get(
-            &self,
-            key: TableKey<Bytes>,
-            read_options: ReadOptions,
-        ) -> StorageResult<Option<Bytes>> {
-            self.get(key, read_options).await
-        }
-
         async fn iter(
             &self,
             key_range: TableKeyRange,
@@ -1150,14 +1149,6 @@ mod dyn_state_store {
         type FlushedSnapshotReader = StateStoreReadDynRef;
         type Iter<'a> = BoxLocalStateStoreIterStream<'a>;
         type RevIter<'a> = BoxLocalStateStoreIterStream<'a>;
-
-        fn get(
-            &self,
-            key: TableKey<Bytes>,
-            read_options: ReadOptions,
-        ) -> impl Future<Output = StorageResult<Option<Bytes>>> + Send + '_ {
-            (*self.0).get(key, read_options)
-        }
 
         fn iter(
             &self,
@@ -1286,25 +1277,35 @@ mod dyn_state_store {
     }
 
     state_store_pointer_dyn_as_ref!(Arc<dyn DynStateStoreRead>, DynStateStoreRead);
+    state_store_pointer_dyn_as_ref!(Arc<dyn DynStateStoreRead>, DynStateStoreGet);
+    state_store_pointer_dyn_as_ref!(Box<dyn DynLocalStateStore>, DynStateStoreGet);
 
     #[derive(Clone)]
     pub struct StateStorePointer<P>(pub(crate) P);
 
+    impl<P> StateStoreGet for StateStorePointer<P>
+    where
+        StateStorePointer<P>: AsRef<dyn DynStateStoreGet> + StaticSendSync,
+    {
+        async fn on_key_value<O: Send + 'static>(
+            &self,
+            key: TableKey<Bytes>,
+            read_options: ReadOptions,
+            on_key_value_fn: impl KeyValueFn<O>,
+        ) -> StorageResult<Option<O>> {
+            let option = self.as_ref().get_keyed_row(key, read_options).await?;
+            option
+                .map(|(key, value)| on_key_value_fn(key.to_ref(), value.as_ref()))
+                .transpose()
+        }
+    }
+
     impl<P> StateStoreRead for StateStorePointer<P>
     where
-        StateStorePointer<P>: AsRef<dyn DynStateStoreRead> + StaticSendSync,
+        StateStorePointer<P>: AsRef<dyn DynStateStoreRead> + StateStoreGet + StaticSendSync,
     {
         type Iter = BoxStateStoreReadIter;
         type RevIter = BoxStateStoreReadIter;
-
-        fn get_keyed_row(
-            &self,
-            key: TableKey<Bytes>,
-
-            read_options: ReadOptions,
-        ) -> impl Future<Output = StorageResult<Option<StateStoreKeyedRow>>> + Send + '_ {
-            self.as_ref().get_keyed_row(key, read_options)
-        }
 
         fn iter(
             &self,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Currently we have `get` method in `LocalStateStore`, and `get` and `get_keyed_row` in `StateStoreRead`, which is somehow verbose and duplicated. Besides, for these methods, in most usages, we won't use the returned `Bytes` value directly, and instead deserialize the `&[u8]` of it, which makes the memory allocation and clone to construct the `Bytes` unnecessary.

For these reasons, in this PR, we will extract the common `StateStoreGet` trait, so that we won't have two traits for get related methods. Besides, instead of having `get` or `get_keyed_row` method to return a `Bytes` value, we will change to have `on_key_value` and pass a `impl Fn(FullKey<&[u8]>, &[u8])` to observe the reference to key and value, so that we can avoid allocate and clone the `Bytes` when unnecessary. 

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
