### PR TITLE
feat(sink): Avro with AWS Glue Schema Registry

### DIFF
--- a/e2e_test/source_inline/kafka/avro/glue.slt.serial
+++ b/e2e_test/source_inline/kafka/avro/glue.slt.serial
@@ -145,6 +145,76 @@ foo 2006-01-02 22:04:05.123456+00:00 NULL
 AB  2022-04-08 00:00:00.123456+00:00 \xdeadbeef
 
 statement ok
+create sink sk as select
+  'bar' as f1,
+  to_timestamp(1735689600) as f2,
+  'a0A'::bytea as f3
+with (
+  connector = 'kafka',
+  properties.bootstrap.server='${RISEDEV_KAFKA_BOOTSTRAP_SERVERS}',
+  topic = 'glue-sample-my-event')
+format plain encode avro (
+  aws.glue.schema_arn = 'arn:aws:glue:ap-southeast-1:123456123456:schema/default-registry/MyEvent',
+  aws.glue.mock_config = '{
+    "by_id":{
+      "5af405ef-11b5-4442-81a2-e0563e5a7346": {
+        "type": "record",
+        "name": "MyEvent",
+        "fields": [
+          {
+            "name": "f1",
+            "type": "string"
+          },
+          {
+            "name": "f2",
+            "type": {
+              "type": "long",
+              "logicalType": "timestamp-micros"
+            }
+          }
+        ]
+      },
+      "4516411b-b1e7-4e67-839f-3ef1b8c29280": {
+        "type": "record",
+        "name": "MyEvent",
+        "fields": [
+          {
+            "name": "f1",
+            "type": "string"
+          },
+          {
+            "name": "f2",
+            "type": {
+              "type": "long",
+              "logicalType": "timestamp-micros"
+            }
+          },
+          {
+            "name": "f3",
+            "type": ["null", "bytes"],
+            "default": null
+          }
+        ]
+      }
+    },
+    "arn_to_latest_id":{
+      "arn:aws:glue:ap-southeast-1:123456123456:schema/default-registry/MyEvent": "4516411b-b1e7-4e67-839f-3ef1b8c29280"
+    }
+  }');
+
+sleep 1s
+
+query TTT
+select * from t order by 2;
+----
+foo 2006-01-02 22:04:05.123456+00:00 NULL
+AB  2022-04-08 00:00:00.123456+00:00 \xdeadbeef
+bar 2025-01-01 00:00:00+00:00        \x613041
+
+statement ok
+drop sink sk;
+
+statement ok
 drop source t;
 
 system ok

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -93,7 +93,7 @@ impl ProtobufParserConfig {
         }
         let pool = if protobuf_config.use_schema_registry {
             let client = Client::new(url, &protobuf_config.client_config)?;
-            let loader = SchemaLoader {
+            let loader = SchemaLoader::Confluent {
                 client,
                 name_strategy: protobuf_config.name_strategy,
                 topic: protobuf_config.topic,

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -26,7 +26,7 @@ use crate::parser::unified::AccessImpl;
 use crate::parser::utils::bytes_from_url;
 use crate::parser::{AccessBuilder, EncodingProperties};
 use crate::schema::schema_registry::{extract_schema_id, handle_sr_list, Client, WireFormatError};
-use crate::schema::SchemaLoader;
+use crate::schema::{ConfluentSchemaLoader, SchemaLoader};
 
 #[derive(Debug)]
 pub struct ProtobufAccessBuilder {
@@ -93,13 +93,13 @@ impl ProtobufParserConfig {
         }
         let pool = if protobuf_config.use_schema_registry {
             let client = Client::new(url, &protobuf_config.client_config)?;
-            let loader = SchemaLoader::Confluent {
+            let loader = SchemaLoader::Confluent(ConfluentSchemaLoader {
                 client,
                 name_strategy: protobuf_config.name_strategy,
                 topic: protobuf_config.topic,
                 key_record_name: None,
                 val_record_name: Some(message_name.clone()),
-            };
+            });
             let (_schema_id, root_file_descriptor) = loader
                 .load_val_schema::<FileDescriptor>()
                 .await

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -20,70 +20,143 @@ use super::schema_registry::{
     get_subject_by_strategy, handle_sr_list, name_strategy_from_str, Client, Subject,
 };
 use super::{
-    invalid_option_error, InvalidOptionError, SchemaFetchError, KEY_MESSAGE_NAME_KEY,
-    MESSAGE_NAME_KEY, NAME_STRATEGY_KEY, SCHEMA_REGISTRY_KEY,
+    invalid_option_error, InvalidOptionError, SchemaFetchError, AWS_GLUE_SCHEMA_ARN_KEY,
+    KEY_MESSAGE_NAME_KEY, MESSAGE_NAME_KEY, NAME_STRATEGY_KEY, SCHEMA_REGISTRY_KEY,
 };
+use crate::connector_common::AwsAuthProps;
 
-pub struct SchemaLoader {
-    pub client: Client,
-    pub name_strategy: PbSchemaRegistryNameStrategy,
-    pub topic: String,
-    pub key_record_name: Option<String>,
-    pub val_record_name: Option<String>,
+pub enum SchemaLoader {
+    Confluent {
+        client: Client,
+        name_strategy: PbSchemaRegistryNameStrategy,
+        topic: String,
+        key_record_name: Option<String>,
+        val_record_name: Option<String>,
+    },
+    Glue {
+        client: aws_sdk_glue::Client,
+        schema_arn: String,
+        mock: Option<() /* MockGlueSchemaCache */>,
+    },
+}
+
+pub enum SchemaVersion {
+    Confluent(i32),
+    Glue(uuid::Uuid),
 }
 
 impl SchemaLoader {
-    pub fn from_format_options(
+    pub async fn from_format_options(
         topic: &str,
         format_options: &BTreeMap<String, String>,
-    ) -> Result<Self, SchemaFetchError> {
-        let schema_location = format_options
-            .get(SCHEMA_REGISTRY_KEY)
-            .ok_or_else(|| invalid_option_error!("{SCHEMA_REGISTRY_KEY} required"))?;
-        let client_config = format_options.into();
-        let urls = handle_sr_list(schema_location)?;
-        let client = Client::new(urls, &client_config)?;
-
-        let name_strategy = format_options
-            .get(NAME_STRATEGY_KEY)
-            .map(|s| {
-                name_strategy_from_str(s)
-                    .ok_or_else(|| invalid_option_error!("unrecognized strategy {s}"))
+    ) -> Result<Self, InvalidOptionError> {
+        if let Some(schema_arn) = format_options.get(AWS_GLUE_SCHEMA_ARN_KEY) {
+            let aws_auth_props = serde_json::from_value::<AwsAuthProps>(
+                serde_json::to_value(format_options).unwrap(),
+            )
+            .map_err(|_e| invalid_option_error!(""))?;
+            let mock_config = format_options.get("aws.glue.mock_config").cloned();
+            let client = aws_sdk_glue::Client::new(&aws_auth_props.build_config().await.unwrap());
+            Ok(Self::Glue {
+                client,
+                schema_arn: schema_arn.clone(),
+                mock: Some(()),
             })
-            .transpose()?
-            .unwrap_or_default();
-        let key_record_name = format_options.get(KEY_MESSAGE_NAME_KEY).cloned();
-        let val_record_name = format_options.get(MESSAGE_NAME_KEY).cloned();
+        } else {
+            let schema_location = format_options
+                .get(SCHEMA_REGISTRY_KEY)
+                .ok_or_else(|| invalid_option_error!("{SCHEMA_REGISTRY_KEY} required"))?;
+            let client_config = format_options.into();
+            let urls = handle_sr_list(schema_location)?;
+            let client = Client::new(urls, &client_config)?;
 
-        Ok(Self {
-            client,
-            name_strategy,
-            topic: topic.into(),
-            key_record_name,
-            val_record_name,
-        })
+            let name_strategy = format_options
+                .get(NAME_STRATEGY_KEY)
+                .map(|s| {
+                    name_strategy_from_str(s)
+                        .ok_or_else(|| invalid_option_error!("unrecognized strategy {s}"))
+                })
+                .transpose()?
+                .unwrap_or_default();
+            let key_record_name = format_options.get(KEY_MESSAGE_NAME_KEY).cloned();
+            let val_record_name = format_options.get(MESSAGE_NAME_KEY).cloned();
+
+            Ok(Self::Confluent {
+                client,
+                name_strategy,
+                topic: topic.into(),
+                key_record_name,
+                val_record_name,
+            })
+        }
     }
 
     async fn load_schema<Out: LoadedSchema, const IS_KEY: bool>(
         &self,
-        record: Option<&str>,
-    ) -> Result<(i32, Out), SchemaFetchError> {
-        let subject = get_subject_by_strategy(&self.name_strategy, &self.topic, record, IS_KEY)?;
-        let (primary_subject, dependency_subjects) =
-            self.client.get_subject_and_references(&subject).await?;
-        let schema_id = primary_subject.schema.id;
-        let out = Out::compile(primary_subject, dependency_subjects)?;
-        Ok((schema_id, out))
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        match self {
+            Self::Confluent {
+                client,
+                name_strategy,
+                topic,
+                key_record_name,
+                val_record_name,
+            } => {
+                let record = match IS_KEY {
+                    true => key_record_name,
+                    false => val_record_name,
+                }
+                .as_deref();
+                let subject = get_subject_by_strategy(name_strategy, topic, record, IS_KEY)?;
+                let (primary_subject, dependency_subjects) =
+                    client.get_subject_and_references(&subject).await?;
+                let schema_id = primary_subject.schema.id;
+                let out = Out::compile(primary_subject, dependency_subjects)?;
+                Ok((SchemaVersion::Confluent(schema_id), out))
+            }
+            Self::Glue {
+                client,
+                schema_arn,
+                mock,
+            } => {
+                use aws_sdk_glue::types::{SchemaId, SchemaVersionNumber};
+
+                use super::schema_registry::ConfluentSchema;
+                let res = client
+                    .get_schema_version()
+                    .schema_id(SchemaId::builder().schema_arn(schema_arn).build())
+                    .schema_version_number(
+                        SchemaVersionNumber::builder().latest_version(true).build(),
+                    )
+                    .send()
+                    .await
+                    .unwrap();
+                let schema_version_id = res.schema_version_id().unwrap().parse().unwrap();
+                let definition = res.schema_definition().unwrap();
+                let primary = Subject {
+                    version: 0,
+                    name: "".to_owned(),
+                    schema: ConfluentSchema {
+                        id: 0,
+                        content: definition.to_owned(),
+                    },
+                };
+                let out = Out::compile(primary, vec![])?;
+                Ok((SchemaVersion::Glue(schema_version_id), out))
+            }
+        }
     }
 
-    pub async fn load_key_schema<Out: LoadedSchema>(&self) -> Result<(i32, Out), SchemaFetchError> {
-        self.load_schema::<Out, true>(self.key_record_name.as_deref())
-            .await
+    pub async fn load_key_schema<Out: LoadedSchema>(
+        &self,
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        self.load_schema::<Out, true>().await
     }
 
-    pub async fn load_val_schema<Out: LoadedSchema>(&self) -> Result<(i32, Out), SchemaFetchError> {
-        self.load_schema::<Out, false>(self.val_record_name.as_deref())
-            .await
+    pub async fn load_val_schema<Out: LoadedSchema>(
+        &self,
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        self.load_schema::<Out, false>().await
     }
 }
 

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -26,17 +26,26 @@ use super::{
 use crate::connector_common::AwsAuthProps;
 
 pub enum SchemaLoader {
-    Confluent {
-        client: Client,
-        name_strategy: PbSchemaRegistryNameStrategy,
-        topic: String,
-        key_record_name: Option<String>,
-        val_record_name: Option<String>,
-    },
-    Glue {
+    Confluent(ConfluentSchemaLoader),
+    Glue(GlueSchemaLoader),
+}
+
+pub struct ConfluentSchemaLoader {
+    pub client: Client,
+    pub name_strategy: PbSchemaRegistryNameStrategy,
+    pub topic: String,
+    pub key_record_name: Option<String>,
+    pub val_record_name: Option<String>,
+}
+
+pub enum GlueSchemaLoader {
+    Real {
         client: aws_sdk_glue::Client,
         schema_arn: String,
-        mock: Option<() /* MockGlueSchemaCache */>,
+    },
+    Mock {
+        schema_version_id: uuid::Uuid,
+        definition: String,
     },
 }
 
@@ -45,83 +54,87 @@ pub enum SchemaVersion {
     Glue(uuid::Uuid),
 }
 
-impl SchemaLoader {
+impl ConfluentSchemaLoader {
     pub async fn from_format_options(
         topic: &str,
         format_options: &BTreeMap<String, String>,
     ) -> Result<Self, InvalidOptionError> {
-        if let Some(schema_arn) = format_options.get(AWS_GLUE_SCHEMA_ARN_KEY) {
-            let aws_auth_props = serde_json::from_value::<AwsAuthProps>(
-                serde_json::to_value(format_options).unwrap(),
-            )
-            .map_err(|_e| invalid_option_error!(""))?;
-            let mock_config = format_options.get("aws.glue.mock_config").cloned();
-            let client = aws_sdk_glue::Client::new(&aws_auth_props.build_config().await.unwrap());
-            Ok(Self::Glue {
-                client,
-                schema_arn: schema_arn.clone(),
-                mock: Some(()),
-            })
-        } else {
-            let schema_location = format_options
-                .get(SCHEMA_REGISTRY_KEY)
-                .ok_or_else(|| invalid_option_error!("{SCHEMA_REGISTRY_KEY} required"))?;
-            let client_config = format_options.into();
-            let urls = handle_sr_list(schema_location)?;
-            let client = Client::new(urls, &client_config)?;
+        let schema_location = format_options
+            .get(SCHEMA_REGISTRY_KEY)
+            .ok_or_else(|| invalid_option_error!("{SCHEMA_REGISTRY_KEY} required"))?;
+        let client_config = format_options.into();
+        let urls = handle_sr_list(schema_location)?;
+        let client = Client::new(urls, &client_config)?;
 
-            let name_strategy = format_options
-                .get(NAME_STRATEGY_KEY)
-                .map(|s| {
-                    name_strategy_from_str(s)
-                        .ok_or_else(|| invalid_option_error!("unrecognized strategy {s}"))
-                })
-                .transpose()?
-                .unwrap_or_default();
-            let key_record_name = format_options.get(KEY_MESSAGE_NAME_KEY).cloned();
-            let val_record_name = format_options.get(MESSAGE_NAME_KEY).cloned();
-
-            Ok(Self::Confluent {
-                client,
-                name_strategy,
-                topic: topic.into(),
-                key_record_name,
-                val_record_name,
+        let name_strategy = format_options
+            .get(NAME_STRATEGY_KEY)
+            .map(|s| {
+                name_strategy_from_str(s)
+                    .ok_or_else(|| invalid_option_error!("unrecognized strategy {s}"))
             })
-        }
+            .transpose()?
+            .unwrap_or_default();
+        let key_record_name = format_options.get(KEY_MESSAGE_NAME_KEY).cloned();
+        let val_record_name = format_options.get(MESSAGE_NAME_KEY).cloned();
+
+        Ok(Self {
+            client,
+            name_strategy,
+            topic: topic.into(),
+            key_record_name,
+            val_record_name,
+        })
     }
 
     async fn load_schema<Out: LoadedSchema, const IS_KEY: bool>(
         &self,
     ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
-        match self {
-            Self::Confluent {
-                client,
-                name_strategy,
-                topic,
-                key_record_name,
-                val_record_name,
-            } => {
-                let record = match IS_KEY {
-                    true => key_record_name,
-                    false => val_record_name,
-                }
-                .as_deref();
-                let subject = get_subject_by_strategy(name_strategy, topic, record, IS_KEY)?;
-                let (primary_subject, dependency_subjects) =
-                    client.get_subject_and_references(&subject).await?;
-                let schema_id = primary_subject.schema.id;
-                let out = Out::compile(primary_subject, dependency_subjects)?;
-                Ok((SchemaVersion::Confluent(schema_id), out))
-            }
-            Self::Glue {
-                client,
-                schema_arn,
-                mock,
-            } => {
+        let record = match IS_KEY {
+            true => self.key_record_name.as_deref(),
+            false => self.val_record_name.as_deref(),
+        };
+        let subject = get_subject_by_strategy(&self.name_strategy, &self.topic, record, IS_KEY)?;
+        let (primary_subject, dependency_subjects) =
+            self.client.get_subject_and_references(&subject).await?;
+        let schema_id = primary_subject.schema.id;
+        let out = Out::compile(primary_subject, dependency_subjects)?;
+        Ok((SchemaVersion::Confluent(schema_id), out))
+    }
+}
+
+impl GlueSchemaLoader {
+    pub async fn from_format_options(
+        schema_arn: &str,
+        format_options: &BTreeMap<String, String>,
+    ) -> Result<Self, InvalidOptionError> {
+        let aws_auth_props =
+            serde_json::from_value::<AwsAuthProps>(serde_json::to_value(format_options).unwrap())
+                .map_err(|_e| invalid_option_error!(""))?;
+        let mock_config = format_options.get("aws.glue.mock_config").cloned();
+        let client = aws_sdk_glue::Client::new(&aws_auth_props.build_config().await.unwrap());
+        Ok(Self::Real {
+            client,
+            schema_arn: schema_arn.to_owned(),
+        })
+    }
+
+    async fn load_schema<Out: LoadedSchema, const IS_KEY: bool>(
+        &self,
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        if IS_KEY {
+            return Err(invalid_option_error!(
+                "GlueSchemaRegistry cannot be key. Specify `KEY ENCODE [TEXT | BYTES]` please."
+            )
+            .into());
+        }
+        let (schema_version_id, definition) = match self {
+            Self::Mock {
+                schema_version_id,
+                definition,
+            } => (*schema_version_id, definition.clone()),
+            Self::Real { client, schema_arn } => {
                 use aws_sdk_glue::types::{SchemaId, SchemaVersionNumber};
 
-                use super::schema_registry::ConfluentSchema;
                 let res = client
                     .get_schema_version()
                     .schema_id(SchemaId::builder().schema_arn(schema_arn).build())
@@ -132,18 +145,46 @@ impl SchemaLoader {
                     .await
                     .unwrap();
                 let schema_version_id = res.schema_version_id().unwrap().parse().unwrap();
-                let definition = res.schema_definition().unwrap();
-                let primary = Subject {
-                    version: 0,
-                    name: "".to_owned(),
-                    schema: ConfluentSchema {
-                        id: 0,
-                        content: definition.to_owned(),
-                    },
-                };
-                let out = Out::compile(primary, vec![])?;
-                Ok((SchemaVersion::Glue(schema_version_id), out))
+                let definition = res.schema_definition().unwrap().to_owned();
+                (schema_version_id, definition)
             }
+        };
+
+        let primary = Subject {
+            version: 0,
+            name: "".to_owned(),
+            schema: super::schema_registry::ConfluentSchema {
+                id: 0,
+                content: definition,
+            },
+        };
+        let out = Out::compile(primary, vec![])?;
+        Ok((SchemaVersion::Glue(schema_version_id), out))
+    }
+}
+
+impl SchemaLoader {
+    pub async fn from_format_options(
+        topic: &str,
+        format_options: &BTreeMap<String, String>,
+    ) -> Result<Self, InvalidOptionError> {
+        if let Some(schema_arn) = format_options.get(AWS_GLUE_SCHEMA_ARN_KEY) {
+            Ok(Self::Glue(
+                GlueSchemaLoader::from_format_options(schema_arn, format_options).await?,
+            ))
+        } else {
+            Ok(Self::Confluent(
+                ConfluentSchemaLoader::from_format_options(topic, format_options).await?,
+            ))
+        }
+    }
+
+    async fn load_schema<Out: LoadedSchema, const IS_KEY: bool>(
+        &self,
+    ) -> Result<(SchemaVersion, Out), SchemaFetchError> {
+        match self {
+            Self::Confluent(inner) => inner.load_schema::<Out, IS_KEY>().await,
+            Self::Glue(inner) => inner.load_schema::<Out, IS_KEY>().await,
         }
     }
 

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -108,6 +108,7 @@ impl GlueSchemaLoader {
         schema_arn: &str,
         format_options: &BTreeMap<String, String>,
     ) -> Result<Self, SchemaFetchError> {
+        risingwave_common::license::Feature::GlueSchemaRegistry.check_available()?;
         if let Some(mock_config) = format_options.get("aws.glue.mock_config") {
             // Internal format for easy testing. See `MockGlueSchemaCache` for details.
             let parsed: serde_json::Value =

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -107,10 +107,35 @@ impl GlueSchemaLoader {
         schema_arn: &str,
         format_options: &BTreeMap<String, String>,
     ) -> Result<Self, InvalidOptionError> {
+        if let Some(mock_config) = format_options.get("aws.glue.mock_config") {
+            // Internal format for easy testing. See `MockGlueSchemaCache` for details.
+            let parsed: serde_json::Value =
+                serde_json::from_str(mock_config).expect("mock config shall be valid json");
+            let schema_version_id_str = parsed
+                .get("arn_to_latest_id")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get(schema_arn)
+                .unwrap()
+                .as_str()
+                .unwrap();
+            let definition = parsed
+                .get("by_id")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get(schema_version_id_str)
+                .unwrap()
+                .to_string();
+            return Ok(Self::Mock {
+                schema_version_id: schema_version_id_str.parse().unwrap(),
+                definition,
+            });
+        };
         let aws_auth_props =
             serde_json::from_value::<AwsAuthProps>(serde_json::to_value(format_options).unwrap())
                 .map_err(|_e| invalid_option_error!(""))?;
-        let mock_config = format_options.get("aws.glue.mock_config").cloned();
         let client = aws_sdk_glue::Client::new(&aws_auth_props.build_config().await.unwrap());
         Ok(Self::Real {
             client,
@@ -150,6 +175,8 @@ impl GlueSchemaLoader {
             }
         };
 
+        // https://github.com/awslabs/aws-glue-schema-registry/issues/32
+        // No references in AWS Glue Schema Registry yet
         let primary = Subject {
             version: 0,
             name: "".to_owned(),

--- a/src/connector/src/schema/loader.rs
+++ b/src/connector/src/schema/loader.rs
@@ -20,8 +20,9 @@ use super::schema_registry::{
     get_subject_by_strategy, handle_sr_list, name_strategy_from_str, Client, Subject,
 };
 use super::{
-    invalid_option_error, InvalidOptionError, SchemaFetchError, AWS_GLUE_SCHEMA_ARN_KEY,
-    KEY_MESSAGE_NAME_KEY, MESSAGE_NAME_KEY, NAME_STRATEGY_KEY, SCHEMA_REGISTRY_KEY,
+    invalid_option_error, malformed_response_error, InvalidOptionError, MalformedResponseError,
+    SchemaFetchError, AWS_GLUE_SCHEMA_ARN_KEY, KEY_MESSAGE_NAME_KEY, MESSAGE_NAME_KEY,
+    NAME_STRATEGY_KEY, SCHEMA_REGISTRY_KEY,
 };
 use crate::connector_common::AwsAuthProps;
 
@@ -58,7 +59,7 @@ impl ConfluentSchemaLoader {
     pub async fn from_format_options(
         topic: &str,
         format_options: &BTreeMap<String, String>,
-    ) -> Result<Self, InvalidOptionError> {
+    ) -> Result<Self, SchemaFetchError> {
         let schema_location = format_options
             .get(SCHEMA_REGISTRY_KEY)
             .ok_or_else(|| invalid_option_error!("{SCHEMA_REGISTRY_KEY} required"))?;
@@ -106,7 +107,7 @@ impl GlueSchemaLoader {
     pub async fn from_format_options(
         schema_arn: &str,
         format_options: &BTreeMap<String, String>,
-    ) -> Result<Self, InvalidOptionError> {
+    ) -> Result<Self, SchemaFetchError> {
         if let Some(mock_config) = format_options.get("aws.glue.mock_config") {
             // Internal format for easy testing. See `MockGlueSchemaCache` for details.
             let parsed: serde_json::Value =
@@ -129,14 +130,19 @@ impl GlueSchemaLoader {
                 .unwrap()
                 .to_string();
             return Ok(Self::Mock {
-                schema_version_id: schema_version_id_str.parse().unwrap(),
+                schema_version_id: schema_version_id_str.parse()?,
                 definition,
             });
         };
         let aws_auth_props =
             serde_json::from_value::<AwsAuthProps>(serde_json::to_value(format_options).unwrap())
                 .map_err(|_e| invalid_option_error!(""))?;
-        let client = aws_sdk_glue::Client::new(&aws_auth_props.build_config().await.unwrap());
+        let client = aws_sdk_glue::Client::new(
+            &aws_auth_props
+                .build_config()
+                .await
+                .map_err(SchemaFetchError::YetToMigrate)?,
+        );
         Ok(Self::Real {
             client,
             schema_arn: schema_arn.to_owned(),
@@ -168,9 +174,15 @@ impl GlueSchemaLoader {
                     )
                     .send()
                     .await
-                    .unwrap();
-                let schema_version_id = res.schema_version_id().unwrap().parse().unwrap();
-                let definition = res.schema_definition().unwrap().to_owned();
+                    .map_err(|e| e.into_service_error())?;
+                let schema_version_id = res
+                    .schema_version_id()
+                    .ok_or_else(|| malformed_response_error!("missing schema_version_id"))?
+                    .parse()?;
+                let definition = res
+                    .schema_definition()
+                    .ok_or_else(|| malformed_response_error!("missing schema_definition"))?
+                    .to_owned();
                 (schema_version_id, definition)
             }
         };
@@ -194,7 +206,7 @@ impl SchemaLoader {
     pub async fn from_format_options(
         topic: &str,
         format_options: &BTreeMap<String, String>,
-    ) -> Result<Self, InvalidOptionError> {
+    ) -> Result<Self, SchemaFetchError> {
         if let Some(schema_arn) = format_options.get(AWS_GLUE_SCHEMA_ARN_KEY) {
             Ok(Self::Glue(
                 GlueSchemaLoader::from_format_options(schema_arn, format_options).await?,

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -51,7 +51,7 @@ pub enum SchemaFetchError {
     #[error(transparent)]
     Request(#[from] schema_registry::ConcurrentRequestError),
     #[error(transparent)]
-    AwsGlue(#[from] aws_sdk_glue::operation::get_schema_version::GetSchemaVersionError),
+    AwsGlue(#[from] Box<aws_sdk_glue::operation::get_schema_version::GetSchemaVersionError>),
     #[error(transparent)]
     MalformedResponse(#[from] MalformedResponseError),
     #[error("schema version id invalid: {0}")]

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -47,6 +47,8 @@ pub enum SchemaFetchError {
     #[error(transparent)]
     InvalidOption(#[from] InvalidOptionError),
     #[error(transparent)]
+    License(#[from] risingwave_common::license::FeatureNotAvailable),
+    #[error(transparent)]
     Request(#[from] schema_registry::ConcurrentRequestError),
     #[error(transparent)]
     AwsGlue(#[from] aws_sdk_glue::operation::get_schema_version::GetSchemaVersionError),

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -36,12 +36,24 @@ pub struct InvalidOptionError {
     // source: Option<risingwave_common::error::BoxedError>,
 }
 
+#[derive(Debug, thiserror::Error, thiserror_ext::Macro)]
+#[error("Malformed response: {message}")]
+pub struct MalformedResponseError {
+    pub message: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum SchemaFetchError {
     #[error(transparent)]
     InvalidOption(#[from] InvalidOptionError),
     #[error(transparent)]
     Request(#[from] schema_registry::ConcurrentRequestError),
+    #[error(transparent)]
+    AwsGlue(#[from] aws_sdk_glue::operation::get_schema_version::GetSchemaVersionError),
+    #[error(transparent)]
+    MalformedResponse(#[from] MalformedResponseError),
+    #[error("schema version id invalid: {0}")]
+    InvalidUuid(#[from] uuid::Error),
     #[error("schema compilation error: {0}")]
     SchemaCompile(
         #[source]

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -19,7 +19,7 @@ mod loader;
 pub mod protobuf;
 pub mod schema_registry;
 
-pub use loader::SchemaLoader;
+pub use loader::{SchemaLoader, SchemaVersion};
 
 const MESSAGE_NAME_KEY: &str = "message";
 const KEY_MESSAGE_NAME_KEY: &str = "key.message";

--- a/src/connector/src/schema/mod.rs
+++ b/src/connector/src/schema/mod.rs
@@ -19,7 +19,7 @@ mod loader;
 pub mod protobuf;
 pub mod schema_registry;
 
-pub use loader::{SchemaLoader, SchemaVersion};
+pub use loader::{ConfluentSchemaLoader, SchemaLoader, SchemaVersion};
 
 const MESSAGE_NAME_KEY: &str = "message";
 const KEY_MESSAGE_NAME_KEY: &str = "key.message";

--- a/src/connector/src/schema/protobuf.rs
+++ b/src/connector/src/schema/protobuf.rs
@@ -87,9 +87,17 @@ pub async fn fetch_from_registry(
     format_options: &BTreeMap<String, String>,
     topic: &str,
 ) -> Result<(MessageDescriptor, i32), SchemaFetchError> {
-    let loader = SchemaLoader::from_format_options(topic, format_options)?;
+    let loader = SchemaLoader::from_format_options(topic, format_options).await?;
 
     let (vid, vpb) = loader.load_val_schema::<FileDescriptor>().await?;
+    let vid = match vid {
+        super::SchemaVersion::Confluent(vid) => vid,
+        super::SchemaVersion::Glue(_) => {
+            return Err(
+                invalid_option_error!("Protobuf with Glue Schema Registry unsupported").into(),
+            )
+        }
+    };
 
     Ok((
         vpb.parent_pool().get_message_by_name(message_name).unwrap(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Supports loading schema from and encoding metadata for AWS Glue Schema Registry, in addition to Confluent Schema Registry, when using `encode avro`.

Notes:
* Glue Schema Registry has no references (eg `import` in protobuf).
* Glue Schema Registry has no name strategy. So it would require an additional `aws.glue.key_schema_arn`. This is left unimplemented in favor of real use case `KEY ENCODE [TEXT | BYTES]`.

Related: #17605 for source

Refactor to come next: {Confluent, Glue} x {Source, Sink} x {Avro, Protobuf}

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

Added support for AWS Glue Schema Registry when using `encode avro` for sinks:

```
encode avro (
  aws.glue.schema_arn = 'arn:aws:glue:ap-southeast-1:123456123456:schema/default-registry/MyEvent',
  // other aws auth options same as s3 / kinesis
  aws.region = '...',
  aws.credentials.access_key_id = '...',
  ...
) [KEY ENCODE [TEXT | BYTES]] -- when specifying `primary_key` as kafka key
```

When using IAM permission policies, the following `action`s shall be allowed:
* `glue:GetSchemaVersion`

