### PR TITLE
refactor(meta): use in memory struct for table fragments

### DIFF
--- a/src/meta/service/src/scale_service.rs
+++ b/src/meta/service/src/scale_service.rs
@@ -69,7 +69,7 @@ impl ScaleService for ScaleServiceImpl {
             .table_fragments()
             .await?
             .values()
-            .cloned()
+            .map(|tf| tf.to_protobuf())
             .collect();
 
         let worker_nodes = self

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -208,15 +208,15 @@ impl StreamManagerService for StreamServiceImpl {
 
         let mut info = HashMap::new();
         for job_id in table_ids {
-            let pb_table_fragments = self
+            let table_fragments = self
                 .metadata_manager
                 .catalog_controller
                 .get_job_fragments_by_id(job_id as _)
                 .await?;
             info.insert(
-                pb_table_fragments.table_id,
+                table_fragments.stream_job_id().table_id,
                 TableFragmentInfo {
-                    fragments: pb_table_fragments
+                    fragments: table_fragments
                         .fragments
                         .into_iter()
                         .map(|(id, fragment)| FragmentInfo {
@@ -232,7 +232,7 @@ impl StreamManagerService for StreamServiceImpl {
                                 .collect_vec(),
                         })
                         .collect_vec(),
-                    ctx: pb_table_fragments.ctx,
+                    ctx: Some(table_fragments.ctx.to_protobuf()),
                 },
             );
         }

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -79,11 +79,10 @@ impl GlobalBarrierWorkerContextImpl {
 
         try_join_all(mviews.into_iter().map(|mview| async move {
             let table_id = TableId::new(mview.table_id as _);
-            let table_fragments = mgr
+            let stream_job_fragments = mgr
                 .catalog_controller
                 .get_job_fragments_by_id(mview.table_id)
                 .await?;
-            let stream_job_fragments = StreamJobFragments::from_protobuf(table_fragments);
             assert_eq!(stream_job_fragments.stream_job_id(), table_id);
             Ok((mview.definition, stream_job_fragments))
         }))

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -64,8 +64,8 @@ use crate::controller::utils::{
     FragmentDesc, PartialActorLocation, PartialFragmentStateTables,
 };
 use crate::manager::LocalNotification;
-use crate::model::TableParallelism;
-use crate::stream::SplitAssignment;
+use crate::model::{StreamContext, StreamJobFragments, TableParallelism};
+use crate::stream::{build_actor_split_impls, SplitAssignment};
 use crate::{MetaError, MetaResult};
 
 #[derive(Clone, Debug)]
@@ -344,10 +344,10 @@ impl CatalogController {
         )>,
         parallelism: StreamingParallelism,
         max_parallelism: usize,
-    ) -> MetaResult<PbTableFragments> {
-        let mut pb_fragments = HashMap::new();
+    ) -> MetaResult<StreamJobFragments> {
+        let mut pb_fragments = BTreeMap::new();
         let mut pb_actor_splits = HashMap::new();
-        let mut pb_actor_status = HashMap::new();
+        let mut pb_actor_status = BTreeMap::new();
 
         for (fragment, actors, actor_dispatcher) in fragments {
             let (fragment, fragment_actor_status, fragment_actor_splits) =
@@ -355,28 +355,26 @@ impl CatalogController {
 
             pb_fragments.insert(fragment.fragment_id, fragment);
 
-            pb_actor_splits.extend(fragment_actor_splits.into_iter());
+            pb_actor_splits.extend(build_actor_split_impls(&fragment_actor_splits));
             pb_actor_status.extend(fragment_actor_status.into_iter());
         }
 
-        let table_fragments = PbTableFragments {
-            table_id,
+        let table_fragments = StreamJobFragments {
+            stream_job_id: table_id.into(),
             state: state as _,
             fragments: pb_fragments,
             actor_status: pb_actor_status,
             actor_splits: pb_actor_splits,
-            ctx: Some(ctx.unwrap_or_default()),
-            parallelism: Some(
-                match parallelism {
-                    StreamingParallelism::Custom => TableParallelism::Custom,
-                    StreamingParallelism::Adaptive => TableParallelism::Adaptive,
-                    StreamingParallelism::Fixed(n) => TableParallelism::Fixed(n as _),
-                }
-                .into(),
-            ),
-            node_label: "".to_owned(),
-            backfill_done: true,
-            max_parallelism: Some(max_parallelism as _),
+            ctx: ctx
+                .as_ref()
+                .map(StreamContext::from_protobuf)
+                .unwrap_or_default(),
+            assigned_parallelism: match parallelism {
+                StreamingParallelism::Custom => TableParallelism::Custom,
+                StreamingParallelism::Adaptive => TableParallelism::Adaptive,
+                StreamingParallelism::Fixed(n) => TableParallelism::Fixed(n as _),
+            },
+            max_parallelism,
         };
 
         Ok(table_fragments)
@@ -680,7 +678,10 @@ impl CatalogController {
         Ok(select.into_tuple().all(&inner.db).await?)
     }
 
-    pub async fn get_job_fragments_by_id(&self, job_id: ObjectId) -> MetaResult<PbTableFragments> {
+    pub async fn get_job_fragments_by_id(
+        &self,
+        job_id: ObjectId,
+    ) -> MetaResult<StreamJobFragments> {
         let inner = self.inner.read().await;
         let fragment_actors = Fragment::find()
             .find_with_related(Actor)
@@ -832,7 +833,7 @@ impl CatalogController {
     }
 
     // TODO: This function is too heavy, we should avoid using it and implement others on demand.
-    pub async fn table_fragments(&self) -> MetaResult<BTreeMap<ObjectId, PbTableFragments>> {
+    pub async fn table_fragments(&self) -> MetaResult<BTreeMap<ObjectId, StreamJobFragments>> {
         let inner = self.inner.read().await;
         let jobs = StreamingJob::find().all(&inner.db).await?;
         let mut table_fragments = BTreeMap::new();

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -543,11 +543,9 @@ impl MetadataManager {
         &self,
         job_id: &TableId,
     ) -> MetaResult<StreamJobFragments> {
-        let pb_table_fragments = self
-            .catalog_controller
+        self.catalog_controller
             .get_job_fragments_by_id(job_id.table_id as _)
-            .await?;
-        Ok(StreamJobFragments::from_protobuf(pb_table_fragments))
+            .await
     }
 
     pub async fn get_running_actors_of_fragment(
@@ -581,11 +579,11 @@ impl MetadataManager {
     ) -> MetaResult<Vec<StreamJobFragments>> {
         let mut table_fragments = vec![];
         for id in ids {
-            let pb_table_fragments = self
-                .catalog_controller
-                .get_job_fragments_by_id(id.table_id as _)
-                .await?;
-            table_fragments.push(StreamJobFragments::from_protobuf(pb_table_fragments));
+            table_fragments.push(
+                self.catalog_controller
+                    .get_job_fragments_by_id(id.table_id as _)
+                    .await?,
+            );
         }
         Ok(table_fragments)
     }
@@ -593,8 +591,7 @@ impl MetadataManager {
     pub async fn all_active_actors(&self) -> MetaResult<HashMap<ActorId, StreamActor>> {
         let table_fragments = self.catalog_controller.table_fragments().await?;
         let mut actor_maps = HashMap::new();
-        for (_, fragments) in table_fragments {
-            let tf = StreamJobFragments::from_protobuf(fragments);
+        for (_, tf) in table_fragments {
             for actor in tf.active_actors() {
                 actor_maps
                     .try_insert(actor.actor_id, actor)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Currently, when loading table fragments from meta store, we will first compose the `PbTableFragments`, and then convert it into `StreamJobFragments`. This is for code sharing for both etcd backend and sql backend. However, after etcd backend is deprecated, the code sharing is not required anymore. Therefore, in this PR, we change to directly compose the `StreamJobFragments` when we load from the meta store. The method `StreamJobFragments::from_protobuf` is removed, because it's not used anywhere.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
