### PR TITLE
feat(frontend): allow specifying (partial) schema when creating table with derived schema

### DIFF
--- a/e2e_test/source_inline/connection/ddl.slt
+++ b/e2e_test/source_inline/connection/ddl.slt
@@ -81,7 +81,7 @@ create sink sink_kafka from data_table with (
 
 sleep 3s
 
-query IT rowsort
+query IT rowsort retry 3 backoff 5s
 select a, b from t1;
 ----
 1 a

--- a/e2e_test/source_inline/kafka/avro/alter_table.slt
+++ b/e2e_test/source_inline/kafka/avro/alter_table.slt
@@ -128,18 +128,6 @@ Caused by these errors (recent errors listed first):
   4: Item not found: Invalid column: bar
 
 
-# Can't drop non-generated column
-# TODO(purify): may support it.
-statement error
-ALTER TABLE t DROP COLUMN foo;
-----
-db error: ERROR: Failed to run the query
-
-Caused by:
-  Not supported: alter table with schema registry
-HINT: try `ALTER TABLE .. FORMAT .. ENCODE .. (...)` instead
-
-
 # Drop generated column
 statement ok
 ALTER TABLE t DROP COLUMN gen_col;

--- a/e2e_test/source_inline/kafka/avro/partial_schema.slt
+++ b/e2e_test/source_inline/kafka/avro/partial_schema.slt
@@ -35,7 +35,19 @@ FORMAT PLAIN ENCODE AVRO (
     schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
 );
 
-# Specify incorrect schema
+# Specify partial schema, with a generated column having the same name as a column in the source schema.
+# We should treat the generated column as a new column.
+statement ok
+create table t3 (bar int, foo varchar as 'generated')
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+
+# Specify incorrect schema: inexistent column
 statement error
 create table t (bar int, foo varchar, baz int)
 WITH (
@@ -52,6 +64,7 @@ Caused by:
   Protocol error: Column "baz" is defined in SQL but not found in the source
 
 
+# Specify incorrect schema: data type mismatch
 statement error
 create table t (bar double)
 WITH (
@@ -95,8 +108,9 @@ FORMAT PLAIN ENCODE AVRO (
 query TT rowsort
 SELECT name, SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name LIKE 't%';
 ----
-t1	    CREATE TABLE t1 (foo CHARACTER VARYING, bar INT)
-t2	    CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1)
+t1	CREATE TABLE t1 (foo CHARACTER VARYING, bar INT)
+t2	CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1)
+t3	CREATE TABLE t3 (bar INT, foo CHARACTER VARYING AS 'generated')
 tstar	CREATE TABLE tstar (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
 tstar2	CREATE TABLE tstar2 (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
 
@@ -131,6 +145,18 @@ Caused by:
 
 
 statement ok
+alter table t3 add column baz double;
+
+statement error
+alter table t3 add column foo varchar;
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Invalid input syntax: column "foo" of table "t3" already exists
+
+
+statement ok
 alter table tstar drop column foo;
 
 statement error
@@ -158,8 +184,9 @@ Caused by:
 query TT rowsort
 SELECT name, SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name LIKE 't%';
 ----
-t1	    CREATE TABLE t1 (bar INT)
-t2	    CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1, baz DOUBLE)
+t1	CREATE TABLE t1 (bar INT)
+t2	CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1, baz DOUBLE)
+t3	CREATE TABLE t3 (bar INT, foo CHARACTER VARYING AS 'generated', baz DOUBLE)
 tstar	CREATE TABLE tstar (bar INT, gen_col INT AS bar + 1, baz DOUBLE)
 tstar2	CREATE TABLE tstar2 (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
 
@@ -169,6 +196,25 @@ alter table t1 refresh schema;
 
 statement ok
 alter table t2 refresh schema;
+
+
+# Refreshing schema for t3 will fail, because the name of the generated column conflicts with the one in the external schema.
+# After dropping it, the schema can be refreshed.
+statement error
+alter table t3 refresh schema;
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Invalid input syntax: column "foo" specified more than once
+
+
+statement ok
+alter table t3 drop column foo;
+
+statement ok
+alter table t3 refresh schema;
+
 
 statement ok
 alter table tstar refresh schema;
@@ -180,8 +226,9 @@ alter table tstar2 refresh schema;
 query TT rowsort
 SELECT name, SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name LIKE 't%';
 ----
-t1	    CREATE TABLE t1 (bar INT, foo CHARACTER VARYING, baz DOUBLE)
-t2	    CREATE TABLE t2 (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
+t1	CREATE TABLE t1 (bar INT, foo CHARACTER VARYING, baz DOUBLE)
+t2	CREATE TABLE t2 (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
+t3	CREATE TABLE t3 (bar INT, foo CHARACTER VARYING, baz DOUBLE)
 tstar	CREATE TABLE tstar (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
 tstar2	CREATE TABLE tstar2 (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
 
@@ -191,6 +238,9 @@ DROP TABLE t1;
 
 statement ok
 DROP TABLE t2;
+
+statement ok
+DROP TABLE t3;
 
 statement ok
 DROP TABLE tstar;

--- a/e2e_test/source_inline/kafka/avro/partial_schema.slt
+++ b/e2e_test/source_inline/kafka/avro/partial_schema.slt
@@ -1,0 +1,199 @@
+control substitution on
+
+# cleanup
+system ok
+rpk topic delete 'avro_partial_schema_test' || true; \
+(rpk sr subject delete 'avro_partial_schema_test-value' && rpk sr subject delete 'avro_partial_schema_test-value' --permanent) || true;
+
+# create topic and sr subject
+system ok
+rpk topic create 'avro_partial_schema_test'
+
+# create a schema
+system ok
+sr_register avro_partial_schema_test-value AVRO <<< '{"type":"record","name":"Root","fields":[{"name":"bar","type":"int","default":0},{"name":"foo","type":"string"}]}'
+
+# Specify schema
+statement ok
+create table t1 (foo varchar, bar int)
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+
+# Specify partial schema
+statement ok
+create table t2 (bar int, gen_col int as bar + 1)
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+
+# Specify incorrect schema
+statement error
+create table t (bar int, foo varchar, baz int)
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Protocol error: Column "baz" is defined in SQL but not found in the source
+
+
+statement error
+create table t (bar double)
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Protocol error: Data type mismatch for column "bar". Defined in SQL as "double precision", but found in the source as "integer"
+
+
+# Resolve schema
+statement ok
+create table tstar (*, gen_col int as bar + 1)
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+
+# No wildcard will be interpreted as `*` for syntax backward compatibility
+statement ok
+create table tstar2 (gen_col int as bar + 1)
+WITH (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'avro_partial_schema_test'
+)
+FORMAT PLAIN ENCODE AVRO (
+    schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}'
+);
+
+
+# Demonstrate purified definition
+query TT rowsort
+SELECT name, SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name LIKE 't%';
+----
+t1	    CREATE TABLE t1 (foo CHARACTER VARYING, bar INT)
+t2	    CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1)
+tstar	CREATE TABLE tstar (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
+tstar2	CREATE TABLE tstar2 (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
+
+# create a new schema
+system ok
+sr_register avro_partial_schema_test-value AVRO <<< '{"type":"record","name":"Root","fields":[{"name":"bar","type":"int","default":0},{"name":"foo","type":"string"}, {"name":"baz", "type":"double", "default":0}]}'
+
+# Can perform `[ADD | DROP] COLUMN` no matter whether the schema is from resolved
+# However, the schema will be checked against the resolved schema
+statement ok
+alter table t1 drop column foo;
+
+statement error
+alter table t2 add column baz int;
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Protocol error: Data type mismatch for column "baz". Defined in SQL as "integer", but found in the source as "double precision"
+
+
+statement ok
+alter table t2 add column baz double;
+
+statement error
+alter table t2 add column bbaazz double;
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Protocol error: Column "bbaazz" is defined in SQL but not found in the source
+
+
+statement ok
+alter table tstar drop column foo;
+
+statement error
+alter table tstar add column baz int;
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Protocol error: Data type mismatch for column "baz". Defined in SQL as "integer", but found in the source as "double precision"
+
+
+statement ok
+alter table tstar add column baz double;
+
+statement error
+alter table tstar add column bbaazz double;
+----
+db error: ERROR: Failed to run the query
+
+Caused by:
+  Protocol error: Column "bbaazz" is defined in SQL but not found in the source
+
+
+# Demonstrate purified definition
+query TT rowsort
+SELECT name, SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name LIKE 't%';
+----
+t1	    CREATE TABLE t1 (bar INT)
+t2	    CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1, baz DOUBLE)
+tstar	CREATE TABLE tstar (bar INT, gen_col INT AS bar + 1, baz DOUBLE)
+tstar2	CREATE TABLE tstar2 (bar INT, foo CHARACTER VARYING, gen_col INT AS bar + 1)
+
+# Can refresh schema no matter whether the schema is from resolved
+statement ok
+alter table t1 refresh schema;
+
+statement ok
+alter table t2 refresh schema;
+
+statement ok
+alter table tstar refresh schema;
+
+statement ok
+alter table tstar2 refresh schema;
+
+# Demonstrate purified definition
+query TT rowsort
+SELECT name, SUBSTRING(definition, 1, POSITION(' WITH' IN definition) - 1) FROM rw_tables WHERE name LIKE 't%';
+----
+t1	    CREATE TABLE t1 (bar INT, foo CHARACTER VARYING, baz DOUBLE)
+t2	    CREATE TABLE t2 (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
+tstar	CREATE TABLE tstar (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
+tstar2	CREATE TABLE tstar2 (bar INT, foo CHARACTER VARYING, baz DOUBLE, gen_col INT AS bar + 1)
+
+# Cleanup
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
+
+statement ok
+DROP TABLE tstar;
+
+statement ok
+DROP TABLE tstar2;

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -391,7 +391,7 @@ pub async fn handle_alter_table_column(
         table_name,
         definition,
         &original_catalog,
-        SqlColumnStrategy::Follow,
+        SqlColumnStrategy::FollowUnchecked,
     )
     .await?;
 

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -558,7 +558,7 @@ pub(crate) async fn reparse_table_for_sink(
         None,
         include_column_options,
         engine,
-        SqlColumnStrategy::Follow,
+        SqlColumnStrategy::FollowUnchecked,
     )
     .await?;
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -850,8 +850,18 @@ pub async fn bind_create_source_or_table_with_connector(
         .into());
     }
 
+    // User may specify a generated or additional column with the same name as one from the external schema.
+    // Ensure duplicated column names are handled here.
+    if let Some(duplicated_name) = columns.iter().map(|c| c.name()).duplicates().next() {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "column \"{}\" specified more than once",
+            duplicated_name
+        ))
+        .into());
+    }
+
     // XXX: why do we use col_id_gen here? It doesn't seem to be very necessary.
-    // XXX: should we also chenge the col id for struct fields?
+    // XXX: should we also change the col id for struct fields?
     for c in &mut columns {
         c.column_desc.column_id = col_id_gen.generate(&*c)?;
     }

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -216,6 +216,7 @@ pub(crate) fn bind_all_columns(
             .cloned()
             .collect_vec();
 
+        #[allow(clippy::collapsible_else_if)]
         match sql_column_strategy {
             // Ignore `cols_from_source`, follow `cols_from_sql` without checking.
             SqlColumnStrategy::FollowUnchecked => {

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -698,25 +698,24 @@ pub fn bind_connector_props(
 /// how to handle the regular columns (i.e., non-generated) defined in SQL?
 pub enum SqlColumnStrategy {
     /// Follow all columns defined in SQL, ignore the columns from external system.
+    /// This ensures that no accidental side effect will change the schema.
     ///
-    /// This is the behavior when `SINK INTO` or `[ADD | DROP] COLUMN` atop the purified SQL,
-    /// ensuring that no accidental refresh will happen and the schema remains unchanged.
-    // TODO(purify): we may validate whether defined columns are valid against the resolved schema.
+    /// This is the behavior when re-planning the target table of `SINK INTO`.
     FollowUnchecked,
+
+    /// Follow all column defined in SQL, check the columns from external system with name & type.
+    /// This ensures that no accidental side effect will change the schema.
+    ///
+    /// This is the behavior when creating a new table or source with a resolvable schema;
+    /// adding, or dropping columns on that table.
+    // TODO(purify): `ALTER SOURCE` currently has its own code path and does not check.
+    FollowChecked,
 
     /// Merge the generated columns defined in SQL and columns from external system. If there
     /// are also regular columns defined in SQL, ignore silently.
     ///
     /// This is the behavior when `REFRESH SCHEMA` atop the purified SQL.
     Ignore,
-
-    /// Merge the generated columns defined in SQL and columns from external system. If there
-    /// are also regular columns defined in SQL, reject the request.
-    ///
-    /// This is the behavior when creating a new table or source with a resolvable schema.
-    // TODO(purify): we may accept this as there are some practical use cases, see
-    //               https://github.com/risingwavelabs/risingwave/issues/12199
-    FollowChecked,
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -268,6 +268,7 @@ pub(crate) fn bind_all_columns(
                                 ))));
                             }
                         }
+                        return Ok(cols_from_sql);
                     }
                 } else {
                     if wildcard_idx.is_some() {

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1097,7 +1097,7 @@ pub(super) async fn handle_create_table_plan(
                 col_id_gen,
                 include_column_options,
                 props,
-                SqlColumnStrategy::Reject,
+                SqlColumnStrategy::FollowChecked,
             )
             .await?,
             TableJobType::General,

--- a/src/frontend/src/rpc/mod.rs
+++ b/src/frontend/src/rpc/mod.rs
@@ -107,7 +107,7 @@ async fn get_new_table_plan(
         table_name,
         new_table_definition,
         &original_catalog,
-        SqlColumnStrategy::Follow, // not used
+        SqlColumnStrategy::FollowUnchecked, // not used
     )
     .await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This is a follow-up of #20131:

> we can now modify this behavior simply by passing a different `SqlColumnStrategy`, which will accomplish the objective in https://github.com/risingwavelabs/risingwave/issues/12199.

This PR removes the `Reject` strategy and adds a `FollowChecked` instead, which means that we will follow the columns specified in SQL with schema check against the external system.

As a result, users can now specify the (maybe partial) schema when creating a table with a derived schema (i.e., using a schema registry). Consequently, `REFRESH SCHEMA` and `[ADD | DROP] COLUMN` can be called on any table, regardless of whether its schema was initially derived or manually specified.

Also affect `CREATE SOURCE`. For `ALTER SOURCE`, as its code path now differs from `ALTER TABLE`, the behavior keeps unchanged. Will check it in future PRs.

Close #12199.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

When creating a table with schema registry (Avro, Protobuf, JSON with schema registry), users are now allowed to specify the columns they need to ingest in the column definition list, which will be checked against the external schema. Previously, we only allow wildcard `*` here to ingest all columns.

Manually manipulating the column set by calling `ALTER TABLE [ADD | DROP] COLUMN` on a table with schema registry is also supported now. Previously we only support `REFRESH SCHEMA` to update the full schema.

</details>
