### PR TITLE
refactor: ensure update vnode bitmap after yield barrier

### DIFF
--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -487,7 +487,10 @@ async fn test_row_seq_scan() -> StreamResult<()> {
     ]));
 
     epoch.inc_for_test();
-    state.commit(epoch).await.unwrap();
+    state
+        .commit_assert_no_update_vnode_bitmap(epoch)
+        .await
+        .unwrap();
 
     let executor = Box::new(RowSeqScanExecutor::new(
         table,

--- a/src/stream/benches/bench_state_table.rs
+++ b/src/stream/benches/bench_state_table.rs
@@ -118,7 +118,10 @@ async fn run_bench_state_table_inserts<const USE_WATERMARK_CACHE: bool>(
         state_table.insert(row);
     }
     epoch.inc_for_test();
-    state_table.commit(epoch).await.unwrap();
+    state_table
+        .commit_assert_no_update_vnode_bitmap(epoch)
+        .await
+        .unwrap();
 }
 
 fn bench_state_table_inserts(c: &mut Criterion) {
@@ -178,7 +181,10 @@ async fn run_bench_state_table_chunks<const USE_WATERMARK_CACHE: bool>(
         state_table.write_chunk(chunk);
     }
     epoch.inc_for_test();
-    state_table.commit(epoch).await.unwrap();
+    state_table
+        .commit_assert_no_update_vnode_bitmap(epoch)
+        .await
+        .unwrap();
 }
 
 fn bench_state_table_write_chunk(c: &mut Criterion) {

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -85,7 +85,7 @@ async fn test_state_table_update_insert() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     state_table.delete(OwnedRow::new(vec![
         Some(6_i32.into()),
@@ -144,7 +144,7 @@ async fn test_state_table_update_insert() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     let row6_commit = state_table
         .get_row(&OwnedRow::new(vec![Some(6_i32.into())]))
@@ -184,7 +184,7 @@ async fn test_state_table_update_insert() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     // one epoch: delete (1, 2, 3, 4), insert (5, 6, 7, None), delete(5, 6, 7, None)
     state_table.delete(OwnedRow::new(vec![
@@ -216,7 +216,7 @@ async fn test_state_table_update_insert() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     let row1_commit = state_table
         .get_row(&OwnedRow::new(vec![Some(1_i32.into())]))
@@ -287,7 +287,7 @@ async fn test_state_table_iter_with_prefix() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     state_table.insert(OwnedRow::new(vec![
         Some(1_i32.into()),
@@ -422,7 +422,7 @@ async fn test_state_table_iter_with_pk_range() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     state_table.insert(OwnedRow::new(vec![
         Some(1_i32.into()),
@@ -636,7 +636,7 @@ async fn test_state_table_iter_with_value_indices() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     // write [3, 33, 333], [4, 44, 444], [5, 55, 555], [7, 77, 777], [8, 88, 888]into mem_table,
     // [3, 33, 3333], [6, 66, 666], [9, 99, 999] exists in
@@ -830,7 +830,7 @@ async fn test_state_table_iter_with_shuffle_value_indices() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     // write [3, 33, 333], [4, 44, 444], [5, 55, 555], [7, 77, 777], [8, 88, 888]into mem_table,
     // [3, 33, 3333], [6, 66, 666], [9, 99, 999] exists in
@@ -1405,7 +1405,7 @@ async fn test_state_table_watermark_cache_ignore_null() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     let cache = state_table.get_watermark_cache();
     assert_eq!(cache.len(), 1);
@@ -1492,7 +1492,7 @@ async fn test_state_table_watermark_cache_write_chunk() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     let inserts_1 = vec![
         (
@@ -1604,7 +1604,7 @@ async fn test_state_table_watermark_cache_write_chunk() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     // After sync, we should scan all rows into watermark cache.
     let cache = state_table.get_watermark_cache();
@@ -1707,7 +1707,7 @@ async fn test_state_table_watermark_cache_refill() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     // After the first barrier, watermark cache won't be filled.
     let cache = state_table.get_watermark_cache();
@@ -1779,7 +1779,7 @@ async fn test_state_table_iter_prefix_and_sub_range() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
 
     let pk_prefix = OwnedRow::new(vec![Some(1_i32.into())]);
 
@@ -1966,8 +1966,8 @@ async fn test_replicated_state_table_replication() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
-    replicated_state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
+    replicated_state_table.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     {
@@ -2029,8 +2029,8 @@ async fn test_replicated_state_table_replication() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
-    replicated_state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
+    replicated_state_table.commit_for_test(epoch).await.unwrap();
 
     {
         let range_bounds: (Bound<OwnedRow>, Bound<OwnedRow>) = (
@@ -2163,7 +2163,7 @@ async fn test_non_pk_prefix_watermark_read() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state_table.commit(epoch).await.unwrap();
+    state_table.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     {
@@ -2201,7 +2201,7 @@ async fn test_non_pk_prefix_watermark_read() {
         test_env
             .storage
             .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-        state_table.commit(epoch).await.unwrap();
+        state_table.commit_for_test(epoch).await.unwrap();
         test_env.commit_epoch(epoch.prev).await;
 
         // do not rewrite key-range or filter data for non-pk-prefix watermark

--- a/src/stream/src/common/table/test_storage_table.rs
+++ b/src/stream/src/common/table/test_storage_table.rs
@@ -118,7 +118,7 @@ async fn test_storage_table_value_indices() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state.commit(epoch).await.unwrap();
+    state.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     let get_row1_res = table
@@ -237,7 +237,7 @@ async fn test_shuffled_column_id_for_storage_table_get_row() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state.commit(epoch).await.unwrap();
+    state.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     let get_row1_res = table
@@ -346,7 +346,7 @@ async fn test_row_based_storage_table_point_get_in_batch_mode() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state.commit(epoch).await.unwrap();
+    state.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     let get_row1_res = table
@@ -463,7 +463,7 @@ async fn test_batch_scan_with_value_indices() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state.commit(epoch).await.unwrap();
+    state.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     let iter = table
@@ -586,7 +586,7 @@ async fn test_batch_scan_chunk_with_value_indices() {
     test_env
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
-    state.commit(epoch).await.unwrap();
+    state.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
 
     let chunk_size = 2;

--- a/src/stream/src/executor/aggregation/distinct.rs
+++ b/src/stream/src/executor/aggregation/distinct.rs
@@ -423,7 +423,7 @@ mod tests {
 
         epoch.inc_for_test();
         for table in dedup_tables.values_mut() {
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
         }
 
         // --- chunk 2 ---
@@ -464,7 +464,7 @@ mod tests {
 
         epoch.inc_for_test();
         for table in dedup_tables.values_mut() {
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
         }
 
         drop(deduplicater);
@@ -530,7 +530,7 @@ mod tests {
 
         epoch.inc_for_test();
         for table in dedup_tables.values_mut() {
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
         }
     }
 
@@ -606,7 +606,7 @@ mod tests {
 
         epoch.inc_for_test();
         for table in dedup_tables.values_mut() {
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
         }
 
         let chunk = StreamChunk::from_pretty(
@@ -657,7 +657,7 @@ mod tests {
 
         epoch.inc_for_test();
         for table in dedup_tables.values_mut() {
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
         }
     }
 }

--- a/src/stream/src/executor/aggregation/minput.rs
+++ b/src/stream/src/executor/aggregation/minput.rs
@@ -426,7 +426,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -446,7 +446,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -532,7 +532,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -552,7 +552,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -682,8 +682,8 @@ mod tests {
             state_2.apply_chunk(&chunk_2)?;
 
             epoch.inc_for_test();
-            table_1.commit(epoch).await.unwrap();
-            table_2.commit(epoch).await.unwrap();
+            table_1.commit_for_test(epoch).await.unwrap();
+            table_2.commit_for_test(epoch).await.unwrap();
 
             let out1 = state_1
                 .get_output_no_stats(&table_1, group_key.as_ref(), &agg1)
@@ -756,7 +756,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -776,7 +776,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -877,7 +877,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -906,7 +906,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -970,7 +970,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -992,7 +992,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -1016,7 +1016,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -1090,7 +1090,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -1109,7 +1109,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -1178,7 +1178,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)
@@ -1197,7 +1197,7 @@ mod tests {
             state.apply_chunk(&chunk)?;
 
             epoch.inc_for_test();
-            table.commit(epoch).await.unwrap();
+            table.commit_for_test(epoch).await.unwrap();
 
             let res = state
                 .get_output_no_stats(&table, group_key.as_ref(), &agg)

--- a/src/stream/src/executor/approx_percentile/global_state.rs
+++ b/src/stream/src/executor/approx_percentile/global_state.rs
@@ -236,8 +236,12 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
                 .count_state_table
                 .update(last_row_count_state, row_count_row),
         }
-        self.count_state_table.commit(epoch).await?;
-        self.bucket_state_table.commit(epoch).await?;
+        self.count_state_table
+            .commit_assert_no_update_vnode_bitmap(epoch)
+            .await?;
+        self.bucket_state_table
+            .commit_assert_no_update_vnode_bitmap(epoch)
+            .await?;
         Ok(())
     }
 }

--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -338,6 +338,7 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive> AsOfJoinExecutor
             "Join",
         );
         pin_mut!(aligned_stream);
+        let actor_id = self.ctx.id;
 
         let barrier = expect_first_barrier_from_aligned_stream(&mut aligned_stream).await?;
         let first_epoch = barrier.epoch;
@@ -447,17 +448,24 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive> AsOfJoinExecutor
                 }
                 AlignedMessage::Barrier(barrier) => {
                     let barrier_start_time = Instant::now();
-                    self.flush_data(barrier.epoch).await?;
+                    let (left_post_commit, right_post_commit) =
+                        self.flush_data(barrier.epoch).await?;
+
+                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(actor_id);
+                    yield Message::Barrier(barrier);
 
                     // Update the vnode bitmap for state tables of both sides if asked.
-                    if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {
-                        if self.side_l.ht.update_vnode_bitmap(vnode_bitmap.clone()) {
-                            self.watermark_buffers
-                                .values_mut()
-                                .for_each(|buffers| buffers.clear());
-                            // self.inequality_watermarks.fill(None);
-                        }
-                        self.side_r.ht.update_vnode_bitmap(vnode_bitmap);
+                    right_post_commit
+                        .post_yield_barrier(update_vnode_bitmap.clone())
+                        .await?;
+                    if left_post_commit
+                        .post_yield_barrier(update_vnode_bitmap)
+                        .await?
+                        .unwrap_or(false)
+                    {
+                        self.watermark_buffers
+                            .values_mut()
+                            .for_each(|buffers| buffers.clear());
                     }
 
                     // Report metrics of cached join rows/entries
@@ -470,19 +478,24 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive> AsOfJoinExecutor
 
                     barrier_join_match_duration_ns
                         .inc_by(barrier_start_time.elapsed().as_nanos() as u64);
-                    yield Message::Barrier(barrier);
                 }
             }
             start_time = Instant::now();
         }
     }
 
-    async fn flush_data(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
+    async fn flush_data(
+        &mut self,
+        epoch: EpochPair,
+    ) -> StreamExecutorResult<(
+        JoinHashMapPostCommit<'_, K, S>,
+        JoinHashMapPostCommit<'_, K, S>,
+    )> {
         // All changes to the state has been buffered in the mem-table of the state table. Just
         // `commit` them here.
-        self.side_l.ht.flush(epoch).await?;
-        self.side_r.ht.flush(epoch).await?;
-        Ok(())
+        let left = self.side_l.ht.flush(epoch).await?;
+        let right = self.side_r.ht.flush(epoch).await?;
+        Ok((left, right))
     }
 
     async fn try_flush_data(&mut self) -> StreamExecutorResult<()> {

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -448,7 +448,9 @@ where
                     upstream_table.write_chunk(chunk);
                 }
 
-                upstream_table.commit(barrier.epoch).await?;
+                upstream_table
+                    .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                    .await?;
 
                 metrics
                     .backfill_snapshot_read_row_count
@@ -549,7 +551,9 @@ where
                 if let Message::Barrier(barrier) = &msg {
                     if is_completely_finished {
                         // If already finished, no need to persist any state. But we need to advance the epoch anyway
-                        self.state_table.commit(barrier.epoch).await?;
+                        self.state_table
+                            .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                            .await?;
                     } else {
                         // If snapshot was empty, we do not need to backfill,
                         // but we still need to persist the finished state.
@@ -595,7 +599,9 @@ where
             if let Some(msg) = mapping_message(msg?, &self.output_indices) {
                 if let Message::Barrier(barrier) = &msg {
                     // If already finished, no need persist any state, but we need to advance the epoch of the state table anyway.
-                    self.state_table.commit(barrier.epoch).await?;
+                    self.state_table
+                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                        .await?;
                 }
                 yield msg;
             }

--- a/src/stream/src/executor/backfill/cdc/state.rs
+++ b/src/stream/src/executor/backfill/cdc/state.rs
@@ -132,6 +132,8 @@ impl<S: StateStore> CdcBackfillState<S> {
 
     /// Persist the state to storage
     pub async fn commit_state(&mut self, new_epoch: EpochPair) -> StreamExecutorResult<()> {
-        self.state_table.commit(new_epoch).await
+        self.state_table
+            .commit_assert_no_update_vnode_bitmap(new_epoch)
+            .await
     }
 }

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -502,7 +502,9 @@ where
                     if is_finished {
                         // If already finished, no need persist any state, but we need to advance the epoch of the state table anyway.
                         if let Some(table) = &mut self.state_table {
-                            table.commit(barrier.epoch).await?;
+                            table
+                                .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                                .await?;
                         }
                     } else {
                         // If snapshot was empty, we do not need to backfill,
@@ -572,7 +574,9 @@ where
                 if let Message::Barrier(barrier) = &msg {
                     // If already finished, no need persist any state, but we need to advance the epoch of the state table anyway.
                     if let Some(table) = &mut self.state_table {
-                        table.commit(barrier.epoch).await?;
+                        table
+                            .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                            .await?;
                     }
                 }
 

--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
@@ -141,7 +141,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                         }
                     })
                     .await?;
-                progress_state.commit(barrier.epoch).await?;
+
                 if !finish_reported {
                     let mut row_count = 0;
                     let mut is_finished = true;
@@ -175,15 +175,14 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                     }
                 }
 
+                let post_commit = progress_state.commit(barrier.epoch).await?;
                 let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.actor_ctx.id);
-                let barrier_epoch = barrier.epoch;
                 yield Message::Barrier(barrier);
-                if let Some(new_vnode_bitmap) = update_vnode_bitmap {
+                if let Some(new_vnode_bitmap) =
+                    post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                {
                     drop(stream);
                     upstream_table.update_vnode_bitmap(new_vnode_bitmap.clone());
-                    progress_state
-                        .update_vnode_bitmap(new_vnode_bitmap, barrier_epoch)
-                        .await?;
                     // recreate the stream on update vnode bitmap
                     stream = ConsumeUpstreamStream::new(
                         progress_state.latest_progress(),

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -210,8 +210,9 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
 
                     let recv_barrier = self.barrier_rx.recv().await.expect("should exist");
                     assert_eq!(first_upstream_barrier.epoch, recv_barrier.epoch);
-                    backfill_state.commit(recv_barrier.epoch).await?;
+                    let post_commit = backfill_state.commit(recv_barrier.epoch).await?;
                     yield Message::Barrier(recv_barrier);
+                    post_commit.post_yield_barrier(None).await?;
                 }
 
                 let mut upstream_buffer = upstream_buffer.start_consuming_log_store();
@@ -286,9 +287,10 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                                 backfill_state.finish_epoch(vnode, barrier.epoch.prev, row_count);
                             })
                             .await?;
-                        backfill_state.commit(barrier.epoch).await?;
+                        let post_commit = backfill_state.commit(barrier.epoch).await?;
                         let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.actor_ctx.id);
                         yield Message::Barrier(barrier);
+                        post_commit.post_yield_barrier(None).await?;
                         if update_vnode_bitmap.is_some() {
                             return Err(anyhow!(
                                 "should not update vnode bitmap during consuming log store"
@@ -350,15 +352,14 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                         need_report_finish = false;
                         self.progress.finish_consuming_log_store(barrier_epoch);
                     }
-                    backfill_state.commit(barrier.epoch).await?;
+                    let post_commit = backfill_state.commit(barrier.epoch).await?;
                     yield Message::Barrier(barrier);
-                    if let Some(new_vnode_bitmap) = update_vnode_bitmap {
+                    if let Some(new_vnode_bitmap) =
+                        post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                    {
                         let _prev_vnode_bitmap = self
                             .upstream_table
                             .update_vnode_bitmap(new_vnode_bitmap.clone());
-                        backfill_state
-                            .update_vnode_bitmap(new_vnode_bitmap, barrier_epoch)
-                            .await?;
                         backfill_state
                             .latest_progress()
                             .for_each(|(vnode, progress)| {
@@ -698,12 +699,13 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                         }
                     })
                     .await?;
-                backfill_state.commit(barrier.epoch).await?;
+                let post_commit = backfill_state.commit(barrier.epoch).await?;
                 debug!(?barrier_epoch, count, epoch_row_count, "update progress");
                 progress.update(barrier_epoch, barrier_epoch.prev, count as _);
                 epoch_row_count = 0;
 
                 yield Message::Barrier(barrier);
+                post_commit.post_yield_barrier(None).await?;
             }
             Either::Right(Some(chunk)) => {
                 count += chunk.cardinality();
@@ -727,17 +729,19 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
             backfill_state.finish_epoch(vnode, snapshot_epoch, row_count);
         })
         .await?;
-    backfill_state.commit(barrier_epoch).await?;
+    let post_commit = backfill_state.commit(barrier_epoch).await?;
     progress.finish(barrier_epoch, count as _);
     yield Message::Barrier(barrier_to_report_finish);
+    post_commit.post_yield_barrier(None).await?;
 
     // keep receiving remaining barriers until receiving a barrier with epoch as snapshot_epoch
     loop {
         let barrier = receive_next_barrier(barrier_rx).await?;
         assert_eq!(barrier.epoch.prev, barrier_epoch.curr);
         barrier_epoch = barrier.epoch;
-        backfill_state.commit(barrier.epoch).await?;
+        let post_commit = backfill_state.commit(barrier.epoch).await?;
         yield Message::Barrier(barrier);
+        post_commit.post_yield_barrier(None).await?;
         if barrier_epoch.curr == snapshot_epoch {
             break;
         }

--- a/src/stream/src/executor/backfill/snapshot_backfill/state.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/state.rs
@@ -201,6 +201,7 @@ use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_storage::StateStore;
 
+use crate::common::table::state_table::StateTablePostCommit;
 use crate::executor::prelude::StateTable;
 use crate::executor::StreamExecutorResult;
 
@@ -352,7 +353,10 @@ impl<S: StateStore> BackfillState<S> {
         })
     }
 
-    pub(super) async fn commit(&mut self, barrier_epoch: EpochPair) -> StreamExecutorResult<()> {
+    pub(super) async fn commit(
+        &mut self,
+        barrier_epoch: EpochPair,
+    ) -> StreamExecutorResult<BackfillStatePostCommit<'_, S>> {
         for (vnode, state) in &self.vnode_state {
             match state {
                 VnodeBackfillState::New(progress) => {
@@ -368,27 +372,53 @@ impl<S: StateStore> BackfillState<S> {
                 VnodeBackfillState::Committed(_) => {}
             }
         }
-        self.state_table.commit(barrier_epoch).await?;
+        let post_commit = self.state_table.commit(barrier_epoch).await?;
         self.vnode_state
             .values_mut()
             .for_each(VnodeBackfillState::mark_committed);
-        Ok(())
+        Ok(BackfillStatePostCommit {
+            inner: post_commit,
+            vnode_state: &mut self.vnode_state,
+            pk_serde: &self.pk_serde,
+        })
+    }
+}
+
+#[must_use]
+pub(super) struct BackfillStatePostCommit<'a, S: StateStore> {
+    inner: StateTablePostCommit<'a, S>,
+    vnode_state: &'a mut HashMap<VirtualNode, VnodeBackfillState>,
+    pk_serde: &'a OrderedRowSerde,
+}
+
+impl<S: StateStore> BackfillStatePostCommit<'_, S> {
+    pub(super) async fn post_yield_barrier(
+        self,
+        new_vnode_bitmap: Option<Arc<Bitmap>>,
+    ) -> StreamExecutorResult<Option<Arc<Bitmap>>> {
+        let new_vnode_bitmap = if let Some(((new_vnode_bitmap, prev_vnode_bitmap, state), _)) =
+            self.inner.post_yield_barrier(new_vnode_bitmap).await?
+        {
+            Self::update_vnode_bitmap(&*state, self.vnode_state, self.pk_serde, prev_vnode_bitmap)
+                .await?;
+            Some(new_vnode_bitmap)
+        } else {
+            None
+        };
+        Ok(new_vnode_bitmap)
     }
 
-    pub(super) async fn update_vnode_bitmap(
-        &mut self,
-        new_vnode_bitmap: Arc<Bitmap>,
-        barrier_epoch: EpochPair,
+    async fn update_vnode_bitmap(
+        state_table: &StateTable<S>,
+        vnode_state: &mut HashMap<VirtualNode, VnodeBackfillState>,
+        pk_serde: &OrderedRowSerde,
+        prev_vnode_bitmap: Arc<Bitmap>,
     ) -> StreamExecutorResult<()> {
-        self.state_table
-            .try_wait_committed_epoch(barrier_epoch.prev)
-            .await?;
-        let (prev_vnode_bitmap, _) = self.state_table.update_vnode_bitmap(new_vnode_bitmap);
-        let committed_progress_rows = Self::load_vnode_progress_row(&self.state_table).await?;
+        let committed_progress_rows = BackfillState::load_vnode_progress_row(state_table).await?;
         let mut new_state = HashMap::new();
         for (vnode, progress_row) in committed_progress_rows {
             if let Some(progress_row) = progress_row {
-                let progress = VnodeBackfillProgress::from_row(&progress_row, &self.pk_serde);
+                let progress = VnodeBackfillProgress::from_row(&progress_row, pk_serde);
                 assert!(new_state
                     .insert(vnode, VnodeBackfillState::Committed(progress))
                     .is_none());
@@ -396,10 +426,10 @@ impl<S: StateStore> BackfillState<S> {
 
             if prev_vnode_bitmap.is_set(vnode.to_index()) {
                 // if the vnode exist previously, the new state should be the same as the previous one
-                assert_eq!(self.vnode_state.get(&vnode), new_state.get(&vnode));
+                assert_eq!(vnode_state.get(&vnode), new_state.get(&vnode));
             }
         }
-        self.vnode_state = new_state;
+        *vnode_state = new_state;
         Ok(())
     }
 }

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -627,7 +627,7 @@ pub(crate) async fn flush_data<S: StateStore, const IS_REPLICATED: bool>(
             })
         });
     }
-    table.commit(epoch).await
+    table.commit_assert_no_update_vnode_bitmap(epoch).await
 }
 
 /// We want to avoid allocating a row for every vnode.
@@ -812,7 +812,7 @@ pub(crate) async fn persist_state_per_vnode<S: StateStore, const IS_REPLICATED: 
         backfill_state.mark_committed(vnode);
     }
 
-    table.commit(epoch).await?;
+    table.commit_assert_no_update_vnode_bitmap(epoch).await?;
     Ok(())
 }
 
@@ -836,7 +836,7 @@ pub(crate) async fn persist_state<S: StateStore, const IS_REPLICATED: bool>(
         flush_data(table, epoch, old_state, current_state).await?;
         *old_state = Some(current_state.into());
     } else {
-        table.commit(epoch).await?;
+        table.commit_assert_no_update_vnode_bitmap(epoch).await?;
     }
     Ok(())
 }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
+use futures::future::try_join_all;
 use futures::stream;
 use itertools::Itertools;
 use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
@@ -33,8 +34,9 @@ use super::aggregation::{
 };
 use super::monitor::HashAggMetrics;
 use super::sort_buffer::SortBuffer;
-use crate::cache::{cache_may_stale, ManagedLruCache};
+use crate::cache::ManagedLruCache;
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::StateTablePostCommit;
 use crate::executor::aggregation::AggGroup as GenericAggGroup;
 use crate::executor::prelude::*;
 
@@ -535,13 +537,12 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
     async fn commit_state_tables(
         this: &mut ExecutorInner<K, S>,
         epoch: EpochPair,
-    ) -> StreamExecutorResult<()> {
+    ) -> StreamExecutorResult<Vec<StateTablePostCommit<'_, S>>> {
         futures::future::try_join_all(
             this.all_state_tables_mut()
                 .map(|table| async { table.commit(epoch).await }),
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     async fn try_flush_data(this: &mut ExecutorInner<K, S>) -> StreamExecutorResult<()> {
@@ -559,6 +560,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             input,
             inner: mut this,
         } = self;
+
+        let actor_id = this.actor_ctx.id;
 
         let window_col_idx_in_group_key = this.intermediate_state_table.pk_indices()[0];
         let window_col_idx = this.group_key_indices[window_col_idx_in_group_key];
@@ -648,9 +651,10 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                         yield Message::Chunk(chunk?);
                     }
                     Self::flush_metrics(&this, &mut vars);
-                    Self::commit_state_tables(&mut this, barrier.epoch).await?;
+                    let emit_on_window_close = this.emit_on_window_close;
+                    let post_commits = Self::commit_state_tables(&mut this, barrier.epoch).await?;
 
-                    if this.emit_on_window_close {
+                    if emit_on_window_close {
                         // ignore watermarks on other columns
                         if let Some(watermark) =
                             vars.buffered_watermarks[window_col_idx_in_group_key].take()
@@ -665,23 +669,27 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                         }
                     }
 
-                    // Update the vnode bitmap for state tables of all agg calls if asked.
-                    if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(this.actor_ctx.id) {
-                        let previous_vnode_bitmap = this.intermediate_state_table.vnodes().clone();
-                        this.all_state_tables_mut().for_each(|table| {
-                            let _ = table.update_vnode_bitmap(vnode_bitmap.clone());
-                        });
+                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(actor_id);
+                    yield Message::Barrier(barrier);
 
+                    // Update the vnode bitmap for state tables of all agg calls if asked.
+                    if let Some(cache_may_stale) =
+                        try_join_all(post_commits.into_iter().map(|post_commit| {
+                            post_commit.post_yield_barrier(update_vnode_bitmap.clone())
+                        }))
+                        .await?
+                        .pop()
+                        .expect("should have at least one table")
+                        .map(|(_, cache_may_stale)| cache_may_stale)
+                    {
                         // Manipulate the cache if necessary.
-                        if cache_may_stale(&previous_vnode_bitmap, &vnode_bitmap) {
+                        if cache_may_stale {
                             vars.agg_group_cache.clear();
                             vars.distinct_dedup.dedup_caches_mut().for_each(|cache| {
                                 cache.clear();
                             });
                         }
                     }
-
-                    yield Message::Barrier(barrier);
                 }
             }
         }

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -529,6 +529,8 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         );
         pin_mut!(aligned_stream);
 
+        let actor_id = self.ctx.id;
+
         let barrier = expect_first_barrier_from_aligned_stream(&mut aligned_stream).await?;
         let first_epoch = barrier.epoch;
         // The first barrier message should be propagated.
@@ -645,17 +647,25 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 }
                 AlignedMessage::Barrier(barrier) => {
                     let barrier_start_time = Instant::now();
-                    self.flush_data(barrier.epoch).await?;
+                    let (left_post_commit, right_post_commit) =
+                        self.flush_data(barrier.epoch).await?;
+
+                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(actor_id);
+                    yield Message::Barrier(barrier);
 
                     // Update the vnode bitmap for state tables of both sides if asked.
-                    if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {
-                        if self.side_l.ht.update_vnode_bitmap(vnode_bitmap.clone()) {
-                            self.watermark_buffers
-                                .values_mut()
-                                .for_each(|buffers| buffers.clear());
-                            self.inequality_watermarks.fill(None);
-                        }
-                        self.side_r.ht.update_vnode_bitmap(vnode_bitmap);
+                    right_post_commit
+                        .post_yield_barrier(update_vnode_bitmap.clone())
+                        .await?;
+                    if left_post_commit
+                        .post_yield_barrier(update_vnode_bitmap)
+                        .await?
+                        .unwrap_or(false)
+                    {
+                        self.watermark_buffers
+                            .values_mut()
+                            .for_each(|buffers| buffers.clear());
+                        self.inequality_watermarks.fill(None);
                     }
 
                     // Report metrics of cached join rows/entries
@@ -668,19 +678,24 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
 
                     barrier_join_match_duration_ns
                         .inc_by(barrier_start_time.elapsed().as_nanos() as u64);
-                    yield Message::Barrier(barrier);
                 }
             }
             start_time = Instant::now();
         }
     }
 
-    async fn flush_data(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
+    async fn flush_data(
+        &mut self,
+        epoch: EpochPair,
+    ) -> StreamExecutorResult<(
+        JoinHashMapPostCommit<'_, K, S>,
+        JoinHashMapPostCommit<'_, K, S>,
+    )> {
         // All changes to the state has been buffered in the mem-table of the state table. Just
         // `commit` them here.
-        self.side_l.ht.flush(epoch).await?;
-        self.side_r.ht.flush(epoch).await?;
-        Ok(())
+        let left = self.side_l.ht.flush(epoch).await?;
+        let right = self.side_r.ht.flush(epoch).await?;
+        Ok((left, right))
     }
 
     async fn try_flush_data(&mut self) -> StreamExecutorResult<()> {

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -281,18 +281,22 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                         self.may_have_downstream,
                         &self.depended_subscription_ids,
                     );
-                    self.state_table
+                    let post_commit = self
+                        .state_table
                         .commit_may_switch_consistent_op(b.epoch, op_consistency_level)
                         .await?;
-                    if !self.state_table.is_consistent_op() {
+                    if !post_commit.inner().is_consistent_op() {
                         assert_eq!(self.conflict_behavior, ConflictBehavior::Overwrite);
                     }
 
-                    // Update the vnode bitmap for the state table if asked.
-                    if let Some(vnode_bitmap) = b.as_update_vnode_bitmap(self.actor_context.id) {
-                        let (_, cache_may_stale) =
-                            self.state_table.update_vnode_bitmap(vnode_bitmap);
+                    let update_vnode_bitmap = b.as_update_vnode_bitmap(self.actor_context.id);
+                    let b_epoch = b.epoch;
+                    yield Message::Barrier(b);
 
+                    // Update the vnode bitmap for the state table if asked.
+                    if let Some((_, cache_may_stale)) =
+                        post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                    {
                         if cache_may_stale {
                             self.materialize_cache.data.clear();
                         }
@@ -300,9 +304,9 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
 
                     self.metrics
                         .materialize_current_epoch
-                        .set(b.epoch.curr as i64);
+                        .set(b_epoch.curr as i64);
 
-                    Message::Barrier(b)
+                    continue;
                 }
             }
         }

--- a/src/stream/src/executor/mview/test_utils.rs
+++ b/src/stream/src/executor/mview/test_utils.rs
@@ -67,7 +67,7 @@ pub async fn gen_basic_table(row_count: usize) -> BatchTable<MemoryStateStore> {
     }
 
     epoch.inc_for_test();
-    state.commit(epoch).await.unwrap();
+    state.commit_for_test(epoch).await.unwrap();
 
     table
 }

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -161,7 +161,9 @@ impl<S: StateStore> NowExecutor<S> {
                     paused = is_pause_on_startup;
                     initialized = true;
                 } else {
-                    state_table.commit(barrier.epoch).await?;
+                    state_table
+                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                        .await?;
                     yield Message::Barrier(barrier);
                 }
 

--- a/src/stream/src/executor/simple_agg.rs
+++ b/src/stream/src/executor/simple_agg.rs
@@ -225,8 +225,11 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         };
 
         // Commit all state tables.
-        futures::future::try_join_all(this.all_state_tables_mut().map(|table| table.commit(epoch)))
-            .await?;
+        futures::future::try_join_all(
+            this.all_state_tables_mut()
+                .map(|table| table.commit_assert_no_update_vnode_bitmap(epoch)),
+        )
+        .await?;
 
         Ok(chunk)
     }

--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -121,20 +121,19 @@ impl<S: StateStore> SortExecutor<S> {
                     this.buffer_table.try_flush().await?;
                 }
                 Message::Barrier(barrier) => {
-                    this.buffer_table.commit(barrier.epoch).await?;
+                    let post_commit = this.buffer_table.commit(barrier.epoch).await?;
+                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(this.actor_ctx.id);
+                    yield Message::Barrier(barrier);
 
                     // Update the vnode bitmap for state tables of all agg calls if asked.
-                    if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(this.actor_ctx.id) {
-                        let (_, cache_may_stale) =
-                            this.buffer_table.update_vnode_bitmap(vnode_bitmap);
-
+                    if let Some((_, cache_may_stale)) =
+                        post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                    {
                         // Manipulate the cache if necessary.
                         if cache_may_stale {
                             vars.buffer.refill_cache(None, &this.buffer_table).await?;
                         }
                     }
-
-                    yield Message::Barrier(barrier);
                 }
             }
         }

--- a/src/stream/src/executor/source/fs_fetch_executor.rs
+++ b/src/stream/src/executor/source/fs_fetch_executor.rs
@@ -246,7 +246,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                     match msg {
                         // This branch will be preferred.
                         Either::Left(msg) => {
-                            match &msg {
+                            match msg {
                                 Message::Barrier(barrier) => {
                                     let mut need_rebuild_reader = false;
 
@@ -272,20 +272,20 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                         }
                                     }
 
-                                    state_store_handler
+                                    let post_commit = state_store_handler
                                         .state_table
                                         .commit(barrier.epoch)
                                         .await?;
 
-                                    if let Some(vnode_bitmap) =
-                                        barrier.as_update_vnode_bitmap(self.actor_ctx.id)
-                                    {
-                                        // if _cache_may_stale, we must rebuild the stream to adjust vnode mappings
-                                        let (_prev_vnode_bitmap, cache_may_stale) =
-                                            state_store_handler
-                                                .state_table
-                                                .update_vnode_bitmap(vnode_bitmap);
+                                    let update_vnode_bitmap =
+                                        barrier.as_update_vnode_bitmap(self.actor_ctx.id);
+                                    // Propagate the barrier.
+                                    yield Message::Barrier(barrier);
 
+                                    if let Some((_, cache_may_stale)) =
+                                        post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                                    {
+                                        // if cache_may_stale, we must rebuild the stream to adjust vnode mappings
                                         if cache_may_stale {
                                             splits_on_fetch = 0;
                                         }
@@ -307,9 +307,6 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                         )
                                         .await?;
                                     }
-
-                                    // Propagate the barrier.
-                                    yield msg;
                                 }
                                 // Receiving file assignments from upstream list executor,
                                 // store into state table.
@@ -364,7 +361,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                     state_store_handler.set_states(file_assignment).await?;
                                     state_store_handler.state_table.try_flush().await?;
                                 }
-                                _ => unreachable!(),
+                                Message::Watermark(_) => unreachable!(),
                             }
                         }
                         // StreamChunk from FsSourceReader, and the reader reads only one file.

--- a/src/stream/src/executor/source/legacy_fs_source_executor.rs
+++ b/src/stream/src/executor/source/legacy_fs_source_executor.rs
@@ -271,7 +271,10 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
             core.split_state_store.set_all_complete(completed).await?
         }
         // commit anyway, even if no message saved
-        core.split_state_store.state_table.commit(epoch).await?;
+        core.split_state_store
+            .state_table
+            .commit_assert_no_update_vnode_bitmap(epoch)
+            .await?;
 
         core.updated_splits_in_epoch.clear();
         Ok(())

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -632,7 +632,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                     .await?;
                                 self.backfill_state_store
                                     .state_store
-                                    .commit(barrier.epoch)
+                                    .commit_assert_no_update_vnode_bitmap(barrier.epoch)
                                     .await?;
 
                                 if self.should_report_finished(&backfill_stage.states) {
@@ -782,7 +782,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                     }
                     self.backfill_state_store
                         .state_store
-                        .commit(barrier.epoch)
+                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
                         .await?;
                     yield Message::Barrier(barrier);
                 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -415,7 +415,10 @@ impl<S: StateStore> SourceExecutor<S> {
         }
 
         // commit anyway, even if no message saved
-        core.split_state_store.state_table.commit(epoch).await?;
+        core.split_state_store
+            .state_table
+            .commit_assert_no_update_vnode_bitmap(epoch)
+            .await?;
 
         let updated_splits = core.updated_splits_in_epoch.clone();
 

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -285,7 +285,7 @@ pub(crate) mod tests {
 
         state_table.init_epoch(init_epoch).await.unwrap();
         state_table.insert(OwnedRow::new(vec![a.clone(), b.clone()]));
-        state_table.commit(next_epoch).await.unwrap();
+        state_table.commit_for_test(next_epoch).await.unwrap();
 
         let a: Arc<str> = String::from("a").into();
         let a: Datum = Some(ScalarImpl::Utf8(a.as_ref().into()));
@@ -312,9 +312,15 @@ pub(crate) mod tests {
         state_table_handler
             .set_states(vec![split_impl.clone()])
             .await?;
-        state_table_handler.state_table.commit(epoch_2).await?;
+        state_table_handler
+            .state_table
+            .commit_for_test(epoch_2)
+            .await?;
 
-        state_table_handler.state_table.commit(epoch_3).await?;
+        state_table_handler
+            .state_table
+            .commit_for_test(epoch_3)
+            .await?;
 
         match state_table_handler
             .try_recover_from_state_store(&split_impl)

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -823,12 +823,16 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
                                 .init_epoch(barrier_epoch)
                                 .await?;
                         } else {
-                            self.memo_table
+                            let post_commit = self
+                                .memo_table
                                 .as_mut()
                                 .unwrap()
                                 .commit(barrier.epoch)
                                 .await?;
                             yield Message::Barrier(barrier);
+                            post_commit
+                                .post_yield_barrier(update_vnode_bitmap.clone())
+                                .await?;
                         }
                     } else {
                         yield Message::Barrier(barrier);

--- a/src/stream/src/executor/top_n/group_top_n.rs
+++ b/src/stream/src/executor/top_n/group_top_n.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use risingwave_common::array::Op;
-use risingwave_common::bitmap::Bitmap;
 use risingwave_common::hash::HashKey;
 use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::epoch::EpochPair;
@@ -28,6 +27,7 @@ use super::utils::*;
 use super::{ManagedTopNState, TopNCache};
 use crate::cache::ManagedLruCache;
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::StateTablePostCommit;
 use crate::executor::monitor::GroupTopNMetrics;
 use crate::executor::prelude::*;
 
@@ -158,6 +158,8 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool> TopNExecutorBase
 where
     TopNCache<WITH_TIES>: TopNCacheTrait,
 {
+    type State = S;
+
     async fn apply_chunk(
         &mut self,
         chunk: StreamChunk,
@@ -229,7 +231,10 @@ where
         Ok(chunk_builder.take())
     }
 
-    async fn flush_data(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
+    async fn flush_data(
+        &mut self,
+        epoch: EpochPair,
+    ) -> StreamExecutorResult<StateTablePostCommit<'_, S>> {
         self.managed_state.flush(epoch).await
     }
 
@@ -237,11 +242,8 @@ where
         self.managed_state.try_flush().await
     }
 
-    fn update_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) {
-        let cache_may_stale = self.managed_state.update_vnode_bitmap(vnode_bitmap);
-        if cache_may_stale {
-            self.caches.clear();
-        }
+    fn clear_cache(&mut self) {
+        self.caches.clear();
     }
 
     fn evict(&mut self) {

--- a/src/stream/src/executor/top_n/group_top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/group_top_n_appendonly.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 
 use risingwave_common::array::Op;
-use risingwave_common::bitmap::Bitmap;
 use risingwave_common::hash::HashKey;
 use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::epoch::EpochPair;
@@ -27,6 +26,7 @@ use super::top_n_cache::AppendOnlyTopNCacheTrait;
 use super::utils::*;
 use super::{ManagedTopNState, TopNCache};
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::StateTablePostCommit;
 use crate::executor::monitor::GroupTopNMetrics;
 use crate::executor::prelude::*;
 
@@ -139,6 +139,8 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool> TopNExecutorBase
 where
     TopNCache<WITH_TIES>: AppendOnlyTopNCacheTrait,
 {
+    type State = S;
+
     async fn apply_chunk(
         &mut self,
         chunk: StreamChunk,
@@ -198,7 +200,10 @@ where
         Ok(chunk_builder.take())
     }
 
-    async fn flush_data(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
+    async fn flush_data(
+        &mut self,
+        epoch: EpochPair,
+    ) -> StreamExecutorResult<StateTablePostCommit<'_, S>> {
         self.managed_state.flush(epoch).await
     }
 
@@ -206,11 +211,8 @@ where
         self.managed_state.try_flush().await
     }
 
-    fn update_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) {
-        let cache_may_stale = self.managed_state.update_vnode_bitmap(vnode_bitmap);
-        if cache_may_stale {
-            self.caches.clear();
-        }
+    fn clear_cache(&mut self) {
+        self.caches.clear();
     }
 
     fn evict(&mut self) {

--- a/src/stream/src/executor/top_n/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/top_n_appendonly.rs
@@ -20,6 +20,7 @@ use risingwave_common::util::sort_util::ColumnOrder;
 use super::top_n_cache::{AppendOnlyTopNCacheTrait, TopNStaging};
 use super::utils::*;
 use super::{ManagedTopNState, TopNCache};
+use crate::common::table::state_table::StateTablePostCommit;
 use crate::executor::prelude::*;
 
 /// If the input is append-only, `AppendOnlyGroupTopNExecutor` does not need
@@ -104,6 +105,8 @@ impl<S: StateStore, const WITH_TIES: bool> TopNExecutorBase
 where
     TopNCache<WITH_TIES>: AppendOnlyTopNCacheTrait,
 {
+    type State = S;
+
     async fn apply_chunk(
         &mut self,
         chunk: StreamChunk,
@@ -136,7 +139,10 @@ where
         Ok(chunk_builder.take())
     }
 
-    async fn flush_data(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
+    async fn flush_data(
+        &mut self,
+        epoch: EpochPair,
+    ) -> StreamExecutorResult<StateTablePostCommit<'_, S>> {
         self.managed_state.flush(epoch).await
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Part of https://github.com/risingwavelabs/risingwave/issues/18312.

As described in https://github.com/risingwavelabs/risingwave/issues/18312, we should ensure a correct handling order as `state_table.commit()` -> `yield barrier` -> `state_table.update_vnode_bitmap()` in streaming executors while update vnode bitmap. 

In this PR, for `state_table.commit()`, we change to return a `StateTablePostCommit<'_>`, which captures the mutable reference to the original `state_table` and will be used as a callback after yielding the barrier. The `StateTablePostCommit` has a method `async fn post_yield_barrier(mut self, new_vnodes: Option<Arc<Bitmap>>)` to be called after the we yield the barrier. 

The `StateTablePostCommit` is marked with `#[must_use]`. The method name `post_yield_barrier` indicates that it should be called after we have yielded the barrier. In state table, we add a flag `on_post_commit`, to indicate that whether the `StateTablePostCommit` is handled properly. On `state_table.commit()`, we will mark the `on_post_commit` as true, and in `StateTablePostCommit::post_yield_barrier`, we will remark the flag as false, and on `state_table.commit()`, we will assert that the `on_post_commit` must be false. Note that, the `post_yield_barrier` should be called for all barriers rather than only for the barrier with update vnode bitmap. In this way, though we don't have scale test for all streaming executor, we can ensure that all executor covered by normal e2e test have properly handled the `StateTablePostCommit`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
