### PR TITLE
fix(frontend): cursor should not be schema-bound

### DIFF
--- a/e2e_test/batch/transaction/cursor.slt
+++ b/e2e_test/batch/transaction/cursor.slt
@@ -30,6 +30,7 @@ DECLARE
     test_cursor CURSOR FOR
         SELECT * FROM test where a > 2 ORDER BY a;
 
+# Cursor with name `test_cursor` is already declared.
 statement error
 DECLARE
     test_cursor CURSOR FOR
@@ -87,6 +88,12 @@ FETCH NEXT from test_cursor;
 
 statement ok
 COMMIT;
+
+# Cursor is not schema-bound.
+statement error sql parser error: expected CURSOR, found: .
+DECLARE
+    test_schema.test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2 ORDER BY a;
 
 statement ok
 drop table test;

--- a/e2e_test/batch/transaction/cursor.slt
+++ b/e2e_test/batch/transaction/cursor.slt
@@ -90,9 +90,15 @@ statement ok
 COMMIT;
 
 # Cursor is not schema-bound.
-statement error sql parser error: expected CURSOR, found: .
+statement error sql parser error: expected CURSOR, found: \.
 DECLARE
     test_schema.test_cursor CURSOR FOR
+        SELECT * FROM test where a > 2 ORDER BY a;
+
+# Cannot use reserved keyword as cursor name.
+statement error sql parser error: syntax error at or near all
+DECLARE
+    all CURSOR FOR
         SELECT * FROM test where a > 2 ORDER BY a;
 
 statement ok

--- a/e2e_test/subscription/check_sql_statement.slt
+++ b/e2e_test/subscription/check_sql_statement.slt
@@ -8,6 +8,12 @@ statement ok
 create subscription sub from t1 with(retention = '1D');
 
 statement ok
+create schema s1;
+
+statement ok
+create subscription s1.sub1 from t1 with(retention = '1D');
+
+statement ok
 declare cur subscription cursor for sub;
 
 statement ok
@@ -28,6 +34,14 @@ declare cur5 subscription cursor for sub since asd;
 statement error
 declare cur6 subscription cursor for sub since 18446744073709551615;
 
+# We should correctly parse the schema for the subscription.
+statement ok
+declare cur7 subscription cursor for s1.sub1;
+
+# However, cursor itself is not schema-bound.
+statement error
+declare s1.cur8 subscription cursor for s1.sub1;
+
 statement error
 declare cur subscription cursor for sub;
 
@@ -42,6 +56,15 @@ close cur2;
 
 statement ok
 close cur3;
+
+statement ok
+close cur7;
+
+statement ok
+drop subscription s1.sub1;
+
+statement ok
+drop schema s1;
 
 statement ok
 drop subscription sub;

--- a/src/frontend/src/binder/declare_cursor.rs
+++ b/src/frontend/src/binder/declare_cursor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_sqlparser::ast::ObjectName;
+use risingwave_sqlparser::ast::Ident;
 
 use super::statement::RewriteExprsRecursive;
 use crate::binder::BoundQuery;
@@ -20,7 +20,7 @@ use crate::expr::ExprRewriter;
 
 #[derive(Debug, Clone)]
 pub struct BoundDeclareCursor {
-    pub cursor_name: ObjectName,
+    pub cursor_name: Ident,
     // Currently we only support cursor with query
     pub query: Box<BoundQuery>, // reuse the BoundQuery struct
 }

--- a/src/frontend/src/handler/close_cursor.rs
+++ b/src/frontend/src/handler/close_cursor.rs
@@ -18,7 +18,6 @@ use risingwave_sqlparser::ast::CloseCursorStatement;
 use super::RwPgResponse;
 use crate::error::Result;
 use crate::handler::HandlerArgs;
-use crate::Binder;
 
 pub async fn handle_close_cursor(
     handle_args: HandlerArgs,
@@ -26,10 +25,10 @@ pub async fn handle_close_cursor(
 ) -> Result<RwPgResponse> {
     let session = handle_args.session.clone();
     let cursor_manager = session.get_cursor_manager();
-    let db_name = &session.database();
     if let Some(cursor_name) = stmt.cursor_name {
-        let (_, cursor_name) = Binder::resolve_schema_qualified_name(db_name, cursor_name.clone())?;
-        cursor_manager.remove_cursor(cursor_name).await?;
+        cursor_manager
+            .remove_cursor(&cursor_name.real_value())
+            .await?;
     } else {
         cursor_manager.remove_all_cursor().await;
     }

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -107,7 +107,10 @@ async fn do_handle_explain(
             } => {
                 let cursor_manager = session.clone().get_cursor_manager();
                 let plan = cursor_manager
-                    .gen_batch_plan_with_subscription_cursor(cursor_name, handler_args)
+                    .gen_batch_plan_with_subscription_cursor(
+                        &cursor_name.real_value(),
+                        handler_args,
+                    )
                     .await
                     .map(|x| x.plan)?;
                 let context = plan.ctx();

--- a/src/frontend/src/handler/fetch_cursor.rs
+++ b/src/frontend/src/handler/fetch_cursor.rs
@@ -58,10 +58,7 @@ pub async fn handle_fetch_cursor(
     formats: &Vec<Format>,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
-    let db_name = &session.database();
-    let (_, cursor_name) =
-        Binder::resolve_schema_qualified_name(db_name, stmt.cursor_name.clone())?;
-
+    let cursor_name = stmt.cursor_name.real_value();
     let with_options = WithOptions::try_from(stmt.with_properties.0.as_slice())?;
 
     if with_options.len() > 1 {
@@ -81,7 +78,7 @@ pub async fn handle_fetch_cursor(
 
     let (rows, pg_descs) = cursor_manager
         .get_rows_with_cursor(
-            cursor_name,
+            &cursor_name,
             stmt.count,
             handler_args,
             formats,
@@ -105,12 +102,10 @@ pub async fn handle_parse(
 ) -> Result<PrepareStatement> {
     if let Statement::FetchCursor { stmt } = &statement {
         let session = handler_args.session.clone();
-        let db_name = &session.database();
-        let (_, cursor_name) =
-            Binder::resolve_schema_qualified_name(db_name, stmt.cursor_name.clone())?;
+        let cursor_name = stmt.cursor_name.real_value();
         let fields = session
             .get_cursor_manager()
-            .get_fields_with_cursor(cursor_name.clone())
+            .get_fields_with_cursor(&cursor_name)
             .await?;
 
         let mut binder = Binder::new_with_param_types(&session, specific_param_types);

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -52,9 +52,7 @@ use crate::optimizer::plan_node::{generic, BatchLogSeqScan};
 use crate::optimizer::property::{Order, RequiredDist};
 use crate::optimizer::PlanRoot;
 use crate::scheduler::{DistributedQueryStream, LocalQueryStream};
-use crate::{
-    Binder, OptimizerContext, OptimizerContextRef, PgResponseStream, PlanRef, TableCatalog,
-};
+use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, PlanRef, TableCatalog};
 
 pub enum CursorDataChunkStream {
     LocalDataChunk(Option<LocalQueryStream>),
@@ -878,7 +876,7 @@ impl CursorManager {
         let create_cursor_timer = Instant::now();
         let subscription_name = subscription.name.clone();
         let cursor = SubscriptionCursor::new(
-            cursor_name.clone(),
+            cursor_name,
             start_timestamp,
             subscription,
             dependent_table_id,
@@ -904,15 +902,17 @@ impl CursorManager {
 
         cursor_map
             .try_insert(cursor.cursor_name.clone(), Cursor::Subscription(cursor))
-            .map_err(|_| {
-                ErrorCode::CatalogError(format!("cursor `{}` already exists", cursor_name).into())
+            .map_err(|error| {
+                ErrorCode::CatalogError(
+                    format!("cursor `{}` already exists", error.entry.key()).into(),
+                )
             })?;
         Ok(())
     }
 
     pub async fn add_query_cursor(
         &self,
-        cursor_name: ObjectName,
+        cursor_name: String,
         chunk_stream: CursorDataChunkStream,
         fields: Vec<Field>,
     ) -> Result<()> {
@@ -920,19 +920,21 @@ impl CursorManager {
         self.cursor_map
             .lock()
             .await
-            .try_insert(cursor_name.to_string(), Cursor::Query(cursor))
-            .map_err(|_| {
-                ErrorCode::CatalogError(format!("cursor `{}` already exists", cursor_name).into())
+            .try_insert(cursor_name, Cursor::Query(cursor))
+            .map_err(|error| {
+                ErrorCode::CatalogError(
+                    format!("cursor `{}` already exists", error.entry.key()).into(),
+                )
             })?;
 
         Ok(())
     }
 
-    pub async fn remove_cursor(&self, cursor_name: String) -> Result<()> {
+    pub async fn remove_cursor(&self, cursor_name: &str) -> Result<()> {
         self.cursor_map
             .lock()
             .await
-            .remove(&cursor_name)
+            .remove(cursor_name)
             .ok_or_else(|| {
                 ErrorCode::CatalogError(format!("cursor `{}` don't exists", cursor_name).into())
             })?;
@@ -952,13 +954,13 @@ impl CursorManager {
 
     pub async fn get_rows_with_cursor(
         &self,
-        cursor_name: String,
+        cursor_name: &str,
         count: u32,
         handler_args: HandlerArgs,
         formats: &Vec<Format>,
         timeout_seconds: Option<u64>,
     ) -> Result<(Vec<Row>, Vec<PgFieldDescriptor>)> {
-        if let Some(cursor) = self.cursor_map.lock().await.get_mut(&cursor_name) {
+        if let Some(cursor) = self.cursor_map.lock().await.get_mut(cursor_name) {
             cursor
                 .next(count, handler_args, formats, timeout_seconds)
                 .await
@@ -967,8 +969,8 @@ impl CursorManager {
         }
     }
 
-    pub async fn get_fields_with_cursor(&self, cursor_name: String) -> Result<Vec<Field>> {
-        if let Some(cursor) = self.cursor_map.lock().await.get_mut(&cursor_name) {
+    pub async fn get_fields_with_cursor(&self, cursor_name: &str) -> Result<Vec<Field>> {
+        if let Some(cursor) = self.cursor_map.lock().await.get_mut(cursor_name) {
             Ok(cursor.get_fields())
         } else {
             Err(ErrorCode::InternalError(format!("Cannot find cursor `{}`", cursor_name)).into())
@@ -1027,13 +1029,10 @@ impl CursorManager {
 
     pub async fn gen_batch_plan_with_subscription_cursor(
         &self,
-        cursor_name: ObjectName,
+        cursor_name: &str,
         handler_args: HandlerArgs,
     ) -> Result<BatchQueryPlanResult> {
-        let session = handler_args.session.clone();
-        let db_name = &session.database();
-        let (_, cursor_name) = Binder::resolve_schema_qualified_name(db_name, cursor_name.clone())?;
-        match self.cursor_map.lock().await.get(&cursor_name).ok_or_else(|| {
+        match self.cursor_map.lock().await.get(cursor_name).ok_or_else(|| {
             ErrorCode::InternalError(format!("Cannot find cursor `{}`", cursor_name))
         })? {
             Cursor::Subscription(cursor) => {

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -686,7 +686,7 @@ pub struct DeclareCursorStatement {
 
 impl ParseTo for DeclareCursorStatement {
     fn parse_to(p: &mut Parser<'_>) -> PResult<Self> {
-        impl_parse_to!(cursor_name: Ident, p);
+        let cursor_name = p.parse_identifier_non_reserved()?;
 
         let declare_cursor = if !p.parse_keyword(Keyword::SUBSCRIPTION) {
             p.expect_keyword(Keyword::CURSOR)?;
@@ -743,7 +743,7 @@ impl ParseTo for FetchCursorStatement {
             literal_u32(p)?
         };
         p.expect_keyword(Keyword::FROM)?;
-        impl_parse_to!(cursor_name: Ident, p);
+        let cursor_name = p.parse_identifier_non_reserved()?;
         impl_parse_to!(with_properties: WithProperties, p);
 
         Ok(Self {
@@ -782,7 +782,7 @@ impl ParseTo for CloseCursorStatement {
         let cursor_name = if p.parse_keyword(Keyword::ALL) {
             None
         } else {
-            Some(p.parse_identifier()?)
+            Some(p.parse_identifier_non_reserved()?)
         };
 
         Ok(Self { cursor_name })


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

According to Postgres' specification, `CURSOR`s are session-scoped objects and are not schema-bound. We should reject the following statement; however, we currently accept it.

```
postgres=# declare a.b cursor for select 1;
ERROR:  syntax error at or near "."
LINE 1: declare a.b cursor for select 1;
```

This PR fixes this by changing the AST type of `cursor_name` from `ObjectName` to `Ident`.

This should not be considered a breaking change, as cursors are temporary and only active within a session.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
