### PR TITLE
refactor(meta): do not store upstream actors in merge node

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -547,7 +547,7 @@ message MergeNode {
   //
   // `upstream_actor_id` stored in the plan node in `Fragment` meta model cannot be directly used.
   // See `compose_fragment`.
-  repeated uint32 upstream_actor_id = 1;
+  repeated uint32 upstream_actor_id = 1 [deprecated = true];
   uint32 upstream_fragment_id = 2;
   // Type of the upstream dispatcher. If there's always one upstream according to this
   // type, the compute node may use the `ReceiverExecutor` as an optimization.

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -969,7 +969,7 @@ message StreamActor {
   // Note that upstream actor ids are also stored in the proto of merge nodes.
   // It is painstaking to traverse through the node tree and get upstream actor id from the root StreamNode.
   // We duplicate the information here to ease the parsing logic in stream manager.
-  repeated uint32 upstream_actor_id = 6;
+  repeated uint32 upstream_actor_id = 6 [deprecated = true];
   // Vnodes that the executors in this actor own.
   // If the fragment is a singleton, this field will not be set and leave a `None`.
   common.Buffer vnode_bitmap = 8;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -547,6 +547,8 @@ message MergeNode {
   //
   // `upstream_actor_id` stored in the plan node in `Fragment` meta model cannot be directly used.
   // See `compose_fragment`.
+  // The field is deprecated because the upstream actor info is provided separately instead of
+  // injected here in the node.
   repeated uint32 upstream_actor_id = 1 [deprecated = true];
   uint32 upstream_fragment_id = 2;
   // Type of the upstream dispatcher. If there's always one upstream according to this
@@ -969,6 +971,7 @@ message StreamActor {
   // Note that upstream actor ids are also stored in the proto of merge nodes.
   // It is painstaking to traverse through the node tree and get upstream actor id from the root StreamNode.
   // We duplicate the information here to ease the parsing logic in stream manager.
+  // The field is deprecated because it's no longer used.
   repeated uint32 upstream_actor_id = 6 [deprecated = true];
   // Vnodes that the executors in this actor own.
   // If the fragment is a singleton, this field will not be set and leave a `None`.

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -17,8 +17,17 @@ message InjectBarrierRequest {
   repeated uint32 table_ids_to_sync = 5;
   uint32 partial_graph_id = 6;
 
+  message BuildActorInfo {
+    message UpstreamActors {
+      repeated uint32 actors = 1;
+    }
+
+    stream_plan.StreamActor actor = 1;
+    map<uint32, UpstreamActors> upstreams = 2;
+  }
+
   repeated common.ActorInfo broadcast_info = 8;
-  repeated stream_plan.StreamActor actors_to_build = 9;
+  repeated BuildActorInfo actors_to_build = 9;
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_add = 10;
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_remove = 11;
 }

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -23,7 +23,7 @@ message InjectBarrierRequest {
     }
 
     stream_plan.StreamActor actor = 1;
-    map<uint32, UpstreamActors> upstreams = 2;
+    map<uint32, UpstreamActors> fragment_upstreams = 2;
   }
 
   repeated common.ActorInfo broadcast_info = 8;

--- a/src/ctl/src/cmd_impl/meta/cluster_info.rs
+++ b/src/ctl/src/cmd_impl/meta/cluster_info.rs
@@ -115,7 +115,7 @@ pub async fn source_split_info(context: &CtlContext, ignore_id: bool) -> anyhow:
             for actor in &fragment.actors {
                 if let Some((split_count, splits)) = actor_splits_map.get(&actor.actor_id) {
                     println!(
-                        "\t\tActor{} ({} splits): [{}]{}",
+                        "\t\tActor{} ({} splits): [{}]",
                         if ignore_id {
                             "".to_owned()
                         } else {
@@ -123,24 +123,6 @@ pub async fn source_split_info(context: &CtlContext, ignore_id: bool) -> anyhow:
                         },
                         split_count,
                         splits,
-                        if !actor.upstream_actor_id.is_empty() {
-                            let upstream_splits = actor
-                                .upstream_actor_id
-                                .iter()
-                                .find_map(|id| actor_splits_map.get(id))
-                                .expect("should have one upstream source actor");
-                            format!(
-                                " <- Upstream Actor{}: [{}]",
-                                if ignore_id {
-                                    "".to_owned()
-                                } else {
-                                    format!(" #{}", actor.upstream_actor_id[0])
-                                },
-                                upstream_splits.1
-                            )
-                        } else {
-                            "".to_owned()
-                        }
                     );
                 } else {
                     println!(

--- a/src/meta/src/barrier/checkpoint/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/status.rs
@@ -21,7 +21,6 @@ use risingwave_common::util::epoch::Epoch;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
-use risingwave_pb::stream_plan::StreamActor;
 use risingwave_pb::stream_service::barrier_complete_response::{
     CreateMviewProgress, PbCreateMviewProgress,
 };
@@ -29,6 +28,7 @@ use tracing::warn;
 
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::barrier::{BarrierInfo, BarrierKind, TracedEpoch};
+use crate::model::StreamActorWithUpstreams;
 
 #[derive(Debug)]
 pub(super) struct CreateMviewLogStoreProgressTracker {
@@ -110,7 +110,7 @@ pub(super) enum CreatingStreamingJobStatus {
         pending_non_checkpoint_barriers: Vec<u64>,
         /// Info of the first barrier: (`actors_to_create`, `mutation`)
         /// Take the mutation out when injecting the first barrier
-        initial_barrier_info: Option<(HashMap<WorkerId, Vec<StreamActor>>, Mutation)>,
+        initial_barrier_info: Option<(HashMap<WorkerId, Vec<StreamActorWithUpstreams>>, Mutation)>,
     },
     /// The creating job is consuming log store.
     ///
@@ -126,7 +126,7 @@ pub(super) enum CreatingStreamingJobStatus {
 
 pub(super) struct CreatingJobInjectBarrierInfo {
     pub barrier_info: BarrierInfo,
-    pub new_actors: Option<HashMap<WorkerId, Vec<StreamActor>>>,
+    pub new_actors: Option<HashMap<WorkerId, Vec<StreamActorWithUpstreams>>>,
     pub mutation: Option<Mutation>,
 }
 
@@ -252,7 +252,10 @@ impl CreatingStreamingJobStatus {
     pub(super) fn new_fake_barrier(
         prev_epoch_fake_physical_time: &mut u64,
         pending_non_checkpoint_barriers: &mut Vec<u64>,
-        initial_barrier_info: &mut Option<(HashMap<WorkerId, Vec<StreamActor>>, Mutation)>,
+        initial_barrier_info: &mut Option<(
+            HashMap<WorkerId, Vec<StreamActorWithUpstreams>>,
+            Mutation,
+        )>,
         is_checkpoint: bool,
     ) -> CreatingJobInjectBarrierInfo {
         {

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -23,7 +23,6 @@ use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::WorkerSlotId;
 use risingwave_meta_model::StreamingParallelism;
-use risingwave_pb::stream_plan::StreamActor;
 use thiserror_ext::AsReport;
 use tokio::time::Instant;
 use tracing::{debug, info, warn};
@@ -34,7 +33,7 @@ use crate::barrier::info::InflightDatabaseInfo;
 use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{ActorId, StreamJobFragments, TableParallelism};
+use crate::model::{ActorId, StreamActorWithUpstreams, StreamJobFragments, TableParallelism};
 use crate::stream::{
     JobParallelismTarget, JobReschedulePolicy, JobRescheduleTarget, JobResourceGroupTarget,
     RescheduleOptions, SourceChange,
@@ -771,7 +770,7 @@ impl GlobalBarrierWorkerContextImpl {
     }
 
     /// Update all actors in compute nodes.
-    async fn load_all_actors(&self) -> MetaResult<HashMap<ActorId, StreamActor>> {
+    async fn load_all_actors(&self) -> MetaResult<HashMap<ActorId, StreamActorWithUpstreams>> {
         self.metadata_manager.all_active_actors().await
     }
 }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -20,13 +20,12 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::meta::PbRecoveryStatus;
-use risingwave_pb::stream_plan::StreamActor;
 use tokio::sync::oneshot::Sender;
 
 use self::notifier::Notifier;
 use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo};
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{ActorId, StreamJobFragments};
+use crate::model::{ActorId, StreamActorWithUpstreams, StreamJobFragments};
 use crate::{MetaError, MetaResult};
 
 mod checkpoint;
@@ -104,7 +103,7 @@ struct BarrierWorkerRuntimeInfoSnapshot {
     database_fragment_infos: HashMap<DatabaseId, InflightDatabaseInfo>,
     state_table_committed_epochs: HashMap<TableId, u64>,
     subscription_infos: HashMap<DatabaseId, InflightSubscriptionInfo>,
-    stream_actors: HashMap<ActorId, StreamActor>,
+    stream_actors: HashMap<ActorId, StreamActorWithUpstreams>,
     source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashMap<TableId, (String, StreamJobFragments)>,
     hummock_version_stats: HummockVersionStats,
@@ -115,7 +114,7 @@ impl BarrierWorkerRuntimeInfoSnapshot {
         database_id: DatabaseId,
         database_info: &InflightDatabaseInfo,
         active_streaming_nodes: &ActiveStreamingWorkerNodes,
-        stream_actors: &HashMap<ActorId, StreamActor>,
+        stream_actors: &HashMap<ActorId, StreamActorWithUpstreams>,
         state_table_committed_epochs: &HashMap<TableId, u64>,
     ) -> MetaResult<()> {
         {
@@ -190,7 +189,7 @@ struct DatabaseRuntimeInfoSnapshot {
     database_fragment_info: InflightDatabaseInfo,
     state_table_committed_epochs: HashMap<TableId, u64>,
     subscription_info: InflightSubscriptionInfo,
-    stream_actors: HashMap<ActorId, StreamActor>,
+    stream_actors: HashMap<ActorId, StreamActorWithUpstreams>,
     source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashMap<TableId, (String, StreamJobFragments)>,
 }

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -32,9 +32,9 @@ use risingwave_pb::common::{ActorInfo, WorkerNode};
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::meta::PausedReason;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
-use risingwave_pb::stream_plan::{
-    AddMutation, Barrier, BarrierMutation, StreamActor, SubscriptionUpstreamInfo,
-};
+use risingwave_pb::stream_plan::{AddMutation, Barrier, BarrierMutation, SubscriptionUpstreamInfo};
+use risingwave_pb::stream_service::inject_barrier_request::build_actor_info::UpstreamActors;
+use risingwave_pb::stream_service::inject_barrier_request::BuildActorInfo;
 use risingwave_pb::stream_service::streaming_control_stream_request::{
     CreatePartialGraphRequest, PbDatabaseInitialPartialGraph, PbInitRequest, PbInitialPartialGraph,
     RemovePartialGraphRequest, ResetDatabaseRequest,
@@ -57,7 +57,7 @@ use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo};
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::MetaSrvEnv;
-use crate::model::{ActorId, StreamJobFragments};
+use crate::model::{ActorId, StreamActorWithUpstreams, StreamJobFragments};
 use crate::stream::build_actor_connector_splits;
 use crate::{MetaError, MetaResult};
 
@@ -320,7 +320,7 @@ impl ControlStreamManager {
         database_id: DatabaseId,
         info: InflightDatabaseInfo,
         state_table_committed_epochs: &mut HashMap<TableId, u64>,
-        stream_actors: &mut HashMap<ActorId, StreamActor>,
+        stream_actors: &mut HashMap<ActorId, StreamActorWithUpstreams>,
         source_splits: &mut HashMap<ActorId, Vec<SplitImpl>>,
         background_jobs: &mut HashMap<TableId, (String, StreamJobFragments)>,
         subscription_info: InflightSubscriptionInfo,
@@ -455,7 +455,7 @@ impl ControlStreamManager {
         barrier_info: &BarrierInfo,
         pre_applied_graph_info: impl IntoIterator<Item = &InflightFragmentInfo>,
         applied_graph_info: impl IntoIterator<Item = &'a InflightFragmentInfo> + 'a,
-        mut new_actors: Option<HashMap<WorkerId, Vec<StreamActor>>>,
+        mut new_actors: Option<HashMap<WorkerId, Vec<StreamActorWithUpstreams>>>,
         subscriptions_to_add: Vec<SubscriptionUpstreamInfo>,
         subscriptions_to_remove: Vec<SubscriptionUpstreamInfo>,
     ) -> MetaResult<HashSet<WorkerId>> {
@@ -484,7 +484,7 @@ impl ControlStreamManager {
             .flatten()
             .flat_map(|(worker_id, actor_infos)| {
                 actor_infos.iter().map(|actor_info| ActorInfo {
-                    actor_id: actor_info.actor_id,
+                    actor_id: actor_info.0.actor_id,
                     host: self
                         .nodes
                         .get(worker_id)
@@ -541,6 +541,22 @@ impl ControlStreamManager {
                                             .into_iter()
                                             .flatten()
                                             .flatten()
+                                            .map(|(actor, upstreams)| BuildActorInfo {
+                                                actor: Some(actor),
+                                                upstreams: upstreams
+                                                    .into_iter()
+                                                    .map(|(fragment_id, upstreams)| {
+                                                        (
+                                                            fragment_id,
+                                                            UpstreamActors {
+                                                                actors: upstreams
+                                                                    .into_iter()
+                                                                    .collect(),
+                                                            },
+                                                        )
+                                                    })
+                                                    .collect(),
+                                            })
                                             .collect(),
                                         subscriptions_to_add: subscriptions_to_add.clone(),
                                         subscriptions_to_remove: subscriptions_to_remove.clone(),

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -543,7 +543,7 @@ impl ControlStreamManager {
                                             .flatten()
                                             .map(|(actor, upstreams)| BuildActorInfo {
                                                 actor: Some(actor),
-                                                upstreams: upstreams
+                                                fragment_upstreams: upstreams
                                                     .into_iter()
                                                     .map(|(fragment_id, upstreams)| {
                                                         (

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1632,7 +1632,6 @@ impl CatalogController {
                         actor_id,
                         fragment_id,
                         dispatcher,
-                        upstream_actor_id,
                         vnode_bitmap,
                         expr_context,
                         ..
@@ -1656,20 +1655,6 @@ impl CatalogController {
                     .into_iter()
                     .map(|(k, v)| (k, v.into_iter().collect()))
                     .collect();
-
-                debug_assert_eq!(
-                    actor_upstreams
-                        .values()
-                        .flatten()
-                        .cloned()
-                        .sorted()
-                        .collect_vec(),
-                    upstream_actor_id
-                        .iter()
-                        .map(|actor_id| *actor_id as i32)
-                        .sorted()
-                        .collect_vec()
-                );
 
                 let actor_upstreams = ActorUpstreamActors(actor_upstreams);
 

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -69,7 +69,7 @@ use crate::manager::{
     LocalNotification, MetaSrvEnv, MetadataManager, NotificationVersion, StreamingJob,
     StreamingJobType, IGNORED_NOTIFICATION_VERSION,
 };
-use crate::model::{StreamContext, StreamJobFragments, TableParallelism};
+use crate::model::{FragmentActorUpstreams, StreamContext, StreamJobFragments, TableParallelism};
 use crate::stream::{
     create_source_worker, validate_sink, ActorGraphBuildResult, ActorGraphBuilder,
     CompleteStreamFragmentGraph, CreateStreamingJobContext, CreateStreamingJobOption,
@@ -747,7 +747,17 @@ impl DdlController {
                 if let Some(node) = &actor.nodes {
                     visit_stream_node(node, |node| {
                         if let NodeBody::Merge(merge_node) = node {
-                            assert!(!merge_node.upstream_actor_id.is_empty(), "All the mergers for the union should have been fully assigned beforehand.");
+                            let fragment_actor_upstreams = stream_job_fragments
+                                .actor_upstreams
+                                .get(&fragment.fragment_id)
+                                .expect("should exist");
+                            let actor_upstreams = fragment_actor_upstreams
+                                .get(&actor.actor_id)
+                                .expect("should exist");
+                            let upstreams = actor_upstreams
+                                .get(&merge_node.upstream_fragment_id)
+                                .expect("should exist");
+                            assert!(!upstreams.is_empty(), "All the mergers for the union should have been fully assigned beforehand.");
                         }
                     });
                 }
@@ -762,7 +772,10 @@ impl DdlController {
         sink_fragment: &PbFragment,
         table: &Table,
         replace_table_ctx: &mut ReplaceStreamJobContext,
-        union_fragment: &mut PbFragment,
+        (union_fragment, union_fragment_actor_upstreams): (
+            &mut PbFragment,
+            &mut FragmentActorUpstreams,
+        ),
         unique_identity: Option<&str>,
     ) {
         let sink_actor_ids = sink_fragment
@@ -853,7 +866,13 @@ impl DdlController {
 
                                 if let Some(NodeBody::Merge(merge_node)) =
                                     &mut merge_stream_node.node_body
-                                    && merge_node.upstream_actor_id.is_empty()
+                                    && union_fragment_actor_upstreams
+                                        .get(&actor.actor_id)
+                                        .and_then(|actor_upstream| {
+                                            actor_upstream.get(&merge_node.upstream_fragment_id)
+                                        })
+                                        .map(|upstream_actor_ids| upstream_actor_ids.is_empty())
+                                        .unwrap_or(true)
                                 {
                                     if let Some(sink_id) = sink_id {
                                         merge_stream_node.identity =
@@ -863,12 +882,24 @@ impl DdlController {
                                             format!("ProjectExecutor(from sink {})", sink_id);
                                     }
 
-                                    **merge_node = MergeNode {
-                                        upstream_actor_id: sink_actor_ids.clone(),
-                                        upstream_fragment_id,
-                                        upstream_dispatcher_type: DispatcherType::Hash as _,
-                                        fields: sink_fields.to_vec(),
+                                    **merge_node = {
+                                        #[expect(deprecated)]
+                                        MergeNode {
+                                            upstream_actor_id: vec![],
+                                            upstream_fragment_id,
+                                            upstream_dispatcher_type: DispatcherType::Hash as _,
+                                            fields: sink_fields.to_vec(),
+                                        }
                                     };
+
+                                    union_fragment_actor_upstreams
+                                        .entry(actor.actor_id)
+                                        .or_default()
+                                        .try_insert(
+                                            upstream_fragment_id,
+                                            HashSet::from_iter(sink_actor_ids.iter().cloned()),
+                                        )
+                                        .expect("checked non-exist");
 
                                     merge_stream_node.fields = sink_fields.to_vec();
 
@@ -1586,6 +1617,7 @@ impl DdlController {
 
         let ActorGraphBuildResult {
             graph,
+            actor_upstreams,
             building_locations,
             existing_locations,
             dispatchers,
@@ -1607,6 +1639,7 @@ impl DdlController {
         let stream_job_fragments = StreamJobFragments::new(
             id.into(),
             graph,
+            actor_upstreams,
             &building_locations.actor_locations,
             stream_ctx.clone(),
             table_parallelism,
@@ -1799,6 +1832,7 @@ impl DdlController {
 
         let ActorGraphBuildResult {
             graph,
+            actor_upstreams,
             building_locations,
             existing_locations,
             dispatchers,
@@ -1819,6 +1853,7 @@ impl DdlController {
         let stream_job_fragments = StreamJobFragments::new(
             (tmp_job_id as u32).into(),
             graph,
+            actor_upstreams,
             &building_locations.actor_locations,
             stream_ctx,
             old_fragments.assigned_parallelism,

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -913,11 +913,6 @@ impl DdlController {
             }
         }
 
-        // update downstream actors' upstream_actor_id and upstream_fragment_id
-        for actor in &mut union_fragment.actors {
-            actor.upstream_actor_id.extend(sink_actor_ids.clone());
-        }
-
         union_fragment
             .upstream_fragment_ids
             .push(upstream_fragment_id);

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -41,7 +41,7 @@ use risingwave_pb::meta::table_fragments::{self, ActorStatus, PbFragment, State}
 use risingwave_pb::meta::FragmentWorkerSlotMappings;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    Dispatcher, DispatcherType, FragmentTypeFlag, PbDispatcher, PbStreamActor, StreamNode,
+    Dispatcher, DispatcherType, FragmentTypeFlag, PbDispatcher, PbStreamActor, StreamActor,
 };
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot::Receiver;
@@ -52,7 +52,7 @@ use tokio::time::{Instant, MissedTickBehavior};
 use crate::barrier::{Command, Reschedule};
 use crate::controller::scale::RescheduleWorkingSet;
 use crate::manager::{LocalNotification, MetaSrvEnv, MetadataManager};
-use crate::model::{ActorId, DispatcherId, FragmentId, TableParallelism};
+use crate::model::{ActorId, ActorUpstreams, DispatcherId, FragmentId, TableParallelism};
 use crate::serving::{
     to_deleted_fragment_worker_slot_mapping, to_fragment_worker_slot_mapping, ServingVnodeMapping,
 };
@@ -139,7 +139,7 @@ impl CustomFragmentInfo {
 }
 
 use educe::Educe;
-use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
+use risingwave_common::util::stream_graph_visitor::{visit_stream_node, visit_stream_node_cont};
 
 use super::SourceChange;
 use crate::controller::id::IdCategory;
@@ -1229,6 +1229,7 @@ impl ScaleController {
             {
                 let new_actor_id = actor_to_create.0;
                 let mut new_actor = sample_actor.clone();
+                let mut new_actor_upstream = ActorUpstreams::new();
 
                 // This should be assigned before the `modify_actor_upstream_and_downstream` call,
                 // because we need to use the new actor id to find the upstream and
@@ -1242,7 +1243,7 @@ impl ScaleController {
                     &fragment_actor_bitmap,
                     &no_shuffle_upstream_actor_map,
                     &no_shuffle_downstream_actors_map,
-                    &mut new_actor,
+                    (&mut new_actor, &mut new_actor_upstream),
                 )?;
 
                 if let Some(bitmap) = fragment_actor_bitmap
@@ -1252,7 +1253,7 @@ impl ScaleController {
                     new_actor.vnode_bitmap = Some(bitmap.to_protobuf());
                 }
 
-                new_created_actors.insert(*new_actor_id, new_actor);
+                new_created_actors.insert(*new_actor_id, (new_actor, new_actor_upstream));
             }
         }
 
@@ -1465,11 +1466,11 @@ impl ScaleController {
         for (fragment_id, actors_to_create) in &fragment_actors_to_create {
             let mut created_actors = HashMap::new();
             for (actor_id, worker_id) in actors_to_create {
-                let actor = new_created_actors.get(actor_id).cloned().unwrap();
+                let (actor, actor_upstreams) = new_created_actors.get(actor_id).cloned().unwrap();
                 created_actors.insert(
                     *actor_id,
                     (
-                        actor,
+                        (actor, actor_upstreams),
                         ActorStatus {
                             location: PbActorLocation::from_worker(*worker_id as _),
                             state: ActorState::Inactive as i32,
@@ -1597,7 +1598,7 @@ impl ScaleController {
         fragment_actor_bitmap: &HashMap<FragmentId, HashMap<ActorId, Bitmap>>,
         no_shuffle_upstream_actor_map: &HashMap<ActorId, HashMap<FragmentId, ActorId>>,
         no_shuffle_downstream_actors_map: &HashMap<ActorId, HashMap<FragmentId, ActorId>>,
-        new_actor: &mut PbStreamActor,
+        (new_actor, actor_upstreams): (&mut StreamActor, &mut ActorUpstreams),
     ) -> MetaResult<()> {
         let fragment = &ctx.fragment_map[&new_actor.fragment_id];
         let mut applied_upstream_fragment_actor_ids = HashMap::new();
@@ -1613,11 +1614,11 @@ impl ScaleController {
                 DispatcherType::Unspecified => unreachable!(),
                 DispatcherType::Hash | DispatcherType::Broadcast | DispatcherType::Simple => {
                     let upstream_fragment = &ctx.fragment_map[upstream_fragment_id];
-                    let mut upstream_actor_ids = upstream_fragment
+                    let mut upstream_actor_ids: HashSet<_> = upstream_fragment
                         .actors
                         .iter()
                         .map(|actor| actor.actor_id as ActorId)
-                        .collect_vec();
+                        .collect();
 
                     if let Some(upstream_actors_to_remove) =
                         fragment_actors_to_remove.get(upstream_fragment_id)
@@ -1632,10 +1633,8 @@ impl ScaleController {
                         upstream_actor_ids.extend(upstream_actors_to_create.keys().cloned());
                     }
 
-                    applied_upstream_fragment_actor_ids.insert(
-                        *upstream_fragment_id as FragmentId,
-                        upstream_actor_ids.clone(),
-                    );
+                    applied_upstream_fragment_actor_ids
+                        .insert(*upstream_fragment_id as FragmentId, upstream_actor_ids);
                 }
                 DispatcherType::NoShuffle => {
                     let no_shuffle_upstream_actor_id = *no_shuffle_upstream_actor_map
@@ -1645,7 +1644,7 @@ impl ScaleController {
 
                     applied_upstream_fragment_actor_ids.insert(
                         *upstream_fragment_id as FragmentId,
-                        vec![no_shuffle_upstream_actor_id as ActorId],
+                        HashSet::from_iter([no_shuffle_upstream_actor_id as ActorId]),
                     );
                 }
             }
@@ -1657,24 +1656,18 @@ impl ScaleController {
             .cloned()
             .collect_vec();
 
-        fn replace_merge_node_upstream(
-            stream_node: &mut StreamNode,
-            applied_upstream_fragment_actor_ids: &HashMap<FragmentId, Vec<ActorId>>,
-        ) {
-            if let Some(NodeBody::Merge(s)) = stream_node.node_body.as_mut() {
-                s.upstream_actor_id = applied_upstream_fragment_actor_ids
-                    .get(&s.upstream_fragment_id)
-                    .cloned()
-                    .unwrap();
-            }
-
-            for child in &mut stream_node.input {
-                replace_merge_node_upstream(child, applied_upstream_fragment_actor_ids);
-            }
-        }
-
         if let Some(node) = new_actor.nodes.as_mut() {
-            replace_merge_node_upstream(node, &applied_upstream_fragment_actor_ids);
+            visit_stream_node(node, |node_body| {
+                if let NodeBody::Merge(s) = node_body {
+                    let upstream_actor_ids = applied_upstream_fragment_actor_ids
+                        .get(&s.upstream_fragment_id)
+                        .cloned()
+                        .unwrap();
+                    actor_upstreams
+                        .try_insert(s.upstream_fragment_id, upstream_actor_ids)
+                        .expect("non-duplicate");
+                }
+            });
         }
 
         // Update downstream actor ids

--- a/src/meta/src/stream/stream_graph/actor.rs
+++ b/src/meta/src/stream/stream_graph/actor.rs
@@ -320,12 +320,6 @@ impl ActorBuilder {
     ) -> MetaResult<StreamActorWithUpstreams> {
         let (rewritten_nodes, actor_upstreams) = self.rewrite()?;
 
-        // TODO: store each upstream separately
-        let upstream_actor_id = self
-            .upstreams
-            .into_values()
-            .flat_map(|ActorUpstream { actors, .. }| actors.as_global_ids())
-            .collect();
         // Only fill the definition when debug assertions enabled, otherwise use name instead.
         #[cfg(not(debug_assertions))]
         let mview_definition = job.name();
@@ -333,12 +327,13 @@ impl ActorBuilder {
         let mview_definition = job.definition();
 
         Ok((
+            #[expect(deprecated)]
             StreamActor {
                 actor_id: self.actor_id.as_global_id(),
                 fragment_id: self.fragment_id.as_global_id(),
                 nodes: Some(rewritten_nodes),
                 dispatcher: self.downstreams.into_values().collect(),
-                upstream_actor_id,
+                upstream_actor_id: vec![],
                 vnode_bitmap: self.vnode_bitmap.map(|b| b.to_protobuf()),
                 mview_definition,
                 expr_context: Some(expr_context),

--- a/src/meta/src/stream/stream_graph/actor.rs
+++ b/src/meta/src/stream/stream_graph/actor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -37,7 +37,9 @@ use super::id::GlobalFragmentIdsExt;
 use super::Locations;
 use crate::controller::cluster::StreamingClusterInfo;
 use crate::manager::{MetaSrvEnv, StreamingJob};
-use crate::model::{DispatcherId, FragmentId};
+use crate::model::{
+    ActorUpstreams, DispatcherId, FragmentActorUpstreams, FragmentId, StreamActorWithUpstreams,
+};
 use crate::stream::stream_graph::fragment::{
     CompleteStreamFragmentGraph, EdgeId, EitherFragment, StreamFragmentEdge,
 };
@@ -126,11 +128,18 @@ impl ActorBuilder {
     /// 1. Replace the logical `Exchange` in node's input with `Merge`, which can be executed on the
     ///    compute nodes.
     /// 2. Fill the upstream mview info of the `Merge` node under the other "leaf" nodes.
-    fn rewrite(&self) -> MetaResult<StreamNode> {
-        self.rewrite_inner(&self.nodes, 0)
+    fn rewrite(&self) -> MetaResult<(StreamNode, ActorUpstreams)> {
+        let mut actor_upstreams = ActorUpstreams::new();
+        let node = self.rewrite_inner(&self.nodes, &mut actor_upstreams, 0)?;
+        Ok((node, actor_upstreams))
     }
 
-    fn rewrite_inner(&self, stream_node: &StreamNode, depth: usize) -> MetaResult<StreamNode> {
+    fn rewrite_inner(
+        &self,
+        stream_node: &StreamNode,
+        actor_upstreams: &mut ActorUpstreams,
+        depth: usize,
+    ) -> MetaResult<StreamNode> {
         match stream_node.get_node_body()? {
             // Leaf node `Exchange`.
             NodeBody::Exchange(exchange) => {
@@ -150,12 +159,23 @@ impl ActorBuilder {
                     link_id: stream_node.get_operator_id(),
                 }];
 
+                let upstream_fragment_id = upstreams.fragment_id.as_global_id();
+                actor_upstreams
+                    .try_insert(
+                        upstream_fragment_id,
+                        HashSet::from_iter(upstreams.actors.as_global_ids()),
+                    )
+                    .expect("non-duplicate");
+
                 Ok(StreamNode {
-                    node_body: Some(NodeBody::Merge(Box::new(MergeNode {
-                        upstream_actor_id: upstreams.actors.as_global_ids(),
-                        upstream_fragment_id: upstreams.fragment_id.as_global_id(),
-                        upstream_dispatcher_type: exchange.get_strategy()?.r#type,
-                        fields: stream_node.get_fields().clone(),
+                    node_body: Some(NodeBody::Merge(Box::new({
+                        #[expect(deprecated)]
+                        MergeNode {
+                            upstream_actor_id: vec![],
+                            upstream_fragment_id,
+                            upstream_dispatcher_type: exchange.get_strategy()?.r#type,
+                            fields: stream_node.get_fields().clone(),
+                        }
                     }))),
                     identity: "MergeExecutor".to_owned(),
                     ..stream_node.clone()
@@ -194,14 +214,22 @@ impl ActorBuilder {
                     DispatcherType::NoShuffle as _
                 };
 
+                let upstream_fragment_id = upstreams.fragment_id.as_global_id();
+                actor_upstreams
+                    .try_insert(upstream_fragment_id, HashSet::from_iter(upstream_actor_id))
+                    .expect("non-duplicate");
+
                 let input = vec![
                     // Fill the merge node body with correct upstream info.
                     StreamNode {
-                        node_body: Some(NodeBody::Merge(Box::new(MergeNode {
-                            upstream_actor_id,
-                            upstream_fragment_id: upstreams.fragment_id.as_global_id(),
-                            upstream_dispatcher_type,
-                            fields: merge_node.fields.clone(),
+                        node_body: Some(NodeBody::Merge(Box::new({
+                            #[expect(deprecated)]
+                            MergeNode {
+                                upstream_actor_id: vec![],
+                                upstream_fragment_id,
+                                upstream_dispatcher_type,
+                                fields: merge_node.fields.clone(),
+                            }
                         }))),
                         ..merge_node.clone()
                     },
@@ -242,15 +270,23 @@ impl ActorBuilder {
                 // So they both should have only one upstream actor.
                 assert_eq!(upstream_actor_id.len(), 1);
 
+                let upstream_fragment_id = upstreams.fragment_id.as_global_id();
+                actor_upstreams
+                    .try_insert(upstream_fragment_id, HashSet::from_iter(upstream_actor_id))
+                    .expect("non-duplicate");
+
                 // rewrite the input
                 let input = vec![
                     // Fill the merge node body with correct upstream info.
                     StreamNode {
-                        node_body: Some(NodeBody::Merge(Box::new(MergeNode {
-                            upstream_actor_id,
-                            upstream_fragment_id: upstreams.fragment_id.as_global_id(),
-                            upstream_dispatcher_type: DispatcherType::NoShuffle as _,
-                            fields: merge_node.fields.clone(),
+                        node_body: Some(NodeBody::Merge(Box::new({
+                            #[expect(deprecated)]
+                            MergeNode {
+                                upstream_actor_id: vec![],
+                                upstream_fragment_id,
+                                upstream_dispatcher_type: DispatcherType::NoShuffle as _,
+                                fields: merge_node.fields.clone(),
+                            }
                         }))),
                         ..merge_node.clone()
                     },
@@ -269,7 +305,7 @@ impl ActorBuilder {
                     .iter()
                     .zip_eq_fast(&mut new_stream_node.input)
                 {
-                    *new_input = self.rewrite_inner(input, depth + 1)?;
+                    *new_input = self.rewrite_inner(input, actor_upstreams, depth + 1)?;
                 }
                 Ok(new_stream_node)
             }
@@ -277,8 +313,12 @@ impl ActorBuilder {
     }
 
     /// Build an actor after all the upstreams and downstreams are processed.
-    fn build(self, job: &StreamingJob, expr_context: ExprContext) -> MetaResult<StreamActor> {
-        let rewritten_nodes = self.rewrite()?;
+    fn build(
+        self,
+        job: &StreamingJob,
+        expr_context: ExprContext,
+    ) -> MetaResult<StreamActorWithUpstreams> {
+        let (rewritten_nodes, actor_upstreams) = self.rewrite()?;
 
         // TODO: store each upstream separately
         let upstream_actor_id = self
@@ -292,16 +332,19 @@ impl ActorBuilder {
         #[cfg(debug_assertions)]
         let mview_definition = job.definition();
 
-        Ok(StreamActor {
-            actor_id: self.actor_id.as_global_id(),
-            fragment_id: self.fragment_id.as_global_id(),
-            nodes: Some(rewritten_nodes),
-            dispatcher: self.downstreams.into_values().collect(),
-            upstream_actor_id,
-            vnode_bitmap: self.vnode_bitmap.map(|b| b.to_protobuf()),
-            mview_definition,
-            expr_context: Some(expr_context),
-        })
+        Ok((
+            StreamActor {
+                actor_id: self.actor_id.as_global_id(),
+                fragment_id: self.fragment_id.as_global_id(),
+                nodes: Some(rewritten_nodes),
+                dispatcher: self.downstreams.into_values().collect(),
+                upstream_actor_id,
+                vnode_bitmap: self.vnode_bitmap.map(|b| b.to_protobuf()),
+                mview_definition,
+                expr_context: Some(expr_context),
+            },
+            actor_upstreams,
+        ))
     }
 }
 
@@ -628,6 +671,7 @@ impl ActorGraphBuildState {
 pub struct ActorGraphBuildResult {
     /// The graph of sealed fragments, including all actors.
     pub graph: BTreeMap<FragmentId, Fragment>,
+    pub actor_upstreams: BTreeMap<FragmentId, FragmentActorUpstreams>,
 
     /// The scheduled locations of the actors to be built.
     pub building_locations: Locations,
@@ -781,28 +825,37 @@ impl ActorGraphBuilder {
         }
 
         // Serialize the graph into a map of sealed fragments.
-        let graph = {
+        let (graph, actor_upstreams) = {
             let mut actors: HashMap<GlobalFragmentId, Vec<StreamActor>> = HashMap::new();
+            let mut fragment_actor_upstreams: BTreeMap<_, FragmentActorUpstreams> = BTreeMap::new();
 
             // As all fragments are processed, we can now `build` the actors where the `Exchange`
             // and `Chain` are rewritten.
             for builder in actor_builders.into_values() {
                 let fragment_id = builder.fragment_id();
-                let actor = builder.build(job, expr_context.clone())?;
+                let (actor, actor_upstreams) = builder.build(job, expr_context.clone())?;
+                fragment_actor_upstreams
+                    .entry(fragment_id.as_global_id())
+                    .or_default()
+                    .try_insert(actor.actor_id, actor_upstreams)
+                    .expect("non-duplicate");
                 actors.entry(fragment_id).or_default().push(actor);
             }
 
-            actors
-                .into_iter()
-                .map(|(fragment_id, actors)| {
-                    let distribution = self.distributions[&fragment_id].clone();
-                    let fragment =
-                        self.fragment_graph
-                            .seal_fragment(fragment_id, actors, distribution);
-                    let fragment_id = fragment_id.as_global_id();
-                    (fragment_id, fragment)
-                })
-                .collect()
+            (
+                actors
+                    .into_iter()
+                    .map(|(fragment_id, actors)| {
+                        let distribution = self.distributions[&fragment_id].clone();
+                        let fragment =
+                            self.fragment_graph
+                                .seal_fragment(fragment_id, actors, distribution);
+                        let fragment_id = fragment_id.as_global_id();
+                        (fragment_id, fragment)
+                    })
+                    .collect(),
+                fragment_actor_upstreams,
+            )
         };
 
         // Convert the actor location map to the `Locations` struct.
@@ -847,6 +900,7 @@ impl ActorGraphBuilder {
 
         Ok(ActorGraphBuildResult {
             graph,
+            actor_upstreams,
             building_locations,
             existing_locations,
             dispatchers,

--- a/src/meta/src/stream/stream_graph/actor.rs
+++ b/src/meta/src/stream/stream_graph/actor.rs
@@ -127,7 +127,7 @@ impl ActorBuilder {
     /// During this process, the following things will be done:
     /// 1. Replace the logical `Exchange` in node's input with `Merge`, which can be executed on the
     ///    compute nodes.
-    /// 2. Fill the upstream mview info of the `Merge` node under the other "leaf" nodes.
+    /// 2. Collect the upstream actor ids of each actor for the `Merge` node to create upstream connection.
     fn rewrite(&self) -> MetaResult<(StreamNode, ActorUpstreams)> {
         let mut actor_upstreams = ActorUpstreams::new();
         let node = self.rewrite_inner(&self.nodes, &mut actor_upstreams, 0)?;

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -471,8 +471,11 @@ async fn test_graph_builder() -> MetaResult<()> {
         make_cluster_info(),
         NonZeroUsize::new(parallel_degree).unwrap(),
     )?;
-    let ActorGraphBuildResult { graph, .. } =
-        actor_graph_builder.generate_graph(&env, &job, expr_context)?;
+    let ActorGraphBuildResult {
+        graph,
+        actor_upstreams,
+        ..
+    } = actor_graph_builder.generate_graph(&env, &job, expr_context)?;
 
     let stream_job_fragments = StreamJobFragments::for_test(TableId::default(), graph);
     let actors = stream_job_fragments.actors();
@@ -534,8 +537,13 @@ async fn test_graph_builder() -> MetaResult<()> {
                         .unwrap()
                         .iter()
                         .collect::<HashSet<_>>(),
-                    merge_node
-                        .get_upstream_actor_id()
+                    actor_upstreams
+                        .get(&actor.fragment_id)
+                        .unwrap()
+                        .get(&actor.actor_id)
+                        .unwrap()
+                        .get(&merge_node.upstream_fragment_id)
+                        .unwrap()
                         .iter()
                         .collect::<HashSet<_>>(),
                 );

--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -32,6 +32,7 @@ use risingwave_expr::expr_context::{expr_context_scope, FRAGMENT_ID, VNODE_COUNT
 use risingwave_expr::ExprError;
 use risingwave_pb::plan_common::ExprContext;
 use risingwave_pb::stream_plan::PbStreamActor;
+use risingwave_pb::stream_service::inject_barrier_request::build_actor_info::UpstreamActors;
 use risingwave_rpc_client::MetaClient;
 use thiserror_ext::AsReport;
 use tokio_stream::StreamExt;
@@ -41,7 +42,7 @@ use super::monitor::StreamingMetrics;
 use super::subtask::SubtaskHandle;
 use super::StreamConsumer;
 use crate::error::StreamResult;
-use crate::task::{ActorId, LocalBarrierManager};
+use crate::task::{ActorId, FragmentId, LocalBarrierManager};
 
 /// Shared by all operators of an actor.
 pub struct ActorContext {
@@ -61,6 +62,7 @@ pub struct ActorContext {
     pub initial_dispatch_num: usize,
     // mv_table_id to subscription id
     pub related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
+    pub initial_upstream_actors: HashMap<FragmentId, UpstreamActors>,
 
     // Meta client. currently used for auto schema change. `None` for test only
     pub meta_client: Option<MetaClient>,
@@ -84,17 +86,20 @@ impl ActorContext {
             // Set 1 for test to enable sanity check on table
             initial_dispatch_num: 1,
             related_subscriptions: HashMap::new().into(),
+            initial_upstream_actors: Default::default(),
             meta_client: None,
             streaming_config: Arc::new(StreamingConfig::default()),
         })
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub fn create(
         stream_actor: &PbStreamActor,
         total_mem_val: Arc<TrAdder<i64>>,
         streaming_metrics: Arc<StreamingMetrics>,
         initial_dispatch_num: usize,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
+        initial_upstream_actors: HashMap<FragmentId, UpstreamActors>,
         meta_client: Option<MetaClient>,
         streaming_config: Arc<StreamingConfig>,
     ) -> ActorContextRef {
@@ -112,6 +117,7 @@ impl ActorContext {
             streaming_metrics,
             initial_dispatch_num,
             related_subscriptions,
+            initial_upstream_actors,
             meta_client,
             streaming_config,
         })

--- a/src/stream/src/from_proto/merge.rs
+++ b/src/stream/src/from_proto/merge.rs
@@ -33,11 +33,14 @@ impl MergeExecutorBuilder {
         node: &MergeNode,
         chunk_size: usize,
     ) -> StreamResult<MergeExecutorInput> {
-        let upstreams = node.get_upstream_actor_id();
         let upstream_fragment_id = node.get_upstream_fragment_id();
 
-        let inputs: Vec<_> = upstreams
-            .iter()
+        let inputs: Vec<_> = actor_context
+            .initial_upstream_actors
+            .get(&node.upstream_fragment_id)
+            .map(|actors| actors.actors.iter())
+            .into_iter()
+            .flatten()
             .map(|&upstream_actor_id| {
                 new_input(
                     &shared_context,

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -762,7 +762,7 @@ impl DatabaseManagedBarrierState {
         let subscriptions =
             LazyCell::new(|| Arc::new(graph_state.mv_depended_subscriptions.clone()));
         for actor in request.actors_to_build {
-            let upstream = actor.upstreams;
+            let upstream = actor.fragment_upstreams;
             let actor = actor.actor.unwrap();
             let actor_id = actor.actor_id;
             assert!(!is_stop_actor(actor_id));

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -762,6 +762,8 @@ impl DatabaseManagedBarrierState {
         let subscriptions =
             LazyCell::new(|| Arc::new(graph_state.mv_depended_subscriptions.clone()));
         for actor in request.actors_to_build {
+            let upstream = actor.upstreams;
+            let actor = actor.actor.unwrap();
             let actor_id = actor.actor_id;
             assert!(!is_stop_actor(actor_id));
             assert!(new_actors.insert(actor_id));
@@ -769,6 +771,7 @@ impl DatabaseManagedBarrierState {
             let (join_handle, monitor_join_handle) = self.actor_manager.spawn_actor(
                 actor,
                 (*subscriptions).clone(),
+                upstream,
                 self.current_shared_context.clone(),
                 self.local_barrier_manager.clone(),
             );

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -34,6 +34,7 @@ use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{StreamActor, StreamNode, StreamScanNode, StreamScanType};
+use risingwave_pb::stream_service::inject_barrier_request::build_actor_info::UpstreamActors;
 use risingwave_pb::stream_service::streaming_control_stream_request::InitRequest;
 use risingwave_pb::stream_service::{
     StreamingControlStreamRequest, StreamingControlStreamResponse,
@@ -603,6 +604,7 @@ impl StreamActorManager {
         actor: StreamActor,
         shared_context: Arc<SharedContext>,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
+        upstreams: HashMap<FragmentId, UpstreamActors>,
         local_barrier_manager: LocalBarrierManager,
     ) -> StreamResult<Actor<DispatchExecutor>> {
         {
@@ -614,6 +616,7 @@ impl StreamActorManager {
                 self.streaming_metrics.clone(),
                 actor.dispatcher.len(),
                 related_subscriptions,
+                upstreams,
                 self.env.meta_client().clone(),
                 streaming_config,
             );
@@ -658,6 +661,7 @@ impl StreamActorManager {
         self: &Arc<Self>,
         actor: StreamActor,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
+        upstreams: HashMap<FragmentId, UpstreamActors>,
         current_shared_context: Arc<SharedContext>,
         local_barrier_manager: LocalBarrierManager,
     ) -> (JoinHandle<()>, Option<JoinHandle<()>>) {
@@ -670,7 +674,7 @@ impl StreamActorManager {
                     format!("Actor {actor_id}: `{}`", stream_actor_ref.mview_definition);
                 let barrier_manager = local_barrier_manager.clone();
                 // wrap the future of `create_actor` with `boxed` to avoid stack overflow
-                let actor = self.clone().create_actor(actor, current_shared_context, related_subscriptions, barrier_manager.clone()).boxed().and_then(|actor| actor.run()).map(move |result| {
+                let actor = self.clone().create_actor(actor, current_shared_context, related_subscriptions, upstreams, barrier_manager.clone()).boxed().and_then(|actor| actor.run()).map(move |result| {
                     if let Err(err) = result {
                         // TODO: check error type and panic if it's unexpected.
                         // Intentionally use `?` on the report to also include the backtrace.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously we store the upstream actors information of each actor in the `upstream_actor_id` of `NodeBody::Merge`  of `StreamNode` of each `StreamActor`. This is the only difference of `StreamNode` for each actor in a same fragment. In this PR, we will change to store the upstream actor information in a separate field besides `StreamActor`.

We define type alias
```
pub type ActorUpstreams = BTreeMap<FragmentId, HashSet<ActorId>>;
pub type StreamActorWithUpstreams = (StreamActor, ActorUpstreams);
```

In code of meta node, most appearance of `StreamActor` will be replaced with `StreamActorWithUpstreams`, so that the upstreams information can be carried together with usage to original `StreamActor`. The field `upstream_actor_id` of `MergeNode` and `StreamActor` is marked deprecated in the proto definition, so that we can review all the original on the fields, to ensure the refactor logic is correct.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
