### PR TITLE
fix(storage): Decoupling `WriteStop` and `Emergency` of compaction strategy

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -661,6 +661,10 @@ message RiseCtlUpdateCompactionConfigRequest {
       uint32 split_weight_by_vnode = 20;
       bool disable_auto_group_scheduling = 21;
       uint64 max_overlapping_level_size = 22;
+      // The emergency compaction limitations for the level0 sstables file count
+      uint32 emergency_level0_sst_file_count = 25;
+      // The emergency compaction limitations for the level0 sub level partition
+      uint32 emergency_level0_sub_level_partition = 26;
     }
   }
   repeated uint64 compaction_group_ids = 1;
@@ -863,6 +867,12 @@ message CompactionConfig {
   // The limitation of the max size of the overlapping-level for the compaction
   // hummock will reorg the commit-sstables to the multi overlapping-level if the size of the commit-sstables is larger than `max_overlapping_level_size`
   optional uint64 max_overlapping_level_size = 24;
+
+  // The emergency compaction limitations for the level0 sstables file count
+  optional uint32 emergency_level0_sst_file_count = 25;
+
+  // The emergency compaction limitations for the level0 sub level partition
+  optional uint32 emergency_level0_sub_level_partition = 26;
 }
 
 message TableStats {

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -2215,6 +2215,8 @@ pub mod default {
         const DEFAULT_MAX_LEVEL: u32 = 6;
         const DEFAULT_MAX_L0_COMPACT_LEVEL_COUNT: u32 = 42;
         const DEFAULT_SST_ALLOWED_TRIVIAL_MOVE_MIN_SIZE: u64 = 4 * MB;
+        const DEFAULT_EMERGENCY_LEVEL0_SST_FILE_COUNT: u32 = 2000; // > 50G / 32M = 1600
+        const DEFAULT_EMERGENCY_LEVEL0_SUB_LEVEL_PARTITION: u32 = 256;
 
         use crate::catalog::hummock::CompactionFilterFlag;
 
@@ -2296,6 +2298,14 @@ pub mod default {
 
         pub fn max_overlapping_level_size() -> u64 {
             256 * MB
+        }
+
+        pub fn emergency_level0_sst_file_count() -> u32 {
+            DEFAULT_EMERGENCY_LEVEL0_SST_FILE_COUNT
+        }
+
+        pub fn emergency_level0_sub_level_partition() -> u32 {
+            DEFAULT_EMERGENCY_LEVEL0_SUB_LEVEL_PARTITION
         }
     }
 

--- a/src/ctl/src/cmd_impl/hummock/compaction_group.rs
+++ b/src/ctl/src/cmd_impl/hummock/compaction_group.rs
@@ -69,6 +69,8 @@ pub fn build_compaction_config_vec(
     sst_allowed_trivial_move_min_size: Option<u64>,
     disable_auto_group_scheduling: Option<bool>,
     max_overlapping_level_size: Option<u64>,
+    emergency_level0_sst_file_count: Option<u32>,
+    emergency_level0_sub_level_partition: Option<u32>,
 ) -> Vec<MutableConfig> {
     let mut configs = vec![];
     if let Some(c) = max_bytes_for_level_base {
@@ -130,6 +132,12 @@ pub fn build_compaction_config_vec(
     }
     if let Some(c) = max_overlapping_level_size {
         configs.push(MutableConfig::MaxOverlappingLevelSize(c))
+    }
+    if let Some(c) = emergency_level0_sst_file_count {
+        configs.push(MutableConfig::EmergencyLevel0SstFileCount(c))
+    }
+    if let Some(c) = emergency_level0_sub_level_partition {
+        configs.push(MutableConfig::EmergencyLevel0SubLevelPartition(c))
     }
 
     configs

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -196,6 +196,10 @@ enum HummockCommands {
         disable_auto_group_scheduling: Option<bool>,
         #[clap(long)]
         max_overlapping_level_size: Option<u64>,
+        #[clap(long)]
+        emergency_level0_sst_file_count: Option<u32>,
+        #[clap(long)]
+        emergency_level0_sub_level_partition: Option<u32>,
     },
     /// Split given compaction group into two. Moves the given tables to the new group.
     SplitCompactionGroup {
@@ -605,6 +609,8 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             sst_allowed_trivial_move_min_size,
             disable_auto_group_scheduling,
             max_overlapping_level_size,
+            emergency_level0_sst_file_count,
+            emergency_level0_sub_level_partition,
         }) => {
             cmd_impl::hummock::update_compaction_config(
                 context,
@@ -638,6 +644,8 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                     sst_allowed_trivial_move_min_size,
                     disable_auto_group_scheduling,
                     max_overlapping_level_size,
+                    emergency_level0_sst_file_count,
+                    emergency_level0_sub_level_partition,
                 ),
             )
             .await?

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -72,6 +72,12 @@ impl CompactionConfigBuilder {
                     compaction_config::disable_auto_group_scheduling(),
                 ),
                 max_overlapping_level_size: Some(compaction_config::max_overlapping_level_size()),
+                emergency_level0_sst_file_count: Some(
+                    compaction_config::emergency_level0_sst_file_count(),
+                ),
+                emergency_level0_sub_level_partition: Some(
+                    compaction_config::emergency_level0_sub_level_partition(),
+                ),
             },
         }
     }

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -36,7 +36,7 @@ use risingwave_pb::hummock::{CompactionConfig, LevelType};
 pub use selector::{CompactionSelector, CompactionSelectorContext};
 
 use self::selector::{EmergencySelector, LocalSelectorStatistic};
-use super::check_cg_write_limit;
+use super::{check_emergency_state, EmergencyState};
 use crate::hummock::compaction::overlap_strategy::{OverlapStrategy, RangeOverlapStrategy};
 use crate::hummock::compaction::picker::CompactionInput;
 use crate::hummock::level_handler::LevelHandler;
@@ -124,7 +124,8 @@ impl CompactStatus {
             return Some(task);
         } else {
             let compaction_group_config = &group.compaction_config;
-            if check_cg_write_limit(levels, compaction_group_config.as_ref()).is_write_stop()
+            if let EmergencyState::Emergency =
+                check_emergency_state(levels, compaction_group_config.as_ref())
                 && compaction_group_config.enable_emergency_picker
             {
                 let selector_context = CompactionSelectorContext {

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -605,6 +605,12 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
             MutableConfig::MaxOverlappingLevelSize(c) => {
                 target.max_overlapping_level_size = Some(*c);
             }
+            MutableConfig::EmergencyLevel0SstFileCount(c) => {
+                target.emergency_level0_sst_file_count = Some(*c);
+            }
+            MutableConfig::EmergencyLevel0SubLevelPartition(c) => {
+                target.emergency_level0_sub_level_partition = Some(*c);
+            }
         }
     }
 }

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -39,6 +39,7 @@ use itertools::Itertools;
 use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+use risingwave_common::config::default::compaction_config;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compact_task::{CompactTask, ReportTask};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
@@ -1732,4 +1733,56 @@ fn update_table_stats_for_vnode_watermark_trivial_reclaim(
         stats.total_key_size = (stats.total_key_size as f64 * ratio).ceil() as i64;
         stats.total_value_size = (stats.total_value_size as f64 * ratio).ceil() as i64;
     }
+}
+
+pub enum EmergencyState {
+    /// The compaction group is in emergency state.
+    Emergency,
+    /// The compaction group is not in emergency state.
+    Normal,
+}
+
+fn too_many_l0_file_count(levels: &Levels, compaction_config: &CompactionConfig) -> bool {
+    let l0_file_count = levels
+        .l0
+        .sub_levels
+        .iter()
+        .map(|l| l.table_infos.len())
+        .sum::<usize>();
+    l0_file_count
+        > compaction_config
+            .emergency_level0_sst_file_count
+            .unwrap_or(compaction_config::emergency_level0_sst_file_count()) as usize
+}
+
+fn too_many_l0_partition_count(levels: &Levels, compaction_config: &CompactionConfig) -> bool {
+    levels.l0.sub_levels.first().map_or(false, |l| {
+        l.table_infos.len()
+            > compaction_config
+                .emergency_level0_sub_level_partition
+                .unwrap_or(compaction_config::emergency_level0_sub_level_partition())
+                as usize
+    })
+}
+
+pub fn check_emergency_state(
+    levels: &Levels,
+    compaction_config: &CompactionConfig,
+) -> EmergencyState {
+    // check write_stop
+    if check_cg_write_limit(levels, compaction_config).is_write_stop() {
+        return EmergencyState::Emergency;
+    }
+
+    // check l0 file count
+    if too_many_l0_file_count(levels, compaction_config) {
+        return EmergencyState::Emergency;
+    }
+
+    // check l0 last sub
+    if too_many_l0_partition_count(levels, compaction_config) {
+        return EmergencyState::Emergency;
+    }
+
+    EmergencyState::Normal
 }

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -70,7 +70,7 @@ mod worker;
 
 pub use commit_epoch::{CommitEpochInfo, NewTableFragmentInfo};
 use compaction::*;
-pub use compaction::{check_cg_write_limit, WriteLimitType};
+pub use compaction::{check_cg_write_limit, check_emergency_state, EmergencyState, WriteLimitType};
 pub(crate) use utils::*;
 
 // Update to states are performed as follow:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

As title. This PR decoup `WriteStop` and `Emergency` of compaction strategy. Moreover, more conditions have been introduced to trigger the Emergency state.

- emergency_level0_sst_file_count
- emergency_level0_sub_level_partition

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
