### PR TITLE
feat(compaction): support trivial move multi ssts

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -661,6 +661,7 @@ message RiseCtlUpdateCompactionConfigRequest {
       uint32 split_weight_by_vnode = 20;
       bool disable_auto_group_scheduling = 21;
       uint64 max_overlapping_level_size = 22;
+      uint32 sst_allowed_trivial_move_max_count = 23;
     }
   }
   repeated uint64 compaction_group_ids = 1;
@@ -863,6 +864,9 @@ message CompactionConfig {
   // The limitation of the max size of the overlapping-level for the compaction
   // hummock will reorg the commit-sstables to the multi overlapping-level if the size of the commit-sstables is larger than `max_overlapping_level_size`
   optional uint64 max_overlapping_level_size = 24;
+
+  // The limitation of the max sst count of the trivial move task
+  optional uint32 sst_allowed_trivial_move_max_count = 25;
 }
 
 message TableStats {

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -2215,6 +2215,7 @@ pub mod default {
         const DEFAULT_MAX_LEVEL: u32 = 6;
         const DEFAULT_MAX_L0_COMPACT_LEVEL_COUNT: u32 = 42;
         const DEFAULT_SST_ALLOWED_TRIVIAL_MOVE_MIN_SIZE: u64 = 4 * MB;
+        const DEFAULT_SST_ALLOWED_TRIVIAL_MOVE_MAX_COUNT: u32 = 64;
 
         use crate::catalog::hummock::CompactionFilterFlag;
 
@@ -2296,6 +2297,10 @@ pub mod default {
 
         pub fn max_overlapping_level_size() -> u64 {
             256 * MB
+        }
+
+        pub fn sst_allowed_trivial_move_max_count() -> u32 {
+            DEFAULT_SST_ALLOWED_TRIVIAL_MOVE_MAX_COUNT
         }
     }
 

--- a/src/ctl/src/cmd_impl/hummock/compaction_group.rs
+++ b/src/ctl/src/cmd_impl/hummock/compaction_group.rs
@@ -69,6 +69,7 @@ pub fn build_compaction_config_vec(
     sst_allowed_trivial_move_min_size: Option<u64>,
     disable_auto_group_scheduling: Option<bool>,
     max_overlapping_level_size: Option<u64>,
+    sst_allowed_trivial_move_max_count: Option<u32>,
 ) -> Vec<MutableConfig> {
     let mut configs = vec![];
     if let Some(c) = max_bytes_for_level_base {
@@ -130,6 +131,9 @@ pub fn build_compaction_config_vec(
     }
     if let Some(c) = max_overlapping_level_size {
         configs.push(MutableConfig::MaxOverlappingLevelSize(c))
+    }
+    if let Some(c) = sst_allowed_trivial_move_max_count {
+        configs.push(MutableConfig::SstAllowedTrivialMoveMaxCount(c))
     }
 
     configs

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -196,6 +196,8 @@ enum HummockCommands {
         disable_auto_group_scheduling: Option<bool>,
         #[clap(long)]
         max_overlapping_level_size: Option<u64>,
+        #[clap(long)]
+        sst_allowed_trivial_move_max_count: Option<u32>,
     },
     /// Split given compaction group into two. Moves the given tables to the new group.
     SplitCompactionGroup {
@@ -605,6 +607,7 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             sst_allowed_trivial_move_min_size,
             disable_auto_group_scheduling,
             max_overlapping_level_size,
+            sst_allowed_trivial_move_max_count,
         }) => {
             cmd_impl::hummock::update_compaction_config(
                 context,
@@ -638,6 +641,7 @@ async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                     sst_allowed_trivial_move_min_size,
                     disable_auto_group_scheduling,
                     max_overlapping_level_size,
+                    sst_allowed_trivial_move_max_count,
                 ),
             )
             .await?

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -72,6 +72,9 @@ impl CompactionConfigBuilder {
                     compaction_config::disable_auto_group_scheduling(),
                 ),
                 max_overlapping_level_size: Some(compaction_config::max_overlapping_level_size()),
+                sst_allowed_trivial_move_max_count: Some(
+                    compaction_config::sst_allowed_trivial_move_max_count(),
+                ),
             },
         }
     }

--- a/src/meta/src/hummock/compaction/overlap_strategy.rs
+++ b/src/meta/src/hummock/compaction/overlap_strategy.rs
@@ -26,6 +26,7 @@ pub trait OverlapInfo: Debug {
     fn check_multiple_overlap(&self, others: &[SstableInfo]) -> Range<usize>;
     fn check_multiple_include(&self, others: &[SstableInfo]) -> Range<usize>;
     fn update(&mut self, table: &SstableInfo);
+    fn clear(&mut self);
 }
 
 pub trait OverlapStrategy: Send + Sync {
@@ -133,6 +134,10 @@ impl OverlapInfo for RangeOverlapInfo {
             return;
         }
         self.target_range = Some(other.clone());
+    }
+
+    fn clear(&mut self) {
+        self.target_range = None;
     }
 }
 

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -142,6 +142,10 @@ impl LevelCompactionPicker {
             } else {
                 0
             },
+            self.config
+                .sst_allowed_trivial_move_max_count
+                .unwrap_or(compaction_config::sst_allowed_trivial_move_max_count())
+                as usize,
         );
 
         trivial_move_picker.pick_trivial_move_task(

--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -267,51 +267,52 @@ impl IntraCompactionPicker {
                 continue;
             }
 
-            let trivial_move_picker = TrivialMovePicker::new(0, 0, overlap_strategy.clone(), 0);
+            let trivial_move_picker = TrivialMovePicker::new(
+                0,
+                0,
+                overlap_strategy.clone(),
+                0,
+                self.config
+                    .sst_allowed_trivial_move_max_count
+                    .unwrap_or(compaction_config::sst_allowed_trivial_move_max_count())
+                    as usize,
+            );
 
-            let select_sst = trivial_move_picker.pick_trivial_move_sst(
+            if let Some(select_ssts) = trivial_move_picker.pick_multi_trivial_move_ssts(
                 &l0.sub_levels[idx + 1].table_infos,
                 &level.table_infos,
                 level_handlers,
                 stats,
-            );
+            ) {
+                let mut overlap = overlap_strategy.create_overlap_info();
+                select_ssts.iter().for_each(|ssts| overlap.update(ssts));
 
-            // only pick tables for trivial move
-            if select_sst.is_none() {
-                continue;
+                assert!(overlap
+                    .check_multiple_overlap(&l0.sub_levels[idx].table_infos)
+                    .is_empty());
+
+                let select_input_size = select_ssts.iter().map(|sst| sst.sst_size).sum();
+                let input_levels = vec![
+                    InputLevel {
+                        level_idx: 0,
+                        level_type: LevelType::Nonoverlapping,
+                        table_infos: select_ssts,
+                    },
+                    InputLevel {
+                        level_idx: 0,
+                        level_type: LevelType::Nonoverlapping,
+                        table_infos: vec![],
+                    },
+                ];
+                return Some(CompactionInput {
+                    input_levels,
+                    target_level: 0,
+                    target_sub_level_id: level.sub_level_id,
+                    select_input_size,
+                    total_file_count: 1,
+                    ..Default::default()
+                });
             }
-
-            let select_sst = select_sst.unwrap();
-
-            // support trivial move cross multi sub_levels
-            let mut overlap = overlap_strategy.create_overlap_info();
-            overlap.update(&select_sst);
-
-            assert!(overlap
-                .check_multiple_overlap(&l0.sub_levels[idx].table_infos)
-                .is_empty());
-
-            let select_input_size = select_sst.sst_size;
-            let input_levels = vec![
-                InputLevel {
-                    level_idx: 0,
-                    level_type: LevelType::Nonoverlapping,
-                    table_infos: vec![select_sst],
-                },
-                InputLevel {
-                    level_idx: 0,
-                    level_type: LevelType::Nonoverlapping,
-                    table_infos: vec![],
-                },
-            ];
-            return Some(CompactionInput {
-                input_levels,
-                target_level: 0,
-                target_sub_level_id: level.sub_level_id,
-                select_input_size,
-                total_file_count: 1,
-                ..Default::default()
-            });
         }
         None
     }

--- a/src/meta/src/hummock/compaction/picker/trivial_move_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/trivial_move_compaction_picker.rs
@@ -29,6 +29,8 @@ pub struct TrivialMovePicker {
 
     // The minimum size of sst that can be selected as trivial move.
     sst_allowed_trivial_move_min_size: u64,
+
+    sst_allowed_trivial_move_max_count: usize,
 }
 
 impl TrivialMovePicker {
@@ -37,25 +39,39 @@ impl TrivialMovePicker {
         target_level: usize,
         overlap_strategy: Arc<dyn OverlapStrategy>,
         sst_allowed_trivial_move_min_size: u64,
+        sst_allowed_trivial_move_max_count: usize,
     ) -> Self {
         Self {
             level,
             target_level,
             overlap_strategy,
             sst_allowed_trivial_move_min_size,
+            sst_allowed_trivial_move_max_count,
         }
     }
 
-    pub fn pick_trivial_move_sst(
+    pub fn pick_multi_trivial_move_ssts(
         &self,
         select_tables: &[SstableInfo],
         target_tables: &[SstableInfo],
         level_handlers: &[LevelHandler],
         stats: &mut LocalPickerStatistic,
-    ) -> Option<SstableInfo> {
+    ) -> Option<Vec<SstableInfo>> {
         let mut skip_by_pending = false;
+
+        // means we have already found some sst but not match `sst_allowed_trivial_move_max_count`.
+        let mut skip_by_size = false;
+        let mut result = vec![];
+
+        let mut overlap_info = self.overlap_strategy.create_overlap_info();
         for sst in select_tables {
-            if sst.sst_size < self.sst_allowed_trivial_move_min_size {
+            if result.len() >= self.sst_allowed_trivial_move_max_count {
+                break;
+            }
+
+            // find the first sst that can be trivial moved.
+            if sst.sst_size < self.sst_allowed_trivial_move_min_size && result.is_empty() {
+                skip_by_size = true;
                 continue;
             }
 
@@ -63,17 +79,32 @@ impl TrivialMovePicker {
                 skip_by_pending = true;
                 continue;
             }
-            let mut overlap_info = self.overlap_strategy.create_overlap_info();
             overlap_info.update(sst);
             let overlap_files_range = overlap_info.check_multiple_overlap(target_tables);
 
             if overlap_files_range.is_empty() {
-                return Some(sst.clone());
+                result.push(sst.clone());
+            } else {
+                // stop probing if we have already found some sst to move.
+                if !result.is_empty() {
+                    break;
+                }
+
+                // reset overlap_info
+                overlap_info.clear();
             }
+        }
+
+        if !result.is_empty() {
+            return Some(result);
         }
 
         if skip_by_pending {
             stats.skip_by_pending_files += 1;
+        }
+
+        if skip_by_size {
+            stats.skip_by_count_limit += 1;
         }
 
         None
@@ -86,17 +117,17 @@ impl TrivialMovePicker {
         level_handlers: &[LevelHandler],
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
-        if let Some(trivial_move_sst) =
-            self.pick_trivial_move_sst(select_tables, target_tables, level_handlers, stats)
+        if let Some(trivial_move_ssts) =
+            self.pick_multi_trivial_move_ssts(select_tables, target_tables, level_handlers, stats)
         {
             return Some(CompactionInput {
-                select_input_size: trivial_move_sst.sst_size,
+                select_input_size: trivial_move_ssts.iter().map(|s| s.sst_size).sum(),
                 total_file_count: 1,
                 input_levels: vec![
                     InputLevel {
                         level_idx: self.level as u32,
                         level_type: LevelType::Nonoverlapping,
-                        table_infos: vec![trivial_move_sst],
+                        table_infos: trivial_move_ssts,
                     },
                     InputLevel {
                         level_idx: self.target_level as u32,
@@ -143,8 +174,8 @@ pub mod tests {
         let overlap_strategy = create_overlap_strategy(config.compaction_mode());
         {
             let trivial_move_picker =
-                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 200);
-            let trivial_move_task = trivial_move_picker.pick_trivial_move_task(
+                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 200, 1);
+            let trivial_move_task = trivial_move_picker.pick_multi_trivial_move_ssts(
                 &[sst.clone()],
                 &[],
                 &levels_handler,
@@ -156,9 +187,9 @@ pub mod tests {
 
         {
             let trivial_move_picker =
-                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 50);
+                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 50, 1);
 
-            let trivial_move_task = trivial_move_picker.pick_trivial_move_task(
+            let trivial_move_task = trivial_move_picker.pick_multi_trivial_move_ssts(
                 &[sst.clone()],
                 &[],
                 &levels_handler,
@@ -166,6 +197,90 @@ pub mod tests {
             );
 
             assert!(trivial_move_task.is_some());
+        }
+    }
+
+    #[test]
+    fn test_pick_multi_trivial_move_sst() {
+        let sst1: SstableInfo = SstableInfoInner {
+            sst_id: 1,
+            file_size: 100,
+            sst_size: 100,
+            ..Default::default()
+        }
+        .into();
+        let sst2: SstableInfo = SstableInfoInner {
+            sst_id: 2,
+            file_size: 100,
+            sst_size: 100,
+            ..Default::default()
+        }
+        .into();
+        let sst3: SstableInfo = SstableInfoInner {
+            sst_id: 3,
+            file_size: 100,
+            sst_size: 100,
+            ..Default::default()
+        }
+        .into();
+        let sst4: SstableInfo = SstableInfoInner {
+            sst_id: 4,
+            file_size: 100,
+            sst_size: 100,
+            ..Default::default()
+        }
+        .into();
+
+        let config = Arc::new(
+            CompactionConfigBuilder::new()
+                .level0_tier_compact_file_number(2)
+                .level0_sub_level_compact_level_count(1)
+                .sst_allowed_trivial_move_min_size(Some(50))
+                .build(),
+        );
+        let levels_handler = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let overlap_strategy = create_overlap_strategy(config.compaction_mode());
+        {
+            let trivial_move_picker =
+                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 200, 10);
+            let trivial_move_task = trivial_move_picker.pick_multi_trivial_move_ssts(
+                &[sst1.clone(), sst2.clone(), sst3.clone(), sst4.clone()],
+                &[],
+                &levels_handler,
+                &mut Default::default(),
+            );
+
+            assert!(trivial_move_task.is_none());
+        }
+
+        {
+            let trivial_move_picker =
+                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 50, 10);
+
+            let trivial_move_task = trivial_move_picker.pick_multi_trivial_move_ssts(
+                &[sst1.clone(), sst2.clone(), sst3.clone(), sst4.clone()],
+                &[],
+                &levels_handler,
+                &mut Default::default(),
+            );
+
+            assert!(trivial_move_task.is_some());
+            assert_eq!(trivial_move_task.unwrap().len(), 4);
+        }
+
+        {
+            let trivial_move_picker =
+                super::TrivialMovePicker::new(0, 1, overlap_strategy.clone(), 50, 2);
+
+            let trivial_move_task = trivial_move_picker.pick_multi_trivial_move_ssts(
+                &[sst1.clone(), sst2.clone(), sst3.clone(), sst4.clone()],
+                &[],
+                &levels_handler,
+                &mut Default::default(),
+            );
+
+            assert!(trivial_move_task.is_some());
+            assert_eq!(trivial_move_task.unwrap().len(), 2);
         }
     }
 }

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -605,6 +605,9 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
             MutableConfig::MaxOverlappingLevelSize(c) => {
                 target.max_overlapping_level_size = Some(*c);
             }
+            MutableConfig::SstAllowedTrivialMoveMaxCount(c) => {
+                target.sst_allowed_trivial_move_max_count = Some(*c);
+            }
         }
     }
 }

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -87,7 +87,8 @@ use crate::hummock::manager::transaction::{
 };
 use crate::hummock::manager::versioning::Versioning;
 use crate::hummock::metrics_utils::{
-    build_compact_task_level_type_metrics_label, trigger_local_table_stat, trigger_sst_stat,
+    build_compact_task_level_type_metrics_label, trigger_compact_tasks_stat,
+    trigger_local_table_stat,
 };
 use crate::hummock::model::CompactionGroup;
 use crate::hummock::sequence::next_compaction_task_id;
@@ -147,7 +148,7 @@ fn init_selectors() -> HashMap<compact_task::TaskType, Box<dyn CompactionSelecto
 impl HummockVersionTransaction<'_> {
     fn apply_compact_task(&mut self, compact_task: &CompactTask) {
         let mut version_delta = self.new_delta();
-        let trivial_move = CompactStatus::is_trivial_move_task(compact_task);
+        let trivial_move = compact_task.is_trivial_move_task();
         version_delta.trivial_move = trivial_move;
 
         let group_deltas = &mut version_delta
@@ -797,8 +798,8 @@ impl HummockManager {
                     ..Default::default()
                 };
 
-                let is_trivial_reclaim = CompactStatus::is_trivial_reclaim(&compact_task);
-                let is_trivial_move = CompactStatus::is_trivial_move_task(&compact_task);
+                let is_trivial_reclaim = compact_task.is_trivial_reclaim();
+                let is_trivial_move = compact_task.is_trivial_move_task();
                 if is_trivial_reclaim || (is_trivial_move && can_trivial_move) {
                     let log_label = if is_trivial_reclaim {
                         "TrivialReclaim"
@@ -1044,10 +1045,7 @@ impl HummockManager {
             .await?;
         tasks.retain(|task| {
             if task.task_status == TaskStatus::Success {
-                debug_assert!(
-                    CompactStatus::is_trivial_reclaim(task)
-                        || CompactStatus::is_trivial_move_task(task)
-                );
+                debug_assert!(task.is_trivial_reclaim() || task.is_trivial_move_task());
                 false
             } else {
                 true
@@ -1072,10 +1070,7 @@ impl HummockManager {
             if task.task_status != TaskStatus::Success {
                 return Ok(Some(task));
             }
-            debug_assert!(
-                CompactStatus::is_trivial_reclaim(&task)
-                    || CompactStatus::is_trivial_move_task(&task)
-            );
+            debug_assert!(task.is_trivial_reclaim() || task.is_trivial_move_task());
         }
         Ok(None)
     }
@@ -1281,38 +1276,15 @@ impl HummockManager {
                 compact_task_assignment
             )?;
         }
-        let mut success_groups = vec![];
-        for compact_task in tasks {
-            let task_status = compact_task.task_status;
-            let task_status_label = task_status.as_str_name();
-            let task_type_label = compact_task.task_type.as_str_name();
 
+        let mut success_groups = vec![];
+        for compact_task in &tasks {
             self.compactor_manager
                 .remove_task_heartbeat(compact_task.task_id);
-
-            self.metrics
-                .compact_frequency
-                .with_label_values(&[
-                    "normal",
-                    &compact_task.compaction_group_id.to_string(),
-                    task_type_label,
-                    task_status_label,
-                ])
-                .inc();
-
             tracing::trace!(
                 "Reported compaction task. {}. cost time: {:?}",
-                compact_task_to_string(&compact_task),
+                compact_task_to_string(compact_task),
                 start_time.elapsed(),
-            );
-
-            trigger_sst_stat(
-                &self.metrics,
-                compaction
-                    .compaction_statuses
-                    .get(&compact_task.compaction_group_id),
-                &versioning_guard.current_version,
-                compact_task.compaction_group_id,
             );
 
             if !deterministic_mode
@@ -1326,10 +1298,17 @@ impl HummockManager {
                 );
             }
 
-            if task_status == TaskStatus::Success {
+            if compact_task.task_status == TaskStatus::Success {
                 success_groups.push(compact_task.compaction_group_id);
             }
         }
+
+        trigger_compact_tasks_stat(
+            &self.metrics,
+            &tasks,
+            &compaction.compaction_statuses,
+            &versioning_guard.current_version,
+        );
         drop(versioning_guard);
         if !success_groups.is_empty() {
             self.try_update_write_limits(&success_groups).await;

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -20,6 +20,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use itertools::{enumerate, Itertools};
 use prometheus::core::{AtomicU64, GenericCounter};
 use prometheus::IntGauge;
+use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::object_size_map;
 use risingwave_hummock_sdk::level::Levels;
 use risingwave_hummock_sdk::table_stats::PbTableStatsMap;
@@ -666,4 +667,50 @@ pub fn remove_compact_task_metrics(
             }
         }
     }
+}
+
+pub fn trigger_compact_tasks_stat(
+    metrics: &MetaMetrics,
+    compact_tasks: &[CompactTask],
+    compact_status: &BTreeMap<CompactionGroupId, CompactStatus>,
+    current_version: &HummockVersion,
+) {
+    let mut task_status_label_map = HashMap::new();
+    let mut task_type_label_map = HashMap::new();
+    let mut group_label_map = HashMap::new();
+
+    for task in compact_tasks {
+        let task_status_label = task_status_label_map
+            .entry(task.task_status)
+            .or_insert_with(|| task.task_status.as_str_name().to_owned());
+
+        let task_type_label = task_type_label_map
+            .entry(task.task_type)
+            .or_insert_with(|| task.task_type.as_str_name().to_owned());
+
+        let group_label = group_label_map
+            .entry(task.compaction_group_id)
+            .or_insert_with(|| task.compaction_group_id.to_string());
+
+        metrics
+            .compact_frequency
+            .with_label_values(&["normal", group_label, task_type_label, task_status_label])
+            .inc();
+
+        if task.is_trivial_move_task() {
+            metrics
+                .compact_task_trivial_move_sst_count
+                .with_label_values(&[group_label])
+                .observe(task.input_ssts[0].table_infos.len() as _);
+        }
+    }
+
+    group_label_map.keys().for_each(|group_id| {
+        trigger_sst_stat(
+            metrics,
+            compact_status.get(group_id),
+            current_version,
+            *group_id,
+        );
+    });
 }

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -169,6 +169,7 @@ pub struct MetaMetrics {
     pub split_compaction_group_count: IntCounterVec,
     pub state_table_count: IntGaugeVec,
     pub branched_sst_count: IntGaugeVec,
+    pub compact_task_trivial_move_sst_count: HistogramVec,
 
     pub compaction_event_consumed_latency: Histogram,
     pub compaction_event_loop_iteration_latency: Histogram,
@@ -772,6 +773,14 @@ impl MetaMetrics {
         )
         .unwrap();
 
+        let opts = histogram_opts!(
+            "storage_compact_task_trivial_move_sst_count",
+            "sst count of compact trivial-move task",
+            exponential_buckets(1.0, 2.0, 8).unwrap()
+        );
+        let compact_task_trivial_move_sst_count =
+            register_histogram_vec_with_registry!(opts, &["group"], registry).unwrap();
+
         Self {
             grpc_latency,
             barrier_latency,
@@ -834,6 +843,7 @@ impl MetaMetrics {
             compact_task_size,
             compact_task_file_count,
             compact_task_batch_count,
+            compact_task_trivial_move_sst_count,
             table_write_throughput,
             split_compaction_group_count,
             state_table_count,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR improves the trival-move picker algorithm to support trivial-move tasks with multiple ssts.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
