### PR TITLE
fix(playground): listen to `127.0.0.1` instead of `0.0.0.0` for gRPC services

### DIFF
--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -122,7 +122,7 @@ impl Component {
             Self::Frontend => frontend(parse_opts(matches)),
             Self::Compactor => compactor(parse_opts(matches)),
             Self::Ctl => ctl(parse_opts(matches)),
-            Self::Playground => single_node(SingleNodeOpts::new_for_playground()),
+            Self::Playground => playground(),
             Self::Standalone => standalone(parse_opts(matches)),
             Self::SingleNode => single_node(parse_opts(matches)),
         }
@@ -246,6 +246,10 @@ fn single_node(opts: SingleNodeOpts) -> ! {
         .with_thread_name(true);
     risingwave_rt::init_risingwave_logger(settings);
     risingwave_rt::main_okk(|shutdown| risingwave_cmd_all::standalone(opts, shutdown));
+}
+
+fn playground() -> ! {
+    single_node(SingleNodeOpts::new_for_playground());
 }
 
 #[cfg(test)]

--- a/src/cmd_all/src/single_node.rs
+++ b/src/cmd_all/src/single_node.rs
@@ -194,14 +194,11 @@ pub fn map_single_node_opts_to_standalone_opts(opts: SingleNodeOpts) -> ParsedSt
     }
 
     // Set listen addresses (force to override)
-    meta_opts.listen_addr = "0.0.0.0:5690".to_owned();
+    meta_opts.listen_addr = "127.0.0.1:5690".to_owned();
     meta_opts.advertise_addr = "127.0.0.1:5690".to_owned();
     meta_opts.dashboard_host = Some("0.0.0.0:5691".to_owned());
-    compute_opts.listen_addr = "0.0.0.0:5688".to_owned();
-    compactor_opts.listen_addr = "0.0.0.0:6660".to_owned();
-    if let Some(frontend_addr) = &opts.node_opts.listen_addr {
-        frontend_opts.listen_addr.clone_from(frontend_addr);
-    }
+    compute_opts.listen_addr = "127.0.0.1:5688".to_owned();
+    compactor_opts.listen_addr = "127.0.0.1:6660".to_owned();
 
     // Set Meta addresses for all nodes (force to override)
     let meta_addr = "http://127.0.0.1:5690".to_owned();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`risedev d` listens on `127.0.0.1` while playground (single-node) listens on `0.0.0.0`. As a result, when there's a `risedev d` running in the background, starting `risedev p` can be confusing:

- meta node of `p` listens on `0.0.0.0`, which does not conflict with `risedev d` and starts successfully
- then, compute node and frontend may connect to the meta node of `d`
- no error will occur as long as the wire protocol is compatible between the build of `d` and `p`, but the behavior can be quite weird

This PR changes the gRPC listen addresses of playground (single-node) to `127.0.0.1` as well to prevent this from happening. Please note that we continue to have the frontend pgwire service and the meta dashboard service listening on `0.0.0.0` to allow for remote connections.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
