### PR TITLE
feat(iceberg): support iceberg engine connection

### DIFF
--- a/e2e_test/iceberg/test_case/iceberg_engine.slt
+++ b/e2e_test/iceberg/test_case/iceberg_engine.slt
@@ -113,3 +113,46 @@ select count(_row_id) from t_without_pk;
 
 statement ok
 DROP TABLE t_without_pk
+
+# test iceberg connection in iceberg engine
+statement ok
+create secret my_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+statement ok
+create connection my_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg_connection',
+    s3.access.key = secret my_secret,
+    s3.secret.key = secret my_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2',
+);
+
+statement ok
+set iceberg_engine_connection = 'public.my_conn';
+
+statement ok
+create table t1(i int) with(commit_checkpoint_interval = 1) engine = iceberg;
+
+statement ok
+insert into t1 values(1);
+
+statement ok
+FLUSH;
+
+query ?
+select * from t1;
+----
+1
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP CONNECTION my_conn;
+
+statement ok
+DROP SECRET my_secret;

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -337,6 +337,24 @@ pub struct SessionConfig {
     // a.k.a. vnode count
     #[parameter(default = VirtualNode::COUNT_FOR_COMPAT, check_hook = check_streaming_max_parallelism)]
     streaming_max_parallelism: usize,
+
+    /// Used to provide the connection information for the iceberg engine.
+    /// Format: iceberg_engine_connection = schema_name.connection_name.
+    #[parameter(default = "", check_hook = check_iceberg_engine_connection)]
+    iceberg_engine_connection: String,
+}
+
+fn check_iceberg_engine_connection(val: &str) -> Result<(), String> {
+    if val.is_empty() {
+        return Ok(());
+    }
+
+    let parts: Vec<&str> = val.split('.').collect();
+    if parts.len() != 2 {
+        return Err("Invalid iceberg engine connection format, Should be set to this format: schema_name.connection_name.".to_owned());
+    }
+
+    Ok(())
 }
 
 fn check_timezone(val: &str) -> Result<(), String> {

--- a/src/connector/src/connector_common/connection.rs
+++ b/src/connector/src/connector_common/connection.rs
@@ -210,7 +210,7 @@ impl Connection for IcebergConnection {
             }
         };
 
-        // test storage
+        // Test warehouse
         if let Some((scheme, bucket, root)) = info {
             match scheme.as_str() {
                 "s3" | "s3a" => {
@@ -246,7 +246,13 @@ impl Connection for IcebergConnection {
             }
         }
 
-        // test catalog
+        // If there is no catalog type, we won't test the catalog.
+        // The iceberg connection could be used to provide warehouse information only.
+        if self.catalog_type.is_none() {
+            return Ok(());
+        }
+
+        // Test catalog
         let iceberg_common = IcebergCommon {
             catalog_type: self.catalog_type.clone(),
             region: self.region.clone(),

--- a/src/frontend/src/catalog/root_catalog.rs
+++ b/src/frontend/src/catalog/root_catalog.rs
@@ -864,6 +864,20 @@ impl Catalog {
             .ok_or_else(|| CatalogError::NotFound("secret", secret_name.to_owned()))
     }
 
+    pub fn get_secret_by_id(
+        &self,
+        db_name: &str,
+        secret_id: u32,
+    ) -> CatalogResult<&Arc<SecretCatalog>> {
+        let secret_id = SecretId::new(secret_id);
+        for schema in self.get_database_by_name(db_name)?.iter_schemas() {
+            if let Some(secret) = schema.get_secret_by_id(&secret_id) {
+                return Ok(secret);
+            }
+        }
+        Err(CatalogError::NotFound("secret", secret_id.to_string()))
+    }
+
     pub fn get_connection_by_name<'a>(
         &self,
         db_name: &str,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Related: https://github.com/risingwavelabs/risingwave/issues/19418
- Introduce a session variable `iceberg_engine_connection` to allow users to provide their own bucket for the iceberg engine via iceberg connection. Currently, only warehouse information is allowed to be configured in the iceberg engine connection. Iceberg catalog is still handled by us in the meta sql backend. With this config, it can make us much easier to share iceberg tables with users, since the underlying warehouse is managed by users and they can have a better control of the warehouse credential.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
