### PR TITLE
feat(meta): let stream actors in fragment share same stream node

### DIFF
--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -174,7 +174,7 @@ function buildFragmentDependencyAsEdges(
     const externalParentIds = new Set<number>()
 
     for (const upstreamFragmentId of fragment.upstreamFragmentIds) {
-      if (fragments.fragments.has(upstreamFragmentId)) {
+      if (fragments.fragments[upstreamFragmentId]) {
         parentIds.add(upstreamFragmentId)
       } else {
         externalParentIds.add(upstreamFragmentId)

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -135,7 +135,7 @@ function buildPlanNodeDependency(
   return d3.hierarchy({
     name: dispatcherName,
     actorIds: fragment.actors.map((a) => a.actorId.toString()),
-    children: firstActor.nodes ? [hierarchyActorNode(firstActor.nodes)] : [],
+    children: fragment.nodes ? [hierarchyActorNode(fragment.nodes)] : [],
     operatorId: "dispatcher",
     node: dispatcherNode,
   })
@@ -173,16 +173,11 @@ function buildFragmentDependencyAsEdges(
     const parentIds = new Set<number>()
     const externalParentIds = new Set<number>()
 
-    for (const actor of fragment.actors) {
-      for (const upstreamActorId of actor.upstreamActorId) {
-        const upstreamFragmentId = actorToFragmentMapping.get(upstreamActorId)
-        if (upstreamFragmentId) {
-          parentIds.add(upstreamFragmentId)
-        } else {
-          for (const m of findMergeNodes(actor.nodes!)) {
-            externalParentIds.add(m.upstreamFragmentId)
-          }
-        }
+    for (const upstreamFragmentId of fragment.upstreamFragmentIds) {
+      if (fragments.fragments.has(upstreamFragmentId)) {
+        parentIds.add(upstreamFragmentId)
+      } else {
+        externalParentIds.add(upstreamFragmentId)
       }
     }
     nodes.push({

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -97,6 +97,8 @@ message TableFragments {
     // supported, in which case a default value of 256 (or 1 for singleton) should be used.
     // Use `VnodeCountCompat::vnode_count` to access it.
     optional uint32 maybe_vnode_count = 8;
+
+    stream_plan.StreamNode nodes = 9;
   }
   // The id of the streaming job.
   uint32 table_id = 1;
@@ -218,7 +220,6 @@ message ListTableFragmentsRequest {
 message ListTableFragmentsResponse {
   message ActorInfo {
     uint32 id = 1;
-    stream_plan.StreamNode node = 2;
     repeated stream_plan.Dispatcher dispatcher = 3;
   }
   message FragmentInfo {
@@ -258,6 +259,7 @@ message ListFragmentDistributionResponse {
     uint32 fragment_type_mask = 6;
     uint32 parallelism = 7;
     uint32 vnode_count = 8;
+    stream_plan.StreamNode node = 9;
   }
   repeated FragmentDistribution distributions = 1;
 }

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -220,6 +220,7 @@ message ListTableFragmentsRequest {
 message ListTableFragmentsResponse {
   message ActorInfo {
     uint32 id = 1;
+    stream_plan.StreamNode node = 2;
     repeated stream_plan.Dispatcher dispatcher = 3;
   }
   message FragmentInfo {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -963,19 +963,12 @@ message Dispatcher {
 
 // A StreamActor is a running fragment of the overall stream graph,
 message StreamActor {
-  reserved 7;
-  reserved "colocated_upstream_actor_id";
+  reserved 3, 7, 6;
+  reserved "colocated_upstream_actor_id", "nodes", "upstream_actor_id";
 
   uint32 actor_id = 1;
   uint32 fragment_id = 2;
-  StreamNode nodes = 3 [deprecated = true];
   repeated Dispatcher dispatcher = 4;
-  // The actors that send messages to this actor.
-  // Note that upstream actor ids are also stored in the proto of merge nodes.
-  // It is painstaking to traverse through the node tree and get upstream actor id from the root StreamNode.
-  // We duplicate the information here to ease the parsing logic in stream manager.
-  // The field is deprecated because it's no longer used.
-  repeated uint32 upstream_actor_id = 6 [deprecated = true];
   // Vnodes that the executors in this actor own.
   // If the fragment is a singleton, this field will not be set and leave a `None`.
   common.Buffer vnode_bitmap = 8;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -968,7 +968,7 @@ message StreamActor {
 
   uint32 actor_id = 1;
   uint32 fragment_id = 2;
-  StreamNode nodes = 3;
+  StreamNode nodes = 3 [deprecated = true];
   repeated Dispatcher dispatcher = 4;
   // The actors that send messages to this actor.
   // Note that upstream actor ids are also stored in the proto of merge nodes.

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -17,6 +17,12 @@ message InjectBarrierRequest {
   repeated uint32 table_ids_to_sync = 5;
   uint32 partial_graph_id = 6;
 
+  message FragmentBuildActorInfo {
+    uint32 fragment_id = 1;
+    stream_plan.StreamNode node = 2;
+    repeated BuildActorInfo actors = 3;
+  }
+
   message BuildActorInfo {
     message UpstreamActors {
       repeated uint32 actors = 1;
@@ -27,7 +33,7 @@ message InjectBarrierRequest {
   }
 
   repeated common.ActorInfo broadcast_info = 8;
-  repeated BuildActorInfo actors_to_build = 9;
+  repeated FragmentBuildActorInfo actors_to_build = 9;
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_add = 10;
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_remove = 11;
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_actor_infos.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_actor_infos.rs
@@ -25,6 +25,7 @@ struct RwActorInfo {
     #[primary_key]
     actor_id: i32,
     fragment_id: i32,
+    node: JsonbVal,
     dispatcher: JsonbVal,
 }
 
@@ -46,6 +47,7 @@ async fn read_rw_actors(reader: &SysCatalogReaderImpl) -> Result<Vec<RwActorInfo
                 fragment.actors.into_iter().map(move |actor| RwActorInfo {
                     actor_id: actor.id as _,
                     fragment_id: fragment_id as _,
+                    node: json!(actor.node).into(),
                     dispatcher: json!(actor.dispatcher).into(),
                 })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_actor_infos.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_actor_infos.rs
@@ -25,7 +25,6 @@ struct RwActorInfo {
     #[primary_key]
     actor_id: i32,
     fragment_id: i32,
-    node: JsonbVal,
     dispatcher: JsonbVal,
 }
 
@@ -47,7 +46,6 @@ async fn read_rw_actors(reader: &SysCatalogReaderImpl) -> Result<Vec<RwActorInfo
                 fragment.actors.into_iter().map(move |actor| RwActorInfo {
                     actor_id: actor.id as _,
                     fragment_id: fragment_id as _,
-                    node: json!(actor.node).into(),
                     dispatcher: json!(actor.dispatcher).into(),
                 })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragments.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragments.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::types::Fields;
+use risingwave_common::types::{Fields, JsonbVal};
 use risingwave_frontend_macro::system_catalog;
 use risingwave_pb::stream_plan::FragmentTypeFlag;
+use serde_json::json;
 
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
 use crate::error::Result;
@@ -30,6 +31,7 @@ struct RwFragment {
     flags: Vec<String>,
     parallelism: i32,
     max_parallelism: i32,
+    node: JsonbVal,
 }
 
 pub(super) fn extract_fragment_type_flag(mask: u32) -> Vec<FragmentTypeFlag> {
@@ -73,6 +75,7 @@ async fn read_rw_fragment(reader: &SysCatalogReaderImpl) -> Result<Vec<RwFragmen
                 .collect(),
             parallelism: distribution.parallelism as i32,
             max_parallelism: distribution.vnode_count as i32,
+            node: json!(distribution.node).into(),
         })
         .collect())
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
@@ -112,11 +112,8 @@ fn read_rw_sinks_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSink>> {
     "rw_catalog.rw_sink_decouple",
     "WITH decoupled_sink_internal_table_ids AS (
         SELECT
-            distinct (node->'sink'->'table'->'id')::int as internal_table_id
-        FROM rw_catalog.rw_actor_infos actor
-            JOIN
-                rw_catalog.rw_fragments fragment
-            ON actor.fragment_id = fragment.fragment_id
+            (node->'sink'->'table'->'id')::int as internal_table_id
+        FROM rw_catalog.rw_fragments
         WHERE
             'SINK' = any(flags)
             AND

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -226,6 +226,7 @@ impl StreamManagerService for StreamServiceImpl {
                                 .into_iter()
                                 .map(|actor| ActorInfo {
                                     id: actor.actor_id,
+                                    node: fragment.nodes.clone(),
                                     dispatcher: actor.dispatcher,
                                 })
                                 .collect_vec(),

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -226,7 +226,6 @@ impl StreamManagerService for StreamServiceImpl {
                                 .into_iter()
                                 .map(|actor| ActorInfo {
                                     id: actor.actor_id,
-                                    node: actor.nodes,
                                     dispatcher: actor.dispatcher,
                                 })
                                 .collect_vec(),
@@ -309,6 +308,7 @@ impl StreamManagerService for StreamServiceImpl {
                     fragment_type_mask: fragment_desc.fragment_type_mask as _,
                     parallelism: fragment_desc.parallelism as _,
                     vnode_count: fragment_desc.vnode_count as _,
+                    node: Some(fragment_desc.stream_node.to_protobuf()),
                 },
             )
             .collect_vec();

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -1033,14 +1033,9 @@ impl DatabaseCheckpointControl {
         {
             match job_type {
                 CreateStreamingJobType::Normal | CreateStreamingJobType::SinkIntoTable(_) => {
-                    for stream_actor in info
-                        .stream_job_fragments
-                        .fragments
-                        .values_mut()
-                        .flat_map(|fragment| fragment.actors.iter_mut())
-                    {
+                    for fragment in info.stream_job_fragments.fragments.values_mut() {
                         fill_snapshot_backfill_epoch(
-                            stream_actor.nodes.as_mut().expect("should exist"),
+                            fragment.nodes.as_mut().expect("should exist"),
                             None,
                             cross_db_snapshot_backfill_info,
                         )?;
@@ -1069,14 +1064,9 @@ impl DatabaseCheckpointControl {
                             "must not set previously"
                         );
                     }
-                    for stream_actor in info
-                        .stream_job_fragments
-                        .fragments
-                        .values_mut()
-                        .flat_map(|fragment| fragment.actors.iter_mut())
-                    {
+                    for fragment in info.stream_job_fragments.fragments.values_mut() {
                         fill_snapshot_backfill_epoch(
-                            stream_actor.nodes.as_mut().expect("should exist"),
+                            fragment.nodes.as_mut().expect("should exist"),
                             Some(snapshot_backfill_info),
                             cross_db_snapshot_backfill_info,
                         )?;

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -82,6 +82,16 @@ impl InflightDatabaseInfo {
     pub fn contains_job(&self, job_id: TableId) -> bool {
         self.jobs.contains_key(&job_id)
     }
+
+    pub fn fragment(&self, fragment_id: FragmentId) -> &InflightFragmentInfo {
+        let job_id = self.fragment_location[&fragment_id];
+        self.jobs
+            .get(&job_id)
+            .expect("should exist")
+            .fragment_infos
+            .get(&fragment_id)
+            .expect("should exist")
+    }
 }
 
 impl InflightDatabaseInfo {

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -32,9 +32,13 @@ use risingwave_pb::common::{ActorInfo, WorkerNode};
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::meta::PausedReason;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
-use risingwave_pb::stream_plan::{AddMutation, Barrier, BarrierMutation, SubscriptionUpstreamInfo};
+use risingwave_pb::stream_plan::{
+    AddMutation, Barrier, BarrierMutation, StreamNode, SubscriptionUpstreamInfo,
+};
 use risingwave_pb::stream_service::inject_barrier_request::build_actor_info::UpstreamActors;
-use risingwave_pb::stream_service::inject_barrier_request::BuildActorInfo;
+use risingwave_pb::stream_service::inject_barrier_request::{
+    BuildActorInfo, FragmentBuildActorInfo,
+};
 use risingwave_pb::stream_service::streaming_control_stream_request::{
     CreatePartialGraphRequest, PbDatabaseInitialPartialGraph, PbInitRequest, PbInitialPartialGraph,
     RemovePartialGraphRequest, ResetDatabaseRequest,
@@ -57,7 +61,9 @@ use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo};
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::MetaSrvEnv;
-use crate::model::{ActorId, StreamActorWithUpstreams, StreamJobFragments};
+use crate::model::{
+    ActorId, FragmentId, StreamActorWithUpstreams, StreamJobActorsToCreate, StreamJobFragments,
+};
 use crate::stream::build_actor_connector_splits;
 use crate::{MetaError, MetaResult};
 
@@ -371,12 +377,20 @@ impl ControlStreamManager {
             kind: BarrierKind::Initial,
         };
 
-        let mut node_actors: HashMap<_, Vec<_>> = HashMap::new();
-        for (actor_id, worker_id) in info.fragment_infos().flat_map(|info| info.actors.iter()) {
-            let worker_id = *worker_id as WorkerId;
-            let actor_id = *actor_id as ActorId;
-            let stream_actor = stream_actors.remove(&actor_id).expect("should exist");
-            node_actors.entry(worker_id).or_default().push(stream_actor);
+        let mut node_actors: HashMap<_, HashMap<FragmentId, (StreamNode, Vec<_>)>> = HashMap::new();
+        for fragment_info in info.fragment_infos() {
+            for (actor_id, worker_id) in &fragment_info.actors {
+                let worker_id = *worker_id as WorkerId;
+                let actor_id = *actor_id as ActorId;
+                let stream_actor = stream_actors.remove(&actor_id).expect("should exist");
+                node_actors
+                    .entry(worker_id)
+                    .or_default()
+                    .entry(fragment_info.fragment_id)
+                    .or_insert_with(|| (fragment_info.nodes.clone(), vec![]))
+                    .1
+                    .push(stream_actor);
+            }
         }
 
         let background_mviews = info
@@ -445,7 +459,7 @@ impl ControlStreamManager {
             applied_graph_info.fragment_infos(),
             command
                 .as_ref()
-                .map(|command| command.actors_to_create())
+                .map(|command| command.actors_to_create(pre_applied_graph_info))
                 .unwrap_or_default(),
             subscriptions_to_add,
             subscriptions_to_remove,
@@ -460,7 +474,7 @@ impl ControlStreamManager {
         barrier_info: &BarrierInfo,
         pre_applied_graph_info: impl IntoIterator<Item = &InflightFragmentInfo>,
         applied_graph_info: impl IntoIterator<Item = &'a InflightFragmentInfo> + 'a,
-        mut new_actors: Option<HashMap<WorkerId, Vec<StreamActorWithUpstreams>>>,
+        mut new_actors: Option<StreamJobActorsToCreate>,
         subscriptions_to_add: Vec<SubscriptionUpstreamInfo>,
         subscriptions_to_remove: Vec<SubscriptionUpstreamInfo>,
     ) -> MetaResult<HashSet<WorkerId>> {
@@ -488,16 +502,19 @@ impl ControlStreamManager {
             .iter()
             .flatten()
             .flat_map(|(worker_id, actor_infos)| {
-                actor_infos.iter().map(|actor_info| ActorInfo {
-                    actor_id: actor_info.0.actor_id,
-                    host: self
-                        .nodes
-                        .get(worker_id)
-                        .expect("have checked exist previously")
-                        .worker
-                        .host
-                        .clone(),
-                })
+                actor_infos
+                    .iter()
+                    .flat_map(|(_, (_, actors))| actors.iter())
+                    .map(|actor_info| ActorInfo {
+                        actor_id: actor_info.0.actor_id,
+                        host: self
+                            .nodes
+                            .get(worker_id)
+                            .expect("have checked exist previously")
+                            .worker
+                            .host
+                            .clone(),
+                    })
             })
             .collect_vec();
 
@@ -546,21 +563,30 @@ impl ControlStreamManager {
                                             .into_iter()
                                             .flatten()
                                             .flatten()
-                                            .map(|(actor, upstreams)| BuildActorInfo {
-                                                actor: Some(actor),
-                                                fragment_upstreams: upstreams
-                                                    .into_iter()
-                                                    .map(|(fragment_id, upstreams)| {
-                                                        (
-                                                            fragment_id,
-                                                            UpstreamActors {
-                                                                actors: upstreams
-                                                                    .into_iter()
-                                                                    .collect(),
-                                                            },
-                                                        )
-                                                    })
-                                                    .collect(),
+                                            .map(|(fragment_id, (node, actors))| {
+                                                FragmentBuildActorInfo {
+                                                    fragment_id,
+                                                    node: Some(node),
+                                                    actors: actors
+                                                        .into_iter()
+                                                        .map(|(actor, upstreams)| BuildActorInfo {
+                                                            actor: Some(actor),
+                                                            fragment_upstreams: upstreams
+                                                                .into_iter()
+                                                                .map(|(fragment_id, upstreams)| {
+                                                                    (
+                                                                        fragment_id,
+                                                                        UpstreamActors {
+                                                                            actors: upstreams
+                                                                                .into_iter()
+                                                                                .collect(),
+                                                                        },
+                                                                    )
+                                                                })
+                                                                .collect(),
+                                                        })
+                                                        .collect(),
+                                                }
                                             })
                                             .collect(),
                                         subscriptions_to_add: subscriptions_to_add.clone(),

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -483,13 +483,10 @@ impl CatalogController {
                 pb_actor_splits.insert(actor_id as _, splits.to_protobuf());
             }
 
-            #[expect(deprecated)]
             pb_actors.push(PbStreamActor {
                 actor_id: actor_id as _,
                 fragment_id: fragment_id as _,
-                nodes: None,
                 dispatcher: pb_dispatcher,
-                upstream_actor_id: vec![],
                 vnode_bitmap: pb_vnode_bitmap,
                 mview_definition: "".to_owned(),
                 expr_context: pb_expr_context,
@@ -1799,24 +1796,19 @@ mod tests {
         let stream_node = generate_merger_stream_node(upstream_actor_ids.values().next().unwrap());
 
         let pb_actors = (0..actor_count)
-            .map(|actor_id| {
-                #[expect(deprecated)]
-                PbStreamActor {
-                    actor_id: actor_id as _,
-                    fragment_id: TEST_FRAGMENT_ID as _,
-                    nodes: None,
-                    dispatcher: generate_dispatchers_for_actor(actor_id),
-                    vnode_bitmap: actor_bitmaps
-                        .get(&actor_id)
-                        .cloned()
-                        .map(|bitmap| bitmap.to_protobuf()),
-                    mview_definition: "".to_owned(),
-                    expr_context: Some(PbExprContext {
-                        time_zone: String::from("America/New_York"),
-                        strict_mode: false,
-                    }),
-                    ..Default::default()
-                }
+            .map(|actor_id| PbStreamActor {
+                actor_id: actor_id as _,
+                fragment_id: TEST_FRAGMENT_ID as _,
+                dispatcher: generate_dispatchers_for_actor(actor_id),
+                vnode_bitmap: actor_bitmaps
+                    .get(&actor_id)
+                    .cloned()
+                    .map(|bitmap| bitmap.to_protobuf()),
+                mview_definition: "".to_owned(),
+                expr_context: Some(PbExprContext {
+                    time_zone: String::from("America/New_York"),
+                    strict_mode: false,
+                }),
             })
             .collect_vec();
 

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -298,6 +298,7 @@ pub struct FragmentDesc {
     pub upstream_fragment_id: I32Array,
     pub parallelism: i64,
     pub vnode_count: i32,
+    pub stream_node: StreamNode,
 }
 
 /// List all objects that are using the given one in a cascade way. It runs a recursive CTE to find all the dependencies.

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -650,9 +650,9 @@ impl DdlController {
                 )
             })?;
 
-        for actor in &stream_scan_fragment.actors {
+        {
             if let Some(NodeBody::StreamCdcScan(ref stream_cdc_scan)) =
-                actor.nodes.as_ref().unwrap().node_body
+                stream_scan_fragment.nodes.as_ref().unwrap().node_body
                 && let Some(ref cdc_table_desc) = stream_cdc_scan.cdc_table_desc
             {
                 let options_with_secret = WithOptionsSecResolved::new(
@@ -746,8 +746,8 @@ impl DdlController {
 
         // check if the union fragment is fully assigned.
         for fragment in stream_job_fragments.fragments.values() {
-            for actor in &fragment.actors {
-                if let Some(node) = &actor.nodes {
+            if let Some(node) = &fragment.nodes {
+                for actor in &fragment.actors {
                     visit_stream_node(node, |node| {
                         if let NodeBody::Merge(merge_node) = node {
                             let fragment_actor_upstreams = stream_job_fragments
@@ -793,16 +793,7 @@ impl DdlController {
             .map(|actor| actor.actor_id)
             .collect_vec();
 
-        let mut sink_fields = None;
-
-        for actor in &sink_fragment.actors {
-            if let Some(node) = &actor.nodes {
-                sink_fields = Some(node.fields.clone());
-                break;
-            }
-        }
-
-        let sink_fields = sink_fields.expect("sink fields not found");
+        let sink_fields = sink_fragment.nodes.as_ref().unwrap().fields.clone();
 
         let output_indices = sink_fields
             .iter()
@@ -856,8 +847,8 @@ impl DdlController {
 
         let upstream_fragment_id = sink_fragment.fragment_id;
 
-        for actor in &mut union_fragment.actors {
-            if let Some(node) = &mut actor.nodes {
+        if let Some(node) = &mut union_fragment.nodes {
+            {
                 visit_stream_node_cont_mut(node, |node| {
                     if let Some(NodeBody::Union(_)) = &mut node.node_body {
                         for input_project_node in &mut node.input {
@@ -875,14 +866,29 @@ impl DdlController {
 
                                 if let Some(NodeBody::Merge(merge_node)) =
                                     &mut merge_stream_node.node_body
-                                    && union_fragment_actor_upstreams
-                                        .get(&actor.actor_id)
-                                        .and_then(|actor_upstream| {
-                                            actor_upstream.get(&merge_node.upstream_fragment_id)
-                                        })
-                                        .map(|upstream_actor_ids| upstream_actor_ids.is_empty())
-                                        .unwrap_or(true)
+                                    && union_fragment.actors.iter().any(|actor| {
+                                        union_fragment_actor_upstreams
+                                            .get(&actor.actor_id)
+                                            .and_then(|actor_upstream| {
+                                                actor_upstream.get(&merge_node.upstream_fragment_id)
+                                            })
+                                            .map(|upstream_actor_ids| upstream_actor_ids.is_empty())
+                                            .unwrap_or(true)
+                                    })
                                 {
+                                    if cfg!(debug_assertions) {
+                                        union_fragment.actors.iter().for_each(|actor| {
+                                            assert!(union_fragment_actor_upstreams
+                                                .get(&actor.actor_id)
+                                                .and_then(|actor_upstream| {
+                                                    actor_upstream
+                                                        .get(&merge_node.upstream_fragment_id)
+                                                })
+                                                .map(|upstream_actor_ids| upstream_actor_ids
+                                                    .is_empty())
+                                                .unwrap_or(true), "inconsistent replace table plan for sink. upstreams: {:?} actor_id: {} upstream_fragment_id: {}", union_fragment_actor_upstreams, actor.actor_id, merge_node.upstream_fragment_id)
+                                        });
+                                    }
                                     if let Some(sink_id) = sink_id {
                                         merge_stream_node.identity =
                                             format!("MergeExecutor(from sink {})", sink_id);
@@ -901,14 +907,16 @@ impl DdlController {
                                         }
                                     };
 
-                                    union_fragment_actor_upstreams
-                                        .entry(actor.actor_id)
-                                        .or_default()
-                                        .try_insert(
-                                            upstream_fragment_id,
-                                            HashSet::from_iter(sink_actor_ids.iter().cloned()),
-                                        )
-                                        .expect("checked non-exist");
+                                    for actor in &union_fragment.actors {
+                                        union_fragment_actor_upstreams
+                                            .entry(actor.actor_id)
+                                            .or_default()
+                                            .try_insert(
+                                                upstream_fragment_id,
+                                                HashSet::from_iter(sink_actor_ids.iter().cloned()),
+                                            )
+                                            .expect("checked non-exist");
+                                    }
 
                                     merge_stream_node.fields = sink_fields.to_vec();
 

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -589,7 +589,6 @@ impl ScaleController {
                 let (related_job, job_definition) =
                     related_jobs.get(&job_id).expect("job not found");
 
-                #[expect(deprecated)]
                 let fragment = CustomFragmentInfo {
                     fragment_id: fragment_id as _,
                     fragment_type_mask: fragment_type_mask as _,
@@ -598,11 +597,9 @@ impl ScaleController {
                     upstream_fragment_ids: upstream_fragment_id.into_u32_array(),
                     node: stream_node.to_protobuf(),
                     actor_template: PbStreamActor {
-                        nodes: None,
                         actor_id,
                         fragment_id: fragment_id as _,
                         dispatcher,
-                        upstream_actor_id: vec![],
                         vnode_bitmap: vnode_bitmap.map(|b| b.to_protobuf()),
                         mview_definition: job_definition.to_owned(),
                         expr_context: expr_contexts

--- a/src/meta/src/stream/stream_graph/actor.rs
+++ b/src/meta/src/stream/stream_graph/actor.rs
@@ -308,19 +308,14 @@ impl ActorBuilder {
         #[cfg(debug_assertions)]
         let mview_definition = job.definition();
 
-        Ok(
-            #[expect(deprecated)]
-            StreamActor {
-                actor_id: self.actor_id.as_global_id(),
-                fragment_id: self.fragment_id.as_global_id(),
-                nodes: None,
-                dispatcher: self.downstreams.into_values().collect(),
-                upstream_actor_id: vec![],
-                vnode_bitmap: self.vnode_bitmap.map(|b| b.to_protobuf()),
-                mview_definition,
-                expr_context: Some(expr_context),
-            },
-        )
+        Ok(StreamActor {
+            actor_id: self.actor_id.as_global_id(),
+            fragment_id: self.fragment_id.as_global_id(),
+            dispatcher: self.downstreams.into_values().collect(),
+            vnode_bitmap: self.vnode_bitmap.map(|b| b.to_protobuf()),
+            mview_definition,
+            expr_context: Some(expr_context),
+        })
     }
 }
 

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -928,7 +928,7 @@ impl CompleteStreamFragmentGraph {
                             {
                                 // Resolve the required output columns from the upstream materialized view.
                                 let (dist_key_indices, output_indices) = {
-                                    let nodes = upstream_fragment.actors[0].get_nodes().unwrap();
+                                    let nodes = upstream_fragment.get_nodes().unwrap();
                                     let mview_node =
                                         nodes.get_node_body().unwrap().as_materialize().unwrap();
                                     let all_column_ids = mview_node.column_ids();
@@ -972,7 +972,7 @@ impl CompleteStreamFragmentGraph {
                                     GlobalFragmentId::new(source_fragment.fragment_id);
 
                                 let output_indices = {
-                                    let nodes = upstream_fragment.actors[0].get_nodes().unwrap();
+                                    let nodes = upstream_fragment.get_nodes().unwrap();
                                     let source_node =
                                         nodes.get_node_body().unwrap().as_source().unwrap();
 
@@ -1202,6 +1202,7 @@ impl CompleteStreamFragmentGraph {
         id: GlobalFragmentId,
         actors: Vec<StreamActor>,
         distribution: Distribution,
+        stream_node: StreamNode,
     ) -> Fragment {
         let building_fragment = self.get_fragment(id).into_building().unwrap();
         let internal_tables = building_fragment.extract_internal_tables();
@@ -1240,6 +1241,7 @@ impl CompleteStreamFragmentGraph {
             state_table_ids,
             upstream_fragment_ids,
             maybe_vnode_count: VnodeCount::set(vnode_count).to_protobuf(),
+            nodes: Some(stream_node),
         }
     }
 

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -525,28 +525,32 @@ async fn test_graph_builder() -> MetaResult<()> {
                 .first()
                 .map_or(&vec![], |d| d.get_downstream_actor_id()),
         );
-        let mut node = actor.get_nodes().unwrap();
+    }
+    for fragment in stream_job_fragments.fragments() {
+        let mut node = fragment.get_nodes().unwrap();
         while !node.get_input().is_empty() {
             node = node.get_input().first().unwrap();
         }
         match node.get_node_body().unwrap() {
             NodeBody::Merge(merge_node) => {
-                assert_eq!(
-                    expected_upstream
-                        .get(&actor.get_actor_id())
-                        .unwrap()
-                        .iter()
-                        .collect::<HashSet<_>>(),
-                    actor_upstreams
-                        .get(&actor.fragment_id)
-                        .unwrap()
-                        .get(&actor.actor_id)
-                        .unwrap()
-                        .get(&merge_node.upstream_fragment_id)
-                        .unwrap()
-                        .iter()
-                        .collect::<HashSet<_>>(),
-                );
+                for actor in &fragment.actors {
+                    assert_eq!(
+                        expected_upstream
+                            .get(&actor.get_actor_id())
+                            .unwrap()
+                            .iter()
+                            .collect::<HashSet<_>>(),
+                        actor_upstreams
+                            .get(&actor.fragment_id)
+                            .unwrap()
+                            .get(&actor.actor_id)
+                            .unwrap()
+                            .get(&merge_node.upstream_fragment_id)
+                            .unwrap()
+                            .iter()
+                            .collect::<HashSet<_>>(),
+                    );
+                }
             }
             NodeBody::Source(_) => {
                 // check nothing.

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -602,6 +602,7 @@ impl StreamActorManager {
     async fn create_actor(
         self: Arc<Self>,
         actor: StreamActor,
+        node: Arc<StreamNode>,
         shared_context: Arc<SharedContext>,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
         upstreams: HashMap<FragmentId, UpstreamActors>,
@@ -626,7 +627,7 @@ impl StreamActorManager {
             let (executor, subtasks) = self
                 .create_nodes(
                     actor.fragment_id,
-                    actor.get_nodes()?,
+                    &node,
                     self.env.clone(),
                     &actor_context,
                     vnode_bitmap,
@@ -660,6 +661,7 @@ impl StreamActorManager {
     pub(super) fn spawn_actor(
         self: &Arc<Self>,
         actor: StreamActor,
+        node: Arc<StreamNode>,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
         upstreams: HashMap<FragmentId, UpstreamActors>,
         current_shared_context: Arc<SharedContext>,
@@ -674,7 +676,7 @@ impl StreamActorManager {
                     format!("Actor {actor_id}: `{}`", stream_actor_ref.mview_definition);
                 let barrier_manager = local_barrier_manager.clone();
                 // wrap the future of `create_actor` with `boxed` to avoid stack overflow
-                let actor = self.clone().create_actor(actor, current_shared_context, related_subscriptions, upstreams, barrier_manager.clone()).boxed().and_then(|actor| actor.run()).map(move |result| {
+                let actor = self.clone().create_actor(actor, node, current_shared_context, related_subscriptions, upstreams, barrier_manager.clone()).boxed().and_then(|actor| actor.run()).map(move |result| {
                     if let Err(err) = result {
                         // TODO: check error type and panic if it's unexpected.
                         // Intentionally use `?` on the report to also include the backtrace.

--- a/src/tests/simulation/src/ctl_ext.rs
+++ b/src/tests/simulation/src/ctl_ext.rs
@@ -47,7 +47,7 @@ pub mod predicate {
     pub type BoxedPredicate = Box<dyn Predicate>;
 
     fn root(fragment: &PbFragment) -> &StreamNode {
-        fragment.actors.first().unwrap().nodes.as_ref().unwrap()
+        fragment.nodes.as_ref().unwrap()
     }
 
     fn count(root: &StreamNode, p: &impl Fn(&StreamNode) -> bool) -> usize {

--- a/src/tests/simulation/tests/integration_tests/scale/shared_source.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/shared_source.rs
@@ -47,16 +47,17 @@ fn source_backfill_upstream(
         }
     }
 
+    let (_, source_fragment_id) = source_backfill_fragment
+        .get_nodes()
+        .unwrap()
+        .find_source_backfill()
+        .unwrap();
+    assert_eq!(source_fragment.fragment_id, source_fragment_id);
+
     source_backfill_fragment
         .actors
         .iter()
         .map(|backfill_actor| {
-            let (_, source_fragment_id) = backfill_actor
-                .get_nodes()
-                .unwrap()
-                .find_source_backfill()
-                .unwrap();
-            assert_eq!(source_fragment.fragment_id, source_fragment_id);
             (
                 backfill_actor.actor_id,
                 no_shuffle_downstream_to_upstream[&backfill_actor.actor_id],


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

After https://github.com/risingwavelabs/risingwave/pull/20222, the `nodes` of each `StreamActor` in a single fragment becomes the same. Therefore, in this PR, we will deprecate the field `nodes` in `StreamActor`, and instead move the field to `Fragment` to explicitly enforce that all `StreamActor`s in the `Fragment` has the same `nodes`.

In global barrier worker, the `nodes` is stored in each `InflightFragmentInfo`, and we will use the `nodes` to create new actors when handling fragment reschedule. Note that, the `nodes` will be changed during `ReplaceTable`. More specifically, for the downstream fragments to the replaced table, the `upstream_fragment_id` in the `MergeNode` will be updated to the new `fragment_id` after replacement, and therefore we add a new `CommandFragmentChanges` variant to apply this change to the node.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
