### PR TITLE
feat(stream): normalize unmatched updates

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -144,7 +144,7 @@ steps:
             files: "*-junit.xml"
             format: "junit"
         - ./ci/plugins/upload-failure-logs
-      timeout_in_minutes: 13
+      timeout_in_minutes: 18
       retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory) (release)"
@@ -160,7 +160,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     retry: *auto-retry
 
   - group: "end-to-end connector test (release)"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -342,7 +342,7 @@ steps:
 
   - label: "end-to-end test (madsim)"
     key: "e2e-test-deterministic"
-    command: "TEST_NUM=32 timeout 130m ci/scripts/deterministic-e2e-test.sh"
+    command: "TEST_NUM=32 timeout 135m ci/scripts/deterministic-e2e-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation"
@@ -357,12 +357,12 @@ steps:
           environment:
           - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 135
+    timeout_in_minutes: 140
     retry: *auto-retry
 
   - label: "end-to-end test (madsim, random vnode count)"
     key: "e2e-test-deterministic-random-vnode-count"
-    command: "TEST_NUM=32 RW_SIM_RANDOM_VNODE_COUNT=true timeout 130m ci/scripts/deterministic-e2e-test.sh"
+    command: "TEST_NUM=32 RW_SIM_RANDOM_VNODE_COUNT=true timeout 135m ci/scripts/deterministic-e2e-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation"
@@ -377,12 +377,12 @@ steps:
           environment:
           - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 135
+    timeout_in_minutes: 140
     retry: *auto-retry
 
   - label: "recovery test (madsim)"
     key: "recovery-test-deterministic"
-    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 timeout 70m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 timeout 75m ci/scripts/deterministic-recovery-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
@@ -392,13 +392,13 @@ steps:
       - docker-compose#v5.5.0: *docker-compose
       # Only upload zipped files, otherwise the logs is too much.
       - ./ci/plugins/upload-failure-logs-zipped
-    timeout_in_minutes: 75
+    timeout_in_minutes: 80
     retry: *auto-retry
 
   # Ddl statements will randomly run with background_ddl.
   - label: "background_ddl, arrangement_backfill recovery test (madsim)"
     key: "background-ddl-arrangement-backfill-recovery-test-deterministic"
-    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.8 USE_ARRANGEMENT_BACKFILL=true timeout 70m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.8 USE_ARRANGEMENT_BACKFILL=true timeout 75m ci/scripts/deterministic-recovery-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
@@ -408,7 +408,7 @@ steps:
       - docker-compose#v5.5.0: *docker-compose
       # Only upload zipped files, otherwise the logs is too much.
       - ./ci/plugins/upload-failure-logs-zipped
-    timeout_in_minutes: 70
+    timeout_in_minutes: 80
     retry: *auto-retry
 
   - label: "end-to-end iceberg sink test (release)"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -160,7 +160,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 25
+    timeout_in_minutes: 30
     retry: *auto-retry
 
   - label: "end-to-end test for opendal (parallel)"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -562,7 +562,7 @@ steps:
           environment:
           - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
     cancel_on_build_failing: true
     retry: *auto-retry
 
@@ -583,7 +583,7 @@ steps:
       # - test-collector#v1.0.0:
       #     files: "*-junit.xml"
       #     format: "junit"
-    timeout_in_minutes: 35
+    timeout_in_minutes: 40
     cancel_on_build_failing: true
     retry: *auto-retry
 
@@ -748,7 +748,7 @@ steps:
           run: ci-standard-env
           propagate-environment: true
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 32
+    timeout_in_minutes: 37
     retry: *auto-retry
 
   # FIXME(kwannoel): Let the github PR labeller label it, if sqlsmith source files has changes.

--- a/e2e_test/streaming/bug_fixes/issue_20342.slt
+++ b/e2e_test/streaming/bug_fixes/issue_20342.slt
@@ -1,0 +1,9 @@
+statement ok
+set streaming_use_arrangement_backfill=false;
+
+include ./issue_20342.slt.part
+
+statement ok
+set streaming_use_arrangement_backfill=true;
+
+include ./issue_20342.slt.part

--- a/e2e_test/streaming/bug_fixes/issue_20342.slt.part
+++ b/e2e_test/streaming/bug_fixes/issue_20342.slt.part
@@ -26,6 +26,7 @@ set background_ddl=true;
 statement ok
 create materialized view m2 as select count(*) from m1;
 
+skipif madsim
 sleep 2s
 
 statement ok

--- a/e2e_test/streaming/bug_fixes/issue_20342.slt.part
+++ b/e2e_test/streaming/bug_fixes/issue_20342.slt.part
@@ -1,0 +1,95 @@
+statement ok
+set streaming_parallelism=1;
+
+# pk: [v1]
+# stream key: [v1]
+statement ok
+create table t(v1 int primary key, v2 int);
+
+# pk: [v2, v1]
+# stream key: [v1]
+statement ok
+create materialized view m1 as select * from t order by v2;
+
+statement ok
+insert into t select x as v1, x as v2 from generate_series(1, 10000) t(x);
+
+statement ok
+flush;
+
+statement ok
+set backfill_rate_limit=1;
+
+statement ok
+set background_ddl=true;
+
+statement ok
+create materialized view m2 as select count(*) from m1;
+
+sleep 2s
+
+statement ok
+update t set v2 = 100000 where v1 = 1;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100001 where v1 = 2;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100002 where v1 = 3;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100003 where v1 = 4;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100004 where v1 = 5;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100005 where v1 = 6;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100006 where v1 = 7;
+
+statement ok
+flush;
+
+statement ok
+update t set v2 = 100007 where v1 = 8;
+
+statement ok
+flush;
+
+statement ok
+set backfill_rate_limit=default;
+
+statement ok
+set background_ddl=false;
+
+statement ok
+set streaming_use_arrangement_backfill=true;
+
+statement ok
+alter materialized view m2 set backfill_rate_limit=default;
+
+statement ok
+wait;
+
+statement ok
+drop table t cascade;

--- a/e2e_test/streaming/bug_fixes/issue_20342.slt.part
+++ b/e2e_test/streaming/bug_fixes/issue_20342.slt.part
@@ -17,9 +17,11 @@ insert into t select x as v1, x as v2 from generate_series(1, 10000) t(x);
 statement ok
 flush;
 
+skipif madsim
 statement ok
 set backfill_rate_limit=1;
 
+skipif madsim
 statement ok
 set background_ddl=true;
 
@@ -89,6 +91,7 @@ set streaming_use_arrangement_backfill=true;
 statement ok
 alter materialized view m2 set backfill_rate_limit=default;
 
+skipif madsim
 statement ok
 wait;
 

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -535,14 +535,6 @@ pub fn cmp_datum_iter(
     })
 }
 
-pub fn cmp_datum_iter_le(
-    lhs: impl IntoIterator<Item = impl ToDatumRef>,
-    rhs: impl IntoIterator<Item = impl ToDatumRef>,
-    order_type: impl IntoIterator<Item = OrderType>,
-) -> bool {
-    cmp_datum_iter(lhs, rhs, order_type) != Ordering::Greater
-}
-
 /// Partial compare two `Row`s with specified order types.
 ///
 /// NOTE: This function returns `None` if two rows have different schema.

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -535,6 +535,14 @@ pub fn cmp_datum_iter(
     })
 }
 
+pub fn cmp_datum_iter_le(
+    lhs: impl IntoIterator<Item = impl ToDatumRef>,
+    rhs: impl IntoIterator<Item = impl ToDatumRef>,
+    order_type: impl IntoIterator<Item = OrderType>,
+) -> bool {
+    cmp_datum_iter(lhs, rhs, order_type) != Ordering::Greater
+}
+
 /// Partial compare two `Row`s with specified order types.
 ///
 /// NOTE: This function returns `None` if two rows have different schema.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Closes: https://github.com/risingwavelabs/risingwave/issues/20342

The bug is that stream_key and storage_key can mismatch for an MV, and can result in UpdateDelete + UpdateInsert pairs being split up.
```
dev=> explain create materialized view m1 as select * from t order by v2, v3;
                                                      QUERY PLAN                                                       
-----------------------------------------------------------------------------------------------------------------------
 StreamMaterialize { columns: [v1, v2, v3, v4, v5], stream_key: [v1], pk_columns: [v2, v3, v1], pk_conflict: NoCheck }
 └─StreamTableScan { table: t, columns: [v1, v2, v3, v4, v5] }
```

Details:
1. If upstream updates some record, it will be updated on some stream_key .
2. This propagates to the backfilling MV.
3. When receiving barrier, we will flush buffered upstream chunks. Here we have logic to remove rows which have storage_key > current_pos, where current_pos is the storage_key we have backfilled until.
4. This means that an UpdateDelete + UpdateInsert pair could be split up, because while their stream keys are the same, their storage keys might be different, leading to one being pruned, but not the other. An example is when upstream is an MV with ORDER BY on non-pk columns.
5. Subsequently, UpdateDelete gets propagated to dispatcher, and the dispatcher has some optimization to remove redundant UpdateDelete and UpdateInsert pairs. We may lose an op entry here in this code branch. Then op.len() != col.len(), and we will panic when reconstructing the chunk.

This bug is sort of worked around with https://github.com/risingwavelabs/risingwave/pull/20176/files. Since dispatcher will rewrite U+/U- going to different vnodes into +/-, and dist_key is set to order key. But this PR defensively handles it in backfill as well.

For unmatched update delete, i.e. storage_key <= current_pos, we can rewrite it to a normal delete. Because in the next snapshot read, we should read the new update insert.
For unmatched update insert, we have not backfilled the corresponding update delete key from storage yet. So there won’t be a conflict to just insert it. We can rewrite it to a normal insert.

We also reconstruct the ops lazily, since in most cases it should not be necessary, only when there' a hanging update.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
