### PR TITLE
feat(frontend): add AddLogStore rule

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -60,10 +60,10 @@ user statement_timeout
 user streaming_allow_jsonb_in_stream_key
 user streaming_enable_bushy_join
 user streaming_enable_delta_join
+user streaming_enable_unaligned_join
 user streaming_max_parallelism
 user streaming_over_window_cache_policy
 user streaming_parallelism
-user streaming_unaligned_join
 user streaming_use_arrangement_backfill
 user streaming_use_shared_source
 user streaming_use_snapshot_backfill

--- a/e2e_test/streaming/unaligned-join.slt
+++ b/e2e_test/streaming/unaligned-join.slt
@@ -1,0 +1,55 @@
+statement ok
+DROP TABLE IF EXISTS fact;
+
+statement ok
+DROP TABLE IF EXISTS dim;
+
+statement ok
+set streaming_enable_unaligned_join = true;
+
+statement ok
+create table fact(v0 int primary key, v1 int, v2 varchar, v3 varchar);
+
+# correspond to 1
+statement ok
+INSERT INTO fact
+  SELECT
+    x as v0,
+    1 as v1,
+    'abcdefgakjandjkw' as v2,
+    'jkb1ku1bu' as v3
+  FROM generate_series(1, 100000) t(x);
+
+# correspond to 2
+statement ok
+INSERT INTO fact
+  SELECT
+    x as v0,
+    2 as v1,
+    'abcdefgakjandjkw' as v2,
+    'jkb1ku1bu' as v3
+  FROM generate_series(100001, 200000) t(x);
+
+statement ok
+create table dim(v1 int);
+
+statement ok
+INSERT INTO dim VALUES(1), (2);
+
+statement ok
+create materialized view m1 as
+  select v0, count(*)
+  from fact join dim on fact.v1 = dim.v1
+  group by v0;
+
+statement ok
+DELETE FROM dim;
+
+statement ok
+flush;
+
+statement ok
+DROP TABLE fact cascade;
+
+statement ok
+DROP TABLE dim cascade;

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -345,7 +345,7 @@ pub struct SessionConfig {
 
     /// Whether the streaming join should be unaligned or not.
     #[parameter(default = false)]
-    streaming_unaligned_join: bool,
+    streaming_enable_unaligned_join: bool,
 }
 
 fn check_iceberg_engine_connection(val: &str) -> Result<(), String> {

--- a/src/common/src/util/stream_graph_visitor.rs
+++ b/src/common/src/util/stream_graph_visitor.rs
@@ -266,6 +266,7 @@ pub fn visit_stream_node_tables_inner<F>(
                 always!(node.table, "Materialize")
             }
 
+            // Global Approx Percentile
             NodeBody::GlobalApproxPercentile(node) => {
                 always!(node.bucket_state_table, "GlobalApproxPercentileBucketState");
                 always!(node.count_state_table, "GlobalApproxPercentileCountState");
@@ -275,6 +276,11 @@ pub fn visit_stream_node_tables_inner<F>(
             NodeBody::AsOfJoin(node) => {
                 always!(node.left_table, "AsOfJoinLeft");
                 always!(node.right_table, "AsOfJoinRight");
+            }
+
+            // Synced Log Store
+            NodeBody::SyncLogStore(node) => {
+                always!(node.log_store_table, "StreamSyncLogStore");
             }
             _ => {}
         }

--- a/src/frontend/planner_test/tests/testdata/input/delta_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/delta_join.yaml
@@ -25,3 +25,14 @@
     select * from a join b on a.a1 = b.b1 ;
   expected_outputs:
   - stream_plan
+- name: unaligned delta join
+  sql: |
+    set rw_streaming_enable_delta_join = true;
+    set streaming_enable_unaligned_join = true;
+    create table a (a1 int primary key, a2 int);
+    create table b (b1 int primary key, b2 int);
+    /* should generate delta join plan, and stream index scan */
+    select * from a join b on a.a1 = b.b1 ;
+  expected_outputs:
+  - stream_plan
+

--- a/src/frontend/planner_test/tests/testdata/input/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/join.yaml
@@ -6,6 +6,16 @@
   expected_outputs:
   - logical_plan
   - stream_plan
+- name: unaligned join
+  sql: |
+    set streaming_enable_unaligned_join=true;
+    create table t1 (v1 int, v2 int);
+    create table t2 (v3 int, v4 int);
+    create table t3 (v5 int, v6 int);
+    select * from t1, t2, t3 where t1.v1 = t2.v3 and t1.v1 = t3.v5;
+  expected_outputs:
+  - logical_plan
+  - stream_plan
 - name: self join
   sql: |
     create table t (v1 int, v2 int);

--- a/src/frontend/planner_test/tests/testdata/output/delta_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/delta_join.yaml
@@ -38,3 +38,18 @@
       └─StreamDeltaJoin { type: Inner, predicate: a.a1 = b.b1, output: all }
         ├─StreamTableScan { table: a, columns: [a.a1, a.a2], stream_scan_type: Backfill, stream_key: [a.a1], pk: [a1], dist: UpstreamHashShard(a.a1) }
         └─StreamTableScan { table: b, columns: [b.b1, b.b2], stream_scan_type: UpstreamOnly, stream_key: [b.b1], pk: [b1], dist: UpstreamHashShard(b.b1) }
+- name: unaligned delta join
+  sql: |
+    set rw_streaming_enable_delta_join = true;
+    set streaming_enable_unaligned_join = true;
+    create table a (a1 int primary key, a2 int);
+    create table b (b1 int primary key, b2 int);
+    /* should generate delta join plan, and stream index scan */
+    select * from a join b on a.a1 = b.b1 ;
+  stream_plan: |-
+    StreamMaterialize { columns: [a1, a2, b1, b2], stream_key: [a1], pk_columns: [a1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(a.a1) }
+      └─StreamSyncLogStore
+        └─StreamDeltaJoin { type: Inner, predicate: a.a1 = b.b1, output: all }
+          ├─StreamTableScan { table: a, columns: [a.a1, a.a2], stream_scan_type: Backfill, stream_key: [a.a1], pk: [a1], dist: UpstreamHashShard(a.a1) }
+          └─StreamTableScan { table: b, columns: [b.b1, b.b2], stream_scan_type: UpstreamOnly, stream_key: [b.b1], pk: [b1], dist: UpstreamHashShard(b.b1) }

--- a/src/frontend/planner_test/tests/testdata/output/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/join.yaml
@@ -23,6 +23,33 @@
         │   └─StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
         └─StreamExchange { dist: HashShard(t3.v5) }
           └─StreamTableScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t3._row_id], pk: [_row_id], dist: UpstreamHashShard(t3._row_id) }
+- name: unaligned join
+  sql: |
+    set streaming_enable_unaligned_join=true;
+    create table t1 (v1 int, v2 int);
+    create table t2 (v3 int, v4 int);
+    create table t3 (v5 int, v6 int);
+    select * from t1, t2, t3 where t1.v1 = t2.v3 and t1.v1 = t3.v5;
+  logical_plan: |-
+    LogicalProject { exprs: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6] }
+    └─LogicalFilter { predicate: (t1.v1 = t2.v3) AND (t1.v1 = t3.v5) }
+      └─LogicalJoin { type: Inner, on: true, output: all }
+        ├─LogicalJoin { type: Inner, on: true, output: all }
+        │ ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id, t1._rw_timestamp] }
+        │ └─LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id, t2._rw_timestamp] }
+        └─LogicalScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id, t3._rw_timestamp] }
+  stream_plan: |-
+    StreamMaterialize { columns: [v1, v2, v3, v4, v5, v6, t1._row_id(hidden), t2._row_id(hidden), t3._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, v1, t3._row_id], pk_columns: [t1._row_id, t2._row_id, v1, t3._row_id], pk_conflict: NoCheck }
+    └─StreamSyncLogStore
+      └─StreamHashJoin { type: Inner, predicate: t1.v1 = t3.v5, output: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6, t1._row_id, t2._row_id, t3._row_id] }
+        ├─StreamSyncLogStore
+        │ └─StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v3, output: [t1.v1, t1.v2, t2.v3, t2.v4, t1._row_id, t2._row_id] }
+        │   ├─StreamExchange { dist: HashShard(t1.v1) }
+        │   │ └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+        │   └─StreamExchange { dist: HashShard(t2.v3) }
+        │     └─StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
+        └─StreamExchange { dist: HashShard(t3.v5) }
+          └─StreamTableScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t3._row_id], pk: [_row_id], dist: UpstreamHashShard(t3._row_id) }
 - name: self join
   sql: |
     create table t (v1 int, v2 int);

--- a/src/frontend/src/optimizer/rule/add_logstore_rule.rs
+++ b/src/frontend/src/optimizer/rule/add_logstore_rule.rs
@@ -1,0 +1,33 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::optimizer::plan_node::StreamSyncLogStore;
+use crate::optimizer::rule::{BoxedRule, Rule};
+use crate::PlanRef;
+
+pub struct AddLogstoreRule {}
+
+impl Rule for AddLogstoreRule {
+    fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
+        plan.as_stream_hash_join()?;
+        let log_store_plan = StreamSyncLogStore::new(plan);
+        Some(log_store_plan.into())
+    }
+}
+
+impl AddLogstoreRule {
+    pub fn create() -> BoxedRule {
+        Box::new(Self {})
+    }
+}

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -240,6 +240,7 @@ mod apply_hop_window_transpose_rule;
 pub use apply_hop_window_transpose_rule::*;
 mod agg_call_merge_rule;
 pub use agg_call_merge_rule::*;
+mod add_logstore_rule;
 mod pull_up_correlated_predicate_agg_rule;
 mod source_to_iceberg_scan_rule;
 mod source_to_kafka_scan_rule;
@@ -248,6 +249,7 @@ mod table_function_to_mysql_query_rule;
 mod table_function_to_postgres_query_rule;
 mod values_extract_project_rule;
 
+pub use add_logstore_rule::*;
 pub use batch::batch_iceberg_predicate_pushdown::*;
 pub use batch::batch_push_limit_to_scan_rule::*;
 pub use pull_up_correlated_predicate_agg_rule::*;
@@ -336,6 +338,7 @@ macro_rules! for_all_rules {
             , { PullUpCorrelatedPredicateAggRule }
             , { SourceToKafkaScanRule }
             , { SourceToIcebergScanRule }
+            , { AddLogstoreRule }
         }
     };
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add log store rule which will add log store if `unaligned join` session variable is set. This provides a convenient way to test unaligned join. Subsequent PRs will also deal with re-aligning unaligned joins.

Unaligned Join with log store on output works best when downstream is the majority bottleneck. An example would be several cascading joins.

Instead of having to process the entire chunk, downstream can process it in smaller batches, while barriers can continue to bypass.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
