### PR TITLE
feat(sink): resolve avro `Ref` to corresponding `Record` definition

### DIFF
--- a/e2e_test/source_inline/kafka/avro/ref.slt
+++ b/e2e_test/source_inline/kafka/avro/ref.slt
@@ -34,12 +34,32 @@ Caused by these errors (recent errors listed first):
   2: circular reference detected in Avro schema: Node -> Node
 
 
+# Make sure circular reference does not lead to sink panic (stack overflow)
+# It is not necessary to reject such avro schema, because their SQL type is never circular
+statement ok
+create sink sk as select
+  2 as value, row(3, row(7))::struct<value int, next struct<value int>> as next
+WITH (${RISEDEV_KAFKA_WITH_OPTIONS_COMMON}, topic = 'avro-ref') FORMAT PLAIN ENCODE AVRO (schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}');
+
+
+statement ok
+drop sink sk;
+
+
 system ok
 curl -X DELETE "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/avro-ref-value"
 
 
 system ok
 curl -X DELETE "${RISEDEV_SCHEMA_REGISTRY_URL}/subjects/avro-ref-value?permanent=true"
+
+
+system ok
+rpk topic delete 'avro-ref'
+
+
+system ok
+rpk topic create avro-ref
 
 
 system ok
@@ -97,7 +117,17 @@ rpk topic produce avro-ref --schema-id=topic <<EOF
 EOF
 
 
-query IIIIIIII
+statement ok
+create sink sk as select
+  row(row(6, 7), row(8, 9))::struct<a struct<x int, y int>, b struct<x int, y int>> as foo,
+  row(row(9, 8), row(7, 6))::struct<a struct<x int, y int>, b struct<x int, y int>> as bar WITH
+(${RISEDEV_KAFKA_WITH_OPTIONS_COMMON}, topic = 'avro-ref') FORMAT PLAIN ENCODE AVRO (schema.registry = '${RISEDEV_SCHEMA_REGISTRY_URL}');
+
+
+sleep 1s
+
+
+query IIIIIIII rowsort
 select
   (foo).a.x,
   (foo).a.y,
@@ -110,6 +140,11 @@ select
 from s;
 ----
 3 4 5 6 6 5 4 3
+6 7 8 9 9 8 7 6
+
+
+statement ok
+drop sink sk;
 
 
 statement ok

--- a/src/connector/src/sink/encoder/avro.rs
+++ b/src/connector/src/sink/encoder/avro.rs
@@ -834,11 +834,8 @@ mod tests {
                 ),
             ])),
         );
-    }
 
-    #[test]
-    fn test_encode_avro_err() {
-        test_err(
+        test_ok(
             &DataType::Struct(StructType::new(vec![
                 (
                     "p",
@@ -864,8 +861,7 @@ mod tests {
                     Some(ScalarImpl::Int32(2)),
                     Some(ScalarImpl::Int32(1)),
                 ]))),
-            ])))
-            .to_datum_ref(),
+            ]))),
             r#"{
                 "type": "record",
                 "name": "Segment",
@@ -893,9 +889,27 @@ mod tests {
                     }
                 ]
             }"#,
-            "encode 'q' error: avro name ref unsupported yet",
+            Value::Record(vec![
+                (
+                    "p".to_owned(),
+                    Value::Record(vec![
+                        ("x".to_owned(), Value::Int(-2)),
+                        ("y".to_owned(), Value::Int(-1)),
+                    ]),
+                ),
+                (
+                    "q".to_owned(),
+                    Value::Record(vec![
+                        ("x".to_owned(), Value::Int(2)),
+                        ("y".to_owned(), Value::Int(1)),
+                    ]),
+                ),
+            ]),
         );
+    }
 
+    #[test]
+    fn test_encode_avro_err() {
         test_err(
             &DataType::Interval,
             Some(ScalarRefImpl::Interval(Interval::from_month_day_usec(

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -785,6 +785,8 @@ pub enum SinkError {
     ),
     #[error("Encode error: {0}")]
     Encode(String),
+    #[error("Avro error: {0}")]
+    Avro(#[from] apache_avro::Error),
     #[error("Iceberg error: {0}")]
     Iceberg(
         #[source]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This is the sink analogy for #19601 and #19746. Comparing the source and sink support:
* The sink did not support any form of `Ref` previously, while the source supported a subset (single-layer) via a hack.
* The sink unifies schema and datum handling via `MaybeData`, while the source took 2 PRs to fix separately.
* The sink uses an owned newtype `NamesRef(HashMap<Name, AvroSchema>)` while the source uses `apache_avro::schema::NamesRef<'s> = HashMap<Name, &'s AvroSchema>`. The former requires more memory while the latter requires more time to resolve every time. We can unify to one approach once we learned which is better in practice.
* The sink does not need to reject circular references as source did, because the upstream SQL schema is never circular.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
