### PR TITLE
feat(sink): support geospatial for redis sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "array-init"
@@ -9869,15 +9869,31 @@ version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
 dependencies = [
+ "combine",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.6",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
+dependencies = [
+ "arc-swap",
  "async-std",
- "async-trait",
  "bytes",
  "combine",
  "crc16",
- "futures",
+ "futures-sink",
  "futures-util",
  "itoa",
  "log",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "rand",
@@ -10260,7 +10276,7 @@ dependencies = [
  "log",
  "madsim-rdkafka",
  "madsim-tokio",
- "redis",
+ "redis 0.25.4",
  "regex",
  "reqwest 0.12.4",
  "serde",
@@ -10909,7 +10925,7 @@ dependencies = [
  "pulsar",
  "quote",
  "rand",
- "redis",
+ "redis 0.28.2",
  "regex",
  "reqwest 0.12.4",
  "risingwave_common",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -105,7 +105,7 @@ rdkafka = { workspace = true, features = [
     "gssapi",
     "zstd",
 ] }
-redis = { version = "0.25", features = ["aio", "tokio-comp", "async-std-comp","cluster-async"] }
+redis = { version = "0.28", features = ["aio", "tokio-comp", "async-std-comp","cluster-async","geospatial"] }
 regex = "1.4"
 reqwest = { version = "0.12.2", features = ["json", "stream"] }
 risingwave_common = { workspace = true }

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -35,7 +35,7 @@
 #![feature(never_type)]
 #![register_tool(rw)]
 #![recursion_limit = "256"]
-#![feature(specialization)]
+#![feature(min_specialization)]
 
 use std::time::Duration;
 

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -35,6 +35,7 @@
 #![feature(never_type)]
 #![register_tool(rw)]
 #![recursion_limit = "256"]
+#![feature(specialization)]
 
 use std::time::Duration;
 

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_formatter.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_formatter.rs
@@ -102,7 +102,8 @@ impl ElasticSearchOpenSearchFormatter {
         } else {
             None
         };
-        let key_encoder = TemplateEncoder::new_string(schema.clone(), col_indices.clone(), key_format);
+        let key_encoder =
+            TemplateEncoder::new_string(schema.clone(), col_indices.clone(), key_format);
         let value_encoder = JsonEncoder::new_with_es(schema.clone(), col_indices.clone());
         Ok(Self {
             key_encoder,

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_formatter.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_formatter.rs
@@ -102,7 +102,7 @@ impl ElasticSearchOpenSearchFormatter {
         } else {
             None
         };
-        let key_encoder = TemplateEncoder::new(schema.clone(), col_indices.clone(), key_format);
+        let key_encoder = TemplateEncoder::new_string(schema.clone(), col_indices.clone(), key_format);
         let value_encoder = JsonEncoder::new_with_es(schema.clone(), col_indices.clone());
         Ok(Self {
             key_encoder,
@@ -150,7 +150,7 @@ impl ElasticSearchOpenSearchFormatter {
                 .transpose()?;
             match op {
                 Op::Insert | Op::UpdateInsert => {
-                    let key = self.key_encoder.encode(rows)?;
+                    let key = self.key_encoder.encode(rows)?.into_string()?;
                     let value = self.value_encoder.encode(rows)?;
                     result_vec.push(BuildBulkPara {
                         index: index.to_owned(),
@@ -166,7 +166,7 @@ impl ElasticSearchOpenSearchFormatter {
                             "`Delete` operation is not supported in `append_only` mode"
                         )));
                     }
-                    let key = self.key_encoder.encode(rows)?;
+                    let key = self.key_encoder.encode(rows)?.into_string()?;
                     let mem_size_b = std::mem::size_of_val(&key);
                     result_vec.push(BuildBulkPara {
                         index: index.to_owned(),

--- a/src/connector/src/sink/encoder/template.rs
+++ b/src/connector/src/sink/encoder/template.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use regex::Regex;
 use risingwave_common::catalog::Schema;

--- a/src/connector/src/sink/encoder/template.rs
+++ b/src/connector/src/sink/encoder/template.rs
@@ -18,6 +18,7 @@ use regex::Regex;
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
 use risingwave_common::types::{DataType, ScalarRefImpl, ToText};
+use thiserror_ext::AsReport;
 
 use super::{Result, RowEncoder};
 use crate::sink::encoder::SerTo;
@@ -323,7 +324,7 @@ impl<T: SerTo<Vec<u8>>> SerTo<RedisSinkPayloadWriterInput> for T {
     default fn ser_to(self) -> Result<RedisSinkPayloadWriterInput> {
         let bytes = self.ser_to()?;
         Ok(RedisSinkPayloadWriterInput::String(
-            String::from_utf8(bytes).map_err(|e| SinkError::Redis(e.to_string()))?,
+            String::from_utf8(bytes).map_err(|e| SinkError::Redis(e.to_report_string()))?,
         ))
     }
 }

--- a/src/connector/src/sink/encoder/template.rs
+++ b/src/connector/src/sink/encoder/template.rs
@@ -12,26 +12,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::any::Any;
 use std::collections::HashSet;
 
 use regex::Regex;
-use risingwave_common::catalog::Schema;
+use risingwave_common::{catalog::Schema, types::ScalarRefImpl};
 use risingwave_common::row::Row;
 use risingwave_common::types::ToText;
+use crate::sink::encoder::SerTo;
 
 use super::{Result, RowEncoder};
 use crate::sink::SinkError;
 
+pub enum TemplateEncoder{
+    String(TemplateStringEncoder),
+    RedisGeo(TemplateRedisGeoEncoder),
+}
+impl TemplateEncoder {
+    pub fn new_string(schema: Schema, col_indices: Option<Vec<usize>>, template: String) -> Self {
+        TemplateEncoder::String(TemplateStringEncoder::new(schema, col_indices, template))
+    }
+}
+impl RowEncoder for TemplateEncoder {
+    type Output = TemplateEncoderOutput;
+
+    fn schema(&self) -> &Schema {
+        match self {
+            TemplateEncoder::String(encoder) => &encoder.schema,
+            TemplateEncoder::RedisGeo(encoder) => &encoder.schema,
+        }
+    }
+
+    fn col_indices(&self) -> Option<&[usize]> {
+        match self {
+            TemplateEncoder::String(encoder) => encoder.col_indices.as_deref(),
+            TemplateEncoder::RedisGeo(encoder) => encoder.col_indices.as_deref(),
+        }
+    }
+
+    fn encode_cols(
+            &self,
+            row: impl Row,
+            col_indices: impl Iterator<Item = usize>,
+    ) -> Result<Self::Output> {
+        match self {
+            TemplateEncoder::String(encoder) => Ok(TemplateEncoderOutput::String(encoder.encode_cols(row, col_indices)?)),
+            TemplateEncoder::RedisGeo(encoder) => encoder.encode_cols(row, col_indices),
+        }
+    }
+}
 /// Encode a row according to a specified string template `user_id:{user_id}`.
 /// Data is encoded to string with [`ToText`].
-pub struct TemplateEncoder {
+pub struct TemplateStringEncoder {
     schema: Schema,
     col_indices: Option<Vec<usize>>,
     template: String,
 }
 
 /// todo! improve the performance.
-impl TemplateEncoder {
+impl TemplateStringEncoder {
     pub fn new(schema: Schema, col_indices: Option<Vec<usize>>, template: String) -> Self {
         Self {
             schema,
@@ -62,24 +101,12 @@ impl TemplateEncoder {
         }
         Ok(())
     }
-}
 
-impl RowEncoder for TemplateEncoder {
-    type Output = String;
-
-    fn schema(&self) -> &Schema {
-        &self.schema
-    }
-
-    fn col_indices(&self) -> Option<&[usize]> {
-        self.col_indices.as_ref().map(Vec::as_ref)
-    }
-
-    fn encode_cols(
+    pub fn encode_cols(
         &self,
         row: impl Row,
         col_indices: impl Iterator<Item = usize>,
-    ) -> Result<Self::Output> {
+    ) -> Result<String> {
         let mut s = self.template.clone();
 
         for idx in col_indices {
@@ -93,5 +120,89 @@ impl RowEncoder for TemplateEncoder {
             );
         }
         Ok(s)
+    }
+}
+
+pub struct  TemplateRedisGeoEncoder {
+    schema: Schema,
+    col_indices: Option<Vec<usize>>,
+    lat_col: usize,
+    lon_col: usize,
+    mem_col: usize,
+}
+
+impl TemplateRedisGeoEncoder {
+    pub fn new(schema: Schema, col_indices: Option<Vec<usize>>, lat_col: usize, lon_col: usize, mem_col: usize) -> Self {
+        Self {
+            schema,
+            col_indices,
+            lat_col,
+            lon_col,
+            mem_col,
+        }
+    }
+
+    pub fn encode_cols(
+        &self,
+        row: impl Row,
+        _col_indices: impl Iterator<Item = usize>,
+    ) -> Result<TemplateEncoderOutput> {
+        let lat = into_f64_from_scalar(row.datum_at(self.lat_col).ok_or_else(|| SinkError::Redis("lat is null".to_owned()))?)?;
+        let lon = into_f64_from_scalar(row.datum_at(self.lon_col).ok_or_else(|| SinkError::Redis("lon is null".to_owned()))?)?;
+        let member = row.datum_at(self.mem_col).ok_or_else(|| SinkError::Redis("member is null".to_owned()))?.to_text();
+        let redis_geo = redis::geo::Coord::lon_lat(lon,lat);
+        Ok(TemplateEncoderOutput::RedisGeo((redis_geo , member)))
+    }
+}
+
+fn into_f64_from_scalar(scalar: ScalarRefImpl<'_>) -> Result<f64> {
+    match scalar {
+        ScalarRefImpl::Float32(ordered_float) => Ok(Into::<f32>::into(ordered_float) as f64),
+        ScalarRefImpl::Float64(ordered_float) => Ok(ordered_float.into()),
+        _ => Err(SinkError::Encode("Only f32 and f64 can convert to redis geo".to_owned())),
+    }
+}
+
+pub enum TemplateEncoderOutput {
+    String(String),
+    RedisGeo((redis::geo::Coord<f64>,String)),
+}
+
+impl TemplateEncoderOutput {
+    pub fn into_string(self) -> Result<String> {
+        match self {
+            TemplateEncoderOutput::String(s) => Ok(s),
+            TemplateEncoderOutput::RedisGeo((_, _)) => Err(SinkError::Encode("RedisGeo can't convert to string".to_owned())),
+        }
+    }
+}
+
+impl SerTo<String> for TemplateEncoderOutput {
+    fn ser_to(self) -> Result<String> {
+        match self {
+            TemplateEncoderOutput::String(s) => Ok(s),
+            TemplateEncoderOutput::RedisGeo((_, _)) => Err(SinkError::Encode("RedisGeo can't convert to string".to_owned())),
+        }
+    }
+}
+
+pub enum RedisEncoderOutput {
+    String(String),
+    RedisGeo((redis::geo::Coord<f64>,String)),
+}
+
+impl SerTo<RedisEncoderOutput> for TemplateEncoderOutput {
+    fn ser_to(self) -> Result<RedisEncoderOutput> {
+        match self {
+            TemplateEncoderOutput::String(s) => Ok(RedisEncoderOutput::String(s)),
+            TemplateEncoderOutput::RedisGeo((lat, lon)) => Ok(RedisEncoderOutput::RedisGeo((lat, lon))),
+        }
+    }
+}
+
+impl<T: SerTo<Vec<u8>>> SerTo<RedisEncoderOutput> for T {
+    default fn ser_to(self) -> Result<RedisEncoderOutput> {
+        let bytes = self.ser_to()?;
+        Ok(RedisEncoderOutput::String(String::from_utf8(bytes).map_err(|e| SinkError::Redis(e.to_string()))?))
     }
 }

--- a/src/connector/src/sink/encoder/template.rs
+++ b/src/connector/src/sink/encoder/template.rs
@@ -13,28 +13,47 @@
 // limitations under the License.
 
 use core::any::Any;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use regex::Regex;
-use risingwave_common::{catalog::Schema, types::ScalarRefImpl};
+use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
-use risingwave_common::types::ToText;
-use crate::sink::encoder::SerTo;
+use risingwave_common::types::{DataType, ScalarRefImpl, ToText};
 
 use super::{Result, RowEncoder};
+use crate::sink::encoder::SerTo;
 use crate::sink::SinkError;
 
-pub enum TemplateEncoder{
+pub enum TemplateEncoder {
     String(TemplateStringEncoder),
-    RedisGeo(TemplateRedisGeoEncoder),
+    RedisGeoKey(TemplateRedisGeoKeyEncoder),
+    RedisGeoValue(TemplateRedisGeoValueEncoder),
 }
 impl TemplateEncoder {
     pub fn new_string(schema: Schema, col_indices: Option<Vec<usize>>, template: String) -> Self {
         TemplateEncoder::String(TemplateStringEncoder::new(schema, col_indices, template))
     }
 
-    pub fn new_geo(schema: Schema, col_indices: Option<Vec<usize>>, lat_name: &str, lon_name: &str, member_name: &str) -> Result<Self> {
-        Ok(TemplateEncoder::RedisGeo(TemplateRedisGeoEncoder::new(schema, col_indices, lat_name, lon_name, member_name)?))
+    pub fn new_geo_value(
+        schema: Schema,
+        col_indices: Option<Vec<usize>>,
+        lat_name: &str,
+        lon_name: &str,
+    ) -> Result<Self> {
+        Ok(TemplateEncoder::RedisGeoValue(
+            TemplateRedisGeoValueEncoder::new(schema, col_indices, lat_name, lon_name)?,
+        ))
+    }
+
+    pub fn new_geo_key(
+        schema: Schema,
+        col_indices: Option<Vec<usize>>,
+        member_name: &str,
+        template: String,
+    ) -> Result<Self> {
+        Ok(TemplateEncoder::RedisGeoKey(
+            TemplateRedisGeoKeyEncoder::new(schema, col_indices, member_name, template)?,
+        ))
     }
 }
 impl RowEncoder for TemplateEncoder {
@@ -43,25 +62,30 @@ impl RowEncoder for TemplateEncoder {
     fn schema(&self) -> &Schema {
         match self {
             TemplateEncoder::String(encoder) => &encoder.schema,
-            TemplateEncoder::RedisGeo(encoder) => &encoder.schema,
+            TemplateEncoder::RedisGeoValue(encoder) => &encoder.schema,
+            TemplateEncoder::RedisGeoKey(encoder) => &encoder.key_encoder.schema,
         }
     }
 
     fn col_indices(&self) -> Option<&[usize]> {
         match self {
             TemplateEncoder::String(encoder) => encoder.col_indices.as_deref(),
-            TemplateEncoder::RedisGeo(encoder) => encoder.col_indices.as_deref(),
+            TemplateEncoder::RedisGeoValue(encoder) => encoder.col_indices.as_deref(),
+            TemplateEncoder::RedisGeoKey(encoder) => encoder.key_encoder.col_indices.as_deref(),
         }
     }
 
     fn encode_cols(
-            &self,
-            row: impl Row,
-            col_indices: impl Iterator<Item = usize>,
+        &self,
+        row: impl Row,
+        col_indices: impl Iterator<Item = usize>,
     ) -> Result<Self::Output> {
         match self {
-            TemplateEncoder::String(encoder) => Ok(TemplateEncoderOutput::String(encoder.encode_cols(row, col_indices)?)),
-            TemplateEncoder::RedisGeo(encoder) => encoder.encode_cols(row, col_indices),
+            TemplateEncoder::String(encoder) => Ok(TemplateEncoderOutput::String(
+                encoder.encode_cols(row, col_indices)?,
+            )),
+            TemplateEncoder::RedisGeoValue(encoder) => encoder.encode_cols(row, col_indices),
+            TemplateEncoder::RedisGeoKey(encoder) => encoder.encode_cols(row, col_indices),
         }
     }
 }
@@ -83,7 +107,7 @@ impl TemplateStringEncoder {
         }
     }
 
-    pub fn check_string_format(format: &str, set: &HashSet<String>) -> Result<()> {
+    pub fn check_string_format(format: &str, map: &HashMap<String, DataType>) -> Result<()> {
         // We will check if the string inside {} corresponds to a column name in rw.
         // In other words, the content within {} should exclusively consist of column names from rw,
         // which means '{{column_name}}' or '{{column_name1},{column_name2}}' would be incorrect.
@@ -95,7 +119,7 @@ impl TemplateStringEncoder {
         }
         for capture in re.captures_iter(format) {
             if let Some(inner_content) = capture.get(1)
-                && !set.contains(inner_content.as_str())
+                && !map.contains_key(inner_content.as_str())
             {
                 return Err(SinkError::Redis(format!(
                     "Can't find field({:?}) in key_format or value_format",
@@ -127,37 +151,39 @@ impl TemplateStringEncoder {
     }
 }
 
-pub struct  TemplateRedisGeoEncoder {
+pub struct TemplateRedisGeoValueEncoder {
     schema: Schema,
     col_indices: Option<Vec<usize>>,
     lat_col: usize,
     lon_col: usize,
-    member_col: usize,
 }
 
-impl TemplateRedisGeoEncoder {
-    pub fn new(schema: Schema, col_indices: Option<Vec<usize>>, lat_name: &str, lon_name: &str, member_name: &str) -> Result<Self> {
+impl TemplateRedisGeoValueEncoder {
+    pub fn new(
+        schema: Schema,
+        col_indices: Option<Vec<usize>>,
+        lat_name: &str,
+        lon_name: &str,
+    ) -> Result<Self> {
         let lat_col = schema
             .names_str()
             .iter()
             .position(|name| name == &lat_name)
-            .ok_or_else(|| SinkError::Redis(format!("Can't find lat column({}) in schema", lat_name)))?;
+            .ok_or_else(|| {
+                SinkError::Redis(format!("Can't find lat column({}) in schema", lat_name))
+            })?;
         let lon_col = schema
             .names_str()
             .iter()
             .position(|name| name == &lon_name)
-            .ok_or_else(|| SinkError::Redis(format!("Can't find lon column({}) in schema", lon_name)))?;
-        let member_col = schema
-            .names_str()
-            .iter()
-            .position(|name| name == &member_name)
-            .ok_or_else(|| SinkError::Redis(format!("Can't find member column({}) in schema", member_name)))?;
+            .ok_or_else(|| {
+                SinkError::Redis(format!("Can't find lon column({}) in schema", lon_name))
+            })?;
         Ok(Self {
             schema,
             col_indices,
             lat_col,
             lon_col,
-            member_col,
         })
     }
 
@@ -166,10 +192,15 @@ impl TemplateRedisGeoEncoder {
         row: impl Row,
         _col_indices: impl Iterator<Item = usize>,
     ) -> Result<TemplateEncoderOutput> {
-        let lat = into_string_from_scalar(row.datum_at(self.lat_col).ok_or_else(|| SinkError::Redis("lat is null".to_owned()))?)?;
-        let lon = into_string_from_scalar(row.datum_at(self.lon_col).ok_or_else(|| SinkError::Redis("lon is null".to_owned()))?)?;
-        let member = row.datum_at(self.member_col).ok_or_else(|| SinkError::Redis("member is null".to_owned()))?.to_text();
-        Ok(TemplateEncoderOutput::RedisGeo((lat, lon , member)))
+        let lat = into_string_from_scalar(
+            row.datum_at(self.lat_col)
+                .ok_or_else(|| SinkError::Redis("lat is null".to_owned()))?,
+        )?;
+        let lon = into_string_from_scalar(
+            row.datum_at(self.lon_col)
+                .ok_or_else(|| SinkError::Redis("lon is null".to_owned()))?,
+        )?;
+        Ok(TemplateEncoderOutput::RedisGeoValue((lat, lon)))
     }
 }
 
@@ -177,20 +208,76 @@ fn into_string_from_scalar(scalar: ScalarRefImpl<'_>) -> Result<String> {
     match scalar {
         ScalarRefImpl::Float32(ordered_float) => Ok(Into::<f32>::into(ordered_float).to_string()),
         ScalarRefImpl::Float64(ordered_float) => Ok(Into::<f64>::into(ordered_float).to_string()),
-        _ => Err(SinkError::Encode("Only f32 and f64 can convert to redis geo".to_owned())),
+        ScalarRefImpl::Utf8(s) => Ok(s.to_owned()),
+        _ => Err(SinkError::Encode(
+            "Only f32 and f64 can convert to redis geo".to_owned(),
+        )),
+    }
+}
+
+pub struct TemplateRedisGeoKeyEncoder {
+    key_encoder: TemplateStringEncoder,
+    member_col: usize,
+}
+
+impl TemplateRedisGeoKeyEncoder {
+    pub fn new(
+        schema: Schema,
+        col_indices: Option<Vec<usize>>,
+        member_name: &str,
+        template: String,
+    ) -> Result<Self> {
+        let member_col = schema
+            .names_str()
+            .iter()
+            .position(|name| name == &member_name)
+            .ok_or_else(|| {
+                SinkError::Redis(format!(
+                    "Can't find member column({}) in schema",
+                    member_name
+                ))
+            })?;
+        let key_encoder = TemplateStringEncoder::new(schema, col_indices, template);
+        Ok(Self {
+            key_encoder,
+            member_col,
+        })
+    }
+
+    pub fn encode_cols(
+        &self,
+        row: impl Row,
+        col_indices: impl Iterator<Item = usize>,
+    ) -> Result<TemplateEncoderOutput> {
+        let member = row
+            .datum_at(self.member_col)
+            .ok_or_else(|| SinkError::Redis("member is null".to_owned()))?
+            .to_text()
+            .clone();
+        let key = self.key_encoder.encode_cols(row, col_indices)?;
+        Ok(TemplateEncoderOutput::RedisGeoKey((key, member)))
     }
 }
 
 pub enum TemplateEncoderOutput {
+    // String formatted according to the template
     String(String),
-    RedisGeo((String,String,String)),
+    // The value of redis's geospatial, including longitude and latitude
+    RedisGeoValue((String, String)),
+    // The key of redis's geospatial, including redis's key and member
+    RedisGeoKey((String, String)),
 }
 
 impl TemplateEncoderOutput {
     pub fn into_string(self) -> Result<String> {
         match self {
             TemplateEncoderOutput::String(s) => Ok(s),
-            TemplateEncoderOutput::RedisGeo((_, _,_)) => Err(SinkError::Encode("RedisGeo can't convert to string".to_owned())),
+            TemplateEncoderOutput::RedisGeoKey(_) => Err(SinkError::Encode(
+                "RedisGeoKey can't convert to string".to_owned(),
+            )),
+            TemplateEncoderOutput::RedisGeoValue(_) => Err(SinkError::Encode(
+                "RedisGeoVelue can't convert to string".to_owned(),
+            )),
         }
     }
 }
@@ -199,28 +286,45 @@ impl SerTo<String> for TemplateEncoderOutput {
     fn ser_to(self) -> Result<String> {
         match self {
             TemplateEncoderOutput::String(s) => Ok(s),
-            TemplateEncoderOutput::RedisGeo((_, _,_)) => Err(SinkError::Encode("RedisGeo can't convert to string".to_owned())),
+            TemplateEncoderOutput::RedisGeoKey(_) => Err(SinkError::Encode(
+                "RedisGeoKey can't convert to string".to_owned(),
+            )),
+            TemplateEncoderOutput::RedisGeoValue(_) => Err(SinkError::Encode(
+                "RedisGeoVelue can't convert to string".to_owned(),
+            )),
         }
     }
 }
 
-pub enum RedisEncoderOutput {
+/// The enum of inputs to `RedisSinkPayloadWriter`
+pub enum RedisSinkPayloadWriterInput {
+    // Json and String will be convert to string
     String(String),
-    RedisGeo((String,String,String)),
+    // The value of redis's geospatial, including longitude and latitude
+    RedisGeoValue((String, String)),
+    // The key of redis's geospatial, including redis's key and member
+    RedisGeoKey((String, String)),
 }
 
-impl SerTo<RedisEncoderOutput> for TemplateEncoderOutput {
-    fn ser_to(self) -> Result<RedisEncoderOutput> {
+impl SerTo<RedisSinkPayloadWriterInput> for TemplateEncoderOutput {
+    fn ser_to(self) -> Result<RedisSinkPayloadWriterInput> {
         match self {
-            TemplateEncoderOutput::String(s) => Ok(RedisEncoderOutput::String(s)),
-            TemplateEncoderOutput::RedisGeo((lat, lon, member)) => Ok(RedisEncoderOutput::RedisGeo((lat, lon, member))),
+            TemplateEncoderOutput::String(s) => Ok(RedisSinkPayloadWriterInput::String(s)),
+            TemplateEncoderOutput::RedisGeoKey((lat, lon)) => {
+                Ok(RedisSinkPayloadWriterInput::RedisGeoKey((lat, lon)))
+            }
+            TemplateEncoderOutput::RedisGeoValue((key, member)) => {
+                Ok(RedisSinkPayloadWriterInput::RedisGeoValue((key, member)))
+            }
         }
     }
 }
 
-impl<T: SerTo<Vec<u8>>> SerTo<RedisEncoderOutput> for T {
-    default fn ser_to(self) -> Result<RedisEncoderOutput> {
+impl<T: SerTo<Vec<u8>>> SerTo<RedisSinkPayloadWriterInput> for T {
+    default fn ser_to(self) -> Result<RedisSinkPayloadWriterInput> {
         let bytes = self.ser_to()?;
-        Ok(RedisEncoderOutput::String(String::from_utf8(bytes).map_err(|e| SinkError::Redis(e.to_string()))?))
+        Ok(RedisSinkPayloadWriterInput::String(
+            String::from_utf8(bytes).map_err(|e| SinkError::Redis(e.to_string()))?,
+        ))
     }
 }

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -308,10 +308,10 @@ impl EncoderBuild for TemplateEncoder {
             REDIS_VALUE_TYPE_GEO => match pk_indices {
                 Some(_) => {
                     let member_name = b.format_desc.options.get(MEMBER_NAME).ok_or_else(|| {
-                        SinkError::Config(anyhow!("Cannot find 'member',please set it."))
+                        SinkError::Config(anyhow!("Cannot find `{MEMBER_NAME}`,please set it."))
                     })?;
                     let template = b.format_desc.options.get(KEY_FORMAT).ok_or_else(|| {
-                        SinkError::Config(anyhow!("Cannot find '{KEY_FORMAT}',please set it."))
+                        SinkError::Config(anyhow!("Cannot find `{KEY_FORMAT}`,please set it."))
                     })?;
                     TemplateEncoder::new_geo_key(
                         b.schema,
@@ -322,10 +322,10 @@ impl EncoderBuild for TemplateEncoder {
                 }
                 None => {
                     let lat_name = b.format_desc.options.get(LAT_NAME).ok_or_else(|| {
-                        SinkError::Config(anyhow!("Cannot find 'lat',please set it."))
+                        SinkError::Config(anyhow!("Cannot find `{LAT_NAME}`, please set it."))
                     })?;
                     let lon_name = b.format_desc.options.get(LON_NAME).ok_or_else(|| {
-                        SinkError::Config(anyhow!("Cannot find 'lon',please set it."))
+                        SinkError::Config(anyhow!("Cannot find `{LON_NAME}`,please set it."))
                     })?;
                     TemplateEncoder::new_geo_value(b.schema, pk_indices, lat_name, lon_name)
                 }

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -36,7 +36,10 @@ use super::encoder::{
     DateHandlingMode, JsonbHandlingMode, KafkaConnectParams, TimeHandlingMode,
     TimestamptzHandlingMode,
 };
-use super::redis::{KEY_FORMAT, LAT_NAME, LON_NAME, MEMBER_NAME, REDIS_VALUE_TYPE, REDIS_VALUE_TYPE_GEO, REDIS_VALUE_TYPE_STRING, VALUE_FORMAT};
+use super::redis::{
+    KEY_FORMAT, LAT_NAME, LON_NAME, MEMBER_NAME, REDIS_VALUE_TYPE, REDIS_VALUE_TYPE_GEO,
+    REDIS_VALUE_TYPE_STRING, VALUE_FORMAT,
+};
 use crate::sink::encoder::{
     AvroEncoder, AvroHeader, JsonEncoder, ProtoEncoder, ProtoHeader, TimestampHandlingMode,
 };
@@ -282,48 +285,55 @@ impl EncoderBuild for AvroEncoder {
 
 impl EncoderBuild for TemplateEncoder {
     async fn build(b: EncoderParams<'_>, pk_indices: Option<Vec<usize>>) -> Result<Self> {
-        if let Some(_) = pk_indices {
-            let template = b.format_desc.options.get(KEY_FORMAT).ok_or_else(|| {
-                SinkError::Config(anyhow!(
-                    "Cannot find '{KEY_FORMAT}',please set it or use JSON"
-                ))
-            })?;
-            return Ok(TemplateEncoder::new_string(b.schema, pk_indices, template.clone()))
-        }
-        let redis_value_type = b.format_desc.options.get(REDIS_VALUE_TYPE).map_or(REDIS_VALUE_TYPE_STRING, |s| s.as_str());
+        let redis_value_type = b
+            .format_desc
+            .options
+            .get(REDIS_VALUE_TYPE)
+            .map_or(REDIS_VALUE_TYPE_STRING, |s| s.as_str());
         match redis_value_type {
             REDIS_VALUE_TYPE_STRING => {
-                let template = b.format_desc.options.get(VALUE_FORMAT).ok_or_else(|| {
-                    SinkError::Config(anyhow!(
-                        "Cannot find '{VALUE_FORMAT}',please set it."
-                    ))
+                let option_name = match pk_indices {
+                    Some(_) => KEY_FORMAT,
+                    None => VALUE_FORMAT,
+                };
+                let template = b.format_desc.options.get(option_name).ok_or_else(|| {
+                    SinkError::Config(anyhow!("Cannot find '{option_name}',please set it."))
                 })?;
-                Ok(TemplateEncoder::new_string(b.schema, pk_indices, template.clone()))
-            },
-            REDIS_VALUE_TYPE_GEO => {
-                let lat_name = b.format_desc.options.get(LAT_NAME).ok_or_else(|| {
-                    SinkError::Config(anyhow!(
-                        "Cannot find 'lat',please set it."
-                    ))
-                })?;
-                let lon_name = b.format_desc.options.get(LON_NAME).ok_or_else(|| {
-                    SinkError::Config(anyhow!(
-                        "Cannot find 'lon',please set it."
-                    ))
-                })?;
-                let member_name = b.format_desc.options.get(MEMBER_NAME).ok_or_else(|| {
-                    SinkError::Config(anyhow!(
-                        "Cannot find 'member',please set it."
-                    ))
-                })?;
-                TemplateEncoder::new_geo(b.schema, pk_indices, lat_name, lon_name, member_name)
-            },
-            _ => {
-                return Err(SinkError::Config(anyhow!(
-                    "The value type {} is not supported",
-                    redis_value_type
-                )))
+                Ok(TemplateEncoder::new_string(
+                    b.schema,
+                    pk_indices,
+                    template.clone(),
+                ))
             }
+            REDIS_VALUE_TYPE_GEO => match pk_indices {
+                Some(_) => {
+                    let member_name = b.format_desc.options.get(MEMBER_NAME).ok_or_else(|| {
+                        SinkError::Config(anyhow!("Cannot find 'member',please set it."))
+                    })?;
+                    let template = b.format_desc.options.get(KEY_FORMAT).ok_or_else(|| {
+                        SinkError::Config(anyhow!("Cannot find '{KEY_FORMAT}',please set it."))
+                    })?;
+                    TemplateEncoder::new_geo_key(
+                        b.schema,
+                        pk_indices,
+                        member_name,
+                        template.clone(),
+                    )
+                }
+                None => {
+                    let lat_name = b.format_desc.options.get(LAT_NAME).ok_or_else(|| {
+                        SinkError::Config(anyhow!("Cannot find 'lat',please set it."))
+                    })?;
+                    let lon_name = b.format_desc.options.get(LON_NAME).ok_or_else(|| {
+                        SinkError::Config(anyhow!("Cannot find 'lon',please set it."))
+                    })?;
+                    TemplateEncoder::new_geo_value(b.schema, pk_indices, lat_name, lon_name)
+                }
+            },
+            _ => Err(SinkError::Config(anyhow!(
+                "The value type {} is not supported",
+                redis_value_type
+            ))),
         }
     }
 }

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -291,7 +291,7 @@ impl EncoderBuild for TemplateEncoder {
                 "Cannot find '{option_name}',please set it or use JSON"
             ))
         })?;
-        Ok(TemplateEncoder::new(b.schema, pk_indices, template.clone()))
+        Ok(TemplateEncoder::new_string(b.schema, pk_indices, template.clone()))
     }
 }
 

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -48,8 +48,8 @@ pub const VALUE_FORMAT: &str = "value_format";
 pub const REDIS_VALUE_TYPE: &str = "redis_value_type";
 pub const REDIS_VALUE_TYPE_STRING: &str = "string";
 pub const REDIS_VALUE_TYPE_GEO: &str = "geospatial";
-pub const LON_NAME: &str = "lon";
-pub const LAT_NAME: &str = "lat";
+pub const LON_NAME: &str = "longitude";
+pub const LAT_NAME: &str = "latitude";
 pub const MEMBER_NAME: &str = "member";
 
 #[derive(Deserialize, Debug, Clone, WithOptions)]
@@ -284,7 +284,7 @@ impl Sink for RedisSink {
         ) {
             let key_format = self.format_desc.options.get(KEY_FORMAT).ok_or_else(|| {
                 SinkError::Config(anyhow!(
-                    "Cannot find 'key_format', please set it or use JSON"
+                    "Cannot find '{KEY_FORMAT}', please set it or use JSON"
                 ))
             })?;
             TemplateStringEncoder::check_string_format(key_format, &pk_map)?;
@@ -298,7 +298,7 @@ impl Sink for RedisSink {
                     let value_format =
                         self.format_desc.options.get(VALUE_FORMAT).ok_or_else(|| {
                             SinkError::Config(anyhow!(
-                                "Cannot find 'value_format', please set it or use JSON"
+                                "Cannot find `{VALUE_FORMAT}`, please set it or use JSON"
                             ))
                         })?;
                     TemplateStringEncoder::check_string_format(value_format, &all_map)?;
@@ -306,17 +306,17 @@ impl Sink for RedisSink {
                 Some(REDIS_VALUE_TYPE_GEO) => {
                     let lon_name = self.format_desc.options.get(LON_NAME).ok_or_else(|| {
                         SinkError::Config(anyhow!(
-                            "Cannot find `lon`, please set it or use JSON or set `redis_value_type` to `string`"
+                            "Cannot find `{LON_NAME}`, please set it or use JSON or set `{REDIS_VALUE_TYPE}` to `{REDIS_VALUE_TYPE_STRING}`"
                         ))
                     })?;
                     let lat_name = self.format_desc.options.get(LAT_NAME).ok_or_else(|| {
                         SinkError::Config(anyhow!(
-                            "Cannot find `lat`, please set it or use JSON or set `redis_value_type` to `string`"
+                            "Cannot find `{LAT_NAME}`, please set it or use JSON or set `{REDIS_VALUE_TYPE}` to `{REDIS_VALUE_TYPE_STRING}`"
                         ))
                     })?;
                     let member_name = self.format_desc.options.get(MEMBER_NAME).ok_or_else(|| {
                         SinkError::Config(anyhow!(
-                            "Cannot find `member`, please set it or use JSON or set `redis_value_type` to `string`"
+                            "Cannot find `{MEMBER_NAME}`, please set it or use JSON or set `{REDIS_VALUE_TYPE}` to `{REDIS_VALUE_TYPE_STRING}`"
                         ))
                     })?;
                     if let Some(lon_type) = all_map.get(lon_name)
@@ -327,7 +327,7 @@ impl Sink for RedisSink {
                         // do nothing
                     } else {
                         return Err(SinkError::Config(anyhow!(
-                            "`lon` must be set to `float64` or `float32` or `varchar`"
+                            "`{LON_NAME}` must be set to `float64` or `float32` or `varchar`"
                         )));
                     }
                     if let Some(lat_type) = all_map.get(lat_name)
@@ -338,7 +338,7 @@ impl Sink for RedisSink {
                         // do nothing
                     } else {
                         return Err(SinkError::Config(anyhow!(
-                            "`lat` must be set to `float64` or `float32` or `varchar`"
+                            "`{LAT_NAME}` must be set to `float64` or `float32` or `varchar`"
                         )));
                     }
                     if let Some(member_type) = pk_map.get(member_name)
@@ -347,13 +347,13 @@ impl Sink for RedisSink {
                         // do nothing
                     } else {
                         return Err(SinkError::Config(anyhow!(
-                            "`member` must be set to `varchar` and `primary_key`"
+                            "`{MEMBER_NAME}` must be set to `varchar` and `primary_key`"
                         )));
                     }
                 }
                 _ => {
                     return Err(SinkError::Config(anyhow!(
-                        "`redis_value_type` must be set to `string` or `geospatial`"
+                        "`{REDIS_VALUE_TYPE}` must be set to `{REDIS_VALUE_TYPE_STRING}` or `{REDIS_VALUE_TYPE_GEO}`"
                     )))
                 }
             }

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
 use redis::aio::MultiplexedConnection;
 use redis::cluster::{ClusterClient, ClusterConnection, ClusterPipeline};
-use redis::{Client as RedisClient, Pipeline, ToRedisArgs};
+use redis::{Client as RedisClient, Pipeline};
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::DataType;
@@ -28,9 +28,7 @@ use serde_with::serde_as;
 use with_options::WithOptions;
 
 use super::catalog::SinkFormatDesc;
-use super::encoder::template::{
-    RedisSinkPayloadWriterInput, TemplateEncoder, TemplateStringEncoder,
-};
+use super::encoder::template::{RedisSinkPayloadWriterInput, TemplateStringEncoder};
 use super::formatter::SinkFormatterImpl;
 use super::writer::FormattedSink;
 use super::{SinkError, SinkParam};
@@ -102,7 +100,7 @@ impl RedisPipe {
                 ) => {
                     pipe.geo_add(key, (lon, lat, member));
                 }
-                _ => return Err(SinkError::Redis("RedisPipe set not match".to_owned()).into()),
+                _ => return Err(SinkError::Redis("RedisPipe set not match".to_owned())),
             },
             RedisPipe::Single(pipe) => match (k, v) {
                 (
@@ -117,7 +115,7 @@ impl RedisPipe {
                 ) => {
                     pipe.geo_add(key, (lon, lat, member));
                 }
-                _ => return Err(SinkError::Redis("RedisPipe set not match".to_owned()).into()),
+                _ => return Err(SinkError::Redis("RedisPipe set not match".to_owned())),
             },
         };
         Ok(())
@@ -132,7 +130,7 @@ impl RedisPipe {
                 RedisSinkPayloadWriterInput::RedisGeoKey((key, member)) => {
                     pipe.zrem(key, member);
                 }
-                _ => return Err(SinkError::Redis("RedisPipe del not match".to_owned()).into()),
+                _ => return Err(SinkError::Redis("RedisPipe del not match".to_owned())),
             },
             RedisPipe::Single(pipe) => match k {
                 RedisSinkPayloadWriterInput::String(k) => {

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -27,7 +27,7 @@ use serde_with::serde_as;
 use with_options::WithOptions;
 
 use super::catalog::SinkFormatDesc;
-use super::encoder::template::TemplateEncoder;
+use super::encoder::template::{TemplateEncoder, TemplateStringEncoder};
 use super::formatter::SinkFormatterImpl;
 use super::writer::FormattedSink;
 use super::{SinkError, SinkParam};
@@ -241,8 +241,8 @@ impl Sink for RedisSink {
                     "Cannot find 'value_format', please set it or use JSON"
                 ))
             })?;
-            TemplateEncoder::check_string_format(key_format, &pk_set)?;
-            TemplateEncoder::check_string_format(value_format, &all_set)?;
+            TemplateStringEncoder::check_string_format(key_format, &pk_set)?;
+            TemplateStringEncoder::check_string_format(value_format, &all_set)?;
         }
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

in this pr, we support geospatial type for redis sink
https://redis.io/glossary/geospatial-indexing/

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation
<summary><b>Release note</b></summary>

We can use geospatial like 

```
create table t1(v1 float, v2 float,v3 varchar, v4 varchar);
CREATE SINK s1
FROM
    t1 WITH (
    primary_key = 'v3,v4',
    connector = 'redis',
    redis.url= 'redis://127.0.0.1:6379/',
)FORMAT UPSERT ENCODE TEMPLATE
(redis_value_type ='geospatial', 
longitude = 'v1', 
latitude = 'v2', 
member = 'v3',
key_format = 'abcd3:{v4}'
);
insert into t1 values(1.1, 1.1, 'test','test');
```
then we can get it in redis like 
```
GEOPOS abcd3:test test
------
1) 1) "1.10000044298171997"
   2) "1.10000000482478555"
```

`redis_value_type` must be set to `string` and `geospatial`, default is `string`
if `redis_value_type` is set to `string`, we must set `key_format` and `value_fomat`(Consistent with previous behavior)
if `redis_value_type` is set to `geospatial`, we must set `key_format`, `longitude`, `latitude` and `member` 
The meaning of `key_format` is consistent with `redis_value_type = string`
The `longitude` is the column name of rw, the datatype must be float, real or varchar
The `latitude` is the column name of rw, the datatype must be float, real or varchar
The `member` is the column name of rw, the datatype must be varchar, and must be `primary_key`

---- 

rewrite the release note (@tabVersion) 

* New Features
  * Added support for Redis geospatial data type in sink connectors
  * Introduced new configuration parameter redis_value_type with options:
    * string (default): Traditional key-value storage
    * geospatial: Store location data using Redis' geospatial features
* Configuration Requirements
  * For geospatial storage:
    * Required parameters: key_format, longitude, latitude, and member
    * longitude and latitude columns must be float, real, or varchar type
    * member column must be varchar type and part of the primary key
  * For string storage (unchanged):
    * Required parameters: key_format and value_format

