### PR TITLE
fix(storage): reset partition_vnode_count after merge

### DIFF
--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -293,6 +293,20 @@ impl HummockManager {
                 );
             }
 
+            // clear `partition_vnode_count` for the hybrid group
+            {
+                if let Err(err) = compaction_groups_txn.update_compaction_config(
+                    &[left_group_id],
+                    &[MutableConfig::SplitWeightByVnode(0)], // default
+                ) {
+                    tracing::error!(
+                        error = %err.as_report(),
+                        "failed to update compaction config for group-{}",
+                        left_group_id
+                    );
+                }
+            }
+
             new_version_delta.pre_apply();
 
             // remove right_group_id


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

as title

see https://grafana.test.risingwave-cloud.xyz/a/grafana-lokiexplore-app/explore/service/benchmark-risingwave-compactor-c/logs?patterns=%5B%5D&from=2025-02-06T21:48:25.000Z&to=2025-02-06T23:20:33.000Z&var-ds=87981a45-1e5a-a649-c39e-c075d3f38b24&var-filters=namespace%7C%3D%7Cch-benchmark-pg-cdc-daily-20250206&var-filters=service_name%7C%3D%7Cbenchmark-risingwave-compactor-c&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&timezone=browser&urlColumns=%5B%22Time%22,%22Line%22%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&sortOrder=%22Descending%22&wrapLogMessage&var-lineFilters=caseInsensitive,0%7C%21%3D%7Crunning_parallelism_count&var-lineFilters=caseInsensitive,1%7C%21%3D%7Cbloom_filter_kind

This pr resets the vnode partition count configuration after merging cgs.

The vnode partition count is designed for single-table groups, whereas the merged cg must contain multiple tables, so it is a hybird group. The vnode partition optimize strategy will generate more ssts, which is fatal in low throughput, multi-table groups. 

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
