### PR TITLE
chore(install script): use release page redirection instead of github api to get latest version

### DIFF
--- a/scripts/install/install-risingwave.sh
+++ b/scripts/install/install-risingwave.sh
@@ -9,9 +9,11 @@ fi
 STATE_STORE_PATH="${HOME}/.risingwave/state_store"
 META_STORE_PATH="${HOME}/.risingwave/meta_store"
 
-VERSION=$(curl -s https://api.github.com/repos/risingwavelabs/risingwave/releases/latest \
- | grep '.tag_name' \
- | sed -E -n 's/.*(v[0-9]+.[0-9]+.[0-9]+.*)\",/\1/p')
+VERSION=$(
+  curl -sI 'https://github.com/risingwavelabs/risingwave/releases/latest' |
+    grep "location:" |
+    sed -E -n 's/.*(v[0-9]+.[0-9]+.[0-9]+.*)$/\1/p'
+)
 
 BASE_URL="https://github.com/risingwavelabs/risingwave/releases/download"
 

--- a/scripts/install/install-risingwave.sh
+++ b/scripts/install/install-risingwave.sh
@@ -11,7 +11,7 @@ META_STORE_PATH="${HOME}/.risingwave/meta_store"
 
 VERSION=$(
   curl -sI 'https://github.com/risingwavelabs/risingwave/releases/latest' |
-    grep "location:" |
+    grep -i "location:" |
     sed -E -n 's/.*(v[0-9]+.[0-9]+.[0-9]+.*)$/\1/p'
 )
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

We currently use `curl -s https://api.github.com/repos/risingwavelabs/risingwave/releases/latest` to get the latest released risingwave version. However, this method is very likely subject to the API rate limit restriction especially in work places sharing one single public IP. In such case, the script will not work:

```sh
$ curl -s https://api.github.com/repos/risingwavelabs/risingwave/releases/latest
{"message":"API rate limit exceeded for 101.127.221.250. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

```sh
$ curl -L https://risingwave.com/sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  3077  100  3077    0     0   8754      0 --:--:-- --:--:-- --:--:--  8754

Downloading RisingWave@ from https://github.com/risingwavelabs/risingwave/releases/download//risingwave--aarch64-unknown-linux-all-in-one.tar.gz into /Users/richard.

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0    243      0 --:--:-- --:--:-- --:--:--   250

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

This PR changes the script to rely on the redirection of `https://github.com/risingwavelabs/risingwave/releases/latest` page, which is less likely to be restricted.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
