### PR TITLE
fix(sink): fix iceberg sink partition_by panic 

### DIFF
--- a/e2e_test/iceberg/benches/predicate_pushdown.slt
+++ b/e2e_test/iceberg/benches/predicate_pushdown.slt
@@ -20,7 +20,6 @@ CREATE SINK sink1 AS select * from t1 WITH (
     s3.secret.key = 'hummockadmin',
     commit_checkpoint_interval = 1,
     create_table_if_not_exists = 'true',
-    partition_by = 'i1'
 );
 
 statement ok

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -331,20 +331,28 @@ impl IcebergSink {
                     }
                     let caps = re.captures_iter(partition_field);
                     for mat in caps {
-                        let (column, transform) = if mat.name("n").is_none() && mat.name("field").is_none()
-                        {
-                            (&mat["transform"], Transform::Identity)
-                        } else {
-                            let mut func = mat["transform"].to_owned();
-                            if func == "bucket" || func == "truncate" {
-                                let n = &mat.name("n").ok_or_else(||{
-                                    SinkError::Iceberg(anyhow!("The `n` must be set with `bucket` and `truncate`"))
-                                })?.as_str();
-                                func = format!("{func}[{n}]");
-                            }
-                            (&mat["field"], Transform::from_str(&func).map_err(|e| SinkError::Iceberg(anyhow!(e)))?)
-                        };
-                        println!("column: {}, transform: {:?}", column, transform);
+                        let (column, transform) =
+                            if mat.name("n").is_none() && mat.name("field").is_none() {
+                                (&mat["transform"], Transform::Identity)
+                            } else {
+                                let mut func = mat["transform"].to_owned();
+                                if func == "bucket" || func == "truncate" {
+                                    let n = &mat
+                                        .name("n")
+                                        .ok_or_else(|| {
+                                            SinkError::Iceberg(anyhow!(
+                                                "The `n` must be set with `bucket` and `truncate`"
+                                            ))
+                                        })?
+                                        .as_str();
+                                    func = format!("{func}[{n}]");
+                                }
+                                (
+                                    &mat["field"],
+                                    Transform::from_str(&func)
+                                        .map_err(|e| SinkError::Iceberg(anyhow!(e)))?,
+                                )
+                            };
 
                         match iceberg_schema.field_id_by_name(column) {
                             Some(id) => partition_fields.push(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

In this pr https://github.com/risingwavelabs/risingwave/pull/20340
we support partition_by  for iceberg, But it will panic, when `partition_by` is the column name

this pr fix panic. 
But iceberg-rust doesn't support func now, so this option is currently only supported by column name
https://github.com/apache/iceberg-rust/blob/75c7e8d67942fc6e29413d8011c508bdba95abe9/crates/iceberg/src/spec/partition.rs#L537

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

iceberg sink
with option: partition_by  Optional. A partition operation is performed based on the value of this column.  When the user sets partition_by  to a value that changes frequently, it will write too many files and lead to commit errors
