### PR TITLE
feat(source): update split state after yield barrier on split change for source executor

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -193,7 +193,7 @@ where
         Ok(())
     }
 
-    async fn try_wait_committed_epoch(&self, prev_epoch: u64) -> StorageResult<()> {
+    pub async fn try_wait_committed_epoch(&self, prev_epoch: u64) -> StorageResult<()> {
         self.store
             .try_wait_epoch(
                 HummockReadEpoch::Committed(prev_epoch),

--- a/src/stream/src/executor/source/fs_fetch_executor.rs
+++ b/src/stream/src/executor/source/fs_fetch_executor.rs
@@ -87,9 +87,9 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
         rate_limit_rps: Option<u32>,
     ) -> StreamExecutorResult<()> {
         let mut batch = Vec::with_capacity(SPLIT_BATCH_SIZE);
-        'vnodes: for vnode in state_store_handler.state_table.vnodes().iter_vnodes() {
-            let table_iter = state_store_handler
-                .state_table
+        let state_table = state_store_handler.state_table();
+        'vnodes: for vnode in state_table.vnodes().iter_vnodes() {
+            let table_iter = state_table
                 .iter_with_vnode(
                     vnode,
                     &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
@@ -273,8 +273,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                     }
 
                                     let post_commit = state_store_handler
-                                        .state_table
-                                        .commit(barrier.epoch)
+                                        .commit_may_update_vnode_bitmap(barrier.epoch)
                                         .await?;
 
                                     let update_vnode_bitmap =
@@ -359,7 +358,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                             .collect()
                                     };
                                     state_store_handler.set_states(file_assignment).await?;
-                                    state_store_handler.state_table.try_flush().await?;
+                                    state_store_handler.try_flush().await?;
                                 }
                                 Message::Watermark(_) => unreachable!(),
                             }

--- a/src/stream/src/executor/source/legacy_fs_source_executor.rs
+++ b/src/stream/src/executor/source/legacy_fs_source_executor.rs
@@ -139,14 +139,15 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
         Ok(())
     }
 
-    async fn apply_split_change<const BIASED: bool>(
+    async fn apply_split_change_after_yield_barrier<const BIASED: bool>(
         &mut self,
+        barrier_epoch: EpochPair,
         source_desc: &LegacyFsSourceDesc,
         stream: &mut StreamReaderWithPause<BIASED, StreamChunk>,
         target_splits: Vec<SplitImpl>,
     ) -> StreamExecutorResult<()> {
         {
-            if let Some(target_state) = self.get_diff(target_splits).await? {
+            if let Some(target_state) = self.get_diff(barrier_epoch, target_splits).await? {
                 tracing::info!(
                     actor_id = self.actor_ctx.id,
                     state = ?target_state,
@@ -163,7 +164,11 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
 
     // Note: get_diff will modify the state_cache
     // rhs can not be None because we do not support split number reduction
-    async fn get_diff(&mut self, rhs: Vec<SplitImpl>) -> StreamExecutorResult<ConnectorState> {
+    async fn get_diff(
+        &mut self,
+        epoch: EpochPair,
+        rhs: Vec<SplitImpl>,
+    ) -> StreamExecutorResult<ConnectorState> {
         let core = &mut self.stream_source_core;
         let all_completed: HashSet<SplitId> = core.split_state_store.get_all_completed().await?;
 
@@ -171,6 +176,7 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
 
         let mut target_state: Vec<SplitImpl> = Vec::new();
         let mut no_change_flag = true;
+        let committed_reader = core.split_state_store.new_committed_reader(epoch).await?;
         for sc in rhs {
             if let Some(s) = core.updated_splits_in_epoch.get(&sc.id()) {
                 let fs = s
@@ -186,10 +192,8 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
             } else {
                 no_change_flag = false;
                 // write new assigned split to state cache. snapshot is base on cache.
-                let state = if let Some(recover_state) = core
-                    .split_state_store
-                    .try_recover_from_state_store(&sc)
-                    .await?
+                let state = if let Some(recover_state) =
+                    committed_reader.try_recover_from_state_store(&sc).await?
                 {
                     recover_state
                 } else {
@@ -271,10 +275,7 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
             core.split_state_store.set_all_complete(completed).await?
         }
         // commit anyway, even if no message saved
-        core.split_state_store
-            .state_table
-            .commit_assert_no_update_vnode_bitmap(epoch)
-            .await?;
+        core.split_state_store.commit(epoch).await?;
 
         core.updated_splits_in_epoch.clear();
         Ok(())
@@ -283,7 +284,7 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
     async fn try_flush_data(&mut self) -> StreamExecutorResult<()> {
         let core = &mut self.stream_source_core;
 
-        core.split_state_store.state_table.try_flush().await?;
+        core.split_state_store.try_flush().await?;
 
         Ok(())
     }
@@ -342,15 +343,19 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
             .filter(|split| !all_completed.contains(&split.id()))
             .collect_vec();
 
-        // restore the newest split info
-        for ele in &mut boot_state {
-            if let Some(recover_state) = self
+        {
+            let committed_reader = self
                 .stream_source_core
                 .split_state_store
-                .try_recover_from_state_store(ele)
-                .await?
-            {
-                *ele = recover_state;
+                .new_committed_reader(first_epoch)
+                .await?;
+            // restore the newest split info
+            for ele in &mut boot_state {
+                if let Some(recover_state) =
+                    committed_reader.try_recover_from_state_store(ele).await?
+                {
+                    *ele = recover_state;
+                }
             }
         }
 
@@ -453,15 +458,13 @@ impl<S: StateStore> LegacyFsSourceExecutor<S> {
                         yield msg;
 
                         if let Some((source_desc, stream, target_splits)) = split_change {
-                            // do `try_wait_committed_epoch` to ensure that when `apply_split_change`,
-                            // we can read the latest state written by other source executor
-                            self.stream_source_core
-                                .split_state_store
-                                .state_table
-                                .try_wait_committed_epoch(epoch.prev)
-                                .await?;
-                            self.apply_split_change(source_desc, stream, target_splits)
-                                .await?;
+                            self.apply_split_change_after_yield_barrier(
+                                epoch,
+                                source_desc,
+                                stream,
+                                target_splits,
+                            )
+                            .await?;
                         }
                     }
                     _ => {

--- a/src/stream/src/executor/source/mod.rs
+++ b/src/stream/src/executor/source/mod.rs
@@ -43,7 +43,7 @@ mod fs_fetch_executor;
 pub use fs_fetch_executor::*;
 
 mod source_backfill_state_table;
-pub use source_backfill_state_table::BackfillStateTableHandler;
+pub(crate) use source_backfill_state_table::BackfillStateTableHandler;
 
 pub mod state_table_handler;
 use futures_async_stream::try_stream;

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -110,8 +110,8 @@ impl<S: StateStore> SourceExecutor<S> {
         let (wait_checkpoint_tx, wait_checkpoint_rx) = mpsc::unbounded_channel();
         let wait_checkpoint_worker = WaitCheckpointWorker {
             wait_checkpoint_rx,
-            state_store: core.split_state_store.state_table.state_store().clone(),
-            table_id: core.split_state_store.state_table.table_id().into(),
+            state_store: core.split_state_store.state_table().state_store().clone(),
+            table_id: core.split_state_store.state_table().table_id().into(),
         };
         tokio::spawn(wait_checkpoint_worker.run());
         Ok(Some(WaitCheckpointTaskBuilder {
@@ -246,8 +246,9 @@ impl<S: StateStore> SourceExecutor<S> {
     ///
     ///    For source split change, split will not be migrated and we can trim states
     ///    for deleted splits.
-    async fn apply_split_change<const BIASED: bool>(
+    async fn apply_split_change_after_yield_barrier<const BIASED: bool>(
         &mut self,
+        barrier_epoch: EpochPair,
         source_desc: &SourceDesc,
         stream: &mut StreamReaderWithPause<BIASED, StreamChunk>,
         target_splits: Vec<SplitImpl>,
@@ -257,7 +258,7 @@ impl<S: StateStore> SourceExecutor<S> {
         {
             source_split_change_count_metrics.inc();
             if self
-                .update_state_if_changed(target_splits, should_trim_state)
+                .update_state_if_changed(barrier_epoch, target_splits, should_trim_state)
                 .await?
             {
                 self.rebuild_stream_reader(source_desc, stream).await?;
@@ -270,6 +271,7 @@ impl<S: StateStore> SourceExecutor<S> {
     /// Returns `true` if split changed. Otherwise `false`.
     async fn update_state_if_changed(
         &mut self,
+        barrier_epoch: EpochPair,
         target_splits: Vec<SplitImpl>,
         should_trim_state: bool,
     ) -> StreamExecutorResult<bool> {
@@ -285,6 +287,11 @@ impl<S: StateStore> SourceExecutor<S> {
 
         let mut split_changed = false;
 
+        let committed_reader = core
+            .split_state_store
+            .new_committed_reader(barrier_epoch)
+            .await?;
+
         // Checks added splits
         for (split_id, split) in target_splits {
             if let Some(s) = core.latest_split_info.get(&split_id) {
@@ -295,8 +302,7 @@ impl<S: StateStore> SourceExecutor<S> {
                 split_changed = true;
                 // write new assigned split to state cache. snapshot is base on cache.
 
-                let initial_state = if let Some(recover_state) = core
-                    .split_state_store
+                let initial_state = if let Some(recover_state) = committed_reader
                     .try_recover_from_state_store(&split)
                     .await?
                 {
@@ -415,10 +421,7 @@ impl<S: StateStore> SourceExecutor<S> {
         }
 
         // commit anyway, even if no message saved
-        core.split_state_store
-            .state_table
-            .commit_assert_no_update_vnode_bitmap(epoch)
-            .await?;
+        core.split_state_store.commit(epoch).await?;
 
         let updated_splits = core.updated_splits_in_epoch.clone();
 
@@ -430,7 +433,7 @@ impl<S: StateStore> SourceExecutor<S> {
     /// try mem table spill
     async fn try_flush_data(&mut self) -> StreamExecutorResult<()> {
         let core = self.stream_source_core.as_mut().unwrap();
-        core.split_state_store.state_table.try_flush().await?;
+        core.split_state_store.try_flush().await?;
 
         Ok(())
     }
@@ -485,20 +488,24 @@ impl<S: StateStore> SourceExecutor<S> {
         // initial_dispatch_num is 0 means the source executor doesn't have downstream jobs
         // and is newly created
         let mut is_uninitialized = self.actor_ctx.initial_dispatch_num == 0;
-        for ele in &mut boot_state {
-            if let Some(recover_state) = core
+        {
+            let committed_reader = core
                 .split_state_store
-                .try_recover_from_state_store(ele)
-                .await?
-            {
-                *ele = recover_state;
-                // if state store is non-empty, we consider it's initialized.
-                is_uninitialized = false;
-            } else {
-                // This is a new split, not in state table.
-                // make sure it is written to state table later.
-                // Then even it receives no messages, we can observe it in state table.
-                core.updated_splits_in_epoch.insert(ele.id(), ele.clone());
+                .new_committed_reader(first_epoch)
+                .await?;
+            for ele in &mut boot_state {
+                if let Some(recover_state) =
+                    committed_reader.try_recover_from_state_store(ele).await?
+                {
+                    *ele = recover_state;
+                    // if state store is non-empty, we consider it's initialized.
+                    is_uninitialized = false;
+                } else {
+                    // This is a new split, not in state table.
+                    // make sure it is written to state table later.
+                    // Then even it receives no messages, we can observe it in state table.
+                    core.updated_splits_in_epoch.insert(ele.id(), ele.clone());
+                }
             }
         }
 
@@ -787,14 +794,8 @@ impl<S: StateStore> SourceExecutor<S> {
                         source_split_change_count,
                     )) = split_change
                     {
-                        let core = self.stream_source_core.as_mut().unwrap();
-                        // do `try_wait_committed_epoch` to ensure that when `apply_split_change`,
-                        // we can read the latest state written by other source executor
-                        core.split_state_store
-                            .state_table
-                            .try_wait_committed_epoch(barrier_epoch.prev)
-                            .await?;
-                        self.apply_split_change(
+                        self.apply_split_change_after_yield_barrier(
+                            barrier_epoch,
                             source_desc,
                             stream,
                             target_splits,
@@ -1081,7 +1082,7 @@ mod tests {
     use risingwave_common::catalog::{ColumnId, Field, TableId};
     use risingwave_common::system_param::local_manager::LocalSystemParamsManager;
     use risingwave_common::test_prelude::StreamChunkTestExt;
-    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_common::util::epoch::{test_epoch, EpochExt};
     use risingwave_connector::source::datagen::DatagenSplit;
     use risingwave_connector::source::reader::desc::test_utils::create_source_desc_builder;
     use risingwave_pb::catalog::StreamSourceInfo;
@@ -1238,8 +1239,9 @@ mod tests {
         );
         let mut handler = executor.boxed().execute();
 
+        let mut epoch = test_epoch(1);
         let init_barrier =
-            Barrier::new_test_barrier(test_epoch(1)).with_mutation(Mutation::Add(AddMutation {
+            Barrier::new_test_barrier(epoch).with_mutation(Mutation::Add(AddMutation {
                 adds: HashMap::new(),
                 added_actors: HashSet::new(),
                 splits: hashmap! {
@@ -1287,24 +1289,31 @@ mod tests {
             }),
         ];
 
-        let change_split_mutation = Barrier::new_test_barrier(test_epoch(2)).with_mutation(
-            Mutation::SourceChangeSplit(hashmap! {
+        epoch.inc_epoch();
+        let change_split_mutation =
+            Barrier::new_test_barrier(epoch).with_mutation(Mutation::SourceChangeSplit(hashmap! {
                 ActorId::default() => new_assignment.clone()
-            }),
-        );
+            }));
 
         barrier_tx.send(change_split_mutation).unwrap();
 
         let _ = ready_chunks.next().await.unwrap(); // barrier
+
+        epoch.inc_epoch();
+        let barrier = Barrier::new_test_barrier(epoch);
+        barrier_tx.send(barrier).unwrap();
+
+        ready_chunks.next().await.unwrap(); // barrier
 
         let mut source_state_handler = SourceStateTableHandler::from_table_catalog(
             &default_source_internal_table(0x2333),
             mem_state_store.clone(),
         )
         .await;
+
         // there must exist state for new add partition
         source_state_handler
-            .init_epoch(EpochPair::new_test_epoch(test_epoch(2)))
+            .init_epoch(EpochPair::new_test_epoch(epoch))
             .await
             .unwrap();
         source_state_handler
@@ -1317,10 +1326,12 @@ mod tests {
 
         let _ = ready_chunks.next().await.unwrap();
 
-        let barrier = Barrier::new_test_barrier(test_epoch(3)).with_mutation(Mutation::Pause);
+        epoch.inc_epoch();
+        let barrier = Barrier::new_test_barrier(epoch).with_mutation(Mutation::Pause);
         barrier_tx.send(barrier).unwrap();
 
-        let barrier = Barrier::new_test_barrier(test_epoch(4)).with_mutation(Mutation::Resume);
+        epoch.inc_epoch();
+        let barrier = Barrier::new_test_barrier(epoch).with_mutation(Mutation::Resume);
         barrier_tx.send(barrier).unwrap();
 
         // receive all
@@ -1329,13 +1340,19 @@ mod tests {
         let prev_assignment = new_assignment;
         let new_assignment = vec![prev_assignment[2].clone()];
 
-        let drop_split_mutation = Barrier::new_test_barrier(test_epoch(5)).with_mutation(
-            Mutation::SourceChangeSplit(hashmap! {
+        epoch.inc_epoch();
+        let drop_split_mutation =
+            Barrier::new_test_barrier(epoch).with_mutation(Mutation::SourceChangeSplit(hashmap! {
                 ActorId::default() => new_assignment.clone()
-            }),
-        );
+            }));
 
         barrier_tx.send(drop_split_mutation).unwrap();
+
+        ready_chunks.next().await.unwrap(); // barrier
+
+        epoch.inc_epoch();
+        let barrier = Barrier::new_test_barrier(epoch);
+        barrier_tx.send(barrier).unwrap();
 
         ready_chunks.next().await.unwrap(); // barrier
 
@@ -1345,24 +1362,26 @@ mod tests {
         )
         .await;
 
-        source_state_handler
-            .init_epoch(EpochPair::new_test_epoch(5 * test_epoch(1)))
+        let new_epoch = EpochPair::new_test_epoch(epoch);
+        source_state_handler.init_epoch(new_epoch).await.unwrap();
+
+        let committed_reader = source_state_handler
+            .new_committed_reader(new_epoch)
             .await
             .unwrap();
-
-        assert!(source_state_handler
+        assert!(committed_reader
             .try_recover_from_state_store(&prev_assignment[0])
             .await
             .unwrap()
             .is_none());
 
-        assert!(source_state_handler
+        assert!(committed_reader
             .try_recover_from_state_store(&prev_assignment[1])
             .await
             .unwrap()
             .is_none());
 
-        assert!(source_state_handler
+        assert!(committed_reader
             .try_recover_from_state_store(&prev_assignment[2])
             .await
             .unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously on source split change (either on explicit split change, or on split migration during scale), we write the state of target splits (splits to read after barrier) before yielding the barrier, so as to include the state of target splits in the checkpoint of the barrier. However, before the barrier, some of the target splits may be owned by other source parallelisms, and the state of the splits may be written by these other source parallelisms, and if we also write the state in the current parallelism, the splits may be written in multiple parallelisms and hit assertion in storage on something like a write conflict. Semantically, in current parallelism, we start to read the split after the barrier, which means it owns the split only after the barrier, and before the barrier, it should not write state for split it has not owned yet.

Therefore, in this PR, on source split change, we will change to write the state of the target splits after yielding the barrier. Besides, when applying split change, we have call `try_recover_from_state_store`, which loads the splits across all parallelisms. However, in current code, we don't wait for the committed epoch, and the loaded state may be stale if the split is owned by other parallelisms. Therefore in this PR, we will wait for the committed epoch before `try_recover_from_state_store` to ensure that we read the latest split state. Since we have yielded the barrier before applying split change, we can ensure that we won't block the checkpoint committed epoch, and we can always eventually see the committed epoch bump up. The idea is the same as https://github.com/risingwavelabs/risingwave/issues/18312.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
