### PR TITLE
refactor(source): simplify Avro field to SQL column mapping

### DIFF
--- a/src/connector/codec/src/decoder/avro/schema.rs
+++ b/src/connector/codec/src/decoder/avro/schema.rs
@@ -85,19 +85,18 @@ pub fn avro_schema_to_column_descs(
         resolved.get_names(),
         map_handling,
     )?;
-    if let DataType::Struct(root_struct) = root_type {
-        let fields = root_struct
-            .iter()
-            .map(|(name, data_type)| {
-                use risingwave_common::catalog::{ColumnDesc, ColumnId};
-                let desc = ColumnDesc::named(name, ColumnId::placeholder(), data_type.clone());
-                desc.to_protobuf()
-            })
-            .collect();
-        Ok(fields)
-    } else {
+    let DataType::Struct(root_struct) = root_type else {
         bail!("schema invalid, record type required at top level of the schema.");
-    }
+    };
+    let fields = root_struct
+        .iter()
+        .map(|(name, data_type)| {
+            use risingwave_common::catalog::{ColumnDesc, ColumnId};
+            let desc = ColumnDesc::named(name, ColumnId::placeholder(), data_type.clone());
+            desc.to_protobuf()
+        })
+        .collect();
+    Ok(fields)
 }
 
 const DBZ_VARIABLE_SCALE_DECIMAL_NAME: &str = "VariableScaleDecimal";

--- a/src/connector/codec/src/decoder/avro/schema.rs
+++ b/src/connector/codec/src/decoder/avro/schema.rs
@@ -112,32 +112,18 @@ fn avro_field_to_column_desc(
     map_handling: Option<MapHandling>,
 ) -> anyhow::Result<ColumnDesc> {
     let data_type = avro_type_mapping(schema, ancestor_records, refs, map_handling)?;
-    match schema {
-        Schema::Ref { name: ref_name } => {
-            avro_field_to_column_desc(
-                name,
-                refs[ref_name], // `ResolvedSchema::try_from` already handles lookup failure
-                index,
-                ancestor_records,
-                refs,
-                map_handling,
-            )
-        }
-        _ => {
-            *index += 1;
-            Ok(ColumnDesc {
-                column_type: Some(data_type.to_protobuf()),
-                column_id: *index,
-                name: name.to_owned(),
-                generated_or_default_column: None,
-                description: None,
-                additional_column_type: 0, // deprecated
-                additional_column: Some(AdditionalColumn { column_type: None }),
-                version: ColumnDescVersion::LATEST as _,
-                // ..Default::default()
-            })
-        }
-    }
+    *index += 1;
+    Ok(ColumnDesc {
+        column_type: Some(data_type.to_protobuf()),
+        column_id: *index,
+        name: name.to_owned(),
+        generated_or_default_column: None,
+        description: None,
+        additional_column_type: 0, // deprecated
+        additional_column: Some(AdditionalColumn { column_type: None }),
+        version: ColumnDescVersion::LATEST as _,
+        // ..Default::default()
+    })
 }
 
 /// This function expects original schema (with `Ref`).

--- a/src/connector/codec/src/decoder/avro/schema.rs
+++ b/src/connector/codec/src/decoder/avro/schema.rs
@@ -123,30 +123,8 @@ fn avro_field_to_column_desc(
                 map_handling,
             )
         }
-        Schema::Record(RecordSchema {
-            // TODO(struct): assign type name once supported.
-            name: _type_name,
-            fields,
-            ..
-        }) => {
-            // TODO(struct): since we deprecated `field_descs` in `ColumnDesc`, there's no need to
-            // traverse the fields here except for maintaining the same column id (index) as the
-            // original implementation.
-            let _field_descs: Vec<ColumnDesc> = fields
-                .iter()
-                .map(|f| {
-                    avro_field_to_column_desc(
-                        &f.name,
-                        &f.schema,
-                        index,
-                        ancestor_records,
-                        refs,
-                        map_handling,
-                    )
-                })
-                .collect::<anyhow::Result<_>>()?;
+        _ => {
             *index += 1;
-
             Ok(ColumnDesc {
                 column_type: Some(data_type.to_protobuf()),
                 column_id: *index,
@@ -156,17 +134,7 @@ fn avro_field_to_column_desc(
                 additional_column_type: 0, // deprecated
                 additional_column: Some(AdditionalColumn { column_type: None }),
                 version: ColumnDescVersion::LATEST as _,
-            })
-        }
-        _ => {
-            *index += 1;
-            Ok(ColumnDesc {
-                column_type: Some(data_type.to_protobuf()),
-                column_id: *index,
-                name: name.to_owned(),
-                additional_column: Some(AdditionalColumn { column_type: None }),
-                version: ColumnDescVersion::LATEST as _,
-                ..Default::default()
+                // ..Default::default()
             })
         }
     }

--- a/src/connector/codec/tests/integration_tests/avro.rs
+++ b/src/connector/codec/tests/integration_tests/avro.rs
@@ -202,17 +202,17 @@ fn test_simple() {
         },
         expect![[r#"
             [
-                id(#1): Int32,
-                sequence_id(#2): Int64,
-                name(#3): Varchar,
-                score(#4): Float32,
-                avg_score(#5): Float64,
-                is_lasted(#6): Boolean,
-                entrance_date(#7): Date,
-                birthday(#8): Timestamptz,
-                anniversary(#9): Timestamptz,
-                passed(#10): Interval,
-                bytes(#11): Bytea,
+                id(#2147483646): Int32,
+                sequence_id(#2147483646): Int64,
+                name(#2147483646): Varchar,
+                score(#2147483646): Float32,
+                avg_score(#2147483646): Float64,
+                is_lasted(#2147483646): Boolean,
+                entrance_date(#2147483646): Date,
+                birthday(#2147483646): Timestamptz,
+                anniversary(#2147483646): Timestamptz,
+                passed(#2147483646): Interval,
+                bytes(#2147483646): Bytea,
             ]"#]],
         expect![[r#"
             Owned(Int32(32))
@@ -343,16 +343,16 @@ fn test_nullable_union() {
         },
         expect![[r#"
             [
-                id(#1): Int32,
-                age(#2): Int32,
-                sequence_id(#3): Int64,
-                name(#4): Varchar,
-                score(#5): Float32,
-                avg_score(#6): Float64,
-                is_lasted(#7): Boolean,
-                entrance_date(#8): Date,
-                birthday(#9): Timestamptz,
-                anniversary(#10): Timestamptz,
+                id(#2147483646): Int32,
+                age(#2147483646): Int32,
+                sequence_id(#2147483646): Int64,
+                name(#2147483646): Varchar,
+                score(#2147483646): Float32,
+                avg_score(#2147483646): Float64,
+                is_lasted(#2147483646): Boolean,
+                entrance_date(#2147483646): Date,
+                birthday(#2147483646): Timestamptz,
+                anniversary(#2147483646): Timestamptz,
             ]"#]],
         expect![[r#"
             Owned(Int32(5))
@@ -518,20 +518,20 @@ fn test_1() {
         },
         expect![[r#"
             [
-                op_type(#1): Varchar,
-                ID(#2): Varchar,
-                CLASS_ID(#3): Varchar,
-                ITEM_ID(#4): Varchar,
-                ATTR_ID(#5): Varchar,
-                ATTR_VALUE(#6): Varchar,
-                ORG_ID(#7): Varchar,
-                UNIT_INFO(#8): Varchar,
-                UPD_TIME(#9): Varchar,
-                DEC_VAL(#10): Decimal,
-                REFERRED(#11): Struct { a: Varchar },
-                REF(#12): Struct { a: Varchar },
-                uuid(#13): Varchar,
-                rate(#14): Float64,
+                op_type(#2147483646): Varchar,
+                ID(#2147483646): Varchar,
+                CLASS_ID(#2147483646): Varchar,
+                ITEM_ID(#2147483646): Varchar,
+                ATTR_ID(#2147483646): Varchar,
+                ATTR_VALUE(#2147483646): Varchar,
+                ORG_ID(#2147483646): Varchar,
+                UNIT_INFO(#2147483646): Varchar,
+                UPD_TIME(#2147483646): Varchar,
+                DEC_VAL(#2147483646): Decimal,
+                REFERRED(#2147483646): Struct { a: Varchar },
+                REF(#2147483646): Struct { a: Varchar },
+                uuid(#2147483646): Varchar,
+                rate(#2147483646): Float64,
             ]"#]],
         expect![[r#"
             Borrowed(Utf8("update"))
@@ -809,7 +809,7 @@ fn test_union() {
         },
         expect![[r#"
             [
-                metrics(#1): List(
+                metrics(#2147483646): List(
                     Struct {
                         id: Varchar,
                         name: Varchar,
@@ -910,8 +910,8 @@ fn test_map() {
         },
         expect![[r#"
             [
-                map_str(#1): Map(Varchar,Varchar),
-                map_map_int(#2): Map(Varchar,Map(Varchar,Int32)),
+                map_str(#2147483646): Map(Varchar,Varchar),
+                map_map_int(#2147483646): Map(Varchar,Map(Varchar,Int32)),
             ]"#]],
         expect![[r#"
             Owned([
@@ -966,8 +966,8 @@ fn test_map() {
         },
         expect![[r#"
             [
-                map_str(#1): Jsonb,
-                map_map_int(#2): Jsonb,
+                map_str(#2147483646): Jsonb,
+                map_map_int(#2147483646): Jsonb,
             ]"#]],
         expect![[r#"
             Owned(Jsonb({"a": "x", "b": "y"}))

--- a/src/connector/codec/tests/integration_tests/json.rs
+++ b/src/connector/codec/tests/integration_tests/json.rs
@@ -214,14 +214,14 @@ async fn test_json_schema_parse() {
 
     expect![[r#"
         [
-            cats(#1): Jsonb,
-            id(#2): Varchar,
-            meta(#3): Struct {
+            cats(#2147483646): Jsonb,
+            id(#2147483646): Varchar,
+            meta(#2147483646): Struct {
                 active: Jsonb,
                 tags: Jsonb,
             },
-            name(#4): Jsonb,
-            recurrent(#5): Struct {
+            name(#2147483646): Jsonb,
+            recurrent(#2147483646): Struct {
                 id: Varchar,
                 next: Struct {
                     id: Varchar,

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -198,7 +198,7 @@ mod tests {
     use itertools::Itertools;
     use maplit::{btreemap, convert_args};
     use risingwave_common::array::Op;
-    use risingwave_common::catalog::ColumnDesc as CatColumnDesc;
+    use risingwave_common::catalog::{ColumnDesc as CatColumnDesc, ColumnId};
     use risingwave_common::row::{OwnedRow, Row};
     use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_pb::catalog::StreamSourceInfo;
@@ -374,22 +374,22 @@ mod tests {
 
         assert_eq!(columns.len(), 4);
         assert_eq!(
-            CatColumnDesc::new_atomic(DataType::Int32, "id", 1),
+            CatColumnDesc::named("id", ColumnId::placeholder(), DataType::Int32),
             columns[0]
         );
 
         assert_eq!(
-            CatColumnDesc::new_atomic(DataType::Varchar, "first_name", 2),
+            CatColumnDesc::named("first_name", ColumnId::placeholder(), DataType::Varchar),
             columns[1]
         );
 
         assert_eq!(
-            CatColumnDesc::new_atomic(DataType::Varchar, "last_name", 3),
+            CatColumnDesc::named("last_name", ColumnId::placeholder(), DataType::Varchar),
             columns[2]
         );
 
         assert_eq!(
-            CatColumnDesc::new_atomic(DataType::Varchar, "email", 4),
+            CatColumnDesc::named("email", ColumnId::placeholder(), DataType::Varchar),
             columns[3]
         );
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

It used to give `record` (but not `record` inside `array`/`map`) special treatment and traverse a tree-of-tree (#19538). These are no longer needed thanks to #20497.

It also supports a top-level Avro `union` (in addition to `record`) which also maps to SQL `struct`. However the [practical e2e usage](https://www.confluent.io/blog/multiple-event-types-in-the-same-kafka-topic/#avro-unions-with-schema-references) is still blocked by avro lib bug #17632.

The ColumnIds are initialized with placeholder, as the actual assignment happens in frontend `create table` / `create source` / `alter` handler.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
