### PR TITLE
feat(frontend): alter column type for debugging purposes

### DIFF
--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -27,7 +27,7 @@ use risingwave_pb::ddl_service::TableJobType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{ProjectNode, StreamFragmentGraph};
 use risingwave_sqlparser::ast::{
-    AlterColumnOperation, AlterTableOperation, ColumnOption, Ident, ObjectName, Statement,
+    AlterColumnOperation, AlterTableOperation, ColumnOption, ObjectName, Statement,
 };
 
 use super::create_source::SqlColumnStrategy;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -683,7 +683,9 @@ pub async fn handle(
             }
         },
         Statement::AlterTable { name, operation } => match operation {
-            AlterTableOperation::AddColumn { .. } | AlterTableOperation::DropColumn { .. } => {
+            AlterTableOperation::AddColumn { .. }
+            | AlterTableOperation::DropColumn { .. }
+            | AlterTableOperation::AlterColumn { .. } => {
                 alter_table_column::handle_alter_table_column(handler_args, name, operation).await
             }
             AlterTableOperation::RenameTable { table_name } => {

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -771,8 +771,7 @@ pub async fn handle(
             | AlterTableOperation::DropConstraint { .. }
             | AlterTableOperation::RenameColumn { .. }
             | AlterTableOperation::ChangeColumn { .. }
-            | AlterTableOperation::RenameConstraint { .. }
-            | AlterTableOperation::AlterColumn { .. } => {
+            | AlterTableOperation::RenameConstraint { .. } => {
                 bail_not_implemented!(
                     "Unhandled statement: {}",
                     Statement::AlterTable { name, operation }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Support handling `ALTER TABLE .. ALTER COLUMN .. <new-type>` in the frontend, as a step towards #19755.

The implementation is as simple as modifying the table definition, replanning, and replacing the table plan. However, since we verify that the data type matches the original definition (since #19828), altering the column type cannot succeed solely with the changes in this PR.

As a result, this is currently mainly for debugging purposes, i.e., there will be no need to rely on an external schema registry to test the behavior of column type change (which will be done in future PRs).

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

SHOULD KEEP UNDOCUMENTED.

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
