### PR TITLE
feat(frontend): generate column id to struct fields

### DIFF
--- a/e2e_test/source_inline/kafka/avro/alter_table.slt
+++ b/e2e_test/source_inline/kafka/avro/alter_table.slt
@@ -95,19 +95,23 @@ select * from t
 2 DEF (2)  3
 8 XYZ NULL 9
 
-# create a new version of schema that added a new field to "nested"
-system ok
-sr_register avro_alter_table_test-value AVRO <<< '{"type":"record","name":"Root","fields":[{"name":"bar","type":"int","default":0},{"name":"foo","type":"string"},{"name":"nested","type":["null",{"type":"record","name":"Nested","fields":[{"name":"baz","type":"int"},{"name":"qux","type":"string","default":""}]}],"default":null}]}'
+# Adding a nested field used to fail, but now it is allowed since we assign ids to the fields.
+# However, the encoding part is not yet implemented, so we cannot test it here.
+# TODO(struct): uncomment the following lines and test the select output.
 
-# Refresh table schema should fail
-statement error
-ALTER TABLE t REFRESH SCHEMA;
-----
-db error: ERROR: Failed to run the query
+# # create a new version of schema that added a new field to "nested"
+# system ok
+# sr_register avro_alter_table_test-value AVRO <<< '{"type":"record","name":"Root","fields":[{"name":"bar","type":"int","default":0},{"name":"foo","type":"string"},{"name":"nested","type":["null",{"type":"record","name":"Nested","fields":[{"name":"baz","type":"int"},{"name":"qux","type":"string","default":""}]}],"default":null}]}'
 
-Caused by:
-  Feature is not yet implemented: The data type of column "nested" has been changed from "struct<baz integer>" to "struct<baz integer, qux character varying>". This is currently not supported, even if it could be a compatible change in external systems.
-No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
+# # Refresh table schema should fail
+# statement error
+# ALTER TABLE t REFRESH SCHEMA;
+# ----
+# db error: ERROR: Failed to run the query
+
+# Caused by:
+#   Feature is not yet implemented: The data type of column "nested" has been changed from "struct<baz integer>" to "struct<baz integer, qux character varying>". This is currently not supported, even if it could be a compatible change in external systems.
+# No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
 
 
 

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -32,7 +32,6 @@ message ColumnDesc {
 
   // Deprecated fields for struct type.
   // TODO(struct): support struct type name and store it in `DataType`.
-  // TODO(struct): support id for nested fields.
   reserved 4;
   reserved "field_descs";
   reserved 5;

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -36,6 +36,7 @@
 #![feature(negative_impls)]
 #![feature(register_tool)]
 #![feature(btree_cursors)]
+#![feature(assert_matches)]
 #![register_tool(rw)]
 
 #[cfg_attr(not(test), allow(unused_extern_crates))]

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -17,6 +17,7 @@
 // NOTE: When adding or modifying data types, remember to update the type matrix in
 // src/expr/macro/src/types.rs
 
+use std::assert_matches::assert_matches;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::str::FromStr;

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -17,7 +17,6 @@
 // NOTE: When adding or modifying data types, remember to update the type matrix in
 // src/expr/macro/src/types.rs
 
-use std::assert_matches::assert_matches;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::str::FromStr;

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -328,14 +328,14 @@ pub mod tests {
             ("address", DataType::Varchar),
             ("zipcode", DataType::Varchar),
         ])
-        .with_ids([5, 6].map(ColumnId::new))
+        // .with_ids([5, 6].map(ColumnId::new))
         .into();
         let expected_columns = maplit::hashmap! {
             ROW_ID_COLUMN_NAME => DataType::Serial,
             "country" => StructType::new(
                  vec![("address", DataType::Varchar),("city", city_type),("zipcode", DataType::Varchar)],
             )
-            .with_ids([3, 4, 7].map(ColumnId::new))
+            // .with_ids([3, 4, 7].map(ColumnId::new))
             .into(),
             RW_TIMESTAMP_COLUMN_NAME => DataType::Timestamptz,
         };

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -279,7 +279,8 @@ pub mod tests {
 
     use pgwire::pg_response::StatementType::CREATE_MATERIALIZED_VIEW;
     use risingwave_common::catalog::{
-        DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME, RW_TIMESTAMP_COLUMN_NAME,
+        ColumnId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME,
+        RW_TIMESTAMP_COLUMN_NAME,
     };
     use risingwave_common::types::{DataType, StructType};
 
@@ -327,15 +328,18 @@ pub mod tests {
             ("address", DataType::Varchar),
             ("zipcode", DataType::Varchar),
         ])
+        .with_ids([5, 6].map(ColumnId::new))
         .into();
         let expected_columns = maplit::hashmap! {
             ROW_ID_COLUMN_NAME => DataType::Serial,
             "country" => StructType::new(
                  vec![("address", DataType::Varchar),("city", city_type),("zipcode", DataType::Varchar)],
-            ).into(),
+            )
+            .with_ids([3, 4, 7].map(ColumnId::new))
+            .into(),
             RW_TIMESTAMP_COLUMN_NAME => DataType::Timestamptz,
         };
-        assert_eq!(columns, expected_columns);
+        assert_eq!(columns, expected_columns, "{columns:#?}");
     }
 
     /// When creating MV, a unique column name must be specified for each column

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -279,8 +279,7 @@ pub mod tests {
 
     use pgwire::pg_response::StatementType::CREATE_MATERIALIZED_VIEW;
     use risingwave_common::catalog::{
-        ColumnId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME,
-        RW_TIMESTAMP_COLUMN_NAME,
+        DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME, RW_TIMESTAMP_COLUMN_NAME,
     };
     use risingwave_common::types::{DataType, StructType};
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -866,7 +866,7 @@ pub async fn bind_create_source_or_table_with_connector(
     // XXX: why do we use col_id_gen here? It doesn't seem to be very necessary.
     // XXX: should we also change the col id for struct fields?
     for c in &mut columns {
-        c.column_desc.column_id = col_id_gen.generate(&*c)?;
+        col_id_gen.generate_new(c)?;
     }
     debug_assert_column_ids_distinct(&columns);
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -1031,7 +1031,7 @@ pub mod tests {
     use std::sync::Arc;
 
     use risingwave_common::catalog::{
-        DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME,
+        ColumnId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME,
     };
     use risingwave_common::types::{DataType, StructType};
 
@@ -1076,6 +1076,7 @@ pub mod tests {
             ("address", DataType::Varchar),
             ("zipcode", DataType::Varchar),
         ])
+        .with_ids([5, 6].map(ColumnId::new))
         .into();
         let expected_columns = maplit::hashmap! {
             ROW_ID_COLUMN_NAME => DataType::Serial,
@@ -1084,9 +1085,11 @@ pub mod tests {
             "rate" => DataType::Float32,
             "country" => StructType::new(
                 vec![("address", DataType::Varchar),("city", city_type),("zipcode", DataType::Varchar)],
-            ).into(),
+            )
+            .with_ids([3, 4, 7].map(ColumnId::new))
+            .into(),
         };
-        assert_eq!(columns, expected_columns);
+        assert_eq!(columns, expected_columns, "{columns:#?}");
     }
 
     #[tokio::test]

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -864,9 +864,15 @@ pub async fn bind_create_source_or_table_with_connector(
     }
 
     // XXX: why do we use col_id_gen here? It doesn't seem to be very necessary.
-    // XXX: should we also change the col id for struct fields?
     for c in &mut columns {
+        let original_data_type = c.data_type().clone();
         col_id_gen.generate(c)?;
+        // TODO: Now we restore the data type for `CREATE SOURCE`, so that keep the nested field id unset.
+        //       This behavior is inconsistent with `CREATE TABLE`, and should be fixed once we refactor
+        //       `ALTER SOURCE` to also use `ColumnIdGenerator` in the future.
+        if is_create_source {
+            c.column_desc.data_type = original_data_type;
+        }
     }
     debug_assert_column_ids_distinct(&columns);
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -1082,7 +1082,7 @@ pub mod tests {
             ("address", DataType::Varchar),
             ("zipcode", DataType::Varchar),
         ])
-        .with_ids([5, 6].map(ColumnId::new))
+        // .with_ids([5, 6].map(ColumnId::new))
         .into();
         let expected_columns = maplit::hashmap! {
             ROW_ID_COLUMN_NAME => DataType::Serial,
@@ -1092,7 +1092,7 @@ pub mod tests {
             "country" => StructType::new(
                 vec![("address", DataType::Varchar),("city", city_type),("zipcode", DataType::Varchar)],
             )
-            .with_ids([3, 4, 7].map(ColumnId::new))
+            // .with_ids([3, 4, 7].map(ColumnId::new))
             .into(),
         };
         assert_eq!(columns, expected_columns, "{columns:#?}");

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -1037,7 +1037,7 @@ pub mod tests {
     use std::sync::Arc;
 
     use risingwave_common::catalog::{
-        ColumnId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME,
+        DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, ROW_ID_COLUMN_NAME,
     };
     use risingwave_common::types::{DataType, StructType};
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -866,7 +866,7 @@ pub async fn bind_create_source_or_table_with_connector(
     // XXX: why do we use col_id_gen here? It doesn't seem to be very necessary.
     // XXX: should we also change the col id for struct fields?
     for c in &mut columns {
-        col_id_gen.generate_new(c)?;
+        col_id_gen.generate(c)?;
     }
     debug_assert_column_ids_distinct(&columns);
 

--- a/src/frontend/src/handler/create_source/external_schema/nexmark.rs
+++ b/src/frontend/src/handler/create_source/external_schema/nexmark.rs
@@ -59,7 +59,13 @@ pub fn check_nexmark_schema(
         })
         .collect_vec();
 
-    if expected != user_defined {
+    let schema_eq = expected.len() == user_defined.len()
+        && expected
+            .iter()
+            .zip_eq_fast(user_defined.iter())
+            .all(|((name1, type1), (name2, type2))| name1 == name2 && type1.equals_datatype(type2));
+
+    if !schema_eq {
         let cmp = pretty_assertions::Comparison::new(&expected, &user_defined);
         return Err(RwError::from(ProtocolError(format!(
             "The schema of the nexmark source must specify all columns in order:\n{cmp}",

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -2105,11 +2105,13 @@ mod tests {
             "v1" => DataType::Int16,
             "v2" => StructType::new(
                 vec![("v3", DataType::Int64),("v4", DataType::Float64),("v5", DataType::Float64)],
-            ).into(),
+            )
+            .with_ids([3, 4, 5].map(ColumnId::new))
+            .into(),
             RW_TIMESTAMP_COLUMN_NAME => DataType::Timestamptz,
         };
 
-        assert_eq!(columns, expected_columns);
+        assert_eq!(columns, expected_columns, "{columns:#?}");
     }
 
     #[test]

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -536,8 +536,7 @@ pub(crate) fn gen_create_table_plan(
 ) -> Result<(PlanRef, PbTable)> {
     let mut columns = bind_sql_columns(&column_defs, is_for_replace_plan)?;
     for c in &mut columns {
-        col_id_gen.generate_new(c)?;
-        // c.column_desc.column_id = col_id_gen.generate(&*c)?;
+        col_id_gen.generate(c)?;
     }
 
     let (_, secret_refs, connection_refs) = context.with_options().clone().into_parts();
@@ -812,7 +811,7 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
     )?;
 
     for c in &mut columns {
-        col_id_gen.generate_new(c)?;
+        col_id_gen.generate(c)?;
     }
 
     let (mut columns, pk_column_ids, _row_id_index) =
@@ -2167,7 +2166,7 @@ mod tests {
                 let mut columns = bind_sql_columns(&column_defs, false)?;
                 let mut col_id_gen = ColumnIdGenerator::new_initial();
                 for c in &mut columns {
-                    col_id_gen.generate_new(c)?;
+                    col_id_gen.generate(c)?;
                 }
 
                 let pk_names =

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -536,7 +536,8 @@ pub(crate) fn gen_create_table_plan(
 ) -> Result<(PlanRef, PbTable)> {
     let mut columns = bind_sql_columns(&column_defs, is_for_replace_plan)?;
     for c in &mut columns {
-        c.column_desc.column_id = col_id_gen.generate(&*c)?;
+        col_id_gen.generate_new(c)?;
+        // c.column_desc.column_id = col_id_gen.generate(&*c)?;
     }
 
     let (_, secret_refs, connection_refs) = context.with_options().clone().into_parts();
@@ -811,7 +812,7 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
     )?;
 
     for c in &mut columns {
-        c.column_desc.column_id = col_id_gen.generate(&*c)?;
+        col_id_gen.generate_new(c)?;
     }
 
     let (mut columns, pk_column_ids, _row_id_index) =
@@ -2166,7 +2167,7 @@ mod tests {
                 let mut columns = bind_sql_columns(&column_defs, false)?;
                 let mut col_id_gen = ColumnIdGenerator::new_initial();
                 for c in &mut columns {
-                    c.column_desc.column_id = col_id_gen.generate(&*c).unwrap();
+                    col_id_gen.generate_new(c)?;
                 }
 
                 let pk_names =

--- a/src/frontend/src/handler/create_table/col_id_gen.rs
+++ b/src/frontend/src/handler/create_table/col_id_gen.rs
@@ -388,11 +388,11 @@ mod tests {
             ColumnId::new(1)
         );
 
-        // mismatched data type
+        // mismatched simple data type
         let err = gen
             .generate_simple(Field::new("f64", DataType::Float32))
             .unwrap_err();
-        expect![[r#"incompatible data type change from Float64 to Float32 at path "f64""#]]
+        expect![[r#"column "f64" cannot be altered; only types containing struct can be altered"#]]
             .assert_eq(&err.to_report_string());
 
         // mismatched composite data type

--- a/src/frontend/src/handler/create_table/col_id_gen.rs
+++ b/src/frontend/src/handler/create_table/col_id_gen.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::{ColumnCatalog, INITIAL_TABLE_VERSION_ID, TableVersionId};
 use risingwave_common::types::{DataType, MapType, StructType, data_types};
+use risingwave_common::util::iter_util::ZipEqFast;
 
 use crate::TableCatalog;
 use crate::catalog::ColumnId;
@@ -104,7 +105,7 @@ impl ColumnIdGenerator {
                     }
 
                     for ((field_name, field_data_type), field_id) in
-                        fields.iter().zip_eq(fields.ids_or_placeholder())
+                        fields.iter().zip_eq_fast(fields.ids_or_placeholder())
                     {
                         with_segment!(Segment::Field(field_name.to_owned()), {
                             handle(existing, alterable, path, field_id, field_data_type.clone());

--- a/src/frontend/src/handler/create_table/col_id_gen.rs
+++ b/src/frontend/src/handler/create_table/col_id_gen.rs
@@ -228,6 +228,26 @@ impl ColumnIdGenerator {
                 None => None,
             };
 
+            // Only top-level column and struct fields need an ID.
+            let need_gen_id = matches!(path.last().unwrap(), Segment::Field(_));
+
+            let new_id = if need_gen_id {
+                if let Some(id) = original_column_id {
+                    assert!(
+                        id != ColumnId::placeholder(),
+                        "original column id should not be placeholder"
+                    );
+                    id
+                } else {
+                    let id = this.next_column_id;
+                    this.next_column_id = this.next_column_id.next();
+                    id
+                }
+            } else {
+                // Column ID is actually unused by caller (for list and map types), just use a placeholder.
+                ColumnId::placeholder()
+            };
+
             let new_data_type = match data_type {
                 DataType::Struct(fields) => {
                     let mut new_fields = Vec::new();
@@ -257,26 +277,6 @@ impl ColumnIdGenerator {
                 }
 
                 data_types::simple!() => data_type,
-            };
-
-            // Only top-level column and struct fields need an ID.
-            let need_gen_id = matches!(path.last().unwrap(), Segment::Field(_));
-
-            let new_id = if need_gen_id {
-                if let Some(id) = original_column_id {
-                    assert!(
-                        id != ColumnId::placeholder(),
-                        "original column id should not be placeholder"
-                    );
-                    id
-                } else {
-                    let id = this.next_column_id;
-                    this.next_column_id = this.next_column_id.next();
-                    id
-                }
-            } else {
-                // Column ID is actually unused by caller (for list and map types), just use a placeholder.
-                ColumnId::placeholder()
             };
 
             Ok((new_id, new_data_type))
@@ -520,8 +520,8 @@ mod tests {
                                                                 ),
                                                             ],
                                                             field_ids: [
-                                                                #2,
-                                                                #3,
+                                                                #4,
+                                                                #5,
                                                             ],
                                                         },
                                                     ),
@@ -532,12 +532,12 @@ mod tests {
                                 ),
                             ],
                             field_ids: [
-                                #1,
-                                #4,
+                                #2,
+                                #3,
                             ],
                         },
                     ),
-                    column_id: #5,
+                    column_id: #1,
                     name: "nested",
                     generated_or_default_column: None,
                     description: None,
@@ -546,6 +546,7 @@ mod tests {
                     },
                     version: Pr13707,
                     system_column: None,
+                    nullable: true,
                 },
                 is_hidden: false,
             }
@@ -602,7 +603,7 @@ mod tests {
                                                             ],
                                                             field_ids: [
                                                                 #7,
-                                                                #3,
+                                                                #5,
                                                                 #8,
                                                             ],
                                                         },
@@ -615,11 +616,11 @@ mod tests {
                             ],
                             field_ids: [
                                 #6,
-                                #4,
+                                #3,
                             ],
                         },
                     ),
-                    column_id: #5,
+                    column_id: #1,
                     name: "nested",
                     generated_or_default_column: None,
                     description: None,
@@ -628,6 +629,7 @@ mod tests {
                     },
                     version: Pr13707,
                     system_column: None,
+                    nullable: true,
                 },
                 is_hidden: false,
             }

--- a/src/frontend/src/handler/create_table_as.rs
+++ b/src/frontend/src/handler/create_table_as.rs
@@ -71,10 +71,12 @@ pub async fn handle_create_as(
                 .fields()
                 .iter()
                 .map(|field| {
-                    col_id_gen.generate(field).map(|id| ColumnCatalog {
-                        column_desc: ColumnDesc::from_field_with_column_id(field, id.get_id()),
+                    let mut col = ColumnCatalog {
+                        column_desc: ColumnDesc::from_field_without_column_id(field),
                         is_hidden: false,
-                    })
+                    };
+                    col_id_gen.generate_new(&mut col)?;
+                    Result::Ok(col)
                 })
                 .try_collect()?
         } else {

--- a/src/frontend/src/handler/create_table_as.rs
+++ b/src/frontend/src/handler/create_table_as.rs
@@ -75,7 +75,7 @@ pub async fn handle_create_as(
                         column_desc: ColumnDesc::from_field_without_column_id(field),
                         is_hidden: false,
                     };
-                    col_id_gen.generate_new(&mut col)?;
+                    col_id_gen.generate(&mut col)?;
                     Result::Ok(col)
                 })
                 .try_collect()?

--- a/src/frontend/src/handler/create_table_as.rs
+++ b/src/frontend/src/handler/create_table_as.rs
@@ -70,19 +70,20 @@ pub async fn handle_create_as(
                 .schema()
                 .fields()
                 .iter()
-                .map(|field| {
-                    let mut col = ColumnCatalog {
-                        column_desc: ColumnDesc::from_field_without_column_id(field),
-                        is_hidden: false,
-                    };
-                    col_id_gen.generate(&mut col)?;
-                    Result::Ok(col)
+                .map(|field| ColumnCatalog {
+                    column_desc: ColumnDesc::from_field_without_column_id(field),
+                    is_hidden: false,
                 })
-                .try_collect()?
+                .collect()
         } else {
             unreachable!()
         }
     };
+
+    // Generate column id.
+    for c in &mut columns {
+        col_id_gen.generate(c)?;
+    }
 
     if column_defs.len() > columns.len() {
         return Err(ErrorCode::InvalidInputSyntax(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Update `ColumnIdGenerator` to also generate id for nested fields (#20620) by traversing the data type of the columns.

When creating a new `ColumnIdGenerator` from an existing table, we traverse the fields of each column recursively and collect them into a map indexed by their access **path**s. When generating ids, we check against the map to decide whether a change is considered compatible and whether there's an ID to reuse.

To reviewers: don't be scared as half of lines are unit tests. 😄

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
