### PR TITLE
fix(meta): delete large time travel metadata in smaller batch

### DIFF
--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -143,6 +143,34 @@ impl HummockManager {
                 .into_tuple()
                 .all(&txn)
                 .await?;
+        // Reuse hummock_time_travel_epoch_version_insert_batch_size as threshold.
+        let delete_sst_batch_size = self
+            .env
+            .opts
+            .hummock_time_travel_epoch_version_insert_batch_size;
+        let mut sst_ids_to_delete: HashSet<_> = HashSet::default();
+        async fn delete_sst_in_batch(
+            txn: &DatabaseTransaction,
+            sst_ids_to_delete: HashSet<HummockSstableId>,
+            delete_sst_batch_size: usize,
+        ) -> Result<()> {
+            for start_idx in 0..=(sst_ids_to_delete.len().saturating_sub(1) / delete_sst_batch_size)
+            {
+                hummock_sstable_info::Entity::delete_many()
+                    .filter(
+                        hummock_sstable_info::Column::SstId.is_in(
+                            sst_ids_to_delete
+                                .iter()
+                                .skip(start_idx * delete_sst_batch_size)
+                                .take(delete_sst_batch_size)
+                                .copied(),
+                        ),
+                    )
+                    .exec(txn)
+                    .await?;
+            }
+            Ok(())
+        }
         for delta_id_to_delete in delta_ids_to_delete {
             let delta_to_delete = hummock_time_travel_delta::Entity::find_by_id(delta_id_to_delete)
                 .one(&txn)
@@ -158,21 +186,19 @@ impl HummockManager {
             );
             let new_sst_ids = delta_to_delete.newly_added_sst_ids();
             // The SST ids added and then deleted by compaction between the 2 versions.
-            let sst_ids_to_delete = &new_sst_ids - &latest_valid_version_sst_ids;
-            let res = hummock_sstable_info::Entity::delete_many()
-                .filter(hummock_sstable_info::Column::SstId.is_in(sst_ids_to_delete))
-                .exec(&txn)
+            sst_ids_to_delete.extend(&new_sst_ids - &latest_valid_version_sst_ids);
+            if sst_ids_to_delete.len() >= delete_sst_batch_size {
+                delete_sst_in_batch(
+                    &txn,
+                    std::mem::take(&mut sst_ids_to_delete),
+                    delete_sst_batch_size,
+                )
                 .await?;
+            }
             let new_object_ids = delta_to_delete.newly_added_object_ids();
             object_ids_to_delete.extend(&new_object_ids - &latest_valid_version_object_ids);
-            tracing::debug!(
-                delta_id = delta_to_delete.id.to_u64(),
-                "delete {} rows from hummock_sstable_info",
-                res.rows_affected
-            );
         }
         let mut next_version_sst_ids = latest_valid_version_sst_ids;
-        let mut sst_ids_to_delete: HashSet<_> = HashSet::default();
         for prev_version_id in version_ids_to_delete {
             let prev_version = {
                 let prev_version = hummock_time_travel_version::Entity::find_by_id(prev_version_id)
@@ -191,38 +217,20 @@ impl HummockManager {
             let sst_ids = prev_version.get_sst_ids();
             // The SST ids deleted by compaction between the 2 versions.
             sst_ids_to_delete.extend(&sst_ids - &next_version_sst_ids);
-            // Reuse hummock_time_travel_epoch_version_insert_batch_size as threshold.
-            if sst_ids_to_delete.len()
-                >= self
-                    .env
-                    .opts
-                    .hummock_time_travel_epoch_version_insert_batch_size
-            {
-                let res = hummock_sstable_info::Entity::delete_many()
-                    .filter(
-                        hummock_sstable_info::Column::SstId
-                            .is_in(std::mem::take(&mut sst_ids_to_delete)),
-                    )
-                    .exec(&txn)
-                    .await?;
-                tracing::debug!(
-                    "delete {} rows from hummock_sstable_info",
-                    res.rows_affected
-                );
+            if sst_ids_to_delete.len() >= delete_sst_batch_size {
+                delete_sst_in_batch(
+                    &txn,
+                    std::mem::take(&mut sst_ids_to_delete),
+                    delete_sst_batch_size,
+                )
+                .await?;
             }
             let new_object_ids = prev_version.get_object_ids();
             object_ids_to_delete.extend(&new_object_ids - &latest_valid_version_object_ids);
             next_version_sst_ids = sst_ids;
         }
         if !sst_ids_to_delete.is_empty() {
-            let res = hummock_sstable_info::Entity::delete_many()
-                .filter(hummock_sstable_info::Column::SstId.is_in(sst_ids_to_delete))
-                .exec(&txn)
-                .await?;
-            tracing::debug!(
-                "delete {} rows from hummock_sstable_info",
-                res.rows_affected
-            );
+            delete_sst_in_batch(&txn, sst_ids_to_delete, delete_sst_batch_size).await?;
         }
 
         if !object_ids_to_delete.is_empty() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously the timetravel sst metadata is deleted in one query, i.e. `delete from xx where sst_id is in (...)`. However, in extremly heavy write workload, the `is in` condition can exceed the threshold 65536 and result in error: `failed to access meta store: Execution Error: encountered unexpected or invalid data: PgConnection::run(): too many arguments for query: 118133 (sqlx_postgres::connection::executor:213)`.

This PR addresses the bug by splitting the deletion into smaller batches.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
