### PR TITLE
fix(connector): rollback transaction before closing connection for jdbc sink

### DIFF
--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSink.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSink.java
@@ -178,6 +178,7 @@ public class JDBCSink implements SinkWriter {
                         LOG.info("Recreate the JDBC connection due to connection broken");
                         // close the statements and connection first
                         jdbcStatements.close();
+                        conn.rollback();
                         conn.close();
 
                         // create a new connection if the current connection is invalid
@@ -394,6 +395,7 @@ public class JDBCSink implements SinkWriter {
 
         try {
             if (conn != null) {
+                conn.rollback();
                 conn.close();
             }
         } catch (SQLException e) {

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSink.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSink.java
@@ -55,7 +55,10 @@ public class JDBCSink implements SinkWriter {
         try {
             conn =
                     JdbcUtils.getConnection(
-                            config.getJdbcUrl(), config.getUser(), config.getPassword());
+                            config.getJdbcUrl(),
+                            config.getUser(),
+                            config.getPassword(),
+                            config.isAutoCommit());
             // Table schema has been validated before, so we get the PK from it directly
             this.pkColumnNames = tableSchema.getPrimaryKeys();
             // column name -> java.sql.Types
@@ -94,7 +97,9 @@ public class JDBCSink implements SinkWriter {
                     conn.getAutoCommit(),
                     conn.getTransactionIsolation());
             // Commit the `getTransactionIsolation`
-            conn.commit();
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
 
             jdbcStatements = new JdbcStatements(conn, config.getQueryTimeout());
         } catch (SQLException e) {
@@ -178,7 +183,10 @@ public class JDBCSink implements SinkWriter {
                         LOG.info("Recreate the JDBC connection due to connection broken");
                         // close the statements and connection first
                         jdbcStatements.close();
-                        conn.rollback();
+                        if (!conn.getAutoCommit()) {
+                            LOG.info("rollback the transaction");
+                            conn.rollback();
+                        }
                         conn.close();
 
                         // create a new connection if the current connection is invalid
@@ -186,7 +194,8 @@ public class JDBCSink implements SinkWriter {
                                 JdbcUtils.getConnection(
                                         config.getJdbcUrl(),
                                         config.getUser(),
-                                        config.getPassword());
+                                        config.getPassword(),
+                                        config.isAutoCommit());
                         // reset the flag since we will retry to prepare the batch again
                         updateFlag = false;
                         jdbcStatements = new JdbcStatements(conn, config.getQueryTimeout());
@@ -342,7 +351,9 @@ public class JDBCSink implements SinkWriter {
             executeStatement(this.upsertStatement);
             executeStatement(this.insertStatement);
 
-            this.conn.commit();
+            if (!conn.getAutoCommit()) {
+                this.conn.commit();
+            }
         }
 
         @Override
@@ -395,7 +406,10 @@ public class JDBCSink implements SinkWriter {
 
         try {
             if (conn != null) {
-                conn.rollback();
+                if (!conn.getAutoCommit()) {
+                    LOG.info("rollback the transaction");
+                    conn.rollback();
+                }
                 conn.close();
             }
         } catch (SQLException e) {

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSinkConfig.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSinkConfig.java
@@ -39,6 +39,9 @@ public class JDBCSinkConfig extends CommonSinkConfig {
     @JsonProperty(value = "jdbc.query.timeout")
     private int queryTimeoutSeconds = 600;
 
+    @JsonProperty(value = "jdbc.auto.commit")
+    private boolean autoCommit = false;
+
     @JsonCreator
     public JDBCSinkConfig(
             @JsonProperty(value = "jdbc.url") String jdbcUrl,
@@ -80,5 +83,9 @@ public class JDBCSinkConfig extends CommonSinkConfig {
 
     public int getQueryTimeout() {
         return queryTimeoutSeconds;
+    }
+
+    public boolean isAutoCommit() {
+        return autoCommit;
     }
 }

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JdbcUtils.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JdbcUtils.java
@@ -39,8 +39,8 @@ public abstract class JdbcUtils {
     }
 
     /** The connection returned by this method is *not* autoCommit */
-    public static Connection getConnection(String jdbcUrl, String user, String password)
-            throws SQLException {
+    public static Connection getConnection(
+            String jdbcUrl, String user, String password, boolean autoCommit) throws SQLException {
         var props = new Properties();
         // enable TCP keep alive to avoid connection closed by server
         // both MySQL and PG support this property
@@ -65,7 +65,7 @@ public abstract class JdbcUtils {
 
         var conn = DriverManager.getConnection(jdbcUrl, props);
         // disable auto commit can improve performance
-        conn.setAutoCommit(false);
+        conn.setAutoCommit(autoCommit);
         // explicitly set isolation level to RC
         conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
         return conn;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- RisingWave uses transactions (i.e. autoCommit = false) for jdbc sink, however, we haven't rollbacked the transaction before closing connection. 
- In this PR, we also provide a sink parameter `jdbc.auto.commit` to allow users to control whether to use transaction for jdbc sink.

### Example
```
CREATE SINK s_pg FROM t WITH (
    connector = 'jdbc', 
    jdbc.url = 'jdbc:postgresql://127.0.0.1:5432/dev?user=xxxx&password=xxxx',
    table.name = 't', 
    type = 'upsert', 
    primary_key = 'id', 
    jdbc.query.timeout = 60, 
    jdbc.auto.commit=true
);
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

- Support `jdbc.auto.commit` parameter for jdbc sink. the default value is false.

</details>
