### PR TITLE
fix(sink): align init epoch for coordinated sinks

### DIFF
--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -380,6 +380,10 @@ impl Sink for DeltaLakeSink {
         Ok(())
     }
 
+    fn is_coordinated_sink(&self) -> bool {
+        true
+    }
+
     async fn new_coordinator(&self) -> Result<Self::Coordinator> {
         Ok(DeltaLakeSinkCommitter {
             table: self.config.common.create_deltalake_client().await?,

--- a/src/connector/src/sink/elasticsearch_opensearch/opensearch.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/opensearch.rs
@@ -126,8 +126,4 @@ impl Sink for OpenSearchSink {
             risingwave_common::session_config::sink_decouple::SinkDecouple::Disable => Ok(false),
         }
     }
-
-    async fn new_coordinator(&self) -> Result<Self::Coordinator> {
-        Err(SinkError::Coordinator(anyhow!("no coordinator")))
-    }
 }

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -500,6 +500,10 @@ impl Sink for IcebergSink {
         ))
     }
 
+    fn is_coordinated_sink(&self) -> bool {
+        true
+    }
+
     async fn new_coordinator(&self) -> Result<Self::Coordinator> {
         let catalog = self.config.create_catalog().await?;
         let table = self.create_and_validate_table().await?;

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -645,6 +645,11 @@ pub trait Sink: TryFrom<SinkParam, Error = SinkError> {
 
     async fn validate(&self) -> Result<()>;
     async fn new_log_sinker(&self, writer_param: SinkWriterParam) -> Result<Self::LogSinker>;
+
+    fn is_coordinated_sink(&self) -> bool {
+        false
+    }
+
     #[expect(clippy::unused_async)]
     async fn new_coordinator(&self) -> Result<Self::Coordinator> {
         Err(SinkError::Coordinator(anyhow!("no coordinator")))
@@ -736,6 +741,10 @@ impl SinkImpl {
 
     pub fn is_blackhole(&self) -> bool {
         matches!(self, SinkImpl::BlackHole(_))
+    }
+
+    pub fn is_coordinated_sink(&self) -> bool {
+        dispatch_sink!(self, sink, sink.is_coordinated_sink())
     }
 }
 

--- a/src/connector/src/sink/remote.rs
+++ b/src/connector/src/sink/remote.rs
@@ -551,6 +551,10 @@ impl<R: RemoteSinkTrait> Sink for CoordinatedRemoteSink<R> {
         .into_log_sinker(metrics))
     }
 
+    fn is_coordinated_sink(&self) -> bool {
+        true
+    }
+
     async fn new_coordinator(&self) -> Result<Self::Coordinator> {
         RemoteCoordinator::new::<R>(self.param.clone()).await
     }

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -339,6 +339,10 @@ impl Sink for StarrocksSink {
         ))
     }
 
+    fn is_coordinated_sink(&self) -> bool {
+        true
+    }
+
     async fn new_coordinator(&self) -> Result<Self::Coordinator> {
         let header = HeaderBuilder::new()
             .add_common_header()

--- a/src/stream/src/common/log_store_impl/kv_log_store/buffer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/buffer.rs
@@ -17,9 +17,11 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 
 use await_tree::InstrumentAwait;
+use bytes::Bytes;
 use parking_lot::{Mutex, MutexGuard};
 use risingwave_common::array::StreamChunk;
 use risingwave_common::bitmap::Bitmap;
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_connector::sink::log_store::{ChunkId, LogStoreResult, TruncateOffset};
 use tokio::sync::{Notify, oneshot};
 
@@ -241,20 +243,24 @@ impl<T> SharedMutex<T> {
 }
 
 pub(crate) struct LogStoreBufferSender {
-    init_epoch_tx: Option<oneshot::Sender<u64>>,
+    init_epoch_tx: Option<oneshot::Sender<(EpochPair, Option<Option<Bytes>>)>>,
     buffer: SharedMutex<LogStoreBufferInner>,
     update_notify: Arc<Notify>,
 }
 
 impl LogStoreBufferSender {
-    pub(crate) fn init(&mut self, epoch: u64) {
+    pub(crate) fn init(
+        &mut self,
+        epoch: EpochPair,
+        aligned_init_range_start: Option<Option<Bytes>>,
+    ) {
         if let Err(e) = self
             .init_epoch_tx
             .take()
             .expect("should be Some in first init")
-            .send(epoch)
+            .send((epoch, aligned_init_range_start))
         {
-            error!("unable to send init epoch: {}", e);
+            error!("unable to send init epoch: {:?}", e);
         }
     }
 
@@ -351,13 +357,13 @@ impl LogStoreBufferSender {
 }
 
 pub(crate) struct LogStoreBufferReceiver {
-    init_epoch_rx: Option<oneshot::Receiver<u64>>,
+    init_epoch_rx: Option<oneshot::Receiver<(EpochPair, Option<Option<Bytes>>)>>,
     buffer: SharedMutex<LogStoreBufferInner>,
     update_notify: Arc<Notify>,
 }
 
 impl LogStoreBufferReceiver {
-    pub(crate) async fn init(&mut self) -> u64 {
+    pub(crate) async fn init(&mut self) -> (EpochPair, Option<Option<Bytes>>) {
         self.init_epoch_rx
             .take()
             .expect("should be Some in first init")

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -376,9 +376,12 @@ pub struct KvLogStoreFactory<S: StateStore> {
     identity: String,
 
     pk_info: &'static KvLogStorePkInfo,
+
+    align_epoch_on_init: bool,
 }
 
 impl<S: StateStore> KvLogStoreFactory<S> {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         state_store: S,
         table_catalog: Table,
@@ -387,6 +390,7 @@ impl<S: StateStore> KvLogStoreFactory<S> {
         metrics: KvLogStoreMetrics,
         identity: impl Into<String>,
         pk_info: &'static KvLogStorePkInfo,
+        align_epoch_on_init: bool,
     ) -> Self {
         Self {
             state_store,
@@ -396,6 +400,7 @@ impl<S: StateStore> KvLogStoreFactory<S> {
             metrics,
             identity: identity.into(),
             pk_info,
+            align_epoch_on_init,
         }
     }
 }
@@ -411,9 +416,7 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
         let local_state_store = self
             .state_store
             .new_local(NewLocalOptions {
-                table_id: TableId {
-                    table_id: self.table_catalog.id,
-                },
+                table_id,
                 op_consistency_level: OpConsistencyLevel::Inconsistent,
                 table_option: TableOption {
                     retention_seconds: None,
@@ -433,9 +436,17 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
             self.metrics.clone(),
             pause_rx,
             self.identity.clone(),
+            self.align_epoch_on_init,
         );
 
-        let writer = KvLogStoreWriter::new(write_state, tx, self.metrics, pause_tx, self.identity);
+        let writer = KvLogStoreWriter::new(
+            write_state,
+            tx,
+            self.metrics,
+            pause_tx,
+            self.identity,
+            self.align_epoch_on_init,
+        );
 
         (reader, writer)
     }
@@ -459,10 +470,7 @@ mod tests {
     use risingwave_connector::sink::log_store::{
         ChunkId, LogReader, LogStoreFactory, LogStoreReadItem, LogWriter, TruncateOffset,
     };
-    use risingwave_hummock_sdk::HummockReadEpoch;
     use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
-    use risingwave_storage::StateStore;
-    use risingwave_storage::store::TryWaitEpochOptions;
 
     use crate::common::log_store_impl::kv_log_store::test_utils::{
         LogWriterTestExt, TEST_DATA_SIZE, calculate_vnode_bitmap, check_rows_eq,
@@ -506,6 +514,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -622,6 +631,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -669,7 +679,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(!is_checkpoint)
             }
@@ -689,7 +699,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint)
             }
@@ -700,14 +710,6 @@ mod tests {
         // The truncate does not work because it is after the sync
         reader
             .truncate(TruncateOffset::Barrier { epoch: epoch2 })
-            .unwrap();
-        test_env
-            .storage
-            .try_wait_epoch(
-                HummockReadEpoch::Committed(epoch2),
-                TryWaitEpochOptions::for_test(table.id.into()),
-            )
-            .await
             .unwrap();
 
         drop(writer);
@@ -724,6 +726,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
         test_env
@@ -748,7 +751,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(!is_checkpoint)
             }
@@ -768,7 +771,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint)
             }
@@ -818,6 +821,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -879,7 +883,7 @@ mod tests {
         };
         assert!(chunk_id2 > chunk_id1);
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(is_checkpoint)
             }
@@ -914,7 +918,7 @@ mod tests {
             .unwrap();
 
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint)
             }
@@ -923,14 +927,6 @@ mod tests {
 
         // Truncation on epoch1 should work because it is before this sync
         test_env.commit_epoch(epoch2).await;
-        test_env
-            .storage
-            .try_wait_epoch(
-                HummockReadEpoch::Committed(epoch2),
-                TryWaitEpochOptions::for_test(table.id.into()),
-            )
-            .await
-            .unwrap();
 
         drop(writer);
 
@@ -946,6 +942,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -974,7 +971,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(is_checkpoint)
             }
@@ -994,7 +991,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint)
             }
@@ -1017,6 +1014,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_vnode_recover() {
+        test_update_vnode_recover_inner(false).await
+    }
+
+    #[tokio::test]
+    async fn test_update_vnode_recover_with_align_init_epoch() {
+        test_update_vnode_recover_inner(true).await
+    }
+
+    async fn test_update_vnode_recover_inner(align_init_epoch: bool) {
         let pk_info: &'static KvLogStorePkInfo = &KV_LOG_STORE_V2_INFO;
         let test_env = prepare_hummock_test_env().await;
 
@@ -1043,6 +1049,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let factory2 = KvLogStoreFactory::new(
             test_env.storage.clone(),
@@ -1052,6 +1059,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            align_init_epoch,
         );
         let (mut reader1, mut writer1) = factory1.build().await;
         let (mut reader2, mut writer2) = factory2.build().await;
@@ -1102,7 +1110,7 @@ mod tests {
             _ => unreachable!(),
         };
         match reader1.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(!is_checkpoint);
             }
@@ -1117,7 +1125,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader2.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(!is_checkpoint);
             }
@@ -1155,14 +1163,14 @@ mod tests {
             .unwrap();
 
         match reader1.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint);
             }
             _ => unreachable!(),
         }
         match reader2.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint);
             }
@@ -1171,14 +1179,6 @@ mod tests {
 
         // Truncation of reader1 on epoch1 should work because it is before this sync
         test_env.commit_epoch(epoch2).await;
-        test_env
-            .storage
-            .try_wait_epoch(
-                HummockReadEpoch::Committed(epoch2),
-                TryWaitEpochOptions::for_test(table.id.into()),
-            )
-            .await
-            .unwrap();
 
         drop(writer1);
         drop(writer2);
@@ -1195,6 +1195,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            align_init_epoch,
         );
         let (mut reader, mut writer) = factory.build().await;
         test_env
@@ -1205,19 +1206,23 @@ mod tests {
             .await
             .unwrap();
         reader.init().await.unwrap();
-        match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
-                assert_eq!(epoch, epoch1);
-                assert!(check_stream_chunk_eq(&chunk1_2, &chunk));
+        if !align_init_epoch {
+            // Though we don't truncate reader2 with epoch1, we have truncated reader1 with epoch1, and with align_init_epoch
+            // set to true, we won't receive the following commented items.
+            match reader.next_item().await.unwrap() {
+                (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                    assert_eq!(epoch, epoch1);
+                    assert!(check_stream_chunk_eq(&chunk1_2, &chunk));
+                }
+                _ => unreachable!(),
             }
-            _ => unreachable!(),
-        }
-        match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
-                assert_eq!(epoch, epoch1);
-                assert!(!is_checkpoint);
+            match reader.next_item().await.unwrap() {
+                (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
+                    assert_eq!(epoch, epoch1);
+                    assert!(!is_checkpoint);
+                }
+                _ => unreachable!(),
             }
-            _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
             (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
@@ -1230,7 +1235,7 @@ mod tests {
             _ => unreachable!(),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch2);
                 assert!(is_checkpoint);
             }
@@ -1260,6 +1265,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -1305,10 +1311,10 @@ mod tests {
                 assert_eq!(epoch, epoch1);
                 assert!(check_stream_chunk_eq(&stream_chunk1, &read_stream_chunk));
             }
-            _ => unreachable!(),
+            item => unreachable!("{:?}", item),
         }
         match reader.next_item().await.unwrap() {
-            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                 assert_eq!(epoch, epoch1);
                 assert!(is_checkpoint)
             }
@@ -1382,7 +1388,7 @@ mod tests {
                 }
                 if last_sealed || i != size - 1 {
                     match reader.next_item().await.unwrap() {
-                        (item_epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                        (item_epoch, LogStoreReadItem::Barrier { is_checkpoint, .. }) => {
                             assert_eq!(item_epoch, *epoch);
                             assert!(is_checkpoint)
                         }
@@ -1407,6 +1413,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -1450,15 +1457,6 @@ mod tests {
         test_env.commit_epoch(epoch1).await;
         test_env.commit_epoch(epoch2).await;
         test_env.commit_epoch(epoch3).await;
-
-        test_env
-            .storage
-            .try_wait_epoch(
-                HummockReadEpoch::Committed(epoch3),
-                TryWaitEpochOptions::for_test(table.id.into()),
-            )
-            .await
-            .unwrap();
 
         reader.init().await.unwrap();
 
@@ -1530,6 +1528,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -1595,6 +1594,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -1714,8 +1714,9 @@ mod tests {
                 (
                     LogStoreReadItem::Barrier {
                         is_checkpoint: expected_is_checkpoint,
+                        ..
                     },
-                    LogStoreReadItem::Barrier { is_checkpoint },
+                    LogStoreReadItem::Barrier { is_checkpoint, .. },
                 ) => {
                     assert_eq!(expected_is_checkpoint, is_checkpoint);
                 }
@@ -1759,6 +1760,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
 
@@ -1841,6 +1843,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
         test_env
@@ -1908,6 +1911,7 @@ mod tests {
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
+            false,
         );
         let (mut reader, mut writer) = factory.build().await;
         test_env
@@ -1937,5 +1941,235 @@ mod tests {
             ],
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_align_init_epoch() {
+        let pk_info: &'static KvLogStorePkInfo = &KV_LOG_STORE_V2_INFO;
+        let test_env = prepare_hummock_test_env().await;
+
+        let table = gen_test_log_store_table(pk_info);
+
+        test_env.register_table(table.clone()).await;
+
+        fn build_bitmap(indexes: impl Iterator<Item = usize>) -> Arc<Bitmap> {
+            let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+            for i in indexes {
+                builder.set(i, true);
+            }
+            Arc::new(builder.finish())
+        }
+
+        let vnodes1 = build_bitmap((0..VirtualNode::COUNT_FOR_TEST).filter(|i| i % 2 == 0));
+        let vnodes2 = build_bitmap((0..VirtualNode::COUNT_FOR_TEST).filter(|i| i % 2 == 1));
+
+        let factory1 = KvLogStoreFactory::new(
+            test_env.storage.clone(),
+            table.clone(),
+            Some(vnodes1.clone()),
+            10 * TEST_DATA_SIZE,
+            KvLogStoreMetrics::for_test(),
+            "test",
+            pk_info,
+            true,
+        );
+        let factory2 = KvLogStoreFactory::new(
+            test_env.storage.clone(),
+            table.clone(),
+            Some(vnodes2.clone()),
+            10 * TEST_DATA_SIZE,
+            KvLogStoreMetrics::for_test(),
+            "test",
+            pk_info,
+            true,
+        );
+        let (mut reader1, mut writer1) = factory1.build().await;
+        let (mut reader2, mut writer2) = factory2.build().await;
+
+        let epoch1 = test_env
+            .storage
+            .get_pinned_version()
+            .table_committed_epoch(TableId::new(table.id))
+            .unwrap()
+            .next_epoch();
+        test_env
+            .storage
+            .start_epoch(epoch1, HashSet::from_iter([TableId::new(table.id)]));
+        writer1
+            .init(EpochPair::new_test_epoch(epoch1), false)
+            .await
+            .unwrap();
+        writer2
+            .init(EpochPair::new_test_epoch(epoch1), false)
+            .await
+            .unwrap();
+        reader1.init().await.unwrap();
+        reader2.init().await.unwrap();
+        let [chunk1_1, chunk1_2] = gen_multi_vnode_stream_chunks::<2>(0, 100, pk_info);
+        writer1.write_chunk(chunk1_1.clone()).await.unwrap();
+        writer2.write_chunk(chunk1_2.clone()).await.unwrap();
+        let epoch2 = epoch1.next_epoch();
+        test_env
+            .storage
+            .start_epoch(epoch2, HashSet::from_iter([TableId::new(table.id)]));
+        writer1
+            .flush_current_epoch_for_test(epoch2, false)
+            .await
+            .unwrap();
+        writer2
+            .flush_current_epoch_for_test(epoch2, false)
+            .await
+            .unwrap();
+        let [chunk2_1, chunk2_2] = gen_multi_vnode_stream_chunks::<2>(200, 100, pk_info);
+        writer1.write_chunk(chunk2_1.clone()).await.unwrap();
+        writer2.write_chunk(chunk2_2.clone()).await.unwrap();
+
+        match reader1.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                assert_eq!(epoch, epoch1);
+                assert!(check_stream_chunk_eq(&chunk1_1, &chunk));
+            }
+            _ => unreachable!(),
+        };
+        match reader1.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                assert_eq!(epoch, epoch1);
+                assert!(!is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+
+        match reader2.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                assert_eq!(epoch, epoch1);
+                assert!(check_stream_chunk_eq(&chunk1_2, &chunk));
+            }
+            _ => unreachable!(),
+        }
+        match reader2.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                assert_eq!(epoch, epoch1);
+                assert!(!is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+
+        // Only reader1 will truncate
+        reader1
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .unwrap();
+
+        match reader1.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(check_stream_chunk_eq(&chunk2_1, &chunk));
+            }
+            _ => unreachable!(),
+        }
+        match reader2.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(check_stream_chunk_eq(&chunk2_2, &chunk));
+            }
+            _ => unreachable!(),
+        }
+
+        let epoch3 = epoch2.next_epoch();
+        writer1
+            .flush_current_epoch_for_test(epoch3, true)
+            .await
+            .unwrap();
+        writer2
+            .flush_current_epoch_for_test(epoch3, true)
+            .await
+            .unwrap();
+
+        match reader1.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+        match reader2.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+
+        // Truncation of reader1 on epoch1 should work because it is before this sync
+        test_env.commit_epoch(epoch2).await;
+
+        drop(writer1);
+        drop(writer2);
+
+        // Recovery
+        test_env.storage.clear_shared_buffer().await;
+
+        let factory1 = KvLogStoreFactory::new(
+            test_env.storage.clone(),
+            table.clone(),
+            Some(vnodes1.clone()),
+            10 * TEST_DATA_SIZE,
+            KvLogStoreMetrics::for_test(),
+            "test",
+            pk_info,
+            true,
+        );
+        let factory2 = KvLogStoreFactory::new(
+            test_env.storage.clone(),
+            table.clone(),
+            Some(vnodes2.clone()),
+            10 * TEST_DATA_SIZE,
+            KvLogStoreMetrics::for_test(),
+            "test",
+            pk_info,
+            true,
+        );
+        let (mut reader1, mut writer1) = factory1.build().await;
+        let (mut reader2, mut writer2) = factory2.build().await;
+        test_env
+            .storage
+            .start_epoch(epoch3, HashSet::from_iter([TableId::new(table.id)]));
+        writer1
+            .init(EpochPair::new(epoch3, epoch2), false)
+            .await
+            .unwrap();
+        writer2
+            .init(EpochPair::new(epoch3, epoch2), false)
+            .await
+            .unwrap();
+        reader1.init().await.unwrap();
+        match reader1.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(check_rows_eq(chunk2_1.rows(), chunk.rows()));
+            }
+            _ => unreachable!(),
+        }
+        match reader1.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
+        reader2.init().await.unwrap();
+        match reader2.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::StreamChunk { chunk, .. }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(check_rows_eq(chunk2_2.rows(), chunk.rows()));
+            }
+            _ => unreachable!(),
+        }
+        match reader2.next_item().await.unwrap() {
+            (epoch, LogStoreReadItem::Barrier { is_checkpoint }) => {
+                assert_eq!(epoch, epoch2);
+                assert!(is_checkpoint);
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/state.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/state.rs
@@ -15,10 +15,11 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::TableId;
-use risingwave_common::hash::VnodeBitmapExt;
+use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_connector::sink::log_store::LogStoreResult;
@@ -138,6 +139,15 @@ impl<S: LocalStateStore> LogStoreWriteState<S> {
 
         self.on_post_seal = true;
         LogStorePostSealCurrentEpoch { inner: self }
+    }
+
+    pub(crate) fn aligned_init_range_start(&self) -> Option<Bytes> {
+        (0..self.serde.vnodes().len())
+            .flat_map(|vnode| {
+                self.state_store
+                    .get_table_watermark(VirtualNode::from_index(vnode))
+            })
+            .max()
     }
 }
 

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -81,6 +81,7 @@ use risingwave_storage::store::{
 use rw_futures_util::drop_either_future;
 
 use crate::common::log_store_impl::kv_log_store::buffer::LogStoreBufferItem;
+use crate::common::log_store_impl::kv_log_store::reader::LogStoreReadStateStreamRangeStart;
 use crate::common::log_store_impl::kv_log_store::reader::timeout_auto_rebuild::TimeoutAutoRebuildIter;
 use crate::common::log_store_impl::kv_log_store::serde::{
     KvLogStoreItem, LogStoreItemMergeStream, LogStoreRowSerde,
@@ -276,7 +277,11 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
             };
             let mut read_future = ReadFuture::ReadingPersistedStream(
                 read_state
-                    .read_persisted_log_store(&self.metrics, initial_write_epoch.prev, None)
+                    .read_persisted_log_store(
+                        &self.metrics,
+                        initial_write_epoch.prev,
+                        LogStoreReadStateStreamRangeStart::Unbounded,
+                    )
                     .await?,
             );
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Resolve https://github.com/risingwavelabs/risingwave/issues/19337

In coordinated sinks, different parallelisms coordinate with each other by their epoch progress. More specifically, they should write the data of the same epoch simultaneously, and then commit together on the epoch, and then write the same epoch truncate offset to storage. Since different parallelisms should work on the same epoch, we need to ensure that after recovery they are initialized from the same epoch. However, in sink log store, since we only need to ensure at-least-once delivery, the truncation offset set by log reader is not guaranteed to be applied and written to persistent storage. This works for normal sinks in which different parallelisms work independently. But for coordinated sink, it may happen that, for example, the truncate offset on epoch1 of parallelism1 is applied to storage, but on parallelism2, the offset is not applied. After recovery, parallelism1 will be initialized from the next epoch of epoch1, but parallelism2 will still be initialized from epoch1, and then the two parallelisms won't be initialized at the same epoch, and then cause error in https://github.com/risingwavelabs/risingwave/issues/19337.

In this PR, we introduce a flag to KvLogStoreFactory named `align_epoch_on_init`. The flag will be set to true for coordinated sinks. When this feature is on, in initialization, we won't use left unbounded to read the historical stream. Instead, we will load the truncate offset globally from all vnodes from the committed snapshot, and use the latest truncate offset as the left bound to read historical stream. In the example above, parallelism2 can see that some other parallelisms have written truncate offset on epoch1, and then it will skip epoch1 and initialize from the next epoch, though itself never writes the truncate offset yet.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
