### PR TITLE
feat: recursively use col-aware encoding for structs

### DIFF
--- a/src/common/benches/bench_column_aware_row_encoding.rs
+++ b/src/common/benches/bench_column_aware_row_encoding.rs
@@ -68,13 +68,13 @@ fn bench_column_aware_encoding_16_columns(c: &mut Criterion) {
         .collect::<Vec<_>>();
 
     c.bench_function("column_aware_row_encoding_16_columns_encode", |b| {
-        let serializer = Serializer::new(&column_ids[..]);
+        let serializer = Serializer::new(&column_ids[..], data_types.iter().cloned());
         b.iter(|| {
             black_box(serializer.serialize(&row));
         });
     });
 
-    let serializer = Serializer::new(&column_ids[..]);
+    let serializer = Serializer::new(&column_ids[..], data_types.iter().cloned());
     let encoded = serializer.serialize(&row);
 
     c.bench_function("column_aware_row_encoding_16_columns_decode", |b| {
@@ -109,13 +109,13 @@ fn bench_column_aware_encoding_4_columns(c: &mut Criterion) {
         .collect::<Vec<_>>();
 
     c.bench_function("column_aware_row_encoding_4_columns_encode", |b| {
-        let serializer = Serializer::new(&column_ids[..]);
+        let serializer = Serializer::new(&column_ids[..], data_types.iter().cloned());
         b.iter(|| {
             black_box(serializer.serialize(&row));
         });
     });
 
-    let serializer = Serializer::new(&column_ids[..]);
+    let serializer = Serializer::new(&column_ids[..], data_types.iter().cloned());
     let encoded = serializer.serialize(&row);
 
     c.bench_function("column_aware_row_encoding_4_columns_decode", |b| {

--- a/src/common/src/util/value_encoding/column_aware_row_encoding.rs
+++ b/src/common/src/util/value_encoding/column_aware_row_encoding.rs
@@ -58,8 +58,8 @@ mod new_serde {
 
     fn new_serialize_struct(struct_type: &StructType, value: StructRef<'_>, buf: &mut impl BufMut) {
         let serializer = super::Serializer::new_new(
-            &[],                          // TODO: column ids
-            struct_type.types().cloned(), // TODO: avoid this clone
+            &struct_type.ids().unwrap().collect_vec(), // TODO: avoid this clone
+            struct_type.types().cloned(),              // TODO: avoid this clone
         );
 
         let bytes = serializer.serialize(value); // TODO: serialize into the buf directly
@@ -115,7 +115,7 @@ mod new_serde {
 
     fn new_deserialize_struct(struct_def: &StructType, data: &mut &[u8]) -> Result<ScalarImpl> {
         let deserializer = super::Deserializer::new(
-            &[],                                              // TODO: column ids
+            &struct_def.ids().unwrap().collect_vec(), // TODO: avoid this clone
             struct_def.types().cloned().collect_vec().into(), // TODO: avoid this clone
             std::iter::empty(),
         );
@@ -329,7 +329,10 @@ impl Serializer {
         }
     }
 
-    pub fn new_new(column_ids: &[ColumnId], data_types: impl Iterator<Item = DataType>) -> Self {
+    pub fn new_new(
+        column_ids: &[ColumnId],
+        data_types: impl IntoIterator<Item = DataType>,
+    ) -> Self {
         // currently we hard-code ColumnId as i32
         let mut encoded_column_ids = Vec::with_capacity(column_ids.len() * 4);
         for id in column_ids {
@@ -338,7 +341,7 @@ impl Serializer {
 
         Self {
             encoded_column_ids,
-            data_types: data_types.collect(),
+            data_types: data_types.into_iter().collect(),
         }
     }
 

--- a/src/common/src/util/value_encoding/column_aware_row_encoding.rs
+++ b/src/common/src/util/value_encoding/column_aware_row_encoding.rs
@@ -38,7 +38,7 @@ mod new_serde {
 
     use super::*;
     use crate::array::{ListRef, ListValue, MapRef, MapValue, StructRef, StructValue};
-    use crate::types::{MapType, ScalarImpl, StructType};
+    use crate::types::{MapType, ScalarImpl, StructType, data_types};
     use crate::util::value_encoding::{
         deserialize_value as plain_deserialize_scalar, serialize_scalar as plain_serialize_scalar,
     };
@@ -160,7 +160,7 @@ mod new_serde {
             DataType::List(item_type) => new_deserialize_list(item_type, data)?,
             DataType::Map(map_type) => new_deserialize_map(map_type, data)?,
 
-            _ => plain_deserialize_scalar(ty, data)?,
+            data_types::simple!() => plain_deserialize_scalar(ty, data)?,
         })
     }
 }

--- a/src/common/src/util/value_encoding/column_aware_row_encoding.rs
+++ b/src/common/src/util/value_encoding/column_aware_row_encoding.rs
@@ -140,7 +140,7 @@ mod new_serde {
 
         let (struct_data, remaining) = data.split_at(encoded_len);
         *data = remaining;
-        let fields = deserializer.deserialize(&struct_data)?;
+        let fields = deserializer.deserialize(struct_data)?;
 
         Ok(ScalarImpl::Struct(StructValue::new(fields)))
     }

--- a/src/storage/src/row_serde/value_serde.rs
+++ b/src/storage/src/row_serde/value_serde.rs
@@ -126,7 +126,7 @@ impl ValueRowSerdeNew for ColumnAwareSerde {
             }
         });
 
-        let serializer = Serializer::new(&column_ids);
+        let serializer = Serializer::new_new(&column_ids, schema.clone());
         let deserializer = Deserializer::new(&column_ids, schema.into(), column_with_default);
         ColumnAwareSerde {
             serializer,

--- a/src/storage/src/row_serde/value_serde.rs
+++ b/src/storage/src/row_serde/value_serde.rs
@@ -439,8 +439,8 @@ mod tests {
                 12, 0, 0, 0, // field id = 12 "f3"
                 0, // offset 11 = 0
                 4, // offset 12 = 4
-                6, // "f2": i32 = 6
-                0, 0, 0, 1, // "f3": bool = true
+                6, 0, 0, 0, // "f2": i32 = 6
+                1, // "f3": bool = true
             ]
         );
 

--- a/src/storage/src/row_serde/value_serde.rs
+++ b/src/storage/src/row_serde/value_serde.rs
@@ -126,7 +126,7 @@ impl ValueRowSerdeNew for ColumnAwareSerde {
             }
         });
 
-        let serializer = Serializer::new_new(&column_ids, schema.clone());
+        let serializer = Serializer::new(&column_ids, schema.clone());
         let deserializer = Deserializer::new(&column_ids, schema.into(), column_with_default);
         ColumnAwareSerde {
             serializer,
@@ -160,7 +160,10 @@ mod tests {
         let row3 = OwnedRow::new(vec![Some(Int16(6)), Some(Utf8("abc".into()))]);
         let rows = vec![row1, row2, row3];
         let mut array = vec![];
-        let serializer = column_aware_row_encoding::Serializer::new(&column_ids);
+        let serializer = column_aware_row_encoding::Serializer::new(
+            &column_ids,
+            [DataType::Int16, DataType::Varchar],
+        );
         for row in &rows {
             let row_bytes = serializer.serialize(row);
             array.push(row_bytes);
@@ -202,7 +205,10 @@ mod tests {
     fn test_row_decoding() {
         let column_ids = vec![ColumnId::new(0), ColumnId::new(1)];
         let row1 = OwnedRow::new(vec![Some(Int16(5)), Some(Utf8("abc".into()))]);
-        let serializer = column_aware_row_encoding::Serializer::new(&column_ids);
+        let serializer = column_aware_row_encoding::Serializer::new(
+            &column_ids,
+            [DataType::Int16, DataType::Varchar],
+        );
         let row_bytes = serializer.serialize(row1);
         let data_types = vec![DataType::Int16, DataType::Varchar];
         let deserializer = column_aware_row_encoding::Deserializer::new(
@@ -281,7 +287,10 @@ mod tests {
             Some(Utf8("abc".into())),
             Some(Utf8("ABC".into())),
         ]);
-        let serializer = column_aware_row_encoding::Serializer::new(&column_ids);
+        let serializer = column_aware_row_encoding::Serializer::new(
+            &column_ids,
+            [DataType::Int16, DataType::Varchar, DataType::Varchar],
+        );
         let row_bytes = serializer.serialize(row1);
 
         // no columns is dropped
@@ -317,7 +326,10 @@ mod tests {
             Some(Utf8("abc".into())),
             Some(Utf8("ABC".into())),
         ]);
-        let serializer = column_aware_row_encoding::Serializer::new(&column_ids);
+        let serializer = column_aware_row_encoding::Serializer::new(
+            &column_ids,
+            [DataType::Int16, DataType::Varchar, DataType::Varchar],
+        );
         let row_bytes = serializer.serialize(row1);
 
         let deserializer = column_aware_row_encoding::Deserializer::new(
@@ -340,7 +352,10 @@ mod tests {
             Some(Utf8("abc".into())),
             Some(Utf8("ABC".into())),
         ]);
-        let serializer = column_aware_row_encoding::Serializer::new(&column_ids);
+        let serializer = column_aware_row_encoding::Serializer::new(
+            &column_ids,
+            [DataType::Int16, DataType::Varchar, DataType::Varchar],
+        );
         let row_bytes = serializer.serialize(row1);
 
         // default column of ColumnId::new(3)

--- a/src/storage/src/row_serde/value_serde.rs
+++ b/src/storage/src/row_serde/value_serde.rs
@@ -146,6 +146,7 @@ mod tests {
     use std::collections::HashSet;
 
     use risingwave_common::catalog::ColumnId;
+    use risingwave_common::row::Row;
     use risingwave_common::types::ScalarImpl::*;
     use risingwave_common::util::value_encoding::column_aware_row_encoding;
     use risingwave_common::util::value_encoding::column_aware_row_encoding::try_drop_invalid_columns;
@@ -377,5 +378,79 @@ mod tests {
                 Some(Int16(5))
             ]
         );
+    }
+
+    #[test]
+    fn test_row_composite_types() {
+        let inner_struct: DataType =
+            StructType::new([("f2", DataType::Int32), ("f3", DataType::Boolean)])
+                .with_ids([ColumnId::new(11), ColumnId::new(12)])
+                .into();
+        let list = DataType::List(Box::new(inner_struct.clone()));
+        let map = MapType::from_kv(DataType::Varchar, list.clone()).into();
+        let outer_struct = StructType::new([("f1", DataType::Int32), ("map", map)])
+            .with_ids([ColumnId::new(1), ColumnId::new(2)])
+            .into();
+
+        let inner_struct_value = StructValue::new(vec![Some(Int32(6)), Some(Bool(true))]);
+        let list_value =
+            ListValue::from_datum_iter(&inner_struct, [Some(Struct(inner_struct_value))]);
+        let map_value = MapValue::try_from_kv(
+            ListValue::from_datum_iter(&DataType::Varchar, [Some(Utf8("key".into()))]),
+            ListValue::from_datum_iter(&list, [Some(List(list_value))]),
+        )
+        .unwrap();
+        let outer_struct_value = StructValue::new(vec![Some(Int32(5)), Some(Map(map_value))]);
+
+        let datum = Some(Struct(outer_struct_value));
+        let row1 = [datum];
+
+        let column_ids = &[ColumnId::new(0)];
+        let data_types = vec![outer_struct];
+
+        let serializer = column_aware_row_encoding::Serializer::new(column_ids, data_types.clone());
+        let row_bytes = serializer.serialize(row1.clone());
+
+        assert_eq!(
+            row_bytes,
+            [
+                0b10000001, // flag mid WW mid BB
+                1, 0, 0, 0, // column num = 1
+                0, 0, 0, 0,  // column id = 0 "outer"
+                0,  // offset 0 = 0
+                60, // struct length = 60,
+                0, 0, 0, 0b10000001, // recursive col-aware flag
+                2, 0, 0, 0, // field num = 2
+                1, 0, 0, 0, // field id = 1 "f1"
+                2, 0, 0, 0, // field id = 2 "map"
+                0, // offset 1 = 0
+                4, // offset 2 = 4
+                5, 0, 0, 0, // "f1": i32 = 5
+                1, 0, 0, 0, // map length = 1
+                3, 0, 0, 0, // map key string length = 3
+                b'k', b'e', b'y', // map key = "key"
+                1,    // map value is non NULL
+                1, 0, 0, 0, // map value list length = 1
+                1, // map value list element (struct) is non NULL
+                20, 0, 0, 0,          // struct length = 20
+                0b10000001, // recursive col-aware flag
+                2, 0, 0, 0, // field num = 2
+                11, 0, 0, 0, // field id = 11 "f2"
+                12, 0, 0, 0, // field id = 12 "f3"
+                0, // offset 11 = 0
+                4, // offset 12 = 4
+                6, // "f2": i32 = 6
+                0, 0, 0, 1, // "f3": bool = true
+            ]
+        );
+
+        let deserializer = column_aware_row_encoding::Deserializer::new(
+            column_ids,
+            data_types.into(),
+            std::iter::empty(),
+        );
+        let decoded = deserializer.deserialize(&row_bytes).unwrap();
+
+        assert_eq!(OwnedRow::new(decoded), row1.to_owned_row());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Follow-up of #20563.

If the `ids` field of a struct type is set, we dispatch to a new encoding that recursively uses column-aware encoding for struct types. In this way, the IDs of nested fields are encoded, enabling compatibility during schema change.

Several TODOs related to performance remain in the code, which will be addressed with some refactoring in future PRs. See micro-benchmark results in https://github.com/risingwavelabs/risingwave/pull/20604#issuecomment-2731805679.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
