### PR TITLE
feat: add aws.msk.signer_timeout_sec to config the timeout of signer

### DIFF
--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -96,17 +96,8 @@ pub struct AwsAuthProps {
     pub external_id: Option<String>,
     #[serde(rename = "aws.profile", alias = "profile")]
     pub profile: Option<String>,
-    #[serde(
-        rename = "aws.msk.signer_timeout_sec",
-        default = "default::default_msk_signer_timeout_sec"
-    )]
-    pub msk_signer_timeout_sec: u64,
-}
-
-mod default {
-    pub fn default_msk_signer_timeout_sec() -> u64 {
-        10
-    }
+    #[serde(rename = "aws.msk.signer_timeout_sec")]
+    pub msk_signer_timeout_sec: Option<u64>,
 }
 
 impl AwsAuthProps {

--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -96,6 +96,17 @@ pub struct AwsAuthProps {
     pub external_id: Option<String>,
     #[serde(rename = "aws.profile", alias = "profile")]
     pub profile: Option<String>,
+    #[serde(
+        rename = "aws.msk.signer_timeout_sec",
+        default = "default::default_msk_signer_timeout_sec"
+    )]
+    pub msk_signer_timeout_sec: u64,
+}
+
+mod default {
+    pub fn default_msk_signer_timeout_sec() -> u64 {
+        10
+    }
 }
 
 impl AwsAuthProps {
@@ -591,6 +602,7 @@ impl KinesisCommon {
             arn: self.assume_role_arn.clone(),
             external_id: self.assume_role_external_id.clone(),
             profile: Default::default(),
+            msk_signer_timeout_sec: Default::default(),
         };
         let aws_config = config.build_config().await?;
         let mut builder = aws_sdk_kinesis::config::Builder::from(&aws_config);

--- a/src/connector/src/source/filesystem/s3/mod.rs
+++ b/src/connector/src/source/filesystem/s3/mod.rs
@@ -90,6 +90,7 @@ impl From<&LegacyS3Properties> for AwsAuthProps {
             arn: Default::default(),
             external_id: Default::default(),
             profile: Default::default(),
+            msk_signer_timeout_sec: Default::default(),
         }
     }
 }

--- a/src/connector/src/source/kafka/client_context.rs
+++ b/src/connector/src/source/kafka/client_context.rs
@@ -36,6 +36,7 @@ struct IamAuthEnv {
     // XXX(runji): madsim does not support `Handle` for now
     #[cfg(not(madsim))]
     rt: tokio::runtime::Handle,
+    signer_timeout_sec: u64,
 }
 
 pub struct KafkaContextCommon {
@@ -76,6 +77,7 @@ impl KafkaContextCommon {
                 region,
                 #[cfg(not(madsim))]
                 rt: tokio::runtime::Handle::current(),
+                signer_timeout_sec: auth.msk_signer_timeout_sec,
             })
         } else {
             None
@@ -115,16 +117,18 @@ impl KafkaContextCommon {
             credentials_provider,
             region,
             rt,
+            signer_timeout_sec,
         }) = &self.auth
         {
             let region = region.clone();
             let credentials_provider = credentials_provider.clone();
             let rt = rt.clone();
+            let signer_timeout_sec = *signer_timeout_sec;
             let (token, expiration_time_ms) = {
                 let handle = thread::spawn(move || {
                     rt.block_on(async {
                         timeout(
-                            Duration::from_secs(10),
+                            Duration::from_secs(signer_timeout_sec),
                             generate_auth_token_from_credentials_provider(
                                 region,
                                 credentials_provider,

--- a/src/connector/src/source/kafka/client_context.rs
+++ b/src/connector/src/source/kafka/client_context.rs
@@ -77,7 +77,9 @@ impl KafkaContextCommon {
                 region,
                 #[cfg(not(madsim))]
                 rt: tokio::runtime::Handle::current(),
-                signer_timeout_sec: auth.msk_signer_timeout_sec,
+                signer_timeout_sec: auth
+                    .msk_signer_timeout_sec
+                    .unwrap_or(Self::default_msk_signer_timeout_sec()),
             })
         } else {
             None
@@ -88,6 +90,10 @@ impl KafkaContextCommon {
             metrics,
             auth,
         })
+    }
+
+    fn default_msk_signer_timeout_sec() -> u64 {
+        10
     }
 }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -107,6 +107,10 @@ BigQueryConfig:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
   - name: r#type
     field_type: String
     required: true
@@ -190,6 +194,10 @@ DeltaLakeConfig:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
   - name: gcs.service.account
     field_type: String
     required: false
@@ -282,6 +290,10 @@ DynamoDbConfig:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
   - name: dynamodb.max_batch_item_nums
     field_type: usize
     required: false
@@ -778,6 +790,10 @@ KafkaConfig:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
 KinesisSinkConfig:
   fields:
   - name: stream
@@ -1059,6 +1075,10 @@ PulsarConfig:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
   - name: properties.batch.size
     field_type: u32
     required: false

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -110,7 +110,6 @@ BigQueryConfig:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
   - name: r#type
     field_type: String
     required: true
@@ -197,7 +196,6 @@ DeltaLakeConfig:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
   - name: gcs.service.account
     field_type: String
     required: false
@@ -293,7 +291,6 @@ DynamoDbConfig:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
   - name: dynamodb.max_batch_item_nums
     field_type: usize
     required: false
@@ -793,7 +790,6 @@ KafkaConfig:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
 KinesisSinkConfig:
   fields:
   - name: stream
@@ -1078,7 +1074,6 @@ PulsarConfig:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
   - name: properties.batch.size
     field_type: u32
     required: false

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -432,7 +432,6 @@ KafkaProperties:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
 KinesisProperties:
   fields:
   - name: scan.startup.mode
@@ -1087,7 +1086,6 @@ PulsarProperties:
   - name: aws.msk.signer_timeout_sec
     field_type: u64
     required: false
-    default: default::default_msk_signer_timeout_sec
   - name: iceberg.enabled
     field_type: bool
     required: false

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -429,6 +429,10 @@ KafkaProperties:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
 KinesisProperties:
   fields:
   - name: scan.startup.mode
@@ -1080,6 +1084,10 @@ PulsarProperties:
     required: false
     alias:
     - profile
+  - name: aws.msk.signer_timeout_sec
+    field_type: u64
+    required: false
+    default: default::default_msk_signer_timeout_sec
   - name: iceberg.enabled
     field_type: bool
     required: false


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously the value was hardcoded to 10s. We make it configurable to accommodate some low provide credential case.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

add with property `aws.msk.signer_timeout_sec` for AWS MSK source. This controls the timeout limit for loading AWS credentials for AWS MSK.

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
