### PR TITLE
fix(log-store): rebuild decoupled sink on scale to fix data loss

### DIFF
--- a/src/bench/sink_bench/main.rs
+++ b/src/bench/sink_bench/main.rs
@@ -131,8 +131,8 @@ impl LogReader for MockRangeLogReader {
         Ok(())
     }
 
-    async fn rewind(&mut self) -> LogStoreResult<(bool, Option<Bitmap>)> {
-        Ok((false, None))
+    async fn rewind(&mut self) -> LogStoreResult<()> {
+        Err(anyhow!("should not call rewind"))
     }
 }
 

--- a/src/stream/src/common/log_store_impl/in_mem.rs
+++ b/src/stream/src/common/log_store_impl/in_mem.rs
@@ -104,6 +104,9 @@ impl LogStoreFactory for BoundedInMemLogStoreFactory {
     type Reader = BoundedInMemLogStoreReader;
     type Writer = BoundedInMemLogStoreWriter;
 
+    const ALLOW_REWIND: bool = false;
+    const REBUILD_SINK_ON_UPDATE_VNODE_BITMAP: bool = false;
+
     async fn build(self) -> (Self::Reader, Self::Writer) {
         let (init_epoch_tx, init_epoch_rx) = oneshot::channel();
         let (item_tx, item_rx) = channel(self.bound);
@@ -241,8 +244,8 @@ impl LogReader for BoundedInMemLogStoreReader {
         Ok(())
     }
 
-    async fn rewind(&mut self) -> LogStoreResult<(bool, Option<Bitmap>)> {
-        Ok((false, None))
+    async fn rewind(&mut self) -> LogStoreResult<()> {
+        Err(anyhow!("should not call rewind on it"))
     }
 }
 

--- a/src/stream/src/common/log_store_impl/kv_log_store/state.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/state.rs
@@ -160,7 +160,7 @@ impl<'a, S: LocalStateStore> LogStorePostSealCurrentEpoch<'a, S> {
     pub(crate) async fn post_yield_barrier(
         self,
         new_vnodes: Option<Arc<Bitmap>>,
-    ) -> LogStoreResult<()> {
+    ) -> LogStoreResult<&'a mut LogStoreWriteState<S>> {
         if let Some(new_vnodes) = new_vnodes {
             self.inner.serde.update_vnode_bitmap(new_vnodes.clone());
             self.inner
@@ -169,7 +169,7 @@ impl<'a, S: LocalStateStore> LogStorePostSealCurrentEpoch<'a, S> {
                 .await?;
         }
         self.inner.on_post_seal = false;
-        Ok(())
+        Ok(self.inner)
     }
 }
 

--- a/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use bytes::Bytes;
 use futures::FutureExt;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::bitmap::Bitmap;
@@ -23,7 +24,8 @@ use risingwave_connector::sink::log_store::{
     LogStoreResult, LogWriter, LogWriterPostFlushCurrentEpoch,
 };
 use risingwave_storage::store::LocalStateStore;
-use tokio::sync::watch;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{oneshot, watch};
 
 use crate::common::log_store_impl::kv_log_store::buffer::LogStoreBufferSender;
 use crate::common::log_store_impl::kv_log_store::state::LogStoreWriteState;
@@ -35,6 +37,8 @@ pub struct KvLogStoreWriter<LS: LocalStateStore> {
     state: LogStoreWriteState<LS>,
 
     tx: LogStoreBufferSender,
+    init_epoch_tx: Option<oneshot::Sender<(EpochPair, Option<Option<Bytes>>)>>,
+    update_vnode_bitmap_tx: UnboundedSender<(Arc<Bitmap>, u64, Option<Option<Bytes>>)>,
 
     metrics: KvLogStoreMetrics,
 
@@ -48,9 +52,12 @@ pub struct KvLogStoreWriter<LS: LocalStateStore> {
 }
 
 impl<LS: LocalStateStore> KvLogStoreWriter<LS> {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         state: LogStoreWriteState<LS>,
         tx: LogStoreBufferSender,
+        init_epoch_tx: oneshot::Sender<(EpochPair, Option<Option<Bytes>>)>,
+        update_vnode_bitmap_tx: UnboundedSender<(Arc<Bitmap>, u64, Option<Option<Bytes>>)>,
         metrics: KvLogStoreMetrics,
         paused_notifier: watch::Sender<bool>,
         identity: String,
@@ -60,6 +67,8 @@ impl<LS: LocalStateStore> KvLogStoreWriter<LS> {
             seq_id: FIRST_SEQ_ID,
             state,
             tx,
+            init_epoch_tx: Some(init_epoch_tx),
+            update_vnode_bitmap_tx,
             metrics,
             paused_notifier,
             identity,
@@ -86,7 +95,14 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
         } else {
             None
         };
-        self.tx.init(epoch, init_offset_range_start);
+        if let Err((e, _)) = self
+            .init_epoch_tx
+            .take()
+            .expect("should be Some in first init")
+            .send((epoch, init_offset_range_start))
+        {
+            error!("unable to send init epoch: {:?}", e);
+        }
         Ok(())
     }
 
@@ -156,16 +172,26 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
         let truncate_offset = self.tx.pop_truncation(epoch);
         let post_seal_epoch = self.state.seal_current_epoch(next_epoch, truncate_offset);
         self.tx.barrier(epoch, is_checkpoint, next_epoch);
+        let update_vnode_bitmap_tx = &mut self.update_vnode_bitmap_tx;
         let tx = &mut self.tx;
+        let align_epoch_on_init = self.align_epoch_on_init;
         self.seq_id = FIRST_SEQ_ID;
         Ok(LogWriterPostFlushCurrentEpoch::new(
             move |new_vnodes: Option<Arc<Bitmap>>| {
                 async move {
-                    post_seal_epoch
+                    let state = post_seal_epoch
                         .post_yield_barrier(new_vnodes.clone())
                         .await?;
                     if let Some(new_vnodes) = new_vnodes {
-                        tx.update_vnode(next_epoch, new_vnodes);
+                        let aligned_range_start = if align_epoch_on_init {
+                            Some(state.aligned_init_range_start())
+                        } else {
+                            None
+                        };
+                        update_vnode_bitmap_tx
+                            .send((new_vnodes, next_epoch, aligned_range_start))
+                            .map_err(|_| anyhow!("fail to send update vnode bitmap to reader"))?;
+                        tx.clear();
                     }
                     Ok(())
                 }

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -20,6 +20,7 @@ use futures::{FutureExt, TryFutureExt, TryStreamExt};
 use itertools::Itertools;
 use risingwave_common::array::Op;
 use risingwave_common::array::stream_chunk::StreamChunkMut;
+use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnCatalog, Field};
 use risingwave_common::metrics::{GLOBAL_ERROR_METRICS, LabelGuardedIntGauge};
 use risingwave_common_estimate_size::EstimateSize;
@@ -35,7 +36,9 @@ use risingwave_connector::sink::{
     GLOBAL_SINK_METRICS, LogSinker, Sink, SinkImpl, SinkParam, SinkWriterParam,
 };
 use thiserror_ext::AsReport;
+use tokio::select;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use tokio::sync::oneshot;
 
 use crate::common::compact_chunk::{StreamChunkCompactor, merge_chunk_row};
 use crate::executor::prelude::*;
@@ -248,6 +251,8 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             // Init the rate limit
             rate_limit_tx.send(self.rate_limit.into()).unwrap();
 
+            let (rebuild_sink_tx, rebuild_sink_rx) = unbounded_channel();
+
             self.log_store_factory
                 .build()
                 .map(move |(log_reader, log_writer)| {
@@ -256,6 +261,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         log_writer.monitored(log_writer_metrics),
                         actor_id,
                         rate_limit_tx,
+                        rebuild_sink_tx,
                     );
 
                     let consume_log_stream_future = dispatch_sink!(self.sink, sink, {
@@ -267,9 +273,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             self.sink_writer_param,
                             self.actor_context,
                             rate_limit_rx,
+                            rebuild_sink_rx,
                         )
                         .instrument_await(format!("consume_log (sink_id {sink_id})"))
-                        .map_ok(|never| match never {}); // unify return type to `Message`
+                        .map_ok(|never| never); // unify return type to `Message`
 
                         consume_log_stream.boxed()
                     });
@@ -282,11 +289,12 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
-    async fn execute_write_log(
+    async fn execute_write_log<W: LogWriter>(
         input: impl MessageStream,
-        mut log_writer: impl LogWriter,
+        mut log_writer: W,
         actor_id: ActorId,
         rate_limit_tx: UnboundedSender<RateLimit>,
+        rebuild_sink_tx: UnboundedSender<(Arc<Bitmap>, oneshot::Sender<()>)>,
     ) {
         pin_mut!(input);
         let barrier = expect_first_barrier(&mut input).await?;
@@ -319,6 +327,16 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(actor_id);
                     let mutation = barrier.mutation.clone();
                     yield Message::Barrier(barrier);
+                    if F::REBUILD_SINK_ON_UPDATE_VNODE_BITMAP
+                        && let Some(new_vnode_bitmap) = update_vnode_bitmap.clone()
+                    {
+                        let (tx, rx) = oneshot::channel();
+                        rebuild_sink_tx
+                            .send((new_vnode_bitmap, tx))
+                            .map_err(|_| anyhow!("fail to send rebuild sink to reader"))?;
+                        rx.await
+                            .map_err(|_| anyhow!("fail to wait rebuild sink finish"))?;
+                    }
                     post_flush.post_yield_barrier(update_vnode_bitmap).await?;
 
                     if let Some(mutation) = mutation.as_deref() {
@@ -485,6 +503,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn execute_consume_log<S: Sink, R: LogReader>(
         sink: S,
         log_reader: R,
@@ -493,6 +512,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         mut sink_writer_param: SinkWriterParam,
         actor_context: ActorContextRef,
         rate_limit_rx: UnboundedReceiver<RateLimit>,
+        mut rebuild_sink_rx: UnboundedReceiver<(Arc<Bitmap>, oneshot::Sender<()>)>,
     ) -> StreamExecutorResult<!> {
         let visible_columns = columns
             .iter()
@@ -538,55 +558,72 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             .monitored(metrics)
             .rate_limited(rate_limit_rx);
 
-        log_reader.init().await?;
+        loop {
+            let future = async {
+                log_reader.init().await?;
 
-        #[expect(irrefutable_let_patterns)] // false positive
-        while let Err(e) = sink
-            .new_log_sinker(sink_writer_param.clone())
-            .and_then(|log_sinker| log_sinker.consume_log_and_sink(&mut log_reader))
-            .await
-        {
-            GLOBAL_ERROR_METRICS.user_sink_error.report([
-                "sink_executor_error".to_owned(),
-                sink_param.sink_id.to_string(),
-                sink_param.sink_name.clone(),
-                actor_context.fragment_id.to_string(),
-            ]);
+                loop {
+                    let Err(e) = sink
+                        .new_log_sinker(sink_writer_param.clone())
+                        .and_then(|log_sinker| log_sinker.consume_log_and_sink(&mut log_reader))
+                        .await;
+                    GLOBAL_ERROR_METRICS.user_sink_error.report([
+                        "sink_executor_error".to_owned(),
+                        sink_param.sink_id.to_string(),
+                        sink_param.sink_name.clone(),
+                        actor_context.fragment_id.to_string(),
+                    ]);
 
-            if let Some(meta_client) = sink_writer_param.meta_client.as_ref() {
-                meta_client
-                    .add_sink_fail_evet_log(
-                        sink_writer_param.sink_id.sink_id,
-                        sink_writer_param.sink_name.clone(),
-                        sink_writer_param.connector.clone(),
-                        e.to_report_string(),
-                    )
-                    .await;
-            }
+                    if let Some(meta_client) = sink_writer_param.meta_client.as_ref() {
+                        meta_client
+                            .add_sink_fail_evet_log(
+                                sink_writer_param.sink_id.sink_id,
+                                sink_writer_param.sink_name.clone(),
+                                sink_writer_param.connector.clone(),
+                                e.to_report_string(),
+                            )
+                            .await;
+                    }
 
-            match log_reader.rewind().await {
-                Ok((true, curr_vnode_bitmap)) => {
-                    warn!(
-                        error = %e.as_report(),
-                        executor_id = sink_writer_param.executor_id,
-                        sink_id = sink_param.sink_id.sink_id,
-                        "rewind successfully after sink error"
-                    );
-                    sink_writer_param.vnode_bitmap = curr_vnode_bitmap;
-                    Ok(())
+                    if F::ALLOW_REWIND {
+                        match log_reader.rewind().await {
+                            Ok(()) => {
+                                warn!(
+                                    error = %e.as_report(),
+                                    executor_id = sink_writer_param.executor_id,
+                                    sink_id = sink_param.sink_id.sink_id,
+                                    "rewind successfully after sink error"
+                                );
+                                Ok(())
+                            }
+                            Err(rewind_err) => {
+                                error!(
+                                    error = %rewind_err.as_report(),
+                                    "fail to rewind log reader"
+                                );
+                                Err(e)
+                            }
+                        }
+                    } else {
+                        Err(e)
+                    }
+                    .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id.sink_id)))?;
                 }
-                Ok((false, _)) => Err(e),
-                Err(rewind_err) => {
-                    error!(
-                        error = %rewind_err.as_report(),
-                        "fail to rewind log reader"
-                    );
-                    Err(e)
+            };
+            select! {
+                result = future => {
+                    let Err(e): StreamExecutorResult<!> = result;
+                    return Err(e);
+                }
+                result = rebuild_sink_rx.recv() => {
+                    let (new_vnode, notify) = result.ok_or_else(|| anyhow!("failed to receive rebuild sink notify"))?;
+                    sink_writer_param.vnode_bitmap = Some((*new_vnode).clone());
+                    if notify.send(()).is_err() {
+                        warn!("failed to notify rebuild sink");
+                    }
                 }
             }
-            .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id.sink_id)))?;
         }
-        Err(anyhow!("end of stream").into())
     }
 }
 

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -479,9 +479,6 @@ impl<S: StateStoreRead> ReadFuture<S> {
                     LogStoreBufferItem::Barrier { .. } => {
                         continue;
                     }
-                    LogStoreBufferItem::UpdateVnodes(_) => {
-                        unreachable!("UpdateVnodes should not be in buffer")
-                    }
                 }
             },
         }
@@ -535,9 +532,7 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                         *flushed = true;
                     }
                 }
-                LogStoreBufferItem::Flushed { .. }
-                | LogStoreBufferItem::Barrier { .. }
-                | LogStoreBufferItem::UpdateVnodes(_) => {}
+                LogStoreBufferItem::Flushed { .. } | LogStoreBufferItem::Barrier { .. } => {}
             }
         }
 
@@ -683,7 +678,6 @@ impl SyncedLogStoreBuffer {
                 LogStoreBufferItem::Barrier { .. } => {
                     epoch_count += 1;
                 }
-                LogStoreBufferItem::UpdateVnodes(_) => {}
             }
         }
         self.metrics.buffer_unconsumed_epoch_count.set(epoch_count);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Currently in decoupled sinks, which use KvLogStore, we handle scale in a similar mechanism to online scale in normal streaming jobs. When scale happen, the barrier with scale mutation will arrive at log writer first, and then instead of applying the scale mutation to log reader immediately, the scale mutation will be added to the buffer queue as a special item, and the reader will not apply this item until all previous items before it has been consumed.

However, this works when no sink parallelism exists in the scale. For a sink parallelism that will exit after receiving the barrier with scale mutation, unlike normal streaming jobs, it will exit without waiting for all previous items being consumed. The sink parallelisms that exist previously and start taking charge of the vnodes owned by the exited sink parallelism won't read the pending data of these transferred vnodes from log store, and then these pending data is lost.

The following example shows the data loss


||exec1 |   exec2|
|-|-----------|---------------|
||start with vnode [1] | start with vnode [2] |
||write chunk1 | write chunk2 |
|scale barrier|exit| change to own vnode [1,2]|

When exec1 receives the scale barrier, If the log reader of exec1 has not truncated on chunk1, it will not wait for chunk1 being truncated, and will only write chunk1 to storage and then exit anyway. However, when exec2 receive the scale barrier and start owning a new vnode1, it will not scan the storage on vnode1 for pending data, and therefore chunk1 is lost.

In this PR, we change to reinitialize the log reader during scale. During log reader reinitialization, it will rescan the vnode it owns, so that all pending data in the vnodes can be read. In the example, we will let exec2 scan the storage on vnode1, so that chunk1 won't lose. This is similar to offline scale in normal streaming jobs.

Besides, we also rebuild the sink during scale. This is because, in the lifecycle of a created sink, when receiving a barrier, it may assume that it has received all data at the epoch of the barrier. However, in the scenario above, when receiving the barrier and start owning new vnodes, there might still be pending data in the new vnodes, and if we yield these pending data to the sink, it will break the assumption above. Therefore, to make it simple, we will rebuild the whole sink during scale.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
