### PR TITLE
fix(streaming): asof join can panic in some cases

### DIFF
--- a/e2e_test/streaming/asof_join.slt
+++ b/e2e_test/streaming/asof_join.slt
@@ -4,16 +4,16 @@ SET RW_IMPLICIT_FLUSH TO true;
 # asof inner join
 
 statement ok
-create table t1 (v1 int, v2 int, v3 int primary key);
+create table t1 (v1 int, v2 int, v3 int, v4 int primary key);
 
 statement ok
 create table t2 (v1 int, v2 int, v3 int primary key);
 
 statement ok
-create materialized view mv1 as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 <= t2.v2;
+create materialized view mv1 as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t1.v4 t1_v4, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 <= t2.v2;
 
 statement ok
-insert into t1 values (1, 2, 3);
+insert into t1 values (1, 2, 3, 3);
 
 statement ok
 insert into t2 values (1, 3, 4);
@@ -21,7 +21,7 @@ insert into t2 values (1, 3, 4);
 query III
 select * from mv1;
 ----
-1 2 3 1 3 4
+1 2 3 3 1 3 4
 
 statement ok
 insert into t2 values (1, 2, 3);
@@ -29,7 +29,7 @@ insert into t2 values (1, 2, 3);
 query III
 select * from mv1;
 ----
-1 2 3 1 2 3
+1 2 3 3 1 2 3
 
 statement ok
 delete from t1 where v3 = 3;
@@ -40,15 +40,31 @@ select * from mv1;
 
 
 statement ok
-insert into t1 values (2, 3, 4);
+insert into t1 values (2, 3, 4, 4);
 
 statement ok
-insert into t2 values (2, 3, 6), (2, 3, 7), (2, 3, 5);
+insert into t2 values (2, 3, 6);
 
 query III
 select * from mv1;
 ----
-2 3 4 2 3 5
+2 3 4 4 2 3 6
+
+statement ok
+insert into t2 values (2, 3, 7);
+
+query III
+select * from mv1;
+----
+2 3 4 4 2 3 6
+
+statement ok
+insert into t2 values (2, 3, 5);
+
+query III
+select * from mv1;
+----
+2 3 4 4 2 3 5
 
 statement ok
 insert into t2 values (2, 3, 1), (2, 3, 2);
@@ -56,7 +72,7 @@ insert into t2 values (2, 3, 1), (2, 3, 2);
 query III
 select * from mv1;
 ----
-2 3 4 2 3 1
+2 3 4 4 2 3 1
 
 statement ok
 drop materialized view mv1;

--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -756,7 +756,7 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive> AsOfJoinExecutor
                 let (row_to_delete_r, row_to_insert_r) =
                     if let Some(pks) = right_inequality_index.get(&inequal_key) {
                         assert!(!pks.is_empty());
-                        let row_pk = side_match.ht.serialize_pk_from_row(row);
+                        let row_pk = side_update.ht.serialize_pk_from_row(row);
                         match op {
                             Op::Insert | Op::UpdateInsert => {
                                 // If there are multiple rows match the inequality key in the right table, we use one with smallest pk.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

 asof join can panic or cause downstream panic in some cases might panic when there are more than 1 identical inequality key.

IMPACT: after this PR, existing asof join can cause downstream panic or inconsistent result. But only in rare cases this can happen.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
