### PR TITLE
fix(file source): clear counter `splits_on_fetch` when updating rate limit

### DIFF
--- a/src/stream/src/executor/source/fs_fetch_executor.rs
+++ b/src/stream/src/executor/source/fs_fetch_executor.rs
@@ -248,8 +248,6 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                         Either::Left(msg) => {
                             match msg {
                                 Message::Barrier(barrier) => {
-                                    let mut need_rebuild_reader = false;
-
                                     if let Some(mutation) = barrier.mutation.as_deref() {
                                         match mutation {
                                             Mutation::Pause => stream.pause_stream(),
@@ -265,7 +263,6 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                                         *new_rate_limit
                                                     );
                                                     self.rate_limit_rps = *new_rate_limit;
-                                                    need_rebuild_reader = true;
                                                     splits_on_fetch = 0;
                                                 }
                                             }
@@ -291,7 +288,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                         }
                                     }
 
-                                    if splits_on_fetch == 0 || need_rebuild_reader {
+                                    if splits_on_fetch == 0 {
                                         Self::replace_with_new_batch_reader(
                                             &mut splits_on_fetch,
                                             &state_store_handler,

--- a/src/stream/src/executor/source/fs_fetch_executor.rs
+++ b/src/stream/src/executor/source/fs_fetch_executor.rs
@@ -266,6 +266,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                                     );
                                                     self.rate_limit_rps = *new_rate_limit;
                                                     need_rebuild_reader = true;
+                                                    splits_on_fetch = 0;
                                                 }
                                             }
                                             _ => (),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?
Close https://github.com/risingwavelabs/risingwave/issues/20593
How to reproduce
```
CREATE source s1(
        id int,
    ) WITH (
    connector = 's3',
    match_pattern = '*.parquet',
    s3.region_name = 'custom',
    s3.bucket_name = 'hummock001',
    s3.credentials.access = 'hummockadmin',
    s3.credentials.secret = 'hummockadmin',
    s3.endpoint_url = 'http://hummock001.127.0.0.1:9301',
    refresh.interval.sec = 1,
    ) FORMAT PLAIN ENCODE PARQUET;
create table d(id int);
create sink sink1 into d as select id from s1 with (
      type = 'append-only',
      force_append_only = 'true',
  );
alter sink sink1 set PARALLELISM to 1;
```
upload file1
`ALTER SOURCE s1 SET source_rate_limit TO 0;`
upload file2
`ALTER SOURCE s1 SET source_rate_limit TO default;`
upload file 3 4 5

File 3 4 5 cannot be read, but is in the fetch state table.

## root cause

This is a bug that only occurs when applying rate limits on the file source. After updating the rate limit, we set `need_rebuild_reader` to true, but we do not sync the modification of `splits_on_fetch`. Each time we call `replace_with_new_batch_reader`, it reads the state table of the fetch executor and updates the counter for `splits_on_fetch`. As a result, this leads to pending files being counted twice during this period. Subsequently, because `splits_on_fetch` is not zero, it causes further files to remain pending.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
