### PR TITLE
fix(barrier): ensure causal order in local barrier manager event

### DIFF
--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -855,10 +855,30 @@ impl DatabaseManagedBarrierState {
             let (actor_id, err) = option.expect("non-empty when tx in local_barrier_manager");
             return Poll::Ready(ManagedBarrierStateEvent::ActorError { actor_id, err });
         }
+        // yield some pending collected epochs
+        for (partial_graph_id, graph_state) in &mut self.graph_states {
+            if let Some(barrier) = graph_state.may_have_collected_all() {
+                if let Some(actors_to_stop) = barrier.all_stop_actors() {
+                    self.current_shared_context.drop_actors(actors_to_stop);
+                }
+                return Poll::Ready(ManagedBarrierStateEvent::BarrierCollected {
+                    partial_graph_id: *partial_graph_id,
+                    barrier,
+                });
+            }
+        }
         while let Poll::Ready(event) = self.barrier_event_rx.poll_recv(cx) {
             match event.expect("non-empty when tx in local_barrier_manager") {
                 LocalBarrierEvent::ReportActorCollected { actor_id, epoch } => {
-                    self.collect(actor_id, epoch);
+                    if let Some((partial_graph_id, barrier)) = self.collect(actor_id, epoch) {
+                        if let Some(actors_to_stop) = barrier.all_stop_actors() {
+                            self.current_shared_context.drop_actors(actors_to_stop);
+                        }
+                        return Poll::Ready(ManagedBarrierStateEvent::BarrierCollected {
+                            partial_graph_id,
+                            barrier,
+                        });
+                    }
                 }
                 LocalBarrierEvent::ReportCreateProgress {
                     epoch,
@@ -877,34 +897,23 @@ impl DatabaseManagedBarrierState {
                 }
             }
         }
-        if let Some((partial_graph_id, barrier)) = self.next_collected_epoch() {
-            return Poll::Ready(ManagedBarrierStateEvent::BarrierCollected {
-                partial_graph_id,
-                barrier,
-            });
-        }
-        Poll::Pending
-    }
 
-    pub(super) fn next_collected_epoch(&mut self) -> Option<(PartialGraphId, Barrier)> {
-        {
-            let mut output = None;
-            for (partial_graph_id, graph_state) in &mut self.graph_states {
-                if let Some(barrier) = graph_state.may_have_collected_all() {
-                    if let Some(actors_to_stop) = barrier.all_stop_actors() {
-                        self.current_shared_context.drop_actors(actors_to_stop);
-                    }
-                    output = Some((*partial_graph_id, barrier));
-                    break;
-                }
-            }
-            output
-        }
+        debug_assert!(
+            self.graph_states
+                .values_mut()
+                .all(|graph_state| graph_state.may_have_collected_all().is_none())
+        );
+        Poll::Pending
     }
 }
 
 impl DatabaseManagedBarrierState {
-    pub(super) fn collect(&mut self, actor_id: ActorId, epoch: EpochPair) {
+    #[must_use]
+    pub(super) fn collect(
+        &mut self,
+        actor_id: ActorId,
+        epoch: EpochPair,
+    ) -> Option<(PartialGraphId, Barrier)> {
         let (prev_partial_graph_id, is_finished) = self
             .actor_states
             .get_mut(&actor_id)
@@ -921,6 +930,9 @@ impl DatabaseManagedBarrierState {
             .get_mut(&prev_partial_graph_id)
             .expect("should exist");
         prev_graph_state.collect(actor_id, epoch);
+        prev_graph_state
+            .may_have_collected_all()
+            .map(|barrier| (prev_partial_graph_id, barrier))
     }
 
     pub(super) fn pop_barrier_to_complete(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

In the event loop of local barrier manager, we need to ensure that events do not break the causal order. For example, let's say, an actor has two event, `collect barrier1` and then `collect barrier2`, each causing event of `barrier1 all collected` and `barrier2 all collected`, and then we should ensure that the local barrier manager must handle `barrier1 all collected` before `barrier2 all collected`.

In current implementation, when we poll the next barrier manager event, we will poll all ready actor events first, and apply them to the graph state, and in the end see if we can yield any `barrier all collected` event. Since we poll all ready actor events and apply them all together to the graph state first, we may lose the causal order of these ready events. Within a partial graph, the causal order of events is ensured by using an epoch queue, in which we will always check the earliest epoch first. However, in snapshot backfill, actor will migrate from the partial graph of creating job to the database partial graph when backfill finishes. Since we don't ensure the causal order between two partial graphs, the two events may be out of causal order. 

For example, let's say a backfilling actor finishes backfill in epoch1, and will migrate to the database partial graph starting from epoch2. The actor handles message very fast, and then two actor events `barrier of epoch1 collected` and `barrier of epoch2 collected` become ready at the same time and apply to the two partial graphs. Since we don't ensure order when we  check two partial graphs, we may see `barrier of epoch2 all collected` first, and then see `barrier of epoch1 all collected`, and then we will handle the epoch2 event earlier than the epoch1 event.

In this PR, we fix this issue by not polling all ready actor events all at once. Instead, when we get a ready actor event, we will apply to the graph and immediately see if there is any new event.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
