### PR TITLE
feat(expr): add expression to reveal license status & content

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -305,6 +305,7 @@ message ExprNode {
     VNODE = 1101;
     TEST_PAID_TIER = 1102;
     VNODE_USER = 1103;
+    LICENSE = 1104;
     // Non-deterministic functions
     PROCTIME = 2023;
     PG_SLEEP = 2024;

--- a/src/expr/impl/src/scalar/test_license.rs
+++ b/src/expr/impl/src/scalar/test_license.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Functions for testing whether license and paid tier features are working.
+
 use anyhow::Context;
 use risingwave_common::license::{Feature, LicenseManager};
 use risingwave_common::types::JsonbVal;
 use risingwave_expr::{ExprError, Result, function};
 
-/// A function that checks if the `TestPaid` feature is available.
-///
-/// It's mainly for testing purposes only.
+/// Checks if the `TestPaid` feature is available.
 #[function("test_paid_tier() -> boolean")]
 pub fn test_paid_tier() -> Result<bool> {
     Feature::TestPaid
@@ -28,6 +28,7 @@ pub fn test_paid_tier() -> Result<bool> {
     Ok(true)
 }
 
+/// Dump the license information.
 #[function("license() -> jsonb")]
 pub fn license() -> Result<JsonbVal> {
     let license = LicenseManager::get()

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -681,6 +681,7 @@ impl Binder {
                 ("rw_epoch_to_ts", raw_call(ExprType::RwEpochToTs)),
                 // internal
                 ("rw_vnode", raw_call(ExprType::VnodeUser)),
+                ("rw_license", raw_call(ExprType::License)),
                 ("rw_test_paid_tier", raw_call(ExprType::TestPaidTier)), // for testing purposes
                 // TODO: choose which pg version we should return.
                 ("version", raw_literal(ExprImpl::literal_varchar(current_cluster_version()))),

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -276,6 +276,7 @@ impl ExprVisitor for ImpureAnalyzer {
             // expression output is not deterministic
             Type::Vnode // obtain vnode count from the context
             | Type::TestPaidTier
+            | Type::License
             | Type::Proctime
             | Type::PgSleep
             | Type::PgSleepFor

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -308,6 +308,7 @@ impl Strong {
             | ExprType::Vnode
             | ExprType::VnodeUser
             | ExprType::TestPaidTier
+            | ExprType::License
             | ExprType::Proctime
             | ExprType::PgSleep
             | ExprType::PgSleepFor

--- a/src/license/src/manager.rs
+++ b/src/license/src/manager.rs
@@ -16,7 +16,7 @@ use std::num::NonZeroUsize;
 use std::sync::{LazyLock, RwLock};
 
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use thiserror_ext::AsReport;
 
@@ -25,7 +25,7 @@ use crate::LicenseKeyRef;
 /// License tier.
 ///
 /// Each enterprise [`Feature`](super::Feature) is available for a specific tier and above.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Tier {
     /// Free tier.
@@ -43,7 +43,7 @@ pub enum Tier {
 ///
 /// The issuer must be `prod.risingwave.com` in production, and can be `test.risingwave.com` in
 /// development. This will be validated when refreshing the license key.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Issuer {
     #[serde(rename = "prod.risingwave.com")]
     Prod,
@@ -62,7 +62,7 @@ pub enum Issuer {
 /// Prefer calling [`crate::Feature::check_available`] to check the availability of a feature,
 /// other than directly checking the content of the license.
 // TODO(license): Shall we add a version field?
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct License {
     /// Subject of the license.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add a function `rw_license()` (returning a jsonb) to dump the license information.

If the current license is valid, the output will be like this:

```
dev=> select rw_license();
                                                 rw_license
-------------------------------------------------------------------------------------------------------------
 {"cpu_core_limit": null, "exp": 9999999999, "iss": "test.risingwave.com", "sub": "rw-test", "tier": "paid"}
(1 row)
```

Otherwise, it will yield an error indicating what's going wrong (like invalid token, expired license).

~~Note that a valid license does not mean that the paid features are available. Should also check the result of `rw_test_paid_tier()`.~~

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

See PR body above.

</details>
