### PR TITLE
feat: remove support for default column from CDC

### DIFF
--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -215,16 +215,16 @@ statement ok
 INSERT INTO test_my_default_value VALUES (2, 'jack');
 
 query II
-select * from test_pg_default_value order by id asc;
+select * from test_my_default_value order by id asc;
 ----
 1 bugen Shanghai
 2 jack NULL
 
 statement ok
-INSERT INTO test_pg_default_value_disorderd (id) VALUES (2);
+INSERT INTO test_my_default_value_disorderd (id) VALUES (2);
 
 query II
-select * from test_pg_default_value_disorderd order by id asc;
+select * from test_my_default_value_disorderd order by id asc;
 ----
 Shanghai 1
 NULL 2

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -698,6 +698,7 @@ select * from test_pg_default_value;
 ----
 1 bugen Shanghai
 2 jack NULL
+
 statement ok
 INSERT INTO test_pg_default_value_disorderd (id) VALUES (1);
 

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -214,17 +214,17 @@ SET RW_IMPLICIT_FLUSH=true;
 statement ok
 INSERT INTO test_my_default_value VALUES (2, 'jack');
 
-query II rowsort
-select * from test_my_default_value;
+query II
+select * from test_pg_default_value order by id asc;
 ----
 1 bugen Shanghai
 2 jack NULL
 
 statement ok
-INSERT INTO test_my_default_value_disorderd (id) VALUES (2);
+INSERT INTO test_pg_default_value_disorderd (id) VALUES (2);
 
-query II rowsort
-select * from test_my_default_value_disorderd;
+query II
+select * from test_pg_default_value_disorderd order by id asc;
 ----
 Shanghai 1
 NULL 2
@@ -693,17 +693,17 @@ SET RW_IMPLICIT_FLUSH=true;
 statement ok
 INSERT INTO test_pg_default_value VALUES (2, 'jack');
 
-query II rowsort
-select * from test_pg_default_value;
+query II
+select * from test_pg_default_value order by id asc;
 ----
 1 bugen Shanghai
 2 jack NULL
 
 statement ok
-INSERT INTO test_pg_default_value_disorderd (id) VALUES (1);
+INSERT INTO test_pg_default_value_disorderd (id) VALUES (2);
 
-query II rowsort
-select * from test_pg_default_value_disorderd;
+query II
+select * from test_pg_default_value_disorderd order by id asc;
 ----
 Shanghai 1
 NULL 2

--- a/e2e_test/source_legacy/cdc/cdc.share_stream.slt
+++ b/e2e_test/source_legacy/cdc/cdc.share_stream.slt
@@ -214,18 +214,20 @@ SET RW_IMPLICIT_FLUSH=true;
 statement ok
 INSERT INTO test_my_default_value VALUES (2, 'jack');
 
-query II
+query II rowsort
 select * from test_my_default_value;
 ----
-2 jack Shanghai
+1 bugen Shanghai
+2 jack NULL
 
 statement ok
 INSERT INTO test_my_default_value_disorderd (id) VALUES (2);
 
-query II
+query II rowsort
 select * from test_my_default_value_disorderd;
 ----
-Shanghai 2
+Shanghai 1
+NULL 2
 
 statement ok
 create table kt1 (*) from mysql_source table 'kdb.kt1';
@@ -676,33 +678,34 @@ CREATE TABLE test_pg_default_value (
     name varchar,
     city varchar,
     PRIMARY KEY (id)
-) FROM pg_source TABLE 'public.test_default_value';
+) FROM pg_source TABLE 'public.test_pg_default_value';
 
 statement ok
 CREATE TABLE test_pg_default_value_disorderd (
     city varchar,
     id int,
     PRIMARY KEY (id)
-) FROM pg_source TABLE 'public.test_default_value';
+) FROM pg_source TABLE 'public.test_pg_default_value';
 
 statement ok
 SET RW_IMPLICIT_FLUSH=true;
 
 statement ok
-INSERT INTO test_pg_default_value VALUES (1, 'noris');
+INSERT INTO test_pg_default_value VALUES (2, 'jack');
 
-query II
+query II rowsort
 select * from test_pg_default_value;
 ----
-1 noris Shanghai
-
+1 bugen Shanghai
+2 jack NULL
 statement ok
 INSERT INTO test_pg_default_value_disorderd (id) VALUES (1);
 
-query II
+query II rowsort
 select * from test_pg_default_value_disorderd;
 ----
 Shanghai 1
+NULL 2
 
 ### BEGIN reset the password to the original one
 onlyif can-use-recover

--- a/e2e_test/source_legacy/cdc/mysql_create.sql
+++ b/e2e_test/source_legacy/cdc/mysql_create.sql
@@ -56,3 +56,4 @@ CREATE TABLE test_my_default_value (
     city varchar(200) default 'Shanghai',
     PRIMARY KEY (id)
 );
+INSERT INTO test_my_default_value VALUES (1, 'bugen');

--- a/e2e_test/source_legacy/cdc/mysql_create.sql
+++ b/e2e_test/source_legacy/cdc/mysql_create.sql
@@ -56,4 +56,4 @@ CREATE TABLE test_my_default_value (
     city varchar(200) default 'Shanghai',
     PRIMARY KEY (id)
 );
-INSERT INTO test_my_default_value VALUES (1, 'bugen');
+INSERT INTO test_my_default_value(id, name) VALUES (1, 'bugen');

--- a/e2e_test/source_legacy/cdc/postgres_cdc.sql
+++ b/e2e_test/source_legacy/cdc/postgres_cdc.sql
@@ -157,4 +157,4 @@ CREATE TABLE test_pg_default_value (
     "city" varchar(200) default 'Shanghai',
     PRIMARY KEY ("id")
 );
-INSERT INTO test_pg_default_value VALUES (1, 'bugen');
+INSERT INTO test_pg_default_value(id, name) VALUES (1, 'bugen');

--- a/e2e_test/source_legacy/cdc/postgres_cdc.sql
+++ b/e2e_test/source_legacy/cdc/postgres_cdc.sql
@@ -151,9 +151,10 @@ INSERT INTO partitioned_timestamp_table (c_int, c_boolean, c_timestamp) VALUES
 create publication rw_publication_pubviaroot_false for TABLE partitioned_timestamp_table;
 
 
-CREATE TABLE test_default_value (
+CREATE TABLE test_pg_default_value (
     "id" int,
     "name" varchar(64),
     "city" varchar(200) default 'Shanghai',
     PRIMARY KEY ("id")
 );
+INSERT INTO test_pg_default_value VALUES (1, 'bugen');

--- a/e2e_test/source_legacy/cdc_inline/sql_server_cdc/sql_server_cdc.slt
+++ b/e2e_test/source_legacy/cdc_inline/sql_server_cdc/sql_server_cdc.slt
@@ -207,7 +207,7 @@ CREATE TABLE shared_orders (
 )  from mssql_source table 'mydb.dbo.orders';
 
 # column name mismatch
-statement error Column 'wrong_order_date' doesn't exist in the upstream database
+statement error Column 'wrong_order_date' not found in the upstream database
 CREATE TABLE shared_orders (
     order_id INT,
     wrong_order_date BIGINT,
@@ -302,7 +302,7 @@ CREATE TABLE upper_table (
     PRIMARY KEY ("ID")
 )  from mssql_source table 'mydb.UpperSchema.UpperTable';
 
-statement error Column 'name' doesn't exist in the upstream database
+statement error Column 'name' not found in the upstream database
 CREATE TABLE upper_table (
     "ID" INT,
     name VARCHAR,

--- a/e2e_test/source_legacy/cdc_inline/sql_server_cdc/sql_server_cdc.slt
+++ b/e2e_test/source_legacy/cdc_inline/sql_server_cdc/sql_server_cdc.slt
@@ -171,7 +171,7 @@ CREATE TABLE shared_orders (
 )  from mssql_source table 'orders';
 
 # invalid table name
-statement error Sql Server table 'dbo'.'wrong_orders' not found
+statement error Sql Server table 'dbo'.'wrong_orders' doesn't exist
 CREATE TABLE shared_orders (
     order_id INT,
     order_date BIGINT,
@@ -183,7 +183,7 @@ CREATE TABLE shared_orders (
 )  from mssql_source table 'mydb.dbo.wrong_orders';
 
 # invalid schema name
-statement error Sql Server table 'wrong_dbo'.'orders' not found
+statement error Sql Server table 'wrong_dbo'.'orders' doesn't exist
 CREATE TABLE shared_orders (
     order_id INT,
     order_date BIGINT,
@@ -207,7 +207,7 @@ CREATE TABLE shared_orders (
 )  from mssql_source table 'mydb.dbo.orders';
 
 # column name mismatch
-statement error Column 'wrong_order_date' not found in the upstream database
+statement error Column 'wrong_order_date' doesn't exist in the upstream database
 CREATE TABLE shared_orders (
     order_id INT,
     wrong_order_date BIGINT,
@@ -295,21 +295,21 @@ CREATE TABLE shared_sqlserver_all_data_types (
     PRIMARY KEY (id)
 ) from mssql_source table 'mydb.dbo.sqlserver_all_data_types';
 
-statement error Sql Server table 'UpperSchema'.'UpperTable' not found in 'mydb'
+statement error Sql Server table 'UpperSchema'.'UpperTable' doesn't exist in 'mydb'
 CREATE TABLE upper_table (
     "ID" INT,
     "Name" VARCHAR,
     PRIMARY KEY ("ID")
 )  from mssql_source table 'mydb.UpperSchema.UpperTable';
 
-statement error Column 'name' not found in the upstream database
+statement error Column 'name' doesn't exist in the upstream database
 CREATE TABLE upper_table (
     "ID" INT,
     name VARCHAR,
     PRIMARY KEY ("ID")
 )  from upper_mssql_source table 'UpperDB.UpperSchema.UpperTable';
 
-statement error Sql Server table 'upperSchema'.'upperTable' not found in 'UpperDB'
+statement error Sql Server table 'upperSchema'.'upperTable' doesn't exist in 'UpperDB'
 CREATE TABLE upper_table (
     "ID" INT,
     "Name" VARCHAR,


### PR DESCRIPTION


I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?
From @BugenZhao:
This feature doesn’t make much sense because…
- all upstream data are already filled default value by CDC driver (if applicable)
- it’s only applicable for performing DML in our side, which might be rare in CDC table’s case
- only the most trivial expressions (that can be parsed by us) are supported, which is quite limited

Another motivation is #20625

apply #20626 in main

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
