### PR TITLE
refactor(meta): remove dispatcher field from StreamActor

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -4,6 +4,7 @@ package stream_service;
 
 import "common.proto";
 import "hummock.proto";
+import "plan_common.proto";
 import "stream_plan.proto";
 
 option java_package = "com.risingwave.proto";
@@ -27,9 +28,12 @@ message InjectBarrierRequest {
     message UpstreamActors {
       repeated uint32 actors = 1;
     }
-
-    stream_plan.StreamActor actor = 1;
+    uint32 actor_id = 1;
     map<uint32, UpstreamActors> fragment_upstreams = 2;
+    repeated stream_plan.Dispatcher dispatchers = 3;
+    common.Buffer vnode_bitmap = 4;
+    string mview_definition = 5;
+    plan_common.ExprContext expr_context = 6;
   }
 
   repeated common.ActorInfo broadcast_info = 8;

--- a/src/meta/service/src/scale_service.rs
+++ b/src/meta/service/src/scale_service.rs
@@ -79,7 +79,17 @@ impl ScaleService for ScaleServiceImpl {
                 .catalog_controller
                 .upstream_fragments(stream_job_fragments.fragment_ids())
                 .await?;
-            table_fragments.push(stream_job_fragments.to_protobuf(&upstreams))
+            let dispatchers = self
+                .metadata_manager
+                .catalog_controller
+                .get_fragment_actor_dispatchers(
+                    stream_job_fragments
+                        .fragment_ids()
+                        .map(|id| id as _)
+                        .collect(),
+                )
+                .await?;
+            table_fragments.push(stream_job_fragments.to_protobuf(&upstreams, &dispatchers))
         }
 
         let worker_nodes = self

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -213,6 +213,14 @@ impl StreamManagerService for StreamServiceImpl {
                 .catalog_controller
                 .get_job_fragments_by_id(job_id as _)
                 .await?;
+            let mut dispatchers = self
+                .metadata_manager
+                .catalog_controller
+                .get_fragment_actor_dispatchers(
+                    table_fragments.fragment_ids().map(|id| id as _).collect(),
+                )
+                .await?;
+            let ctx = table_fragments.ctx.to_protobuf();
             info.insert(
                 table_fragments.stream_job_id().table_id,
                 TableFragmentInfo {
@@ -227,12 +235,17 @@ impl StreamManagerService for StreamServiceImpl {
                                 .map(|actor| ActorInfo {
                                     id: actor.actor_id,
                                     node: Some(fragment.nodes.clone()),
-                                    dispatcher: actor.dispatcher,
+                                    dispatcher: dispatchers
+                                        .get_mut(&(fragment.fragment_id as _))
+                                        .and_then(|dispatchers| {
+                                            dispatchers.remove(&(actor.actor_id as _))
+                                        })
+                                        .unwrap_or_default(),
                                 })
                                 .collect_vec(),
                         })
                         .collect_vec(),
-                    ctx: Some(table_fragments.ctx.to_protobuf()),
+                    ctx: Some(ctx),
                 },
             );
         }

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -990,7 +990,7 @@ impl DatabaseCheckpointControl {
         {
             match job_type {
                 CreateStreamingJobType::Normal | CreateStreamingJobType::SinkIntoTable(_) => {
-                    for fragment in info.stream_job_fragments.fragments.values_mut() {
+                    for fragment in info.stream_job_fragments.inner.fragments.values_mut() {
                         fill_snapshot_backfill_epoch(
                             &mut fragment.nodes,
                             None,
@@ -1021,7 +1021,7 @@ impl DatabaseCheckpointControl {
                             "must not set previously"
                         );
                     }
-                    for fragment in info.stream_job_fragments.fragments.values_mut() {
+                    for fragment in info.stream_job_fragments.inner.fragments.values_mut() {
                         fill_snapshot_backfill_epoch(
                             &mut fragment.nodes,
                             Some(snapshot_backfill_info),

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -78,8 +78,8 @@ impl CreatingStreamingJobControl {
             info.stream_job_fragments
                 .actors_to_create()
                 .flat_map(|(fragment_id, _, actors)| {
-                    actors.map(move |(actor, _)| {
-                        (actor.actor_id, fragment_id, actor.dispatcher.as_slice())
+                    actors.map(move |(actor, dispatchers, _)| {
+                        (actor.actor_id, fragment_id, dispatchers.as_slice())
                     })
                 })
                 .chain(
@@ -95,7 +95,7 @@ impl CreatingStreamingJobControl {
         );
         let mut actors_to_create = StreamJobActorsToCreate::default();
         for (fragment_id, node, actors) in info.stream_job_fragments.actors_to_create() {
-            for (actor, worker_id) in actors {
+            for (actor, dispatchers, worker_id) in actors {
                 actors_to_create
                     .entry(worker_id)
                     .or_default()
@@ -105,6 +105,7 @@ impl CreatingStreamingJobControl {
                     .push((
                         actor.clone(),
                         actor_upstreams.remove(&actor.actor_id).unwrap_or_default(),
+                        dispatchers.clone(),
                     ))
             }
         }

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -162,7 +162,7 @@ impl CommandContext {
                             .metadata_manager
                             .catalog_controller
                             .post_collect_job_fragments(
-                                new_fragments.stream_job_id().table_id as _,
+                                new_fragments.stream_job_id.table_id as _,
                                 new_fragments.actor_ids(),
                                 dispatchers,
                                 init_split_assignment,
@@ -283,7 +283,7 @@ impl CommandContext {
                     .metadata_manager
                     .catalog_controller
                     .post_collect_job_fragments(
-                        new_fragments.stream_job_id().table_id as _,
+                        new_fragments.stream_job_id.table_id as _,
                         new_fragments.actor_ids(),
                         dispatchers,
                         init_split_assignment,

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -18,12 +18,10 @@ use std::time::Duration;
 use anyhow::{Context, anyhow};
 use futures::future::try_join_all;
 use itertools::Itertools;
-use risingwave_common::bail;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::WorkerSlotId;
 use risingwave_meta_model::StreamingParallelism;
-use risingwave_pb::stream_plan::StreamActor;
 use thiserror_ext::AsReport;
 use tokio::time::Instant;
 use tracing::{debug, info, warn};
@@ -34,7 +32,10 @@ use crate::barrier::info::InflightDatabaseInfo;
 use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{ActorId, StreamJobFragments, TableParallelism};
+use crate::model::{
+    ActorId, FragmentActorDispatchers, StreamActor, StreamActorWithDispatchers, StreamJobFragments,
+    TableParallelism,
+};
 use crate::stream::{
     JobParallelismTarget, JobReschedulePolicy, JobRescheduleTarget, JobResourceGroupTarget,
     RescheduleOptions, SourceChange,
@@ -292,6 +293,20 @@ impl GlobalBarrierWorkerContextImpl {
                         warn!(error = %err.as_report(), "update actors failed");
                     })?;
 
+                    let stream_actor_dispatchers = self
+                        .metadata_manager
+                        .catalog_controller
+                        .get_fragment_actor_dispatchers(
+                            info.values()
+                                .flat_map(|database| database.fragment_infos())
+                                .map(|fragment| fragment.fragment_id as _)
+                                .collect(),
+                        )
+                        .await?;
+
+                    let stream_actors =
+                        Self::fill_dispatchers(stream_actors, stream_actor_dispatchers);
+
                     let background_jobs = {
                         let jobs = self
                             .list_background_mv_progress()
@@ -421,10 +436,22 @@ impl GlobalBarrierWorkerContextImpl {
             mv_depended_subscriptions,
         };
 
+        let stream_actor_dispatchers = self
+            .metadata_manager
+            .catalog_controller
+            .get_fragment_actor_dispatchers(
+                info.fragment_infos()
+                    .map(|fragment| fragment.fragment_id as _)
+                    .collect(),
+            )
+            .await?;
+
         // update and build all actors.
         let stream_actors = self.load_all_actors().await.inspect_err(|err| {
             warn!(error = %err.as_report(), "update actors failed");
         })?;
+
+        let stream_actors = Self::fill_dispatchers(stream_actors, stream_actor_dispatchers);
 
         // get split assignments for all actors
         let source_splits = self.source_manager.list_assignments().await;
@@ -436,6 +463,22 @@ impl GlobalBarrierWorkerContextImpl {
             source_splits,
             background_jobs,
         }))
+    }
+
+    fn fill_dispatchers(
+        actors: HashMap<ActorId, StreamActor>,
+        mut dispatchers: FragmentActorDispatchers,
+    ) -> HashMap<ActorId, StreamActorWithDispatchers> {
+        actors
+            .into_iter()
+            .map(|(actor_id, actor)| {
+                let dispatchers = dispatchers
+                    .get_mut(&(actor.fragment_id as _))
+                    .and_then(|dispatchers| dispatchers.remove(&(actor.actor_id as _)))
+                    .unwrap_or_default();
+                (actor_id, (actor, dispatchers))
+            })
+            .collect()
     }
 }
 
@@ -598,8 +641,8 @@ impl GlobalBarrierWorkerContextImpl {
             Ok(_) => {
                 info!("integrity check passed");
             }
-            Err(_) => {
-                bail!("integrity check failed");
+            Err(e) => {
+                return Err(anyhow!(e).context("integrity check failed").into());
             }
         }
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -20,13 +20,12 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::meta::PbRecoveryStatus;
-use risingwave_pb::stream_plan::StreamActor;
 use tokio::sync::oneshot::Sender;
 
 use self::notifier::Notifier;
 use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo};
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{ActorId, StreamJobFragments};
+use crate::model::{ActorId, StreamActorWithDispatchers, StreamJobFragments};
 use crate::{MetaError, MetaResult};
 
 mod checkpoint;
@@ -104,7 +103,7 @@ struct BarrierWorkerRuntimeInfoSnapshot {
     database_fragment_infos: HashMap<DatabaseId, InflightDatabaseInfo>,
     state_table_committed_epochs: HashMap<TableId, u64>,
     subscription_infos: HashMap<DatabaseId, InflightSubscriptionInfo>,
-    stream_actors: HashMap<ActorId, StreamActor>,
+    stream_actors: HashMap<ActorId, StreamActorWithDispatchers>,
     source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashMap<TableId, (String, StreamJobFragments)>,
     hummock_version_stats: HummockVersionStats,
@@ -115,7 +114,7 @@ impl BarrierWorkerRuntimeInfoSnapshot {
         database_id: DatabaseId,
         database_info: &InflightDatabaseInfo,
         active_streaming_nodes: &ActiveStreamingWorkerNodes,
-        stream_actors: &HashMap<ActorId, StreamActor>,
+        stream_actors: &HashMap<ActorId, StreamActorWithDispatchers>,
         state_table_committed_epochs: &HashMap<TableId, u64>,
     ) -> MetaResult<()> {
         {
@@ -190,7 +189,7 @@ struct DatabaseRuntimeInfoSnapshot {
     database_fragment_info: InflightDatabaseInfo,
     state_table_committed_epochs: HashMap<TableId, u64>,
     subscription_info: InflightSubscriptionInfo,
-    stream_actors: HashMap<ActorId, StreamActor>,
+    stream_actors: HashMap<ActorId, StreamActorWithDispatchers>,
     source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashMap<TableId, (String, StreamJobFragments)>,
 }

--- a/src/meta/src/controller/scale.rs
+++ b/src/meta/src/controller/scale.rs
@@ -25,8 +25,8 @@ use risingwave_meta_model::prelude::{
     Actor, Fragment, FragmentRelation, Sink, Source, StreamingJob, Table,
 };
 use risingwave_meta_model::{
-    ActorId, ConnectorSplits, FragmentId, ObjectId, VnodeBitmap, actor, fragment,
-    fragment_relation, sink, source, streaming_job, table,
+    ConnectorSplits, FragmentId, ObjectId, VnodeBitmap, actor, fragment, fragment_relation, sink,
+    source, streaming_job, table,
 };
 use risingwave_meta_model_migration::{
     Alias, CommonTableExpression, Expr, IntoColumnRef, QueryStatementBuilder, SelectStatement,
@@ -40,6 +40,7 @@ use sea_orm::{
 
 use crate::controller::catalog::CatalogController;
 use crate::controller::utils::{get_existing_job_resource_group, get_fragment_actor_dispatchers};
+use crate::model::ActorId;
 use crate::{MetaError, MetaResult};
 
 /// This function will construct a query using recursive cte to find `no_shuffle` upstream relation graph for target fragments.
@@ -405,7 +406,7 @@ impl CatalogController {
 
         let actors: HashMap<_, _> = actors
             .into_iter()
-            .map(|actor| (actor.actor_id, actor))
+            .map(|actor| (actor.actor_id as _, actor))
             .collect();
 
         let fragments: HashMap<FragmentId, _> = fragments
@@ -501,7 +502,7 @@ impl CatalogController {
         #[derive(Clone, DerivePartialModel, FromQueryResult)]
         #[sea_orm(entity = "Actor")]
         pub struct PartialActor {
-            pub actor_id: ActorId,
+            pub actor_id: risingwave_meta_model::ActorId,
             pub fragment_id: FragmentId,
             pub status: ActorStatus,
             pub splits: Option<ConnectorSplits>,

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -64,6 +64,7 @@ use sea_orm::{
 use thiserror_ext::AsReport;
 
 use crate::controller::ObjectModel;
+use crate::model::FragmentActorDispatchers;
 use crate::{MetaError, MetaResult};
 
 /// This function will construct a query using recursive cte to find all objects[(id, `obj_type`)] that are used by the given object.
@@ -903,7 +904,7 @@ pub fn extract_grant_obj_id(object: &PbGrantObject) -> ObjectId {
 pub async fn get_fragment_actor_dispatchers<C>(
     db: &C,
     fragment_ids: Vec<FragmentId>,
-) -> MetaResult<HashMap<FragmentId, HashMap<ActorId, Vec<PbDispatcher>>>>
+) -> MetaResult<FragmentActorDispatchers>
 where
     C: ConnectionTrait,
 {
@@ -991,10 +992,12 @@ where
             dist_key_indices.into_u32_array(),
             output_indices.into_u32_array(),
         );
-        let actor_dispatchers_map = actor_dispatchers_map.entry(source_fragment_id).or_default();
+        let actor_dispatchers_map = actor_dispatchers_map
+            .entry(source_fragment_id as _)
+            .or_default();
         for (actor_id, dispatchers) in dispatchers {
             actor_dispatchers_map
-                .entry(actor_id)
+                .entry(actor_id as _)
                 .or_default()
                 .push(dispatchers);
         }

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -282,7 +282,17 @@ pub(super) mod handlers {
             .upstream_fragments(table_fragments.fragment_ids())
             .await
             .map_err(err)?;
-        Ok(Json(table_fragments.to_protobuf(&upstream_fragments)))
+        let dispatchers = srv
+            .metadata_manager
+            .catalog_controller
+            .get_fragment_actor_dispatchers(
+                table_fragments.fragment_ids().map(|id| id as _).collect(),
+            )
+            .await
+            .map_err(err)?;
+        Ok(Json(
+            table_fragments.to_protobuf(&upstream_fragments, &dispatchers),
+        ))
     }
 
     pub async fn list_users(Extension(srv): Extension<Service>) -> Result<Json<Vec<PbUserInfo>>> {

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -25,7 +25,7 @@ use risingwave_pb::catalog::{PbSink, PbSource, PbTable};
 use risingwave_pb::common::worker_node::{PbResource, Property as AddNodeProperty, State};
 use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, WorkerNode, WorkerType};
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
-use risingwave_pb::stream_plan::{PbDispatchStrategy, PbStreamScanType, StreamActor};
+use risingwave_pb::stream_plan::{PbDispatchStrategy, PbStreamScanType};
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 use tokio::sync::oneshot;
 use tokio::time::{Instant, sleep};
@@ -36,7 +36,9 @@ use crate::controller::catalog::CatalogControllerRef;
 use crate::controller::cluster::{ClusterControllerRef, StreamingClusterInfo, WorkerExtraInfo};
 use crate::controller::fragment::FragmentParallelismInfo;
 use crate::manager::{LocalNotification, NotificationVersion};
-use crate::model::{ActorId, ClusterId, Fragment, FragmentId, StreamJobFragments, SubscriptionId};
+use crate::model::{
+    ActorId, ClusterId, Fragment, FragmentId, StreamActor, StreamJobFragments, SubscriptionId,
+};
 use crate::stream::{JobReschedulePostUpdates, SplitAssignment};
 use crate::telemetry::MetaTelemetryJobDesc;
 use crate::{MetaError, MetaResult};

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -34,7 +34,6 @@ use risingwave_connector::source::{
 use risingwave_meta_model::SourceId;
 use risingwave_pb::catalog::Source;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
-use risingwave_pb::stream_plan::Dispatcher;
 use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -380,7 +379,7 @@ impl SourceManager {
             .values()
             .flatten()
             .flat_map(|fragment_id| fragments.get(fragment_id).unwrap().actors.iter())
-            .map(|actor| actor.get_actor_id())
+            .map(|actor| actor.actor_id)
             .collect::<HashSet<_>>();
 
         self.apply_source_change(SourceChange::ReplaceJob {

--- a/src/meta/src/stream/source_manager/split_assignment.rs
+++ b/src/meta/src/stream/source_manager/split_assignment.rs
@@ -15,6 +15,7 @@
 use itertools::Itertools;
 
 use super::*;
+use crate::model::{FragmentActorDispatchers, StreamJobFragments};
 
 impl SourceManager {
     /// Migrates splits from previous actors to the new actors for a rescheduled fragment.
@@ -231,7 +232,7 @@ impl SourceManager {
         &self,
         table_fragments: &StreamJobFragments,
         // dispatchers from SourceExecutor to SourceBackfillExecutor
-        dispatchers: &HashMap<FragmentId, HashMap<ActorId, Vec<Dispatcher>>>,
+        dispatchers: &FragmentActorDispatchers,
     ) -> MetaResult<SplitAssignment> {
         let core = self.core.lock().await;
 

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -38,14 +38,14 @@ use risingwave_pb::stream_plan::stream_fragment_graph::{
 };
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    DispatchStrategy, DispatcherType, FragmentTypeFlag, StreamActor,
+    DispatchStrategy, DispatcherType, FragmentTypeFlag,
     StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamScanNode, StreamScanType,
 };
 
 use crate::MetaResult;
 use crate::barrier::SnapshotBackfillInfo;
 use crate::manager::{MetaSrvEnv, StreamingJob, StreamingJobType};
-use crate::model::{ActorId, Fragment, FragmentId};
+use crate::model::{ActorId, Fragment, FragmentId, StreamActor};
 use crate::stream::stream_graph::id::{GlobalFragmentId, GlobalFragmentIdGen, GlobalTableIdGen};
 use crate::stream::stream_graph::schedule::Distribution;
 

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -25,7 +25,6 @@ use anyhow::Context;
 use either::Either;
 use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
-use risingwave_common::bitmap::Bitmap;
 use risingwave_common::hash::{ActorMapping, VnodeCountCompat, WorkerSlotId, WorkerSlotMapping};
 use risingwave_common::util::stream_graph_visitor::visit_fragment;
 use risingwave_common::{bail, hash};
@@ -164,7 +163,7 @@ impl Distribution {
                     .map(|actor| {
                         (
                             actor.actor_id as hash::ActorId,
-                            Bitmap::from(actor.vnode_bitmap.as_ref().unwrap()),
+                            actor.vnode_bitmap.clone().unwrap(),
                         )
                     })
                     .collect();

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -474,6 +474,7 @@ async fn test_graph_builder() -> MetaResult<()> {
     let ActorGraphBuildResult {
         graph,
         actor_upstreams,
+        actor_dispatchers,
         ..
     } = actor_graph_builder.generate_graph(&env, &job, expr_context)?;
 
@@ -509,9 +510,12 @@ async fn test_graph_builder() -> MetaResult<()> {
 
     for actor in actors {
         assert_eq!(
-            expected_downstream.get(&actor.get_actor_id()).unwrap(),
-            actor
-                .dispatcher
+            expected_downstream.get(&actor.actor_id).unwrap(),
+            actor_dispatchers
+                .get(&actor.fragment_id)
+                .unwrap()
+                .get(&actor.actor_id)
+                .unwrap()
                 .first()
                 .map_or(&vec![], |d| d.get_downstream_actor_id()),
         );
@@ -526,7 +530,7 @@ async fn test_graph_builder() -> MetaResult<()> {
                 for actor in &fragment.actors {
                     assert_eq!(
                         expected_upstream
-                            .get(&actor.get_actor_id())
+                            .get(&actor.actor_id)
                             .unwrap()
                             .iter()
                             .collect::<HashSet<_>>(),

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -741,7 +741,9 @@ impl Mutation {
 
     fn from_protobuf(prost: &PbMutation) -> StreamExecutorResult<Self> {
         let mutation = match prost {
-            PbMutation::Stop(stop) => Mutation::Stop(HashSet::from_iter(stop.get_actors().clone())),
+            PbMutation::Stop(stop) => {
+                Mutation::Stop(HashSet::from_iter(stop.actors.iter().cloned()))
+            }
 
             PbMutation::Update(update) => Mutation::Update(UpdateMutation {
                 dispatchers: update

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -762,28 +762,27 @@ impl DatabaseManagedBarrierState {
         let mut new_actors = HashSet::new();
         let subscriptions =
             LazyCell::new(|| Arc::new(graph_state.mv_depended_subscriptions.clone()));
-        for (node, actor) in request
-            .actors_to_build
-            .into_iter()
-            .flat_map(|fragment_actors| {
-                let node = Arc::new(fragment_actors.node.unwrap());
-                fragment_actors
-                    .actors
-                    .into_iter()
-                    .map(move |actor| (node.clone(), actor))
-            })
+        for (node, fragment_id, actor) in
+            request
+                .actors_to_build
+                .into_iter()
+                .flat_map(|fragment_actors| {
+                    let node = Arc::new(fragment_actors.node.unwrap());
+                    fragment_actors
+                        .actors
+                        .into_iter()
+                        .map(move |actor| (node.clone(), fragment_actors.fragment_id, actor))
+                })
         {
-            let upstream = actor.fragment_upstreams;
-            let actor = actor.actor.unwrap();
             let actor_id = actor.actor_id;
             assert!(!is_stop_actor(actor_id));
             assert!(new_actors.insert(actor_id));
             assert!(request.actor_ids_to_collect.contains(&actor_id));
             let (join_handle, monitor_join_handle) = self.actor_manager.spawn_actor(
                 actor,
+                fragment_id,
                 node,
                 (*subscriptions).clone(),
-                upstream,
                 self.current_shared_context.clone(),
                 self.local_barrier_manager.clone(),
             );

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -210,7 +210,7 @@ impl SharedContext {
     pub(crate) fn add_actors(&self, new_actor_infos: impl Iterator<Item = ActorInfo>) {
         let mut actor_infos = self.actor_infos.write();
         for actor in new_actor_infos {
-            if let Some(prev_actor) = actor_infos.get(&actor.get_actor_id()) {
+            if let Some(prev_actor) = actor_infos.get(&actor.actor_id) {
                 if cfg!(debug_assertions) {
                     panic!("duplicate actor info: {:?} {:?}", actor, actor_infos);
                 }
@@ -222,7 +222,7 @@ impl SharedContext {
                     );
                 }
             } else {
-                actor_infos.insert(actor.get_actor_id(), actor);
+                actor_infos.insert(actor.actor_id, actor);
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

tldr: 
- remove the dispatcher from StreamActor used in `StreamJobFragment` so that we don't have to always recompose the dispatchers when loading `StreamJobFragment`
- for a next PR to compose the fragment dispatchers inside barrier manager when handle the command.

Currently, the `StreamActor` protobuf struct is used in 3 places. One in `StreamJobFragments` to be used internal in meta node to load fragment actor info, one in meta node rpc service used by dashboard or other external callers, and one in inject barrier request to carry necessary information to create actors.

In `StreamActor`, it contains a dispatcher field to store the dispatcher information to downstream actors. Every time we load and build a `StreamActor`, we will have to recompose the dispatcher information. However, for `StreamJobFragments` used internally in meta node, the dispatcher information is rarely used. We only use this dispatcher information in  `StreamJobFragments`'s `StreamActor` when handling create streaming job and replace streaming job command. Therefore, in most usages of `StreamJobFragments`, it is unnecessary to recompose the dispatcher information.

In this PR, we will remove the `dispatcher` field for `StreamActor` in `StreamJobFragments`. Since the `StreamActor` protobuf may still used by some external caller to meta rpc service (e.g. dashboard), we will not change the definition of the protobuf `StreamActor`. Instead, we introduce an in-memory struct `StreamActor`, which includes most field of `StreamActor` protobuf except the dispatcher field. For inject barrier request, we will copy the fields in protobuf `StreamActor` to the existing `BuildActorInfo`, and the inject barrier request won't include `StreamActor`. The difference between the three actor structs is summarized in the following tables

| fields| protobuf StreamActor| in memory StreamActor| BuildActorInfo
|--|----|--|--|
|dispatchers| yes| no| yes|
|upstreams|no|no|yes|
|other fields|yes|yes|yes|

For create streaming job and replace streaming job command, they still need the dispatcher information. Therefore, we introduce a new struct `StreamJobFragmentsToCreate` to be used in the two commands. It include the `StreamJobFragments`, and the extra dispatcher information.

```
pub struct StreamJobFragmentsToCreate {
    pub inner: StreamJobFragments,
    pub dispatchers: FragmentActorDispatchers,
}
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
