### PR TITLE
feat(meta): compose fragment dispatcher in barrier workers

### DIFF
--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -31,6 +31,7 @@ use status::CreatingStreamingJobStatus;
 use tracing::info;
 
 use crate::MetaResult;
+use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::barrier::rpc::ControlStreamManager;
@@ -63,6 +64,7 @@ impl CreatingStreamingJobControl {
         version_stat: &HummockVersionStats,
         initial_mutation: Mutation,
         control_stream_manager: &mut ControlStreamManager,
+        edges: &mut FragmentEdgeBuildResult,
     ) -> MetaResult<Self> {
         let job_id = info.stream_job_fragments.stream_job_id();
         let database_id = DatabaseId::new(info.streaming_job.database_id());
@@ -84,41 +86,8 @@ impl CreatingStreamingJobControl {
         let table_id = info.stream_job_fragments.stream_job_id();
         let table_id_str = format!("{}", table_id.table_id);
 
-        let mut actor_upstreams = Command::collect_actor_upstreams(
-            info.stream_job_fragments
-                .actors_to_create()
-                .flat_map(|(fragment_id, _, actors)| {
-                    actors.map(move |(actor, dispatchers, _)| {
-                        (actor.actor_id, fragment_id, dispatchers.as_slice())
-                    })
-                })
-                .chain(
-                    info.dispatchers
-                        .iter()
-                        .flat_map(|(fragment_id, dispatchers)| {
-                            dispatchers.iter().map(|(actor_id, dispatchers)| {
-                                (*actor_id, *fragment_id, dispatchers.as_slice())
-                            })
-                        }),
-                ),
-            None,
-        );
-        let mut actors_to_create = StreamJobActorsToCreate::default();
-        for (fragment_id, node, actors) in info.stream_job_fragments.actors_to_create() {
-            for (actor, dispatchers, worker_id) in actors {
-                actors_to_create
-                    .entry(worker_id)
-                    .or_default()
-                    .entry(fragment_id)
-                    .or_insert_with(|| (node.clone(), vec![]))
-                    .1
-                    .push((
-                        actor.clone(),
-                        actor_upstreams.remove(&actor.actor_id).unwrap_or_default(),
-                        dispatchers.clone(),
-                    ))
-            }
-        }
+        let actors_to_create =
+            edges.collect_actors_to_create(info.stream_job_fragments.actors_to_create());
 
         let graph_info = InflightStreamingJobInfo {
             job_id: table_id,

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -41,15 +41,16 @@ use tracing::warn;
 
 use super::info::{CommandFragmentChanges, InflightDatabaseInfo, InflightStreamingJobInfo};
 use crate::barrier::InflightSubscriptionInfo;
+use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::BarrierInfo;
 use crate::barrier::utils::collect_resp_info;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
 use crate::manager::{StreamingJob, StreamingJobType};
 use crate::model::{
-    ActorId, ActorUpstreams, DispatcherId, FragmentActorDispatchers, FragmentId,
-    StreamActorWithDispatchers, StreamJobActorsToCreate, StreamJobFragments,
-    StreamJobFragmentsToCreate,
+    ActorId, ActorUpstreams, DispatcherId, FragmentActorDispatchers, FragmentDownstreamRelation,
+    FragmentId, FragmentReplaceUpstream, StreamActorWithDispatchers, StreamJobActorsToCreate,
+    StreamJobFragments, StreamJobFragmentsToCreate,
 };
 use crate::stream::{
     JobReschedulePostUpdates, SplitAssignment, ThrottleConfig, build_actor_connector_splits,
@@ -99,8 +100,8 @@ pub struct ReplaceStreamJobPlan {
     pub new_fragments: StreamJobFragmentsToCreate,
     /// Downstream jobs of the replaced job need to update their `Merge` node to
     /// connect to the new fragment.
-    pub merge_updates: HashMap<FragmentId, Vec<MergeUpdate>>,
-    pub dispatchers: FragmentActorDispatchers,
+    pub replace_upstream: FragmentReplaceUpstream,
+    pub upstream_fragment_downstreams: FragmentDownstreamRelation,
     /// For a table with connector, the `SourceExecutor` actor will also be rebuilt with new actor ids.
     /// We need to reassign splits for it.
     ///
@@ -130,19 +131,11 @@ impl ReplaceStreamJobPlan {
                 .try_insert(fragment.fragment_id, CommandFragmentChanges::RemoveFragment)
                 .expect("non-duplicate");
         }
-        for (fragment_id, merge_updates) in &self.merge_updates {
-            let replace_map = merge_updates
-                .iter()
-                .filter_map(|m| {
-                    m.new_upstream_fragment_id.map(|new_upstream_fragment_id| {
-                        (m.upstream_fragment_id, new_upstream_fragment_id)
-                    })
-                })
-                .collect();
+        for (fragment_id, replace_map) in &self.replace_upstream {
             fragment_changes
                 .try_insert(
                     *fragment_id,
-                    CommandFragmentChanges::ReplaceNodeUpstream(replace_map),
+                    CommandFragmentChanges::ReplaceNodeUpstream(replace_map.clone()),
                 )
                 .expect("non-duplicate");
         }
@@ -152,13 +145,15 @@ impl ReplaceStreamJobPlan {
     /// `old_fragment_id` -> `new_fragment_id`
     pub fn fragment_replacements(&self) -> HashMap<FragmentId, FragmentId> {
         let mut fragment_replacements = HashMap::new();
-        for merge_update in self.merge_updates.values().flatten() {
-            if let Some(new_upstream_fragment_id) = merge_update.new_upstream_fragment_id {
-                let r = fragment_replacements
-                    .insert(merge_update.upstream_fragment_id, new_upstream_fragment_id);
+        for (upstream_fragment_id, new_upstream_fragment_id) in
+            self.replace_upstream.values().flatten()
+        {
+            {
+                let r =
+                    fragment_replacements.insert(*upstream_fragment_id, *new_upstream_fragment_id);
                 if let Some(r) = r {
                     assert_eq!(
-                        new_upstream_fragment_id, r,
+                        *new_upstream_fragment_id, r,
                         "one fragment is replaced by multiple fragments"
                     );
                 }
@@ -173,7 +168,7 @@ impl ReplaceStreamJobPlan {
 pub struct CreateStreamingJobCommandInfo {
     #[educe(Debug(ignore))]
     pub stream_job_fragments: StreamJobFragmentsToCreate,
-    pub dispatchers: FragmentActorDispatchers,
+    pub upstream_fragment_downstreams: FragmentDownstreamRelation,
     pub init_split_assignment: SplitAssignment,
     pub definition: String,
     pub job_type: StreamingJobType,
@@ -300,7 +295,7 @@ pub enum Command {
         post_updates: JobReschedulePostUpdates,
     },
 
-    /// `ReplaceStreamJob` command generates a `Update` barrier with the given `merge_updates`. This is
+    /// `ReplaceStreamJob` command generates a `Update` barrier with the given `replace_upstream`. This is
     /// essentially switching the downstream of the old job fragments to the new ones, and
     /// dropping the old job fragments. Used for schema change.
     ///
@@ -627,7 +622,11 @@ impl CommandContext {
 
 impl Command {
     /// Generate a mutation for the given command.
-    pub fn to_mutation(&self, is_currently_paused: bool) -> Option<Mutation> {
+    pub(super) fn to_mutation(
+        &self,
+        is_currently_paused: bool,
+        edges: &mut Option<FragmentEdgeBuildResult>,
+    ) -> Option<Mutation> {
         match self {
             Command::Flush => None,
 
@@ -685,25 +684,14 @@ impl Command {
                 info:
                     CreateStreamingJobCommandInfo {
                         stream_job_fragments: table_fragments,
-                        dispatchers,
                         init_split_assignment: split_assignment,
+                        upstream_fragment_downstreams,
                         ..
                     },
                 job_type,
                 ..
             } => {
-                let actor_dispatchers = dispatchers
-                    .values()
-                    .flatten()
-                    .map(|(&actor_id, dispatchers)| {
-                        (
-                            actor_id,
-                            Dispatchers {
-                                dispatchers: dispatchers.clone(),
-                            },
-                        )
-                    })
-                    .collect();
+                let edges = edges.as_mut().expect("should exist");
                 let added_actors = table_fragments.actor_ids();
                 let actor_splits = split_assignment
                     .values()
@@ -725,7 +713,14 @@ impl Command {
                         Default::default()
                     };
                 let add = Some(Mutation::Add(AddMutation {
-                    actor_dispatchers,
+                    actor_dispatchers: edges
+                        .dispatchers
+                        .extract_if(|fragment_id, _| {
+                            upstream_fragment_downstreams.contains_key(fragment_id)
+                        })
+                        .flat_map(|(_, fragment_dispatchers)| fragment_dispatchers.into_iter())
+                        .map(|(actor_id, dispatchers)| (actor_id, Dispatchers { dispatchers }))
+                        .collect(),
                     added_actors,
                     actor_splits,
                     // If the cluster is already paused, the new actors should be paused too.
@@ -735,13 +730,22 @@ impl Command {
 
                 if let CreateStreamingJobType::SinkIntoTable(ReplaceStreamJobPlan {
                     old_fragments,
-                    new_fragments: _,
-                    merge_updates,
-                    dispatchers,
                     init_split_assignment,
+                    replace_upstream,
+                    upstream_fragment_downstreams,
                     ..
                 }) = job_type
                 {
+                    let merge_updates = edges
+                        .merge_updates
+                        .extract_if(|fragment_id, _| replace_upstream.contains_key(fragment_id))
+                        .collect();
+                    let dispatchers = edges
+                        .dispatchers
+                        .extract_if(|fragment_id, _| {
+                            upstream_fragment_downstreams.contains_key(fragment_id)
+                        })
+                        .collect();
                     let update = Self::generate_update_mutation_for_replace_table(
                         old_fragments,
                         merge_updates,
@@ -777,16 +781,29 @@ impl Command {
 
             Command::ReplaceStreamJob(ReplaceStreamJobPlan {
                 old_fragments,
-                merge_updates,
-                dispatchers,
+                replace_upstream,
+                upstream_fragment_downstreams,
                 init_split_assignment,
                 ..
-            }) => Self::generate_update_mutation_for_replace_table(
-                old_fragments,
-                merge_updates,
-                dispatchers,
-                init_split_assignment,
-            ),
+            }) => {
+                let edges = edges.as_mut().expect("should exist");
+                let merge_updates = edges
+                    .merge_updates
+                    .extract_if(|fragment_id, _| replace_upstream.contains_key(fragment_id))
+                    .collect();
+                let dispatchers = edges
+                    .dispatchers
+                    .extract_if(|fragment_id, _| {
+                        upstream_fragment_downstreams.contains_key(fragment_id)
+                    })
+                    .collect();
+                Self::generate_update_mutation_for_replace_table(
+                    old_fragments,
+                    merge_updates,
+                    dispatchers,
+                    init_split_assignment,
+                )
+            }
 
             Command::RescheduleFragment {
                 reschedules,
@@ -956,9 +973,10 @@ impl Command {
         }
     }
 
-    pub fn actors_to_create(
+    pub(super) fn actors_to_create(
         &self,
         graph_info: &InflightDatabaseInfo,
+        edges: &mut Option<FragmentEdgeBuildResult>,
     ) -> Option<StreamJobActorsToCreate> {
         match self {
             Command::CreateStreamingJob { info, job_type, .. } => {
@@ -977,54 +995,8 @@ impl Command {
                         .flatten()
                         .chain(info.stream_job_fragments.actors_to_create())
                 };
-                let mut actor_upstreams = Self::collect_actor_upstreams(
-                    get_actors_to_create()
-                        .flat_map(|(fragment_id, _, actors)| {
-                            actors.map(move |(actor, dispatchers, _)| {
-                                (actor.actor_id, fragment_id, dispatchers.as_slice())
-                            })
-                        })
-                        .chain(
-                            sink_into_table_replace_plan
-                                .map(|plan| {
-                                    plan.dispatchers.iter().flat_map(
-                                        |(fragment_id, dispatchers)| {
-                                            dispatchers.iter().map(|(actor_id, dispatchers)| {
-                                                (*actor_id, *fragment_id, dispatchers.as_slice())
-                                            })
-                                        },
-                                    )
-                                })
-                                .into_iter()
-                                .flatten(),
-                        )
-                        .chain(
-                            info.dispatchers
-                                .iter()
-                                .flat_map(|(fragment_id, dispatchers)| {
-                                    dispatchers.iter().map(|(actor_id, dispatchers)| {
-                                        (*actor_id, *fragment_id, dispatchers.as_slice())
-                                    })
-                                }),
-                        ),
-                    None,
-                );
-                let mut map = StreamJobActorsToCreate::default();
-                for (fragment_id, node, actors) in get_actors_to_create() {
-                    for (actor, dispatchers, worker_id) in actors {
-                        map.entry(worker_id)
-                            .or_default()
-                            .entry(fragment_id)
-                            .or_insert_with(|| (node.clone(), vec![]))
-                            .1
-                            .push((
-                                actor.clone(),
-                                actor_upstreams.remove(&actor.actor_id).unwrap_or_default(),
-                                dispatchers.clone(),
-                            ))
-                    }
-                }
-                Some(map)
+                let edges = edges.as_mut().expect("should exist");
+                Some(edges.collect_actors_to_create(get_actors_to_create()))
             }
             Command::RescheduleFragment {
                 reschedules,
@@ -1065,40 +1037,8 @@ impl Command {
                 Some(map)
             }
             Command::ReplaceStreamJob(replace_table) => {
-                let mut actor_upstreams = Self::collect_actor_upstreams(
-                    replace_table
-                        .new_fragments
-                        .actors_to_create()
-                        .flat_map(|(fragment_id, _, actors)| {
-                            actors.map(move |(actor, dispatchers, _)| {
-                                (actor.actor_id, fragment_id, dispatchers.as_slice())
-                            })
-                        })
-                        .chain(replace_table.dispatchers.iter().flat_map(
-                            |(fragment_id, dispatchers)| {
-                                dispatchers.iter().map(|(actor_id, dispatchers)| {
-                                    (*actor_id, *fragment_id, dispatchers.as_slice())
-                                })
-                            },
-                        )),
-                    None,
-                );
-                let mut map = StreamJobActorsToCreate::default();
-                for (fragment_id, node, actors) in replace_table.new_fragments.actors_to_create() {
-                    for (actor, dispatchers, worker_id) in actors {
-                        map.entry(worker_id)
-                            .or_default()
-                            .entry(fragment_id)
-                            .or_insert_with(|| (node.clone(), vec![]))
-                            .1
-                            .push((
-                                actor.clone(),
-                                actor_upstreams.remove(&actor.actor_id).unwrap_or_default(),
-                                dispatchers.clone(),
-                            ))
-                    }
-                }
-                Some(map)
+                let edges = edges.as_mut().expect("should exist");
+                Some(edges.collect_actors_to_create(replace_table.new_fragments.actors_to_create()))
             }
             _ => None,
         }
@@ -1106,23 +1046,16 @@ impl Command {
 
     fn generate_update_mutation_for_replace_table(
         old_fragments: &StreamJobFragments,
-        merge_updates: &HashMap<FragmentId, Vec<MergeUpdate>>,
-        dispatchers: &FragmentActorDispatchers,
+        merge_updates: HashMap<FragmentId, Vec<MergeUpdate>>,
+        dispatchers: FragmentActorDispatchers,
         init_split_assignment: &SplitAssignment,
     ) -> Option<Mutation> {
         let dropped_actors = old_fragments.actor_ids();
 
         let actor_new_dispatchers = dispatchers
-            .values()
+            .into_values()
             .flatten()
-            .map(|(&actor_id, dispatchers)| {
-                (
-                    actor_id,
-                    Dispatchers {
-                        dispatchers: dispatchers.clone(),
-                    },
-                )
-            })
+            .map(|(actor_id, dispatchers)| (actor_id, Dispatchers { dispatchers }))
             .collect();
 
         let actor_splits = init_split_assignment
@@ -1132,7 +1065,7 @@ impl Command {
 
         Some(Mutation::Update(UpdateMutation {
             actor_new_dispatchers,
-            merge_update: merge_updates.values().flatten().cloned().collect(),
+            merge_update: merge_updates.into_values().flatten().collect(),
             dropped_actors,
             actor_splits,
             ..Default::default()

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -622,6 +622,8 @@ impl CommandContext {
 
 impl Command {
     /// Generate a mutation for the given command.
+    ///
+    /// `edges` contains the information of `dispatcher`s of `DispatchExecutor` and `actor_upstreams`s of `MergeNode`
     pub(super) fn to_mutation(
         &self,
         is_currently_paused: bool,

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -156,7 +156,7 @@ impl CommandContext {
                         replace_plan @ ReplaceStreamJobPlan {
                             old_fragments,
                             new_fragments,
-                            dispatchers,
+                            upstream_fragment_downstreams,
                             init_split_assignment,
                             ..
                         },
@@ -168,7 +168,7 @@ impl CommandContext {
                             .post_collect_job_fragments(
                                 new_fragments.stream_job_id.table_id as _,
                                 new_fragments.actor_ids(),
-                                dispatchers,
+                                upstream_fragment_downstreams,
                                 init_split_assignment,
                             )
                             .await?;
@@ -232,7 +232,7 @@ impl CommandContext {
                 // we won't mark the job as `Creating`, and then the job will be later clean by the recovery triggered by the returned error.
                 let CreateStreamingJobCommandInfo {
                     stream_job_fragments,
-                    dispatchers,
+                    upstream_fragment_downstreams,
                     init_split_assignment,
                     streaming_job,
                     ..
@@ -243,7 +243,7 @@ impl CommandContext {
                     .post_collect_job_fragments_inner(
                         stream_job_fragments.stream_job_id().table_id as _,
                         stream_job_fragments.actor_ids(),
-                        dispatchers,
+                        upstream_fragment_downstreams,
                         init_split_assignment,
                         streaming_job.is_materialized_view(),
                     )
@@ -276,7 +276,7 @@ impl CommandContext {
                 replace_plan @ ReplaceStreamJobPlan {
                     old_fragments,
                     new_fragments,
-                    dispatchers,
+                    upstream_fragment_downstreams,
                     init_split_assignment,
                     to_drop_state_table_ids,
                     ..
@@ -289,7 +289,7 @@ impl CommandContext {
                     .post_collect_job_fragments(
                         new_fragments.stream_job_id.table_id as _,
                         new_fragments.actor_ids(),
-                        dispatchers,
+                        upstream_fragment_downstreams,
                         init_split_assignment,
                     )
                     .await?;

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -32,10 +32,7 @@ use crate::barrier::info::InflightDatabaseInfo;
 use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{
-    ActorId, FragmentActorDispatchers, StreamActor, StreamActorWithDispatchers, StreamJobFragments,
-    TableParallelism,
-};
+use crate::model::{ActorId, StreamActor, StreamJobFragments, TableParallelism};
 use crate::stream::{
     JobParallelismTarget, JobReschedulePolicy, JobRescheduleTarget, JobResourceGroupTarget,
     RescheduleOptions, SourceChange,
@@ -293,19 +290,16 @@ impl GlobalBarrierWorkerContextImpl {
                         warn!(error = %err.as_report(), "update actors failed");
                     })?;
 
-                    let stream_actor_dispatchers = self
+                    let fragment_relations = self
                         .metadata_manager
                         .catalog_controller
-                        .get_fragment_actor_dispatchers(
+                        .get_fragment_downstream_relations(
                             info.values()
                                 .flat_map(|database| database.fragment_infos())
                                 .map(|fragment| fragment.fragment_id as _)
                                 .collect(),
                         )
                         .await?;
-
-                    let stream_actors =
-                        Self::fill_dispatchers(stream_actors, stream_actor_dispatchers);
 
                     let background_jobs = {
                         let jobs = self
@@ -332,6 +326,7 @@ impl GlobalBarrierWorkerContextImpl {
                         state_table_committed_epochs,
                         subscription_infos,
                         stream_actors,
+                        fragment_relations,
                         source_splits,
                         background_jobs,
                         hummock_version_stats: self.hummock_manager.get_version_stats().await,
@@ -436,10 +431,10 @@ impl GlobalBarrierWorkerContextImpl {
             mv_depended_subscriptions,
         };
 
-        let stream_actor_dispatchers = self
+        let fragment_relations = self
             .metadata_manager
             .catalog_controller
-            .get_fragment_actor_dispatchers(
+            .get_fragment_downstream_relations(
                 info.fragment_infos()
                     .map(|fragment| fragment.fragment_id as _)
                     .collect(),
@@ -451,8 +446,6 @@ impl GlobalBarrierWorkerContextImpl {
             warn!(error = %err.as_report(), "update actors failed");
         })?;
 
-        let stream_actors = Self::fill_dispatchers(stream_actors, stream_actor_dispatchers);
-
         // get split assignments for all actors
         let source_splits = self.source_manager.list_assignments().await;
         Ok(Some(DatabaseRuntimeInfoSnapshot {
@@ -460,25 +453,10 @@ impl GlobalBarrierWorkerContextImpl {
             state_table_committed_epochs,
             subscription_info,
             stream_actors,
+            fragment_relations,
             source_splits,
             background_jobs,
         }))
-    }
-
-    fn fill_dispatchers(
-        actors: HashMap<ActorId, StreamActor>,
-        mut dispatchers: FragmentActorDispatchers,
-    ) -> HashMap<ActorId, StreamActorWithDispatchers> {
-        actors
-            .into_iter()
-            .map(|(actor_id, actor)| {
-                let dispatchers = dispatchers
-                    .get_mut(&(actor.fragment_id as _))
-                    .and_then(|dispatchers| dispatchers.remove(&(actor.actor_id as _)))
-                    .unwrap_or_default();
-                (actor_id, (actor, dispatchers))
-            })
-            .collect()
     }
 }
 

--- a/src/meta/src/barrier/edge_builder.rs
+++ b/src/meta/src/barrier/edge_builder.rs
@@ -1,0 +1,201 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use risingwave_common::bitmap::Bitmap;
+use risingwave_meta_model::WorkerId;
+use risingwave_meta_model::fragment::DistributionType;
+use risingwave_pb::stream_plan::StreamNode;
+use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
+use tracing::warn;
+
+use crate::controller::fragment::InflightFragmentInfo;
+use crate::controller::utils::compose_dispatchers;
+use crate::model::{
+    ActorId, DownstreamFragmentRelation, FragmentActorDispatchers, FragmentActorUpstreams,
+    FragmentDownstreamRelation, FragmentId, StreamActor, StreamJobActorsToCreate,
+};
+
+#[derive(Debug)]
+struct FragmentInfo {
+    distribution_type: DistributionType,
+    actors: HashMap<ActorId, Option<Bitmap>>,
+}
+
+pub(super) struct FragmentEdgeBuildResult {
+    pub(super) upstreams: HashMap<FragmentId, FragmentActorUpstreams>,
+    pub(super) dispatchers: FragmentActorDispatchers,
+    pub(super) merge_updates: HashMap<FragmentId, Vec<MergeUpdate>>,
+}
+
+impl FragmentEdgeBuildResult {
+    pub(super) fn collect_actors_to_create(
+        &mut self,
+        actors: impl Iterator<
+            Item = (
+                FragmentId,
+                &StreamNode,
+                impl Iterator<Item = (&StreamActor, WorkerId)> + '_,
+            ),
+        >,
+    ) -> StreamJobActorsToCreate {
+        let mut actors_to_create = StreamJobActorsToCreate::default();
+        for (fragment_id, node, actors) in actors {
+            for (actor, worker_id) in actors {
+                let upstreams = self
+                    .upstreams
+                    .get_mut(&fragment_id)
+                    .and_then(|upstreams| upstreams.remove(&actor.actor_id))
+                    .unwrap_or_default();
+                let dispatchers = self
+                    .dispatchers
+                    .get_mut(&fragment_id)
+                    .and_then(|upstreams| upstreams.remove(&actor.actor_id))
+                    .unwrap_or_default();
+                actors_to_create
+                    .entry(worker_id)
+                    .or_default()
+                    .entry(fragment_id)
+                    .or_insert_with(|| (node.clone(), vec![]))
+                    .1
+                    .push((actor.clone(), upstreams, dispatchers))
+            }
+        }
+        actors_to_create
+    }
+}
+
+pub(super) struct FragmentEdgeBuilder {
+    fragments: HashMap<FragmentId, FragmentInfo>,
+    result: FragmentEdgeBuildResult,
+}
+
+impl FragmentEdgeBuilder {
+    pub(super) fn new(fragment_infos: impl Iterator<Item = &InflightFragmentInfo>) -> Self {
+        let mut fragments = HashMap::new();
+        for info in fragment_infos {
+            fragments
+                .try_insert(
+                    info.fragment_id,
+                    FragmentInfo {
+                        distribution_type: info.distribution_type,
+                        actors: info
+                            .actors
+                            .iter()
+                            .map(|(actor_id, actor)| (*actor_id, actor.vnode_bitmap.clone()))
+                            .collect(),
+                    },
+                )
+                .expect("non-duplicate");
+        }
+        Self {
+            fragments,
+            result: FragmentEdgeBuildResult {
+                upstreams: Default::default(),
+                dispatchers: Default::default(),
+                merge_updates: Default::default(),
+            },
+        }
+    }
+
+    pub(super) fn add_relations(&mut self, relations: &FragmentDownstreamRelation) {
+        for (fragment_id, relations) in relations {
+            for relation in relations {
+                self.add_edge(*fragment_id, relation);
+            }
+        }
+    }
+
+    fn add_edge(&mut self, fragment_id: FragmentId, downstream: &DownstreamFragmentRelation) {
+        let fragment = &self
+            .fragments
+            .get(&fragment_id)
+            .unwrap_or_else(|| panic!("cannot find {}", fragment_id));
+        let downstream_fragment = &self.fragments[&downstream.downstream_fragment_id];
+        let dispatchers = compose_dispatchers(
+            fragment.distribution_type,
+            &fragment.actors,
+            downstream.downstream_fragment_id,
+            downstream_fragment.distribution_type,
+            &downstream_fragment.actors,
+            downstream.dispatcher_type,
+            downstream.dist_key_indices.clone(),
+            downstream.output_indices.clone(),
+        );
+        let downstream_fragment_upstreams = self
+            .result
+            .upstreams
+            .entry(downstream.downstream_fragment_id)
+            .or_default();
+        for (actor_id, dispatcher) in dispatchers {
+            for downstream_actor in &dispatcher.downstream_actor_id {
+                downstream_fragment_upstreams
+                    .entry(*downstream_actor)
+                    .or_default()
+                    .entry(fragment_id)
+                    .or_default()
+                    .insert(actor_id);
+            }
+            self.result
+                .dispatchers
+                .entry(fragment_id)
+                .or_default()
+                .entry(actor_id)
+                .or_default()
+                .push(dispatcher);
+        }
+    }
+
+    pub(super) fn replace_upstream(
+        &mut self,
+        fragment_id: FragmentId,
+        original_upstream_fragment_id: FragmentId,
+        new_upstream_fragment_id: FragmentId,
+    ) {
+        let fragment_merge_updates = self.result.merge_updates.entry(fragment_id).or_default();
+        if let Some(fragment_upstreams) = self.result.upstreams.get_mut(&fragment_id) {
+            fragment_upstreams.retain(|&actor_id, actor_upstreams| {
+                if let Some(new_upstreams) = actor_upstreams.remove(&new_upstream_fragment_id) {
+                    fragment_merge_updates.push(MergeUpdate {
+                        actor_id,
+                        upstream_fragment_id: original_upstream_fragment_id,
+                        new_upstream_fragment_id: Some(new_upstream_fragment_id),
+                        added_upstream_actor_id: new_upstreams.into_iter().collect(),
+                        removed_upstream_actor_id: vec![],
+                    })
+                } else if cfg!(debug_assertions) {
+                    panic!("cannot find new upstreams for actor {} in fragment {} to new_upstream {}. Current upstreams {:?}", actor_id, fragment_id, new_upstream_fragment_id, actor_upstreams);
+                } else {
+                    warn!(actor_id, fragment_id, new_upstream_fragment_id, ?actor_upstreams, "cannot find new upstreams for actor");
+                }
+                !actor_upstreams.is_empty()
+            })
+        } else if cfg!(debug_assertions) {
+            panic!(
+                "cannot find new upstreams for fragment {} to new_upstream {} to replace {}. Current upstreams: {:?}",
+                fragment_id,
+                new_upstream_fragment_id,
+                original_upstream_fragment_id,
+                self.result.upstreams
+            );
+        } else {
+            warn!(fragment_id, new_upstream_fragment_id, original_upstream_fragment_id, upstreams = ?self.result.upstreams, "cannot find new upstreams to replace");
+        }
+    }
+
+    pub(super) fn build(self) -> FragmentEdgeBuildResult {
+        self.result
+    }
+}

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -303,6 +303,11 @@ impl InflightDatabaseInfo {
                 Command::ReplaceStreamJob(replace_job) => (None, Some(replace_job)),
             },
         };
+        // `existing_fragment_ids` consists of
+        //  - keys of `info.upstream_fragment_downstreams`, which are the `fragment_id` the upstream fragment of the newly created job
+        //  - keys of `replace_job.upstream_fragment_downstreams`, which are the `fragment_id` of upstream fragment of replace_job,
+        // if the upstream fragment previously exists
+        //  - keys of `replace_upstream`, which are the `fragment_id` of downstream fragments that will update their upstream fragments.
         let existing_fragment_ids = info
             .into_iter()
             .flat_map(|info| info.upstream_fragment_downstreams.keys())

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::TableId;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_mut;
@@ -22,7 +23,8 @@ use risingwave_pb::stream_plan::PbSubscriptionUpstreamInfo;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use tracing::warn;
 
-use crate::barrier::{BarrierKind, Command, TracedEpoch};
+use crate::barrier::edge_builder::{FragmentEdgeBuildResult, FragmentEdgeBuilder};
+use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::model::{ActorId, FragmentId, SubscriptionId};
 
@@ -270,6 +272,92 @@ impl InflightDatabaseInfo {
                 }
             }
         }
+    }
+
+    pub(super) fn build_edge(&self, command: Option<&Command>) -> Option<FragmentEdgeBuildResult> {
+        let (info, replace_job) = match command {
+            None => {
+                return None;
+            }
+            Some(command) => match command {
+                Command::Flush
+                | Command::Pause
+                | Command::Resume
+                | Command::DropStreamingJobs { .. }
+                | Command::MergeSnapshotBackfillStreamingJobs(_)
+                | Command::RescheduleFragment { .. }
+                | Command::SourceChangeSplit(_)
+                | Command::Throttle(_)
+                | Command::CreateSubscription { .. }
+                | Command::DropSubscription { .. } => {
+                    return None;
+                }
+                Command::CreateStreamingJob { info, job_type, .. } => {
+                    let replace_job = match job_type {
+                        CreateStreamingJobType::Normal
+                        | CreateStreamingJobType::SnapshotBackfill(_) => None,
+                        CreateStreamingJobType::SinkIntoTable(replace_job) => Some(replace_job),
+                    };
+                    (Some(info), replace_job)
+                }
+                Command::ReplaceStreamJob(replace_job) => (None, Some(replace_job)),
+            },
+        };
+        let existing_fragment_ids = info
+            .into_iter()
+            .flat_map(|info| info.upstream_fragment_downstreams.keys())
+            .chain(replace_job.into_iter().flat_map(|replace_job| {
+                replace_job
+                    .upstream_fragment_downstreams
+                    .keys()
+                    .filter(|fragment_id| {
+                        info.map(|info| {
+                            !info
+                                .stream_job_fragments
+                                .fragments
+                                .contains_key(fragment_id)
+                        })
+                        .unwrap_or(true)
+                    })
+                    .chain(replace_job.replace_upstream.keys())
+            }))
+            .cloned();
+        let new_fragment_infos = info
+            .into_iter()
+            .flat_map(|info| info.stream_job_fragments.new_fragment_info())
+            .chain(
+                replace_job
+                    .into_iter()
+                    .flat_map(|replace_job| replace_job.new_fragments.new_fragment_info()),
+            )
+            .collect_vec();
+        let mut builder = FragmentEdgeBuilder::new(
+            existing_fragment_ids
+                .map(|fragment_id| self.fragment(fragment_id))
+                .chain(new_fragment_infos.iter().map(|(_, info)| info)),
+        );
+        if let Some(info) = info {
+            builder.add_relations(&info.upstream_fragment_downstreams);
+            builder.add_relations(&info.stream_job_fragments.downstreams);
+        }
+        if let Some(replace_job) = replace_job {
+            builder.add_relations(&replace_job.upstream_fragment_downstreams);
+            builder.add_relations(&replace_job.new_fragments.downstreams);
+        }
+        if let Some(replace_job) = replace_job {
+            for (fragment_id, fragment_replacement) in &replace_job.replace_upstream {
+                for (original_upstream_fragment_id, new_upstream_fragment_id) in
+                    fragment_replacement
+                {
+                    builder.replace_upstream(
+                        *fragment_id,
+                        *original_upstream_fragment_id,
+                        *new_upstream_fragment_id,
+                    );
+                }
+            }
+        }
+        Some(builder.build())
     }
 }
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -25,13 +25,14 @@ use tokio::sync::oneshot::Sender;
 use self::notifier::Notifier;
 use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo};
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{ActorId, StreamActorWithDispatchers, StreamJobFragments};
+use crate::model::{ActorId, FragmentDownstreamRelation, StreamActor, StreamJobFragments};
 use crate::{MetaError, MetaResult};
 
 mod checkpoint;
 mod command;
 mod complete_task;
 mod context;
+mod edge_builder;
 mod info;
 mod manager;
 mod notifier;
@@ -103,7 +104,8 @@ struct BarrierWorkerRuntimeInfoSnapshot {
     database_fragment_infos: HashMap<DatabaseId, InflightDatabaseInfo>,
     state_table_committed_epochs: HashMap<TableId, u64>,
     subscription_infos: HashMap<DatabaseId, InflightSubscriptionInfo>,
-    stream_actors: HashMap<ActorId, StreamActorWithDispatchers>,
+    stream_actors: HashMap<ActorId, StreamActor>,
+    fragment_relations: FragmentDownstreamRelation,
     source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashMap<TableId, (String, StreamJobFragments)>,
     hummock_version_stats: HummockVersionStats,
@@ -114,7 +116,7 @@ impl BarrierWorkerRuntimeInfoSnapshot {
         database_id: DatabaseId,
         database_info: &InflightDatabaseInfo,
         active_streaming_nodes: &ActiveStreamingWorkerNodes,
-        stream_actors: &HashMap<ActorId, StreamActorWithDispatchers>,
+        stream_actors: &HashMap<ActorId, StreamActor>,
         state_table_committed_epochs: &HashMap<TableId, u64>,
     ) -> MetaResult<()> {
         {
@@ -192,7 +194,8 @@ struct DatabaseRuntimeInfoSnapshot {
     database_fragment_info: InflightDatabaseInfo,
     state_table_committed_epochs: HashMap<TableId, u64>,
     subscription_info: InflightSubscriptionInfo,
-    stream_actors: HashMap<ActorId, StreamActorWithDispatchers>,
+    stream_actors: HashMap<ActorId, StreamActor>,
+    fragment_relations: FragmentDownstreamRelation,
     source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashMap<TableId, (String, StreamJobFragments)>,
 }

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -72,8 +72,8 @@ use crate::controller::utils::{
 };
 use crate::manager::LocalNotification;
 use crate::model::{
-    Fragment, FragmentActorDispatchers, StreamActor, StreamContext, StreamJobFragments,
-    TableParallelism,
+    DownstreamFragmentRelation, Fragment, FragmentActorDispatchers, FragmentDownstreamRelation,
+    StreamActor, StreamContext, StreamJobFragments, TableParallelism,
 };
 use crate::stream::{SplitAssignment, build_actor_split_impls};
 use crate::{MetaError, MetaResult, model};
@@ -580,6 +580,30 @@ impl CatalogController {
     ) -> MetaResult<FragmentActorDispatchers> {
         let inner = self.inner.read().await;
         get_fragment_actor_dispatchers(&inner.db, fragment_ids).await
+    }
+
+    pub async fn get_fragment_downstream_relations(
+        &self,
+        fragment_ids: Vec<FragmentId>,
+    ) -> MetaResult<FragmentDownstreamRelation> {
+        let inner = self.inner.read().await;
+        let mut stream = FragmentRelation::find()
+            .filter(fragment_relation::Column::SourceFragmentId.is_in(fragment_ids))
+            .stream(&inner.db)
+            .await?;
+        let mut relations = FragmentDownstreamRelation::new();
+        while let Some(relation) = stream.try_next().await? {
+            relations
+                .entry(relation.source_fragment_id as _)
+                .or_default()
+                .push(DownstreamFragmentRelation {
+                    downstream_fragment_id: relation.target_fragment_id as _,
+                    dispatcher_type: relation.dispatcher_type,
+                    dist_key_indices: relation.dist_key_indices.into_u32_array(),
+                    output_indices: relation.output_indices.into_u32_array(),
+                });
+        }
+        Ok(relations)
     }
 
     pub async fn get_job_fragment_backfill_scan_type(

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 
 use anyhow::anyhow;
@@ -40,7 +40,6 @@ use risingwave_pb::meta::{PbFragmentWorkerSlotMapping, PbObject, PbObjectGroup};
 use risingwave_pb::source::{PbConnectorSplit, PbConnectorSplits};
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
-use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use risingwave_pb::stream_plan::{PbFragmentTypeFlag, PbStreamNode};
 use risingwave_pb::user::PbUserInfo;
 use sea_orm::ActiveValue::Set;
@@ -59,12 +58,13 @@ use crate::controller::rename::ReplaceTableExprRewriter;
 use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_relation_name_duplicate,
     check_sink_into_table_cycle, ensure_object_id, ensure_user_id, get_fragment_actor_ids,
-    get_fragment_mappings, get_internal_tables_by_id, rebuild_fragment_mapping_from_actors,
+    get_fragment_mappings, get_internal_tables_by_id, insert_fragment_relations,
+    rebuild_fragment_mapping_from_actors,
 };
 use crate::manager::{NotificationVersion, StreamingJob, StreamingJobType};
 use crate::model::{
-    FragmentActorDispatchers, StreamActor, StreamContext, StreamJobFragmentsToCreate,
-    TableParallelism,
+    FragmentDownstreamRelation, FragmentReplaceUpstream, StreamActor, StreamContext,
+    StreamJobFragmentsToCreate, TableParallelism,
 };
 use crate::stream::{JobReschedulePostUpdates, SplitAssignment};
 use crate::{MetaError, MetaResult};
@@ -405,51 +405,6 @@ impl CatalogController {
         let mut objects = vec![];
         let txn = inner.db.begin().await?;
 
-        let mut fragment_relations = BTreeMap::new();
-
-        // Fill in the fragment relation based on the actor dispatcher.
-        for (fragment, actors) in &fragment_actors {
-            let actor_dispatchers = stream_job_fragments
-                .dispatchers
-                .get(&(fragment.fragment_id as _));
-            for actor in actors {
-                if let Some(dispatcher) = actor_dispatchers
-                    .and_then(|actor_dispatchers| actor_dispatchers.get(&(actor.actor_id as _)))
-                {
-                    for dispatcher in dispatcher {
-                        let key = (fragment.fragment_id, dispatcher.dispatcher_id);
-
-                        if fragment_relations.contains_key(&key) {
-                            continue;
-                        }
-
-                        let target_fragment_id = dispatcher.dispatcher_id as FragmentId;
-
-                        fragment_relations.insert(
-                            key,
-                            fragment_relation::Model {
-                                source_fragment_id: fragment.fragment_id,
-                                target_fragment_id,
-                                dispatcher_type: dispatcher.get_type().unwrap().into(),
-                                dist_key_indices: dispatcher
-                                    .dist_key_indices
-                                    .iter()
-                                    .map(|idx| *idx as i32)
-                                    .collect_vec()
-                                    .into(),
-                                output_indices: dispatcher
-                                    .output_indices
-                                    .iter()
-                                    .map(|idx| *idx as i32)
-                                    .collect_vec()
-                                    .into(),
-                            },
-                        );
-                    }
-                }
-            }
-        }
-
         // Add fragments.
         let (fragments, actors): (Vec<_>, Vec<_>) = fragment_actors.into_iter().unzip();
         for fragment in fragments {
@@ -492,11 +447,7 @@ impl CatalogController {
             }
         }
 
-        for (_, relation) in fragment_relations {
-            FragmentRelation::insert(relation.into_active_model())
-                .exec(&txn)
-                .await?;
-        }
+        insert_fragment_relations(&txn, &stream_job_fragments.downstreams).await?;
 
         // Add actors and actor dispatchers.
         for actors in actors {
@@ -652,13 +603,13 @@ impl CatalogController {
         &self,
         job_id: ObjectId,
         actor_ids: Vec<crate::model::ActorId>,
-        new_actor_dispatchers: &FragmentActorDispatchers,
+        upstream_fragment_new_downstreams: &FragmentDownstreamRelation,
         split_assignment: &SplitAssignment,
     ) -> MetaResult<()> {
         self.post_collect_job_fragments_inner(
             job_id,
             actor_ids,
-            new_actor_dispatchers,
+            upstream_fragment_new_downstreams,
             split_assignment,
             false,
         )
@@ -669,7 +620,7 @@ impl CatalogController {
         &self,
         job_id: ObjectId,
         actor_ids: Vec<crate::model::ActorId>,
-        new_actor_dispatchers: &FragmentActorDispatchers,
+        upstream_fragment_new_downstreams: &FragmentDownstreamRelation,
         split_assignment: &SplitAssignment,
         is_mv: bool,
     ) -> MetaResult<()> {
@@ -702,37 +653,7 @@ impl CatalogController {
             }
         }
 
-        let mut fragment_relations = BTreeMap::new();
-
-        // Fill in the fragment relation based on the new creating actor dispatchers.
-        for (&fragment_id, actor_dispatchers) in new_actor_dispatchers {
-            for dispatchers in actor_dispatchers.values() {
-                for dispatcher in dispatchers {
-                    let key = (fragment_id, dispatcher.dispatcher_id);
-
-                    if fragment_relations.contains_key(&key) {
-                        continue;
-                    }
-
-                    fragment_relations.insert(
-                        key,
-                        fragment_relation::Model {
-                            source_fragment_id: fragment_id as FragmentId,
-                            target_fragment_id: dispatcher.dispatcher_id as FragmentId,
-                            dispatcher_type: dispatcher.r#type().into(),
-                            dist_key_indices: I32Array::from(dispatcher.dist_key_indices.clone()),
-                            output_indices: I32Array::from(dispatcher.output_indices.clone()),
-                        },
-                    );
-                }
-            }
-        }
-
-        for (_, relation) in fragment_relations {
-            FragmentRelation::insert(relation.into_active_model())
-                .exec(&txn)
-                .await?;
-        }
+        insert_fragment_relations(&txn, upstream_fragment_new_downstreams).await?;
 
         // Mark job as CREATING.
         streaming_job::ActiveModel {
@@ -981,7 +902,7 @@ impl CatalogController {
         let replace_table_mapping_update = match replace_stream_job_info {
             Some(ReplaceStreamJobPlan {
                 streaming_job,
-                merge_updates,
+                replace_upstream,
                 tmp_id,
                 ..
             }) => {
@@ -989,7 +910,7 @@ impl CatalogController {
 
                 let (relations, fragment_mapping, _) = Self::finish_replace_streaming_job_inner(
                     tmp_id as ObjectId,
-                    merge_updates,
+                    replace_upstream,
                     None,
                     SinkIntoTableContext {
                         creating_sink_id: Some(incoming_sink_id as _),
@@ -1047,7 +968,7 @@ impl CatalogController {
         &self,
         tmp_id: ObjectId,
         streaming_job: StreamingJob,
-        merge_updates: HashMap<crate::model::FragmentId, Vec<MergeUpdate>>,
+        replace_upstream: FragmentReplaceUpstream,
         col_index_mapping: Option<ColIndexMapping>,
         sink_into_table_context: SinkIntoTableContext,
         drop_table_connector_ctx: Option<&DropTableConnectorContext>,
@@ -1058,7 +979,7 @@ impl CatalogController {
         let (objects, fragment_mapping, delete_notification_objs) =
             Self::finish_replace_streaming_job_inner(
                 tmp_id,
-                merge_updates,
+                replace_upstream,
                 col_index_mapping,
                 sink_into_table_context,
                 &txn,
@@ -1098,7 +1019,7 @@ impl CatalogController {
 
     pub async fn finish_replace_streaming_job_inner(
         tmp_id: ObjectId,
-        merge_updates: HashMap<crate::model::FragmentId, Vec<MergeUpdate>>,
+        replace_upstream: FragmentReplaceUpstream,
         col_index_mapping: Option<ColIndexMapping>,
         SinkIntoTableContext {
             creating_sink_id,
@@ -1213,7 +1134,7 @@ impl CatalogController {
 
         // 2. update merges.
         // update downstream fragment's Merge node, and upstream_fragment_id
-        for (fragment_id, merge_updates) in merge_updates {
+        for (fragment_id, fragment_replace_map) in replace_upstream {
             let (fragment_id, mut stream_node) = Fragment::find_by_id(fragment_id as FragmentId)
                 .select_only()
                 .columns([fragment::Column::FragmentId, fragment::Column::StreamNode])
@@ -1222,15 +1143,6 @@ impl CatalogController {
                 .await?
                 .map(|(id, node)| (id, node.to_protobuf()))
                 .ok_or_else(|| MetaError::catalog_id_not_found("fragment", fragment_id))?;
-            let fragment_replace_map: HashMap<_, _> = merge_updates
-                .iter()
-                .map(|update| {
-                    (
-                        update.upstream_fragment_id,
-                        update.new_upstream_fragment_id.unwrap(),
-                    )
-                })
-                .collect();
 
             visit_stream_node_mut(&mut stream_node, |body| {
                 if let PbNodeBody::Merge(m) = body

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -23,6 +23,7 @@ use risingwave_common::hash::{
 };
 use risingwave_common::util::stream_graph_visitor::{self, visit_stream_node};
 use risingwave_connector::source::SplitImpl;
+use risingwave_meta_model::actor_dispatcher::DispatcherType;
 use risingwave_meta_model::{SourceId, StreamingParallelism, WorkerId};
 use risingwave_pb::catalog::Table;
 use risingwave_pb::common::PbActorLocation;
@@ -39,7 +40,8 @@ use risingwave_pb::meta::{PbTableFragments, PbTableParallelism};
 use risingwave_pb::plan_common::PbExprContext;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    Dispatcher, FragmentTypeFlag, PbDispatcher, PbStreamActor, PbStreamContext, StreamNode,
+    DispatchStrategy, Dispatcher, FragmentTypeFlag, PbDispatcher, PbStreamActor, PbStreamContext,
+    StreamNode,
 };
 
 use super::{ActorId, FragmentId};
@@ -119,10 +121,36 @@ pub type StreamActorWithDispatchers = (StreamActor, Vec<PbDispatcher>);
 pub type StreamActorWithUpDownstreams = (StreamActor, ActorUpstreams, Vec<PbDispatcher>);
 pub type FragmentActorDispatchers = HashMap<FragmentId, HashMap<ActorId, Vec<PbDispatcher>>>;
 
+pub type FragmentDownstreamRelation = HashMap<FragmentId, Vec<DownstreamFragmentRelation>>;
+/// downstream `fragment_id` -> original upstream `fragment_id` -> new upstream `fragment_id`
+pub type FragmentReplaceUpstream = HashMap<FragmentId, HashMap<FragmentId, FragmentId>>;
+/// The newly added no-shuffle actor dispatcher from upstream fragment to downstream fragment
+/// upstream `fragment_id` -> downstream `fragment_id` -> upstream `actor_id` -> downstream `actor_id`
+pub type FragmentNewNoShuffle = HashMap<FragmentId, HashMap<FragmentId, HashMap<ActorId, ActorId>>>;
+
+#[derive(Debug, Clone)]
+pub struct DownstreamFragmentRelation {
+    pub downstream_fragment_id: FragmentId,
+    pub dispatcher_type: DispatcherType,
+    pub dist_key_indices: Vec<u32>,
+    pub output_indices: Vec<u32>,
+}
+
+impl From<(FragmentId, DispatchStrategy)> for DownstreamFragmentRelation {
+    fn from((fragment_id, dispatch): (FragmentId, DispatchStrategy)) -> Self {
+        Self {
+            downstream_fragment_id: fragment_id,
+            dispatcher_type: dispatch.get_type().unwrap().into(),
+            dist_key_indices: dispatch.dist_key_indices,
+            output_indices: dispatch.output_indices,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StreamJobFragmentsToCreate {
     pub inner: StreamJobFragments,
-    pub dispatchers: FragmentActorDispatchers,
+    pub downstreams: FragmentDownstreamRelation,
 }
 
 impl Deref for StreamJobFragmentsToCreate {
@@ -130,20 +158,6 @@ impl Deref for StreamJobFragmentsToCreate {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
-    }
-}
-
-impl StreamJobFragmentsToCreate {
-    pub fn actors_to_create(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            FragmentId,
-            &StreamNode,
-            impl Iterator<Item = (&StreamActor, &Vec<PbDispatcher>, WorkerId)> + '_,
-        ),
-    > + '_ {
-        self.inner.actors_to_create(&self.dispatchers)
     }
 }
 
@@ -676,18 +690,16 @@ impl StreamJobFragments {
         actors
     }
 
-    fn actors_to_create<'a>(
-        &'a self,
-        fragment_actor_dispatchers: &'a FragmentActorDispatchers,
+    pub fn actors_to_create(
+        &self,
     ) -> impl Iterator<
         Item = (
             FragmentId,
-            &'a StreamNode,
-            impl Iterator<Item = (&'a StreamActor, &'a Vec<PbDispatcher>, WorkerId)> + 'a,
+            &StreamNode,
+            impl Iterator<Item = (&StreamActor, WorkerId)> + '_,
         ),
-    > + 'a {
+    > + '_ {
         self.fragments.values().map(move |fragment| {
-            let actor_dispatchers = fragment_actor_dispatchers.get(&fragment.fragment_id);
             (
                 fragment.fragment_id,
                 &fragment.nodes,
@@ -697,11 +709,7 @@ impl StreamJobFragments {
                         .get(&actor.actor_id)
                         .expect("should exist")
                         .worker_id() as WorkerId;
-                    static EMPTY_VEC: Vec<PbDispatcher> = Vec::new();
-                    let disptachers = actor_dispatchers
-                        .and_then(|dispatchers| dispatchers.get(&actor.actor_id))
-                        .unwrap_or(&EMPTY_VEC);
-                    (actor, disptachers, worker_id)
+                    (actor, worker_id)
                 }),
             )
         })

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,19 +21,20 @@ use std::time::Duration;
 use anyhow::{Context, anyhow};
 use itertools::Itertools;
 use risingwave_common::config::DefaultParallelism;
-use risingwave_common::hash::{ActorMapping, VnodeCountCompat};
+use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::secret::{LocalSecretManager, SecretEncryption};
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::stream_graph_visitor::{
     visit_stream_node, visit_stream_node_cont_mut,
 };
-use risingwave_common::{bail, bail_not_implemented, hash, must_match};
+use risingwave_common::{bail, bail_not_implemented, must_match};
 use risingwave_connector::WithOptionsSecResolved;
 use risingwave_connector::connector_common::validate_connection;
 use risingwave_connector::source::{
     ConnectorProperties, SourceEnumeratorContext, UPSTREAM_SOURCE_KEY,
 };
+use risingwave_meta_model::actor_dispatcher::DispatcherType;
 use risingwave_meta_model::exactly_once_iceberg_sink::{Column, Entity};
 use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::{
@@ -49,10 +50,9 @@ use risingwave_pb::ddl_service::{
     DdlProgress, TableJobType, WaitVersion, alter_name_request, alter_set_schema_request,
     alter_swap_rename_request,
 };
-use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    Dispatcher, DispatcherType, FragmentTypeFlag, MergeNode, PbStreamFragmentGraph,
+    FragmentTypeFlag, MergeNode, PbDispatcherType, PbStreamFragmentGraph,
     StreamFragmentGraph as StreamFragmentGraphProto,
 };
 use risingwave_pb::telemetry::{PbTelemetryDatabaseObject, PbTelemetryEventStage};
@@ -72,7 +72,8 @@ use crate::manager::{
     NotificationVersion, StreamingJob, StreamingJobType,
 };
 use crate::model::{
-    Fragment, StreamContext, StreamJobFragments, StreamJobFragmentsToCreate, TableParallelism,
+    DownstreamFragmentRelation, Fragment, StreamContext, StreamJobFragments,
+    StreamJobFragmentsToCreate, TableParallelism,
 };
 use crate::stream::{
     ActorGraphBuildResult, ActorGraphBuilder, CompleteStreamFragmentGraph,
@@ -786,36 +787,36 @@ impl DdlController {
         // check if the union fragment is fully assigned.
         for fragment in stream_job_fragments.fragments.values() {
             {
-                for actor in &fragment.actors {
+                {
                     visit_stream_node(&fragment.nodes, |node| {
                         if let NodeBody::Merge(merge_node) = node {
                             let upstream_fragment_id = merge_node.upstream_fragment_id;
-                            if let Some(external_upstream_fragment_dispatchers) =
-                                replace_table_ctx.dispatchers.get(&upstream_fragment_id)
+                            if let Some(external_upstream_fragment_downstreams) = replace_table_ctx
+                                .upstream_fragment_downstreams
+                                .get(&upstream_fragment_id)
                             {
-                                let mut upstream_dispatchers_to_actor =
-                                    external_upstream_fragment_dispatchers
-                                        .values()
-                                        .flatten()
-                                        .filter(|dispatcher| {
-                                            dispatcher.downstream_actor_id.contains(&actor.actor_id)
-                                        });
+                                let mut upstream_fragment_downstreams =
+                                    external_upstream_fragment_downstreams.iter().filter(
+                                        |downstream| {
+                                            downstream.downstream_fragment_id
+                                                == fragment.fragment_id
+                                        },
+                                    );
                                 assert!(
-                                    upstream_dispatchers_to_actor.next().is_some(),
+                                    upstream_fragment_downstreams.next().is_some(),
                                     "All the mergers for the union should have been fully assigned beforehand."
                                 );
                             } else {
-                                let mut upstream_dispatchers_to_actor = stream_job_fragments
-                                    .dispatchers
+                                let mut upstream_fragment_downstreams = stream_job_fragments
+                                    .downstreams
                                     .get(&upstream_fragment_id)
-                                    .expect("should exist")
-                                    .values()
-                                    .flat_map(|dispatchers| dispatchers.iter())
-                                    .filter(|dispatcher| {
-                                        dispatcher.downstream_actor_id.contains(&actor.actor_id)
+                                    .into_iter()
+                                    .flatten()
+                                    .filter(|downstream| {
+                                        downstream.downstream_fragment_id == fragment.fragment_id
                                     });
                                 assert!(
-                                    upstream_dispatchers_to_actor.next().is_some(),
+                                    upstream_fragment_downstreams.next().is_some(),
                                     "All the mergers for the union should have been fully assigned beforehand."
                                 );
                             }
@@ -836,12 +837,6 @@ impl DdlController {
         union_fragment: &mut Fragment,
         unique_identity: Option<&str>,
     ) {
-        let downstream_actor_ids = union_fragment
-            .actors
-            .iter()
-            .map(|actor| actor.actor_id)
-            .collect_vec();
-
         let sink_fields = sink_fragment.nodes.fields.clone();
 
         let output_indices = sink_fields
@@ -852,46 +847,18 @@ impl DdlController {
 
         let dist_key_indices = table.distribution_key.iter().map(|i| *i as _).collect_vec();
 
-        let mapping = match union_fragment.distribution_type {
-            FragmentDistributionType::Unspecified => unreachable!(),
-            FragmentDistributionType::Single => None,
-            FragmentDistributionType::Hash => {
-                let actor_bitmaps: HashMap<_, _> = union_fragment
-                    .actors
-                    .iter()
-                    .map(|actor| {
-                        (
-                            actor.actor_id as hash::ActorId,
-                            actor.vnode_bitmap.clone().unwrap(),
-                        )
-                    })
-                    .collect();
-
-                let actor_mapping = ActorMapping::from_bitmaps(&actor_bitmaps);
-                Some(actor_mapping)
-            }
-        };
-
-        let upstream_actors = &sink_fragment.actors;
-        let sink_fragment_dispatchers = replace_table_ctx
-            .dispatchers
+        let sink_fragment_downstreams = replace_table_ctx
+            .upstream_fragment_downstreams
             .entry(sink_fragment.fragment_id)
             .or_default();
 
-        for actor in upstream_actors {
-            sink_fragment_dispatchers
-                .try_insert(
-                    actor.actor_id,
-                    vec![Dispatcher {
-                        r#type: DispatcherType::Hash as _,
-                        dist_key_indices: dist_key_indices.clone(),
-                        output_indices: output_indices.clone(),
-                        hash_mapping: mapping.as_ref().map(|m| m.to_protobuf()),
-                        dispatcher_id: union_fragment.fragment_id as _,
-                        downstream_actor_id: downstream_actor_ids.clone(),
-                    }],
-                )
-                .expect("non-duplicate");
+        {
+            sink_fragment_downstreams.push(DownstreamFragmentRelation {
+                downstream_fragment_id: union_fragment.fragment_id,
+                dispatcher_type: DispatcherType::Hash,
+                dist_key_indices: dist_key_indices.clone(),
+                output_indices: output_indices.clone(),
+            });
         }
 
         let upstream_fragment_id = sink_fragment.fragment_id;
@@ -929,7 +896,7 @@ impl DdlController {
                                         MergeNode {
                                             upstream_actor_id: vec![],
                                             upstream_fragment_id,
-                                            upstream_dispatcher_type: DispatcherType::Hash as _,
+                                            upstream_dispatcher_type: PbDispatcherType::Hash as _,
                                             fields: sink_fields.to_vec(),
                                         }
                                     };
@@ -1282,7 +1249,7 @@ impl DdlController {
                 .await?;
 
             let result: MetaResult<_> = try {
-                let merge_updates = ctx.merge_updates.clone();
+                let replace_upstream = ctx.replace_upstream.clone();
 
                 self.metadata_manager
                     .catalog_controller
@@ -1293,18 +1260,18 @@ impl DdlController {
                     .replace_stream_job(stream_job_fragments, ctx)
                     .await?;
 
-                merge_updates
+                replace_upstream
             };
 
             version = match result {
-                Ok(merge_updates) => {
+                Ok(replace_upstream) => {
                     let version = self
                         .metadata_manager
                         .catalog_controller
                         .finish_replace_streaming_job(
                             tmp_id as _,
                             streaming_job,
-                            merge_updates,
+                            replace_upstream,
                             None,
                             SinkIntoTableContext {
                                 creating_sink_id: None,
@@ -1484,7 +1451,7 @@ impl DdlController {
                 }
             }
 
-            let merge_updates = ctx.merge_updates.clone();
+            let replace_upstream = ctx.replace_upstream.clone();
 
             self.metadata_manager
                 .catalog_controller
@@ -1494,18 +1461,18 @@ impl DdlController {
             self.stream_manager
                 .replace_stream_job(stream_job_fragments, ctx)
                 .await?;
-            merge_updates
+            replace_upstream
         };
 
         match result {
-            Ok(merge_updates) => {
+            Ok(replace_upstream) => {
                 let version = self
                     .metadata_manager
                     .catalog_controller
                     .finish_replace_streaming_job(
                         tmp_id,
                         streaming_job,
-                        merge_updates,
+                        replace_upstream,
                         col_index_mapping,
                         SinkIntoTableContext {
                             creating_sink_id: None,
@@ -1683,6 +1650,16 @@ impl DdlController {
             }
         }
 
+        let upstream_actors = upstream_root_fragments
+            .values()
+            .map(|fragment| {
+                (
+                    fragment.fragment_id,
+                    fragment.actors.iter().map(|actor| actor.actor_id).collect(),
+                )
+            })
+            .collect();
+
         let complete_graph = CompleteStreamFragmentGraph::with_upstreams(
             fragment_graph,
             upstream_root_fragments,
@@ -1727,14 +1704,15 @@ impl DdlController {
 
         let ActorGraphBuildResult {
             graph,
-            actor_dispatchers,
+            downstream_fragment_relations,
             building_locations,
             existing_locations,
-            dispatchers,
-            merge_updates,
+            upstream_fragment_downstreams,
+            new_no_shuffle,
+            replace_upstream,
             ..
         } = actor_graph_builder.generate_graph(&self.env, &stream_job, expr_context)?;
-        assert!(merge_updates.is_empty());
+        assert!(replace_upstream.is_empty());
 
         // 3. Build the table fragments structure that will be persisted in the stream manager,
         // and the context that contains all information needed for building the
@@ -1811,7 +1789,9 @@ impl DdlController {
         };
 
         let ctx = CreateStreamingJobContext {
-            dispatchers,
+            upstream_fragment_downstreams,
+            new_no_shuffle,
+            upstream_actors,
             internal_tables,
             building_locations,
             existing_locations,
@@ -1830,7 +1810,7 @@ impl DdlController {
             ctx,
             StreamJobFragmentsToCreate {
                 inner: stream_job_fragments,
-                dispatchers: actor_dispatchers,
+                downstreams: downstream_fragment_relations,
             },
         ))
     }
@@ -1973,11 +1953,12 @@ impl DdlController {
 
         let ActorGraphBuildResult {
             graph,
-            actor_dispatchers,
+            downstream_fragment_relations,
             building_locations,
             existing_locations,
-            dispatchers,
-            merge_updates,
+            upstream_fragment_downstreams,
+            replace_upstream,
+            new_no_shuffle,
             ..
         } = actor_graph_builder.generate_graph(&self.env, stream_job, expr_context)?;
 
@@ -1986,7 +1967,7 @@ impl DdlController {
             job_type,
             StreamingJobType::Source | StreamingJobType::Table(TableJobType::General)
         ) {
-            assert!(dispatchers.is_empty());
+            assert!(upstream_fragment_downstreams.is_empty());
         }
 
         // 3. Build the table fragments structure that will be persisted in the stream manager, and
@@ -2006,8 +1987,9 @@ impl DdlController {
 
         let ctx = ReplaceStreamJobContext {
             old_fragments,
-            merge_updates,
-            dispatchers,
+            replace_upstream,
+            new_no_shuffle,
+            upstream_fragment_downstreams,
             building_locations,
             existing_locations,
             streaming_job: stream_job.clone(),
@@ -2019,7 +2001,7 @@ impl DdlController {
             ctx,
             StreamJobFragmentsToCreate {
                 inner: stream_job_fragments,
-                dispatchers: actor_dispatchers,
+                downstreams: downstream_fragment_relations,
             },
         ))
     }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -34,7 +34,6 @@ use risingwave_connector::source::{
 use risingwave_meta_model::SourceId;
 use risingwave_pb::catalog::Source;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
-use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex, MutexGuard, oneshot};

--- a/src/meta/src/stream/source_manager/split_assignment.rs
+++ b/src/meta/src/stream/source_manager/split_assignment.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::anyhow;
 use itertools::Itertools;
 
 use super::*;
-use crate::model::{FragmentActorDispatchers, StreamJobFragments};
+use crate::model::{FragmentNewNoShuffle, FragmentReplaceUpstream, StreamJobFragments};
 
 impl SourceManager {
     /// Migrates splits from previous actors to the new actors for a rescheduled fragment.
@@ -147,10 +148,16 @@ impl SourceManager {
     pub async fn allocate_splits_for_replace_source(
         &self,
         table_fragments: &StreamJobFragments,
-        merge_updates: &HashMap<FragmentId, Vec<MergeUpdate>>,
+        upstream_updates: &FragmentReplaceUpstream,
+        // new_no_shuffle:
+        //     upstream fragment_id ->
+        //     downstream fragment_id ->
+        //     upstream actor_id ->
+        //     downstream actor_id
+        new_no_shuffle: &FragmentNewNoShuffle,
     ) -> MetaResult<SplitAssignment> {
-        tracing::debug!(?merge_updates, "allocate_splits_for_replace_source");
-        if merge_updates.is_empty() {
+        tracing::debug!(?upstream_updates, "allocate_splits_for_replace_source");
+        if upstream_updates.is_empty() {
             // no existing downstream. We can just re-allocate splits arbitrarily.
             return self.allocate_splits(table_fragments).await;
         }
@@ -172,24 +179,27 @@ impl SourceManager {
         let fragment_id = fragments.into_iter().next().unwrap();
 
         debug_assert!(
-            merge_updates.values().flatten().next().is_some()
-                && merge_updates.values().flatten().all(|merge_update| {
-                    merge_update.new_upstream_fragment_id == Some(fragment_id)
-                })
-                && merge_updates
+            upstream_updates.values().flatten().next().is_some()
+                && upstream_updates
                     .values()
                     .flatten()
-                    .map(|merge_update| merge_update.upstream_fragment_id)
+                    .all(|(_, new_upstream_fragment_id)| {
+                        *new_upstream_fragment_id == fragment_id
+                    })
+                && upstream_updates
+                    .values()
+                    .flatten()
+                    .map(|(upstream_fragment_id, _)| upstream_fragment_id)
                     .all_equal(),
-            "merge update should only replace one fragment: {:?}",
-            merge_updates
+            "upstream update should only replace one fragment: {:?}",
+            upstream_updates
         );
-        let prev_fragment_id = merge_updates
+        let prev_fragment_id = upstream_updates
             .values()
             .flatten()
             .next()
-            .expect("non-empty")
-            .upstream_fragment_id;
+            .map(|(upstream_fragment_id, _)| *upstream_fragment_id)
+            .expect("non-empty");
         // Here we align the new source executor to backfill executors
         //
         // old_source => new_source            backfill_1
@@ -202,18 +212,13 @@ impl SourceManager {
         //
         // Note: we can choose any backfill actor to align here.
         // We use `HashMap` to dedup.
-        let aligned_actors: HashMap<ActorId, ActorId> = merge_updates
-            .values()
+        let aligned_actors: HashMap<ActorId, ActorId> = new_no_shuffle
+            .get(&fragment_id)
+            .map(HashMap::values)
+            .into_iter()
             .flatten()
-            .map(|merge_update| {
-                assert_eq!(merge_update.added_upstream_actor_id.len(), 1);
-                // Note: removed_upstream_actor_id is not set for replace job, so we can't use it.
-                assert_eq!(merge_update.removed_upstream_actor_id.len(), 0);
-                (
-                    merge_update.added_upstream_actor_id[0],
-                    merge_update.actor_id,
-                )
-            })
+            .flatten()
+            .map(|(upstream_actor_id, actor_id)| (*upstream_actor_id, *actor_id))
             .collect();
         let assignment = align_splits(
             aligned_actors.into_iter(),
@@ -231,8 +236,8 @@ impl SourceManager {
     pub async fn allocate_splits_for_backfill(
         &self,
         table_fragments: &StreamJobFragments,
-        // dispatchers from SourceExecutor to SourceBackfillExecutor
-        dispatchers: &FragmentActorDispatchers,
+        upstream_new_no_shuffle: &FragmentNewNoShuffle,
+        upstream_actors: &HashMap<FragmentId, HashSet<ActorId>>,
     ) -> MetaResult<SplitAssignment> {
         let core = self.core.lock().await;
 
@@ -242,31 +247,35 @@ impl SourceManager {
 
         for (_source_id, fragments) in source_backfill_fragments {
             for (fragment_id, upstream_source_fragment_id) in fragments {
-                let fragment_dispatchers = dispatchers.get(&upstream_source_fragment_id);
-                let upstream_actors = core
-                    .metadata_manager
-                    .get_running_actors_of_fragment(upstream_source_fragment_id)
-                    .await?;
+                let source_upstream_new_no_shuffle =
+                    upstream_new_no_shuffle.get(&upstream_source_fragment_id);
+
+                let upstream_actors = upstream_actors
+                    .get(&upstream_source_fragment_id)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "no upstream actors found from fragment {} to upstream source fragment {}",
+                            fragment_id,
+                            upstream_source_fragment_id
+                        )
+                    })?;
                 let mut backfill_actors = vec![];
                 for upstream_actor in upstream_actors {
-                    if let Some(dispatchers) = fragment_dispatchers
-                        .and_then(|dispatchers| dispatchers.get(&upstream_actor))
+                    if let Some(no_shuffle_backfill_actor) = source_upstream_new_no_shuffle
+                        .and_then(|source_upstream_new_no_shuffle| {
+                            source_upstream_new_no_shuffle.get(&fragment_id)
+                        })
+                        .and_then(|new_no_shuffle| new_no_shuffle.get(upstream_actor))
                     {
-                        let err = || {
-                            anyhow::anyhow!(
-                                "source backfill fragment's upstream fragment should have one dispatcher, fragment_id: {fragment_id}, upstream_fragment_id: {upstream_source_fragment_id}, upstream_actor: {upstream_actor}, dispatchers: {dispatchers:?}",
-                                fragment_id = fragment_id,
-                                upstream_source_fragment_id = upstream_source_fragment_id,
-                                upstream_actor = upstream_actor,
-                                dispatchers = dispatchers
-                            )
-                        };
-                        if dispatchers.len() != 1 || dispatchers[0].downstream_actor_id.len() != 1 {
-                            return Err(err().into());
-                        }
-
-                        backfill_actors
-                            .push((dispatchers[0].downstream_actor_id[0], upstream_actor));
+                        backfill_actors.push((*no_shuffle_backfill_actor, *upstream_actor));
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "source backfill fragment's upstream fragment should have one-on-one no_shuffle mapping, fragment_id: {fragment_id}, upstream_fragment_id: {upstream_source_fragment_id}, upstream_actor: {upstream_actor}, source_upstream_new_no_shuffle: {source_upstream_new_no_shuffle:?}",
+                            fragment_id = fragment_id,
+                            upstream_source_fragment_id = upstream_source_fragment_id,
+                            upstream_actor = upstream_actor,
+                            source_upstream_new_no_shuffle = source_upstream_new_no_shuffle
+                        ).into());
                     }
                 }
                 assigned.insert(

--- a/src/meta/src/stream/stream_graph/actor.rs
+++ b/src/meta/src/stream/stream_graph/actor.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::num::NonZeroUsize;
 
@@ -20,25 +19,23 @@ use assert_matches::assert_matches;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
-use risingwave_common::hash::{ActorId, ActorMapping, IsSingleton, VnodeCount, WorkerSlotId};
+use risingwave_common::hash::{IsSingleton, VnodeCount, WorkerSlotId};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::stream_graph_visitor::visit_tables;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::plan_common::ExprContext;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use risingwave_pb::stream_plan::{
-    DispatchStrategy, Dispatcher, DispatcherType, MergeNode, StreamNode, StreamScanType,
+    DispatchStrategy, DispatcherType, MergeNode, StreamNode, StreamScanType,
 };
 
 use super::Locations;
-use super::id::GlobalFragmentIdsExt;
 use crate::MetaResult;
 use crate::controller::cluster::StreamingClusterInfo;
 use crate::manager::{MetaSrvEnv, StreamingJob};
 use crate::model::{
-    DispatcherId, Fragment, FragmentActorDispatchers, FragmentActorUpstreams, FragmentId,
-    StreamActor, StreamActorWithDispatchers,
+    Fragment, FragmentDownstreamRelation, FragmentId, FragmentNewNoShuffle,
+    FragmentReplaceUpstream, StreamActor,
 };
 use crate::stream::stream_graph::fragment::{
     CompleteStreamFragmentGraph, DownstreamExternalEdgeId, EdgeId, EitherFragment,
@@ -48,17 +45,6 @@ use crate::stream::stream_graph::id::{GlobalActorId, GlobalActorIdGen, GlobalFra
 use crate::stream::stream_graph::schedule;
 use crate::stream::stream_graph::schedule::Distribution;
 
-/// The upstream information of an actor during the building process. This will eventually be used
-/// to create the `MergeNode`s as the leaf executor of each actor.
-#[derive(Debug, Clone)]
-struct ActorUpstream {
-    /// Upstream actors.
-    actors: Vec<GlobalActorId>,
-
-    /// The fragment ID of this upstream.
-    fragment_id: GlobalFragmentId,
-}
-
 /// [`ActorBuilder`] builds a stream actor in a stream DAG.
 #[derive(Debug)]
 struct ActorBuilder {
@@ -67,9 +53,6 @@ struct ActorBuilder {
 
     /// The fragment ID of this actor.
     fragment_id: GlobalFragmentId,
-
-    /// The dispatchers to the downstream actors.
-    downstreams: HashMap<DispatcherId, Dispatcher>,
 
     /// The virtual node bitmap, if this fragment is hash distributed.
     vnode_bitmap: Option<Bitmap>,
@@ -84,47 +67,12 @@ impl ActorBuilder {
         Self {
             actor_id,
             fragment_id,
-            downstreams: HashMap::new(),
             vnode_bitmap,
         }
-    }
-
-    /// Add a dispatcher to this actor.
-    fn add_dispatcher(&mut self, dispatcher: Dispatcher) {
-        self.downstreams
-            .try_insert(dispatcher.dispatcher_id, dispatcher)
-            .unwrap();
     }
 }
 
 impl FragmentActorBuilder {
-    fn build(
-        self,
-    ) -> MetaResult<(
-        StreamNode,
-        FragmentActorUpstreams,
-        BTreeMap<GlobalActorId, ActorBuilder>,
-    )> {
-        let node = self.rewrite()?;
-        let mut fragment_actor_upstreams = FragmentActorUpstreams::new();
-        for (upstream_fragment_id, upstreams) in self.upstreams.into_values() {
-            let upstream_fragment_id = upstream_fragment_id.as_global_id();
-            for (actor_id, upstream_actors) in upstreams {
-                fragment_actor_upstreams
-                    .entry(actor_id.as_global_id())
-                    .or_default()
-                    .entry(upstream_fragment_id)
-                    .or_default()
-                    .extend(
-                        upstream_actors
-                            .into_iter()
-                            .map(|actor_id| actor_id.as_global_id()),
-                    );
-            }
-        }
-        Ok((node, fragment_actor_upstreams, self.actor_builders))
-    }
-
     /// Rewrite the actor body.
     ///
     /// During this process, the following things will be done:
@@ -188,7 +136,7 @@ impl FragmentActorBuilder {
                 assert_matches!(batch_plan_node.node_body, Some(NodeBody::BatchPlan(_)));
 
                 // Index the upstreams by the an external edge ID.
-                let (upstream_fragment_id, upstream_actors) = &self.upstreams
+                let (upstream_fragment_id, upstream_no_shuffle_actor) = &self.upstreams
                     [&EdgeId::UpstreamExternal {
                         upstream_table_id: stream_scan.table_id.into(),
                         downstream_fragment_id: self.fragment_id,
@@ -198,9 +146,7 @@ impl FragmentActorBuilder {
                     == StreamScanType::ArrangementBackfill as i32
                     || stream_scan.stream_scan_type == StreamScanType::SnapshotBackfill as i32;
                 if !is_shuffled_backfill {
-                    upstream_actors
-                        .values()
-                        .for_each(|upstream_actors| assert_eq!(upstream_actors.len(), 1));
+                    assert!(upstream_no_shuffle_actor.is_some());
                 }
 
                 let upstream_dispatcher_type = if is_shuffled_backfill {
@@ -259,12 +205,12 @@ impl FragmentActorBuilder {
                         downstream_fragment_id: self.fragment_id,
                     }];
 
-                upstream_actors.values().for_each(|upstreams| {
-                    // Upstream Cdc Source should be singleton.
-                    // SourceBackfill is NoShuffle 1-1 correspondence.
-                    // So they both should have only one upstream actor.
-                    assert_eq!(upstreams.len(), 1);
-                });
+                assert!(
+                    upstream_actors.is_some(),
+                    "Upstream Cdc Source should be singleton. \
+                    SourceBackfill is NoShuffle 1-1 correspondence. \
+                    So they both should have only one upstream actor."
+                );
 
                 let upstream_fragment_id = upstream_fragment_id.as_global_id();
 
@@ -308,27 +254,20 @@ impl FragmentActorBuilder {
 
 impl ActorBuilder {
     /// Build an actor after all the upstreams and downstreams are processed.
-    fn build(
-        self,
-        job: &StreamingJob,
-        expr_context: ExprContext,
-    ) -> MetaResult<StreamActorWithDispatchers> {
+    fn build(self, job: &StreamingJob, expr_context: ExprContext) -> MetaResult<StreamActor> {
         // Only fill the definition when debug assertions enabled, otherwise use name instead.
         #[cfg(not(debug_assertions))]
         let mview_definition = job.name();
         #[cfg(debug_assertions)]
         let mview_definition = job.definition();
 
-        Ok((
-            StreamActor {
-                actor_id: self.actor_id.as_global_id(),
-                fragment_id: self.fragment_id.as_global_id(),
-                vnode_bitmap: self.vnode_bitmap,
-                mview_definition,
-                expr_context: Some(expr_context),
-            },
-            self.downstreams.into_values().collect(),
-        ))
+        Ok(StreamActor {
+            actor_id: self.actor_id.as_global_id(),
+            fragment_id: self.fragment_id.as_global_id(),
+            vnode_bitmap: self.vnode_bitmap,
+            mview_definition,
+            expr_context: Some(expr_context),
+        })
     }
 }
 
@@ -338,41 +277,61 @@ impl ActorBuilder {
 /// to the upstream actors, by adding new dispatchers.
 #[derive(Default)]
 struct UpstreamFragmentChange {
-    /// The new downstreams to be added, indexed by the dispatcher ID.
-    new_downstreams: HashMap<DispatcherId, Dispatcher>,
+    /// The new downstreams to be added.
+    new_downstreams: HashMap<GlobalFragmentId, DispatchStrategy>,
 }
 
 #[derive(Default)]
 struct DownstreamFragmentChange {
     /// The new upstreams to be added (replaced), indexed by the edge id to upstream fragment.
-    new_upstreams: HashMap<DownstreamExternalEdgeId, ActorUpstream>,
+    /// `edge_id` -> new upstream fragment id
+    new_upstreams:
+        HashMap<DownstreamExternalEdgeId, (GlobalFragmentId, Option<NewExternalNoShuffle>)>,
 }
 
 impl UpstreamFragmentChange {
     /// Add a dispatcher to the external actor.
-    fn add_dispatcher(&mut self, dispatcher: Dispatcher) {
+    fn add_dispatcher(
+        &mut self,
+        downstream_fragment_id: GlobalFragmentId,
+        dispatch: DispatchStrategy,
+    ) {
         self.new_downstreams
-            .try_insert(dispatcher.dispatcher_id, dispatcher)
+            .try_insert(downstream_fragment_id, dispatch)
             .unwrap();
     }
 }
 
 impl DownstreamFragmentChange {
     /// Add an upstream to the external actor.
-    fn add_upstream(&mut self, edge_id: DownstreamExternalEdgeId, upstream: ActorUpstream) {
-        self.new_upstreams.try_insert(edge_id, upstream).unwrap();
+    fn add_upstream(
+        &mut self,
+        edge_id: DownstreamExternalEdgeId,
+        new_upstream_fragment_id: GlobalFragmentId,
+        no_shuffle_actor_mapping: Option<HashMap<GlobalActorId, GlobalActorId>>,
+    ) {
+        self.new_upstreams
+            .try_insert(
+                edge_id,
+                (new_upstream_fragment_id, no_shuffle_actor_mapping),
+            )
+            .unwrap();
     }
 }
 
 /// The worker slot location of actors.
 type ActorLocations = BTreeMap<GlobalActorId, WorkerSlotId>;
+// no_shuffle upstream actor_id -> actor_id
+type NewExternalNoShuffle = HashMap<GlobalActorId, GlobalActorId>;
 
 #[derive(Debug)]
 struct FragmentActorBuilder {
     fragment_id: GlobalFragmentId,
     node: StreamNode,
     actor_builders: BTreeMap<GlobalActorId, ActorBuilder>,
-    upstreams: HashMap<EdgeId, (GlobalFragmentId, HashMap<GlobalActorId, Vec<GlobalActorId>>)>,
+    downstreams: HashMap<GlobalFragmentId, DispatchStrategy>,
+    // edge_id -> (upstream fragment_id, no shuffle actor pairs if it's no shuffle dispatched)
+    upstreams: HashMap<EdgeId, (GlobalFragmentId, Option<NewExternalNoShuffle>)>,
 }
 
 impl FragmentActorBuilder {
@@ -381,6 +340,7 @@ impl FragmentActorBuilder {
             fragment_id,
             node,
             actor_builders: Default::default(),
+            downstreams: Default::default(),
             upstreams: Default::default(),
         }
     }
@@ -400,13 +360,13 @@ struct ActorGraphBuildStateInner {
     /// The scheduled locations of the actors to be built.
     building_locations: ActorLocations,
 
-    /// The required changes to the external actors in downstream fragment. See [`DownstreamFragmentChange`].
-    downstream_fragment_changes:
-        BTreeMap<GlobalFragmentId, BTreeMap<GlobalActorId, DownstreamFragmentChange>>,
+    /// The required changes to the external downstream fragment. See [`DownstreamFragmentChange`].
+    /// Indexed by the `fragment_id` of fragments that have updates on its downstream.
+    downstream_fragment_changes: BTreeMap<GlobalFragmentId, DownstreamFragmentChange>,
 
-    /// The required changes to the external actors in upstream fragment. See [`UpstreamFragmentChange`].
-    upstream_fragment_changes:
-        BTreeMap<GlobalFragmentId, BTreeMap<GlobalActorId, UpstreamFragmentChange>>,
+    /// The required changes to the external upstream fragment. See [`UpstreamFragmentChange`].
+    /// /// Indexed by the `fragment_id` of fragments that have updates on its upstream.
+    upstream_fragment_changes: BTreeMap<GlobalFragmentId, UpstreamFragmentChange>,
 
     /// The actual locations of the external actors.
     external_locations: ActorLocations,
@@ -416,7 +376,6 @@ struct ActorGraphBuildStateInner {
 struct FragmentLinkNode<'a> {
     fragment_id: GlobalFragmentId,
     actor_ids: &'a [GlobalActorId],
-    distribution: &'a Distribution,
 }
 
 impl ActorGraphBuildStateInner {
@@ -451,66 +410,26 @@ impl ActorGraphBuildStateInner {
             .unwrap();
     }
 
-    /// Create a new hash dispatcher.
-    fn new_hash_dispatcher(
-        strategy: &DispatchStrategy,
-        downstream_fragment_id: GlobalFragmentId,
-        downstream_actors: &[GlobalActorId],
-        downstream_actor_mapping: ActorMapping,
-    ) -> Dispatcher {
-        assert_eq!(strategy.r#type(), DispatcherType::Hash);
-
-        Dispatcher {
-            r#type: DispatcherType::Hash as _,
-            dist_key_indices: strategy.dist_key_indices.clone(),
-            output_indices: strategy.output_indices.clone(),
-            hash_mapping: Some(downstream_actor_mapping.to_protobuf()),
-            dispatcher_id: downstream_fragment_id.as_global_id() as u64,
-            downstream_actor_id: downstream_actors.as_global_ids(),
-        }
-    }
-
-    /// Create a new dispatcher for non-hash types.
-    fn new_normal_dispatcher(
-        strategy: &DispatchStrategy,
-        downstream_fragment_id: GlobalFragmentId,
-        downstream_actors: &[GlobalActorId],
-    ) -> Dispatcher {
-        assert_ne!(strategy.r#type(), DispatcherType::Hash);
-        assert!(strategy.dist_key_indices.is_empty());
-
-        Dispatcher {
-            r#type: strategy.r#type,
-            dist_key_indices: vec![],
-            output_indices: strategy.output_indices.clone(),
-            hash_mapping: None,
-            dispatcher_id: downstream_fragment_id.as_global_id() as u64,
-            downstream_actor_id: downstream_actors.as_global_ids(),
-        }
-    }
-
-    /// Add the new dispatcher for an actor.
+    /// Add the new downstream fragment relation to a fragment.
     ///
-    /// - If the actor is to be built, the dispatcher will be added to the actor builder.
-    /// - If the actor is an external actor, the dispatcher will be added to the external changes.
+    /// - If the fragment is to be built, the fragment relation will be added to the fragment actor builder.
+    /// - If the fragment is an external existing fragment, the fragment relation will be added to the external changes.
     fn add_dispatcher(
         &mut self,
-        (fragment_id, actor_id): (GlobalFragmentId, GlobalActorId),
-        dispatcher: Dispatcher,
+        fragment_id: GlobalFragmentId,
+        downstream_fragment_id: GlobalFragmentId,
+        dispatch: DispatchStrategy,
     ) {
         if let Some(builder) = self.fragment_actor_builders.get_mut(&fragment_id) {
             builder
-                .actor_builders
-                .get_mut(&actor_id)
-                .expect("should be added previously")
-                .add_dispatcher(dispatcher);
+                .downstreams
+                .try_insert(downstream_fragment_id, dispatch)
+                .unwrap();
         } else {
             self.upstream_fragment_changes
                 .entry(fragment_id)
                 .or_default()
-                .entry(actor_id)
-                .or_default()
-                .add_dispatcher(dispatcher);
+                .add_dispatcher(downstream_fragment_id, dispatch);
         }
     }
 
@@ -520,24 +439,16 @@ impl ActorGraphBuildStateInner {
     /// - If the actor is an external actor, the upstream will be added to the external changes.
     fn add_upstream(
         &mut self,
-        (fragment_id, actor_id): (GlobalFragmentId, GlobalActorId),
+        fragment_id: GlobalFragmentId,
         edge_id: EdgeId,
-        upstream: ActorUpstream,
+        upstream_fragment_id: GlobalFragmentId,
+        no_shuffle_actor_mapping: Option<HashMap<GlobalActorId, GlobalActorId>>,
     ) {
         if let Some(builder) = self.fragment_actor_builders.get_mut(&fragment_id) {
-            let upstreams = match builder.upstreams.entry(edge_id) {
-                Entry::Occupied(entry) => {
-                    let (upstream_fragment_id, upstreams) = entry.into_mut();
-                    assert_eq!(*upstream_fragment_id, upstream.fragment_id);
-                    upstreams
-                }
-                Entry::Vacant(entry) => {
-                    &mut entry.insert((upstream.fragment_id, Default::default())).1
-                }
-            };
-            upstreams
-                .try_insert(actor_id, upstream.actors)
-                .expect("non-duplicate");
+            builder
+                .upstreams
+                .try_insert(edge_id, (upstream_fragment_id, no_shuffle_actor_mapping))
+                .unwrap();
         } else {
             let EdgeId::DownstreamExternal(edge_id) = edge_id else {
                 unreachable!("edge from internal to external must be `DownstreamExternal`")
@@ -545,9 +456,7 @@ impl ActorGraphBuildStateInner {
             self.downstream_fragment_changes
                 .entry(fragment_id)
                 .or_default()
-                .entry(actor_id)
-                .or_default()
-                .add_upstream(edge_id, upstream);
+                .add_upstream(edge_id, upstream_fragment_id, no_shuffle_actor_mapping);
         }
     }
 
@@ -563,11 +472,11 @@ impl ActorGraphBuildStateInner {
 
     /// Add a "link" between two fragments in the graph.
     ///
-    /// The `edge` will be expanded into multiple (downstream - upstream) pairs for the actors in
-    /// the two fragments, based on the distribution and the dispatch strategy. They will be
+    /// The `edge` will be transformed into the fragment relation (downstream - upstream) pair between two fragments,
+    /// based on the distribution and the dispatch strategy. They will be
     /// finally transformed to `Dispatcher` and `Merge` nodes when building the actors.
     ///
-    /// If there're existing (external) fragments, the info will be recorded in `external_changes`,
+    /// If there're existing (external) fragments, the info will be recorded in `upstream_fragment_changes` and `downstream_fragment_changes`,
     /// instead of the actor builders.
     fn add_link<'a>(
         &mut self,
@@ -592,77 +501,38 @@ impl ActorGraphBuildStateInner {
                     .map(|id| (self.get_location(*id), *id))
                     .collect();
 
-                for (location, upstream_id) in upstream_locations {
-                    let downstream_id = downstream_locations.get(&location).unwrap();
+                // Create a new dispatcher just between these two actors.
+                self.add_dispatcher(
+                    upstream.fragment_id,
+                    downstream.fragment_id,
+                    edge.dispatch_strategy.clone(),
+                );
 
-                    // Create a new dispatcher just between these two actors.
-                    self.add_dispatcher(
-                        (upstream.fragment_id, upstream_id),
-                        Self::new_normal_dispatcher(
-                            &edge.dispatch_strategy,
-                            downstream.fragment_id,
-                            &[*downstream_id],
-                        ),
-                    );
-
-                    // Also record the upstream for the downstream actor.
-                    self.add_upstream(
-                        (downstream.fragment_id, *downstream_id),
-                        edge.id,
-                        ActorUpstream {
-                            actors: vec![upstream_id],
-                            fragment_id: upstream.fragment_id,
-                        },
-                    );
-                }
+                // Also record the upstream for the downstream actor.
+                self.add_upstream(
+                    downstream.fragment_id,
+                    edge.id,
+                    upstream.fragment_id,
+                    Some(
+                        downstream_locations
+                            .iter()
+                            .map(|(location, downstream_actor_id)| {
+                                let upstream_actor_id = upstream_locations.get(location).unwrap();
+                                (*upstream_actor_id, *downstream_actor_id)
+                            })
+                            .collect(),
+                    ),
+                );
             }
 
             // Otherwise, make m * n links between the actors.
             DispatcherType::Hash | DispatcherType::Broadcast | DispatcherType::Simple => {
-                // Add dispatchers for the upstream actors.
-                let dispatcher = if let DispatcherType::Hash = dt {
-                    // Transform the `WorkerSlotMapping` from the downstream distribution to the
-                    // `ActorMapping`, used for the `HashDispatcher` for the upstream actors.
-                    let downstream_locations: HashMap<WorkerSlotId, ActorId> = downstream
-                        .actor_ids
-                        .iter()
-                        .map(|&actor_id| (self.get_location(actor_id), actor_id.as_global_id()))
-                        .collect();
-                    let actor_mapping = downstream
-                        .distribution
-                        .as_hash()
-                        .unwrap()
-                        .to_actor(&downstream_locations);
-
-                    Self::new_hash_dispatcher(
-                        &edge.dispatch_strategy,
-                        downstream.fragment_id,
-                        downstream.actor_ids,
-                        actor_mapping,
-                    )
-                } else {
-                    Self::new_normal_dispatcher(
-                        &edge.dispatch_strategy,
-                        downstream.fragment_id,
-                        downstream.actor_ids,
-                    )
-                };
-                for upstream_id in upstream.actor_ids {
-                    self.add_dispatcher((upstream.fragment_id, *upstream_id), dispatcher.clone());
-                }
-
-                // Add upstreams for the downstream actors.
-                let actor_upstream = ActorUpstream {
-                    actors: upstream.actor_ids.to_vec(),
-                    fragment_id: upstream.fragment_id,
-                };
-                for downstream_id in downstream.actor_ids {
-                    self.add_upstream(
-                        (downstream.fragment_id, *downstream_id),
-                        edge.id,
-                        actor_upstream.clone(),
-                    );
-                }
+                self.add_dispatcher(
+                    upstream.fragment_id,
+                    downstream.fragment_id,
+                    edge.dispatch_strategy.clone(),
+                );
+                self.add_upstream(downstream.fragment_id, edge.id, upstream.fragment_id, None);
             }
 
             DispatcherType::Unspecified => unreachable!(),
@@ -718,9 +588,8 @@ impl ActorGraphBuildState {
 pub struct ActorGraphBuildResult {
     /// The graph of sealed fragments, including all actors.
     pub graph: BTreeMap<FragmentId, Fragment>,
-    pub actor_upstreams: BTreeMap<FragmentId, FragmentActorUpstreams>,
-    /// The dispatchers from the new graph to be create.
-    pub actor_dispatchers: FragmentActorDispatchers,
+    /// The downstream fragments of the fragments from the new graph to be created.
+    pub downstream_fragment_relations: FragmentDownstreamRelation,
 
     /// The scheduled locations of the actors to be built.
     pub building_locations: Locations,
@@ -729,11 +598,16 @@ pub struct ActorGraphBuildResult {
     pub existing_locations: Locations,
 
     /// The new dispatchers to be added to the upstream mview actors. Used for MV on MV.
-    pub dispatchers: FragmentActorDispatchers,
+    pub upstream_fragment_downstreams: FragmentDownstreamRelation,
 
-    /// The updates to be applied to the downstream chain actors. Used for schema change (replace
+    /// The updates to be applied to the downstream fragment merge node. Used for schema change (replace
     /// table plan).
-    pub merge_updates: HashMap<FragmentId, Vec<MergeUpdate>>,
+    pub replace_upstream: FragmentReplaceUpstream,
+
+    /// The new no shuffle added to create the new streaming job, including the no shuffle from existing fragments to
+    /// the newly created fragments, between two newly created fragments, and from newly created fragments to existing
+    /// downstream fragments (for create sink into table and replace table).
+    pub new_no_shuffle: FragmentNewNoShuffle,
 }
 
 /// [`ActorGraphBuilder`] builds the actor graph for the given complete fragment graph, based on the
@@ -875,46 +749,61 @@ impl ActorGraphBuilder {
             }
         }
 
+        let mut downstream_fragment_relations: FragmentDownstreamRelation = HashMap::new();
+        let mut new_no_shuffle: FragmentNewNoShuffle = HashMap::new();
         // Serialize the graph into a map of sealed fragments.
-        let (graph, actor_upstreams, actor_dispatchers) = {
+        let graph = {
             let mut fragment_actors: HashMap<GlobalFragmentId, (StreamNode, Vec<StreamActor>)> =
                 HashMap::new();
-            let mut fragment_actor_upstreams: BTreeMap<_, FragmentActorUpstreams> = BTreeMap::new();
-            let mut fragment_actor_dispatchers: HashMap<_, HashMap<_, _>> = HashMap::new();
 
             // As all fragments are processed, we can now `build` the actors where the `Exchange`
             // and `Chain` are rewritten.
             for (fragment_id, builder) in fragment_actor_builders {
-                let (node, actor_upstreams, builders) = builder.build()?;
-                fragment_actor_upstreams
-                    .try_insert(fragment_id.as_global_id(), actor_upstreams)
+                let global_fragment_id = fragment_id.as_global_id();
+                let node = builder.rewrite()?;
+                for (upstream_fragment_id, no_shuffle_upstream) in builder.upstreams.into_values() {
+                    if let Some(no_shuffle_upstream) = no_shuffle_upstream {
+                        new_no_shuffle
+                            .entry(upstream_fragment_id.as_global_id())
+                            .or_default()
+                            .try_insert(
+                                global_fragment_id,
+                                no_shuffle_upstream
+                                    .iter()
+                                    .map(|(upstream_actor_id, actor_id)| {
+                                        (upstream_actor_id.as_global_id(), actor_id.as_global_id())
+                                    })
+                                    .collect(),
+                            )
+                            .expect("non-duplicate");
+                    }
+                }
+                downstream_fragment_relations
+                    .try_insert(
+                        global_fragment_id,
+                        builder
+                            .downstreams
+                            .into_iter()
+                            .map(|(id, dispatch)| (id.as_global_id(), dispatch).into())
+                            .collect(),
+                    )
                     .expect("non-duplicate");
                 fragment_actors
                     .try_insert(
                         fragment_id,
                         (
                             node,
-                            builders
+                            builder
+                                .actor_builders
                                 .into_values()
-                                .map(|builder| {
-                                    builder.build(job, expr_context.clone()).map(
-                                        |(actor, dispatchers)| {
-                                            fragment_actor_dispatchers
-                                                .entry(fragment_id.as_global_id())
-                                                .or_default()
-                                                .try_insert(actor.actor_id, dispatchers)
-                                                .expect("non-duplicate");
-                                            actor
-                                        },
-                                    )
-                                })
+                                .map(|builder| builder.build(job, expr_context.clone()))
                                 .try_collect()?,
                         ),
                     )
                     .expect("non-duplicate");
             }
 
-            (
+            {
                 fragment_actors
                     .into_iter()
                     .map(|(fragment_id, (stream_node, actors))| {
@@ -928,81 +817,88 @@ impl ActorGraphBuilder {
                         let fragment_id = fragment_id.as_global_id();
                         (fragment_id, fragment)
                     })
-                    .collect(),
-                fragment_actor_upstreams,
-                fragment_actor_dispatchers,
-            )
+                    .collect()
+            }
         };
 
         // Convert the actor location map to the `Locations` struct.
         let building_locations = self.build_locations(building_locations);
         let existing_locations = self.build_locations(external_locations);
 
-        // Extract the new dispatchers from the external changes.
-        let dispatchers = upstream_fragment_changes
+        // Extract the new fragment relation from the external changes.
+        let upstream_fragment_downstreams = upstream_fragment_changes
             .into_iter()
             .map(|(fragment_id, changes)| {
                 (
                     fragment_id.as_global_id(),
                     changes
+                        .new_downstreams
                         .into_iter()
-                        .map(|(actor_id, change)| {
-                            (
-                                actor_id.as_global_id(),
-                                change.new_downstreams.into_values().collect_vec(),
-                            )
-                        })
-                        .filter(|(_, v)| !v.is_empty())
-                        .collect::<HashMap<_, _>>(),
-                )
-            })
-            .filter(|(_, m)| !m.is_empty())
-            .collect();
-
-        // Extract the updates for merge executors from the external changes.
-        let merge_updates = downstream_fragment_changes
-            .into_iter()
-            .map(|(fragment_id, changes)| {
-                (
-                    fragment_id.as_global_id(),
-                    changes
-                        .into_iter()
-                        .flat_map(|(actor_id, change)| {
-                            change
-                                .new_upstreams
-                                .into_iter()
-                                .map(move |(edge_id, upstream)| {
-                                    let DownstreamExternalEdgeId {
-                                        original_upstream_fragment_id,
-                                        ..
-                                    } = edge_id;
-
-                                    MergeUpdate {
-                                        actor_id: actor_id.as_global_id(),
-                                        upstream_fragment_id: original_upstream_fragment_id
-                                            .as_global_id(),
-                                        new_upstream_fragment_id: Some(
-                                            upstream.fragment_id.as_global_id(),
-                                        ),
-                                        added_upstream_actor_id: upstream.actors.as_global_ids(),
-                                        removed_upstream_actor_id: vec![],
-                                    }
-                                })
+                        .map(|(downstream_fragment_id, new_dispatch)| {
+                            (downstream_fragment_id.as_global_id(), new_dispatch).into()
                         })
                         .collect(),
                 )
             })
-            .filter(|(_, fragment_changes): &(_, Vec<_>)| !fragment_changes.is_empty())
+            .collect();
+
+        // Extract the updates for merge executors from the external changes.
+        let replace_upstream = downstream_fragment_changes
+            .into_iter()
+            .map(|(fragment_id, changes)| {
+                let fragment_id = fragment_id.as_global_id();
+                let new_no_shuffle = &mut new_no_shuffle;
+                (
+                    fragment_id,
+                    changes
+                        .new_upstreams
+                        .into_iter()
+                        .map(
+                            move |(edge_id, (upstream_fragment_id, upstream_new_no_shuffle))| {
+                                let upstream_fragment_id = upstream_fragment_id.as_global_id();
+                                if let Some(upstream_new_no_shuffle) = upstream_new_no_shuffle
+                                    && !upstream_new_no_shuffle.is_empty()
+                                {
+                                    let no_shuffle_actors = new_no_shuffle
+                                        .entry(upstream_fragment_id)
+                                        .or_default()
+                                        .entry(fragment_id)
+                                        .or_default();
+                                    no_shuffle_actors.extend(
+                                        upstream_new_no_shuffle.into_iter().map(
+                                            |(upstream_actor_id, actor_id)| {
+                                                (
+                                                    upstream_actor_id.as_global_id(),
+                                                    actor_id.as_global_id(),
+                                                )
+                                            },
+                                        ),
+                                    );
+                                }
+                                let DownstreamExternalEdgeId {
+                                    original_upstream_fragment_id,
+                                    ..
+                                } = edge_id;
+                                (
+                                    original_upstream_fragment_id.as_global_id(),
+                                    upstream_fragment_id,
+                                )
+                            },
+                        )
+                        .collect(),
+                )
+            })
+            .filter(|(_, fragment_changes): &(_, HashMap<_, _>)| !fragment_changes.is_empty())
             .collect();
 
         Ok(ActorGraphBuildResult {
             graph,
-            actor_upstreams,
-            actor_dispatchers,
+            downstream_fragment_relations,
             building_locations,
             existing_locations,
-            dispatchers,
-            merge_updates,
+            upstream_fragment_downstreams,
+            replace_upstream,
+            new_no_shuffle,
         })
     }
 
@@ -1087,18 +983,14 @@ impl ActorGraphBuilder {
                 .get(&downstream_fragment_id)
                 .expect("downstream fragment not processed yet");
 
-            let downstream_distribution = self.get_distribution(downstream_fragment_id);
-
             state.inner.add_link(
                 FragmentLinkNode {
                     fragment_id,
                     actor_ids: &actor_ids,
-                    distribution,
                 },
                 FragmentLinkNode {
                     fragment_id: downstream_fragment_id,
                     actor_ids: downstream_actors,
-                    distribution: downstream_distribution,
                 },
                 edge,
             );

--- a/src/meta/src/stream/stream_graph/id.rs
+++ b/src/meta/src/stream/stream_graph/id.rs
@@ -80,11 +80,3 @@ pub(super) type GlobalTableIdGen = GlobalIdGen<{ IdCategory::Table }>;
 
 pub(super) type GlobalActorId = GlobalId<{ IdCategory::Actor }>;
 pub(super) type GlobalActorIdGen = GlobalIdGen<{ IdCategory::Actor }>;
-
-/// Extension for converting a slice of [`GlobalActorId`] to a vector of global IDs.
-#[easy_ext::ext(GlobalFragmentIdsExt)]
-pub(super) impl<A: AsRef<[GlobalActorId]>> A {
-    fn as_global_ids(&self) -> Vec<u32> {
-        self.as_ref().iter().map(|x| x.as_global_id()).collect()
-    }
-}

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -25,7 +25,6 @@ use risingwave_pb::catalog::{CreateType, Subscription, Table};
 use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::{Operation, PbInfo};
 use risingwave_pb::meta::{PbObject, PbObjectGroup};
-use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{Mutex, oneshot};
@@ -45,8 +44,8 @@ use crate::manager::{
     MetaSrvEnv, MetadataManager, NotificationVersion, StreamingJob, StreamingJobType,
 };
 use crate::model::{
-    ActorId, FragmentActorDispatchers, FragmentId, StreamJobFragments, StreamJobFragmentsToCreate,
-    TableParallelism,
+    ActorId, FragmentDownstreamRelation, FragmentId, FragmentNewNoShuffle, FragmentReplaceUpstream,
+    StreamJobFragments, StreamJobFragmentsToCreate, TableParallelism,
 };
 use crate::stream::{SourceChange, SourceManagerRef};
 use crate::{MetaError, MetaResult};
@@ -62,8 +61,10 @@ pub struct CreateStreamingJobOption {
 ///
 /// Note: for better readability, keep this struct complete and immutable once created.
 pub struct CreateStreamingJobContext {
-    /// New dispatchers to add from upstream actors to downstream actors.
-    pub dispatchers: FragmentActorDispatchers,
+    /// New fragment relation to add from upstream fragments to downstream fragments.
+    pub upstream_fragment_downstreams: FragmentDownstreamRelation,
+    pub new_no_shuffle: FragmentNewNoShuffle,
+    pub upstream_actors: HashMap<FragmentId, HashSet<ActorId>>,
 
     /// Internal tables in the streaming job.
     pub internal_tables: BTreeMap<u32, Table>,
@@ -184,10 +185,11 @@ pub struct ReplaceStreamJobContext {
     pub old_fragments: StreamJobFragments,
 
     /// The updates to be applied to the downstream chain actors. Used for schema change.
-    pub merge_updates: HashMap<FragmentId, Vec<MergeUpdate>>,
+    pub replace_upstream: FragmentReplaceUpstream,
+    pub new_no_shuffle: FragmentNewNoShuffle,
 
-    /// New dispatchers to add from upstream actors to downstream actors.
-    pub dispatchers: FragmentActorDispatchers,
+    /// New fragment relation to add from existing upstream fragment to downstream fragment.
+    pub upstream_fragment_downstreams: FragmentDownstreamRelation,
 
     /// The locations of the actors to build in the new job to replace.
     pub building_locations: Locations,
@@ -375,7 +377,9 @@ impl GlobalStreamManager {
         stream_job_fragments: StreamJobFragmentsToCreate,
         CreateStreamingJobContext {
             streaming_job,
-            dispatchers,
+            upstream_fragment_downstreams,
+            new_no_shuffle,
+            upstream_actors,
             definition,
             create_type,
             job_type,
@@ -408,8 +412,8 @@ impl GlobalStreamManager {
             replace_table_command = Some(ReplaceStreamJobPlan {
                 old_fragments: context.old_fragments,
                 new_fragments: stream_job_fragments,
-                merge_updates: context.merge_updates,
-                dispatchers: context.dispatchers,
+                replace_upstream: context.replace_upstream,
+                upstream_fragment_downstreams: context.upstream_fragment_downstreams,
                 init_split_assignment,
                 streaming_job,
                 tmp_id: tmp_table_id.table_id,
@@ -427,7 +431,11 @@ impl GlobalStreamManager {
             .await?;
         init_split_assignment.extend(
             self.source_manager
-                .allocate_splits_for_backfill(&stream_job_fragments, &dispatchers)
+                .allocate_splits_for_backfill(
+                    &stream_job_fragments,
+                    &new_no_shuffle,
+                    &upstream_actors,
+                )
                 .await?,
         );
 
@@ -437,7 +445,7 @@ impl GlobalStreamManager {
 
         let info = CreateStreamingJobCommandInfo {
             stream_job_fragments,
-            dispatchers,
+            upstream_fragment_downstreams,
             init_split_assignment,
             definition: definition.clone(),
             streaming_job: streaming_job.clone(),
@@ -482,8 +490,9 @@ impl GlobalStreamManager {
         new_fragments: StreamJobFragmentsToCreate,
         ReplaceStreamJobContext {
             old_fragments,
-            merge_updates,
-            dispatchers,
+            replace_upstream,
+            new_no_shuffle,
+            upstream_fragment_downstreams,
             tmp_id,
             streaming_job,
             drop_table_connector_ctx,
@@ -492,7 +501,11 @@ impl GlobalStreamManager {
     ) -> MetaResult<()> {
         let init_split_assignment = if streaming_job.is_source() {
             self.source_manager
-                .allocate_splits_for_replace_source(&new_fragments, &merge_updates)
+                .allocate_splits_for_replace_source(
+                    &new_fragments,
+                    &replace_upstream,
+                    &new_no_shuffle,
+                )
                 .await?
         } else {
             self.source_manager.allocate_splits(&new_fragments).await?
@@ -508,8 +521,8 @@ impl GlobalStreamManager {
                 Command::ReplaceStreamJob(ReplaceStreamJobPlan {
                     old_fragments,
                     new_fragments,
-                    merge_updates,
-                    dispatchers,
+                    replace_upstream,
+                    upstream_fragment_downstreams,
                     init_split_assignment,
                     streaming_job,
                     tmp_id,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

### Motivation

After we deprecated the dispatcher table in https://github.com/risingwavelabs/risingwave/pull/20541, we will not persist the dispatcher info, and instead, we recompose the dispatcher and upstreams actor information of each actor by the newly introduced `FragmentRelation`. By now, we have two implementations of building the edges between actors, one in the original `FragmentActorBuilder`, and the other in global barrier worker for recovery. 

Having two implementations is redundant, and the implementation in global barrier worker during recovery is inevitable. Therefore, we may remove the logic of building physical edges between actors in `FragmentActorBuilder`, and unify the logic to the implementation of global barrier worker. The `FragmentActorBuilder`, or any logic outside global barrier worker, is only responsible for composing the logical relation between fragments, and the global barrier worker will be the only one responsible for composing the physical edges between actors.

Besides, if the global barrier worker have the full control over the physical edges between actors, it can be more flexible to dynamically connect actors, rather than following the instruction in Command. For example, in snapshot backfill, while the backfill actor is consuming the fixed upstream snapshot, we don't have to connect the backfill actors with the upstream actors, and instead we can delay building the edges after backfill finishes.

### Key Changes

Previously, when we create streaming job, we compose the dispatchers between fragments outside barrier manager and include the dispatcher information in the create streaming job command. In this PR, we will change to compose the dispatchers inside barrier manager, and outside barrier manager, we only compose the fragment relations between fragments.

The following tables shows the corresponding relation between the terms before and after this PR
| meaning | before this PR | after this PR
|---------|---------------|--------------|
|edges from existing upstream fragments to fragments of the new job| dispatchers| upstream_fragment_downstreams|
|edges from new fragments to their downstreams|StreamJobFragmentsToCreate::dispatchers|StreamJobFragmentsToCreate::downstreams|
|edges for replace upstream| merge_updates | replace_upstream|
|newly created no shuffle actor mapping| dispatchers | new_no_shuffle|

Note that the newly created no shuffle actor mapping is used to assign source split for source backfill actors.

The `FragmentActorBuilder` previously compose the new actor dispatchers between fragments. In this PR, it will change to compose the new fragment relations.

In barrier manager, we will maintain the fragment distribution type in `InflightFragmentInfo`. We also introduce a `InflightActor` to maintain the vnode bitmap of each actor in `InflightFragmentInfo`. We implement a simple `FragmentEdgeBuilder`, which collects the information involved fragments, and then applies the newly added fragment relations and simply calls the previously implemented `compose_dispatchers` util method to compose the `dispatchers`, `upstreams` and `merge_updates`.

In recovery, we will also recompose the dispatchers in barrier manager, rather than composing the dispatchers in catalog control.

Scale related code is not changed yet. The dispatchers information are still composed outside barrier manager. We will change to also compose it inside barrier manager in the future.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
