### PR TITLE
refactor(frontend):  also check column data type when generating column index mapping for replacing table

### DIFF
--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::hash::VnodeCount;
+use risingwave_common::types::DataType;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::{bail, bail_not_implemented};
 use risingwave_connector::sink::catalog::SinkCatalog;
@@ -40,6 +41,7 @@ use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{Expr, ExprImpl, InputRef, Literal};
 use crate::handler::create_sink::{fetch_incoming_sinks, insert_merger_to_union_with_project};
 use crate::session::SessionImpl;
+use crate::session::current::notice_to_user;
 use crate::{Binder, TableCatalog};
 
 /// Used in auto schema change process
@@ -115,13 +117,40 @@ pub async fn get_replace_table_plan(
     .await?;
 
     // Calculate the mapping from the original columns to the new columns.
+    // This will be used to map the output of the table in the dispatcher to make
+    // existing downstream jobs work correctly.
     let col_index_mapping = ColIndexMapping::new(
         old_catalog
             .columns()
             .iter()
             .map(|old_c| {
                 table.columns.iter().position(|new_c| {
-                    new_c.get_column_desc().unwrap().column_id == old_c.column_id().get_id()
+                    let new_c = new_c.get_column_desc().unwrap();
+
+                    // We consider both the column ID and the data type.
+                    // If either of them does not match, we will treat it as a new column.
+                    //
+                    // TODO: Since we've succeeded in assigning column IDs in the step above,
+                    //       the new data type is actually _compatible_ with the old one.
+                    //       Theoretically, it's also possible to do some sort of mapping for
+                    //       the downstream job to work correctly. However, the current impl
+                    //       only supports simple column projection, which we may improve in
+                    //       future works.
+                    //       However, by treating it as a new column, we can at least reject
+                    //       the case where the column with type change is referenced by any
+                    //       downstream jobs (because the original column is considered dropped).
+                    let id_matches = || new_c.column_id == old_c.column_id().get_id();
+                    let type_matches = || {
+                        let original_data_type = old_c.data_type();
+                        let new_data_type = DataType::from(new_c.column_type.as_ref().unwrap());
+                        let matches = original_data_type == &new_data_type;
+                        if !matches {
+                            notice_to_user(format!("the data type of column \"{}\" has changed, treating as a new column", old_c.name()));
+                        }
+                        matches
+                    };
+
+                    id_matches() && type_matches()
                 })
             })
             .collect(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

When generating `ColIndexMapping` (which is used to map the output of the new table job to make the schema compatible with existing downstream jobs), also check whether the data type matches. If not, treat it as a new column to avoid runtime schema mismatch.


Note that we don't currently have this issue because the `ColumnIdGenerator` has already checked the data type (https://github.com/risingwavelabs/risingwave/pull/19828) when matching the column IDs for the altered table.

However, in following PRs (like https://github.com/risingwavelabs/risingwave/pull/20563), we won't restrict the data type to be exactly the same as the original; it just needs to be _compatible_ for the sake of #19755. We need more comprehensive support for schema compatibility with downstream jobs (instead of simple projection with the column index mapping), which may require a considerable amount of works.

For now, let's just check the data type when generating the column index mapping. This way, a column with altered type will be treated as dropped, resulting in rejection if there are any downstream jobs currently referencing this column. This ensures correctness.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
