### PR TITLE
feat(frontend,meta,stream): explain analyze stream job

### DIFF
--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -93,6 +93,9 @@ message TieredCacheTracingRequest {
 
 message TieredCacheTracingResponse {}
 
+message ProfileStatsRequest {}
+message ProfileStatsResponse {}
+
 service MonitorService {
   rpc StackTrace(StackTraceRequest) returns (StackTraceResponse);
   rpc Profiling(ProfilingRequest) returns (ProfilingResponse);
@@ -101,4 +104,5 @@ service MonitorService {
   rpc AnalyzeHeap(AnalyzeHeapRequest) returns (AnalyzeHeapResponse);
   rpc GetStreamingStats(GetStreamingStatsRequest) returns (GetStreamingStatsResponse);
   rpc TieredCacheTracing(TieredCacheTracingRequest) returns (TieredCacheTracingResponse);
+  rpc GetProfileStats(ProfileStatsRequest) returns (ProfileStatsResponse);
 }

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -93,7 +93,10 @@ message TieredCacheTracingRequest {
 
 message TieredCacheTracingResponse {}
 
-message GetProfileStatsRequest {}
+message GetProfileStatsRequest {
+  repeated uint64 operator_ids = 1;
+}
+
 message GetProfileStatsResponse {
   map<uint64, uint64> stream_node_output_row_count = 1;
   map<uint64, uint64> stream_node_output_blocking_duration_ms = 2;

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -95,10 +95,10 @@ message TieredCacheTracingResponse {}
 
 message GetProfileStatsRequest {}
 message GetProfileStatsResponse {
-  map<uint32, uint32> stream_node_input_row_count = 1;
-  map<uint32, uint32> stream_node_output_row_count = 2;
-  map<uint32, uint32> stream_node_input_blocking_duration_ns = 3;
-  map<uint32, uint32> stream_node_output_blocking_duration_ns = 4;
+  map<uint64, uint32> stream_node_input_row_count = 1;
+  map<uint64, uint32> stream_node_output_row_count = 2;
+  map<uint64, uint32> stream_node_input_blocking_duration_ns = 3;
+  map<uint64, uint32> stream_node_output_blocking_duration_ns = 4;
 }
 
 service MonitorService {

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -95,9 +95,7 @@ message TieredCacheTracingResponse {}
 
 message GetProfileStatsRequest {}
 message GetProfileStatsResponse {
-  map<uint64, uint32> stream_node_input_row_count = 1;
   map<uint64, uint32> stream_node_output_row_count = 2;
-  map<uint64, uint32> stream_node_input_blocking_duration_ns = 3;
   map<uint64, uint32> stream_node_output_blocking_duration_ns = 4;
 }
 

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -95,8 +95,8 @@ message TieredCacheTracingResponse {}
 
 message GetProfileStatsRequest {}
 message GetProfileStatsResponse {
-  map<uint64, uint32> stream_node_output_row_count = 2;
-  map<uint64, uint32> stream_node_output_blocking_duration_ns = 4;
+  map<uint64, uint64> stream_node_output_row_count = 2;
+  map<uint64, uint64> stream_node_output_blocking_duration_ms = 4;
 }
 
 service MonitorService {

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -93,8 +93,13 @@ message TieredCacheTracingRequest {
 
 message TieredCacheTracingResponse {}
 
-message ProfileStatsRequest {}
-message ProfileStatsResponse {}
+message GetProfileStatsRequest {}
+message GetProfileStatsResponse {
+  map<uint32, uint32> stream_node_input_row_count = 1;
+  map<uint32, uint32> stream_node_output_row_count = 2;
+  map<uint32, uint32> stream_node_input_blocking_duration_ns = 3;
+  map<uint32, uint32> stream_node_output_blocking_duration_ns = 4;
+}
 
 service MonitorService {
   rpc StackTrace(StackTraceRequest) returns (StackTraceResponse);
@@ -104,5 +109,5 @@ service MonitorService {
   rpc AnalyzeHeap(AnalyzeHeapRequest) returns (AnalyzeHeapResponse);
   rpc GetStreamingStats(GetStreamingStatsRequest) returns (GetStreamingStatsResponse);
   rpc TieredCacheTracing(TieredCacheTracingRequest) returns (TieredCacheTracingResponse);
-  rpc GetProfileStats(ProfileStatsRequest) returns (ProfileStatsResponse);
+  rpc GetProfileStats(GetProfileStatsRequest) returns (GetProfileStatsResponse);
 }

--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -95,8 +95,8 @@ message TieredCacheTracingResponse {}
 
 message GetProfileStatsRequest {}
 message GetProfileStatsResponse {
-  map<uint64, uint64> stream_node_output_row_count = 2;
-  map<uint64, uint64> stream_node_output_blocking_duration_ms = 4;
+  map<uint64, uint64> stream_node_output_row_count = 1;
+  map<uint64, uint64> stream_node_output_blocking_duration_ms = 2;
 }
 
 service MonitorService {

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -1191,6 +1191,10 @@ pub struct StreamingDeveloperConfig {
     /// For example, if this is set to 1000, it means we can have at most 1000 rows in cache.
     #[serde(default = "default::developer::streaming_hash_join_entry_state_max_rows")]
     pub hash_join_entry_state_max_rows: usize,
+
+    /// Enable / Disable profiling stats used by `EXPLAIN ANALYZE`
+    #[serde(default = "default::developer::enable_explain_analyze_stats")]
+    pub enable_explain_analyze_stats: bool,
 }
 
 /// The subsections `[batch.developer]`.
@@ -2191,6 +2195,10 @@ pub mod default {
         pub fn streaming_hash_join_entry_state_max_rows() -> usize {
             // NOTE(kwannoel): This is just an arbitrary number.
             30000
+        }
+
+        pub fn enable_explain_analyze_stats() -> bool {
+            true
         }
     }
 

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -80,6 +80,7 @@ pub use {
     risingwave_license as license,
 };
 pub mod lru;
+pub mod operator;
 pub mod opts;
 pub mod range;
 pub mod row;

--- a/src/common/src/operator.rs
+++ b/src/common/src/operator.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Generate a globally unique operator id.
 pub fn unique_operator_id(fragment_id: u32, operator_id: u64) -> u64 {
     assert!(operator_id <= u32::MAX as u64);

--- a/src/common/src/operator.rs
+++ b/src/common/src/operator.rs
@@ -1,0 +1,11 @@
+/// Generate a globally unique operator id.
+pub fn unique_operator_id(fragment_id: u32, operator_id: u64) -> u64 {
+    assert!(operator_id <= u32::MAX as u64);
+    ((fragment_id as u64) << 32) + operator_id
+}
+
+/// Generate a globally unique executor id.
+pub fn unique_executor_id(actor_id: u32, operator_id: u64) -> u64 {
+    assert!(operator_id <= u32::MAX as u64);
+    ((actor_id as u64) << 32) + operator_id
+}

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -290,12 +290,15 @@ impl MonitorService for MonitorServiceImpl {
 
     async fn get_profile_stats(
         &self,
-        _request: Request<GetProfileStatsRequest>,
+        request: Request<GetProfileStatsRequest>,
     ) -> Result<Response<GetProfileStatsResponse>, Status> {
         let metrics = global_streaming_metrics(MetricLevel::Info);
-        let stream_node_output_row_count = metrics.stream_node_output_row_count.collect();
-        let stream_node_output_blocking_duration_ms =
-            metrics.stream_node_output_blocking_duration_ms.collect();
+        let operator_ids = &request.into_inner().operator_ids;
+        let stream_node_output_row_count =
+            metrics.stream_node_output_row_count.collect(operator_ids);
+        let stream_node_output_blocking_duration_ms = metrics
+            .stream_node_output_blocking_duration_ms
+            .collect(operator_ids);
         Ok(Response::new(GetProfileStatsResponse {
             stream_node_output_row_count,
             stream_node_output_blocking_duration_ms,

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -28,11 +28,11 @@ use risingwave_hummock_sdk::HummockSstableObjectId;
 use risingwave_jni_core::jvm_runtime::dump_jvm_stack_traces;
 use risingwave_pb::monitor_service::monitor_service_server::MonitorService;
 use risingwave_pb::monitor_service::{
-    AnalyzeHeapRequest, AnalyzeHeapResponse, ChannelStats, FragmentStats, GetStreamingStatsRequest,
-    GetStreamingStatsResponse, HeapProfilingRequest, HeapProfilingResponse,
-    ListHeapProfilingRequest, ListHeapProfilingResponse, ProfilingRequest, ProfilingResponse,
-    RelationStats, StackTraceRequest, StackTraceResponse, TieredCacheTracingRequest,
-    TieredCacheTracingResponse,
+    AnalyzeHeapRequest, AnalyzeHeapResponse, ChannelStats, FragmentStats, GetProfileStatsRequest,
+    GetProfileStatsResponse, GetStreamingStatsRequest, GetStreamingStatsResponse,
+    HeapProfilingRequest, HeapProfilingResponse, ListHeapProfilingRequest,
+    ListHeapProfilingResponse, ProfilingRequest, ProfilingResponse, RelationStats,
+    StackTraceRequest, StackTraceResponse, TieredCacheTracingRequest, TieredCacheTracingResponse,
 };
 use risingwave_rpc_client::error::ToTonicStatus;
 use risingwave_storage::hummock::compactor::await_tree_key::Compaction;
@@ -293,7 +293,18 @@ impl MonitorService for MonitorServiceImpl {
         _request: Request<GetProfileStatsRequest>,
     ) -> Result<Response<GetProfileStatsResponse>, Status> {
         let metrics = global_streaming_metrics(MetricLevel::Info);
-        todo!()
+        let stream_node_input_row_count = metrics.stream_node_input_row_count.collect();
+        let stream_node_output_row_count = metrics.stream_node_output_row_count.collect();
+        let stream_node_input_blocking_duration_ns =
+            metrics.stream_node_input_blocking_duration_ns.collect();
+        let stream_node_output_blocking_duration_ns =
+            metrics.stream_node_output_blocking_duration_ns.collect();
+        Ok(Response::new(GetProfileStatsResponse {
+            stream_node_input_row_count,
+            stream_node_output_row_count,
+            stream_node_input_blocking_duration_ns,
+            stream_node_output_blocking_duration_ns,
+        }))
     }
 
     #[cfg_attr(coverage, coverage(off))]

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -294,10 +294,11 @@ impl MonitorService for MonitorServiceImpl {
     ) -> Result<Response<GetProfileStatsResponse>, Status> {
         let metrics = global_streaming_metrics(MetricLevel::Info);
         let operator_ids = &request.into_inner().operator_ids;
-        let stream_node_output_row_count =
-            metrics.stream_node_output_row_count.collect(operator_ids);
+        let stream_node_output_row_count = metrics
+            .mem_stream_node_output_row_count
+            .collect(operator_ids);
         let stream_node_output_blocking_duration_ms = metrics
-            .stream_node_output_blocking_duration_ms
+            .mem_stream_node_output_blocking_duration_ms
             .collect(operator_ids);
         Ok(Response::new(GetProfileStatsResponse {
             stream_node_output_row_count,

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -294,11 +294,11 @@ impl MonitorService for MonitorServiceImpl {
     ) -> Result<Response<GetProfileStatsResponse>, Status> {
         let metrics = global_streaming_metrics(MetricLevel::Info);
         let stream_node_output_row_count = metrics.stream_node_output_row_count.collect();
-        let stream_node_output_blocking_duration_ns =
-            metrics.stream_node_output_blocking_duration_ns.collect();
+        let stream_node_output_blocking_duration_ms =
+            metrics.stream_node_output_blocking_duration_ms.collect();
         Ok(Response::new(GetProfileStatsResponse {
             stream_node_output_row_count,
-            stream_node_output_blocking_duration_ns,
+            stream_node_output_blocking_duration_ms,
         }))
     }
 

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -293,16 +293,11 @@ impl MonitorService for MonitorServiceImpl {
         _request: Request<GetProfileStatsRequest>,
     ) -> Result<Response<GetProfileStatsResponse>, Status> {
         let metrics = global_streaming_metrics(MetricLevel::Info);
-        let stream_node_input_row_count = metrics.stream_node_input_row_count.collect();
         let stream_node_output_row_count = metrics.stream_node_output_row_count.collect();
-        let stream_node_input_blocking_duration_ns =
-            metrics.stream_node_input_blocking_duration_ns.collect();
         let stream_node_output_blocking_duration_ns =
             metrics.stream_node_output_blocking_duration_ns.collect();
         Ok(Response::new(GetProfileStatsResponse {
-            stream_node_input_row_count,
             stream_node_output_row_count,
-            stream_node_input_blocking_duration_ns,
             stream_node_output_blocking_duration_ns,
         }))
     }

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -288,6 +288,14 @@ impl MonitorService for MonitorServiceImpl {
         Ok(Response::new(AnalyzeHeapResponse { result: file }))
     }
 
+    async fn get_profile_stats(
+        &self,
+        _request: Request<GetProfileStatsRequest>,
+    ) -> Result<Response<GetProfileStatsResponse>, Status> {
+        let metrics = global_streaming_metrics(MetricLevel::Info);
+        todo!()
+    }
+
     #[cfg_attr(coverage, coverage(off))]
     async fn get_streaming_stats(
         &self,

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -169,6 +169,7 @@ stream_enable_shared_source = true
 stream_switch_jdbc_pg_to_native = false
 stream_max_barrier_batch_size = 1024
 stream_hash_join_entry_state_max_rows = 30000
+enable_explain_analyze_stats = false
 
 [storage]
 share_buffers_sync_parallelism = 1

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -169,7 +169,7 @@ stream_enable_shared_source = true
 stream_switch_jdbc_pg_to_native = false
 stream_max_barrier_batch_size = 1024
 stream_hash_join_entry_state_max_rows = 30000
-enable_explain_analyze_stats = false
+enable_explain_analyze_stats = true
 
 [storage]
 share_buffers_sync_parallelism = 1

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -169,7 +169,7 @@ stream_enable_shared_source = true
 stream_switch_jdbc_pg_to_native = false
 stream_max_barrier_batch_size = 1024
 stream_hash_join_entry_state_max_rows = 30000
-enable_explain_analyze_stats = true
+stream_enable_explain_analyze_stats = true
 
 [storage]
 share_buffers_sync_parallelism = 1

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -292,6 +292,8 @@ pub async fn handle_explain(
     analyze: bool,
 ) -> Result<RwPgResponse> {
     if analyze {
+        // NOTE(kwannoel): This path is for explain analyze on stream and batch queries.
+        // For existing stream jobs, see the handler module `explain_analyze` instead.
         bail_not_implemented!(issue = 4856, "explain analyze");
     }
     if options.trace && options.explain_format == ExplainFormat::Json {

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -1,4 +1,6 @@
-use std::ops::Deref;
+use std::collections::{HashMap, HashSet};
+
+use risingwave_pb::meta::list_table_fragments_response::FragmentInfo;
 
 use crate::error::Result;
 use crate::handler::{HandlerArgs, RwPgResponse};
@@ -10,25 +12,261 @@ pub async fn handle_explain_analyze_stream_job(
     // query meta for fragment graph (names only)
     let meta_client = handler_args.session.env().meta_client();
     // TODO(kwannoel): Only fetch the names, actor_ids and graph of the fragments
+    // Otherwise memory utilization can be high
     let fragments = {
         let mut fragment_map = meta_client.list_table_fragments(&[job_id]).await?;
         let (fragment_job_id, table_fragment_info) = fragment_map.drain().next().unwrap();
         assert_eq!(fragment_job_id, job_id);
         table_fragment_info.fragments
     };
+    let adjacency_list = extract_stream_node_infos(fragments);
+    let root_node = find_root_node(&adjacency_list);
+
+    // Trigger barrier via meta node to profile specific actors
+
+    // Scrape baseline metrics from the meta node, group by actors.
+
+    // Scrape metrics after `DURATION` from the meta node,
+    // group by actors.
+    // Call get streaming stats via compute client.
+
+    // Trigger barrier via meta node to stop profiling specific actors
+
+    // Render graph with metrics
+    let rows = render_graph_with_metrics(&adjacency_list, root_node);
     todo!()
 }
-// fn fragments_to_graph(fragments: Vec<TableFragmentInfo>) -> FragmentGraph {
-//     let mut graph = FragmentGraph::new();
-//     for fragment in fragments {
-//         let fragment_id = fragment.fragment_id;
-//         let fragment_name = fragment.fragment_name;
-//         let actor_id = fragment.actor_id;
-//         let mut fragment_node = FragmentNode::new(fragment_id, fragment_name, actor_id);
-//         for dep in fragment.dependencies {
-//             fragment_node.add_dependency(dep);
-//         }
-//         graph.add_node(fragment_node);
-//     }
-//     graph
-// }
+
+/// This is an internal struct used ONLY for explain analyze stream job.
+struct StreamNode {
+    operator_id: u32,
+    identity: String,
+    actor_ids: Vec<u32>,
+    dependencies: Vec<u32>,
+}
+
+fn extract_stream_node_infos(fragments: Vec<FragmentInfo>) -> HashMap<u32, StreamNode> {
+    let mut operator_id_to_stream_node = HashMap::new();
+    for fragment in fragments {
+        let actors = fragment.actors;
+        for actor in actors {
+            let actor_id = actor.id;
+            let node = actor.node.unwrap();
+            let operator_id = node.operator_id as u32;
+            let entry = operator_id_to_stream_node
+                .entry(operator_id)
+                .or_insert_with(|| {
+                    let dependencies = node
+                        .input
+                        .into_iter()
+                        .map(|input| input.operator_id as u32)
+                        .collect();
+                    StreamNode {
+                        operator_id,
+                        identity: node.identity,
+                        actor_ids: vec![],
+                        dependencies,
+                    }
+                });
+            entry.actor_ids.push(actor_id);
+        }
+    }
+    operator_id_to_stream_node
+}
+
+fn find_root_node(stream_nodes: &HashMap<u32, StreamNode>) -> u32 {
+    let mut all_nodes = stream_nodes.keys().copied().collect::<HashSet<_>>();
+    for node in stream_nodes.values() {
+        for dependency in &node.dependencies {
+            all_nodes.remove(dependency);
+        }
+    }
+    assert_eq!(all_nodes.len(), 1);
+    let mut all_nodes = all_nodes.drain();
+    all_nodes.next().unwrap()
+}
+
+// Do a DFS based rendering. Each node will occupy its own row.
+// Schema:
+// | Operator ID | Identity | Actor IDs | Metrics ... |
+// Each node will be indented based on its depth in the graph.
+fn render_graph_with_metrics(
+    adjacency_list: &HashMap<u32, StreamNode>,
+    root_node: u32,
+) -> Vec<Vec<String>> {
+    let mut rows = vec![];
+    let mut stack = vec![(String::new(), true, root_node)];
+    while let Some((prefix, last_child, node_id)) = stack.pop() {
+        let node = adjacency_list.get(&node_id).unwrap();
+        let is_root = node_id == root_node;
+
+        let identity_rendered = if is_root {
+            node.identity.clone()
+        } else {
+            let connector = if last_child { "└─ " } else { "├─ " };
+            format!("{}{}{}", prefix, connector, node.identity)
+        };
+
+        let child_prefix = if is_root {
+            ""
+        } else {
+            if last_child { "   " } else { "│  " }
+        };
+        let child_prefix = format!("{}{}", prefix, child_prefix);
+
+        let row = vec![
+            node.operator_id.to_string(),
+            identity_rendered,
+            node.actor_ids
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        ];
+        rows.push(row);
+        for (position, dependency) in node.dependencies.iter().enumerate() {
+            stack.push((
+                child_prefix.clone(),
+                position == 0,
+                *dependency,
+            ));
+        }
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Use this graph:
+    // A -> B -> C -> D
+    #[test]
+    fn render_linear_graph() {
+        let mut adjacency_list = HashMap::new();
+        adjacency_list.insert(
+            1,
+            StreamNode {
+                operator_id: 1,
+                identity: "A".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![2],
+            },
+        );
+        adjacency_list.insert(
+            2,
+            StreamNode {
+                operator_id: 2,
+                identity: "B".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![3],
+            },
+        );
+        adjacency_list.insert(
+            3,
+            StreamNode {
+                operator_id: 3,
+                identity: "C".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![4],
+            },
+        );
+        adjacency_list.insert(
+            4,
+            StreamNode {
+                operator_id: 4,
+                identity: "D".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![],
+            },
+        );
+        let root_node = find_root_node(&adjacency_list);
+        let rows = render_graph_with_metrics(&adjacency_list, root_node);
+        assert_eq!(
+            rows,
+            vec![
+                vec!["1".to_string(), "A".to_string(), "".to_string()],
+                vec!["2".to_string(), "└─ B".to_string(), "".to_string()],
+                vec!["3".to_string(), "   └─ C".to_string(), "".to_string()],
+                vec!["4".to_string(), "      └─ D".to_string(), "".to_string()],
+            ]
+        );
+    }
+
+    // Use this graph:
+    // A -> B -> C
+    // |\
+    // |  -> D -> E
+    // |---> F
+    #[test]
+    fn render_tree_graph() {
+        let mut adjacency_list = HashMap::new();
+        adjacency_list.insert(
+            1,
+            StreamNode {
+                operator_id: 1,
+                identity: "A".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![2, 4, 6],
+            },
+        );
+        adjacency_list.insert(
+            2,
+            StreamNode {
+                operator_id: 2,
+                identity: "B".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![3],
+            },
+        );
+        adjacency_list.insert(
+            3,
+            StreamNode {
+                operator_id: 3,
+                identity: "C".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![],
+            },
+        );
+        adjacency_list.insert(
+            4,
+            StreamNode {
+                operator_id: 4,
+                identity: "D".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![5],
+            },
+        );
+        adjacency_list.insert(
+            5,
+            StreamNode {
+                operator_id: 5,
+                identity: "E".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![],
+            },
+        );
+        adjacency_list.insert(
+            6,
+            StreamNode {
+                operator_id: 6,
+                identity: "F".to_string(),
+                actor_ids: vec![],
+                dependencies: vec![],
+            },
+        );
+        let root_node = find_root_node(&adjacency_list);
+        let rows = render_graph_with_metrics(&adjacency_list, root_node);
+        assert_eq!(
+            rows,
+            vec![
+                vec!["1".to_string(), "A".to_string(), "".to_string()],
+                vec!["6".to_string(), "├─ F".to_string(), "".to_string()],
+                vec!["4".to_string(), "├─ D".to_string(), "".to_string()],
+                vec!["5".to_string(), "│  └─ E".to_string(), "".to_string()],
+                vec!["2".to_string(), "└─ B".to_string(), "".to_string()],
+                vec!["3".to_string(), "   └─ C".to_string(), "".to_string()],
+            ]
+        );
+    }
+}

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -4,6 +4,7 @@ use risingwave_pb::meta::list_table_fragments_response::FragmentInfo;
 
 use crate::error::Result;
 use crate::handler::{HandlerArgs, RwPgResponse};
+use crate::session::FrontendEnv;
 
 pub async fn handle_explain_analyze_stream_job(
     handler_args: HandlerArgs,
@@ -43,6 +44,14 @@ struct StreamNode {
     identity: String,
     actor_ids: Vec<u32>,
     dependencies: Vec<u32>,
+}
+
+async fn list_stream_worker_nodes(env: &FrontendEnv) -> Result<()> {
+    let worker_nodes = env.meta_client().list_all_nodes().await?;
+    let stream_worker_nodes = worker_nodes
+        .into_iter()
+        .filter(|node| node.property.as_ref().unwrap().is_streaming)
+        .collect::<Vec<_>>();
 }
 
 fn extract_stream_node_infos(fragments: Vec<FragmentInfo>) -> HashMap<u32, StreamNode> {

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -99,7 +99,6 @@ pub async fn handle_explain_analyze_stream_job(
         table_fragment_info.fragments
     };
     let (root_node, adjacency_list) = extract_stream_node_infos(fragments);
-    println!("adjacency_list: {:?}", adjacency_list);
 
     // Get the worker nodes
     let worker_nodes = list_stream_worker_nodes(handler_args.session.env()).await?;

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -16,6 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use pgwire::pg_response::StatementType;
+use risingwave_common::operator::unique_operator_id;
 use risingwave_common::types::Fields;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::meta::list_table_fragments_response::FragmentInfo;
@@ -416,10 +417,4 @@ fn render_graph_with_metrics(
         }
     }
     rows
-}
-
-/// Generate a globally unique operator id.
-fn unique_operator_id(fragment_id: u32, operator_id: u64) -> u64 {
-    assert!(operator_id <= u32::MAX as u64);
-    ((fragment_id as u64) << 32) + operator_id
 }

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -8,6 +8,7 @@ use risingwave_pb::meta::list_table_fragments_response::FragmentInfo;
 use risingwave_pb::monitor_service::{GetProfileStatsRequest, GetProfileStatsResponse};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{MergeNode, StreamNode as PbStreamNode};
+use risingwave_sqlparser::ast::AnalyzeTarget;
 use tokio::time::sleep;
 
 use crate::error::Result;
@@ -25,8 +26,12 @@ struct ExplainAnalyzeStreamJobOutput {
 
 pub async fn handle_explain_analyze_stream_job(
     handler_args: HandlerArgs,
-    job_id: u32,
+    target: AnalyzeTarget,
 ) -> Result<RwPgResponse> {
+    let job_id = match target {
+        AnalyzeTarget::Id(id) => id,
+        _ => unreachable!(),
+    };
     let profiling_duration = Duration::from_secs(10);
     // query meta for fragment graph (names only)
     let meta_client = handler_args.session.env().meta_client();

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -250,9 +250,12 @@ impl StreamNodeStats {
     }
 }
 
+/// Extracts the root node of the plan, as well as the adjacency list
 fn extract_stream_node_infos(
     fragments: Vec<FragmentInfo>,
 ) -> (OperatorId, HashMap<OperatorId, StreamNode>) {
+    // Recursively extracts stream node info, and builds an adjacency list between stream nodes
+    // and their dependencies
     fn extract_stream_node_info(
         fragment_id: u32,
         fragment_id_to_merge_operator_id: &mut HashMap<u32, OperatorId>,
@@ -303,6 +306,8 @@ fn extract_stream_node_infos(
         }
     }
 
+    // build adjacency list and hanging merge edges.
+    // hanging merge edges will be filled in the following section.
     let mut operator_id_to_stream_node = HashMap::new();
     let mut fragment_id_to_merge_operator_id = HashMap::new();
     for fragment in fragments {
@@ -320,8 +325,8 @@ fn extract_stream_node_infos(
         }
     }
 
+    // find root node, and fill in dispatcher edges + nodes.
     let root_or_dispatch_nodes = find_root_nodes(&operator_id_to_stream_node);
-
     let mut root_node = None;
     for operator_id in root_or_dispatch_nodes {
         let node = operator_id_to_stream_node.get_mut(&operator_id).unwrap();

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::error::Result;
 use crate::handler::{HandlerArgs, RwPgResponse};
 
@@ -5,5 +7,28 @@ pub async fn handle_explain_analyze_stream_job(
     handler_args: HandlerArgs,
     job_id: u32,
 ) -> Result<RwPgResponse> {
+    // query meta for fragment graph (names only)
+    let meta_client = handler_args.session.env().meta_client();
+    // TODO(kwannoel): Only fetch the names, actor_ids and graph of the fragments
+    let fragments = {
+        let mut fragment_map = meta_client.list_table_fragments(&[job_id]).await?;
+        let (fragment_job_id, table_fragment_info) = fragment_map.drain().next().unwrap();
+        assert_eq!(fragment_job_id, job_id);
+        table_fragment_info.fragments
+    };
     todo!()
 }
+// fn fragments_to_graph(fragments: Vec<TableFragmentInfo>) -> FragmentGraph {
+//     let mut graph = FragmentGraph::new();
+//     for fragment in fragments {
+//         let fragment_id = fragment.fragment_id;
+//         let fragment_name = fragment.fragment_name;
+//         let actor_id = fragment.actor_id;
+//         let mut fragment_node = FragmentNode::new(fragment_id, fragment_name, actor_id);
+//         for dep in fragment.dependencies {
+//             fragment_node.add_dependency(dep);
+//         }
+//         graph.add_node(fragment_node);
+//     }
+//     graph
+// }

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -109,8 +109,10 @@ fn render_graph_with_metrics(
 
         let child_prefix = if is_root {
             ""
+        } else if last_child {
+            "   "
         } else {
-            if last_child { "   " } else { "│  " }
+            "│  "
         };
         let child_prefix = format!("{}{}", prefix, child_prefix);
 
@@ -125,11 +127,7 @@ fn render_graph_with_metrics(
         ];
         rows.push(row);
         for (position, dependency) in node.dependencies.iter().enumerate() {
-            stack.push((
-                child_prefix.clone(),
-                position == 0,
-                *dependency,
-            ));
+            stack.push((child_prefix.clone(), position == 0, *dependency));
         }
     }
     rows

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -1,0 +1,9 @@
+use crate::error::Result;
+use crate::handler::{HandlerArgs, RwPgResponse};
+
+pub async fn handle_explain_analyze_stream_job(
+    handler_args: HandlerArgs,
+    job_id: u32,
+) -> Result<RwPgResponse> {
+    todo!()
+}

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -265,8 +265,8 @@ pub async fn handle(
             analyze,
             options,
         } => explain::handle_explain(handler_args, *statement, options, analyze).await,
-        Statement::ExplainAnalyzeStreamJob { job_id } => {
-            explain_analyze_stream_job::handle_explain_analyze_stream_job(handler_args, job_id)
+        Statement::ExplainAnalyzeStreamJob { target } => {
+            explain_analyze_stream_job::handle_explain_analyze_stream_job(handler_args, target)
                 .await
         }
         Statement::CreateSource { stmt } => {

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -91,6 +91,7 @@ pub mod drop_table;
 pub mod drop_user;
 mod drop_view;
 pub mod explain;
+pub mod explain_analyze_stream_job;
 pub mod extended_handle;
 pub mod fetch_cursor;
 mod flush;
@@ -264,6 +265,10 @@ pub async fn handle(
             analyze,
             options,
         } => explain::handle_explain(handler_args, *statement, options, analyze).await,
+        Statement::ExplainAnalyzeStreamJob { job_id } => {
+            explain_analyze_stream_job::handle_explain_analyze_stream_job(handler_args, job_id)
+                .await
+        }
         Statement::CreateSource { stmt } => {
             create_source::handle_create_source(handler_args, stmt).await
         }

--- a/src/sqlparser/src/ast/analyze.rs
+++ b/src/sqlparser/src/ast/analyze.rs
@@ -1,0 +1,26 @@
+use core::fmt::Display;
+
+use crate::ast::ObjectName;
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum AnalyzeTarget {
+    Id(u32),
+    Table(ObjectName),
+    MaterializedView(ObjectName),
+    Index(ObjectName),
+    View(ObjectName),
+    Sink(ObjectName),
+}
+
+impl Display for AnalyzeTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AnalyzeTarget::Id(id) => write!(f, "ID {}", id),
+            AnalyzeTarget::Table(name) => write!(f, "TABLE {}", name),
+            AnalyzeTarget::MaterializedView(name) => write!(f, "MATERIALIZED VIEW {}", name),
+            AnalyzeTarget::Index(name) => write!(f, "INDEX {}", name),
+            AnalyzeTarget::View(name) => write!(f, "VIEW {}", name),
+            AnalyzeTarget::Sink(name) => write!(f, "SINK {}", name),
+        }
+    }
+}

--- a/src/sqlparser/src/ast/analyze.rs
+++ b/src/sqlparser/src/ast/analyze.rs
@@ -1,8 +1,12 @@
 use core::fmt::Display;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::ast::ObjectName;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AnalyzeTarget {
     Id(u32),
     Table(ObjectName),

--- a/src/sqlparser/src/ast/analyze.rs
+++ b/src/sqlparser/src/ast/analyze.rs
@@ -8,7 +8,6 @@ pub enum AnalyzeTarget {
     Table(ObjectName),
     MaterializedView(ObjectName),
     Index(ObjectName),
-    View(ObjectName),
     Sink(ObjectName),
 }
 
@@ -19,7 +18,6 @@ impl Display for AnalyzeTarget {
             AnalyzeTarget::Table(name) => write!(f, "TABLE {}", name),
             AnalyzeTarget::MaterializedView(name) => write!(f, "MATERIALIZED VIEW {}", name),
             AnalyzeTarget::Index(name) => write!(f, "INDEX {}", name),
-            AnalyzeTarget::View(name) => write!(f, "VIEW {}", name),
             AnalyzeTarget::Sink(name) => write!(f, "SINK {}", name),
         }
     }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 //! SQL Abstract Syntax Tree (AST) types
+mod analyze;
 mod data_type;
 pub(crate) mod ddl;
 mod legacy_source;
@@ -56,6 +57,7 @@ pub use self::value::{
     ConnectionRefValue, CstyleEscapedString, DateTimeField, DollarQuotedString, JsonPredicateType,
     SecretRefAsType, SecretRefValue, TrimWhereField, Value,
 };
+pub use crate::ast::analyze::AnalyzeTarget;
 pub use crate::ast::ddl::{
     AlterIndexOperation, AlterSinkOperation, AlterSourceOperation, AlterSubscriptionOperation,
     AlterViewOperation,
@@ -1618,7 +1620,7 @@ pub enum Statement {
     /// FIXME(kwannoel): Support SINK s, MATERIALIZED VIEW s, etc...
     /// TODO(kwannoel): Make profiling duration configurable: EXPLAIN ANALYZE (DURATION 1s) ...
     ExplainAnalyzeStreamJob {
-        job_id: u32,
+        target: AnalyzeTarget,
     },
     /// CREATE USER
     CreateUser(CreateUserStatement),
@@ -1666,8 +1668,8 @@ impl fmt::Display for Statement {
 
                 write!(f, "{}", statement)
             }
-            Statement::ExplainAnalyzeStreamJob { job_id } => {
-                write!(f, "EXPLAIN ANALYZE {}", job_id)
+            Statement::ExplainAnalyzeStreamJob { target } => {
+                write!(f, "EXPLAIN ANALYZE {}", target)
             }
             Statement::Query(s) => write!(f, "{}", s),
             Statement::Truncate { table_name } => {

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1612,6 +1612,14 @@ pub enum Statement {
         /// options of the explain statement
         options: ExplainOptions,
     },
+    /// EXPLAIN ANALYZE for stream job
+    /// We introduce a new statement rather than reuse `EXPLAIN` because
+    /// the body of the statement is not an SQL query.
+    /// FIXME(kwannoel): Support SINK s, MATERIALIZED VIEW s, etc...
+    /// TODO(kwannoel): Make profiling duration configurable: EXPLAIN ANALYZE (DURATION 1s) ...
+    ExplainAnalyzeStreamJob {
+        job_id: u32,
+    },
     /// CREATE USER
     CreateUser(CreateUserStatement),
     /// ALTER USER
@@ -1657,6 +1665,9 @@ impl fmt::Display for Statement {
                 options.fmt(f)?;
 
                 write!(f, "{}", statement)
+            }
+            Statement::ExplainAnalyzeStreamJob { job_id } => {
+                write!(f, "EXPLAIN ANALYZE {}", job_id)
             }
             Statement::Query(s) => write!(f, "{}", s),
             Statement::Truncate { table_name } => {

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1617,7 +1617,6 @@ pub enum Statement {
     /// EXPLAIN ANALYZE for stream job
     /// We introduce a new statement rather than reuse `EXPLAIN` because
     /// the body of the statement is not an SQL query.
-    /// FIXME(kwannoel): Support SINK s, MATERIALIZED VIEW s, etc...
     /// TODO(kwannoel): Make profiling duration configurable: EXPLAIN ANALYZE (DURATION 1s) ...
     ExplainAnalyzeStreamJob {
         target: AnalyzeTarget,

--- a/src/sqlparser/src/lib.rs
+++ b/src/sqlparser/src/lib.rs
@@ -40,7 +40,6 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-
 pub mod ast;
 pub mod keywords;
 pub mod parser;

--- a/src/sqlparser/src/lib.rs
+++ b/src/sqlparser/src/lib.rs
@@ -40,6 +40,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
 pub mod ast;
 pub mod keywords;
 pub mod parser;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4355,7 +4355,7 @@ impl Parser<'_> {
         }
 
         if analyze {
-            fn parse_analyze_target(parser: &mut Parser<'_>) -> PResult<Option<AnalyzeTarget>> {
+            fn parse_analyze_target(parser: &mut Parser<'_>) -> ModalResult<Option<AnalyzeTarget>> {
                 if parser.parse_keyword(Keyword::TABLE) {
                     let table_name = parser.parse_object_name()?;
                     Ok(Some(AnalyzeTarget::Table(table_name)))

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4355,32 +4355,33 @@ impl Parser<'_> {
         }
 
         if analyze {
-            fn parse_analyze_target(parser: &mut Parser<'_>) -> PResult<AnalyzeTarget> {
+            fn parse_analyze_target(parser: &mut Parser<'_>) -> PResult<Option<AnalyzeTarget>> {
                 if parser.parse_keyword(Keyword::TABLE) {
                     let table_name = parser.parse_object_name()?;
-                    Ok(AnalyzeTarget::Table(table_name))
+                    Ok(Some(AnalyzeTarget::Table(table_name)))
                 } else if parser.parse_keyword(Keyword::INDEX) {
                     let index_name = parser.parse_object_name()?;
-                    Ok(AnalyzeTarget::Index(index_name))
+                    Ok(Some(AnalyzeTarget::Index(index_name)))
                 } else if parser.parse_keywords(&[Keyword::MATERIALIZED, Keyword::VIEW]) {
                     let view_name = parser.parse_object_name()?;
-                    Ok(AnalyzeTarget::MaterializedView(view_name))
+                    Ok(Some(AnalyzeTarget::MaterializedView(view_name)))
                 } else if parser.parse_keyword(Keyword::INDEX) {
                     let index_name = parser.parse_object_name()?;
-                    Ok(AnalyzeTarget::Index(index_name))
+                    Ok(Some(AnalyzeTarget::Index(index_name)))
                 } else if parser.parse_keyword(Keyword::SINK) {
                     let sink_name = parser.parse_object_name()?;
-                    Ok(AnalyzeTarget::Sink(sink_name))
+                    Ok(Some(AnalyzeTarget::Sink(sink_name)))
                 } else if parser.parse_word("ID") {
                     let job_id = parser.parse_literal_uint()? as u32;
-                    Ok(AnalyzeTarget::Id(job_id))
+                    Ok(Some(AnalyzeTarget::Id(job_id)))
                 } else {
-                    parser.expected("TABLE, INDEX, MATERIALIZED VIEW, SINK or ID after ANALYZE")
+                    Ok(None)
                 }
             }
-            let target = parse_analyze_target(self)?;
-            let statement = Statement::ExplainAnalyzeStreamJob { target };
-            return Ok(statement);
+            if let Some(target) = parse_analyze_target(self)? {
+                let statement = Statement::ExplainAnalyzeStreamJob { target };
+                return Ok(statement);
+            }
         }
 
         let statement = self.parse_statement()?;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4354,6 +4354,12 @@ impl Parser<'_> {
             self.expect_token(&Token::RParen)?;
         }
 
+        if analyze {
+            let job_id = self.parse_literal_uint()? as u32;
+            let statement = Statement::ExplainAnalyzeStreamJob { job_id };
+            return Ok(statement);
+        }
+
         let statement = self.parse_statement()?;
         Ok(Statement::Explain {
             analyze,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4368,11 +4368,14 @@ impl Parser<'_> {
                 } else if parser.parse_keyword(Keyword::INDEX) {
                     let index_name = parser.parse_object_name()?;
                     Ok(AnalyzeTarget::Index(index_name))
+                } else if parser.parse_keyword(Keyword::SINK) {
+                    let sink_name = parser.parse_object_name()?;
+                    Ok(AnalyzeTarget::Sink(sink_name))
                 } else if parser.parse_word("ID") {
                     let job_id = parser.parse_literal_uint()? as u32;
                     Ok(AnalyzeTarget::Id(job_id))
                 } else {
-                    parser.expected("TABLE, INDEX, VIEW, MATERIALIZED VIEW or SYSTEM after ANALYZE")
+                    parser.expected("TABLE, INDEX, MATERIALIZED VIEW, SINK or ID after ANALYZE")
                 }
             }
             let target = parse_analyze_target(self)?;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4384,7 +4384,19 @@ impl Parser<'_> {
             }
         }
 
-        let statement = self.parse_statement()?;
+        let statement = match self.parse_statement() {
+            Ok(statement) => statement,
+            error @ Err(_) => {
+                return if analyze {
+                    self.expected_at(
+                        *self,
+                        "SINK, TABLE, MATERIALIZED VIEW, INDEX or a statement after ANALYZE",
+                    )
+                } else {
+                    error
+                };
+            }
+        };
         Ok(Statement::Explain {
             analyze,
             statement: Box::new(statement),

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4365,9 +4365,6 @@ impl Parser<'_> {
                 } else if parser.parse_keywords(&[Keyword::MATERIALIZED, Keyword::VIEW]) {
                     let view_name = parser.parse_object_name()?;
                     Ok(AnalyzeTarget::MaterializedView(view_name))
-                } else if parser.parse_keywords(&[Keyword::VIEW]) {
-                    let view_name = parser.parse_object_name()?;
-                    Ok(AnalyzeTarget::View(view_name))
                 } else if parser.parse_keyword(Keyword::INDEX) {
                     let index_name = parser.parse_object_name()?;
                     Ok(AnalyzeTarget::Index(index_name))

--- a/src/storage/compactor/src/rpc.rs
+++ b/src/storage/compactor/src/rpc.rs
@@ -18,10 +18,11 @@ use risingwave_pb::compactor::{
 };
 use risingwave_pb::monitor_service::monitor_service_server::MonitorService;
 use risingwave_pb::monitor_service::{
-    AnalyzeHeapRequest, AnalyzeHeapResponse, GetStreamingStatsRequest, GetStreamingStatsResponse,
-    HeapProfilingRequest, HeapProfilingResponse, ListHeapProfilingRequest,
-    ListHeapProfilingResponse, ProfilingRequest, ProfilingResponse, StackTraceRequest,
-    StackTraceResponse, TieredCacheTracingRequest, TieredCacheTracingResponse,
+    AnalyzeHeapRequest, AnalyzeHeapResponse, GetProfileStatsRequest, GetProfileStatsResponse,
+    GetStreamingStatsRequest, GetStreamingStatsResponse, HeapProfilingRequest,
+    HeapProfilingResponse, ListHeapProfilingRequest, ListHeapProfilingResponse, ProfilingRequest,
+    ProfilingResponse, StackTraceRequest, StackTraceResponse, TieredCacheTracingRequest,
+    TieredCacheTracingResponse,
 };
 use risingwave_storage::hummock::compactor::CompactionAwaitTreeRegRef;
 use risingwave_storage::hummock::compactor::await_tree_key::Compaction;
@@ -148,6 +149,15 @@ impl MonitorService for MonitorServiceImpl {
     ) -> Result<Response<TieredCacheTracingResponse>, Status> {
         Err(Status::unimplemented(
             "Tiered Cache Tracing unimplemented in compactor",
+        ))
+    }
+
+    async fn get_profile_stats(
+        &self,
+        _request: Request<GetProfileStatsRequest>,
+    ) -> Result<Response<GetProfileStatsResponse>, Status> {
+        Err(Status::unimplemented(
+            "Get Profile Stats unimplemented in compactor",
         ))
     }
 }

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -14,11 +14,11 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::AtomicU64;
 
 use parking_lot::RwLock;
 
-pub type Count = Arc<AtomicU32>;
+pub type Count = Arc<AtomicU64>;
 
 #[derive(Clone)]
 pub struct CountMap(Arc<RwLock<HashMap<u64, Count>>>);
@@ -50,12 +50,12 @@ impl CountMap {
         let mut map = self.0.write();
         let counter = map
             .entry(id)
-            .or_insert_with(|| Arc::new(AtomicU32::new(0)))
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
         counter
     }
 
-    pub fn collect(&self) -> HashMap<u64, u32> {
+    pub fn collect(&self) -> HashMap<u64, u64> {
         let map = self.0.read();
         map.iter()
             .map(|(&k, v)| (k, v.load(std::sync::atomic::Ordering::Relaxed)))

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -82,5 +82,6 @@ impl CountMap {
 
     pub fn gc(map: &mut HashMap<u64, Count>) {
         map.retain(|_, v| Arc::strong_count(v) > 1);
+        tracing::info!("Size of CountMap after GC: {}", map.len());
     }
 }

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -62,7 +62,7 @@ impl CountMap {
             .collect()
     }
 
-    /// GC at 50% drop rate
+    /// GC policy: if more than half of the counters are dropped, then do GC.
     pub fn should_gc(map: &HashMap<u64, Count>) -> bool {
         let total = map.len();
         let dropped = map

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -21,7 +21,7 @@ use parking_lot::RwLock;
 pub type Count = Arc<AtomicU32>;
 
 #[derive(Clone)]
-pub struct CountMap(Arc<RwLock<HashMap<u32, Count>>>);
+pub struct CountMap(Arc<RwLock<HashMap<u64, Count>>>);
 
 impl CountMap {
     pub(crate) fn new() -> Self {
@@ -40,7 +40,7 @@ impl CountMap {
         CountMap(inner)
     }
 
-    pub(crate) fn new_or_get_counter(&self, id: u32) -> Count {
+    pub(crate) fn new_or_get_counter(&self, id: u64) -> Count {
         {
             let map = self.0.read();
             if let Some(counter) = map.get(&id) {
@@ -55,7 +55,7 @@ impl CountMap {
         counter
     }
 
-    pub fn collect(&self) -> HashMap<u32, u32> {
+    pub fn collect(&self) -> HashMap<u64, u32> {
         let map = self.0.read();
         map.iter()
             .map(|(&k, v)| (k, v.load(std::sync::atomic::Ordering::Relaxed)))
@@ -63,7 +63,7 @@ impl CountMap {
     }
 
     /// GC at 50% drop rate
-    pub fn should_gc(map: &HashMap<u32, Count>) -> bool {
+    pub fn should_gc(map: &HashMap<u64, Count>) -> bool {
         let total = map.len();
         let dropped = map
             .iter()
@@ -75,7 +75,7 @@ impl CountMap {
         false
     }
 
-    pub fn gc(map: &mut HashMap<u32, Count>) {
+    pub fn gc(map: &mut HashMap<u64, Count>) {
         map.retain(|_, v| Arc::strong_count(v) > 1);
     }
 }

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -26,6 +26,7 @@ pub struct CountMap(Arc<RwLock<HashMap<u64, Count>>>);
 impl CountMap {
     pub(crate) fn new() -> Self {
         let inner = Arc::new(RwLock::new(HashMap::new()));
+        #[cfg(not(madsim))]
         {
             let inner = inner.clone();
             tokio::spawn(async move {
@@ -41,6 +42,9 @@ impl CountMap {
     }
 
     pub(crate) fn new_or_get_counter(&self, id: u64) -> Count {
+        #[cfg(madsim)]
+        return Arc::new(AtomicU64::new(0));
+
         {
             let map = self.0.read();
             if let Some(counter) = map.get(&id) {

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -34,4 +34,11 @@ impl CountMap {
         map.insert(id, counter.clone());
         counter
     }
+
+    pub fn collect(&self) -> HashMap<u32, u32> {
+        let map = self.0.read();
+        map.iter()
+            .map(|(&k, v)| (k, v.load(std::sync::atomic::Ordering::Relaxed)))
+            .collect()
+    }
 }

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -26,7 +26,7 @@ pub struct CountMap(Arc<RwLock<HashMap<u64, Count>>>);
 impl CountMap {
     pub(crate) fn new() -> Self {
         let inner = Arc::new(RwLock::new(HashMap::new()));
-        #[cfg(not(madsim))]
+        #[cfg(all(not(test), not(madsim)))]
         {
             let inner = inner.clone();
             tokio::spawn(async move {
@@ -42,7 +42,7 @@ impl CountMap {
     }
 
     pub(crate) fn new_or_get_counter(&self, id: u64) -> Count {
-        #[cfg(madsim)]
+        #[cfg(any(test, madsim))]
         return Arc::new(AtomicU64::new(0));
 
         {

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -12,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod in_mem_stats;
-pub mod streaming_stats;
-pub use streaming_stats::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
+
+use parking_lot::RwLock;
+
+pub type Count = Arc<AtomicU32>;
+
+#[derive(Clone)]
+pub struct CountMap(Arc<RwLock<HashMap<u32, Count>>>);
+
+impl CountMap {
+    pub(crate) fn new() -> Self {
+        CountMap(Arc::new(RwLock::new(HashMap::new())))
+    }
+
+    pub(crate) fn new_counter(&self, id: u32) -> Count {
+        let mut map = self.0.write();
+        let counter = Arc::new(AtomicU32::new(0));
+        map.insert(id, counter.clone());
+        counter
+    }
+}

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -42,9 +42,6 @@ impl CountMap {
     }
 
     pub(crate) fn new_or_get_counter(&self, id: u64) -> Count {
-        #[cfg(any(test, madsim))]
-        return Arc::new(AtomicU64::new(0));
-
         {
             let map = self.0.read();
             if let Some(counter) = map.get(&id) {

--- a/src/stream/src/executor/monitor/in_mem_stats.rs
+++ b/src/stream/src/executor/monitor/in_mem_stats.rs
@@ -55,10 +55,14 @@ impl CountMap {
         counter
     }
 
-    pub fn collect(&self) -> HashMap<u64, u64> {
+    pub fn collect(&self, operator_ids: &[u64]) -> HashMap<u64, u64> {
         let map = self.0.read();
-        map.iter()
-            .map(|(&k, v)| (k, v.load(std::sync::atomic::Ordering::Relaxed)))
+        operator_ids
+            .iter()
+            .filter_map(|id| {
+                map.get(id)
+                    .map(|v| (*id, v.load(std::sync::atomic::Ordering::Relaxed)))
+            })
             .collect()
     }
 

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -47,10 +47,6 @@ pub struct StreamingMetrics {
     // Executor metrics (disabled by default)
     pub executor_row_count: RelabeledGuardedIntCounterVec<3>,
 
-    // TODO(kwannoel): I'm considering having a totally separate in-memory
-    // struct for these metrics,
-    // i.e. just store them in a hashmap on the CN,
-    // and drop them once profiling done.
     // Profiling Metrics:
     // Aggregated per stream node (e.g. hash agg, join, project, etc...)
     // Only active when profiling, should be dropped otherwise.

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -1548,7 +1548,7 @@ impl StreamingMetrics {
         }
     }
 
-    pub fn new_profile_metrics(&self, operator_id: u32) -> ProfileMetrics {
+    pub fn new_profile_metrics(&self, operator_id: u64) -> ProfileMetrics {
         ProfileMetrics {
             stream_node_input_row_count: self
                 .stream_node_input_row_count

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -1550,16 +1550,18 @@ impl StreamingMetrics {
 
     pub fn new_profile_metrics(&self, operator_id: u32) -> ProfileMetrics {
         ProfileMetrics {
-            stream_node_input_row_count: self.stream_node_input_row_count.new_counter(operator_id),
+            stream_node_input_row_count: self
+                .stream_node_input_row_count
+                .new_or_get_counter(operator_id),
             stream_node_output_row_count: self
                 .stream_node_output_row_count
-                .new_counter(operator_id),
+                .new_or_get_counter(operator_id),
             stream_node_input_blocking_duration_ns: self
                 .stream_node_input_blocking_duration_ns
-                .new_counter(operator_id),
+                .new_or_get_counter(operator_id),
             stream_node_output_blocking_duration_ns: self
                 .stream_node_output_blocking_duration_ns
-                .new_counter(operator_id),
+                .new_or_get_counter(operator_id),
         }
     }
 }

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -49,10 +49,10 @@ pub struct StreamingMetrics {
     pub executor_row_count: RelabeledGuardedIntCounterVec<3>,
 
     // Profiling Metrics:
-    // Aggregated per stream node (e.g. hash agg, join, project, etc...)
-    // Only active when profiling, should be dropped otherwise.
-    pub stream_node_output_row_count: CountMap,
-    pub stream_node_output_blocking_duration_ms: CountMap,
+    // Aggregated per operator rather than per actor.
+    // These are purely in-memory, never collected by prometheus.
+    pub mem_stream_node_output_row_count: CountMap,
+    pub mem_stream_node_output_blocking_duration_ms: CountMap,
 
     // Streaming actor metrics from tokio (disabled by default)
     actor_execution_time: LabelGuardedGaugeVec<1>,
@@ -1074,8 +1074,8 @@ impl StreamingMetrics {
         Self {
             level,
             executor_row_count,
-            stream_node_output_row_count,
-            stream_node_output_blocking_duration_ms,
+            mem_stream_node_output_row_count: stream_node_output_row_count,
+            mem_stream_node_output_blocking_duration_ms: stream_node_output_blocking_duration_ms,
             actor_execution_time,
             actor_scheduled_duration,
             actor_scheduled_cnt,
@@ -1551,10 +1551,10 @@ impl StreamingMetrics {
         if enable_profiling {
             ProfileMetricsImpl::ProfileMetrics(ProfileMetrics {
                 stream_node_output_row_count: self
-                    .stream_node_output_row_count
+                    .mem_stream_node_output_row_count
                     .new_or_get_counter(operator_id),
                 stream_node_output_blocking_duration_ms: self
-                    .stream_node_output_blocking_duration_ms
+                    .mem_stream_node_output_blocking_duration_ms
                     .new_or_get_counter(operator_id),
             })
         } else {

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -51,7 +51,7 @@ pub struct StreamingMetrics {
     // Aggregated per stream node (e.g. hash agg, join, project, etc...)
     // Only active when profiling, should be dropped otherwise.
     pub stream_node_output_row_count: CountMap,
-    pub stream_node_output_blocking_duration_ns: CountMap,
+    pub stream_node_output_blocking_duration_ms: CountMap,
 
     // Streaming actor metrics from tokio (disabled by default)
     actor_execution_time: LabelGuardedGaugeVec<1>,
@@ -222,7 +222,7 @@ impl StreamingMetrics {
         .relabel_debug_1(level);
 
         let stream_node_output_row_count = CountMap::new();
-        let stream_node_output_blocking_duration_ns = CountMap::new();
+        let stream_node_output_blocking_duration_ms = CountMap::new();
 
         let source_output_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_source_output_rows_counts",
@@ -1074,7 +1074,7 @@ impl StreamingMetrics {
             level,
             executor_row_count,
             stream_node_output_row_count,
-            stream_node_output_blocking_duration_ns,
+            stream_node_output_blocking_duration_ms,
             actor_execution_time,
             actor_scheduled_duration,
             actor_scheduled_cnt,
@@ -1547,8 +1547,8 @@ impl StreamingMetrics {
             stream_node_output_row_count: self
                 .stream_node_output_row_count
                 .new_or_get_counter(operator_id),
-            stream_node_output_blocking_duration_ns: self
-                .stream_node_output_blocking_duration_ns
+            stream_node_output_blocking_duration_ms: self
+                .stream_node_output_blocking_duration_ms
                 .new_or_get_counter(operator_id),
         }
     }
@@ -1648,5 +1648,5 @@ pub struct OverWindowMetrics {
 
 pub struct ProfileMetrics {
     pub stream_node_output_row_count: Count,
-    pub stream_node_output_blocking_duration_ns: Count,
+    pub stream_node_output_blocking_duration_ms: Count,
 }

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -50,9 +50,7 @@ pub struct StreamingMetrics {
     // Profiling Metrics:
     // Aggregated per stream node (e.g. hash agg, join, project, etc...)
     // Only active when profiling, should be dropped otherwise.
-    pub stream_node_input_row_count: CountMap,
     pub stream_node_output_row_count: CountMap,
-    pub stream_node_input_blocking_duration_ns: CountMap,
     pub stream_node_output_blocking_duration_ns: CountMap,
 
     // Streaming actor metrics from tokio (disabled by default)
@@ -223,9 +221,7 @@ impl StreamingMetrics {
         .unwrap()
         .relabel_debug_1(level);
 
-        let stream_node_input_row_count = CountMap::new();
         let stream_node_output_row_count = CountMap::new();
-        let stream_node_input_blocking_duration_ns = CountMap::new();
         let stream_node_output_blocking_duration_ns = CountMap::new();
 
         let source_output_row_count = register_guarded_int_counter_vec_with_registry!(
@@ -1077,9 +1073,7 @@ impl StreamingMetrics {
         Self {
             level,
             executor_row_count,
-            stream_node_input_row_count,
             stream_node_output_row_count,
-            stream_node_input_blocking_duration_ns,
             stream_node_output_blocking_duration_ns,
             actor_execution_time,
             actor_scheduled_duration,
@@ -1550,14 +1544,8 @@ impl StreamingMetrics {
 
     pub fn new_profile_metrics(&self, operator_id: u64) -> ProfileMetrics {
         ProfileMetrics {
-            stream_node_input_row_count: self
-                .stream_node_input_row_count
-                .new_or_get_counter(operator_id),
             stream_node_output_row_count: self
                 .stream_node_output_row_count
-                .new_or_get_counter(operator_id),
-            stream_node_input_blocking_duration_ns: self
-                .stream_node_input_blocking_duration_ns
                 .new_or_get_counter(operator_id),
             stream_node_output_blocking_duration_ns: self
                 .stream_node_output_blocking_duration_ns
@@ -1659,8 +1647,6 @@ pub struct OverWindowMetrics {
 }
 
 pub struct ProfileMetrics {
-    pub stream_node_input_row_count: Count,
     pub stream_node_output_row_count: Count,
-    pub stream_node_input_blocking_duration_ns: Count,
     pub stream_node_output_blocking_duration_ns: Count,
 }

--- a/src/stream/src/executor/wrapper.rs
+++ b/src/stream/src/executor/wrapper.rs
@@ -49,10 +49,8 @@ impl WrapperExecutor {
 
     #[allow(clippy::let_and_return)]
     fn wrap_debug(
-        operator_id: u64,
         info: Arc<ExecutorInfo>,
         stream: impl MessageStream + 'static,
-        actor_context: ActorContextRef,
     ) -> impl MessageStream + 'static {
         // Update check
         let stream = update_check::update_check(info, stream);
@@ -93,7 +91,7 @@ impl WrapperExecutor {
             stream_node_metrics::stream_node_metrics(operator_id, stream, actor_ctx.clone());
 
         if cfg!(debug_assertions) {
-            Self::wrap_debug(operator_id, info, stream, actor_ctx).boxed()
+            Self::wrap_debug(info, stream).boxed()
         } else {
             stream.boxed()
         }

--- a/src/stream/src/executor/wrapper/stream_node_metrics.rs
+++ b/src/stream/src/executor/wrapper/stream_node_metrics.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::Ordering;
+
+use futures_async_stream::try_stream;
+use tokio::time::Instant;
+
+use crate::executor::prelude::*;
+
+#[try_stream(ok = Message, error = StreamExecutorError)]
+pub async fn stream_node_metrics(
+    operator_id: u64,
+    input: impl MessageStream,
+    actor_ctx: ActorContextRef,
+) {
+    let stats = actor_ctx.streaming_metrics.new_profile_metrics(operator_id);
+
+    let blocking_duration = Instant::now();
+
+    #[for_await]
+    for message in input {
+        stats.stream_node_output_blocking_duration_ns.fetch_add(
+            blocking_duration.elapsed().as_nanos() as u32,
+            Ordering::Relaxed,
+        );
+        let message = message?;
+        if let Message::Chunk(ref c) = message {
+            stats
+                .stream_node_output_row_count
+                .fetch_add(c.cardinality() as u32, Ordering::Relaxed);
+        }
+        yield message;
+    }
+}

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -227,15 +227,3 @@ impl SharedContext {
         }
     }
 }
-
-/// Generate a globally unique executor id.
-pub fn unique_executor_id(actor_id: u32, operator_id: u64) -> u64 {
-    assert!(operator_id <= u32::MAX as u64);
-    ((actor_id as u64) << 32) + operator_id
-}
-
-/// Generate a globally unique operator id.
-pub fn unique_operator_id(fragment_id: u32, operator_id: u64) -> u64 {
-    assert!(operator_id <= u32::MAX as u64);
-    ((fragment_id as u64) << 32) + operator_id
-}

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -544,6 +544,7 @@ impl StreamActorManager {
 
         // Wrap the executor for debug purpose.
         let wrapped = WrapperExecutor::new(
+            operator_id,
             executor,
             actor_context.clone(),
             env.config().developer.enable_executor_row_count,

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -29,6 +29,7 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnId, DatabaseId, Field, Schema, TableId};
 use risingwave_common::config::MetricLevel;
 use risingwave_common::must_match;
+use risingwave_common::operator::{unique_executor_id, unique_operator_id};
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan;
@@ -47,7 +48,6 @@ use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 use tonic::Status;
 
-use super::{unique_executor_id, unique_operator_id};
 use crate::common::table::state_table::StateTable;
 use crate::error::StreamResult;
 use crate::executor::exchange::permit::Receiver;

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -548,6 +548,7 @@ impl StreamActorManager {
             executor,
             actor_context.clone(),
             env.config().developer.enable_executor_row_count,
+            env.config().developer.enable_explain_analyze_stats,
         );
         let executor = (info, wrapped).into();
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Closes #20721 

Support explain analyze stream job. See release notes for an example.

<details>

<summary><b>DEMO</b></summary>

https://github.com/user-attachments/assets/90bde9ff-c0d3-40dd-b33f-3aab45291c67

</details>

### Major changes

In this PR every executor will collect profiling metrics, but only 1 set of metrics is allocated per **operator**. For instance, for hash aggregation, we could have 8 parallelism, and hence 8 executors running. But all 8 executors will share a single set of metrics, to avoid high memory consumption when actor counts are high.

When some executor is dropped, it also decrements the metric's reference count. But similar to prometheus metrics, `StreamingMetrics` will still hold a reference to these, and we have hanging metrics as a result. So periodically, for each CN and each metric group, we will run GC on metrics, to check the reference counts and evict entries which are only referenced by the hashmap itself.
We may use `Weak` pointers for some improvement, but the entry itself still needs to be GC'ed eventually.

As such, we can always keep the profiling metric collection on. The alternative would be to add `start` and `stop` RPCs to CNs, and we can reuse the prometheus framework. However we will need some synchronization inside the executor wrappers, to toggle metrics collection. We cannot just leave it on because multiple actors can't share the same metric label. Maintaining the extra RPC + synchronization mechanism seems worst than doing simple GC. The tradeoff is that GC will of course incur CPU usage periodically. Open to suggestions on this part.

Frontend will send an RPC call to meta to list fragments and get the streaming worker nodes.

It will then send an RPC call to the streaming worker nodes to collect streaming stats **twice**. First to get a baseline, second to compute the delta.

Then we will use the fragments from meta to construct a streaming graph, and map metrics to each operator in the graph.

### What's Next

- [ ] Add telemetry: profiling duration, type of jobs being analyzed
- [ ] Use tokio actor metrics.
- [ ] Add some explain analyze tests for the plan node column.
- [ ] Maybe improve GC algorithm for metrics
- [ ] or remove the need for GC entirely -- This can be done by adding RPCs to enable / disable profiling + synchronizing channel per actor.
- [ ] Support changing analyze duration.
- [ ] Give notice / progress bar on how long more it takes for analyze to complete.
- [ ] Populate merge and dispatcher metrics.
- [ ] Add dispatcher type e.g. HashDispatcher, in the identity column.
- [ ] Add join type (left / right / outer) in the identity column.
- [ ] Include operator epoch as a column, to show lag.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Syntax:
```
EXPLAIN ANALYZE (TABLE <name> | MATERIALIZED VIEW <name> | SINK <name> | INDEX <name> | ID <job_id>)
```

Example:
```
CREATE TABLE t(v1 int);

CREATE MATERIALIZED VIEW m1 as 
  select * from 
    t x join t y using(v1)
      join t z using(v1) 
        join t c using(v1);
```

Output:
```
EXPLAIN ANALYZE MATERIALIZED VIEW m1
 operator_id |                    identity                    |  actor_ids  | output_rps | avg_output_pending_ratio
-------------+------------------------------------------------+-------------+------------+--------------------------
 12884901902 | StreamMaterialize                              | 12,11,10,9  | 41589.1    | 0.00005
 12884901901 | └─ MergeExecutor                               | 12,11,10,9  | 41589.1    | 0.8149749999999999
 4           |    └─ Dispatcher                               |             | 0          | NaN
 17179869196 |       └─ StreamHashJoin                        | 16,15,14,13 | 41560.1    | 0.859225
 17179869195 |          ├─ StreamHashJoin                     | 16,15,14,13 | 152.6      | 0.93265
 17179869194 |          │  ├─ MergeExecutor                   | 16,15,14,13 | 25.6       | 1.6336749999999998
 9           |          │  │  └─ Dispatcher                   |             | 0          | NaN
 38654705673 |          │  │     └─ StreamFilter              | 20,19,18,17 | 0          | 0
 38654715839 |          │  │        └─ StreamTableScan        | 20,19,18,17 | 0          | 0
 38654715838 |          │  │           ├─ BatchPlanNode       | 20,19,18,17 | 0          | 0
 38654705664 |          │  │           └─ Upstream            | 20,19,18,17 | 0          | 0
 17179869192 |          │  └─ MergeExecutor                   | 16,15,14,13 | 0          | 0
 8           |          │     └─ Dispatcher                   |             | 0          | NaN
 34359738375 |          │        └─ StreamFilter              | 28,27,26,25 | 0          | 0
 34359748538 |          │           └─ StreamTableScan        | 28,27,26,25 | 0          | 0
 34359748537 |          │              ├─ BatchPlanNode       | 28,27,26,25 | 0          | 0
 34359738368 |          │              └─ Upstream            | 28,27,26,25 | 0          | 0
 17179869190 |          └─ MergeExecutor                      | 16,15,14,13 | 51.2       | 0.71425
 5           |             └─ Dispatcher                      |             | 0          | NaN
 21474836485 |                └─ StreamHashJoin               | 24,23,22,21 | 51.2       | 0.711325
 21474836484 |                   ├─ MergeExecutor             | 24,23,22,21 | 0          | 0
 7           |                   │  └─ Dispatcher             |             | 0          | NaN
 30064771075 |                   │     └─ StreamFilter        | 36,35,34,33 | 0          | 0
 30064781234 |                   │        └─ StreamTableScan  | 36,35,34,33 | 0          | 0
 30064781233 |                   │           ├─ BatchPlanNode | 36,35,34,33 | 0          | 0
 30064771072 |                   │           └─ Upstream      | 36,35,34,33 | 0          | 0
 21474836482 |                   └─ MergeExecutor             | 24,23,22,21 | 0          | 0
 6           |                      └─ Dispatcher             |             | 0          | NaN
 25769803777 |                         └─ StreamFilter        | 32,31,30,29 | 0          | 0
 25769813933 |                            └─ StreamTableScan  | 32,31,30,29 | 0          | 0
 25769813932 |                               ├─ BatchPlanNode | 32,31,30,29 | 0          | 0
 25769803776 |                               └─ Upstream      | 32,31,30,29 | 0          | 0
(32 rows)
```

This feature has a feature gate:
```
[streaming.developer]
enable_explain_analyze_stats = true # change to false to disable profiling cluster-wide.
```

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
