### PR TITLE
feat(meta): isolate database worker node failure

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -280,7 +280,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 70
+    timeout_in_minutes: 90
     retry: *auto-retry
 
   - label: "integration test (madsim) - recovery"
@@ -381,7 +381,7 @@ steps:
 
   - label: "recovery test (madsim)"
     key: "recovery-test-deterministic"
-    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 timeout 75m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 timeout 135m ci/scripts/deterministic-recovery-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
@@ -391,13 +391,13 @@ steps:
       - docker-compose#v5.5.0: *docker-compose
       # Only upload zipped files, otherwise the logs is too much.
       - ./ci/plugins/upload-failure-logs-zipped
-    timeout_in_minutes: 80
+    timeout_in_minutes: 140
     retry: *auto-retry
 
   # Ddl statements will randomly run with background_ddl.
   - label: "background_ddl, arrangement_backfill recovery test (madsim)"
     key: "background-ddl-arrangement-backfill-recovery-test-deterministic"
-    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.8 USE_ARRANGEMENT_BACKFILL=true timeout 75m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.8 USE_ARRANGEMENT_BACKFILL=true timeout 90m ci/scripts/deterministic-recovery-test.sh"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
@@ -407,7 +407,7 @@ steps:
       - docker-compose#v5.5.0: *docker-compose
       # Only upload zipped files, otherwise the logs is too much.
       - ./ci/plugins/upload-failure-logs-zipped
-    timeout_in_minutes: 80
+    timeout_in_minutes: 95
     retry: *auto-retry
 
   - label: "end-to-end iceberg sink test (release)"

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -137,10 +137,10 @@ impl CreatingStreamingJobControl {
         }
     }
 
-    pub(crate) fn is_wait_on_worker(&self, worker_id: WorkerId) -> bool {
-        self.barrier_control.is_wait_on_worker(worker_id)
-            || (self.status.is_finishing()
-                && InflightFragmentInfo::contains_worker(
+    pub(crate) fn is_valid_after_worker_err(&mut self, worker_id: WorkerId) -> bool {
+        self.barrier_control.is_valid_after_worker_err(worker_id)
+            && (!self.status.is_finishing()
+                || InflightFragmentInfo::contains_worker(
                     self.graph_info.fragment_infos(),
                     worker_id,
                 ))

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -20,9 +20,7 @@ use futures::FutureExt;
 use risingwave_common::catalog::DatabaseId;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
-use risingwave_pb::stream_service::streaming_control_stream_response::{
-    ReportDatabaseFailureResponse, ResetDatabaseResponse,
-};
+use risingwave_pb::stream_service::streaming_control_stream_response::ResetDatabaseResponse;
 use thiserror_ext::AsReport;
 use tracing::{info, warn};
 
@@ -32,6 +30,7 @@ use crate::barrier::checkpoint::{CheckpointControl, DatabaseCheckpointControl};
 use crate::barrier::complete_task::BarrierCompleteOutput;
 use crate::barrier::info::InflightDatabaseInfo;
 use crate::barrier::rpc::ControlStreamManager;
+use crate::barrier::utils::{NodeToCollect, is_valid_after_worker_err};
 use crate::barrier::worker::{
     RetryBackoffFuture, RetryBackoffStrategy, get_retry_backoff_strategy,
 };
@@ -68,12 +67,12 @@ use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 enum DatabaseRecoveringStage {
     Resetting {
         remaining_workers: HashSet<WorkerId>,
-        reset_workers: HashMap<WorkerId, ResetDatabaseResponse>,
+        reset_resps: HashMap<WorkerId, ResetDatabaseResponse>,
         reset_request_id: u32,
         backoff_future: Option<RetryBackoffFuture>,
     },
     Initializing {
-        remaining_workers: HashSet<WorkerId>,
+        remaining_workers: NodeToCollect,
         database: DatabaseCheckpointControl,
         prev_epoch: u64,
     },
@@ -97,7 +96,7 @@ impl DatabaseRecoveringState {
         Self {
             stage: DatabaseRecoveringStage::Resetting {
                 remaining_workers: Default::default(),
-                reset_workers: Default::default(),
+                reset_resps: Default::default(),
                 reset_request_id: 0,
                 backoff_future: Some(backoff_future),
             },
@@ -116,7 +115,11 @@ impl DatabaseRecoveringState {
         (backoff_future, request_id)
     }
 
-    pub(super) fn barrier_collected(&mut self, resp: BarrierCompleteResponse) {
+    pub(super) fn barrier_collected(
+        &mut self,
+        database_id: DatabaseId,
+        resp: BarrierCompleteResponse,
+    ) {
         match &mut self.stage {
             DatabaseRecoveringStage::Resetting { .. } => {
                 // ignore the collected barrier on resetting or backoff
@@ -126,20 +129,30 @@ impl DatabaseRecoveringState {
                 prev_epoch,
                 ..
             } => {
-                assert!(remaining_workers.remove(&(resp.worker_id as WorkerId)));
+                let worker_id = resp.worker_id as WorkerId;
+                assert!(remaining_workers.remove(&worker_id).is_some());
                 assert_eq!(resp.epoch, *prev_epoch);
+                info!(
+                    ?database_id,
+                    worker_id,
+                    ?remaining_workers,
+                    "initializing database barrier collected"
+                );
             }
         }
     }
 
-    pub(super) fn remaining_workers(&self) -> &HashSet<WorkerId> {
-        match &self.stage {
+    pub(super) fn is_valid_after_worker_err(&mut self, worker_id: WorkerId) -> bool {
+        match &mut self.stage {
             DatabaseRecoveringStage::Resetting {
                 remaining_workers, ..
+            } => {
+                remaining_workers.remove(&worker_id);
+                true
             }
-            | DatabaseRecoveringStage::Initializing {
+            DatabaseRecoveringStage::Initializing {
                 remaining_workers, ..
-            } => remaining_workers,
+            } => is_valid_after_worker_err(remaining_workers, worker_id),
         }
     }
 
@@ -151,7 +164,7 @@ impl DatabaseRecoveringState {
         match &mut self.stage {
             DatabaseRecoveringStage::Resetting {
                 remaining_workers,
-                reset_workers,
+                reset_resps,
                 reset_request_id,
                 ..
             } => {
@@ -166,7 +179,7 @@ impl DatabaseRecoveringState {
                 } else {
                     assert_eq!(resp.reset_request_id, *reset_request_id);
                     assert!(remaining_workers.remove(&worker_id));
-                    reset_workers
+                    reset_resps
                         .try_insert(worker_id, resp)
                         .expect("non-duplicate");
                 }
@@ -181,7 +194,7 @@ impl DatabaseRecoveringState {
         match &mut self.stage {
             DatabaseRecoveringStage::Resetting {
                 remaining_workers,
-                reset_workers,
+                reset_resps,
                 backoff_future: backoff_future_option,
                 ..
             } => {
@@ -197,7 +210,7 @@ impl DatabaseRecoveringState {
                 };
                 if pass_backoff && remaining_workers.is_empty() {
                     return Poll::Ready(RecoveringStateAction::EnterInitializing(take(
-                        reset_workers,
+                        reset_resps,
                     )));
                 }
             }
@@ -271,7 +284,7 @@ impl DatabaseStatusAction<'_, EnterReset> {
                     DatabaseCheckpointControlStatus::Recovering(DatabaseRecoveringState {
                         stage: DatabaseRecoveringStage::Resetting {
                             remaining_workers,
-                            reset_workers: Default::default(),
+                            reset_resps: Default::default(),
                             reset_request_id,
                             backoff_future: None,
                         },
@@ -289,7 +302,7 @@ impl DatabaseStatusAction<'_, EnterReset> {
                         control_stream_manager.reset_database(self.database_id, reset_request_id);
                     state.stage = DatabaseRecoveringStage::Resetting {
                         remaining_workers,
-                        reset_workers: Default::default(),
+                        reset_resps: Default::default(),
                         reset_request_id,
                         backoff_future: Some(backoff_future),
                     };
@@ -302,10 +315,9 @@ impl DatabaseStatusAction<'_, EnterReset> {
 impl CheckpointControl {
     pub(crate) fn on_report_failure(
         &mut self,
-        resp: ReportDatabaseFailureResponse,
+        database_id: DatabaseId,
         control_stream_manager: &mut ControlStreamManager,
     ) -> Option<DatabaseStatusAction<'_, EnterReset>> {
-        let database_id = DatabaseId::new(resp.database_id);
         let database_status = self.databases.get_mut(&database_id).expect("should exist");
         match database_status {
             DatabaseCheckpointControlStatus::Running(_) => {
@@ -323,7 +335,7 @@ impl CheckpointControl {
                         control_stream_manager.reset_database(database_id, reset_request_id);
                     state.stage = DatabaseRecoveringStage::Resetting {
                         remaining_workers,
-                        reset_workers: Default::default(),
+                        reset_resps: Default::default(),
                         reset_request_id,
                         backoff_future: Some(backoff_future),
                     };
@@ -389,6 +401,7 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
         };
         match result {
             Ok((remaining_workers, database, prev_epoch)) => {
+                info!(?remaining_workers, database_id = ?self.database_id, "database enter initializing");
                 status.stage = DatabaseRecoveringStage::Initializing {
                     remaining_workers,
                     database,
@@ -396,13 +409,17 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
                 };
             }
             Err(e) => {
-                warn!(database_id = self.database_id.database_id,e = ?e.as_report(), "failed to inject initial barrier");
+                warn!(
+                    database_id = self.database_id.database_id,
+                    e = %e.as_report(),
+                    "failed to inject initial barrier"
+                );
                 let (backoff_future, reset_request_id) = status.next_retry();
                 let remaining_workers =
                     control_stream_manager.reset_database(self.database_id, reset_request_id);
                 status.stage = DatabaseRecoveringStage::Resetting {
                     remaining_workers,
-                    reset_workers: Default::default(),
+                    reset_resps: Default::default(),
                     reset_request_id,
                     backoff_future: Some(backoff_future),
                 };
@@ -422,6 +439,7 @@ pub(crate) struct EnterRunning;
 
 impl DatabaseStatusAction<'_, EnterRunning> {
     pub(crate) fn enter(self) {
+        info!(database_id = ?self.database_id, "database enter running");
         let database_status = self
             .control
             .databases
@@ -434,7 +452,7 @@ impl DatabaseStatusAction<'_, EnterRunning> {
             DatabaseCheckpointControlStatus::Recovering(state) => {
                 let temp_place_holder = DatabaseRecoveringStage::Resetting {
                     remaining_workers: Default::default(),
-                    reset_workers: Default::default(),
+                    reset_resps: Default::default(),
                     reset_request_id: 0,
                     backoff_future: None,
                 };

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -24,6 +24,7 @@ use risingwave_pb::meta::PbRecoveryStatus;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
+use tracing::warn;
 
 use crate::MetaResult;
 use crate::barrier::worker::GlobalBarrierWorker;
@@ -58,10 +59,13 @@ impl GlobalBarrierManager {
             .metadata_manager
             .catalog_controller
             .list_background_creating_mviews(true)
-            .await
-            .unwrap();
+            .await?;
         for mview in mviews {
             if let Entry::Vacant(e) = ddl_progress.entry(mview.table_id as _) {
+                warn!(
+                    job_id = mview.table_id,
+                    "background job has no ddl progress"
+                );
                 e.insert(DdlProgress {
                     id: mview.table_id as u64,
                     statement: mview.definition,

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -22,6 +22,7 @@ use risingwave_hummock_sdk::table_watermark::{
     TableWatermarks, merge_multiple_new_table_watermarks,
 };
 use risingwave_hummock_sdk::{HummockSstableObjectId, LocalSstableInfo};
+use risingwave_meta_model::WorkerId;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 
 use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
@@ -103,4 +104,12 @@ pub(super) fn collect_creating_job_commit_epoch_info(
                 table_ids: tables_to_commit,
             });
     };
+}
+
+pub(super) type NodeToCollect = HashMap<WorkerId, bool>;
+pub(super) fn is_valid_after_worker_err(
+    node_to_collect: &mut NodeToCollect,
+    worker_id: WorkerId,
+) -> bool {
+    node_to_collect.remove(&worker_id).unwrap_or(true)
 }

--- a/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
@@ -278,6 +278,7 @@ async fn test_high_barrier_latency_cancel(config: Configuration) -> Result<()> {
     // Keep creating mv1, if it's not created.
     loop {
         session.run(SET_BACKGROUND_DDL).await?;
+        session.run(SET_RATE_LIMIT_2).await?;
         session.run("CREATE MATERIALIZED VIEW mv1 as select fact1.v1 from fact1 join fact2 on fact1.v1 = fact2.v1").await?;
         tracing::info!("created mv in background");
         sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously, we only support the logical error between databases. The logical error is sent back to meta node as a separate control stream response variant. However, for worker node failure, we haven't handled the database isolation properly yet. On worker node failure, we will either ignore the failure, when no database is waiting on a response from the failed worker node, or else trigger global recovery. Moreover, to simplify the handling logic, currently when handling inject barrier request, we will send the request to all existing worker nodes, even there is no actor running on the worker node. As a result, on worker node failure, it's very likely that a database is waiting on the collect barrier response from the worker node, and then should be treated database failure, even though the database has no inflight actor on the worker node.

In this PR, we will support database isolation on worker node failure. When sending inject barrier request, instead of maintaining a `HashSet<WorkerId>` as the remaining workers to collect barrier collect response, we change to maintain a `HashMap<WorkerId, bool>`, where the bool value indicate whether the database actually has actor running on this node when injecting the barrier. On worker node failure, we will try to remove the failed worker id from the map, and check its value. If the value is true, it means that the database can still work after the worker node failure, and otherwise, the database will enter the process of database recovery.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
