### PR TITLE
fix(meta): allow subset of databases enter running after global recovery

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -60,6 +60,7 @@ pub(crate) struct CheckpointControl {
 impl CheckpointControl {
     pub(crate) fn new(
         databases: impl IntoIterator<Item = (DatabaseId, DatabaseCheckpointControl)>,
+        unconnected_databases: HashSet<DatabaseId>,
         hummock_version_stats: HummockVersionStats,
     ) -> Self {
         Self {
@@ -71,6 +72,14 @@ impl CheckpointControl {
                         DatabaseCheckpointControlStatus::Running(control),
                     )
                 })
+                .chain(unconnected_databases.into_iter().map(|database_id| {
+                    (
+                        database_id,
+                        DatabaseCheckpointControlStatus::Recovering(
+                            DatabaseRecoveringState::resetting(),
+                        ),
+                    )
+                }))
                 .collect(),
             hummock_version_stats,
         }
@@ -139,6 +148,12 @@ impl CheckpointControl {
             })
             .max_by_key(|epoch| epoch.value())
             .cloned()
+    }
+
+    pub(crate) fn recovering_databases(&self) -> impl Iterator<Item = DatabaseId> + '_ {
+        self.databases.iter().filter_map(|(database_id, database)| {
+            database.running_state().is_none().then_some(*database_id)
+        })
     }
 
     pub(crate) fn handle_new_barrier(

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -27,14 +27,15 @@ use thiserror_ext::AsReport;
 use tracing::{info, warn};
 
 use crate::MetaResult;
-use crate::barrier::DatabaseRuntimeInfoSnapshot;
 use crate::barrier::checkpoint::control::DatabaseCheckpointControlStatus;
 use crate::barrier::checkpoint::{CheckpointControl, DatabaseCheckpointControl};
 use crate::barrier::complete_task::BarrierCompleteOutput;
+use crate::barrier::info::InflightDatabaseInfo;
 use crate::barrier::rpc::ControlStreamManager;
 use crate::barrier::worker::{
     RetryBackoffFuture, RetryBackoffStrategy, get_retry_backoff_strategy,
 };
+use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 
 /// We can treat each database as a state machine of 3 states: `Running`, `Resetting` and `Initializing`.
 /// The state transition can be triggered when receiving 3 variants of response: `ReportDatabaseFailure`, `BarrierComplete`, `DatabaseReset`.
@@ -90,6 +91,21 @@ pub(super) enum RecoveringStateAction {
 }
 
 impl DatabaseRecoveringState {
+    pub(super) fn resetting() -> Self {
+        let mut retry_backoff_strategy = get_retry_backoff_strategy();
+        let backoff_future = retry_backoff_strategy.next().unwrap();
+        Self {
+            stage: DatabaseRecoveringStage::Resetting {
+                remaining_workers: Default::default(),
+                reset_workers: Default::default(),
+                reset_request_id: 0,
+                backoff_future: Some(backoff_future),
+            },
+            next_reset_request_id: 1,
+            retry_backoff_strategy,
+        }
+    }
+
     fn next_retry(&mut self) -> (RetryBackoffFuture, u32) {
         let backoff_future = self
             .retry_backoff_strategy
@@ -321,6 +337,13 @@ impl CheckpointControl {
 pub(crate) struct EnterInitializing(pub(crate) HashMap<WorkerId, ResetDatabaseResponse>);
 
 impl DatabaseStatusAction<'_, EnterInitializing> {
+    pub(crate) fn inflight_infos(
+        &self,
+    ) -> impl Iterator<Item = (DatabaseId, &InflightSubscriptionInfo, &InflightDatabaseInfo)> + '_
+    {
+        self.control.inflight_infos()
+    }
+
     pub(crate) fn enter(
         self,
         runtime_info: DatabaseRuntimeInfoSnapshot,

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -21,9 +21,11 @@ use risingwave_pb::stream_plan::PbFragmentTypeFlag;
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
 
+use crate::MetaResult;
 use crate::barrier::command::CommandContext;
 use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
 use crate::barrier::progress::TrackingJob;
+use crate::barrier::schedule::MarkReadyOptions;
 use crate::barrier::{
     BarrierManagerStatus, BarrierWorkerRuntimeInfoSnapshot, Command, CreateStreamingJobCommandInfo,
     CreateStreamingJobType, DatabaseRuntimeInfoSnapshot, RecoveryReason, ReplaceStreamJobPlan,
@@ -31,7 +33,6 @@ use crate::barrier::{
 };
 use crate::hummock::CommitEpochInfo;
 use crate::stream::SourceChange;
-use crate::{MetaError, MetaResult};
 
 impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
     async fn commit_epoch(&self, commit_info: CommitEpochInfo) -> MetaResult<HummockVersionStats> {
@@ -57,9 +58,10 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
             .abort_and_mark_blocked(database_id, "cluster is under recovering");
     }
 
-    fn mark_ready(&self, database_id: Option<DatabaseId>) {
-        self.scheduled_barriers.mark_ready(database_id);
-        if database_id.is_none() {
+    fn mark_ready(&self, options: MarkReadyOptions) {
+        let is_global = matches!(&options, MarkReadyOptions::Global { .. });
+        self.scheduled_barriers.mark_ready(options);
+        if is_global {
             self.set_status(BarrierManagerStatus::Running);
         }
     }
@@ -68,8 +70,10 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
         command.post_collect(self).await
     }
 
-    async fn notify_creating_job_failed(&self, err: &MetaError) {
-        self.metadata_manager.notify_finish_failed(err).await
+    async fn notify_creating_job_failed(&self, database_id: Option<DatabaseId>, err: String) {
+        self.metadata_manager
+            .notify_finish_failed(database_id, err)
+            .await
     }
 
     async fn finish_creating_job(&self, job: TrackingJob) -> MetaResult<()> {

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -25,9 +25,10 @@ use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
 
+use crate::MetaResult;
 use crate::barrier::command::CommandContext;
 use crate::barrier::progress::TrackingJob;
-use crate::barrier::schedule::ScheduledBarriers;
+use crate::barrier::schedule::{MarkReadyOptions, ScheduledBarriers};
 use crate::barrier::{
     BarrierManagerStatus, BarrierWorkerRuntimeInfoSnapshot, DatabaseRuntimeInfoSnapshot,
     RecoveryReason, Scheduled,
@@ -35,7 +36,6 @@ use crate::barrier::{
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::stream::{ScaleControllerRef, SourceManagerRef};
-use crate::{MetaError, MetaResult};
 
 pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
     fn commit_epoch(
@@ -49,14 +49,14 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
         database_id: Option<DatabaseId>,
         recovery_reason: RecoveryReason,
     );
-    fn mark_ready(&self, database_id: Option<DatabaseId>);
+    fn mark_ready(&self, options: MarkReadyOptions);
 
     fn post_collect_command<'a>(
         &'a self,
         command: &'a CommandContext,
     ) -> impl Future<Output = MetaResult<()>> + Send + 'a;
 
-    async fn notify_creating_job_failed(&self, err: &MetaError);
+    async fn notify_creating_job_failed(&self, database_id: Option<DatabaseId>, err: String);
 
     fn finish_creating_job(
         &self,

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -391,6 +391,13 @@ impl InflightDatabaseInfo {
         InflightFragmentInfo::contains_worker(self.fragment_infos(), worker_id)
     }
 
+    pub(crate) fn workers(&self) -> HashSet<WorkerId> {
+        self.fragment_infos()
+            .flat_map(|info| info.actors.values())
+            .cloned()
+            .collect()
+    }
+
     pub fn existing_table_ids(&self) -> impl Iterator<Item = TableId> + '_ {
         InflightFragmentInfo::existing_table_ids(self.fragment_infos())
     }

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use fail::fail_point;
 use futures::StreamExt;
-use futures::future::try_join_all;
+use futures::future::join_all;
 use itertools::Itertools;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::util::epoch::Epoch;
@@ -104,6 +104,47 @@ impl ControlStreamManager {
         }
     }
 
+    pub(super) fn contains_worker(&self, worker_id: WorkerId) -> bool {
+        self.nodes.contains_key(&worker_id)
+    }
+
+    pub(super) async fn try_add_worker(
+        &mut self,
+        node: WorkerNode,
+        inflight_infos: impl Iterator<
+            Item = (DatabaseId, &InflightSubscriptionInfo, &InflightDatabaseInfo),
+        >,
+        context: &impl GlobalBarrierWorkerContext,
+    ) {
+        let node_id = node.id as WorkerId;
+        if self.nodes.contains_key(&node_id) {
+            warn!(id = node.id, host = ?node.host, "node already exists");
+            return;
+        }
+        let node_host = node.host.clone().unwrap();
+
+        let init_request = self.collect_init_request(inflight_infos);
+        match context.new_control_stream(&node, &init_request).await {
+            Ok(handle) => {
+                assert!(
+                    self.nodes
+                        .insert(
+                            node_id,
+                            ControlStreamNode {
+                                worker: node.clone(),
+                                handle,
+                            }
+                        )
+                        .is_none()
+                );
+                info!(?node_host, "add control stream worker");
+            }
+            Err(e) => {
+                error!(err = %e.as_report(), ?node_host, "fail to create worker node");
+            }
+        }
+    }
+
     pub(super) async fn add_worker(
         &mut self,
         node: WorkerNode,
@@ -156,26 +197,44 @@ impl ControlStreamManager {
         &mut self,
         nodes: &HashMap<WorkerId, WorkerNode>,
         context: &impl GlobalBarrierWorkerContext,
-    ) -> MetaResult<()> {
+    ) -> HashSet<WorkerId> {
         let init_request = PbInitRequest { databases: vec![] };
         let init_request = &init_request;
-        let nodes = try_join_all(nodes.iter().map(|(worker_id, node)| async move {
-            let handle = context.new_control_stream(node, init_request).await?;
-            Result::<_, MetaError>::Ok((
-                *worker_id,
-                ControlStreamNode {
-                    worker: node.clone(),
-                    handle,
-                },
-            ))
+        let nodes = join_all(nodes.iter().map(|(worker_id, node)| async move {
+            let result = context.new_control_stream(node, init_request).await;
+            (*worker_id, node.clone(), result)
         }))
-        .await?;
+        .await;
         self.nodes.clear();
-        for (worker_id, node) in nodes {
-            assert!(self.nodes.insert(worker_id, node).is_none());
+        let mut failed_workers = HashSet::new();
+        for (worker_id, node, result) in nodes {
+            match result {
+                Ok(handle) => {
+                    assert!(
+                        self.nodes
+                            .insert(
+                                worker_id,
+                                ControlStreamNode {
+                                    worker: node,
+                                    handle
+                                }
+                            )
+                            .is_none()
+                    );
+                }
+                Err(e) => {
+                    failed_workers.insert(worker_id);
+                    warn!(
+                        e = %e.as_report(),
+                        worker_id,
+                        ?node,
+                        "failed to connect to node"
+                    )
+                }
+            }
         }
 
-        Ok(())
+        failed_workers
     }
 
     /// Clear all nodes and response streams in the manager.

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::mem::replace;
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,7 +38,7 @@ use crate::barrier::checkpoint::{CheckpointControl, CheckpointControlEvent};
 use crate::barrier::complete_task::{BarrierCompleteOutput, CompletingTask};
 use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
 use crate::barrier::rpc::{ControlStreamManager, merge_node_rpc_errors};
-use crate::barrier::schedule::PeriodicBarriers;
+use crate::barrier::schedule::{MarkReadyOptions, PeriodicBarriers};
 use crate::barrier::{
     BarrierManagerRequest, BarrierManagerStatus, BarrierWorkerRuntimeInfoSnapshot, RecoveryReason,
     schedule,
@@ -220,7 +220,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
 
             let paused = self.take_pause_on_bootstrap().await.unwrap_or(false);
 
-            self.recovery(paused, None, RecoveryReason::Bootstrap)
+            self.recovery(paused, RecoveryReason::Bootstrap)
                 .instrument(span)
                 .await;
         }
@@ -326,18 +326,28 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     })
                                 }));
                                 Self::report_collect_failure(&self.env, &error);
+                                self.context.notify_creating_job_failed(Some(database_id), format!("{}", error.as_report())).await;
                                 if let Some(runtime_info) = self.context.reload_database_runtime_info(database_id).await? {
                                     runtime_info.validate(database_id, &self.active_streaming_nodes).inspect_err(|e| {
                                         warn!(database_id = database_id.database_id, err = ?e.as_report(), ?runtime_info, "reloaded database runtime info failed to validate");
                                     })?;
+                                    let workers = runtime_info.database_fragment_info.workers();
+                                    for worker_id in workers {
+                                        if !self.control_stream_manager.contains_worker(worker_id) {
+                                            let node = self.active_streaming_nodes.current()[&worker_id].clone();
+                                            self.control_stream_manager.try_add_worker(node, entering_initializing.inflight_infos(), &*self.context).await;
+                                        }
+                                    }
                                     entering_initializing.enter(runtime_info, &mut self.control_stream_manager);
                                 } else {
                                     info!(database_id = database_id.database_id, "database removed after reloading empty runtime info");
+                                    // mark ready to unblock subsequent request
+                                    self.context.mark_ready(MarkReadyOptions::Database(database_id));
                                     entering_initializing.remove();
                                 }
                             }
                             CheckpointControlEvent::EnteringRunning(entering_running) => {
-                                self.context.mark_ready(Some(entering_running.database_id()));
+                                self.context.mark_ready(MarkReadyOptions::Database(entering_running.database_id()));
                                 entering_running.enter();
                             }
                         }
@@ -419,11 +429,14 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 info!("waiting for completing command to finish in recovery");
                 match join_handle.await {
                     Err(e) => {
-                        warn!(err = ?e.as_report(), "failed to join completing task");
+                        warn!(err = %e.as_report(), "failed to join completing task");
                         true
                     }
                     Ok(Err(e)) => {
-                        warn!(err = ?e.as_report(), "failed to complete barrier during clear");
+                        warn!(
+                            err = %e.as_report(),
+                            "failed to complete barrier during clear"
+                        );
                         true
                     }
                     Ok(Ok(hummock_version_stats)) => {
@@ -455,7 +468,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     }
                     Err(e) => {
                         error!(
-                            err = ?e.as_report(),
+                            err = %e.as_report(),
                             "failed to complete barrier during recovery"
                         );
                         break;
@@ -487,13 +500,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 None,
             );
 
-            let reason = RecoveryReason::Failover(err.clone());
+            let reason = RecoveryReason::Failover(err);
 
             // No need to clean dirty tables for barrier recovery,
             // The foreground stream job should cleanup their own tables.
-            self.recovery(false, Some(err), reason)
-                .instrument(span)
-                .await;
+            self.recovery(false, reason).instrument(span).await;
         } else {
             panic!(
                 "a streaming error occurred while recovery is disabled, aborting: {:?}",
@@ -522,7 +533,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
 
         // No need to clean dirty tables for barrier recovery,
         // The foreground stream job should cleanup their own tables.
-        self.recovery(false, Some(err), RecoveryReason::Adhoc)
+        self.recovery(false, RecoveryReason::Adhoc)
             .instrument(span)
             .await;
     }
@@ -591,21 +602,27 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
     /// the cluster or `risectl` command. Used for debugging purpose.
     ///
     /// Returns the new state of the barrier manager after recovery.
-    pub async fn recovery(
-        &mut self,
-        is_paused: bool,
-        err: Option<MetaError>,
-        recovery_reason: RecoveryReason,
-    ) {
-        self.context.abort_and_mark_blocked(None, recovery_reason);
+    pub async fn recovery(&mut self, is_paused: bool, recovery_reason: RecoveryReason) {
         // Clear all control streams to release resources (connections to compute nodes) first.
         self.control_stream_manager.clear();
 
-        self.recovery_inner(is_paused, err).await;
-        self.context.mark_ready(None);
+        let reason_str = match &recovery_reason {
+            RecoveryReason::Bootstrap => "bootstrap".to_owned(),
+            RecoveryReason::Failover(err) => {
+                format!("failed over: {}", err.as_report())
+            }
+            RecoveryReason::Adhoc => "adhoc recovery".to_owned(),
+        };
+
+        self.context.abort_and_mark_blocked(None, recovery_reason);
+
+        self.recovery_inner(is_paused, reason_str).await;
+        self.context.mark_ready(MarkReadyOptions::Global {
+            blocked_databases: self.checkpoint_control.recovering_databases().collect(),
+        });
     }
 
-    async fn recovery_inner(&mut self, is_paused: bool, err: Option<MetaError>) {
+    async fn recovery_inner(&mut self, is_paused: bool, recovery_reason: String) {
         tracing::info!("recovery start!");
         let retry_strategy = get_retry_strategy();
 
@@ -614,9 +631,13 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
         let recovery_timer = GLOBAL_META_METRICS.recovery_latency.start_timer();
 
         let new_state = tokio_retry::Retry::spawn(retry_strategy, || async {
-            if let Some(err) = &err {
-                self.context.notify_creating_job_failed(err).await;
-            };
+            // We need to notify_creating_job_failed in every recovery retry, because in outer create_streaming_job handler,
+            // it holds the reschedule_read_lock and wait for creating job to finish, and caused the following scale_actor fail
+            // to acquire the reschedule_write_lock, and then keep recovering, and then deadlock.
+            // TODO: refactor and fix this hacky implementation.
+            self.context
+                .notify_creating_job_failed(None, recovery_reason.clone())
+                .await;
             let runtime_info_snapshot = self
                 .context
                 .reload_runtime_info()
@@ -639,21 +660,24 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
 
             let mut control_stream_manager = ControlStreamManager::new(self.env.clone());
             let reset_start_time = Instant::now();
-            control_stream_manager
+            let unconnected_worker = control_stream_manager
                 .reset(
                     active_streaming_nodes.current(),
                     &*self.context,
                 )
-                .await
-                .inspect_err(|err| {
-                    warn!(error = %err.as_report(), "reset compute nodes failed");
-                })?;
-            info!(elapsed=?reset_start_time.elapsed(), "control stream reset");
+                .await;
+            info!(elapsed=?reset_start_time.elapsed(), ?unconnected_worker, "control stream reset");
 
             let recovery_result: MetaResult<_> = try {
                 let mut collected_databases = HashMap::new();
                 let mut collecting_databases = HashMap::new();
+                let mut unconnected_databases = HashSet::new();
                 for (database_id, info) in database_fragment_infos {
+                    if !info.workers().is_disjoint(&unconnected_worker) {
+                        unconnected_databases.insert(database_id);
+                        continue;
+                    }
+
                     control_stream_manager.add_partial_graph(database_id, None)?;
                     let (node_to_collect, database, prev_epoch) = control_stream_manager.inject_database_initial_barrier(
                         database_id,
@@ -715,6 +739,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     control_stream_manager,
                     CheckpointControl::new(
                         collected_databases,
+                        unconnected_databases,
                         hummock_version_stats,
                     ),
                 )

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -168,8 +168,9 @@ pub struct CatalogControllerInner {
     ///
     /// `DdlController` will update this map, and pass the `tx` side to `CatalogController`.
     /// On notifying, we can remove the entry from this map.
+    #[expect(clippy::type_complexity)]
     pub creating_table_finish_notifier:
-        HashMap<ObjectId, Vec<Sender<MetaResult<NotificationVersion>>>>,
+        HashMap<DatabaseId, HashMap<ObjectId, Vec<Sender<Result<NotificationVersion, String>>>>>,
 }
 
 impl CatalogController {
@@ -907,10 +908,13 @@ impl CatalogControllerInner {
 
     pub(crate) fn register_finish_notifier(
         &mut self,
-        id: i32,
-        sender: Sender<MetaResult<NotificationVersion>>,
+        database_id: DatabaseId,
+        id: ObjectId,
+        sender: Sender<Result<NotificationVersion, String>>,
     ) {
         self.creating_table_finish_notifier
+            .entry(database_id)
+            .or_default()
             .entry(id)
             .or_default()
             .push(sender);
@@ -932,12 +936,22 @@ impl CatalogControllerInner {
             })
     }
 
-    pub(crate) fn notify_finish_failed(&mut self, err: &MetaError) {
-        for tx in take(&mut self.creating_table_finish_notifier)
-            .into_values()
-            .flatten()
-        {
-            let _ = tx.send(Err(err.clone()));
+    pub(crate) fn notify_finish_failed(&mut self, database_id: Option<DatabaseId>, err: String) {
+        if let Some(database_id) = database_id {
+            if let Some(creating_tables) = self.creating_table_finish_notifier.remove(&database_id)
+            {
+                for tx in creating_tables.into_values().flatten() {
+                    let _ = tx.send(Err(err.clone()));
+                }
+            }
+        } else {
+            for tx in take(&mut self.creating_table_finish_notifier)
+                .into_values()
+                .flatten()
+                .flat_map(|(_, txs)| txs.into_iter())
+            {
+                let _ = tx.send(Err(err.clone()));
+            }
         }
     }
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -50,6 +50,7 @@ use sea_orm::{
     IntoSimpleExpr, JoinType, ModelTrait, NotSet, PaginatorTrait, QueryFilter, QuerySelect,
     RelationTrait, TransactionTrait,
 };
+use thiserror_ext::AsReport;
 
 use crate::barrier::{ReplaceStreamJobPlan, Reschedule};
 use crate::controller::ObjectModel;
@@ -620,21 +621,21 @@ impl CatalogController {
             Object::delete_by_id(source_id).exec(&txn).await?;
         }
 
+        let err = if is_cancelled {
+            MetaError::cancelled(format!("streaming job {job_id} is cancelled"))
+        } else {
+            MetaError::catalog_id_not_found("stream job", format!("streaming job {job_id} failed"))
+        };
+        let abort_reason = format!("streaing job aborted {}", err.as_report());
         for tx in inner
             .creating_table_finish_notifier
-            .remove(&job_id)
+            .get_mut(&database_id)
+            .map(|creating_tables| creating_tables.remove(&job_id).into_iter())
             .into_iter()
             .flatten()
+            .flatten()
         {
-            let err = if is_cancelled {
-                MetaError::cancelled(format!("streaming job {job_id} is cancelled"))
-            } else {
-                MetaError::catalog_id_not_found(
-                    "stream job",
-                    format!("streaming job {job_id} failed"),
-                )
-            };
-            let _ = tx.send(Err(err));
+            let _ = tx.send(Err(abort_reason.clone()));
         }
         txn.commit().await?;
 
@@ -1028,11 +1029,16 @@ impl CatalogController {
                 )
                 .await;
         }
-        if let Some(txs) = inner.creating_table_finish_notifier.remove(&job_id) {
-            for tx in txs {
-                let _ = tx.send(Ok(version));
-            }
-        }
+        inner
+            .creating_table_finish_notifier
+            .values_mut()
+            .for_each(|creating_tables| {
+                if let Some(txs) = creating_tables.remove(&job_id) {
+                    for tx in txs {
+                        let _ = tx.send(Ok(version));
+                    }
+                }
+            });
 
         Ok(())
     }

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -31,6 +31,7 @@ use tokio::sync::oneshot;
 use tokio::time::{Instant, sleep};
 use tracing::warn;
 
+use crate::MetaResult;
 use crate::barrier::Reschedule;
 use crate::controller::catalog::CatalogControllerRef;
 use crate::controller::cluster::{ClusterControllerRef, StreamingClusterInfo, WorkerExtraInfo};
@@ -41,7 +42,6 @@ use crate::model::{
 };
 use crate::stream::{JobReschedulePostUpdates, SplitAssignment};
 use crate::telemetry::MetaTelemetryJobDesc;
-use crate::{MetaError, MetaResult};
 
 #[derive(Clone)]
 pub struct MetadataManager {
@@ -786,6 +786,7 @@ impl MetadataManager {
     /// The progress is updated per barrier.
     pub(crate) async fn wait_streaming_job_finished(
         &self,
+        database_id: DatabaseId,
         id: ObjectId,
     ) -> MetaResult<NotificationVersion> {
         tracing::debug!("wait_streaming_job_finished: {id:?}");
@@ -795,13 +796,16 @@ impl MetadataManager {
         }
         let (tx, rx) = oneshot::channel();
 
-        mgr.register_finish_notifier(id, tx);
+        mgr.register_finish_notifier(database_id.database_id as _, id, tx);
         drop(mgr);
-        rx.await.map_err(|e| anyhow!(e))?
+        rx.await
+            .map_err(|_| "no received reason".to_owned())
+            .and_then(|result| result)
+            .map_err(|reason| anyhow!("failed to wait streaming job finish: {}", reason).into())
     }
 
-    pub(crate) async fn notify_finish_failed(&self, err: &MetaError) {
+    pub(crate) async fn notify_finish_failed(&self, database_id: Option<DatabaseId>, err: String) {
         let mut mgr = self.catalog_controller.get_inner_write_guard().await;
-        mgr.notify_finish_failed(err);
+        mgr.notify_finish_failed(database_id.map(|id| id.database_id as _), err);
     }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -279,6 +279,7 @@ impl GlobalStreamManager {
                 let version = stream_manager
                     .metadata_manager
                     .wait_streaming_job_finished(
+                        streaming_job.database_id().into(),
                         streaming_job.id() as _,
                     )
                     .await?;

--- a/src/tests/simulation/tests/integration_tests/backfill_tests.rs
+++ b/src/tests/simulation/tests/integration_tests/backfill_tests.rs
@@ -326,7 +326,7 @@ async fn test_recovery_cancels_foreground_ddl() -> Result<()> {
     match handle.await? {
         Ok(_) => panic!("create m1 should fail"),
         Err(e) => {
-            assert!(e.to_string().contains("adhoc recovery triggered"));
+            assert!(e.to_string().contains("adhoc recovery"));
         }
     }
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix some bugs about database isolation found in tests of https://github.com/risingwavelabs/risingwave/pull/20734

1. during global recovery, when we failed to connect to some workers, we will fail the global recovery, even though some databases does not need to connect to these failed workers. In this PR, when this happens, we will let the global recovery succeed, and let the databases running on unconnected workers initialized at resetting state, and the other initialized at running state. To support this, we change to pass a `MarkReadyOptions` to the `mark_ready` of schedule queue. It can be either `MarkReadyOptions::Database` to mark a single database as ready after the database is recovered, or `MarkReadyOptions::Global { blocked_databases }` to mark the whole cluster as ready but the `blocked_databases` will still be blocked.
2. when database report failure, we don't notify failure on the creating job in catalog, and the handler won't be aware of the failure until global recovery. In this PR, we change to support notify creating job failure on a single database. The creating job finish notifier will be maintained in per database manner.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
