### PR TITLE
fix(pg_type): `record` shall be included

### DIFF
--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_types.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_types.rs
@@ -55,10 +55,12 @@ macro_rules! impl_pg_type_data {
             // with PostgreSQL.
             (25, "text", "textin",0,1009),
             (1301, "rw_int256", "rw_int256_in",0,0),
+            (2249, "record", "record_in",0,2287),
             // Note: Here is only to avoid some components of psql from not being able to find relevant results, causing errors. We will not use it in the RW.
             $(
             ($oid_array, concat!("_", stringify!($name)), "array_in", $oid, 0),
             )*
+            (2287, "_record", "array_in",2249,0),
         ]
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

On DBeaver <24.3.0,
```
  select row();
  select array[(1,2)]::struct<a integer, b integer>[] as measurements;
```
returns the following error:
```
  Cannot invoke "String.hashCode()" because "typeName" is null
```

It was due to empty result from the the following query:
```
  SELECT n.nspname = SOME(current_schemas(true)), n.nspname, t.typname FROM pg_catalog.pg_type AS t JOIN pg_catalog.pg_namespace AS n ON t.typnamespace = n.oid WHERE t.oid = $1; -- $1 is 2248 or 2287
```

Note that DBeaver >=24.3.0 includes a workaround but we should still include `record` in `pg_type`.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
