### PR TITLE
feat(snapshot-backfill): impose back-pressure to upstream by epoch lag size

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -52,7 +52,7 @@ message BarrierCompleteResponse {
     uint64 consumed_epoch = 3;
     // MV backfill snapshot read rows / Source backfilled rows
     uint64 consumed_rows = 4;
-    uint32 pending_barrier_num = 5;
+    uint64 pending_epoch_lag = 5;
   }
   string request_id = 1;
   common.Status status = 2;

--- a/src/meta/src/barrier/checkpoint/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/status.rs
@@ -15,6 +15,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::mem::take;
+use std::time::Duration;
 
 use risingwave_common::hash::ActorId;
 use risingwave_common::util::epoch::Epoch;
@@ -31,32 +32,33 @@ use crate::model::StreamJobActorsToCreate;
 
 #[derive(Debug)]
 pub(super) struct CreateMviewLogStoreProgressTracker {
-    /// `actor_id` -> `pending_barrier_count`
-    ongoing_actors: HashMap<ActorId, usize>,
+    /// `actor_id` -> `pending_epoch_lag`
+    ongoing_actors: HashMap<ActorId, u64>,
     finished_actors: HashSet<ActorId>,
 }
 
 impl CreateMviewLogStoreProgressTracker {
-    fn new(actors: impl Iterator<Item = ActorId>, initial_pending_count: usize) -> Self {
+    fn new(actors: impl Iterator<Item = ActorId>, pending_barrier_lag: u64) -> Self {
         Self {
-            ongoing_actors: HashMap::from_iter(actors.map(|actor| (actor, initial_pending_count))),
+            ongoing_actors: HashMap::from_iter(actors.map(|actor| (actor, pending_barrier_lag))),
             finished_actors: HashSet::new(),
         }
     }
 
     pub(super) fn gen_ddl_progress(&self) -> String {
-        let sum = self.ongoing_actors.values().sum::<usize>() as f64;
+        let sum = self.ongoing_actors.values().sum::<u64>() as f64;
         let count = if self.ongoing_actors.is_empty() {
             1
         } else {
             self.ongoing_actors.len()
         } as f64;
         let avg = sum / count;
+        let avg_lag_time = Duration::from_millis(Epoch(avg as _).physical_time());
         format!(
-            "finished: {}/{}, avg epoch count {}",
+            "actor: {}/{}, avg epoch lag {:?}",
             self.finished_actors.len(),
             self.ongoing_actors.len() + self.finished_actors.len(),
-            avg
+            avg_lag_time
         )
     }
 
@@ -71,7 +73,7 @@ impl CreateMviewLogStoreProgressTracker {
                             "non-duplicate"
                         );
                     } else {
-                        *entry.get_mut() = progress.pending_barrier_num as _;
+                        *entry.get_mut() = progress.pending_epoch_lag as _;
                     }
                 }
                 Entry::Vacant(_) => {
@@ -182,7 +184,14 @@ impl CreatingStreamingJobStatus {
                     *self = CreatingStreamingJobStatus::ConsumingLogStore {
                         log_store_progress_tracker: CreateMviewLogStoreProgressTracker::new(
                             snapshot_backfill_actors.iter().cloned(),
-                            barriers_to_inject.len(),
+                            barriers_to_inject
+                                .last()
+                                .map(|info| {
+                                    info.barrier_info
+                                        .prev_epoch()
+                                        .saturating_sub(*backfill_epoch)
+                                })
+                                .unwrap_or(0),
                         ),
                     };
                     Some(barriers_to_inject)

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -179,7 +179,7 @@ pub(super) struct BarrierCompleteOutput {
 impl CompletingTask {
     pub(super) fn next_completed_barrier<'a>(
         &'a mut self,
-        scheduled_barriers: &mut PeriodicBarriers,
+        periodic_barriers: &mut PeriodicBarriers,
         checkpoint_control: &mut CheckpointControl,
         control_stream_manager: &mut ControlStreamManager,
         context: &Arc<impl GlobalBarrierWorkerContext>,
@@ -189,7 +189,7 @@ impl CompletingTask {
         // it has been collected.
         if let CompletingTask::None = self {
             if let Some(task) = checkpoint_control
-                .next_complete_barrier_task(Some((scheduled_barriers, control_stream_manager)))
+                .next_complete_barrier_task(Some((periodic_barriers, control_stream_manager)))
             {
                 {
                     let epochs_to_ack = task.epochs_to_ack();

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -364,7 +364,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     let result: MetaResult<()> = try {
                         match resp {
                             Response::CompleteBarrier(resp) => {
-                                self.checkpoint_control.barrier_collected(resp, &mut self.control_stream_manager)?;
+                                self.checkpoint_control.barrier_collected(resp, &mut self.control_stream_manager, &mut self.periodic_barriers)?;
                             },
                             Response::ReportDatabaseFailure(resp) => {
                                 if !self.enable_recovery {

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use futures::future::{Either, try_join_all};
-use futures::{Stream, TryFutureExt, TryStreamExt, pin_mut};
+use futures::{FutureExt, Stream, TryFutureExt, TryStreamExt, pin_mut};
 use risingwave_common::array::StreamChunk;
 use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::metrics::LabelGuardedIntCounter;
@@ -173,6 +173,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                     UpstreamBuffer::new(&mut self.upstream, consume_upstream_row_count);
 
                 let first_barrier_epoch = first_upstream_barrier.epoch;
+                let snapshot_epoch = first_barrier_epoch.prev;
 
                 // Phase 1: consume upstream snapshot
                 {
@@ -216,15 +217,15 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                     post_commit.post_yield_barrier(None).await?;
                 }
 
-                let mut upstream_buffer = upstream_buffer.start_consuming_log_store();
+                let mut upstream_buffer = upstream_buffer.start_consuming_log_store(snapshot_epoch);
 
                 let mut barrier_epoch = first_barrier_epoch;
 
-                let initial_pending_barrier = upstream_buffer.barrier_count();
+                let initial_pending_lag = upstream_buffer.pending_epoch_lag();
                 info!(
                     ?barrier_epoch,
                     table_id = self.upstream_table.table_id().table_id,
-                    initial_pending_barrier,
+                    initial_pending_lag,
                     "start consuming log store"
                 );
 
@@ -279,7 +280,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
 
                         self.progress.update_create_mview_log_store_progress(
                             barrier.epoch,
-                            upstream_buffer.barrier_count(),
+                            upstream_buffer.pending_epoch_lag(),
                         );
 
                         stream
@@ -411,7 +412,8 @@ struct ConsumingLogStore;
 
 struct UpstreamBuffer<'a, S> {
     upstream: &'a mut MergeExecutorInput,
-    max_pending_checkpoint_barrier_num: usize,
+    max_pending_epoch_lag: u64,
+    consumed_epoch: u64,
     pending_non_checkpoint_barriers: Vec<DispatcherBarrier>,
     /// Barriers received from upstream but not yet received the barrier from local barrier worker.
     ///
@@ -440,33 +442,40 @@ impl<'a> UpstreamBuffer<'a, ConsumingSnapshot> {
             pending_non_checkpoint_barriers: vec![],
             upstream_pending_barriers: Default::default(),
             // no limit on the number of pending barrier in the beginning
-            max_pending_checkpoint_barrier_num: usize::MAX,
+            max_pending_epoch_lag: u64::MAX,
+            consumed_epoch: 0,
             _phase: ConsumingSnapshot {},
         }
     }
 
-    fn start_consuming_log_store(self) -> UpstreamBuffer<'a, ConsumingLogStore> {
-        let max_pending_barrier_num = self.barrier_count();
+    fn start_consuming_log_store(
+        self,
+        snapshot_epoch: u64,
+    ) -> UpstreamBuffer<'a, ConsumingLogStore> {
+        let max_pending_epoch_lag = self.pending_epoch_lag();
         UpstreamBuffer {
             upstream: self.upstream,
             pending_non_checkpoint_barriers: self.pending_non_checkpoint_barriers,
             upstream_pending_barriers: self.upstream_pending_barriers,
-            max_pending_checkpoint_barrier_num: max_pending_barrier_num,
+            max_pending_epoch_lag,
             is_polling_epoch_data: self.is_polling_epoch_data,
             consume_upstream_row_count: self.consume_upstream_row_count,
+            consumed_epoch: snapshot_epoch,
             _phase: ConsumingLogStore {},
         }
     }
 }
 
 impl<'a, S> UpstreamBuffer<'a, S> {
+    fn can_consume_upstream(&self) -> bool {
+        self.is_polling_epoch_data || self.pending_epoch_lag() < self.max_pending_epoch_lag
+    }
+
     async fn concurrently_consume_upstream(&mut self) -> StreamExecutorError {
         {
             loop {
                 if let Err(e) = try {
-                    if self.upstream_pending_barriers.len()
-                        >= self.max_pending_checkpoint_barrier_num
-                    {
+                    if !self.can_consume_upstream() {
                         // pause the future to block consuming upstream
                         return pending().await;
                     }
@@ -520,14 +529,29 @@ impl<'a> UpstreamBuffer<'a, ConsumingLogStore> {
     ) -> StreamExecutorResult<Option<Vec<DispatcherBarrier>>> {
         Ok(
             if let Some(barriers) = self.upstream_pending_barriers.pop_back() {
-                // sub(1) to ensure that the lag is monotonically decreasing.
-                self.max_pending_checkpoint_barrier_num = min(
-                    self.upstream_pending_barriers.len(),
-                    self.max_pending_checkpoint_barrier_num.saturating_sub(1),
+                let epoch = barriers.last().expect("non-empty").epoch.prev;
+                assert!(self.consumed_epoch < epoch);
+                let elapsed_epoch = epoch - self.consumed_epoch;
+                self.consumed_epoch = epoch;
+                if !self.upstream_pending_barriers.is_empty() {
+                    // try consuming ready upstreams when we haven't yielded all pending barriers yet.
+                    while self.can_consume_upstream()
+                        && let Some(barriers) =
+                            self.consume_until_next_checkpoint_barrier().now_or_never()
+                    {
+                        self.upstream_pending_barriers.push_front(barriers?);
+                    }
+                }
+                // sub to ensure that the lag is monotonically decreasing.
+                // here we subtract half the elapsed epoch, so that approximately when downstream progresses two epochs,
+                // the upstream can at least progress for one epoch.
+                self.max_pending_epoch_lag = min(
+                    self.pending_epoch_lag(),
+                    self.max_pending_epoch_lag.saturating_sub(elapsed_epoch / 2),
                 );
                 Some(barriers)
             } else {
-                self.max_pending_checkpoint_barrier_num = 0;
+                self.max_pending_epoch_lag = 0;
                 if self.is_polling_epoch_data {
                     let barriers = self.consume_until_next_checkpoint_barrier().await?;
                     Some(barriers)
@@ -558,8 +582,18 @@ impl<'a, S> UpstreamBuffer<'a, S> {
         }
     }
 
-    fn barrier_count(&self) -> usize {
-        self.upstream_pending_barriers.len()
+    fn pending_epoch_lag(&self) -> u64 {
+        self.upstream_pending_barriers
+            .front()
+            .map(|barriers| {
+                barriers
+                    .last()
+                    .expect("non-empty")
+                    .epoch
+                    .prev
+                    .saturating_sub(self.consumed_epoch)
+            })
+            .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously in snapshot backfill, we impose back-pressure to upstream by limiting the number of pending upstream barriers. However, when we support recoverable snapshot backfill, we won't restore all previously pending upstream barriers, and then we won't be able to get the exact number of pending upstream epochs. Therefore, in this PR, we will change to limit the lag between the latest upstream epoch and the consuming epoch. When the lag exceeds a monotonically decreasing lag upper bound, we won't poll upstream to impose back-pressure to upstream.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
