### PR TITLE
refactor(storage): better backtrace display in warn log for `wait_for_update`

### DIFF
--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -635,11 +635,11 @@ pub(crate) async fn wait_for_update(
     loop {
         match tokio::time::timeout(Duration::from_secs(30), receiver.changed()).await {
             Err(_) => {
-                let backtrace = if cfg!(debug_assertions) {
-                    format!("{:?}", Backtrace::capture())
-                } else {
-                    "backtrace log not enabled in non-debug mode".into()
-                };
+                // Provide backtrace iff in debug mode for observability.
+                let backtrace = cfg!(debug_assertions)
+                    .then(Backtrace::capture)
+                    .map(tracing::field::display);
+
                 // The reason that we need to retry here is batch scan in
                 // chain/rearrange_chain is waiting for an
                 // uncommitted epoch carried by the CreateMV barrier, which


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The previous logging is really hard to read:

```
2025-03-10T09:11:13.610591123Z  WARN risingwave_storage::hummock::utils: timeout when waiting for version update info="wait_for_epoch: epoch: 8150230122037248, table_id: 78" elapsed=31.224454231s backtrace="Backtrace [{ fn: \"{async_fn#0}<risingwave_storage::hummock::utils::wait_for_epoch::{async_fn#0}::{closure_env#0}, risingwave_storage::hummock::utils::wait_for_epoch::{async_fn#0}::{closure_env#1}>\", file: \"./src/storage/src/hummock/utils.rs\", line: 639 }, { fn: \"{async_fn#0}\", file: \"./src/storage/src/hummock/utils.rs\", line: 621 }, { fn: \"{async_fn#0}\", file: \"./src/storage/src/hummock/store/local_hummock_storage.rs\", line: 488 }, { fn: \"{async_fn#0}<risingwave_storage::hummock::store::local_hummock_storage::LocalHummockStorage, risingwave_storage::memory::RangeKvLocalStateStore<risingwave_storage::memory::sled::SledRangeKv>>\", file: \"./src/storage/src/store_impl.rs\", line: 549 }, { fn: \"{async_block#0}<risingwave_storage::store_impl::verify::VerifyStateStore<risingwave_storage::hummock::store::local_hummock_storage::LocalHummockStorage, risingwave_storage::memory::RangeKvLocalStateStore<risingwave_storage::memory::sled::SledRangeKv>, ()>>\", file: \"./src/storage/src/store_impl.rs\", line: 1124 }, { fn: \"poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<(), risingwave_storage::error::StorageError>> + core::marker::Send), alloc::alloc::Global>>\", file: \"/rustc/52fd9983996d9fcfb719749838336be66dee68f9/library/core/src/future/future.rs\", line: 123 }, { fn: \"{async_fn#0}<risingwave_storage::store_impl::dyn_state_store::StateStorePointer<alloc::boxed::Box<dyn risingwave_storage::store_impl::dyn_state_store::DynLocalStateStore, alloc::alloc::Global>>>\", file: \"./src/storage/src/monitor/monitored_store.rs\", line: 277 }, { fn: \"{async_fn#0}<risingwave_storage::monitor::monitored_store::MonitoredStateStore<risingwave_storage::store_impl::dyn_state_store::StateStorePointer<alloc::sync::Arc<dyn risingwave_storage::store_impl::dyn_state_store::DynStateStore, alloc::alloc::Global>>>, risingwave_common::util::value_encoding::BasicSerde, false, false>\", file: \"./src/stream/src/common/table/state_table.rs\", line: 188 }, { fn: \"{coroutine#0}<risingwave_storage::monitor::monitored_store::MonitoredStateStore<risingwave_storage::store_impl::dyn_state_store::StateStorePointer<alloc::sync::Arc<dyn risingwave_storage::store_impl::dyn_state_store::DynStateStore, alloc::alloc::Global>>>, risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde>\", file: \"./src/stream/src/executor/backfill/arrangement_backfill.rs\", line: 148 }, { fn: \"poll_next<risingwave_stream::executor::backfill::arrangement_backfill::{impl#0}::execute_inner::{coroutine_env#0}<risingwave_storage::monitor::monitored_store::MonitoredStateStore<risingwave_storage::store_impl::dyn_state_store::StateStorePointer<alloc::sync::Arc<dyn risingwave_storage::store_impl::dyn_state_store::DynStateStore, alloc::alloc::Global>>>, risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde>, risingwave_stream::executor::MessageInner<core::option::Option<alloc::sync::Arc<risingwave_stream::executor::Mutation, alloc::alloc::Global>>>, risingwave_stream::executor::error::StreamExecutorError>\", file: \"./.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-async-stream-0.2.11/src/lib.rs\", line: 492 }, { fn: \"poll_next<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item=core::result::Result<risingwave_stream::executor::MessageInner<core::option::Option<alloc::sync::Arc<risingwave_stream::executor::Mutation, alloc::alloc::Global>>>, risingwave_stream::executor::error::StreamExecutorError>> + core::marker::Send), alloc::alloc::Global>>\", file: \"./.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.31/src/stream.rs\", line: 130 }, { fn: \"poll_next<&mut core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item=core::result::Result<risingwave_stream::executor::MessageInner<core::option::Option<alloc::sync::Arc<risingwave_stream::executor::Mutation, alloc::alloc::Global>>>, risingwave_stream::executor::error::StreamExecutorError>> + core::marker::Send), alloc::alloc::Global>>>\", file: \"./.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.31/src/stream.rs\", line: 130 }, { fn: \"futures_util::stream::stream::StreamExt::poll_next_unpin\", file: \"./.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.31/src/stream/stream/mod.rs\", line: 1638 }, { fn: \"<futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll\", file: \"./.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.31/src/stream/stream/next.rs\", line: 32 }, { fn: \"poll<futures_util::stream::stream::next::Next<core::pin::Pin<&mut core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item=core::result::Result<risingwave_stream::executor::MessageInner<core::option::Option<alloc::sync::Arc<risingwave_stream::executor::Mutation, alloc::alloc::Global>>>, risingwave_stream::executor::error::StreamExecutorError>> + core::marker::Send), alloc::alloc::Global>>>>, false>\", file: \"./.cargo/registry/src/index.crates.io-6f17d22bba15001f/await-tree-0.2.1/src/future.rs\", line: 119 }, { fn: \"{coroutine#0}<core::pin::Pin<alloc::boxed::Box<(dyn ...
```

- Use `Display` impl for human-readable backtrace.
- Omit the field with `Option` in release build.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
