### PR TITLE
refactor(compaction): optimize level_insert_ssts

### DIFF
--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -1356,14 +1356,27 @@ fn level_insert_ssts(operand: &mut Level, insert_table_infos: &Vec<SstableInfo>)
         .iter()
         .map(|sst| sst.uncompressed_file_size)
         .sum::<u64>();
-    operand
-        .table_infos
-        .extend(insert_table_infos.iter().cloned());
-    operand
-        .table_infos
-        .sort_by(|sst1, sst2| sst1.key_range.cmp(&sst2.key_range));
     if operand.level_type == PbLevelType::Overlapping {
         operand.level_type = PbLevelType::Nonoverlapping;
+        operand
+            .table_infos
+            .extend(insert_table_infos.iter().cloned());
+        operand
+            .table_infos
+            .sort_by(|sst1, sst2| sst1.key_range.cmp(&sst2.key_range));
+    } else {
+        if let Some(i) = insert_table_infos.first() {
+            let pos = operand
+                .table_infos
+                .partition_point(|b| b.key_range.cmp(&i.key_range) == Ordering::Less);
+            operand.table_infos.splice(
+                pos..pos,
+                insert_table_infos
+                    .iter()
+                    .sorted_by(|sst1, sst2| sst1.key_range.cmp(&sst2.key_range))
+                    .cloned(),
+            );
+        }
     }
     assert!(
         can_concat(&operand.table_infos),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

part of #20640

This PR addresses the CPU overhead introduced by the sort in `level_insert_ssts`. 

The CPU overhead can be substantial during intensive compaction, often due to numerous trivial move tasks. [This integration test](https://buildkite.com/risingwave-test/compaction-test/builds/285) using append-only write workload illustrates the issue. The flamegraph shows 35% of CPU is utilized by the `sort of SstableInfo`.
![meta-flamegraph-2025-03-11T04-28-49Z](https://github.com/user-attachments/assets/d91a5548-df75-46d5-9ece-feb702119fa9)

The solution is simply to replace the original sort with an insertion sort. We were concerned whether the additional element movement overhead of insertion sort might outweigh its benefits. Fortunately both the [microbench](https://github.com/risingwavelabs/risingwave/tree/wangzheng/bench) and [integretion test](https://buildkite.com/risingwave-test/compaction-test/builds/287) has shown that the insertion sort is significantly faster in this case. 
- The microbench shows the insertion sort is 10 times faster than original sort.
- The flamegraph indicates that the CPU overhead from sorting has been eliminated.

![meta-flamegraph-2025-03-11T06-05-16Z](https://github.com/user-attachments/assets/757c81b9-6d49-48bc-9b78-c386a8c63b00)


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
