### PR TITLE
fix(sqlparser): enforce `Display` of `create table | source` to be valid SQL

### DIFF
--- a/src/sqlparser/src/ast/legacy_source.rs
+++ b/src/sqlparser/src/ast/legacy_source.rs
@@ -427,14 +427,14 @@ impl ParseTo for CsvInfo {
 
 impl fmt::Display for CsvInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut v: Vec<String> = vec![];
         if !self.has_header {
-            v.push(format!(
-                "{}",
-                display_separated(&[Keyword::WITHOUT, Keyword::HEADER], " ")
-            ));
+            write!(f, "WITHOUT HEADER ")?;
         }
-        impl_fmt_display!(delimiter, v, self);
-        v.iter().join(" ").fmt(f)
+        write!(
+            f,
+            "DELIMITED BY {}",
+            AstString((self.delimiter as char).to_string())
+        )?;
+        Ok(())
     }
 }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1651,7 +1651,13 @@ impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut buf = String::new();
         self.fmt_inner(&mut buf)?;
-        let _ = Parser::parse_sql(&buf).expect("normalized SQL should be parsable");
+        // TODO(#20713): expand this check to all statements
+        if matches!(
+            self,
+            Statement::CreateTable { .. } | Statement::CreateSource { .. }
+        ) {
+            let _ = Parser::parse_sql(&buf).expect("normalized SQL should be parsable");
+        }
         f.write_str(&buf)
     }
 }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -2884,7 +2884,7 @@ impl fmt::Display for SqlOption {
             })
             .unwrap_or(false);
         if should_redact {
-            write!(f, "{} = [REDACTED]", self.name)
+            write!(f, "{} = '[REDACTED]'", self.name)
         } else {
             write!(f, "{} = {}", self.name, self.value)
         }

--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -25,6 +25,14 @@
     sql parser error: expected description of the format, found: EOF
     LINE 1: CREATE SOURCE src
                              ^
+- input: |-
+    create table s0 (v1 int, v2 varchar) with (
+      connector = 'kafka',
+      topic = 'kafka_1_csv_topic',
+      properties.bootstrap.server = 'message_queue:29092',
+      scan.startup.mode = 'earliest'
+    ) row format csv DELIMITED BY ',';
+  formatted_sql: CREATE TABLE s0 (v1 INT, v2 CHARACTER VARYING) WITH (connector = 'kafka', topic = 'kafka_1_csv_topic', properties.bootstrap.server = 'message_queue:29092', scan.startup.mode = 'earliest') ROW FORMAT CSV DELIMITED BY ','
 - input: CREATE SOURCE src-a FORMAT PLAIN ENCODE JSON
   error_msg: |-
     sql parser error: expected description of the format, found: -

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -1404,7 +1404,7 @@ mod tests {
         ";
         assert_eq!(
             redact_sql(sql, keywords),
-            "CREATE SOURCE temp (k BIGINT, v CHARACTER VARYING) WITH (connector = 'datagen', v1 = 123, v2 = [REDACTED], v3 = false, v4 = [REDACTED]) FORMAT PLAIN ENCODE JSON (a = '1', b = [REDACTED])"
+            "CREATE SOURCE temp (k BIGINT, v CHARACTER VARYING) WITH (connector = 'datagen', v1 = 123, v2 = '[REDACTED]', v3 = false, v4 = '[REDACTED]') FORMAT PLAIN ENCODE JSON (a = '1', b = '[REDACTED]')"
         );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

See #20713 for how many times we were incautious on this. This PR adds an additional check for `create table | source` before the invalid SQL is persisted in meta catalog (and fixes spotted existing issues).

If the invalid SQL was persisted in meta catalog, the corresponding `table | source` would not be able to `alter`:
```
ERROR:  Failed to run the query

Caused by these errors (recent errors listed first):
  1: unable to parse definition sql
  2: sql parser error: syntax error (...details...)
```

With this check, developers working on new syntax extension would face the following immediately:
```
ERROR:  Panicked when handling the request: normalized SQL should be parsable: ParserError(...details...)
This is a bug. We would appreciate a bug report at:
  https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Fbug&template=bug_report.yml
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
psql (17.2, server 13.14.0)
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
