### PR TITLE
chore: remove false positive blocking consume_log from await-tree output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10796,6 +10796,7 @@ dependencies = [
  "prometheus",
  "prost 0.13.4",
  "rand 0.8.5",
+ "regex",
  "risingwave_batch",
  "risingwave_batch_executors",
  "risingwave_common",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -23,6 +23,7 @@ maplit = "1.0.2"
 pprof = { version = "0.14", features = ["flamegraph"] }
 prometheus = { version = "0.13" }
 prost = { workspace = true }
+regex = "1"
 risingwave_batch = { workspace = true }
 risingwave_batch_executors = { workspace = true }
 risingwave_common = { workspace = true }

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -275,7 +275,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             rate_limit_rx,
                             rebuild_sink_rx,
                         )
-                        .instrument_await(format!("consume_log (sink_id {sink_id})"))
+                        .verbose_instrument_await(format!("consume_log (sink_id {sink_id})"))
                         .map_ok(|never| never); // unify return type to `Message`
 
                         consume_log_stream.boxed()

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -275,7 +275,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             rate_limit_rx,
                             rebuild_sink_rx,
                         )
-                        .verbose_instrument_await(format!("consume_log (sink_id {sink_id})"))
+                        .instrument_await(format!("consume_log (sink_id {sink_id})"))
                         .map_ok(|never| never); // unify return type to `Message`
 
                         consume_log_stream.boxed()

--- a/src/utils/workspace-config/Cargo.toml
+++ b/src/utils/workspace-config/Cargo.toml
@@ -31,9 +31,18 @@ rw-dynamic-link = ["dynamic-zstd-sys"]
 fips = ["aws-lc-rs"]
 
 [dependencies]
+
+# FIPS
+aws-lc-rs ={ version = "1.6", optional = true, default-features = false, features = [
+    "fips",
+] }
+
+# Dynamic linking
+dynamic-zstd-sys = { package = "zstd-sys", version = "2", optional = true, default-features = false, features = [
+    "pkg-config",
+] }
 # Disable verbose logs for release builds
 log = { version = "0.4", features = ["release_max_level_debug"] }
-tracing = { version = "0.1", features = ["release_max_level_debug"] }
 
 # Static linking
 static-libz-sys = { package = "libz-sys", version = "1", optional = true, features = [
@@ -45,18 +54,9 @@ static-lzma-sys = { package = "lzma-sys", version = "0.1", optional = true, feat
 static-sasl2-sys = { package = "sasl2-sys", version = "0.1", optional = true, features = [
     "gssapi-vendored",
 ] }
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
 vendored-openssl-sys = { package = "openssl-sys", version = "0.9.96", optional = true, features = [
     "vendored",
-] }
-
-# Dynamic linking
-dynamic-zstd-sys = { package = "zstd-sys", version = "2", optional = true, default-features = false, features = [
-    "pkg-config",
-] }
-
-# FIPS
-aws-lc-rs ={ version = "1.6", optional = true, default-features = false, features = [
-    "fips",
 ] }
 # workspace-hack = { path = "../../workspace-hack" }
 # Don't add workspace-hack into this crate!


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Seems that we will still enable verbose instrument await in release mode, so using verbose_instrument_await does not help. Changed to use `regex` to remove the false positive `!!!`.

Previously was 
```
[Actor 9]
Actor 9: `CREATE SINK s FROM t WITH (connector = 'blackhole')` [10.429s]
  Epoch 8172558712635392 [422.406ms]
    Sink 900000001 [423.052ms]
      consume_log (sink_id 7) [!!! 10.426s]
        log_reader_next_item [423.059ms]
      StreamScan 90000272A [423.059ms]
        Merge 900000000 [422.591ms]
```

now is
```
[Actor 10]
Actor 10: `CREATE SINK s FROM t WITH (connector = 'blackhole')` [21.220s]
  Epoch 8172482145157120 [214.927ms]
    Sink A00000001 [214.940ms]
      consume_log (sink_id 7) [21.217s]
        log_reader_next_item [214.940ms]
      StreamScan A0000272A [214.947ms]
        Merge A00000000 [214.949ms]
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
