### PR TITLE
fix(meta): isolate database logical error in global recovery

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -427,13 +427,12 @@ impl CheckpointControl {
         &self,
     ) -> impl Iterator<Item = (DatabaseId, &InflightSubscriptionInfo, &InflightDatabaseInfo)> + '_
     {
-        // TODO: should consider the inflight infos of creating snapshot backfill jobs
         self.databases.iter().flat_map(|(database_id, database)| {
-            database.database_state().map(|database_state| {
+            database.checkpoint_control().map(|database| {
                 (
                     *database_id,
-                    &database_state.inflight_subscription_info,
-                    &database_state.inflight_graph_info,
+                    &database.state.inflight_subscription_info,
+                    &database.state.inflight_graph_info,
                 )
             })
         })
@@ -521,10 +520,10 @@ impl DatabaseCheckpointControlStatus {
         }
     }
 
-    fn database_state(&self) -> Option<&BarrierWorkerState> {
+    fn checkpoint_control(&self) -> Option<&DatabaseCheckpointControl> {
         match self {
-            DatabaseCheckpointControlStatus::Running(control) => Some(&control.state),
-            DatabaseCheckpointControlStatus::Recovering(state) => state.database_state(),
+            DatabaseCheckpointControlStatus::Running(control) => Some(control),
+            DatabaseCheckpointControlStatus::Recovering(state) => state.checkpoint_control(),
         }
     }
 

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -61,9 +61,10 @@ pub(crate) struct CheckpointControl {
 }
 
 impl CheckpointControl {
-    pub(crate) fn new(
+    pub(crate) fn recover(
         databases: impl IntoIterator<Item = (DatabaseId, DatabaseCheckpointControl)>,
-        unconnected_databases: HashSet<DatabaseId>,
+        failed_databases: HashSet<DatabaseId>,
+        control_stream_manager: &mut ControlStreamManager,
         hummock_version_stats: HummockVersionStats,
     ) -> Self {
         Self {
@@ -75,11 +76,11 @@ impl CheckpointControl {
                         DatabaseCheckpointControlStatus::Running(control),
                     )
                 })
-                .chain(unconnected_databases.into_iter().map(|database_id| {
+                .chain(failed_databases.into_iter().map(|database_id| {
                     (
                         database_id,
                         DatabaseCheckpointControlStatus::Recovering(
-                            DatabaseRecoveringState::resetting(database_id),
+                            DatabaseRecoveringState::resetting(database_id, control_stream_manager),
                         ),
                     )
                 }))

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -427,12 +427,13 @@ impl CheckpointControl {
         &self,
     ) -> impl Iterator<Item = (DatabaseId, &InflightSubscriptionInfo, &InflightDatabaseInfo)> + '_
     {
+        // TODO: should consider the inflight infos of creating snapshot backfill jobs
         self.databases.iter().flat_map(|(database_id, database)| {
-            database.checkpoint_control().map(|database| {
+            database.database_state().map(|database_state| {
                 (
                     *database_id,
-                    &database.state.inflight_subscription_info,
-                    &database.state.inflight_graph_info,
+                    &database_state.inflight_subscription_info,
+                    &database_state.inflight_graph_info,
                 )
             })
         })
@@ -520,10 +521,10 @@ impl DatabaseCheckpointControlStatus {
         }
     }
 
-    fn checkpoint_control(&self) -> Option<&DatabaseCheckpointControl> {
+    fn database_state(&self) -> Option<&BarrierWorkerState> {
         match self {
-            DatabaseCheckpointControlStatus::Running(control) => Some(control),
-            DatabaseCheckpointControlStatus::Recovering(state) => state.checkpoint_control(),
+            DatabaseCheckpointControlStatus::Running(control) => Some(&control.state),
+            DatabaseCheckpointControlStatus::Recovering(state) => state.database_state(),
         }
     }
 

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -28,6 +28,7 @@ use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use risingwave_pb::stream_service::streaming_control_stream_response::ResetDatabaseResponse;
+use thiserror_ext::AsReport;
 use tracing::{debug, warn};
 
 use crate::barrier::checkpoint::creating_job::{CompleteJobType, CreatingStreamingJobControl};
@@ -161,11 +162,12 @@ impl CheckpointControl {
         })
     }
 
+    /// return Some(failed `database_id` -> `err`)
     pub(crate) fn handle_new_barrier(
         &mut self,
         new_barrier: NewBarrier,
         control_stream_manager: &mut ControlStreamManager,
-    ) -> MetaResult<()> {
+    ) -> Option<HashMap<DatabaseId, MetaError>> {
         let NewBarrier {
             command,
             span,
@@ -207,7 +209,7 @@ impl CheckpointControl {
                             notifier.notify_start_failed(err.clone());
                         }
 
-                        return Ok(());
+                        return None;
                     }
                 }
             }
@@ -237,7 +239,7 @@ impl CheckpointControl {
                         } else {
                             new_database.state.in_flight_prev_epoch().clone()
                         };
-                        control_stream_manager.add_partial_graph(database_id, None)?;
+                        control_stream_manager.add_partial_graph(database_id, None);
                         (
                             entry
                                 .insert(DatabaseCheckpointControlStatus::Running(new_database))
@@ -251,7 +253,7 @@ impl CheckpointControl {
                             notifier.notify_collected();
                         }
                         warn!(?command, "skip command for empty database");
-                        return Ok(());
+                        return None;
                     }
                     _ => {
                         panic!(
@@ -264,14 +266,21 @@ impl CheckpointControl {
 
             let curr_epoch = max_prev_epoch.next();
 
-            database.handle_new_barrier(
+            let mut failed_databases: Option<HashMap<_, _>> = None;
+
+            if let Err(e) = database.handle_new_barrier(
                 Some((command, notifiers)),
                 checkpoint,
                 span.clone(),
                 control_stream_manager,
                 &self.hummock_version_stats,
                 curr_epoch.clone(),
-            )?;
+            ) {
+                failed_databases
+                    .get_or_insert_default()
+                    .try_insert(database_id, e)
+                    .expect("non-duplicate");
+            }
             for database in self.databases.values_mut() {
                 let Some(database) = database.running_state_mut() else {
                     continue;
@@ -279,35 +288,50 @@ impl CheckpointControl {
                 if database.database_id == database_id {
                     continue;
                 }
-                database.handle_new_barrier(
+                if let Err(e) = database.handle_new_barrier(
                     None,
                     checkpoint,
                     span.clone(),
                     control_stream_manager,
                     &self.hummock_version_stats,
                     curr_epoch.clone(),
-                )?;
+                ) {
+                    failed_databases
+                        .get_or_insert_default()
+                        .try_insert(database.database_id, e)
+                        .expect("non-duplicate");
+                }
             }
+            failed_databases
         } else {
+            #[expect(clippy::question_mark)]
             let Some(max_prev_epoch) = self.max_prev_epoch() else {
-                return Ok(());
+                return None;
             };
             let curr_epoch = max_prev_epoch.next();
+
+            let mut failed_databases: Option<HashMap<_, _>> = None;
             for database in self.databases.values_mut() {
                 let Some(database) = database.running_state_mut() else {
                     continue;
                 };
-                database.handle_new_barrier(
+                if let Err(e) = database.handle_new_barrier(
                     None,
                     checkpoint,
                     span.clone(),
                     control_stream_manager,
                     &self.hummock_version_stats,
                     curr_epoch.clone(),
-                )?;
+                ) {
+                    failed_databases
+                        .get_or_insert_default()
+                        .try_insert(database.database_id, e)
+                        .expect("non-duplicate");
+                }
             }
+
+            failed_databases
         }
-        Ok(())
     }
 
     pub(crate) fn update_barrier_nums_metrics(&self) {
@@ -1078,11 +1102,17 @@ impl DatabaseCheckpointControl {
                         );
                     }
                     for fragment in info.stream_job_fragments.inner.fragments.values_mut() {
-                        fill_snapshot_backfill_epoch(
+                        if let Err(e) = fill_snapshot_backfill_epoch(
                             &mut fragment.nodes,
                             Some(snapshot_backfill_info),
                             cross_db_snapshot_backfill_info,
-                        )?;
+                        ) {
+                            warn!(e = %e.as_report(), "failed to fill snapshot backfill epoch");
+                            for notifier in notifiers {
+                                notifier.notify_start_failed(e.clone());
+                            }
+                            return Ok(());
+                        };
                     }
                     let info = info.clone();
                     let job_id = info.stream_job_fragments.stream_job_id();
@@ -1093,7 +1123,7 @@ impl DatabaseCheckpointControl {
                         .to_mutation(false)
                         .expect("should have some mutation in `CreateStreamingJob` command");
 
-                    control_stream_manager.add_partial_graph(self.database_id, Some(job_id))?;
+                    control_stream_manager.add_partial_graph(self.database_id, Some(job_id));
                     self.creating_streaming_job_controls.insert(
                         job_id,
                         CreatingStreamingJobControl::new(

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -14,7 +14,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::fmt::{Debug, Formatter};
 use std::future::poll_fn;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -44,8 +43,8 @@ use risingwave_pb::stream_service::streaming_control_stream_request::{
     RemovePartialGraphRequest, ResetDatabaseRequest,
 };
 use risingwave_pb::stream_service::{
-    BarrierCompleteResponse, InjectBarrierRequest, StreamingControlStreamRequest,
-    streaming_control_stream_request, streaming_control_stream_response,
+    InjectBarrierRequest, StreamingControlStreamRequest, streaming_control_stream_request,
+    streaming_control_stream_response,
 };
 use risingwave_rpc_client::StreamingControlHandle;
 use thiserror_ext::AsReport;
@@ -59,7 +58,7 @@ use crate::barrier::checkpoint::{BarrierWorkerState, DatabaseCheckpointControl};
 use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
 use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo};
 use crate::barrier::progress::CreateMviewProgressTracker;
-use crate::barrier::utils::{NodeToCollect, is_valid_after_worker_err};
+use crate::barrier::utils::NodeToCollect;
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::manager::MetaSrvEnv;
 use crate::model::{
@@ -358,59 +357,13 @@ impl ControlStreamManager {
     }
 }
 
-pub(super) struct DatabaseInitialBarrierCollector {
-    database_id: DatabaseId,
-    node_to_collect: NodeToCollect,
-    database_state: BarrierWorkerState,
-    create_mview_tracker: CreateMviewProgressTracker,
-    committed_epoch: u64,
-}
-
-impl Debug for DatabaseInitialBarrierCollector {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DatabaseInitialBarrierCollector")
-            .field("database_id", &self.database_id)
-            .field("node_to_collect", &self.node_to_collect)
-            .finish()
-    }
-}
-
-impl DatabaseInitialBarrierCollector {
-    pub(super) fn is_collected(&self) -> bool {
-        self.node_to_collect.is_empty()
-    }
-
-    pub(super) fn database_state(&self) -> &BarrierWorkerState {
-        &self.database_state
-    }
-
-    pub(super) fn collect_resp(&mut self, resp: BarrierCompleteResponse) {
-        assert_eq!(self.database_id.database_id, resp.database_id);
-        assert_eq!(resp.epoch, self.committed_epoch);
-        assert!(
-            self.node_to_collect
-                .remove(&(resp.worker_id as _))
-                .is_some()
-        );
-    }
-
-    pub(super) fn finish(self) -> DatabaseCheckpointControl {
-        assert!(self.is_collected());
-        DatabaseCheckpointControl::recovery(
-            self.database_id,
-            self.create_mview_tracker,
-            self.database_state,
-            self.committed_epoch,
-        )
-    }
-
-    pub(super) fn is_valid_after_worker_err(&mut self, worker_id: WorkerId) -> bool {
-        is_valid_after_worker_err(&mut self.node_to_collect, worker_id)
-    }
-}
-
 impl ControlStreamManager {
     /// Extract information from the loaded runtime barrier worker snapshot info, and inject the initial barrier.
+    ///
+    /// Return:
+    ///  - the worker nodes that need to wait for initial barrier collection
+    ///  - the extracted database information
+    ///  - the `prev_epoch` of the initial barrier
     pub(super) fn inject_database_initial_barrier(
         &mut self,
         database_id: DatabaseId,
@@ -422,8 +375,7 @@ impl ControlStreamManager {
         subscription_info: InflightSubscriptionInfo,
         is_paused: bool,
         hummock_version_stats: &HummockVersionStats,
-    ) -> MetaResult<DatabaseInitialBarrierCollector> {
-        self.add_partial_graph(database_id, None);
+    ) -> MetaResult<(NodeToCollect, DatabaseCheckpointControl, u64)> {
         let source_split_assignments = info
             .fragment_infos()
             .flat_map(|info| info.actors.keys())
@@ -529,17 +481,18 @@ impl ControlStreamManager {
             "inject initial barrier"
         );
 
-        let committed_epoch = barrier_info.prev_epoch();
         let new_epoch = barrier_info.curr_epoch;
-        let database_state =
-            BarrierWorkerState::recovery(new_epoch, info, subscription_info, is_paused);
-        Ok(DatabaseInitialBarrierCollector {
-            database_id,
+        let state = BarrierWorkerState::recovery(new_epoch, info, subscription_info, is_paused);
+        Ok((
             node_to_collect,
-            database_state,
-            create_mview_tracker: tracker,
-            committed_epoch,
-        })
+            DatabaseCheckpointControl::recovery(
+                database_id,
+                tracker,
+                state,
+                barrier_info.prev_epoch.value().0,
+            ),
+            barrier_info.prev_epoch.value().0,
+        ))
     }
 
     pub(super) fn inject_command_ctx_barrier(

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -449,7 +449,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                 for (database_id, err) in failed_databases {
                                     if let Some(entering_recovery) = self.checkpoint_control.on_report_failure(database_id, &mut self.control_stream_manager) {
                                         warn!(%database_id, e = %err.as_report(),"database entering recovery on inject failure");
-                                        self.context.abort_and_mark_blocked(Some(database_id), RecoveryReason::Failover(anyhow!("inject barrier failure: {}", err.as_report()).into()));
+                                        self.context.abort_and_mark_blocked(Some(database_id), RecoveryReason::Failover(anyhow!(err).context("inject barrier failure").into()));
                                         // TODO: add log on blocking time
                                         let output = self.completing_task.wait_completing_task().await?;
                                         entering_recovery.enter(output, &mut self.control_stream_manager);

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -758,6 +758,9 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     if collecting_databases.remove(&database_id).is_some() {
                                         warn!(%database_id, worker_id, "database reset during global recovery");
                                         assert!(failed_databases.insert(database_id));
+                                    } else if collected_databases.remove(&database_id).is_some() {
+                                        warn!(%database_id, worker_id, "database initialized but later reset during global recovery");
+                                        assert!(failed_databases.insert(database_id));
                                     } else {
                                         assert!(failed_databases.contains(&database_id));
                                     }

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::mem::replace;
 use std::sync::Arc;
@@ -647,7 +646,8 @@ mod retry_strategy {
 
 pub(crate) use retry_strategy::*;
 use risingwave_common::error::tonic::extra::{Score, ScoredError};
-use risingwave_meta_model::WorkerId;
+
+use crate::barrier::utils::is_valid_after_worker_err;
 
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
     /// Recovery the whole cluster from the latest epoch.
@@ -744,9 +744,9 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         is_paused,
                         &hummock_version_stats,
                     );
-                    let initial_barrier_collector = match result {
-                        Ok(initial_barrier_collector) => {
-                            initial_barrier_collector
+                    let (node_to_collect, database, prev_epoch) = match result {
+                        Ok(info) => {
+                            info
                         }
                         Err(e) => {
                             warn!(%database_id, e = %e.as_report(), "failed to inject database initial barrier");
@@ -754,11 +754,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             continue;
                         }
                     };
-                    if !initial_barrier_collector.is_collected() {
-                        assert!(collecting_databases.insert(database_id, initial_barrier_collector).is_none());
+                    if !node_to_collect.is_empty() {
+                        assert!(collecting_databases.insert(database_id, (node_to_collect, database, prev_epoch)).is_none());
                     } else {
                         warn!(database_id = database_id.database_id, "database has no node to inject initial barrier");
-                        assert!(collected_databases.insert(database_id, initial_barrier_collector.finish()).is_none());
+                        assert!(collected_databases.insert(database_id, database).is_none());
                     }
                 }
                 while !collecting_databases.is_empty() {
@@ -767,8 +767,8 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     let resp = match result {
                         Err(e) => {
                             warn!(worker_id, err = %e.as_report(), "worker node failure during recovery");
-                            for (failed_database_id,_ ) in collecting_databases.extract_if(|_, node_to_collect| {
-                                !node_to_collect.is_valid_after_worker_err(worker_id)
+                            for (failed_database_id,_ ) in collecting_databases.extract_if(|_, (node_to_collect, _, _)| {
+                                !is_valid_after_worker_err(node_to_collect, worker_id)
                             }) {
                                 warn!(%failed_database_id, worker_id, "database failed to recovery in global recovery due to worker node err");
                                 assert!(failed_databases.insert(failed_database_id));
@@ -799,16 +799,13 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             }
                         }
                     };
-                    assert_eq!(worker_id, resp.worker_id as WorkerId);
                     let database_id = DatabaseId::new(resp.database_id);
-                    let Entry::Occupied(mut entry) = collecting_databases.entry(database_id) else {
-                        unreachable!("should exist")
-                    };
-                    let node_to_collect = entry.get_mut();
-                    node_to_collect.collect_resp(resp);
-                    if node_to_collect.is_collected() {
-                        let node_to_collect = entry.remove();
-                        assert!(collected_databases.insert(database_id, node_to_collect.finish()).is_none());
+                    let (node_to_collect, _, prev_epoch) = collecting_databases.get_mut(&database_id).expect("should exist");
+                    assert_eq!(resp.epoch, *prev_epoch);
+                    assert!(node_to_collect.remove(&worker_id).is_some());
+                    if node_to_collect.is_empty() {
+                        let (_, database, _) = collecting_databases.remove(&database_id).expect("should exist");
+                        assert!(collected_databases.insert(database_id, database).is_none());
                     }
                 }
                 debug!("collected initial barrier");

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -733,6 +733,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 let mut collecting_databases = HashMap::new();
                 let mut failed_databases = HashSet::new();
                 for (database_id, info) in database_fragment_infos {
+                    control_stream_manager.add_partial_graph(database_id, None);
                     let result = control_stream_manager.inject_database_initial_barrier(
                         database_id,
                         info,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

In https://github.com/risingwavelabs/risingwave/pull/20862, in global recovery, we have a special logic to early suspend the databases that have actors to be run on failed worker node. However, if some databases failed to collect the first barrier, we will still fail the global recovery and retry everything, and then some problematic databases may block the global recovery.

In this PR, we will remove the special early suspend logic, and then handle any failure happened when collecting the initial barrier in a general manner, and suspend any failed databases. The failed databases will send reset database request to all existing worker nodes and then enter the resetting phase of database recovery. 

Besides, we also isolate inject barrier failure correctly in this PR. Previously the inject barrier failure of any database will trigger a global recovery.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
