### PR TITLE
feat(stream): limit sync log store flushed item read size + only pause on checkpoint barrier

### DIFF
--- a/e2e_test/streaming/unaligned-join.slt
+++ b/e2e_test/streaming/unaligned-join.slt
@@ -18,7 +18,7 @@ INSERT INTO fact
     1 as v1,
     'abcdefgakjandjkw' as v2,
     'jkb1ku1bu' as v3
-  FROM generate_series(1, 100000) t(x);
+  FROM generate_series(1, 200000) t(x);
 
 # correspond to 2
 statement ok
@@ -28,7 +28,7 @@ INSERT INTO fact
     2 as v1,
     'abcdefgakjandjkw' as v2,
     'jkb1ku1bu' as v3
-  FROM generate_series(100001, 200000) t(x);
+  FROM generate_series(200001, 400000) t(x);
 
 statement ok
 create table dim(v1 int);

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -350,7 +350,7 @@ pub struct SessionConfig {
     /// The timeout for reading from the buffer of the sync log store on barrier.
     /// Every epoch we will attempt to read the full buffer of the sync log store.
     /// If we hit the timeout, we will stop reading and continue.
-    #[parameter(default = 256_usize)]
+    #[parameter(default = 64_usize)]
     streaming_sync_log_store_pause_duration_ms: usize,
 
     /// The max buffer size for sync logstore, before we start flushing.

--- a/src/frontend/planner_test/tests/testdata/output/delta_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/delta_join.yaml
@@ -49,7 +49,7 @@
   stream_plan: |-
     StreamMaterialize { columns: [a1, a2, b1, b2], stream_key: [a1], pk_columns: [a1], pk_conflict: NoCheck }
     └─StreamExchange { dist: HashShard(a.a1) }
-      └─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 256 }
+      └─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 64 }
         └─StreamDeltaJoin { type: Inner, predicate: a.a1 = b.b1, output: all }
           ├─StreamTableScan { table: a, columns: [a.a1, a.a2], stream_scan_type: Backfill, stream_key: [a.a1], pk: [a1], dist: UpstreamHashShard(a.a1) }
           └─StreamTableScan { table: b, columns: [b.b1, b.b2], stream_scan_type: UpstreamOnly, stream_key: [b.b1], pk: [b1], dist: UpstreamHashShard(b.b1) }

--- a/src/frontend/planner_test/tests/testdata/output/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/join.yaml
@@ -40,9 +40,9 @@
         └─LogicalScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id, t3._rw_timestamp] }
   stream_plan: |-
     StreamMaterialize { columns: [v1, v2, v3, v4, v5, v6, t1._row_id(hidden), t2._row_id(hidden), t3._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, v1, t3._row_id], pk_columns: [t1._row_id, t2._row_id, v1, t3._row_id], pk_conflict: NoCheck }
-    └─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 256 }
+    └─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 64 }
       └─StreamHashJoin { type: Inner, predicate: t1.v1 = t3.v5, output: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6, t1._row_id, t2._row_id, t3._row_id] }
-        ├─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 256 }
+        ├─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 64 }
         │ └─StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v3, output: [t1.v1, t1.v2, t2.v3, t2.v4, t1._row_id, t2._row_id] }
         │   ├─StreamExchange { dist: HashShard(t1.v1) }
         │   │ └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }

--- a/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
@@ -678,7 +678,7 @@ impl<S: StateStoreRead> LogStoreReadState<S> {
         let table_id = self.table_id;
         async move {
             tracing::trace!(
-                "reading flushed chunk from buffer: start_seq_id: {start_seq_id}, end_seq_id: {end_seq_id}, chunk_id: {chunk_id}"
+                start_seq_id, end_seq_id, chunk_id, item_epoch, "reading flushed chunk"
             );
             let iters = try_join_all(vnode_bitmap.iter_vnodes().map(|vnode| {
                 let range_start =

--- a/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
@@ -678,7 +678,11 @@ impl<S: StateStoreRead> LogStoreReadState<S> {
         let table_id = self.table_id;
         async move {
             tracing::trace!(
-                start_seq_id, end_seq_id, chunk_id, item_epoch, "reading flushed chunk"
+                start_seq_id,
+                end_seq_id,
+                chunk_id,
+                item_epoch,
+                "reading flushed chunk"
             );
             let iters = try_join_all(vnode_bitmap.iter_vnodes().map(|vnode| {
                 let range_start =
@@ -695,7 +699,7 @@ impl<S: StateStoreRead> LogStoreReadState<S> {
                                 (Included(range_start), Included(range_end)),
                                 ReadOptions {
                                     prefetch_options:
-                                    PrefetchOptions::prefetch_for_large_range_scan(),
+                                        PrefetchOptions::prefetch_for_large_range_scan(),
                                     cache_policy: CachePolicy::Fill(CacheHint::Low),
                                     table_id,
                                     ..Default::default()
@@ -705,8 +709,8 @@ impl<S: StateStoreRead> LogStoreReadState<S> {
                     )
                 }
             }))
-                .instrument_await("Wait Create Iter Stream")
-                .await?;
+            .instrument_await("Wait Create Iter Stream")
+            .await?;
 
             let chunk = serde
                 .deserialize_stream_chunk(
@@ -720,7 +724,8 @@ impl<S: StateStoreRead> LogStoreReadState<S> {
                 .await?;
 
             Ok((chunk_id, chunk, item_epoch))
-        }.instrument_await("Read Flushed Chunk")
+        }
+        .instrument_await("Read Flushed Chunk")
     }
 }
 

--- a/src/stream/src/common/log_store_impl/kv_log_store/state.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/state.rs
@@ -213,6 +213,7 @@ impl<S: LocalStateStore> LogStoreStateWriter<'_, S> {
         start_seq_id: SeqIdType,
         end_seq_id: SeqIdType,
     ) -> LogStoreResult<()> {
+        tracing::trace!(epoch, start_seq_id, end_seq_id, "write_chunk");
         for (i, (op, row)) in chunk.rows().enumerate() {
             let seq_id = start_seq_id + (i as SeqIdType);
             assert!(seq_id <= end_seq_id);

--- a/src/stream/src/common/log_store_impl/kv_log_store/test_utils.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/test_utils.rs
@@ -217,6 +217,18 @@ pub(crate) fn check_stream_chunk_eq(first: &StreamChunk, second: &StreamChunk) -
     check_rows_eq(first.rows(), second.rows())
 }
 
+#[macro_export]
+macro_rules! assert_stream_chunk_eq {
+    ($left:expr, $right:expr) => {
+        assert!(
+            check_stream_chunk_eq(&$left, &$right),
+            "stream chunk not equal: left: {:?}, right: {:?}",
+            $left,
+            $right
+        );
+    };
+}
+
 pub(crate) trait LogWriterTestExt: LogWriter {
     async fn flush_current_epoch_for_test(
         &mut self,

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -403,7 +403,13 @@ impl<S: LocalStateStore> WriteFuture<S> {
         start_seq_id: SeqIdType,
         end_seq_id: SeqIdType,
     ) -> Self {
-        tracing::trace!(start_seq_id, end_seq_id, epoch, cardinality=chunk.cardinality(), "write_future: flushing chunk");
+        tracing::trace!(
+            start_seq_id,
+            end_seq_id,
+            epoch,
+            cardinality = chunk.cardinality(),
+            "write_future: flushing chunk"
+        );
         Self::FlushingChunk {
             epoch,
             start_seq_id,
@@ -662,7 +668,14 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                                         let new_seq_id = seq_id + chunk.cardinality() as SeqIdType;
                                         let end_seq_id = new_seq_id - 1;
                                         let epoch = write_state.epoch().curr;
-                                        tracing::trace!(start_seq_id, end_seq_id, new_seq_id, epoch, cardinality=chunk.cardinality(), "received chunk");
+                                        tracing::trace!(
+                                            start_seq_id,
+                                            end_seq_id,
+                                            new_seq_id,
+                                            epoch,
+                                            cardinality = chunk.cardinality(),
+                                            "received chunk"
+                                        );
                                         if let Some(chunk_to_flush) = buffer.add_or_flush_chunk(
                                             start_seq_id,
                                             end_seq_id,
@@ -806,7 +819,13 @@ impl<S: StateStoreRead> ReadFuture<S> {
                         ..
                     } => {
                         metrics.buffer_read_count.inc_by(chunk.cardinality() as _);
-                        tracing::trace!(start_seq_id, end_seq_id, flushed, cardinality=chunk.cardinality(), "read buffered chunk of size");
+                        tracing::trace!(
+                            start_seq_id,
+                            end_seq_id,
+                            flushed,
+                            cardinality = chunk.cardinality(),
+                            "read buffered chunk of size"
+                        );
                         return Ok((chunk, Some((item_epoch, Some(end_seq_id)))));
                     }
                     LogStoreBufferItem::Flushed {
@@ -951,23 +970,18 @@ impl SyncedLogStoreBuffer {
         let current_size = self.current_size;
         let chunk_size = chunk.cardinality();
 
-        tracing::trace!(current_size, chunk_size, max_size=self.max_size, "checking chunk size");
+        tracing::trace!(
+            current_size,
+            chunk_size,
+            max_size = self.max_size,
+            "checking chunk size"
+        );
         let should_flush_chunk = current_size + chunk_size > self.max_size;
         if should_flush_chunk {
-            tracing::trace!(
-                start_seq_id,
-                end_seq_id,
-                epoch,
-                "flushing chunk",
-            );
+            tracing::trace!(start_seq_id, end_seq_id, epoch, "flushing chunk",);
             Some(chunk)
         } else {
-            tracing::trace!(
-                start_seq_id,
-                end_seq_id,
-                epoch,
-                "buffering chunk",
-            );
+            tracing::trace!(start_seq_id, end_seq_id, epoch, "buffering chunk",);
             self.add_chunk_to_buffer(chunk, start_seq_id, end_seq_id, epoch);
             None
         }
@@ -1120,9 +1134,9 @@ mod tests {
     use risingwave_common::test_prelude::*;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_storage::memory::MemoryStateStore;
-    use crate::assert_stream_chunk_eq;
 
     use super::*;
+    use crate::assert_stream_chunk_eq;
     use crate::common::log_store_impl::kv_log_store::KV_LOG_STORE_V2_INFO;
     use crate::common::log_store_impl::kv_log_store::test_utils::{
         check_stream_chunk_eq, gen_test_log_store_table, test_payload_schema,

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -952,8 +952,7 @@ impl SyncedLogStoreBuffer {
         let chunk_size = chunk.cardinality();
 
         tracing::trace!(current_size, chunk_size, max_size=self.max_size, "checking chunk size");
-        // FIXME: should be > max_size
-        let should_flush_chunk = current_size + chunk_size >= self.max_size;
+        let should_flush_chunk = current_size + chunk_size > self.max_size;
         if should_flush_chunk {
             tracing::trace!(
                 start_seq_id,

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -61,6 +61,7 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
 
         let pause_duration_ms = node.pause_duration_ms as _;
         let buffer_max_size = node.buffer_size as usize;
+        let chunk_size = actor_context.streaming_config.developer.chunk_size as u32;
 
         let executor = SyncedKvLogStoreExecutor::new(
             actor_context,
@@ -69,6 +70,7 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             serde,
             store,
             buffer_max_size,
+            chunk_size,
             upstream,
             Duration::from_millis(pause_duration_ms),
         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

If read size is unbounded, we can end up reading a really large chunk, and lead to barrier latency spike, if it cannot be processed next barrier.

We also only pause on ckpt barrier, because if we pause on chunk buffer full, the state will transition to the read state immediately, and after polling, the chunk buffer will have free space again, and we resume immediately. After that, the state transitions back to the write state, and the whole cycle repeats. In normal circumstances this is fine. But if there's high write pressure, it will backpressure the write side, instead of letting barriers pass.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
