### PR TITLE
feat(sink): fix clickhouse sink datetime64 bug

### DIFF
--- a/ci/scripts/e2e-clickhouse-sink-test.sh
+++ b/ci/scripts/e2e-clickhouse-sink-test.sh
@@ -27,12 +27,12 @@ sink_test_env_setup "$profile"
 echo "--- create clickhouse table"
 curl https://clickhouse.com/ | sh
 sleep 2
-./clickhouse client --host=clickhouse-server --port=9000 --password='default' --query="SET enable_json_type = 1;CREATE table demo_test(v1 Int32,v2 Int64,v3 String,v4 Enum16('A'=1,'B'=2), v5 decimal64(3),v6 json)ENGINE = ReplacingMergeTree PRIMARY KEY (v1);"
+./clickhouse client --host=clickhouse-server --port=9000 --password='default' --query="SET enable_json_type = 1;CREATE table demo_test(v1 Int32,v2 Int64,v3 String,v4 Enum16('A'=1,'B'=2), v5 decimal64(3), v6 Nullable(String), v7 DateTime64(6), v8 json)ENGINE = ReplacingMergeTree PRIMARY KEY (v1);"
 
 echo "--- testing sinks"
 sqllogictest -p 4566 -d dev './e2e_test/sink/clickhouse_sink.slt'
 sleep 5
-./clickhouse client --host=clickhouse-server --port=9000 --password='default' --query="select * from demo_test FORMAT CSV;" > ./query_result.csv
+./clickhouse client --host=clickhouse-server --port=9000 --password='default' --query="select v1,v2,v3,v4,v5,v6,v7,v8 from demo_test FORMAT CSV;" > ./query_result.csv
 
 # check sink destination using shell
 # Check each expected row exists in CSV output (order independent)
@@ -40,13 +40,13 @@ sleep 5
 if awk -F "," '
 BEGIN { c1=0; c2=0; c3=0; c4=0; c5=0; c6=0; c7=0; }
 {
-  if ($1 == 1 && $2 == 50 && $3 == "\"1-50\"" && $4 == "\"A\"" && $5 == 1.1 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c1++;
-  if ($1 == 13 && $2 == 2 && $3 == "\"13-2\"" && $4 == "\"B\"" && $5 == 0 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c2++;
-  if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $4 == "\"B\"" && $5 == 2.2 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c3++;
-  if ($1 == 21 && $2 == 2 && $3 == "\"21-2\"" && $4 == "\"A\"" && $5 == 0 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c4++;
-  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $4 == "\"A\"" && $5 == 3.3 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c5++;
-  if ($1 == 5 && $2 == 2 && $3 == "\"5-2\"" && $4 == "\"B\"" && $5 == 4.4 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c6++;
-  if ($1 == 8 && $2 == 2 && $3 == "\"8-2\"" && $4 == "\"A\"" && $5 == 0 && $6 == "\"{\"\"sd\"\":123" && $7 == "\"\"sda\"\":23}\"") c7++;
+  if ($1 == 1 && $2 == 50 && $3 == "\"1-50\"" && $4 == "\"A\"" && $5 == 1.1 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c1++;
+  if ($1 == 13 && $2 == 2 && $3 == "\"13-2\"" && $4 == "\"B\"" && $5 == 0 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c2++;
+  if ($1 == 2 && $2 == 2 && $3 == "\"2-2\"" && $4 == "\"B\"" && $5 == 2.2 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c3++;
+  if ($1 == 21 && $2 == 2 && $3 == "\"21-2\"" && $4 == "\"A\"" && $5 == 0 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c4++;
+  if ($1 == 3 && $2 == 2 && $3 == "\"3-2\"" && $4 == "\"A\"" && $5 == 3.3 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c5++;
+  if ($1 == 5 && $2 == 2 && $3 == "\"5-2\"" && $4 == "\"B\"" && $5 == 4.4 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c6++;
+  if ($1 == 8 && $2 == 2 && $3 == "\"8-2\"" && $4 == "\"A\"" && $5 == 0 && $6 == "\\N" && $7 == "\"2013-01-01 00:01:01.000000\"" && $8 == "\"{\"\"sd\"\":123" && $9 == "\"\"sda\"\":23}\"") c7++;
 }
 END { exit !(c1 == 1 && c2 == 1 && c3 == 1 && c4 == 1 && c5 == 1 && c6 == 1 && c7 == 1); }
 ' ./query_result.csv; then

--- a/e2e_test/sink/clickhouse_sink.slt
+++ b/e2e_test/sink/clickhouse_sink.slt
@@ -2,13 +2,13 @@ statement ok
 set sink_decouple = false;
 
 statement ok
-CREATE TABLE t6 (v1 int primary key, v2 bigint, v3 varchar, v4 smallint, v5 decimal, v6 jsonb);
+CREATE TABLE t6 (v1 int primary key, v2 bigint, v3 varchar, v4 smallint, v5 decimal, v6 timestamptz, v7 jsonb);
 
 statement ok
 CREATE MATERIALIZED VIEW mv6 AS SELECT * FROM t6;
 
 statement ok
-CREATE SINK s6 AS select mv6.v1 as v1, mv6.v2 as v2, mv6.v3 as v3, mv6.v4 as v4, mv6.v5 as v5,mv6.v6 as v6 from mv6 WITH (
+CREATE SINK s6 AS select mv6.v1 as v1, mv6.v2 as v2, mv6.v3 as v3, mv6.v4 as v4, mv6.v5 as v5, mv6.v6 as v7, mv6.v7 as v8 from mv6 WITH (
     connector = 'clickhouse',
     type = 'append-only',
     force_append_only='true',
@@ -34,7 +34,7 @@ where name = 's6'
 1
 
 statement ok
-INSERT INTO t6 VALUES (1, 50, '1-50', 1, 1.1,'{"sd":123,"sda":23}'), (2, 2, '2-2', 2, 2.2,'{"sd":123,"sda":23}'), (3, 2, '3-2', 1, 3.3,'{"sd":123,"sda":23}'), (5, 2, '5-2', 2, 4.4,'{"sd":123,"sda":23}'), (8, 2, '8-2', 1, 'inf','{"sd":123,"sda":23}'), (13, 2, '13-2', 2, '-inf','{"sd":123,"sda":23}'), (21, 2, '21-2', 1, 'nan','{"sd":123,"sda":23}');
+INSERT INTO t6 VALUES (1, 50, '1-50', 1, 1.1, '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}'), (2, 2, '2-2', 2, 2.2, '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}'), (3, 2, '3-2', 1, 3.3, '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}'), (5, 2, '5-2', 2, 4.4, '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}'), (8, 2, '8-2', 1, 'inf', '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}'), (13, 2, '13-2', 2, '-inf', '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}'), (21, 2, '21-2', 1, 'nan', '2013-01-01 01:01:01+01:00', '{"sd":123,"sda":23}');
 
 statement ok
 FLUSH;

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -22,9 +22,10 @@ use clickhouse::{Client as ClickHouseClient, Row as ClickHouseRow};
 use itertools::Itertools;
 use phf::{Set, phf_set};
 use risingwave_common::array::{Op, StreamChunk};
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{FieldLike, Schema};
 use risingwave_common::row::Row;
 use risingwave_common::types::{DataType, Decimal, ScalarRefImpl, Serial};
+use risingwave_common::util::iter_util::ZipEqDebug;
 use serde::ser::{SerializeSeq, SerializeStruct};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -81,7 +82,6 @@ impl EnforceSecret for ClickHouseCommon {
         "clickhouse.password", "clickhouse.user"
     };
 }
-
 
 #[derive(Debug)]
 enum ClickHouseEngine {
@@ -603,7 +603,6 @@ impl Sink for ClickHouseSink {
 }
 pub struct ClickHouseSinkWriter {
     pub config: ClickHouseConfig,
-    #[expect(dead_code)]
     schema: Schema,
     #[expect(dead_code)]
     pk_indices: Vec<usize>,
@@ -611,7 +610,7 @@ pub struct ClickHouseSinkWriter {
     #[expect(dead_code)]
     is_append_only: bool,
     // Save some features of the clickhouse column type
-    column_correct_vec: Vec<ClickHouseSchemaFeature>,
+    column_correct_map: HashMap<String, ClickHouseSchemaFeature>,
     rw_fields_name_after_calibration: Vec<String>,
     clickhouse_engine: ClickHouseEngine,
     inserter: Option<Insert<ClickHouseColumn>>,
@@ -637,10 +636,11 @@ impl ClickHouseSinkWriter {
         let (clickhouse_column, clickhouse_engine) =
             query_column_engine_from_ck(client.clone(), &config).await?;
 
-        let column_correct_vec: Result<Vec<ClickHouseSchemaFeature>> = clickhouse_column
-            .iter()
-            .map(Self::build_column_correct_vec)
-            .collect();
+        let column_correct_map: Result<HashMap<String, ClickHouseSchemaFeature>> =
+            clickhouse_column
+                .iter()
+                .map(Self::build_column_correct_map)
+                .collect();
         let mut rw_fields_name_after_calibration = build_fields_name_type_from_schema(&schema)?
             .iter()
             .map(|(a, _)| a.clone())
@@ -658,7 +658,7 @@ impl ClickHouseSinkWriter {
             pk_indices,
             client,
             is_append_only,
-            column_correct_vec: column_correct_vec?,
+            column_correct_map: column_correct_map?,
             rw_fields_name_after_calibration,
             clickhouse_engine,
             inserter: None,
@@ -666,8 +666,10 @@ impl ClickHouseSinkWriter {
     }
 
     /// Check if clickhouse's column is 'Nullable', valid bits of `DateTime64`. And save it in
-    /// `column_correct_vec`
-    fn build_column_correct_vec(ck_column: &SystemColumn) -> Result<ClickHouseSchemaFeature> {
+    /// `column_correct_map`
+    fn build_column_correct_map(
+        ck_column: &SystemColumn,
+    ) -> Result<(String, ClickHouseSchemaFeature)> {
         let can_null = ck_column.r#type.contains("Nullable");
         // `DateTime64` without precision is already displayed as `DateTime(3)` in `system.columns`.
         let accuracy_time = if ck_column.r#type.contains("DateTime64(") {
@@ -719,11 +721,14 @@ impl ClickHouseSinkWriter {
         } else {
             (0_u8, 0_u8)
         };
-        Ok(ClickHouseSchemaFeature {
-            can_null,
-            accuracy_time,
-            accuracy_decimal,
-        })
+        Ok((
+            ck_column.name.clone(),
+            ClickHouseSchemaFeature {
+                can_null,
+                accuracy_time,
+                accuracy_decimal,
+            },
+        ))
     }
 
     async fn write(&mut self, chunk: StreamChunk) -> Result<()> {
@@ -735,11 +740,12 @@ impl ClickHouseSinkWriter {
         }
         for (op, row) in chunk.rows() {
             let mut clickhouse_filed_vec = vec![];
-            for (index, data) in row.iter().enumerate() {
+            for (data, field) in row.iter().zip_eq_debug(self.schema.fields()) {
                 clickhouse_filed_vec.extend(ClickHouseFieldWithNull::from_scalar_ref(
                     data,
-                    &self.column_correct_vec,
-                    index,
+                    &self.column_correct_map,
+                    field.name(),
+                    &field.data_type(),
                 )?);
             }
             match op {
@@ -917,13 +923,26 @@ enum ClickHouseFieldWithNull {
 impl ClickHouseFieldWithNull {
     pub fn from_scalar_ref(
         data: Option<ScalarRefImpl<'_>>,
-        clickhouse_schema_feature_vec: &Vec<ClickHouseSchemaFeature>,
-        clickhouse_schema_feature_index: usize,
+        clickhouse_schema_feature_map: &HashMap<String, ClickHouseSchemaFeature>,
+        rw_name: &str,
+        rw_type: &DataType,
     ) -> Result<Vec<ClickHouseFieldWithNull>> {
-        let clickhouse_schema_feature = clickhouse_schema_feature_vec
-            .get(clickhouse_schema_feature_index)
-            .ok_or_else(|| SinkError::ClickHouse(format!("No column found from clickhouse table schema, index is {clickhouse_schema_feature_index}")))?;
-        if data.is_none() {
+        let clickhouse_schema_feature = if !matches!(rw_type, DataType::Struct(_)) {
+            Some(clickhouse_schema_feature_map.get(rw_name).ok_or_else(|| {
+                SinkError::ClickHouse(format!(
+                    "No column found from clickhouse table schema, name is {rw_name}"
+                ))
+            })?)
+        } else {
+            None
+        };
+
+        let Some(data) = data else {
+            let Some(clickhouse_schema_feature) = clickhouse_schema_feature else {
+                return Err(SinkError::ClickHouse(
+                    "clickhouse's nested can not insert null".to_owned(),
+                ));
+            };
             if !clickhouse_schema_feature.can_null {
                 return Err(SinkError::ClickHouse(
                     "Cannot insert null value into non-nullable ClickHouse column".to_owned(),
@@ -931,8 +950,8 @@ impl ClickHouseFieldWithNull {
             } else {
                 return Ok(vec![ClickHouseFieldWithNull::None]);
             }
-        }
-        let data = match data.unwrap() {
+        };
+        let data = match data {
             ScalarRefImpl::Int16(v) => ClickHouseField::Int16(v),
             ScalarRefImpl::Int32(v) => ClickHouseField::Int32(v),
             ScalarRefImpl::Int64(v) => ClickHouseField::Int64(v),
@@ -948,23 +967,23 @@ impl ClickHouseFieldWithNull {
             ScalarRefImpl::Bool(v) => ClickHouseField::Bool(v),
             ScalarRefImpl::Decimal(d) => {
                 let d = if let Decimal::Normalized(d) = d {
-                    let scale =
-                        clickhouse_schema_feature.accuracy_decimal.1 as i32 - d.scale() as i32;
+                    let scale = clickhouse_schema_feature.unwrap().accuracy_decimal.1 as i32
+                        - d.scale() as i32;
                     if scale < 0 {
                         d.mantissa() / 10_i128.pow(scale.unsigned_abs())
                     } else {
                         d.mantissa() * 10_i128.pow(scale as u32)
                     }
-                } else if clickhouse_schema_feature.can_null {
+                } else if clickhouse_schema_feature.unwrap().can_null {
                     warn!("Inf, -Inf, Nan in RW decimal is converted into clickhouse null!");
                     return Ok(vec![ClickHouseFieldWithNull::None]);
                 } else {
                     warn!("Inf, -Inf, Nan in RW decimal is converted into clickhouse 0!");
                     0_i128
                 };
-                if clickhouse_schema_feature.accuracy_decimal.0 <= 9 {
+                if clickhouse_schema_feature.unwrap().accuracy_decimal.0 <= 9 {
                     ClickHouseField::Decimal(ClickHouseDecimal::Decimal32(d as i32))
-                } else if clickhouse_schema_feature.accuracy_decimal.0 <= 18 {
+                } else if clickhouse_schema_feature.unwrap().accuracy_decimal.0 <= 18 {
                     ClickHouseField::Decimal(ClickHouseDecimal::Decimal64(d as i64))
                 } else {
                     ClickHouseField::Decimal(ClickHouseDecimal::Decimal128(d))
@@ -991,13 +1010,16 @@ impl ClickHouseFieldWithNull {
             }
             ScalarRefImpl::Timestamptz(v) => {
                 let micros = v.timestamp_micros();
-                let ticks = match clickhouse_schema_feature.accuracy_time <= 6 {
+                let ticks = match clickhouse_schema_feature.unwrap().accuracy_time <= 6 {
                     true => {
-                        micros / 10_i64.pow((6 - clickhouse_schema_feature.accuracy_time).into())
+                        micros
+                            / 10_i64
+                                .pow((6 - clickhouse_schema_feature.unwrap().accuracy_time).into())
                     }
                     false => micros
                         .checked_mul(
-                            10_i64.pow((clickhouse_schema_feature.accuracy_time - 6).into()),
+                            10_i64
+                                .pow((clickhouse_schema_feature.unwrap().accuracy_time - 6).into()),
                         )
                         .ok_or_else(|| SinkError::ClickHouse("DateTime64 overflow".to_owned()))?,
                 };
@@ -1009,11 +1031,15 @@ impl ClickHouseFieldWithNull {
             }
             ScalarRefImpl::Struct(v) => {
                 let mut struct_vec = vec![];
-                for (index, field) in v.iter_fields_ref().enumerate() {
+                for (field, (struct_field_name, struct_field_type)) in
+                    v.iter_fields_ref().zip_eq_debug(rw_type.as_struct().iter())
+                {
+                    let name = format!("{}.{}", rw_name, struct_field_name);
                     let a = Self::from_scalar_ref(
                         field,
-                        clickhouse_schema_feature_vec,
-                        clickhouse_schema_feature_index + index,
+                        clickhouse_schema_feature_map,
+                        &name,
+                        struct_field_type,
                     )?;
                     struct_vec.push(ClickHouseFieldWithNull::WithoutSome(ClickHouseField::List(
                         a,
@@ -1026,8 +1052,9 @@ impl ClickHouseFieldWithNull {
                 for i in v.iter() {
                     vec.extend(Self::from_scalar_ref(
                         i,
-                        clickhouse_schema_feature_vec,
-                        clickhouse_schema_feature_index,
+                        clickhouse_schema_feature_map,
+                        rw_name,
+                        rw_type,
                     )?)
                 }
                 return Ok(vec![ClickHouseFieldWithNull::WithoutSome(
@@ -1050,7 +1077,9 @@ impl ClickHouseFieldWithNull {
                 ));
             }
         };
-        let data = if clickhouse_schema_feature.can_null {
+        let data = if let Some(clickhouse_schema_feature) = clickhouse_schema_feature
+            && clickhouse_schema_feature.can_null
+        {
             vec![ClickHouseFieldWithNull::WithSome(data)]
         } else {
             vec![ClickHouseFieldWithNull::WithoutSome(data)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR fixes ClickHouse sink handling for `DateTime64` columns after relaxing the earlier one-to-one column correspondence assumption between ClickHouse and RisingWave.

The previous implementation relied on positional matching through a vector, which could pick the wrong ClickHouse column metadata when the schemas were not aligned exactly. This PR changes the lookup to use a column map, so validation and encoding use the metadata for the intended target column.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes ClickHouse sink schema handling for `DateTime64` columns when ClickHouse and RisingWave columns are not in a strict one-to-one positional layout.

</details>
