### PR TITLE
feat: introduce `rw_resource_groups` view 

### DIFF
--- a/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
@@ -62,5 +62,6 @@ mod rw_actor_id_to_ddl;
 mod rw_actor_splits;
 mod rw_fragment_id_to_ddl;
 mod rw_internal_table_info;
+mod rw_resource_groups;
 mod rw_streaming_jobs;
 mod rw_worker_actor_count;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_resource_groups.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_resource_groups.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::Fields;
+use risingwave_frontend_macro::system_catalog;
+
+/// `rw_resource_groups` is a view that shows all resource groups in all databases.
+#[system_catalog(
+    view,
+    "rw_catalog.rw_resource_groups",
+    "WITH all_groups AS (SELECT DISTINCT resource_group
+                    FROM (SELECT resource_group
+                          FROM rw_worker_nodes
+                          WHERE is_streaming
+                          UNION ALL
+                          SELECT resource_group
+                          FROM rw_databases
+                          UNION ALL
+                          SELECT resource_group
+                          FROM rw_streaming_jobs) t),
+     worker_node_stats AS (SELECT resource_group,
+                                  COUNT(*)         AS streaming_workers,
+                                  SUM(parallelism) AS parallelism
+                           FROM rw_worker_nodes
+                           WHERE is_streaming
+                           GROUP BY resource_group),
+     database_stats AS (SELECT resource_group,
+                               COUNT(*) AS databases
+                        FROM rw_databases
+                        GROUP BY resource_group),
+     streaming_job_stats AS (SELECT resource_group,
+                                    COUNT(*) AS streaming_jobs
+                             FROM rw_streaming_jobs
+                             GROUP BY resource_group)
+    SELECT ag.resource_group                AS name,
+           COALESCE(w.streaming_workers, 0) AS streaming_workers,
+           COALESCE(w.parallelism, 0)       AS parallelism,
+           COALESCE(d.databases, 0)         AS databases,
+           COALESCE(j.streaming_jobs, 0)    AS streaming_jobs
+    FROM all_groups ag
+             LEFT JOIN worker_node_stats w ON ag.resource_group = w.resource_group
+             LEFT JOIN database_stats d ON ag.resource_group = d.resource_group
+             LEFT JOIN streaming_job_stats j ON ag.resource_group = j.resource_group"
+)]
+#[derive(Fields)]
+struct RwResourceGroup {
+    name: String,
+    streaming_workers: i64,
+    parallelism: i64,
+    databases: i64,
+    streaming_jobs: i64,
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds the `rw_resource_groups` view, which aggregates the number of workers in the cluster, total parallelism, and the number of databases and streaming jobs bound to this resource group.

Currently, this is implemented through a view, but in the future, if resource groups become a type of resource, we may need to turn this into an RPC operation.

```
dev=> select * from rw_resource_groups;
  name   | streaming_workers | parallelism | databases | streaming_jobs
---------+-------------------+-------------+-----------+----------------
 test    |                 2 |           8 |         0 |              1
 default |                 1 |           4 |         1 |              1
(2 rows)
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
