### PR TITLE
fix(sink): correctly get primary keys from starrocks aggregate table

### DIFF
--- a/ci/scripts/e2e-starrocks-sink-test.sh
+++ b/ci/scripts/e2e-starrocks-sink-test.sh
@@ -35,6 +35,9 @@ mysql -uroot -P 9030 -h starrocks-fe-server -e "CREATE database demo;use demo;
 CREATE table demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 date,v8 datetime,v9 boolean,v10 json,v11 decimal(10,5)) ENGINE=OLAP
 PRIMARY KEY(\`v1\`)
 DISTRIBUTED BY HASH(\`v1\`) properties(\"replication_num\" = \"1\");
+CREATE table demo_agg_table(id int, value string REPLACE_IF_NOT_NULL) ENGINE=OLAP
+AGGREGATE KEY(\`id\`)
+DISTRIBUTED BY HASH(\`id\`) properties(\"replication_num\" = \"1\");
 CREATE TABLE demo_reserved_words(id int, \`order\` string, \`from\` string) ENGINE=OLAP
 PRIMARY KEY(id) DISTRIBUTED BY HASH (id) properties(\"replication_num\" = \"1\");
 CREATE USER 'users'@'%' IDENTIFIED BY '123456';
@@ -45,16 +48,25 @@ echo "--- testing sinks"
 sqllogictest -p 4566 -d dev './e2e_test/sink/starrocks_sink.slt'
 sleep 1
 mysql -uroot -P 9030 -h starrocks-fe-server -e "select * from demo.demo_bhv_table" > ./query_result.csv
+mysql -uroot -P 9030 -h starrocks-fe-server -e "select * from demo.demo_agg_table" > ./query_result_agg.csv
 
-
-if cat ./query_result.csv | sed '1d; s/\t/,/g' | awk -F "," '{
-    exit !($1 == 1 && $2 == 1 && $3 == 1 && $4 == 1.1 && $5 == 1.2 && $6 == "test" && $7 == "2013-01-01" && $8 == "2013-01-01 01:01:01" && $9 == 0 && $10 = "{"v101": 100}" && $11 == 1.12346); }'; then
-  echo "Starrocks sink check passed"
-else
+if ! cat ./query_result.csv | sed '1d; s/\t/,/g' | awk -F "," '{
+    exit !($1 == 1 && $2 == 1 && $3 == 1 && $4 == 1.1 && $5 == 1.2 && $6 == "test" && $7 == "2013-01-01" && $8 == "2013-01-01 01:01:01" && $9 == 0 && $10 = "{"v101": 100}" && $11 == 1.12346); }'
+then
   cat ./query_result.csv
   echo "The output is not as expected."
   exit 1
 fi
+
+if ! cat ./query_result_agg.csv | sed '1d; s/\t/,/g' | awk -F "," '{
+    exit !($1 == 1 && $2 == "v"); }'
+then
+  cat ./query_result_agg.csv
+  echo "The output is not as expected."
+  exit 1
+fi
+
+echo "Starrocks sink check passed"
 
 echo "--- Kill cluster"
 risedev ci-kill

--- a/e2e_test/sink/starrocks_sink.slt
+++ b/e2e_test/sink/starrocks_sink.slt
@@ -39,6 +39,38 @@ statement ok
 DROP TABLE t6;
 
 statement ok
+CREATE TABLE agg_table(id int primary key, value string);
+
+statement ok
+CREATE SINK sink_agg_table
+FROM
+    agg_table WITH (
+    connector = 'starrocks',
+    type = 'append-only',
+    force_append_only='true',
+    starrocks.host = 'starrocks-fe-server',
+    starrocks.mysqlport = '9030',
+    starrocks.httpport = '8030',
+    starrocks.user = 'users',
+    starrocks.password = '123456',
+    starrocks.database = 'demo',
+    starrocks.table = 'demo_agg_table',
+    primary_key = 'id'
+);
+
+statement ok
+INSERT INTO agg_table VALUES (1, 'v');
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK sink_agg_table;
+
+statement ok
+DROP TABLE agg_table;
+
+statement ok
 CREATE TABLE reserved_words (id int primary key, "order" text, "from" text);
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?
This PR fixes the pk validation issue for aggregate table.

Currently, we support customized upsert unique key table through the [changelog](https://github.com/risingwavelabs/risingwave/pull/17321), however, the aggregate table should be taken into account. Because the unique key table is just a special case of aggregate table where `agg_type` of all columns is set to `REPLACE`.

In the sink creation phase, we retrieve the primary keys from `tables_config.primary_key` field, which is true for the primary key table and unique key table, but the primary keys of an aggregate table should be retrieved from `sort_key` field. Before starrocks 3.3.0, the key columns of unique key, duplicate key and aggregate table were [coupled](https://docs.starrocks.io/docs/3.2/table_design/table_types/table_capabilities/) with sort key. Since starrocks 3.3.0, the order of key columns may differ from sort key columns, but the columns remain the same. Thus, it is safe to use the `sort_key` as the primary key for sink validation.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
