### PR TITLE
fix(snapshot-backfill): fix panic in cross db snapshot backfill recovery

### DIFF
--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -410,6 +410,16 @@ test_scale_in() {
   risedev clean-data
 }
 
+test_cross_db_snapshot_backfill() {
+  echo "--- e2e, cross db snapshot backfill test, $RUNTIME_CLUSTER_PROFILE"
+
+  risedev ci-start $RUNTIME_CLUSTER_PROFILE
+
+  sqllogictest -p 4566 -d dev 'e2e_test/backfill/cross_db/cross_db_mv.slt'
+
+  kill_cluster
+}
+
 main() {
   set -euo pipefail
   test_snapshot_and_upstream_read
@@ -419,6 +429,8 @@ main() {
   test_snapshot_backfill
 
   test_scale_in
+
+  test_cross_db_snapshot_backfill
 
   # Only if profile is "ci-release", run it.
   if [[ ${profile:-} == "ci-release" ]]; then

--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -325,6 +325,8 @@ test_scale_in() {
   risedev psql-env
   source .risingwave/config/psql-env
 
+  psql -c "alter system set per_database_isolation = false"
+
   psql -c "create table t(v1 int); insert into t select * from generate_series(1, 1000); flush"
   psql -c "set background_ddl=true; set backfill_rate_limit=10; create materialized view m1 as select * from t; flush"
   internal_table=$(psql -t -c "show internal tables;" | grep -v 'INFO')

--- a/e2e_test/backfill/cross_db/cross_db_mv.slt
+++ b/e2e_test/backfill/cross_db/cross_db_mv.slt
@@ -1,0 +1,86 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create database d1;
+
+statement ok
+create database d2;
+
+statement ok
+set database to d1;
+
+statement ok
+create table t1(v1 int);
+
+statement ok
+insert into t1 select * from generate_series(1, 10000);
+
+statement ok
+set database to d2;
+
+statement ok
+set database to d1;
+
+statement ok
+create subscription sub from t1 with(retention = '1D');
+
+statement ok
+set database to d2;
+
+query ok
+select count(*) from d1.public.t1;
+----
+10000
+
+statement ok
+set backfill_rate_limit = 200;
+
+statement ok
+set streaming_parallelism=2;
+
+statement ok
+set background_ddl=true;
+
+statement ok
+create materialized view mv1 as select * from d1.public.t1;
+
+query ok
+select count(*) from rw_ddl_progress;
+----
+1
+
+sleep 2s
+
+statement ok
+recover
+
+statement ok
+wait
+
+query ok
+select count(*) from mv1;
+----
+10000
+
+statement ok
+set database to d2;
+
+statement ok
+drop materialized view mv1;
+
+statement ok
+set database to d1;
+
+statement ok
+drop subscription sub;
+
+statement ok
+drop table t1;
+
+statement ok
+drop database d2;
+
+connection other
+statement ok
+drop database d1;

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -461,6 +461,7 @@ pub(crate) fn plan_can_use_background_ddl(plan: &PlanRef) -> bool {
         } else if let Some(scan) = plan.as_stream_table_scan() {
             scan.stream_scan_type() == StreamScanType::Backfill
                 || scan.stream_scan_type() == StreamScanType::ArrangementBackfill
+                || scan.stream_scan_type() == StreamScanType::CrossDbSnapshotBackfill
         } else {
             false
         }

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -833,7 +833,12 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 if !state_table_committed_epochs.is_empty() {
                     warn!(?state_table_committed_epochs, "unused state table committed epoch in recovery");
                 }
-
+                if !self.enable_per_database_isolation && !failed_databases.is_empty() {
+                    return Err(anyhow!(
+                        "global recovery failed due to failure of databases {:?}",
+                        failed_databases.iter().map(|database_id| database_id.database_id).collect_vec()).into()
+                    );
+                }
                 let checkpoint_control = CheckpointControl::recover(
                     collected_databases,
                     failed_databases,

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -472,6 +472,7 @@ impl stream_plan::PbStreamScanType {
             // todo: should this be true?
             PbStreamScanType::UpstreamOnly => false,
             PbStreamScanType::ArrangementBackfill => true,
+            PbStreamScanType::CrossDbSnapshotBackfill => true,
             // todo: true when stable
             PbStreamScanType::SnapshotBackfill => false,
             _ => false,

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -267,7 +267,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                         while let Some(chunk) =
                             upstream_buffer.run_future(stream.try_next()).await?
                         {
-                            debug!(
+                            trace!(
                                 ?barrier_epoch,
                                 size = chunk.cardinality(),
                                 "consume change log yield chunk",

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -252,7 +252,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                             assert_eq!(next_prev_epoch, barrier.epoch.prev);
                         }
                         barrier_epoch = barrier.epoch;
-                        debug!(?barrier_epoch, kind = ?barrier.kind, "before consume change log");
+                        debug!(?barrier_epoch, kind = ?barrier.kind, "start consume epoch change log");
                         // use `upstream_buffer.run_future` to poll upstream concurrently so that we won't have back-pressure
                         // on the upstream. Otherwise, in `batch_iter_log_with_pk_bounds`, we may wait upstream epoch to be committed,
                         // and the back-pressure may cause the upstream unable to consume the barrier and then cause deadlock.
@@ -276,7 +276,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                             yield Message::Chunk(chunk);
                         }
 
-                        debug!(?barrier_epoch, "after consume change log");
+                        trace!(?barrier_epoch, "after consume change log");
 
                         self.progress.update_create_mview_log_store_progress(
                             barrier.epoch,

--- a/src/stream/src/executor/backfill/snapshot_backfill/state.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/state.rs
@@ -99,10 +99,10 @@ impl VnodeBackfillProgress {
             row_count,
             progress: if !is_finished {
                 EpochBackfillProgress::Consuming {
-                    latest_pk: row.slice(EXTRA_COLUMN_TYPES.len()..).to_owned_row(),
+                    latest_pk: row.slice(EXTRA_COLUMN_TYPES.len() - 1..).to_owned_row(),
                 }
             } else {
-                row.slice(EXTRA_COLUMN_TYPES.len()..)
+                row.slice(EXTRA_COLUMN_TYPES.len() - 1..)
                     .iter()
                     .enumerate()
                     .for_each(|(i, datum)| {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Hits the following panic for cross db snapshot backfill after recovery.
```
thread 'rw-streaming' panicked at /Users/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/itertools-0.14.0/src/zip_eq_impl.rs:50:17:
itertools: .zip_eq() reached end of one iterator before the other
```

We used the wrong column size to resolve the consume progress from the progress rows loaded from progress state table. The bug will be reproduced when backfill recover from half of an epoch.

Add an e2e test to cover the case. Before this PR the e2e will failed with the panic above.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
