### PR TITLE
fix(frontend): `encode protobuf` shall pass options without `legacy_source::ProtobufSchema`

### DIFF
--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -71,7 +71,7 @@ use risingwave_pb::stream_plan::PbStreamFragmentGraph;
 use risingwave_pb::telemetry::TelemetryDatabaseObject;
 use risingwave_sqlparser::ast::{
     AstString, ColumnDef, CreateSourceStatement, Encode, Format, FormatEncodeOptions, ObjectName,
-    ProtobufSchema, SourceWatermark, TableConstraint, get_delimiter,
+    SourceWatermark, TableConstraint, get_delimiter,
 };
 use risingwave_sqlparser::parser::{IncludeOption, IncludeOptionItem};
 use thiserror_ext::AsReport;

--- a/src/frontend/src/handler/create_source/external_schema.rs
+++ b/src/frontend/src/handler/create_source/external_schema.rs
@@ -139,26 +139,22 @@ async fn bind_columns_from_source_for_non_cdc(
         (Format::Plain, Encode::Protobuf) | (Format::Upsert, Encode::Protobuf) => {
             let (row_schema_location, use_schema_registry) =
                 get_schema_location(&mut format_encode_options_to_consume)?;
-            let protobuf_schema = ProtobufSchema {
-                message_name: consume_string_from_options(
-                    &mut format_encode_options_to_consume,
-                    MESSAGE_NAME_KEY,
-                )?,
-                row_schema_location,
-                use_schema_registry,
-            };
+            let message_name = consume_string_from_options(
+                &mut format_encode_options_to_consume,
+                MESSAGE_NAME_KEY,
+            )?;
             let name_strategy = get_sr_name_strategy_check(
                 &mut format_encode_options_to_consume,
-                protobuf_schema.use_schema_registry,
+                use_schema_registry,
             )?;
 
-            stream_source_info.use_schema_registry = protobuf_schema.use_schema_registry;
+            stream_source_info.use_schema_registry = use_schema_registry;
             stream_source_info
                 .row_schema_location
-                .clone_from(&protobuf_schema.row_schema_location.0);
+                .clone_from(&row_schema_location.0);
             stream_source_info
                 .proto_message_name
-                .clone_from(&protobuf_schema.message_name.0);
+                .clone_from(&message_name.0);
             stream_source_info.key_message_name =
                 get_key_message_name(&mut format_encode_options_to_consume);
             stream_source_info.name_strategy =
@@ -166,7 +162,7 @@ async fn bind_columns_from_source_for_non_cdc(
 
             Some(
                 extract_protobuf_table_schema(
-                    &protobuf_schema,
+                    &stream_source_info,
                     &options_with_secret,
                     &mut format_encode_options_to_consume,
                 )

--- a/src/frontend/src/handler/create_source/external_schema/protobuf.rs
+++ b/src/frontend/src/handler/create_source/external_schema/protobuf.rs
@@ -18,20 +18,11 @@ use super::*;
 
 /// Map a protobuf schema to a relational schema.
 pub async fn extract_protobuf_table_schema(
-    schema: &ProtobufSchema,
+    info: &StreamSourceInfo,
     with_properties: &WithOptionsSecResolved,
     format_encode_options: &mut BTreeMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
-    let info = StreamSourceInfo {
-        proto_message_name: schema.message_name.0.clone(),
-        row_schema_location: schema.row_schema_location.0.clone(),
-        use_schema_registry: schema.use_schema_registry,
-        format: FormatType::Plain.into(),
-        row_encode: EncodeType::Protobuf.into(),
-        format_encode_options: format_encode_options.clone(),
-        ..Default::default()
-    };
-    let parser_config = SpecificParserConfig::new(&info, with_properties)?;
+    let parser_config = SpecificParserConfig::new(info, with_properties)?;
     try_consume_string_from_options(format_encode_options, SCHEMA_REGISTRY_USERNAME);
     try_consume_string_from_options(format_encode_options, SCHEMA_REGISTRY_PASSWORD);
     try_consume_string_from_options(format_encode_options, PROTOBUF_MESSAGES_AS_JSONB);

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -43,9 +43,7 @@ pub use self::ddl::{
     ColumnDef, ColumnOption, ColumnOptionDef, ReferentialAction, SourceWatermark, TableConstraint,
     WebhookSourceInfo,
 };
-pub use self::legacy_source::{
-    AvroSchema, CompatibleFormatEncode, DebeziumAvroSchema, ProtobufSchema, get_delimiter,
-};
+pub use self::legacy_source::{CompatibleFormatEncode, get_delimiter};
 pub use self::operator::{BinaryOperator, QualifiedOperator, UnaryOperator};
 pub use self::query::{
     Corresponding, Cte, CteInner, Distinct, Fetch, Join, JoinConstraint, JoinOperator, LateralView,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

|`legacy_source::ProtobufSchema`|`StreamSourceInfo`|
|-|-|
|message_name|proto_message_name|
|row_schema_location|row_schema_location|
|use_schema_registry|use_schema_registry|
||name_strategy|
||key_message_name|
||format|
||...|

As a result, `name_strategy` was not passed down compared to `extract_avro_table_schema`, and `format` was hard-coded to `Plain` despite it does not affect schema derivation.

Note:
* Name strategy is still considered unsupported.
  * It is mainly used together with multiple event types within a single topic, which is not well supported yet.
  * We may provide a `subject = ` option to provide more flexibility than the 3 preset name strategies.
  * Json Schema and Debezium Avro are not following name strategy. This protobuf fix is not covered by tests.
* Need to refactor relevant source implementation to avoid/fix similar issues. 

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
