### PR TITLE
refactor(snapshot-backfill): refine snapshot backfill tracking logic in meta

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -48,8 +48,7 @@ use crate::barrier::utils::{
     NodeToCollect, collect_creating_job_commit_epoch_info, is_valid_after_worker_err,
 };
 use crate::barrier::{
-    BarrierKind, Command, CreateStreamingJobCommandInfo, CreateStreamingJobType,
-    InflightSubscriptionInfo, SnapshotBackfillInfo, TracedEpoch,
+    BarrierKind, Command, CreateStreamingJobType, InflightSubscriptionInfo, TracedEpoch,
 };
 use crate::manager::MetaSrvEnv;
 use crate::rpc::metrics::GLOBAL_META_METRICS;
@@ -129,14 +128,13 @@ impl CheckpointControl {
     pub(crate) fn barrier_collected(
         &mut self,
         resp: BarrierCompleteResponse,
-        control_stream_manager: &mut ControlStreamManager,
         periodic_barriers: &mut PeriodicBarriers,
     ) -> MetaResult<()> {
         let database_id = DatabaseId::new(resp.database_id);
         let database_status = self.databases.get_mut(&database_id).expect("should exist");
         match database_status {
             DatabaseCheckpointControlStatus::Running(database) => {
-                database.barrier_collected(resp, control_stream_manager, periodic_barriers)
+                database.barrier_collected(resp, periodic_barriers)
             }
             DatabaseCheckpointControlStatus::Recovering(state) => {
                 state.barrier_collected(database_id, resp);
@@ -375,11 +373,7 @@ impl CheckpointControl {
                 .values()
             {
                 progress.extend([(
-                    creating_job
-                        .info
-                        .stream_job_fragments
-                        .stream_job_id()
-                        .table_id,
+                    creating_job.job_id.table_id,
                     creating_job.gen_ddl_progress(),
                 )]);
             }
@@ -441,16 +435,27 @@ impl CheckpointControl {
 
     pub(crate) fn inflight_infos(
         &self,
-    ) -> impl Iterator<Item = (DatabaseId, &InflightSubscriptionInfo, &InflightDatabaseInfo)> + '_
-    {
+    ) -> impl Iterator<
+        Item = (
+            DatabaseId,
+            &InflightSubscriptionInfo,
+            &InflightDatabaseInfo,
+            impl Iterator<Item = &InflightStreamingJobInfo> + '_,
+        ),
+    > + '_ {
         self.databases.iter().flat_map(|(database_id, database)| {
-            database.checkpoint_control().map(|database| {
-                (
-                    *database_id,
-                    &database.state.inflight_subscription_info,
-                    &database.state.inflight_graph_info,
-                )
-            })
+            database
+                .database_state()
+                .map(|(database_state, creating_jobs)| {
+                    (
+                        *database_id,
+                        &database_state.inflight_subscription_info,
+                        &database_state.inflight_graph_info,
+                        creating_jobs
+                            .values()
+                            .filter_map(|job| job.inflight_graph_info()),
+                    )
+                })
         })
     }
 }
@@ -536,10 +541,17 @@ impl DatabaseCheckpointControlStatus {
         }
     }
 
-    fn checkpoint_control(&self) -> Option<&DatabaseCheckpointControl> {
+    fn database_state(
+        &self,
+    ) -> Option<(
+        &BarrierWorkerState,
+        &HashMap<TableId, CreatingStreamingJobControl>,
+    )> {
         match self {
-            DatabaseCheckpointControlStatus::Running(control) => Some(control),
-            DatabaseCheckpointControlStatus::Recovering(state) => state.checkpoint_control(),
+            DatabaseCheckpointControlStatus::Running(control) => {
+                Some((&control.state, &control.creating_streaming_job_controls))
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => state.database_state(),
         }
     }
 
@@ -654,16 +666,18 @@ impl DatabaseCheckpointControl {
 
     fn jobs_to_merge(
         &self,
-    ) -> Option<HashMap<TableId, (SnapshotBackfillInfo, InflightStreamingJobInfo)>> {
+    ) -> Option<HashMap<TableId, (HashSet<TableId>, InflightStreamingJobInfo)>> {
         let mut table_ids_to_merge = HashMap::new();
 
         for (table_id, creating_streaming_job) in &self.creating_streaming_job_controls {
-            if creating_streaming_job.should_merge_to_upstream() {
+            if let Some(graph_info) = creating_streaming_job.should_merge_to_upstream() {
                 table_ids_to_merge.insert(
                     *table_id,
                     (
-                        creating_streaming_job.snapshot_backfill_info.clone(),
-                        creating_streaming_job.graph_info.clone(),
+                        creating_streaming_job
+                            .snapshot_backfill_upstream_tables
+                            .clone(),
+                        graph_info.clone(),
                     ),
                 );
             }
@@ -719,7 +733,6 @@ impl DatabaseCheckpointControl {
     fn barrier_collected(
         &mut self,
         resp: BarrierCompleteResponse,
-        control_stream_manager: &mut ControlStreamManager,
         periodic_barriers: &mut PeriodicBarriers,
     ) -> MetaResult<()> {
         let worker_id = resp.worker_id;
@@ -753,7 +766,7 @@ impl DatabaseCheckpointControl {
                     .creating_streaming_job_controls
                     .get_mut(&creating_job_id)
                     .expect("should exist")
-                    .collect(prev_epoch, worker_id as _, resp, control_stream_manager)?;
+                    .collect(prev_epoch, worker_id as _, resp)?;
                 if should_merge_to_upstream {
                     periodic_barriers.force_checkpoint_in_next_barrier();
                 }
@@ -798,12 +811,7 @@ impl DatabaseCheckpointControl {
                             *table_id,
                             (
                                 progress_epoch,
-                                creating_job
-                                    .snapshot_backfill_info
-                                    .upstream_mv_table_id_to_backfill_epoch
-                                    .keys()
-                                    .cloned()
-                                    .collect(),
+                                creating_job.snapshot_backfill_upstream_tables.clone(),
                             ),
                         )
                     })
@@ -867,12 +875,7 @@ impl DatabaseCheckpointControl {
                     .remove(&table_id)
                     .expect("should exist");
                 assert!(creating_streaming_job.is_finished());
-                assert!(
-                    epoch_state
-                        .finished_jobs
-                        .insert(table_id, (creating_streaming_job.info, resps))
-                        .is_none()
-                );
+                assert!(epoch_state.finished_jobs.insert(table_id, resps).is_none());
             }
         }
         assert!(self.completing_barrier.is_none());
@@ -908,10 +911,10 @@ impl DatabaseCheckpointControl {
                 node.state
                     .finished_jobs
                     .drain()
-                    .for_each(|(_, (info, resps))| {
+                    .for_each(|(job_id, resps)| {
                         node.state.resps.extend(resps);
                         finished_jobs.push(TrackingJob::New(TrackingCommand {
-                            info,
+                            job_id,
                             replace_stream_job: None,
                         }));
                     });
@@ -940,11 +943,7 @@ impl DatabaseCheckpointControl {
                     &mut task.commit_info,
                     epoch,
                     resps,
-                    self.creating_streaming_job_controls[&table_id]
-                        .info
-                        .stream_job_fragments
-                        .all_table_ids()
-                        .map(TableId::new),
+                    self.creating_streaming_job_controls[&table_id].state_table_ids(),
                     is_first_time,
                 );
                 let (_, creating_job_epochs) =
@@ -999,7 +998,7 @@ struct BarrierEpochState {
 
     creating_jobs_to_wait: HashSet<TableId>,
 
-    finished_jobs: HashMap<TableId, (CreateStreamingJobCommandInfo, Vec<BarrierCompleteResponse>)>,
+    finished_jobs: HashMap<TableId, Vec<BarrierCompleteResponse>>,
 }
 
 impl BarrierEpochState {
@@ -1107,10 +1106,9 @@ impl DatabaseCheckpointControl {
                         .upstream_mv_table_id_to_backfill_epoch
                         .values_mut()
                     {
-                        assert!(
-                            snapshot_backfill_epoch
-                                .replace(barrier_info.prev_epoch())
-                                .is_none(),
+                        assert_eq!(
+                            snapshot_backfill_epoch.replace(barrier_info.prev_epoch()),
+                            None,
                             "must not set previously"
                         );
                     }
@@ -1129,23 +1127,27 @@ impl DatabaseCheckpointControl {
                     }
                     let info = info.clone();
                     let job_id = info.stream_job_fragments.stream_job_id();
-                    let snapshot_backfill_info = snapshot_backfill_info.clone();
+                    let snapshot_backfill_upstream_tables = snapshot_backfill_info
+                        .upstream_mv_table_id_to_backfill_epoch
+                        .keys()
+                        .cloned()
+                        .collect();
                     let mutation = command
                         .as_ref()
                         .expect("checked Some")
                         .to_mutation(false)
                         .expect("should have some mutation in `CreateStreamingJob` command");
 
-                    control_stream_manager.add_partial_graph(self.database_id, Some(job_id));
                     self.creating_streaming_job_controls.insert(
                         job_id,
                         CreatingStreamingJobControl::new(
                             info,
-                            snapshot_backfill_info,
+                            snapshot_backfill_upstream_tables,
                             barrier_info.prev_epoch(),
                             hummock_version_stats,
                             mutation,
-                        ),
+                            control_stream_manager,
+                        )?,
                     );
                 }
             }

--- a/src/meta/src/barrier/checkpoint/creating_job/barrier_control.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/barrier_control.rs
@@ -34,6 +34,7 @@ struct CreatingStreamingJobEpochState {
     node_to_collect: NodeToCollect,
     resps: Vec<BarrierCompleteResponse>,
     is_checkpoint: bool,
+    is_first_commit: bool,
     enqueue_time: Instant,
 }
 
@@ -43,7 +44,7 @@ pub(super) struct CreatingStreamingJobBarrierControl {
     // key is prev_epoch of barrier
     inflight_barrier_queue: BTreeMap<u64, CreatingStreamingJobEpochState>,
     backfill_epoch: u64,
-    initial_epoch: Option<u64>,
+    is_first_committed: bool,
     max_collected_epoch: Option<u64>,
     // newer epoch at the front.
     pending_barriers_to_complete: VecDeque<CreatingStreamingJobEpochState>,
@@ -58,13 +59,13 @@ pub(super) struct CreatingStreamingJobBarrierControl {
 }
 
 impl CreatingStreamingJobBarrierControl {
-    pub(super) fn new(table_id: TableId, backfill_epoch: u64) -> Self {
+    pub(super) fn new(table_id: TableId, backfill_epoch: u64, is_first_committed: bool) -> Self {
         let table_id_str = format!("{}", table_id.table_id);
         Self {
             table_id,
             inflight_barrier_queue: Default::default(),
             backfill_epoch,
-            initial_epoch: None,
+            is_first_committed,
             max_collected_epoch: None,
             pending_barriers_to_complete: Default::default(),
             completing_barrier: None,
@@ -123,8 +124,9 @@ impl CreatingStreamingJobBarrierControl {
             table_id = self.table_id.table_id,
             "creating job enqueue epoch"
         );
-        if self.initial_epoch.is_none() {
-            self.initial_epoch = Some(epoch);
+        let is_first_commit = !self.is_first_committed;
+        if !self.is_first_committed {
+            self.is_first_committed = true;
             assert!(is_checkpoint, "first barrier must be checkpoint barrier");
         }
         if let Some(latest_epoch) = self.latest_epoch() {
@@ -135,6 +137,7 @@ impl CreatingStreamingJobBarrierControl {
             node_to_collect,
             resps: vec![],
             is_checkpoint,
+            is_first_commit,
             enqueue_time: Instant::now(),
         };
         if epoch_state.node_to_collect.is_empty() && self.inflight_barrier_queue.is_empty() {
@@ -195,7 +198,7 @@ impl CreatingStreamingJobBarrierControl {
                 .pop_back()
                 .expect("non-empty");
             let epoch = epoch_state.epoch;
-            let is_first = self.initial_epoch.expect("should have set") == epoch;
+            let is_first = epoch_state.is_first_commit;
             if is_first {
                 assert!(epoch_state.is_checkpoint);
             } else if !epoch_state.is_checkpoint {

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -16,7 +16,7 @@ mod barrier_control;
 mod status;
 
 use std::cmp::max;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Bound::{Excluded, Unbounded};
 
 use barrier_control::CreatingStreamingJobBarrierControl;
@@ -27,25 +27,27 @@ use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
-use status::{CreatingJobInjectBarrierInfo, CreatingStreamingJobStatus};
+use status::CreatingStreamingJobStatus;
 use tracing::info;
 
 use crate::MetaResult;
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::barrier::rpc::ControlStreamManager;
-use crate::barrier::{Command, CreateStreamingJobCommandInfo, SnapshotBackfillInfo};
+use crate::barrier::{Command, CreateStreamingJobCommandInfo};
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::model::StreamJobActorsToCreate;
 use crate::rpc::metrics::GLOBAL_META_METRICS;
 
 #[derive(Debug)]
 pub(crate) struct CreatingStreamingJobControl {
-    pub(crate) info: CreateStreamingJobCommandInfo,
-    pub(super) snapshot_backfill_info: SnapshotBackfillInfo,
+    database_id: DatabaseId,
+    pub(super) job_id: TableId,
+    definition: String,
+    pub(super) snapshot_backfill_upstream_tables: HashSet<TableId>,
     backfill_epoch: u64,
 
-    pub(super) graph_info: InflightStreamingJobInfo,
+    graph_info: InflightStreamingJobInfo,
 
     barrier_control: CreatingStreamingJobBarrierControl,
     status: CreatingStreamingJobStatus,
@@ -56,19 +58,27 @@ pub(crate) struct CreatingStreamingJobControl {
 impl CreatingStreamingJobControl {
     pub(super) fn new(
         info: CreateStreamingJobCommandInfo,
-        snapshot_backfill_info: SnapshotBackfillInfo,
+        snapshot_backfill_upstream_tables: HashSet<TableId>,
         backfill_epoch: u64,
         version_stat: &HummockVersionStats,
         initial_mutation: Mutation,
-    ) -> Self {
+        control_stream_manager: &mut ControlStreamManager,
+    ) -> MetaResult<Self> {
+        let job_id = info.stream_job_fragments.stream_job_id();
+        let database_id = DatabaseId::new(info.streaming_job.database_id());
         info!(
-            table_id = info.stream_job_fragments.stream_job_id().table_id,
+            %job_id,
             definition = info.definition,
             "new creating job"
         );
         let snapshot_backfill_actors = info.stream_job_fragments.snapshot_backfill_actor_ids();
-        let mut create_mview_tracker = CreateMviewProgressTracker::default();
-        create_mview_tracker.update_tracking_jobs(Some((&info, None)), [], version_stat);
+        let create_mview_tracker = CreateMviewProgressTracker::recover(
+            [(
+                job_id,
+                (info.definition.clone(), &*info.stream_job_fragments),
+            )],
+            version_stat,
+        );
         let fragment_infos: HashMap<_, _> = info.stream_job_fragments.new_fragment_info().collect();
 
         let table_id = info.stream_job_fragments.stream_job_id();
@@ -115,26 +125,54 @@ impl CreatingStreamingJobControl {
             fragment_infos,
         };
 
-        Self {
-            info,
-            snapshot_backfill_info,
-            barrier_control: CreatingStreamingJobBarrierControl::new(table_id, backfill_epoch),
+        let mut barrier_control =
+            CreatingStreamingJobBarrierControl::new(table_id, backfill_epoch, false);
+
+        let mut prev_epoch_fake_physical_time = 0;
+        let mut pending_non_checkpoint_barriers = vec![];
+
+        let initial_barrier_info = CreatingStreamingJobStatus::new_fake_barrier(
+            &mut prev_epoch_fake_physical_time,
+            &mut pending_non_checkpoint_barriers,
+            true,
+        );
+
+        control_stream_manager.add_partial_graph(database_id, Some(job_id));
+        Self::inject_barrier(
+            database_id,
+            job_id,
+            control_stream_manager,
+            &mut barrier_control,
+            &graph_info,
+            Some(&graph_info),
+            initial_barrier_info,
+            Some(actors_to_create),
+            Some(initial_mutation),
+        )?;
+
+        assert!(pending_non_checkpoint_barriers.is_empty());
+
+        Ok(Self {
+            database_id,
+            definition: info.definition,
+            job_id,
+            snapshot_backfill_upstream_tables,
+            barrier_control,
             backfill_epoch,
             graph_info,
             status: CreatingStreamingJobStatus::ConsumingSnapshot {
-                prev_epoch_fake_physical_time: 0,
+                prev_epoch_fake_physical_time,
                 pending_upstream_barriers: vec![],
                 version_stats: version_stat.clone(),
                 create_mview_tracker,
                 snapshot_backfill_actors,
                 backfill_epoch,
-                pending_non_checkpoint_barriers: vec![],
-                initial_barrier_info: Some((actors_to_create, initial_mutation)),
+                pending_non_checkpoint_barriers,
             },
             upstream_lag: GLOBAL_META_METRICS
                 .snapshot_backfill_lag
                 .with_guarded_label_values(&[&table_id_str]),
-        }
+        })
     }
 
     pub(crate) fn is_valid_after_worker_err(&mut self, worker_id: WorkerId) -> bool {
@@ -157,7 +195,7 @@ impl CreatingStreamingJobControl {
                 } else {
                     let progress = create_mview_tracker
                         .gen_ddl_progress()
-                        .remove(&self.info.stream_job_fragments.stream_job_id().table_id)
+                        .remove(&self.job_id.table_id)
                         .expect("should exist");
                     format!("Snapshot [{}]", progress.progress)
                 }
@@ -179,8 +217,8 @@ impl CreatingStreamingJobControl {
             }
         };
         DdlProgress {
-            id: self.info.stream_job_fragments.stream_job_id().table_id as u64,
-            statement: self.info.definition.clone(),
+            id: self.job_id.table_id as u64,
+            statement: self.definition.clone(),
             progress,
         }
     }
@@ -204,11 +242,9 @@ impl CreatingStreamingJobControl {
         barrier_control: &mut CreatingStreamingJobBarrierControl,
         pre_applied_graph_info: &InflightStreamingJobInfo,
         applied_graph_info: Option<&InflightStreamingJobInfo>,
-        CreatingJobInjectBarrierInfo {
-            barrier_info,
-            new_actors,
-            mutation,
-        }: CreatingJobInjectBarrierInfo,
+        barrier_info: BarrierInfo,
+        new_actors: Option<StreamJobActorsToCreate>,
+        mutation: Option<Mutation>,
     ) -> MetaResult<()> {
         let node_to_collect = control_stream_manager.inject_barrier(
             database_id,
@@ -238,7 +274,7 @@ impl CreatingStreamingJobControl {
         command: Option<&Command>,
         barrier_info: &BarrierInfo,
     ) -> MetaResult<()> {
-        let table_id = self.info.stream_job_fragments.stream_job_id();
+        let table_id = self.job_id;
         let start_consume_upstream =
             if let Some(Command::MergeSnapshotBackfillStreamingJobs(jobs_to_merge)) = command {
                 jobs_to_merge.contains_key(&table_id)
@@ -247,7 +283,7 @@ impl CreatingStreamingJobControl {
             };
         if start_consume_upstream {
             info!(
-                table_id = self.info.stream_job_fragments.stream_job_id().table_id,
+                table_id = self.job_id.table_id,
                 prev_epoch = barrier_info.prev_epoch(),
                 "start consuming upstream"
             );
@@ -265,23 +301,33 @@ impl CreatingStreamingJobControl {
                 .0
                 .saturating_sub(progress_epoch) as _,
         );
-        if let Some(barrier_to_inject) = self
-            .status
-            .on_new_upstream_epoch(barrier_info, start_consume_upstream)
-        {
+        if start_consume_upstream {
+            self.status.start_consume_upstream(barrier_info);
             Self::inject_barrier(
-                DatabaseId::new(self.info.streaming_job.database_id()),
-                self.info.stream_job_fragments.stream_job_id(),
+                self.database_id,
+                self.job_id,
                 control_stream_manager,
                 &mut self.barrier_control,
                 &self.graph_info,
-                if start_consume_upstream {
-                    None
-                } else {
-                    Some(&self.graph_info)
-                },
-                barrier_to_inject,
+                None,
+                barrier_info.clone(),
+                None,
+                None,
             )?;
+        } else {
+            for barrier_to_inject in self.status.on_new_upstream_epoch(barrier_info) {
+                Self::inject_barrier(
+                    self.database_id,
+                    self.job_id,
+                    control_stream_manager,
+                    &mut self.barrier_control,
+                    &self.graph_info,
+                    Some(&self.graph_info),
+                    barrier_to_inject,
+                    None,
+                    None,
+                )?;
+            }
         }
         Ok(())
     }
@@ -291,36 +337,23 @@ impl CreatingStreamingJobControl {
         epoch: u64,
         worker_id: WorkerId,
         resp: BarrierCompleteResponse,
-        control_stream_manager: &mut ControlStreamManager,
     ) -> MetaResult<bool> {
-        let prev_barriers_to_inject = self.status.update_progress(&resp.create_mview_progress);
+        self.status.update_progress(&resp.create_mview_progress);
         self.barrier_control.collect(epoch, worker_id, resp);
-        if let Some(prev_barriers_to_inject) = prev_barriers_to_inject {
-            let table_id = self.info.stream_job_fragments.stream_job_id();
-            for info in prev_barriers_to_inject {
-                Self::inject_barrier(
-                    DatabaseId::new(self.info.streaming_job.database_id()),
-                    table_id,
-                    control_stream_manager,
-                    &mut self.barrier_control,
-                    &self.graph_info,
-                    Some(&self.graph_info),
-                    info,
-                )?;
-            }
-        }
-        Ok(self.should_merge_to_upstream())
+        Ok(self.should_merge_to_upstream().is_some())
     }
 
-    pub(super) fn should_merge_to_upstream(&self) -> bool {
+    pub(super) fn should_merge_to_upstream(&self) -> Option<&InflightStreamingJobInfo> {
         if let CreatingStreamingJobStatus::ConsumingLogStore {
             log_store_progress_tracker,
+            barriers_to_inject,
         } = &self.status
+            && barriers_to_inject.is_none()
             && log_store_progress_tracker.is_finished()
         {
-            true
+            Some(&self.graph_info)
         } else {
-            false
+            None
         }
     }
 }
@@ -386,5 +419,17 @@ impl CreatingStreamingJobControl {
 
     pub(super) fn is_finished(&self) -> bool {
         self.barrier_control.is_empty() && self.status.is_finishing()
+    }
+
+    pub fn inflight_graph_info(&self) -> Option<&InflightStreamingJobInfo> {
+        match &self.status {
+            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. } => Some(&self.graph_info),
+            CreatingStreamingJobStatus::Finishing(_) => None,
+        }
+    }
+
+    pub fn state_table_ids(&self) -> impl Iterator<Item = TableId> + '_ {
+        self.graph_info.existing_table_ids()
     }
 }

--- a/src/meta/src/barrier/checkpoint/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/status.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use risingwave_common::hash::ActorId;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::hummock::HummockVersionStats;
-use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_service::barrier_complete_response::{
     CreateMviewProgress, PbCreateMviewProgress,
 };
@@ -28,7 +27,6 @@ use tracing::warn;
 
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::barrier::{BarrierInfo, BarrierKind, TracedEpoch};
-use crate::model::StreamJobActorsToCreate;
 
 #[derive(Debug)]
 pub(super) struct CreateMviewLogStoreProgressTracker {
@@ -55,7 +53,7 @@ impl CreateMviewLogStoreProgressTracker {
         let avg = sum / count;
         let avg_lag_time = Duration::from_millis(Epoch(avg as _).physical_time());
         format!(
-            "actor: {}/{}, avg epoch lag {:?}",
+            "actor: {}/{}, avg lag {:?}",
             self.finished_actors.len(),
             self.ongoing_actors.len() + self.finished_actors.len(),
             avg_lag_time
@@ -109,15 +107,13 @@ pub(super) enum CreatingStreamingJobStatus {
         backfill_epoch: u64,
         /// The `prev_epoch` of pending non checkpoint barriers
         pending_non_checkpoint_barriers: Vec<u64>,
-        /// Info of the first barrier: (`actors_to_create`, `mutation`)
-        /// Take the mutation out when injecting the first barrier
-        initial_barrier_info: Option<(StreamJobActorsToCreate, Mutation)>,
     },
     /// The creating job is consuming log store.
     ///
     /// Will transit to `Finishing` on `on_new_upstream_epoch` when `start_consume_upstream` is `true`.
     ConsumingLogStore {
         log_store_progress_tracker: CreateMviewLogStoreProgressTracker,
+        barriers_to_inject: Option<Vec<BarrierInfo>>,
     },
     /// All backfill actors have started consuming upstream, and the job
     /// will be finished when all previously injected barriers have been collected
@@ -125,17 +121,11 @@ pub(super) enum CreatingStreamingJobStatus {
     Finishing(u64),
 }
 
-pub(super) struct CreatingJobInjectBarrierInfo {
-    pub barrier_info: BarrierInfo,
-    pub new_actors: Option<StreamJobActorsToCreate>,
-    pub mutation: Option<Mutation>,
-}
-
 impl CreatingStreamingJobStatus {
     pub(super) fn update_progress(
         &mut self,
         create_mview_progress: impl IntoIterator<Item = &CreateMviewProgress>,
-    ) -> Option<Vec<CreatingJobInjectBarrierInfo>> {
+    ) {
         match self {
             &mut Self::ConsumingSnapshot {
                 ref mut create_mview_tracker,
@@ -144,7 +134,6 @@ impl CreatingStreamingJobStatus {
                 ref mut pending_upstream_barriers,
                 ref mut pending_non_checkpoint_barriers,
                 ref backfill_epoch,
-                ref mut initial_barrier_info,
                 ref snapshot_backfill_actors,
                 ..
             } => {
@@ -154,31 +143,16 @@ impl CreatingStreamingJobStatus {
                     version_stats,
                 );
                 if create_mview_tracker.has_pending_finished_jobs() {
-                    let (new_actors, mutation) = match initial_barrier_info.take() {
-                        Some((new_actors, mutation)) => (Some(new_actors), Some(mutation)),
-                        None => (None, None),
-                    };
-                    assert!(initial_barrier_info.is_none());
                     pending_non_checkpoint_barriers.push(*backfill_epoch);
 
                     let prev_epoch = Epoch::from_physical_time(*prev_epoch_fake_physical_time);
-                    let barriers_to_inject: Vec<_> = [CreatingJobInjectBarrierInfo {
-                        barrier_info: BarrierInfo {
-                            curr_epoch: TracedEpoch::new(Epoch(*backfill_epoch)),
-                            prev_epoch: TracedEpoch::new(prev_epoch),
-                            kind: BarrierKind::Checkpoint(take(pending_non_checkpoint_barriers)),
-                        },
-                        new_actors,
-                        mutation,
+                    let barriers_to_inject: Vec<_> = [BarrierInfo {
+                        curr_epoch: TracedEpoch::new(Epoch(*backfill_epoch)),
+                        prev_epoch: TracedEpoch::new(prev_epoch),
+                        kind: BarrierKind::Checkpoint(take(pending_non_checkpoint_barriers)),
                     }]
                     .into_iter()
-                    .chain(pending_upstream_barriers.drain(..).map(|barrier_info| {
-                        CreatingJobInjectBarrierInfo {
-                            barrier_info,
-                            new_actors: None,
-                            mutation: None,
-                        }
-                    }))
+                    .chain(pending_upstream_barriers.drain(..))
                     .collect();
 
                     *self = CreatingStreamingJobStatus::ConsumingLogStore {
@@ -186,17 +160,13 @@ impl CreatingStreamingJobStatus {
                             snapshot_backfill_actors.iter().cloned(),
                             barriers_to_inject
                                 .last()
-                                .map(|info| {
-                                    info.barrier_info
-                                        .prev_epoch()
-                                        .saturating_sub(*backfill_epoch)
+                                .map(|barrier_info| {
+                                    barrier_info.prev_epoch().saturating_sub(*backfill_epoch)
                                 })
                                 .unwrap_or(0),
                         ),
+                        barriers_to_inject: Some(barriers_to_inject),
                     };
-                    Some(barriers_to_inject)
-                } else {
-                    None
                 }
             }
             CreatingStreamingJobStatus::ConsumingLogStore {
@@ -204,55 +174,56 @@ impl CreatingStreamingJobStatus {
                 ..
             } => {
                 log_store_progress_tracker.update(create_mview_progress);
-                None
             }
-            CreatingStreamingJobStatus::Finishing(_) => None,
+            CreatingStreamingJobStatus::Finishing(_) => {}
         }
     }
 
-    pub(super) fn on_new_upstream_epoch(
-        &mut self,
-        barrier_info: &BarrierInfo,
-        start_consume_upstream: bool,
-    ) -> Option<CreatingJobInjectBarrierInfo> {
+    pub(super) fn start_consume_upstream(&mut self, barrier_info: &BarrierInfo) {
+        match self {
+            CreatingStreamingJobStatus::ConsumingSnapshot { .. } => {
+                unreachable!(
+                    "should not start consuming upstream for a job that are consuming snapshot"
+                )
+            }
+            CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
+                let prev_epoch = barrier_info.prev_epoch();
+                {
+                    assert!(barrier_info.kind.is_checkpoint());
+                    *self = CreatingStreamingJobStatus::Finishing(prev_epoch);
+                }
+            }
+            CreatingStreamingJobStatus::Finishing { .. } => {
+                unreachable!("should not start consuming upstream for a job again")
+            }
+        }
+    }
+
+    pub(super) fn on_new_upstream_epoch(&mut self, barrier_info: &BarrierInfo) -> Vec<BarrierInfo> {
         match self {
             CreatingStreamingJobStatus::ConsumingSnapshot {
                 pending_upstream_barriers,
                 prev_epoch_fake_physical_time,
                 pending_non_checkpoint_barriers,
-                initial_barrier_info,
                 ..
             } => {
-                assert!(
-                    !start_consume_upstream,
-                    "should not start consuming upstream for a job that are consuming snapshot"
-                );
                 pending_upstream_barriers.push(barrier_info.clone());
-                Some(CreatingStreamingJobStatus::new_fake_barrier(
+                vec![CreatingStreamingJobStatus::new_fake_barrier(
                     prev_epoch_fake_physical_time,
                     pending_non_checkpoint_barriers,
-                    initial_barrier_info,
                     barrier_info.kind.is_checkpoint(),
-                ))
+                )]
             }
-            CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
-                let prev_epoch = barrier_info.prev_epoch();
-                if start_consume_upstream {
-                    assert!(barrier_info.kind.is_checkpoint());
-                    *self = CreatingStreamingJobStatus::Finishing(prev_epoch);
-                }
-                Some(CreatingJobInjectBarrierInfo {
-                    barrier_info: barrier_info.clone(),
-                    new_actors: None,
-                    mutation: None,
-                })
-            }
+            CreatingStreamingJobStatus::ConsumingLogStore {
+                barriers_to_inject, ..
+            } => barriers_to_inject
+                .take()
+                .into_iter()
+                .flatten()
+                .chain([barrier_info.clone()])
+                .collect(),
             CreatingStreamingJobStatus::Finishing { .. } => {
-                assert!(
-                    !start_consume_upstream,
-                    "should not start consuming upstream for a job again"
-                );
-                None
+                vec![]
             }
         }
     }
@@ -260,9 +231,8 @@ impl CreatingStreamingJobStatus {
     pub(super) fn new_fake_barrier(
         prev_epoch_fake_physical_time: &mut u64,
         pending_non_checkpoint_barriers: &mut Vec<u64>,
-        initial_barrier_info: &mut Option<(StreamJobActorsToCreate, Mutation)>,
         is_checkpoint: bool,
-    ) -> CreatingJobInjectBarrierInfo {
+    ) -> BarrierInfo {
         {
             {
                 let prev_epoch =
@@ -276,20 +246,10 @@ impl CreatingStreamingJobStatus {
                 } else {
                     BarrierKind::Barrier
                 };
-                let (new_actors, mutation) =
-                    if let Some((new_actors, mutation)) = initial_barrier_info.take() {
-                        (Some(new_actors), Some(mutation))
-                    } else {
-                        Default::default()
-                    };
-                CreatingJobInjectBarrierInfo {
-                    barrier_info: BarrierInfo {
-                        prev_epoch,
-                        curr_epoch,
-                        kind,
-                    },
-                    new_actors,
-                    mutation,
+                BarrierInfo {
+                    prev_epoch,
+                    curr_epoch,
+                    kind,
                 }
             }
         }

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -14,11 +14,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::mem::{replace, take};
+use std::sync::LazyLock;
 use std::task::{Context, Poll};
 
 use futures::FutureExt;
 use prometheus::{HistogramTimer, IntCounter};
-use risingwave_common::catalog::DatabaseId;
+use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::meta::event_log::{Event, EventRecovery};
 use risingwave_pb::stream_service::BarrierCompleteResponse;
@@ -27,16 +28,15 @@ use thiserror_ext::AsReport;
 use tracing::{info, warn};
 
 use crate::MetaResult;
+use crate::barrier::DatabaseRuntimeInfoSnapshot;
 use crate::barrier::checkpoint::control::DatabaseCheckpointControlStatus;
-use crate::barrier::checkpoint::{CheckpointControl, DatabaseCheckpointControl};
+use crate::barrier::checkpoint::creating_job::CreatingStreamingJobControl;
+use crate::barrier::checkpoint::{BarrierWorkerState, CheckpointControl};
 use crate::barrier::complete_task::BarrierCompleteOutput;
-use crate::barrier::info::InflightDatabaseInfo;
-use crate::barrier::rpc::ControlStreamManager;
-use crate::barrier::utils::{NodeToCollect, is_valid_after_worker_err};
+use crate::barrier::rpc::{ControlStreamManager, DatabaseInitialBarrierCollector};
 use crate::barrier::worker::{
     RetryBackoffFuture, RetryBackoffStrategy, get_retry_backoff_strategy,
 };
-use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 use crate::rpc::metrics::GLOBAL_META_METRICS;
 
 /// We can treat each database as a state machine of 3 states: `Running`, `Resetting` and `Initializing`.
@@ -75,9 +75,7 @@ enum DatabaseRecoveringStage {
         backoff_future: Option<RetryBackoffFuture>,
     },
     Initializing {
-        remaining_workers: NodeToCollect,
-        database: DatabaseCheckpointControl,
-        prev_epoch: u64,
+        initial_barrier_collector: Box<DatabaseInitialBarrierCollector>,
     },
 }
 
@@ -161,17 +159,14 @@ impl DatabaseRecoveringState {
                 // ignore the collected barrier on resetting or backoff
             }
             DatabaseRecoveringStage::Initializing {
-                remaining_workers,
-                prev_epoch,
-                ..
+                initial_barrier_collector,
             } => {
                 let worker_id = resp.worker_id as WorkerId;
-                assert!(remaining_workers.remove(&worker_id).is_some());
-                assert_eq!(resp.epoch, *prev_epoch);
+                initial_barrier_collector.collect_resp(resp);
                 info!(
                     ?database_id,
                     worker_id,
-                    ?remaining_workers,
+                    remaining_workers = ?initial_barrier_collector,
                     "initializing database barrier collected"
                 );
             }
@@ -187,8 +182,9 @@ impl DatabaseRecoveringState {
                 true
             }
             DatabaseRecoveringStage::Initializing {
-                remaining_workers, ..
-            } => is_valid_after_worker_err(remaining_workers, worker_id),
+                initial_barrier_collector,
+                ..
+            } => initial_barrier_collector.is_valid_after_worker_err(worker_id),
         }
     }
 
@@ -251,9 +247,10 @@ impl DatabaseRecoveringState {
                 }
             }
             DatabaseRecoveringStage::Initializing {
-                remaining_workers, ..
+                initial_barrier_collector,
+                ..
             } => {
-                if remaining_workers.is_empty() {
+                if initial_barrier_collector.is_collected() {
                     return Poll::Ready(RecoveringStateAction::EnterRunning);
                 }
             }
@@ -261,10 +258,23 @@ impl DatabaseRecoveringState {
         Poll::Pending
     }
 
-    pub(super) fn checkpoint_control(&self) -> Option<&DatabaseCheckpointControl> {
+    pub(super) fn database_state(
+        &self,
+    ) -> Option<(
+        &BarrierWorkerState,
+        &HashMap<TableId, CreatingStreamingJobControl>,
+    )> {
         match &self.stage {
             DatabaseRecoveringStage::Resetting { .. } => None,
-            DatabaseRecoveringStage::Initializing { database, .. } => Some(database),
+            DatabaseRecoveringStage::Initializing {
+                initial_barrier_collector,
+                ..
+            } => Some((initial_barrier_collector.database_state(), {
+                static EMPTY_CREATING_JOBS: LazyLock<
+                    HashMap<TableId, CreatingStreamingJobControl>,
+                > = LazyLock::new(HashMap::new);
+                &EMPTY_CREATING_JOBS
+            })),
         }
     }
 }
@@ -396,11 +406,8 @@ impl CheckpointControl {
 pub(crate) struct EnterInitializing(pub(crate) HashMap<WorkerId, ResetDatabaseResponse>);
 
 impl DatabaseStatusAction<'_, EnterInitializing> {
-    pub(crate) fn inflight_infos(
-        &self,
-    ) -> impl Iterator<Item = (DatabaseId, &InflightSubscriptionInfo, &InflightDatabaseInfo)> + '_
-    {
-        self.control.inflight_infos()
+    pub(crate) fn control(&self) -> &CheckpointControl {
+        &*self.control
     }
 
     pub(crate) fn enter(
@@ -433,7 +440,6 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
             mut background_jobs,
         } = runtime_info;
         let result: MetaResult<_> = try {
-            control_stream_manager.add_partial_graph(self.database_id, None);
             control_stream_manager.inject_database_initial_barrier(
                 self.database_id,
                 database_fragment_info,
@@ -447,12 +453,10 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
             )?
         };
         match result {
-            Ok((remaining_workers, database, prev_epoch)) => {
-                info!(?remaining_workers, database_id = ?self.database_id, "database enter initializing");
+            Ok(initial_barrier_collector) => {
+                info!(node_to_collect = ?initial_barrier_collector, database_id = ?self.database_id, "database enter initializing");
                 status.stage = DatabaseRecoveringStage::Initializing {
-                    remaining_workers,
-                    database,
-                    prev_epoch,
+                    initial_barrier_collector: initial_barrier_collector.into(),
                 };
             }
             Err(e) => {
@@ -528,12 +532,11 @@ impl DatabaseStatusAction<'_, EnterRunning> {
                         unreachable!("can only enter running during initializing")
                     }
                     DatabaseRecoveringStage::Initializing {
-                        remaining_workers,
-                        database,
-                        ..
+                        initial_barrier_collector,
                     } => {
-                        assert!(remaining_workers.is_empty());
-                        *database_status = DatabaseCheckpointControlStatus::Running(database);
+                        *database_status = DatabaseCheckpointControlStatus::Running(
+                            initial_barrier_collector.finish(),
+                        );
                     }
                 }
             }

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -20,7 +20,6 @@ use risingwave_common::util::epoch::Epoch;
 
 use crate::barrier::info::{BarrierInfo, InflightDatabaseInfo, InflightSubscriptionInfo};
 use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
-use crate::controller::fragment::InflightFragmentInfo;
 
 /// The latest state of `GlobalBarrierWorker` after injecting the latest barrier.
 pub(crate) struct BarrierWorkerState {
@@ -165,9 +164,7 @@ impl BarrierWorkerState {
         if let Some(Command::MergeSnapshotBackfillStreamingJobs(jobs_to_merge)) = command {
             for (table_id, (_, graph_info)) in jobs_to_merge {
                 jobs_to_wait.insert(*table_id);
-                table_ids_to_commit.extend(InflightFragmentInfo::existing_table_ids(
-                    graph_info.fragment_infos(),
-                ));
+                table_ids_to_commit.extend(graph_info.existing_table_ids());
                 self.inflight_graph_info.extend(graph_info.clone());
             }
         }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -284,7 +284,7 @@ pub enum Command {
         cross_db_snapshot_backfill_info: SnapshotBackfillInfo,
     },
     MergeSnapshotBackfillStreamingJobs(
-        HashMap<TableId, (SnapshotBackfillInfo, InflightStreamingJobInfo)>,
+        HashMap<TableId, (HashSet<TableId>, InflightStreamingJobInfo)>,
     ),
 
     /// `Reschedule` command generates a `Update` barrier by the [`Reschedule`] of each fragment.
@@ -763,10 +763,9 @@ impl Command {
                 Some(Mutation::DropSubscriptions(DropSubscriptionsMutation {
                     info: jobs_to_merge
                         .iter()
-                        .flat_map(|(table_id, (backfill_info, _))| {
-                            backfill_info
-                                .upstream_mv_table_id_to_backfill_epoch
-                                .keys()
+                        .flat_map(|(table_id, (backfill_upstream_tables, _))| {
+                            backfill_upstream_tables
+                                .iter()
                                 .map(move |upstream_table_id| SubscriptionUpstreamInfo {
                                     subscriber_id: table_id.table_id,
                                     upstream_mv_table_id: upstream_table_id.table_id,

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -70,6 +70,20 @@ impl InflightStreamingJobInfo {
     pub fn fragment_infos(&self) -> impl Iterator<Item = &InflightFragmentInfo> + '_ {
         self.fragment_infos.values()
     }
+
+    pub fn existing_table_ids(&self) -> impl Iterator<Item = TableId> + '_ {
+        InflightFragmentInfo::existing_table_ids(self.fragment_infos())
+    }
+}
+
+impl<'a> IntoIterator for &'a InflightStreamingJobInfo {
+    type Item = &'a InflightFragmentInfo;
+
+    type IntoIter = impl Iterator<Item = &'a InflightFragmentInfo> + 'a;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fragment_infos()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -224,11 +224,10 @@ impl TrackingJob {
     pub(crate) async fn finish(self, metadata_manager: &MetadataManager) -> MetaResult<()> {
         match self {
             TrackingJob::New(command) => {
-                let CreateStreamingJobCommandInfo { streaming_job, .. } = &command.info;
                 metadata_manager
                     .catalog_controller
                     .finish_streaming_job(
-                        streaming_job.id() as i32,
+                        command.job_id.table_id as i32,
                         command.replace_stream_job.clone(),
                     )
                     .await?;
@@ -246,7 +245,7 @@ impl TrackingJob {
 
     pub(crate) fn table_to_create(&self) -> TableId {
         match self {
-            TrackingJob::New(command) => command.info.stream_job_fragments.stream_job_id(),
+            TrackingJob::New(command) => command.job_id,
             TrackingJob::Recovered(recovered) => (recovered.id as u32).into(),
         }
     }
@@ -255,11 +254,7 @@ impl TrackingJob {
 impl std::fmt::Debug for TrackingJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TrackingJob::New(command) => write!(
-                f,
-                "TrackingJob::New({:?})",
-                command.info.stream_job_fragments.stream_job_id()
-            ),
+            TrackingJob::New(command) => write!(f, "TrackingJob::New({:?})", command.job_id),
             TrackingJob::Recovered(recovered) => {
                 write!(f, "TrackingJob::RecoveredV2({:?})", recovered.id)
             }
@@ -273,7 +268,7 @@ pub struct RecoveredTrackingJob {
 
 /// The command tracking by the [`CreateMviewProgressTracker`].
 pub(super) struct TrackingCommand {
-    pub info: CreateStreamingJobCommandInfo,
+    pub job_id: TableId,
     pub replace_stream_job: Option<ReplaceStreamJobPlan>,
 }
 
@@ -302,12 +297,12 @@ impl CreateMviewProgressTracker {
     /// 1. `CreateMviewProgress`.
     /// 2. `Backfill` position.
     pub fn recover(
-        mview_map: HashMap<TableId, (String, StreamJobFragments)>,
+        mviews: impl IntoIterator<Item = (TableId, (String, &StreamJobFragments))>,
         version_stats: &HummockVersionStats,
     ) -> Self {
         let mut actor_map = HashMap::new();
         let mut progress_map = HashMap::new();
-        for (creating_table_id, (definition, table_fragments)) in mview_map {
+        for (creating_table_id, (definition, table_fragments)) in mviews {
             let mut states = HashMap::new();
             let mut backfill_upstream_types = HashMap::new();
             let actors = table_fragments.tracking_progress_actor_ids();
@@ -513,7 +508,7 @@ impl CreateMviewProgressTracker {
             if actors.is_empty() {
                 // The command can be finished immediately.
                 return Some(TrackingJob::New(TrackingCommand {
-                    info: info.clone(),
+                    job_id: info.stream_job_fragments.stream_job_id,
                     replace_stream_job: replace_stream_job.cloned(),
                 }));
             }
@@ -550,7 +545,7 @@ impl CreateMviewProgressTracker {
             // This still contains the notifiers, so we can tell listeners
             // that the sink job has been created.
             Some(TrackingJob::New(TrackingCommand {
-                info,
+                job_id: creating_mv_id,
                 replace_stream_job: replace_table_info,
             }))
         } else {
@@ -559,7 +554,7 @@ impl CreateMviewProgressTracker {
                 (
                     progress,
                     TrackingJob::New(TrackingCommand {
-                        info,
+                        job_id: creating_mv_id,
                         replace_stream_job: replace_table_info,
                     }),
                 ),

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::mem::replace;
 use std::sync::Arc;
@@ -346,7 +347,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                     for worker_id in workers {
                                         if !self.control_stream_manager.contains_worker(worker_id) {
                                             let node = self.active_streaming_nodes.current()[&worker_id].clone();
-                                            self.control_stream_manager.try_add_worker(node, entering_initializing.inflight_infos(), self.term_id.clone(), &*self.context).await;
+                                            self.control_stream_manager.try_add_worker(node, entering_initializing.control().inflight_infos(), self.term_id.clone(), &*self.context).await;
                                         }
                                     }
                                     entering_initializing.enter(runtime_info, &mut self.control_stream_manager);
@@ -399,7 +400,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         };
                         match resp {
                             Response::CompleteBarrier(resp) => {
-                                self.checkpoint_control.barrier_collected(resp, &mut self.control_stream_manager, &mut self.periodic_barriers)?;
+                                self.checkpoint_control.barrier_collected(resp, &mut self.periodic_barriers)?;
                             },
                             Response::ReportDatabaseFailure(resp) => {
                                 if !self.enable_recovery {
@@ -647,9 +648,8 @@ mod retry_strategy {
 
 pub(crate) use retry_strategy::*;
 use risingwave_common::error::tonic::extra::{Score, ScoredError};
+use risingwave_meta_model::WorkerId;
 use risingwave_pb::meta::event_log::{Event, EventRecovery};
-
-use crate::barrier::utils::is_valid_after_worker_err;
 
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
     /// Recovery the whole cluster from the latest epoch.
@@ -741,7 +741,6 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 let mut collecting_databases = HashMap::new();
                 let mut failed_databases = HashSet::new();
                 for (database_id, info) in database_fragment_infos {
-                    control_stream_manager.add_partial_graph(database_id, None);
                     let result = control_stream_manager.inject_database_initial_barrier(
                         database_id,
                         info,
@@ -753,7 +752,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         is_paused,
                         &hummock_version_stats,
                     );
-                    let (node_to_collect, database, prev_epoch) = match result {
+                    let node_to_collect = match result {
                         Ok(info) => {
                             info
                         }
@@ -763,11 +762,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             continue;
                         }
                     };
-                    if !node_to_collect.is_empty() {
-                        assert!(collecting_databases.insert(database_id, (node_to_collect, database, prev_epoch)).is_none());
+                    if !node_to_collect.is_collected() {
+                        assert!(collecting_databases.insert(database_id, node_to_collect).is_none());
                     } else {
                         warn!(database_id = database_id.database_id, "database has no node to inject initial barrier");
-                        assert!(collected_databases.insert(database_id, database).is_none());
+                        assert!(collected_databases.insert(database_id, node_to_collect.finish()).is_none());
                     }
                 }
                 while !collecting_databases.is_empty() {
@@ -776,8 +775,8 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     let resp = match result {
                         Err(e) => {
                             warn!(worker_id, err = %e.as_report(), "worker node failure during recovery");
-                            for (failed_database_id,_ ) in collecting_databases.extract_if(|_, (node_to_collect, _, _)| {
-                                !is_valid_after_worker_err(node_to_collect, worker_id)
+                            for (failed_database_id,_ ) in collecting_databases.extract_if(|_, node_to_collect| {
+                                !node_to_collect.is_valid_after_worker_err(worker_id)
                             }) {
                                 warn!(%failed_database_id, worker_id, "database failed to recovery in global recovery due to worker node err");
                                 assert!(failed_databases.insert(failed_database_id));
@@ -808,19 +807,21 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             }
                         }
                     };
+                    assert_eq!(worker_id, resp.worker_id as WorkerId);
                     let database_id = DatabaseId::new(resp.database_id);
                     if failed_databases.contains(&database_id) {
                         assert!(!collecting_databases.contains_key(&database_id));
                         // ignore the lately arrived collect resp of failed database
                         continue;
                     }
-                    assert!(!collected_databases.contains_key(&database_id));
-                    let (node_to_collect, _, prev_epoch) = collecting_databases.get_mut(&database_id).expect("should exist");
-                    assert_eq!(resp.epoch, *prev_epoch);
-                    assert!(node_to_collect.remove(&worker_id).is_some());
-                    if node_to_collect.is_empty() {
-                        let (_, database, _) = collecting_databases.remove(&database_id).expect("should exist");
-                        assert!(collected_databases.insert(database_id, database).is_none());
+                    let Entry::Occupied(mut entry) = collecting_databases.entry(database_id) else {
+                        unreachable!("should exist")
+                    };
+                    let node_to_collect = entry.get_mut();
+                    node_to_collect.collect_resp(resp);
+                    if node_to_collect.is_collected() {
+                        let node_to_collect = entry.remove();
+                        assert!(collected_databases.insert(database_id, node_to_collect.finish()).is_none());
                     }
                 }
                 debug!("collected initial barrier");

--- a/src/stream/src/task/barrier_manager/progress.rs
+++ b/src/stream/src/task/barrier_manager/progress.rs
@@ -275,7 +275,8 @@ impl CreateMviewProgressReporter {
         assert_matches!(
             self.state,
             Some(BackfillState::DoneConsumingUpstreamTableOrSource(_))
-                | Some(BackfillState::ConsumingLogStore { .. }),
+                | Some(BackfillState::ConsumingLogStore { .. })
+                | None,
             "cannot update log store progress at state {:?}",
             self.state
         );

--- a/src/stream/src/task/barrier_manager/progress.rs
+++ b/src/stream/src/task/barrier_manager/progress.rs
@@ -289,7 +289,8 @@ impl CreateMviewProgressReporter {
         assert_matches!(
             self.state,
             Some(BackfillState::DoneConsumingUpstreamTableOrSource(_))
-                | Some(BackfillState::ConsumingLogStore { .. }),
+                | Some(BackfillState::ConsumingLogStore { .. })
+                | None,
             "cannot finish log store progress at state {:?}",
             self.state
         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Before the [PR](https://github.com/risingwavelabs/risingwave/pull/20848) to support recoverable snapshot backfill, we will refine the current logic of tracking snapshot backfill in global barrier manager, so that we can simplify the implementation in the subsequent PR.

We will make the following changes:
- Previously, we store initial mutation and new actors to create in the tracker of snapshot backfill(`CreatingStreamingJobControl`), and take them out to include it when later injecting the first barrier. In this PR we will change to injecting the first barrier along with creating a new `CreatingStreamingJobControl`, so that we don't have to store the initial mutation and new actors.
- We handle the transition from `ConsumingSnapshot` to `ConsumingLogStore` when we collect a new `CompleteBarrierResponse` and see that all actors have finished consuming the snapshot. During this transition, we will inject all the pending upstream barriers immediately in this `collect_barrier` method. In this PR, we will change to store the pending upstream barriers in `ConsumingLogStore` first, and then when handling the next upstream barrier, we then inject all the pending barriers. The reason for this change is to avoid injecting barrier in the `collect` of `CreatingStreamingJobControl`.
- extract the logic of collecting initial barriers during recovery to a `DatabaseInitialBarrierCollector` and provide some util methods
- simplify some fields for the structs that track snapshot backfill. For example, previously we store a `StreamJobFragment` as a field, but we actually only access its `job_id`, and then we change to only store a `job_id`


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
