### PR TITLE
fix(frontend): `encode protobuf` shall pass options without `legacy_source::ProtobufSchema` (#20949)

### DIFF
--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -73,7 +73,7 @@ use risingwave_pb::stream_plan::PbStreamFragmentGraph;
 use risingwave_pb::telemetry::TelemetryDatabaseObject;
 use risingwave_sqlparser::ast::{
     get_delimiter, AstString, ColumnDef, CreateSourceStatement, Encode, Format,
-    FormatEncodeOptions, ObjectName, ProtobufSchema, SourceWatermark, TableConstraint,
+    FormatEncodeOptions, ObjectName, SourceWatermark, TableConstraint,
 };
 use risingwave_sqlparser::parser::{IncludeOption, IncludeOptionItem};
 use thiserror_ext::AsReport;

--- a/src/frontend/src/handler/create_source/external_schema.rs
+++ b/src/frontend/src/handler/create_source/external_schema.rs
@@ -141,26 +141,22 @@ async fn bind_columns_from_source_for_non_cdc(
         (Format::Plain, Encode::Protobuf) | (Format::Upsert, Encode::Protobuf) => {
             let (row_schema_location, use_schema_registry) =
                 get_schema_location(&mut format_encode_options_to_consume)?;
-            let protobuf_schema = ProtobufSchema {
-                message_name: consume_string_from_options(
-                    &mut format_encode_options_to_consume,
-                    MESSAGE_NAME_KEY,
-                )?,
-                row_schema_location,
-                use_schema_registry,
-            };
+            let message_name = consume_string_from_options(
+                &mut format_encode_options_to_consume,
+                MESSAGE_NAME_KEY,
+            )?;
             let name_strategy = get_sr_name_strategy_check(
                 &mut format_encode_options_to_consume,
-                protobuf_schema.use_schema_registry,
+                use_schema_registry,
             )?;
 
-            stream_source_info.use_schema_registry = protobuf_schema.use_schema_registry;
+            stream_source_info.use_schema_registry = use_schema_registry;
             stream_source_info
                 .row_schema_location
-                .clone_from(&protobuf_schema.row_schema_location.0);
+                .clone_from(&row_schema_location.0);
             stream_source_info
                 .proto_message_name
-                .clone_from(&protobuf_schema.message_name.0);
+                .clone_from(&message_name.0);
             stream_source_info.key_message_name =
                 get_key_message_name(&mut format_encode_options_to_consume);
             stream_source_info.name_strategy =
@@ -168,7 +164,7 @@ async fn bind_columns_from_source_for_non_cdc(
 
             Some(
                 extract_protobuf_table_schema(
-                    &protobuf_schema,
+                    &stream_source_info,
                     &options_with_secret,
                     &mut format_encode_options_to_consume,
                 )

--- a/src/frontend/src/handler/create_source/external_schema/protobuf.rs
+++ b/src/frontend/src/handler/create_source/external_schema/protobuf.rs
@@ -18,20 +18,11 @@ use super::*;
 
 /// Map a protobuf schema to a relational schema.
 pub async fn extract_protobuf_table_schema(
-    schema: &ProtobufSchema,
+    info: &StreamSourceInfo,
     with_properties: &WithOptionsSecResolved,
     format_encode_options: &mut BTreeMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
-    let info = StreamSourceInfo {
-        proto_message_name: schema.message_name.0.clone(),
-        row_schema_location: schema.row_schema_location.0.clone(),
-        use_schema_registry: schema.use_schema_registry,
-        format: FormatType::Plain.into(),
-        row_encode: EncodeType::Protobuf.into(),
-        format_encode_options: format_encode_options.clone(),
-        ..Default::default()
-    };
-    let parser_config = SpecificParserConfig::new(&info, with_properties)?;
+    let parser_config = SpecificParserConfig::new(info, with_properties)?;
     try_consume_string_from_options(format_encode_options, SCHEMA_REGISTRY_USERNAME);
     try_consume_string_from_options(format_encode_options, SCHEMA_REGISTRY_PASSWORD);
     try_consume_string_from_options(format_encode_options, PROTOBUF_MESSAGES_AS_JSONB);

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -41,9 +41,7 @@ pub use self::ddl::{
     AlterSchemaOperation, AlterSecretOperation, AlterTableOperation, ColumnDef, ColumnOption,
     ColumnOptionDef, ReferentialAction, SourceWatermark, TableConstraint, WebhookSourceInfo,
 };
-pub use self::legacy_source::{
-    get_delimiter, AvroSchema, CompatibleFormatEncode, DebeziumAvroSchema, ProtobufSchema,
-};
+pub use self::legacy_source::{get_delimiter, CompatibleFormatEncode};
 pub use self::operator::{BinaryOperator, QualifiedOperator, UnaryOperator};
 pub use self::query::{
     Corresponding, Cte, CteInner, Distinct, Fetch, Join, JoinConstraint, JoinOperator, LateralView,


### PR DESCRIPTION
Cherry picking \#20949 onto branch release-2.2,

This PR/issue was created to resolve #20979 by cherry-pick action from commit 3ce8ec6624d084ce85d7c49aa42011af32d13917.,