### PR TITLE
fix(action): cherry-pick-since shall read `github.event.pull_request.labels` on merge

### DIFF
--- a/.github/workflows/cherry-pick-since-release-branch.yml
+++ b/.github/workflows/cherry-pick-since-release-branch.yml
@@ -23,7 +23,12 @@ jobs:
       - name: Get all release branches including label version and higher
         id: filter-release-branches
         run: |
-          label="${{ github.event.label.name }}"
+          if [[ ${{ github.event.action }} == 'labeled' ]]; then
+            label="${{ github.event.label.name }}"
+          else
+            labels='${{ toJson(github.event.pull_request.labels) }}'
+            label=$(echo "$labels" | jq -r '.[] | select(.name | contains("need-cherry-pick-since")).name' | sort -V | head -n 1)
+          fi
           base_version=$(echo "$label" | sed 's/need-cherry-pick-since-release-//')
 
           echo "Base version from label: $base_version"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

There are 2 triggers of the cherry-pick-since action:
* `labeled` on a merged PR. The label name triggering the action is available as `github.event.label.name`
* `closed` on a labeled PR. The list of labels of the PR is available as `github.event.pull_request.labels`

The old implementation only reads `github.event.label.name`, which is empty when triggered on `closed`/merge, resulting in ineffective version filter: #21004 #21008 #21009 #21005 #21006 #21010 #21012 #21011 #21007

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
