### PR TITLE
feat(sink): support registering the more general dyn LogSinker in test

### DIFF
--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -159,7 +159,7 @@ impl BigQueryLogSinker {
 
 #[async_trait]
 impl LogSinker for BigQueryLogSinker {
-    async fn consume_log_and_sink(mut self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         loop {
             tokio::select!(

--- a/src/connector/src/sink/boxed.rs
+++ b/src/connector/src/sink/boxed.rs
@@ -12,42 +12,89 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
 use std::ops::DerefMut;
-use std::sync::Arc;
 
 use async_trait::async_trait;
-use risingwave_common::array::StreamChunk;
-use risingwave_common::bitmap::Bitmap;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use risingwave_pb::connector_service::SinkMetadata;
 
 use super::SinkCommittedEpochSubscriber;
-use crate::sink::{SinkCommitCoordinator, SinkWriter};
+use crate::sink::log_store::{LogStoreReadItem, LogStoreResult, TruncateOffset};
+use crate::sink::{LogSinker, SinkCommitCoordinator, SinkLogReader};
 
-pub type BoxWriter<CM> = Box<dyn SinkWriter<CommitMetadata = CM> + Send + 'static>;
 pub type BoxCoordinator = Box<dyn SinkCommitCoordinator + Send + 'static>;
 
+pub type BoxLogSinker = Box<
+    dyn for<'a> FnOnce(&'a mut dyn DynLogReader) -> BoxFuture<'a, crate::sink::Result<!>>
+        + Send
+        + 'static,
+>;
+
 #[async_trait]
-impl<CM: 'static + Send> SinkWriter for BoxWriter<CM> {
-    type CommitMetadata = CM;
+pub trait DynLogReader: Send {
+    async fn dyn_start_from(&mut self, start_offset: Option<u64>) -> LogStoreResult<()>;
+    async fn dyn_next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)>;
 
-    async fn begin_epoch(&mut self, epoch: u64) -> crate::sink::Result<()> {
-        self.deref_mut().begin_epoch(epoch).await
+    fn dyn_truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()>;
+}
+
+#[async_trait]
+impl<R: SinkLogReader> DynLogReader for R {
+    async fn dyn_start_from(&mut self, start_offset: Option<u64>) -> LogStoreResult<()> {
+        R::start_from(self, start_offset).await
     }
 
-    async fn write_batch(&mut self, chunk: StreamChunk) -> crate::sink::Result<()> {
-        self.deref_mut().write_batch(chunk).await
+    async fn dyn_next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
+        R::next_item(self).await
     }
 
-    async fn barrier(&mut self, is_checkpoint: bool) -> crate::sink::Result<CM> {
-        self.deref_mut().barrier(is_checkpoint).await
+    fn dyn_truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+        R::truncate(self, offset)
+    }
+}
+
+impl SinkLogReader for &mut dyn DynLogReader {
+    fn start_from(
+        &mut self,
+        start_offset: Option<u64>,
+    ) -> impl Future<Output = LogStoreResult<()>> + Send + '_ {
+        (*self).dyn_start_from(start_offset)
     }
 
-    async fn abort(&mut self) -> crate::sink::Result<()> {
-        self.deref_mut().abort().await
+    fn next_item(
+        &mut self,
+    ) -> impl Future<Output = LogStoreResult<(u64, LogStoreReadItem)>> + Send + '_ {
+        (*self).dyn_next_item()
     }
 
-    async fn update_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) -> crate::sink::Result<()> {
-        self.deref_mut().update_vnode_bitmap(vnode_bitmap).await
+    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+        (*self).dyn_truncate(offset)
+    }
+}
+
+pub fn boxed_log_sinker(log_sinker: impl LogSinker) -> BoxLogSinker {
+    fn make_future<'a>(
+        log_sinker: impl LogSinker,
+        log_reader: &'a mut dyn DynLogReader,
+    ) -> BoxFuture<'a, crate::sink::Result<!>> {
+        log_sinker.consume_log_and_sink(log_reader).boxed()
+    }
+
+    // Note: it's magical that the following expression can be cast to the expected return type
+    // without any explicit conversion, such as `<expr> as _` or `<expr>.into()`.
+    // TODO: may investigate the reason. The currently successful compilation seems volatile to future compatibility.
+    Box::new(move |log_reader: &mut dyn DynLogReader| make_future(log_sinker, log_reader))
+}
+
+#[async_trait]
+impl LogSinker for BoxLogSinker {
+    async fn consume_log_and_sink(
+        self,
+        mut log_reader: impl SinkLogReader,
+    ) -> crate::sink::Result<!> {
+        (self)(&mut log_reader).await
     }
 }
 

--- a/src/connector/src/sink/decouple_checkpoint_log_sink.rs
+++ b/src/connector/src/sink/decouple_checkpoint_log_sink.rs
@@ -56,7 +56,7 @@ impl<W> DecoupleCheckpointLogSinkerOf<W> {
 
 #[async_trait]
 impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for DecoupleCheckpointLogSinkerOf<W> {
-    async fn consume_log_and_sink(self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(self, mut log_reader: impl SinkLogReader) -> Result<!> {
         let mut sink_writer = self.writer;
         let rewind_start_offset = sink_writer.rewind_start_offset()?;
         log_reader.start_from(rewind_start_offset).await?;

--- a/src/connector/src/sink/file_sink/batching_log_sink.rs
+++ b/src/connector/src/sink/file_sink/batching_log_sink.rs
@@ -33,7 +33,7 @@ impl BatchingLogSinker {
 
 #[async_trait]
 impl LogSinker for BatchingLogSinker {
-    async fn consume_log_and_sink(self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         let mut sink_writer = self.writer;
         #[derive(Debug)]

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -659,7 +659,7 @@ pub trait Sink: TryFrom<SinkParam, Error = SinkError> {
     }
 }
 
-pub trait SinkLogReader: Send + Sized + 'static {
+pub trait SinkLogReader: Send {
     fn start_from(
         &mut self,
         start_offset: Option<u64>,
@@ -676,29 +676,29 @@ pub trait SinkLogReader: Send + Sized + 'static {
     fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()>;
 }
 
-impl<R: LogReader> SinkLogReader for R {
+impl<R: LogReader> SinkLogReader for &mut R {
     fn next_item(
         &mut self,
     ) -> impl Future<Output = LogStoreResult<(u64, LogStoreReadItem)>> + Send + '_ {
-        <Self as LogReader>::next_item(self)
+        <R as LogReader>::next_item(*self)
     }
 
     fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        <Self as LogReader>::truncate(self, offset)
+        <R as LogReader>::truncate(*self, offset)
     }
 
     fn start_from(
         &mut self,
         start_offset: Option<u64>,
-    ) -> impl std::future::Future<Output = LogStoreResult<()>> + std::marker::Send {
-        <Self as LogReader>::start_from(self, start_offset)
+    ) -> impl Future<Output = LogStoreResult<()>> + Send + '_ {
+        <R as LogReader>::start_from(*self, start_offset)
     }
 }
 
 #[async_trait]
 pub trait LogSinker: 'static + Send {
     // Note: Please rebuild the log reader's read stream before consuming the log store,
-    async fn consume_log_and_sink(self, log_reader: &mut impl SinkLogReader) -> Result<!>;
+    async fn consume_log_and_sink(self, log_reader: impl SinkLogReader) -> Result<!>;
 }
 pub type SinkCommittedEpochSubscriber = Arc<
     dyn Fn(SinkId) -> BoxFuture<'static, Result<(u64, UnboundedReceiver<u64>)>>

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -521,7 +521,7 @@ impl PostgresSinkWriter {
 
 #[async_trait]
 impl LogSinker for PostgresSinkWriter {
-    async fn consume_log_and_sink(mut self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         loop {
             let (epoch, item) = log_reader.next_item().await?;

--- a/src/connector/src/sink/remote.rs
+++ b/src/connector/src/sink/remote.rs
@@ -342,7 +342,7 @@ impl LogSinker for RemoteLogSinker {
             fn truncate_matched_offset(
                 queue: &mut VecDeque<(TruncateOffset, Option<Instant>)>,
                 persisted_offset: TruncateOffset,
-                log_reader: &mut (impl SinkLogReader + ?Sized),
+                log_reader: &mut impl SinkLogReader,
                 sink_writer_metrics: &SinkWriterMetrics,
             ) -> Result<()> {
                 while let Some((sent_offset, _)) = queue.front()

--- a/src/connector/src/sink/trivial.rs
+++ b/src/connector/src/sink/trivial.rs
@@ -81,7 +81,7 @@ impl<T: TrivialSinkName> Sink for TrivialSink<T> {
 
 #[async_trait]
 impl<T: TrivialSinkName> LogSinker for TrivialSink<T> {
-    async fn consume_log_and_sink(self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         loop {
             let (epoch, item) = log_reader.next_item().await?;

--- a/src/connector/src/sink/writer.rs
+++ b/src/connector/src/sink/writer.rs
@@ -132,7 +132,7 @@ impl<W> LogSinkerOf<W> {
 
 #[async_trait]
 impl<W: SinkWriter<CommitMetadata = ()>> LogSinker for LogSinkerOf<W> {
-    async fn consume_log_and_sink(self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         let mut sink_writer = self.writer;
         let metrics = self.sink_writer_metrics;
@@ -249,7 +249,7 @@ impl<W: AsyncTruncateSinkWriter> AsyncTruncateLogSinkerOf<W> {
 
 #[async_trait]
 impl<W: AsyncTruncateSinkWriter> LogSinker for AsyncTruncateLogSinkerOf<W> {
-    async fn consume_log_and_sink(mut self, log_reader: &mut impl SinkLogReader) -> Result<!> {
+    async fn consume_log_and_sink(mut self, mut log_reader: impl SinkLogReader) -> Result<!> {
         log_reader.start_from(None).await?;
         loop {
             let select_result = drop_either_future(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Previously in deterministic sink test, we allow registering the customized logic of `SinkWriter`. However, currently have a more general `LogSinker` trait. In this PR, we will support registering the customized logic of this more general `LogSinker`.

Definition of the `consume_log_and_sink` of `LogSinker` is slightly changed to simplify the support for type erasion in the dynamic dispatch. Previously we impl `SinkLogReader` for `LogReader`, and pass `&mut impl SinkLogReader` to `consume_log_and_sink`. In this PR, will change to impl `SinkLogReader` for `&mut LogReader`, and pass `impl SinkLogReader`. To support type erasion on `SinkLogReader`, we introduce a `DynSinkLogReader`, and impl `SinkLogReader` for `&mut dyn DynSinkLogReader`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
