### PR TITLE
fix: fix the self-reference issue in the sink into table creation

### DIFF
--- a/e2e_test/sink/sink_into_table/cycle.slt
+++ b/e2e_test/sink/sink_into_table/cycle.slt
@@ -1,4 +1,9 @@
 # cycle check
+statement ok
+create table t_t(v int primary key);
+
+statement error Creating such a sink will result in circular dependency
+create sink t_s into t_t from t_t;
 
 statement ok
 create table t_a(v int primary key);
@@ -32,6 +37,9 @@ drop table t_b;
 
 statement ok
 drop table t_c;
+
+statement ok
+drop table t_t;
 
 # cycle check (with materialize view)
 

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -328,6 +328,11 @@ where
         return Ok(false);
     }
 
+    // special check for self referencing
+    if dependent_objs.contains(&target_table) {
+        return Ok(true);
+    }
+
     let query = construct_sink_cycle_check_query(target_table, dependent_objs);
     let (sql, values) = query.build_any(&*db.get_database_backend().get_query_builder());
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

close #20923

## Summary

This pull request introduces key modifications to address circular dependency issues in table and sink creation within the database.

**Self-Referencing Check**:
   - Enhanced the utility functions in `utils.rs` to include a check for self-referencing objects. This improvement enables the system to correctly identify and handle cases where a target table may refer to itself, thus mitigating potential circular dependencies.

This set of changes lays the groundwork for robust dependency management in table and sink operations, paving the way for future enhancements.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
