### PR TITLE
fix(action): update-pr-template-by-version auto branch management

### DIFF
--- a/.github/workflows/update-pr-template-by-version.yml
+++ b/.github/workflows/update-pr-template-by-version.yml
@@ -52,27 +52,12 @@ jobs:
             awk -v version="Highest Release Version: ${VERSION}" '1;/I hereby agree/{print "\n" version}' .github/pull_request_template.md > tmpfile && mv tmpfile .github/pull_request_template.md
           fi
 
-      - name: Commit and push changes
-        if: env.update_needed == 'true'
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-          # Checkout branch correctly: create if it doesn’t exist, otherwise reset it
-          git fetch origin update-pr-template-${{ env.version }} || true
-          git checkout -B update-pr-template-${{ env.version }} origin/update-pr-template-${{ env.version }} || git checkout -b update-pr-template-${{ env.version }}
-
-          git add .github/pull_request_template.md
-          git commit -m "chore: update PR template with highest release version ${{ env.version }}"
-          git diff ..main
-
-          git push --force-with-lease origin update-pr-template-${{ env.version }}
-
       - name: Create pull request
         if: env.update_needed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           title: "Update PR Template for Highest Release Version"
           body: "This PR updates the pull request template to reflect the highest release version: ${{ env.version }}."
+          commit-message: "chore: update PR template with highest release version ${{ env.version }}"
           base: main
           branch: update-pr-template-${{ env.version }}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

It seems we were not using peter-evans/create-pull-request@v7 correctly.

https://github.com/peter-evans/create-pull-request/blob/v7/README.md
> How the action behaves:
> * If there are changes (i.e. a diff exists with the checked-out base branch), the changes will be pushed to a new branch and a pull request created.

That is, when the action executes, `main` (the `base`) shall be checked out and the action will create/update `update-pr-template-${{ env.version }}` (the `branch`). If we already pushed the `branch` to remote, it will be recognized by the action as no action needed:
https://github.com/risingwavelabs/risingwave/actions/runs/14077531058/job/39423132359

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
