### PR TITLE
refactor(frontend,stream): store metrics at an executor level rather than operator level

### DIFF
--- a/proto/monitor_service.proto
+++ b/proto/monitor_service.proto
@@ -94,7 +94,7 @@ message TieredCacheTracingRequest {
 message TieredCacheTracingResponse {}
 
 message GetProfileStatsRequest {
-  repeated uint64 operator_ids = 1;
+  repeated uint64 executor_ids = 1;
 }
 
 message GetProfileStatsResponse {

--- a/src/common/src/operator.rs
+++ b/src/common/src/operator.rs
@@ -23,3 +23,9 @@ pub fn unique_executor_id(actor_id: u32, operator_id: u64) -> u64 {
     assert!(operator_id <= u32::MAX as u64);
     ((actor_id as u64) << 32) + operator_id
 }
+
+pub fn unique_executor_id_from_unique_operator_id(actor_id: u32, unique_operator_id: u64) -> u64 {
+    // keep only low-32 bits
+    let unique_operator_id = unique_operator_id & 0xFFFFFFFF;
+    ((actor_id as u64) << 32) + unique_operator_id
+}

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -293,13 +293,13 @@ impl MonitorService for MonitorServiceImpl {
         request: Request<GetProfileStatsRequest>,
     ) -> Result<Response<GetProfileStatsResponse>, Status> {
         let metrics = global_streaming_metrics(MetricLevel::Info);
-        let operator_ids = &request.into_inner().operator_ids;
+        let executor_ids = &request.into_inner().executor_ids;
         let stream_node_output_row_count = metrics
             .mem_stream_node_output_row_count
-            .collect(operator_ids);
+            .collect(executor_ids);
         let stream_node_output_blocking_duration_ms = metrics
             .mem_stream_node_output_blocking_duration_ms
-            .collect(operator_ids);
+            .collect(executor_ids);
         Ok(Response::new(GetProfileStatsResponse {
             stream_node_output_row_count,
             stream_node_output_blocking_duration_ms,

--- a/src/stream/src/executor/monitor/profiling_stats.rs
+++ b/src/stream/src/executor/monitor/profiling_stats.rs
@@ -14,7 +14,7 @@
 
 use std::sync::atomic::Ordering;
 
-use risingwave_common::monitor::in_mem::Count;
+use risingwave_common::monitor::in_mem::GuardedCount;
 
 use crate::executor::monitor::StreamingMetrics;
 
@@ -25,18 +25,18 @@ pub enum ProfileMetricsImpl {
 
 impl ProfileMetricsImpl {
     pub fn new(
+        executor_id: u64,
         stats: &StreamingMetrics,
-        operator_id: u64,
         enable_profiling: bool,
     ) -> ProfileMetricsImpl {
         if enable_profiling {
             ProfileMetricsImpl::ProfileMetrics(ProfileMetrics {
                 stream_node_output_row_count: stats
                     .mem_stream_node_output_row_count
-                    .new_or_get_counter(operator_id),
+                    .new_count(executor_id),
                 stream_node_output_blocking_duration_ms: stats
                     .mem_stream_node_output_blocking_duration_ms
-                    .new_or_get_counter(operator_id),
+                    .new_count(executor_id),
             })
         } else {
             ProfileMetricsImpl::NoopProfileMetrics
@@ -45,8 +45,8 @@ impl ProfileMetricsImpl {
 }
 
 pub struct ProfileMetrics {
-    pub stream_node_output_row_count: Count,
-    pub stream_node_output_blocking_duration_ms: Count,
+    pub stream_node_output_row_count: GuardedCount,
+    pub stream_node_output_blocking_duration_ms: GuardedCount,
 }
 
 pub trait ProfileMetricsExt {
@@ -57,11 +57,13 @@ pub trait ProfileMetricsExt {
 impl ProfileMetricsExt for ProfileMetrics {
     fn inc_row_count(&self, count: u64) {
         self.stream_node_output_row_count
+            .count
             .fetch_add(count, Ordering::Relaxed);
     }
 
     fn inc_blocking_duration_ms(&self, duration_ms: u64) {
         self.stream_node_output_blocking_duration_ms
+            .count
             .fetch_add(duration_ms, Ordering::Relaxed);
     }
 }

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -233,8 +233,8 @@ impl StreamingMetrics {
         .unwrap()
         .relabel_debug_1(level);
 
-        let stream_node_output_row_count = CountMap::new(level);
-        let stream_node_output_blocking_duration_ms = CountMap::new(level);
+        let stream_node_output_row_count = CountMap::new();
+        let stream_node_output_blocking_duration_ms = CountMap::new();
 
         let source_output_row_count = register_guarded_int_counter_vec_with_registry!(
             "stream_source_output_rows_counts",

--- a/src/stream/src/executor/wrapper.rs
+++ b/src/stream/src/executor/wrapper.rs
@@ -23,8 +23,6 @@ mod update_check;
 
 /// [`WrapperExecutor`] will do some sanity checks and logging for the wrapped executor.
 pub struct WrapperExecutor {
-    operator_id: u64,
-
     input: Executor,
 
     actor_ctx: ActorContextRef,
@@ -36,14 +34,12 @@ pub struct WrapperExecutor {
 
 impl WrapperExecutor {
     pub fn new(
-        operator_id: u64,
         input: Executor,
         actor_ctx: ActorContextRef,
         enable_executor_row_count: bool,
         enable_explain_analyze_stats: bool,
     ) -> Self {
         Self {
-            operator_id,
             input,
             actor_ctx,
             enable_executor_row_count,
@@ -64,7 +60,6 @@ impl WrapperExecutor {
     }
 
     fn wrap(
-        operator_id: u64,
         enable_executor_row_count: bool,
         enable_explain_analyze_stats: bool,
         info: Arc<ExecutorInfo>,
@@ -94,8 +89,8 @@ impl WrapperExecutor {
 
         // operator-level metrics
         let stream = stream_node_metrics::stream_node_metrics(
+            info.clone(),
             enable_explain_analyze_stats,
-            operator_id,
             stream,
             actor_ctx.clone(),
         );
@@ -112,7 +107,6 @@ impl Execute for WrapperExecutor {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         let info = Arc::new(self.input.info().clone());
         Self::wrap(
-            self.operator_id,
             self.enable_executor_row_count,
             self.enable_explain_analyze_stats,
             info,
@@ -125,7 +119,6 @@ impl Execute for WrapperExecutor {
     fn execute_with_epoch(self: Box<Self>, epoch: u64) -> BoxedMessageStream {
         let info = Arc::new(self.input.info().clone());
         Self::wrap(
-            self.operator_id,
             self.enable_executor_row_count,
             self.enable_explain_analyze_stats,
             info,

--- a/src/stream/src/executor/wrapper/stream_node_metrics.rs
+++ b/src/stream/src/executor/wrapper/stream_node_metrics.rs
@@ -20,14 +20,14 @@ use crate::executor::prelude::*;
 
 #[try_stream(ok = Message, error = StreamExecutorError)]
 pub async fn stream_node_metrics(
+    info: Arc<ExecutorInfo>,
     enable_explain_analyze_stats: bool,
-    operator_id: u64,
     input: impl MessageStream,
     actor_ctx: ActorContextRef,
 ) {
     let stats = ProfileMetricsImpl::new(
+        info.id,
         &actor_ctx.streaming_metrics,
-        operator_id,
         enable_explain_analyze_stats,
     );
 

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -551,7 +551,6 @@ impl StreamActorManager {
 
         // Wrap the executor for debug purpose.
         let wrapped = WrapperExecutor::new(
-            operator_id,
             executor,
             actor_context.clone(),
             env.config().developer.enable_executor_row_count,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Highest Release Version: 2.3

## What's changed and what's your intention?

This is done to avoid GC and it avoids synchronization between actors due to them updating the same metric.
It allows us to track metrics at a more granular level as well: We can look at min, max, avg for each metric, and identify the slowest executor for a given operator.

The trade-off is that more memory is utilized per executor. But the memory used per executor is very little. Each metric occupies 8 bytes of memory, with the `Arc` pointer, that's another 8 bytes. Considering the entry in the hash map and the value stored, we can assert another 16bytes. So in total 8x4=32 bytes approximately.
If we have 1000 operators, with parallelism 64, that's 1000 * 64 * 32 = 2048KB ~ 2MB, which still seems acceptable.

When dropping actors, we also need to lock their corresponding metric map, and drop the entry. So there will be some overhead. But I think this should be minimal.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
