### PR TITLE
chore(ci): deprecate `cherry-pick-to-release` in favor of `since`

### DIFF
--- a/.github/workflows/cherry-pick-to-release-branch.yml
+++ b/.github/workflows/cherry-pick-to-release-branch.yml
@@ -1,50 +1,26 @@
-name: PR for release branch
+name: Deprecation Notice for old cherry-pick label
 on:
   pull_request:
     branches:
       - main
-    types: ["closed", "labeled"]
+    types: ["labeled"]
 
 jobs:
-  get-release-branches:
-    if: |
-      github.event.pull_request.merged &&
-      ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'need-cherry-pick-release-')) ||
-      (github.event.action == 'closed' && contains(toJson(github.event.pull_request.labels), 'need-cherry-pick-release-')))
+  deprecation_notice:
+    if: startsWith(github.event.label.name, 'need-cherry-pick-release-')
     runs-on: ubuntu-latest
-    outputs:
-      branches: ${{ steps.get-release-branches.outputs.branches }}
     steps:
-      - name: Get release branches
-        id: get-release-branches
-        run: |
-          if [[ ${{ github.event.action }} == 'labeled' ]]; then
-            echo "branches=[\"$(echo ${{ github.event.label.name }} | cut -d '-' -f 4-)\"]" >> "$GITHUB_OUTPUT"
-          else
-            labels='${{ toJson(github.event.pull_request.labels) }}'
-            echo branches=$(echo "$labels" | jq -r '.[] | select(.name | contains("need-cherry-pick")).name' | cut -d '-' -f 4- | jq --raw-input . | jq --slurp . -c) >> "$GITHUB_OUTPUT"
-          fi
-
-  release_pull_request:
-    needs:
-      - get-release-branches
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: ${{ fromJson(needs.get-release-branches.outputs.branches) }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: Create PR to branch
-        uses: risingwavelabs/github-action-cherry-pick@master
+      - name: Add deprecation notice comment
+        uses: actions/github-script@v6
         with:
-          pr_branch: ${{ matrix.branch }}
-          pr_labels: 'cherry-pick'
-          pr_body: ${{ format('Cherry picking \#{0} onto branch {1}', github.event.number, matrix.branch) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '> [!WARNING]\n> The `need-cherry-pick-release-xx` label is deprecated. Please use `need-cherry-pick-since-release-xx` instead for future PRs.'
+            })
 
 permissions:
   issues: write
   pull-requests: write
-  contents: write

--- a/.github/workflows/cherry-pick-to-release-branch.yml
+++ b/.github/workflows/cherry-pick-to-release-branch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add deprecation notice comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             await github.rest.issues.createComment({


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Highest Release Version: 2.3

## What's changed and what's your intention?

Instruct developers to use `need-cherry-pick-since-release-xx`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
