### PR TITLE
feat(sink): skip some epoch items to align initial coordinate epoch

### DIFF
--- a/proto/connector_service.proto
+++ b/proto/connector_service.proto
@@ -238,6 +238,7 @@ message CoordinateRequest {
     CommitRequest commit_request = 2;
     UpdateVnodeBitmapRequest update_vnode_request = 3;
     bool stop = 4;
+    uint64 align_initial_epoch_request = 5;
   }
 }
 
@@ -254,6 +255,7 @@ message CoordinateResponse {
     StartCoordinationResponse start_response = 1;
     CommitResponse commit_response = 2;
     bool stopped = 3;
+    uint64 align_initial_epoch_response = 4;
   }
 }
 

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::future::pending;
 use std::num::NonZeroU64;
 use std::time::Instant;
@@ -78,16 +79,54 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
             .await?;
         let mut sink_writer = self.writer;
         log_reader.start_from(log_store_rewind_start_epoch).await?;
-        let first_item = log_reader.next_item().await?;
+        let mut first_item = log_reader.next_item().await?;
         if let (Some(log_store_rewind_start_epoch), (first_epoch, _)) =
             (log_store_rewind_start_epoch, &first_item)
-            && log_store_rewind_start_epoch >= *first_epoch
         {
-            bail!(
-                "log_store_rewind_start_epoch {} not later than first_epoch {}",
-                log_store_rewind_start_epoch,
-                first_epoch
-            );
+            if log_store_rewind_start_epoch >= *first_epoch {
+                bail!(
+                    "log_store_rewind_start_epoch {} not later than first_epoch {}",
+                    log_store_rewind_start_epoch,
+                    first_epoch
+                );
+            }
+        } else {
+            let &(initial_epoch, _) = &first_item;
+            let aligned_initial_epoch = coordinator_stream_handle
+                .align_initial_epoch(initial_epoch)
+                .await?;
+            if initial_epoch != aligned_initial_epoch {
+                warn!(
+                    initial_epoch,
+                    aligned_initial_epoch,
+                    sink_id = self.param.sink_id.sink_id,
+                    "initial epoch not matched aligned initial epoch"
+                );
+                let mut peeked_first = Some(first_item);
+                first_item = loop {
+                    let (epoch, item) = if let Some(peeked_first) = peeked_first.take() {
+                        peeked_first
+                    } else {
+                        log_reader.next_item().await?
+                    };
+                    match epoch.cmp(&aligned_initial_epoch) {
+                        Ordering::Less => {
+                            continue;
+                        }
+                        Ordering::Equal => {
+                            break (epoch, item);
+                        }
+                        Ordering::Greater => {
+                            return Err(anyhow!(
+                                "initial epoch {} greater than aligned initial epoch {}",
+                                initial_epoch,
+                                aligned_initial_epoch
+                            )
+                            .into());
+                        }
+                    }
+                };
+            }
         }
 
         let mut first_item = Some(first_item);

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -447,6 +447,7 @@ mod tests {
             sink_from_name: "test".into(),
         };
 
+        let epoch0 = 232;
         let epoch1 = 233;
         let epoch2 = 234;
 
@@ -549,6 +550,15 @@ mod tests {
 
         let (mut client1, mut client2) =
             join(build_client(vnode1), pin!(build_client(vnode2))).await;
+
+        let (aligned_epoch1, aligned_epoch2) = try_join(
+            client1.align_initial_epoch(epoch0),
+            client2.align_initial_epoch(epoch1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(aligned_epoch1, epoch1);
+        assert_eq!(aligned_epoch2, epoch1);
 
         {
             // commit epoch1
@@ -725,6 +735,9 @@ mod tests {
         };
 
         let mut client = build_client(vnode).await;
+
+        let aligned_epoch = client.align_initial_epoch(epoch1).await.unwrap();
+        assert_eq!(aligned_epoch, epoch1);
 
         client
             .commit(
@@ -1067,6 +1080,15 @@ mod tests {
             try_join(build_client(vnode1), pin!(build_client(vnode2)))
                 .await
                 .unwrap();
+
+        let (aligned_epoch1, aligned_epoch2) = try_join(
+            client1.align_initial_epoch(epoch1),
+            client2.align_initial_epoch(epoch1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(aligned_epoch1, epoch1);
+        assert_eq!(aligned_epoch2, epoch1);
 
         {
             // commit epoch1

--- a/src/rpc_client/src/sink_coordinate_client.rs
+++ b/src/rpc_client/src/sink_coordinate_client.rs
@@ -141,4 +141,22 @@ impl CoordinatorStreamHandle {
             msg => Err(anyhow!("should get Stopped but get {:?}", msg)),
         }
     }
+
+    pub async fn align_initial_epoch(&mut self, initial_epoch: u64) -> anyhow::Result<u64> {
+        self.send_request(CoordinateRequest {
+            msg: Some(coordinate_request::Msg::AlignInitialEpochRequest(
+                initial_epoch,
+            )),
+        })
+        .await?;
+        match self.next_response().await? {
+            CoordinateResponse {
+                msg: Some(coordinate_response::Msg::AlignInitialEpochResponse(epoch)),
+            } => Ok(epoch),
+            msg => Err(anyhow!(
+                "should get AlignInitialEpochResponse but get {:?}",
+                msg
+            )),
+        }
+    }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/state.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/state.rs
@@ -15,11 +15,10 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use bytes::Bytes;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::TableId;
-use risingwave_common::hash::{VirtualNode, VnodeBitmapExt};
+use risingwave_common::hash::VnodeBitmapExt;
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_connector::sink::log_store::LogStoreResult;
@@ -133,15 +132,6 @@ impl<S: LocalStateStore> LogStoreWriteState<S> {
 
         self.on_post_seal = true;
         LogStorePostSealCurrentEpoch { inner: self }
-    }
-
-    pub(crate) fn aligned_init_range_start(&self) -> Option<Bytes> {
-        (0..self.serde.vnodes().len())
-            .flat_map(|vnode| {
-                self.state_store
-                    .get_table_watermark(VirtualNode::from_index(vnode))
-            })
-            .max()
     }
 }
 

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -269,8 +269,6 @@ impl ExecutorBuilder for SinkExecutorBuilder {
                 let input_schema = input_executor.schema();
                 let pk_info = resolve_pk_info(input_schema, &table)?;
 
-                let align_init_epoch = sink.is_coordinated_sink();
-
                 // TODO: support setting max row count in config
                 let factory = KvLogStoreFactory::new(
                     state_store,
@@ -280,7 +278,6 @@ impl ExecutorBuilder for SinkExecutorBuilder {
                     metrics,
                     log_store_identity,
                     pk_info,
-                    align_init_epoch,
                 );
 
                 SinkExecutor::new(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Highest Release Version: 2.3

## What's changed and what's your intention?

resolve https://github.com/risingwavelabs/risingwave/issues/21094

For coordinated log sinker, if the `start_epoch` in `StartResponse` is `None`, it will call `log_reader.start_from(None)`, and then peek the first item to get the first epoch. It will send an `AlignInitialEpochRequest` with this `first_epoch` and wait for the `AlignInitialEpochResponse` to get the `aligned_initial_epoch`. If the `aligned_initial_epoch` is later than the `first_epoch`, it will keep calling `next_item`, until the epoch reaches `aligned_initial_epoch`, and then start the later handling.

For coordination worker, if the `start_epoch` returned from `coordinator.init()` is `None`, it will further wait for handling the `AlignInitialEpochRequest` from the initial handles. After received the initial epoch of all handles, it will returns with `AlignInitialEpochResponse` with the maximum of all initial epochs as the `aligned_initial_epoch`.

After introducing this mechanism of aligning initial epochs, the previous `align_init_start_range` is not needed anymore, and the related code is removed.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
