### PR TITLE
refactor(stream): unify remote and local output

### DIFF
--- a/src/compute/src/rpc/service/exchange_service.rs
+++ b/src/compute/src/rpc/service/exchange_service.rs
@@ -175,6 +175,13 @@ impl ExchangeServiceImpl {
                     permits.add_permits(permits_to_add);
                 }
                 Either::Right(MessageWithPermits { message, permits }) => {
+                    let message = match message {
+                        DispatcherMessageBatch::Chunk(chunk) => {
+                            DispatcherMessageBatch::Chunk(chunk.compact())
+                        }
+                        msg @ (DispatcherMessageBatch::Watermark(_)
+                        | DispatcherMessageBatch::BarrierBatch(_)) => msg,
+                    };
                     let proto = message.to_protobuf();
                     // forward the acquired permit to the downstream
                     let response = GetStreamResponse {

--- a/src/stream/src/executor/exchange/output.rs
+++ b/src/stream/src/executor/exchange/output.rs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
-
-use async_trait::async_trait;
 use await_tree::InstrumentAwait;
 use educe::Educe;
-use risingwave_common::util::addr::is_local_address;
 
 use super::error::ExchangeChannelClosed;
 use super::permit::Sender;
@@ -25,28 +21,10 @@ use crate::error::StreamResult;
 use crate::executor::DispatcherMessageBatch as Message;
 use crate::task::{ActorId, SharedContext};
 
-/// `Output` provides an interface for `Dispatcher` to send data into downstream actors.
-#[async_trait]
-pub trait Output: Debug + Send + Sync + 'static {
-    async fn send(&mut self, message: Message) -> StreamResult<()>;
-
-    /// The downstream actor id.
-    fn actor_id(&self) -> ActorId;
-
-    fn boxed(self) -> BoxedOutput
-    where
-        Self: Sized + 'static,
-    {
-        Box::new(self)
-    }
-}
-
-pub type BoxedOutput = Box<dyn Output>;
-
 /// `LocalOutput` sends data to a local channel.
 #[derive(Educe)]
 #[educe(Debug)]
-pub struct LocalOutput {
+pub struct Output {
     actor_id: ActorId,
 
     #[educe(Debug(ignore))]
@@ -56,19 +34,18 @@ pub struct LocalOutput {
     ch: Sender,
 }
 
-impl LocalOutput {
+impl Output {
     pub fn new(actor_id: ActorId, ch: Sender) -> Self {
         Self {
             actor_id,
-            span: await_tree::span!("LocalOutput (actor {:?})", actor_id).verbose(),
+            span: await_tree::span!("Output (actor {:?})", actor_id).verbose(),
             ch,
         }
     }
 }
 
-#[async_trait]
-impl Output for LocalOutput {
-    async fn send(&mut self, message: Message) -> StreamResult<()> {
+impl Output {
+    pub async fn send(&mut self, message: Message) -> StreamResult<()> {
         self.ch
             .send(message)
             .instrument_await(self.span.clone())
@@ -76,54 +53,7 @@ impl Output for LocalOutput {
             .map_err(|_| ExchangeChannelClosed::output(self.actor_id).into())
     }
 
-    fn actor_id(&self) -> ActorId {
-        self.actor_id
-    }
-}
-
-/// `RemoteOutput` compacts the data and send to a local buffer channel, which will be further sent
-/// to the remote actor by [`ExchangeService`].
-///
-/// [`ExchangeService`]: risingwave_pb::task_service::exchange_service_server::ExchangeService
-// FIXME: can we just use the same `Output` with local and compacts it in gRPC server?
-#[derive(Educe)]
-#[educe(Debug)]
-pub struct RemoteOutput {
-    actor_id: ActorId,
-
-    #[educe(Debug(ignore))]
-    span: await_tree::Span,
-
-    #[educe(Debug(ignore))]
-    ch: Sender,
-}
-
-impl RemoteOutput {
-    pub fn new(actor_id: ActorId, ch: Sender) -> Self {
-        Self {
-            actor_id,
-            span: await_tree::span!("RemoteOutput (actor {:?})", actor_id).verbose(),
-            ch,
-        }
-    }
-}
-
-#[async_trait]
-impl Output for RemoteOutput {
-    async fn send(&mut self, message: Message) -> StreamResult<()> {
-        let message = match message {
-            Message::Chunk(chk) => Message::Chunk(chk.compact()),
-            _ => message,
-        };
-
-        self.ch
-            .send(message)
-            .instrument_await(self.span.clone())
-            .await
-            .map_err(|_| ExchangeChannelClosed::output(self.actor_id).into())
-    }
-
-    fn actor_id(&self) -> ActorId {
+    pub fn actor_id(&self) -> ActorId {
         self.actor_id
     }
 }
@@ -134,21 +64,8 @@ pub fn new_output(
     context: &SharedContext,
     actor_id: ActorId,
     down_id: ActorId,
-) -> StreamResult<BoxedOutput> {
+) -> StreamResult<Output> {
     let tx = context.take_sender(&(actor_id, down_id))?;
 
-    let is_local_address = match context.get_actor_info(&down_id) {
-        Ok(info) => is_local_address(&context.addr, &info.get_host()?.into()),
-        // If we can't get the actor info locally, it must be a remote actor.
-        // This may happen when we create a mv-on-mv on different workers from the upstream. #4153
-        Err(_) => false,
-    };
-
-    let output = if is_local_address {
-        LocalOutput::new(down_id, tx).boxed()
-    } else {
-        RemoteOutput::new(down_id, tx).boxed()
-    };
-
-    Ok(output)
+    Ok(Output::new(down_id, tx))
 }

--- a/src/stream/src/executor/exchange/output.rs
+++ b/src/stream/src/executor/exchange/output.rs
@@ -58,7 +58,7 @@ impl Output {
     }
 }
 
-/// Create a [`LocalOutput`] or [`RemoteOutput`] instance for the current actor id and the
+/// Create a [`Output`] instance for the current actor id and the
 /// downstream actor id. Used by dispatchers.
 pub fn new_output(
     context: &SharedContext,

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -32,7 +32,7 @@ use super::exchange::permit::channel_for_test;
 use super::*;
 use crate::executor::aggregate::StatelessSimpleAggExecutor;
 use crate::executor::dispatch::*;
-use crate::executor::exchange::output::{BoxedOutput, LocalOutput};
+use crate::executor::exchange::output::Output;
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::project::ProjectExecutor;
 use crate::executor::test_utils::agg_executor::{
@@ -98,7 +98,7 @@ async fn test_merger_sum_aggr() {
                     .unwrap();
             let consumer = SenderConsumer {
                 input: aggregator.boxed(),
-                channel: Box::new(LocalOutput::new(233, tx)),
+                channel: Output::new(233, tx),
             };
 
             let actor = Actor::new(
@@ -131,7 +131,7 @@ async fn test_merger_sum_aggr() {
         let (actor_future, channel) = make_actor(rx);
         outputs.push(channel);
         actor_futures.push(actor_future);
-        inputs.push(Box::new(LocalOutput::new(233, tx)) as BoxedOutput);
+        inputs.push(Output::new(233, tx));
     }
 
     // create a round robin dispatcher, which dispatches messages to the actors
@@ -345,7 +345,7 @@ impl StreamConsumer for MockConsumer {
 /// `SenderConsumer` consumes data from input executor and send it into a channel.
 pub struct SenderConsumer {
     input: Box<dyn Execute>,
-    channel: BoxedOutput,
+    channel: Output,
 }
 
 impl StreamConsumer for SenderConsumer {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Highest Release Version: 2.3

## What's changed and what's your intention?

Currently, the logic of `RemoteOutput` and `LocalOutput` is basically the same, except that
- the instrument await tree message is different
- remote output calls `chunk.compact()` for `StreamChunk` before adding to `Sender`.

In this PR, we will unify the two `Output`s. The difference in instrument await can be unified without much concern. For calling `chunk.compact()`, we delay calling it in the handler of exchange service.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
