### PR TITLE
refactor(stream): store shared context in local barrier manager

### DIFF
--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -115,11 +115,13 @@ mod test {
     use super::ChainExecutor;
     use crate::executor::test_utils::MockSource;
     use crate::executor::{AddMutation, Barrier, Execute, Message, Mutation, PkIndices};
-    use crate::task::{CreateMviewProgressReporter, LocalBarrierManager};
+    use crate::task::CreateMviewProgressReporter;
+    use crate::task::barrier_test_utils::LocalBarrierTestEnv;
 
     #[tokio::test]
     async fn test_basic() {
-        let barrier_manager = LocalBarrierManager::for_test();
+        let test_env = LocalBarrierTestEnv::for_test().await;
+        let barrier_manager = test_env.local_barrier_manager.clone();
         let progress = CreateMviewProgressReporter::for_test(barrier_manager);
         let actor_id = progress.actor_id();
 

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -1324,7 +1324,6 @@ mod tests {
             ReceiverExecutor::for_test(
                 actor_id,
                 rx,
-                barrier_test_env.shared_context.clone(),
                 barrier_test_env.local_barrier_manager.clone(),
             )
             .boxed(),

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -29,7 +29,7 @@ use crate::executor::{
     BarrierInner, DispatcherBarrier, DispatcherMessage, DispatcherMessageBatch,
     DispatcherMessageStream, DispatcherMessageStreamItem,
 };
-use crate::task::{FragmentId, SharedContext, UpDownActorIds, UpDownFragmentIds};
+use crate::task::{FragmentId, LocalBarrierManager, UpDownActorIds, UpDownFragmentIds};
 
 /// `Input` provides an interface for [`MergeExecutor`](crate::executor::MergeExecutor) and
 /// [`ReceiverExecutor`](crate::executor::ReceiverExecutor) to receive data from upstream actors.
@@ -355,13 +355,14 @@ impl Input for RemoteInput {
 /// Create a [`LocalInput`] or [`RemoteInput`] instance with given info. Used by merge executors and
 /// receiver executors.
 pub(crate) fn new_input(
-    context: &SharedContext,
+    local_barrier_manager: &LocalBarrierManager,
     metrics: Arc<StreamingMetrics>,
     actor_id: ActorId,
     fragment_id: FragmentId,
     upstream_actor_id: ActorId,
     upstream_fragment_id: FragmentId,
 ) -> StreamResult<BoxedInput> {
+    let context = &local_barrier_manager.shared_context;
     let upstream_addr = context
         .get_actor_info(&upstream_actor_id)?
         .get_host()?

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -67,7 +67,6 @@ async fn test_merger_sum_aggr() {
         let input_schema = Schema {
             fields: vec![Field::unnamed(DataType::Int64)],
         };
-        let shared_context = barrier_test_env.shared_context.clone();
         let local_barrier_manager = barrier_test_env.local_barrier_manager.clone();
         let expr_context = expr_context.clone();
         let (tx, rx) = channel_for_test();
@@ -79,13 +78,8 @@ async fn test_merger_sum_aggr() {
                     "ReceiverExecutor".to_owned(),
                     0,
                 ),
-                ReceiverExecutor::for_test(
-                    actor_id,
-                    input_rx,
-                    shared_context.clone(),
-                    local_barrier_manager.clone(),
-                )
-                .boxed(),
+                ReceiverExecutor::for_test(actor_id, input_rx, local_barrier_manager.clone())
+                    .boxed(),
             );
             let agg_calls = vec![
                 AggCall::from_pretty("(count:int8)"),
@@ -151,13 +145,7 @@ async fn test_merger_sum_aggr() {
                     "ReceiverExecutor".to_owned(),
                     0,
                 ),
-                ReceiverExecutor::for_test(
-                    actor_id,
-                    rx,
-                    shared_context.clone(),
-                    local_barrier_manager.clone(),
-                )
-                .boxed(),
+                ReceiverExecutor::for_test(actor_id, rx, local_barrier_manager.clone()).boxed(),
             );
             let dispatcher = DispatchExecutor::new(
                 receiver_op,
@@ -190,7 +178,6 @@ async fn test_merger_sum_aggr() {
 
     let items = Arc::new(Mutex::new(vec![]));
     let actor_future = {
-        let shared_context = barrier_test_env.shared_context.clone();
         let local_barrier_manager = barrier_test_env.local_barrier_manager.clone();
         let expr_context = expr_context.clone();
         let items = items.clone();
@@ -211,7 +198,6 @@ async fn test_merger_sum_aggr() {
                 MergeExecutor::for_test(
                     actor_ctx.id,
                     outputs,
-                    shared_context.clone(),
                     local_barrier_manager.clone(),
                     schema,
                 )

--- a/src/stream/src/executor/values.rs
+++ b/src/stream/src/executor/values.rs
@@ -150,11 +150,13 @@ mod tests {
     use super::ValuesExecutor;
     use crate::executor::test_utils::StreamExecutorTestExt;
     use crate::executor::{ActorContext, AddMutation, Barrier, Execute, Mutation};
-    use crate::task::{CreateMviewProgressReporter, LocalBarrierManager};
+    use crate::task::CreateMviewProgressReporter;
+    use crate::task::barrier_test_utils::LocalBarrierTestEnv;
 
     #[tokio::test]
     async fn test_values() {
-        let barrier_manager = LocalBarrierManager::for_test();
+        let test_env = LocalBarrierTestEnv::for_test().await;
+        let barrier_manager = test_env.local_barrier_manager.clone();
         let progress = CreateMviewProgressReporter::for_test(barrier_manager);
         let actor_id = progress.actor_id();
         let (tx, barrier_receiver) = unbounded_channel();

--- a/src/stream/src/from_proto/merge.rs
+++ b/src/stream/src/from_proto/merge.rs
@@ -20,13 +20,13 @@ use super::*;
 use crate::executor::exchange::input::new_input;
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{ActorContextRef, MergeExecutor, MergeExecutorInput, MergeExecutorUpstream};
-use crate::task::SharedContext;
+use crate::task::LocalBarrierManager;
 
 pub struct MergeExecutorBuilder;
 
 impl MergeExecutorBuilder {
     pub(crate) fn new_input(
-        shared_context: Arc<SharedContext>,
+        local_barrier_manager: LocalBarrierManager,
         executor_stats: Arc<StreamingMetrics>,
         actor_context: ActorContextRef,
         info: ExecutorInfo,
@@ -43,7 +43,7 @@ impl MergeExecutorBuilder {
             .flatten()
             .map(|&upstream_actor_id| {
                 new_input(
-                    &shared_context,
+                    &local_barrier_manager,
                     executor_stats.clone(),
                     actor_context.id,
                     actor_context.fragment_id,
@@ -77,7 +77,7 @@ impl MergeExecutorBuilder {
             upstreams,
             actor_context,
             upstream_fragment_id,
-            shared_context,
+            local_barrier_manager,
             executor_stats,
             info,
             chunk_size,
@@ -97,7 +97,7 @@ impl ExecutorBuilder for MergeExecutorBuilder {
             .local_barrier_manager
             .subscribe_barrier(params.actor_context.id);
         Ok(Self::new_input(
-            params.shared_context,
+            params.local_barrier_manager,
             params.executor_stats,
             params.actor_context,
             params.info,

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::future::{pending, poll_fn};
@@ -337,6 +338,9 @@ impl LocalBarrierWorker {
                 .map(|(database_id, status)| {
                     (*database_id, {
                         match status {
+                            DatabaseStatus::ReceivedExchangeRequest(_) => {
+                                ("ReceivedExchangeRequest".to_owned(), None)
+                            }
                             DatabaseStatus::Running(state) => {
                                 ("running".to_owned(), Some(state.to_debug_info()))
                             }
@@ -353,23 +357,6 @@ impl LocalBarrierWorker {
                 .collect(),
             has_control_stream_connected: self.control_stream_handle.connected(),
         }
-    }
-
-    pub(crate) fn get_or_insert_database_shared_context<'a>(
-        current_shared_context: &'a mut HashMap<DatabaseId, Arc<SharedContext>>,
-        database_id: DatabaseId,
-        actor_manager: &StreamActorManager,
-        term_id: &String,
-    ) -> &'a Arc<SharedContext> {
-        current_shared_context
-            .entry(database_id)
-            .or_insert_with(|| {
-                Arc::new(SharedContext::new(
-                    database_id,
-                    &actor_manager.env,
-                    term_id.clone(),
-                ))
-            })
     }
 
     async fn next_completed_epoch(
@@ -444,7 +431,8 @@ impl LocalBarrierWorker {
                                         DatabaseStatus::Running(database) => {
                                             !database.actor_states.is_empty()
                                         }
-                                        DatabaseStatus::Suspended(_) | DatabaseStatus::Resetting(_) => {
+                                        DatabaseStatus::Suspended(_) | DatabaseStatus::Resetting(_) |
+                                            DatabaseStatus::ReceivedExchangeRequest(_) => {
                                             false
                                         }
                                         DatabaseStatus::Unspecified => {
@@ -487,7 +475,6 @@ impl LocalBarrierWorker {
                 let database_id = DatabaseId::new(req.database_id);
                 let result: StreamResult<()> = try {
                     let barrier = Barrier::from_protobuf(req.get_barrier().unwrap())?;
-                    self.update_actor_info(database_id, req.broadcast_info.iter().cloned());
                     self.send_barrier(&barrier, req)?;
                 };
                 result.map_err(|e| (database_id, e))?;
@@ -543,13 +530,35 @@ impl LocalBarrierWorker {
                             self.term_id
                         ))?;
                     }
-                    LocalBarrierWorker::get_or_insert_database_shared_context(
-                        &mut self.state.current_shared_context,
-                        database_id,
-                        &self.actor_manager,
-                        &self.term_id,
-                    )
-                    .take_receiver(ids)?
+                    let result = match self.state.databases.entry(database_id) {
+                        Entry::Occupied(mut entry) => match entry.get_mut() {
+                            DatabaseStatus::ReceivedExchangeRequest(pending_requests) => {
+                                pending_requests.push((ids, result_sender));
+                                return;
+                            }
+                            DatabaseStatus::Running(database) => database
+                                .local_barrier_manager
+                                .shared_context
+                                .take_receiver(ids),
+                            DatabaseStatus::Suspended(_) => {
+                                Err(anyhow!("database suspended").into())
+                            }
+                            DatabaseStatus::Resetting(_) => {
+                                Err(anyhow!("database resetting").into())
+                            }
+                            DatabaseStatus::Unspecified => {
+                                unreachable!()
+                            }
+                        },
+                        Entry::Vacant(entery) => {
+                            entery.insert(DatabaseStatus::ReceivedExchangeRequest(vec![(
+                                ids,
+                                result_sender,
+                            )]));
+                            return;
+                        }
+                    };
+                    result?
                 };
                 let _ = result_sender.send(result);
             }
@@ -562,7 +571,7 @@ impl LocalBarrierWorker {
                     .unwrap();
                 let database_state = risingwave_common::must_match!(database_status, DatabaseStatus::Running(database_state) => database_state);
                 let _ = sender.send((
-                    database_state.current_shared_context.clone(),
+                    database_state.local_barrier_manager.shared_context.clone(),
                     database_state.local_barrier_manager.clone(),
                 ));
             }
@@ -833,6 +842,10 @@ impl LocalBarrierWorker {
             .get_mut(&DatabaseId::new(request.database_id))
             .expect("should exist");
         if let Some(state) = database_status.state_for_request() {
+            state
+                .local_barrier_manager
+                .shared_context
+                .add_actors(request.broadcast_info.iter().cloned());
             state.transform_to_issued(barrier, request)?;
         }
         Ok(())
@@ -874,20 +887,37 @@ impl LocalBarrierWorker {
     }
 
     fn add_partial_graph(&mut self, database_id: DatabaseId, partial_graph_id: PartialGraphId) {
-        let status = self.state.databases.entry(database_id).or_insert_with(|| {
-            DatabaseStatus::Running(DatabaseManagedBarrierState::new(
-                database_id,
-                self.actor_manager.clone(),
-                LocalBarrierWorker::get_or_insert_database_shared_context(
-                    &mut self.state.current_shared_context,
+        let status = match self.state.databases.entry(database_id) {
+            Entry::Occupied(entry) => {
+                let status = entry.into_mut();
+                if let DatabaseStatus::ReceivedExchangeRequest(pending_requests) = status {
+                    let database = DatabaseManagedBarrierState::new(
+                        database_id,
+                        self.term_id.clone(),
+                        self.actor_manager.clone(),
+                        vec![],
+                    );
+                    for (ids, result_sender) in pending_requests.drain(..) {
+                        let result = database
+                            .local_barrier_manager
+                            .shared_context
+                            .take_receiver(ids);
+                        let _ = result_sender.send(result);
+                    }
+                    *status = DatabaseStatus::Running(database);
+                }
+
+                status
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(DatabaseStatus::Running(DatabaseManagedBarrierState::new(
                     database_id,
-                    &self.actor_manager,
-                    &self.term_id,
-                )
-                .clone(),
-                vec![],
-            ))
-        });
+                    self.term_id.clone(),
+                    self.actor_manager.clone(),
+                    vec![],
+                )))
+            }
+        };
         if let Some(state) = status.state_for_request() {
             assert!(
                 state
@@ -932,7 +962,6 @@ impl LocalBarrierWorker {
                 }
             }
         }
-        self.state.current_shared_context.remove(&database_id);
         self.await_epoch_completed_futures.remove(&database_id);
         self.control_stream_handle.ack_reset_database(
             database_id,
@@ -1005,6 +1034,7 @@ impl DatabaseManagedBarrierState {
 pub struct LocalBarrierManager {
     barrier_event_sender: UnboundedSender<LocalBarrierEvent>,
     actor_failure_sender: UnboundedSender<(ActorId, StreamError)>,
+    pub shared_context: Arc<SharedContext>,
 }
 
 impl LocalBarrierWorker {
@@ -1066,7 +1096,9 @@ impl<T> EventSender<T> {
 }
 
 impl LocalBarrierManager {
-    pub(super) fn new() -> (
+    pub(super) fn new(
+        shared_context: Arc<SharedContext>,
+    ) -> (
         Self,
         UnboundedReceiver<LocalBarrierEvent>,
         UnboundedReceiver<(ActorId, StreamError)>,
@@ -1077,6 +1109,7 @@ impl LocalBarrierManager {
             Self {
                 barrier_event_sender: event_tx,
                 actor_failure_sender: err_tx,
+                shared_context,
             },
             event_rx,
             err_rx,
@@ -1185,19 +1218,6 @@ impl LocalBarrierManager {
             rx,
         );
         EventSender(tx)
-    }
-
-    pub fn for_test() -> Self {
-        let (tx, mut rx) = unbounded_channel();
-        let (failure_tx, failure_rx) = unbounded_channel();
-        let _join_handle = tokio::spawn(async move {
-            let _failure_rx = failure_rx;
-            while rx.recv().await.is_some() {}
-        });
-        Self {
-            barrier_event_sender: tx,
-            actor_failure_sender: failure_tx,
-        }
     }
 }
 

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -550,8 +550,8 @@ impl LocalBarrierWorker {
                                 unreachable!()
                             }
                         },
-                        Entry::Vacant(entery) => {
-                            entery.insert(DatabaseStatus::ReceivedExchangeRequest(vec![(
+                        Entry::Vacant(entry) => {
+                            entry.insert(DatabaseStatus::ReceivedExchangeRequest(vec![(
                                 ids,
                                 result_sender,
                             )]));

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -30,7 +30,6 @@ use risingwave_common::catalog::{ColumnId, DatabaseId, Field, Schema, TableId};
 use risingwave_common::config::MetricLevel;
 use risingwave_common::must_match;
 use risingwave_common::operator::{unique_executor_id, unique_operator_id};
-use risingwave_pb::common::ActorInfo;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -148,8 +147,6 @@ pub struct ExecutorParams {
 
     /// `watermark_epoch` field in `MemoryManager`
     pub watermark_epoch: AtomicU64Ref,
-
-    pub shared_context: Arc<SharedContext>,
 
     pub local_barrier_manager: LocalBarrierManager,
 }
@@ -340,7 +337,7 @@ impl StreamActorManager {
         &self,
         upstream_node: &StreamNode,
         actor_context: &ActorContextRef,
-        shared_context: &Arc<SharedContext>,
+        local_barrier_manager: &LocalBarrierManager,
         chunk_size: usize,
     ) -> StreamResult<MergeExecutorInput> {
         let info = Self::get_executor_info(
@@ -353,7 +350,7 @@ impl StreamActorManager {
         });
 
         MergeExecutorBuilder::new_input(
-            shared_context.clone(),
+            local_barrier_manager.clone(),
             self.streaming_metrics.clone(),
             actor_context.clone(),
             info,
@@ -369,7 +366,6 @@ impl StreamActorManager {
         node: &StreamScanNode,
         actor_context: &ActorContextRef,
         vnode_bitmap: Option<Bitmap>,
-        shared_context: &Arc<SharedContext>,
         env: StreamEnvironment,
         local_barrier_manager: &LocalBarrierManager,
         state_store: impl StateStore,
@@ -379,7 +375,7 @@ impl StreamActorManager {
         let upstream = self.create_snapshot_backfill_input(
             upstream_node,
             actor_context,
-            shared_context,
+            local_barrier_manager,
             chunk_size,
         )?;
 
@@ -443,7 +439,7 @@ impl StreamActorManager {
     }
 
     /// Create a chain(tree) of nodes, with given `store`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[async_recursion]
     async fn create_nodes_inner(
         &self,
@@ -455,7 +451,6 @@ impl StreamActorManager {
         vnode_bitmap: Option<Bitmap>,
         has_stateful: bool,
         subtasks: &mut Vec<SubtaskHandle>,
-        shared_context: &Arc<SharedContext>,
         local_barrier_manager: &LocalBarrierManager,
     ) -> StreamResult<Executor> {
         if let NodeBody::StreamScan(stream_scan) = node.get_node_body().unwrap()
@@ -467,7 +462,6 @@ impl StreamActorManager {
                     stream_scan,
                     actor_context,
                     vnode_bitmap,
-                    shared_context,
                     env,
                     local_barrier_manager,
                     store,
@@ -507,7 +501,6 @@ impl StreamActorManager {
                     vnode_bitmap.clone(),
                     has_stateful || is_stateful,
                     subtasks,
-                    shared_context,
                     local_barrier_manager,
                 )
                 .await?,
@@ -543,7 +536,6 @@ impl StreamActorManager {
             vnode_bitmap,
             eval_error_report,
             watermark_epoch: self.watermark_epoch.clone(),
-            shared_context: shared_context.clone(),
             local_barrier_manager: local_barrier_manager.clone(),
         };
 
@@ -575,7 +567,6 @@ impl StreamActorManager {
     }
 
     /// Create a chain(tree) of nodes and return the head executor.
-    #[expect(clippy::too_many_arguments)]
     async fn create_nodes(
         &self,
         fragment_id: FragmentId,
@@ -583,7 +574,6 @@ impl StreamActorManager {
         env: StreamEnvironment,
         actor_context: &ActorContextRef,
         vnode_bitmap: Option<Bitmap>,
-        shared_context: &Arc<SharedContext>,
         local_barrier_manager: &LocalBarrierManager,
     ) -> StreamResult<(Executor, Vec<SubtaskHandle>)> {
         let mut subtasks = vec![];
@@ -598,7 +588,6 @@ impl StreamActorManager {
                 vnode_bitmap,
                 false,
                 &mut subtasks,
-                shared_context,
                 local_barrier_manager,
             )
             .await
@@ -612,7 +601,6 @@ impl StreamActorManager {
         actor: BuildActorInfo,
         fragment_id: FragmentId,
         node: Arc<StreamNode>,
-        shared_context: Arc<SharedContext>,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
         local_barrier_manager: LocalBarrierManager,
     ) -> StreamResult<Actor<DispatchExecutor>> {
@@ -638,7 +626,6 @@ impl StreamActorManager {
                     self.env.clone(),
                     &actor_context,
                     vnode_bitmap,
-                    &shared_context,
                     &local_barrier_manager,
                 )
                 .await?;
@@ -649,7 +636,7 @@ impl StreamActorManager {
                 &actor.dispatchers,
                 actor_id,
                 fragment_id,
-                &shared_context,
+                &local_barrier_manager.shared_context,
             )?;
             let actor = Actor::new(
                 dispatcher,
@@ -671,7 +658,6 @@ impl StreamActorManager {
         fragment_id: FragmentId,
         node: Arc<StreamNode>,
         related_subscriptions: Arc<HashMap<TableId, HashSet<u32>>>,
-        current_shared_context: Arc<SharedContext>,
         local_barrier_manager: LocalBarrierManager,
     ) -> (JoinHandle<()>, Option<JoinHandle<()>>) {
         {
@@ -689,7 +675,6 @@ impl StreamActorManager {
                         actor,
                         fragment_id,
                         node,
-                        current_shared_context,
                         related_subscriptions,
                         barrier_manager.clone()
                     ).boxed().and_then(|actor| actor.run()).map(move |result| {
@@ -769,27 +754,9 @@ impl StreamActorManager {
     }
 }
 
-impl LocalBarrierWorker {
-    /// This function could only be called once during the lifecycle of `LocalStreamManager` for
-    /// now.
-    pub fn update_actor_info(
-        &mut self,
-        database_id: DatabaseId,
-        new_actor_infos: impl Iterator<Item = ActorInfo>,
-    ) {
-        Self::get_or_insert_database_shared_context(
-            &mut self.state.current_shared_context,
-            database_id,
-            &self.actor_manager,
-            &self.term_id,
-        )
-        .add_actors(new_actor_infos);
-    }
-}
-
 #[cfg(test)]
 pub mod test_utils {
-    use risingwave_pb::common::HostAddress;
+    use risingwave_pb::common::{ActorInfo, HostAddress};
 
     use super::*;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Highest Release Version: 2.3

## What's changed and what's your intention?

Currently when we spawn an actor, we pass two shared structs actor, `SharedContext` and `LocalBarrierManager`. The lifecycle of the two structs is basically the same: they are bind to a database, and get created along with having a new running database, and get cleared when the database is reset or global recovery is triggered. 

Previously we store the `SharedContext` separately to `DatabaseManagedBarrierState`, while the `LocalBarrierManager` is stored in `DatabaseManagedBarrierState`. This is because, `SharedContext` is used to store the exchange channel between actors, and the creation of new running database is asynchronous, and it may happen that the exchange request from other CN is received before the request to create a new running database. As a result, we may create the `SharedContext` of a database before the database is created, and we store the `SharedContext` separately to `DatabaseManagedBarrierState`.

In this PR, we will try to store the `SharedContext` in `LocalBarrierManager`, so that we only need to pass the `LocalBarrierManager` when we spawn a new actor. This means that, the `SharedContext` will be created along with `LocalBarrierManager` when we have a new request to create a new running `DatabaseManagedBarrierState`. To handle the early-arrived exchange requests, we introduce a new variant `DatabaseStatus::ReceivedExchangeRequests`. When receiving exchange request on a database that is not created yet, we will mark the database status as `ReceivedExchangeRequests`, and store this pending requests. When the database is later created, it will create the `SharedContext`, and handle pending requests in the `SharedContext`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
