### PR TITLE
refactor(stream): do not broadcast actor info in shared context

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -58,7 +58,7 @@ message UpdateMutation {
     //   In this case, all the upstream actors should be removed and replaced by the `new` ones.
     optional uint32 new_upstream_fragment_id = 5;
     // Added upstream actors.
-    repeated uint32 added_upstream_actor_id = 3;
+    repeated common.ActorInfo added_upstream_actors = 3;
     // Removed upstream actors.
     // Note: this is empty for replace job.
     repeated uint32 removed_upstream_actor_id = 4;

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -26,7 +26,7 @@ message InjectBarrierRequest {
 
   message BuildActorInfo {
     message UpstreamActors {
-      repeated uint32 actors = 1;
+      repeated common.ActorInfo actors = 1;
     }
     uint32 actor_id = 1;
     map<uint32, UpstreamActors> fragment_upstreams = 2;
@@ -36,7 +36,6 @@ message InjectBarrierRequest {
     plan_common.ExprContext expr_context = 6;
   }
 
-  repeated common.ActorInfo broadcast_info = 8;
   repeated FragmentBuildActorInfo actors_to_build = 9;
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_add = 10;
   repeated stream_plan.SubscriptionUpstreamInfo subscriptions_to_remove = 11;
@@ -78,7 +77,6 @@ message StreamingControlStreamRequest {
   message InitialPartialGraph {
     uint32 partial_graph_id = 1;
     repeated stream_plan.SubscriptionUpstreamInfo subscriptions = 2;
-    repeated common.ActorInfo actor_infos = 3;
   }
 
   message DatabaseInitialPartialGraph {

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -39,7 +39,7 @@ use crate::barrier::checkpoint::recovery::{
 use crate::barrier::checkpoint::state::BarrierWorkerState;
 use crate::barrier::command::CommandContext;
 use crate::barrier::complete_task::{BarrierCompleteOutput, CompleteBarrierTask};
-use crate::barrier::info::{InflightDatabaseInfo, InflightStreamingJobInfo};
+use crate::barrier::info::InflightStreamingJobInfo;
 use crate::barrier::notifier::Notifier;
 use crate::barrier::progress::{CreateMviewProgressTracker, TrackingCommand, TrackingJob};
 use crate::barrier::rpc::{ControlStreamManager, from_partial_graph_id};
@@ -75,9 +75,10 @@ impl CheckpointControl {
         failed_databases: HashSet<DatabaseId>,
         control_stream_manager: &mut ControlStreamManager,
         hummock_version_stats: HummockVersionStats,
+        env: MetaSrvEnv,
     ) -> Self {
         Self {
-            env: control_stream_manager.env.clone(),
+            env,
             databases: databases
                 .into_iter()
                 .map(|(database_id, control)| {
@@ -439,8 +440,7 @@ impl CheckpointControl {
         Item = (
             DatabaseId,
             &InflightSubscriptionInfo,
-            &InflightDatabaseInfo,
-            impl Iterator<Item = &InflightStreamingJobInfo> + '_,
+            impl Iterator<Item = TableId> + '_,
         ),
     > + '_ {
         self.databases.iter().flat_map(|(database_id, database)| {
@@ -450,10 +450,9 @@ impl CheckpointControl {
                     (
                         *database_id,
                         &database_state.inflight_subscription_info,
-                        &database_state.inflight_graph_info,
                         creating_jobs
                             .values()
-                            .filter_map(|job| job.inflight_graph_info()),
+                            .filter_map(|job| job.is_consuming().then_some(job.job_id)),
                     )
                 })
         })
@@ -1073,7 +1072,10 @@ impl DatabaseCheckpointControl {
             return Ok(());
         };
 
-        let mut edges = self.state.inflight_graph_info.build_edge(command.as_ref());
+        let mut edges = self
+            .state
+            .inflight_graph_info
+            .build_edge(command.as_ref(), &*control_stream_manager);
 
         // Insert newly added creating job
         if let Some(Command::CreateStreamingJob {

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -408,11 +408,11 @@ impl CreatingStreamingJobControl {
         self.barrier_control.is_empty() && self.status.is_finishing()
     }
 
-    pub fn inflight_graph_info(&self) -> Option<&InflightStreamingJobInfo> {
+    pub fn is_consuming(&self) -> bool {
         match &self.status {
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
-            | CreatingStreamingJobStatus::ConsumingLogStore { .. } => Some(&self.graph_info),
-            CreatingStreamingJobStatus::Finishing(_) => None,
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. } => true,
+            CreatingStreamingJobStatus::Finishing(_) => false,
         }
     }
 

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -442,7 +442,10 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
             mut background_jobs,
         } = runtime_info;
         let result: MetaResult<_> = try {
-            let mut builder = FragmentEdgeBuilder::new(database_fragment_info.fragment_infos());
+            let mut builder = FragmentEdgeBuilder::new(
+                database_fragment_info.fragment_infos(),
+                control_stream_manager,
+            );
             builder.add_relations(&fragment_relations);
             let mut edges = builder.build();
             control_stream_manager.inject_database_initial_barrier(

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -26,6 +26,7 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_hummock_sdk::change_log::build_table_change_log_delta;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::catalog::{CreateType, Table};
+use risingwave_pb::common::ActorInfo;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
 use risingwave_pb::stream_plan::barrier::BarrierKind as PbBarrierKind;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
@@ -43,6 +44,7 @@ use super::info::{CommandFragmentChanges, InflightDatabaseInfo, InflightStreamin
 use crate::barrier::InflightSubscriptionInfo;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::BarrierInfo;
+use crate::barrier::rpc::ControlStreamManager;
 use crate::barrier::utils::collect_resp_info;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
@@ -628,6 +630,7 @@ impl Command {
         &self,
         is_currently_paused: bool,
         edges: &mut Option<FragmentEdgeBuildResult>,
+        control_stream_manager: &ControlStreamManager,
     ) -> Option<Mutation> {
         match self {
             Command::Flush => None,
@@ -888,11 +891,17 @@ impl Command {
                                         actor_id,
                                         upstream_fragment_id: fragment_id,
                                         new_upstream_fragment_id: None,
-                                        added_upstream_actor_id: reschedule
+                                        added_upstream_actors: reschedule
                                             .added_actors
-                                            .values()
-                                            .flatten()
-                                            .cloned()
+                                            .iter()
+                                            .flat_map(|(worker_id, actors)| {
+                                                let host =
+                                                    control_stream_manager.host_addr(*worker_id);
+                                                actors.iter().map(move |actor_id| ActorInfo {
+                                                    actor_id: *actor_id,
+                                                    host: Some(host.clone()),
+                                                })
+                                            })
                                             .collect(),
                                         removed_upstream_actor_id: reschedule
                                             .removed_actors
@@ -979,6 +988,7 @@ impl Command {
         &self,
         graph_info: &InflightDatabaseInfo,
         edges: &mut Option<FragmentEdgeBuildResult>,
+        control_stream_manager: &ControlStreamManager,
     ) -> Option<StreamJobActorsToCreate> {
         match self {
             Command::CreateStreamingJob { info, job_type, .. } => {
@@ -1006,15 +1016,19 @@ impl Command {
                 ..
             } => {
                 let mut actor_upstreams = Self::collect_actor_upstreams(
-                    reschedules.iter().flat_map(|(fragment_id, reschedule)| {
-                        reschedule
-                            .newly_created_actors
-                            .values()
-                            .map(|((actor, dispatchers), _)| {
-                                (actor.actor_id, *fragment_id, dispatchers.as_slice())
-                            })
+                    reschedules.iter().map(|(fragment_id, reschedule)| {
+                        (
+                            *fragment_id,
+                            reschedule.newly_created_actors.values().map(
+                                |((actor, dispatchers), _)| {
+                                    (actor.actor_id, dispatchers.as_slice())
+                                },
+                            ),
+                        )
                     }),
                     Some((reschedules, fragment_actors)),
+                    graph_info,
+                    control_stream_manager,
                 );
                 let mut map: HashMap<WorkerId, HashMap<_, (_, Vec<_>)>> = HashMap::new();
                 for (fragment_id, (actor, dispatchers), worker_id) in
@@ -1090,35 +1104,56 @@ impl Command {
 
 impl Command {
     #[expect(clippy::type_complexity)]
-    pub fn collect_actor_upstreams(
-        actor_dispatchers: impl Iterator<Item = (ActorId, FragmentId, &[Dispatcher])>,
+    pub(super) fn collect_actor_upstreams(
+        actor_dispatchers: impl Iterator<
+            Item = (FragmentId, impl Iterator<Item = (ActorId, &[Dispatcher])>),
+        >,
         reschedule_dispatcher_update: Option<(
             &HashMap<FragmentId, Reschedule>,
             &HashMap<FragmentId, HashSet<ActorId>>,
         )>,
+        graph_info: &InflightDatabaseInfo,
+        control_stream_manager: &ControlStreamManager,
     ) -> HashMap<ActorId, ActorUpstreams> {
         let mut actor_upstreams: HashMap<ActorId, ActorUpstreams> = HashMap::new();
-        for (upstream_actor_id, upstream_fragment_id, dispatchers) in actor_dispatchers {
-            for downstream_actor_id in dispatchers
-                .iter()
-                .flat_map(|dispatcher| dispatcher.downstream_actor_id.iter())
-            {
-                actor_upstreams
-                    .entry(*downstream_actor_id)
-                    .or_default()
-                    .entry(upstream_fragment_id)
-                    .or_default()
-                    .insert(upstream_actor_id);
+        for (upstream_fragment_id, upstream_actors) in actor_dispatchers {
+            let upstream_fragment = graph_info.fragment(upstream_fragment_id);
+            for (upstream_actor_id, dispatchers) in upstream_actors {
+                let upstream_actor_location =
+                    upstream_fragment.actors[&upstream_actor_id].worker_id;
+                let upstream_actor_host = control_stream_manager.host_addr(upstream_actor_location);
+                for downstream_actor_id in dispatchers
+                    .iter()
+                    .flat_map(|dispatcher| dispatcher.downstream_actor_id.iter())
+                {
+                    actor_upstreams
+                        .entry(*downstream_actor_id)
+                        .or_default()
+                        .entry(upstream_fragment_id)
+                        .or_default()
+                        .insert(
+                            upstream_actor_id,
+                            ActorInfo {
+                                actor_id: upstream_actor_id,
+                                host: Some(upstream_actor_host.clone()),
+                            },
+                        );
+                }
             }
         }
         if let Some((reschedules, fragment_actors)) = reschedule_dispatcher_update {
             for reschedule in reschedules.values() {
                 for (upstream_fragment_id, _) in &reschedule.upstream_fragment_dispatcher_ids {
+                    let upstream_fragment = graph_info.fragment(*upstream_fragment_id);
                     let upstream_reschedule = reschedules.get(upstream_fragment_id);
                     for upstream_actor_id in fragment_actors
                         .get(upstream_fragment_id)
                         .expect("should exist")
                     {
+                        let upstream_actor_location =
+                            upstream_fragment.actors[upstream_actor_id].worker_id;
+                        let upstream_actor_host =
+                            control_stream_manager.host_addr(upstream_actor_location);
                         if let Some(upstream_reschedule) = upstream_reschedule
                             && upstream_reschedule
                                 .removed_actors
@@ -1126,13 +1161,26 @@ impl Command {
                         {
                             continue;
                         }
-                        for downstream_actor_id in reschedule.added_actors.values().flatten() {
+                        for (_, downstream_actor_id) in
+                            reschedule
+                                .added_actors
+                                .iter()
+                                .flat_map(|(worker_id, actors)| {
+                                    actors.iter().map(|actor| (*worker_id, *actor))
+                                })
+                        {
                             actor_upstreams
-                                .entry(*downstream_actor_id)
+                                .entry(downstream_actor_id)
                                 .or_default()
                                 .entry(*upstream_fragment_id)
                                 .or_default()
-                                .insert(*upstream_actor_id);
+                                .insert(
+                                    *upstream_actor_id,
+                                    ActorInfo {
+                                        actor_id: *upstream_actor_id,
+                                        host: Some(upstream_actor_host.clone()),
+                                    },
+                                );
                         }
                     }
                 }

--- a/src/meta/src/barrier/edge_builder.rs
+++ b/src/meta/src/barrier/edge_builder.rs
@@ -17,14 +17,16 @@ use std::collections::HashMap;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_meta_model::WorkerId;
 use risingwave_meta_model::fragment::DistributionType;
+use risingwave_pb::common::{ActorInfo, HostAddress};
 use risingwave_pb::stream_plan::StreamNode;
 use risingwave_pb::stream_plan::update_mutation::MergeUpdate;
 use tracing::warn;
 
+use crate::barrier::rpc::ControlStreamManager;
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::controller::utils::compose_dispatchers;
 use crate::model::{
-    ActorId, DownstreamFragmentRelation, FragmentActorDispatchers, FragmentActorUpstreams,
+    ActorId, ActorUpstreams, DownstreamFragmentRelation, FragmentActorDispatchers,
     FragmentDownstreamRelation, FragmentId, StreamActor, StreamJobActorsToCreate,
 };
 
@@ -32,10 +34,11 @@ use crate::model::{
 struct FragmentInfo {
     distribution_type: DistributionType,
     actors: HashMap<ActorId, Option<Bitmap>>,
+    actor_location: HashMap<ActorId, HostAddress>,
 }
 
 pub(super) struct FragmentEdgeBuildResult {
-    pub(super) upstreams: HashMap<FragmentId, FragmentActorUpstreams>,
+    pub(super) upstreams: HashMap<FragmentId, HashMap<ActorId, ActorUpstreams>>,
     pub(super) dispatchers: FragmentActorDispatchers,
     pub(super) merge_updates: HashMap<FragmentId, Vec<MergeUpdate>>,
 }
@@ -83,21 +86,30 @@ pub(super) struct FragmentEdgeBuilder {
 }
 
 impl FragmentEdgeBuilder {
-    pub(super) fn new(fragment_infos: impl Iterator<Item = &InflightFragmentInfo>) -> Self {
+    pub(super) fn new(
+        fragment_infos: impl Iterator<Item = &InflightFragmentInfo>,
+        control_stream_manager: &ControlStreamManager,
+    ) -> Self {
         let mut fragments = HashMap::new();
         for info in fragment_infos {
             fragments
-                .try_insert(
-                    info.fragment_id,
+                .try_insert(info.fragment_id, {
+                    let (actors, actor_location) = info
+                        .actors
+                        .iter()
+                        .map(|(actor_id, actor)| {
+                            (
+                                (*actor_id, actor.vnode_bitmap.clone()),
+                                (*actor_id, control_stream_manager.host_addr(actor.worker_id)),
+                            )
+                        })
+                        .unzip();
                     FragmentInfo {
                         distribution_type: info.distribution_type,
-                        actors: info
-                            .actors
-                            .iter()
-                            .map(|(actor_id, actor)| (*actor_id, actor.vnode_bitmap.clone()))
-                            .collect(),
-                    },
-                )
+                        actors,
+                        actor_location,
+                    }
+                })
                 .expect("non-duplicate");
         }
         Self {
@@ -140,13 +152,20 @@ impl FragmentEdgeBuilder {
             .entry(downstream.downstream_fragment_id)
             .or_default();
         for (actor_id, dispatcher) in dispatchers {
+            let actor_location = &fragment.actor_location[&actor_id];
             for downstream_actor in &dispatcher.downstream_actor_id {
                 downstream_fragment_upstreams
                     .entry(*downstream_actor)
                     .or_default()
                     .entry(fragment_id)
                     .or_default()
-                    .insert(actor_id);
+                    .insert(
+                        actor_id,
+                        ActorInfo {
+                            actor_id,
+                            host: Some(actor_location.clone()),
+                        },
+                    );
             }
             self.result
                 .dispatchers
@@ -172,7 +191,7 @@ impl FragmentEdgeBuilder {
                         actor_id,
                         upstream_fragment_id: original_upstream_fragment_id,
                         new_upstream_fragment_id: Some(new_upstream_fragment_id),
-                        added_upstream_actor_id: new_upstreams.into_iter().collect(),
+                        added_upstream_actors: new_upstreams.into_values().collect(),
                         removed_upstream_actor_id: vec![],
                     })
                 } else if cfg!(debug_assertions) {

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -1691,7 +1691,11 @@ mod tests {
 
     use crate::MetaResult;
     use crate::controller::catalog::CatalogController;
-    use crate::model::{ActorUpstreams, Fragment, FragmentActorUpstreams, StreamActor};
+    use crate::model::{Fragment, StreamActor};
+
+    type ActorUpstreams = BTreeMap<crate::model::FragmentId, HashSet<crate::model::ActorId>>;
+
+    type FragmentActorUpstreams = HashMap<crate::model::ActorId, ActorUpstreams>;
 
     const TEST_FRAGMENT_ID: FragmentId = 1;
 

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -26,7 +26,7 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_meta_model::actor_dispatcher::DispatcherType;
 use risingwave_meta_model::{SourceId, StreamingParallelism, WorkerId};
 use risingwave_pb::catalog::Table;
-use risingwave_pb::common::PbActorLocation;
+use risingwave_pb::common::{ActorInfo, PbActorLocation};
 use risingwave_pb::meta::table_fragments::actor_status::ActorState;
 use risingwave_pb::meta::table_fragments::fragment::{
     FragmentDistributionType, PbFragmentDistributionType,
@@ -115,8 +115,7 @@ impl From<TableParallelism> for StreamingParallelism {
     }
 }
 
-pub type ActorUpstreams = BTreeMap<FragmentId, HashSet<ActorId>>;
-pub type FragmentActorUpstreams = HashMap<ActorId, ActorUpstreams>;
+pub type ActorUpstreams = BTreeMap<FragmentId, HashMap<ActorId, ActorInfo>>;
 pub type StreamActorWithDispatchers = (StreamActor, Vec<PbDispatcher>);
 pub type StreamActorWithUpDownstreams = (StreamActor, ActorUpstreams, Vec<PbDispatcher>);
 pub type FragmentActorDispatchers = HashMap<FragmentId, HashMap<ActorId, Vec<PbDispatcher>>>;

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -1173,7 +1173,6 @@ mod tests {
     use crate::executor::receiver::ReceiverExecutor;
     use crate::executor::{BarrierInner as Barrier, MessageInner as Message};
     use crate::task::barrier_test_utils::LocalBarrierTestEnv;
-    use crate::task::test_utils::helper_make_local_actor;
 
     // TODO: this test contains update being shuffled to different partitions, which is not
     // supported for now.
@@ -1263,12 +1262,6 @@ mod tests {
         let (untouched, old, new) = (234, 235, 238); // broadcast downstream actors
         let (old_simple, new_simple) = (114, 514); // simple downstream actors
 
-        // 1. Register info in context.
-        ctx.add_actors(
-            [actor_id, untouched, old, new, old_simple, new_simple]
-                .into_iter()
-                .map(helper_make_local_actor),
-        );
         // actor_id -> untouched, old, new, old_simple, new_simple
 
         let broadcast_dispatcher_id = 666;

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -173,6 +173,7 @@ pub struct RemoteInput {
 
 use remote_input::RemoteInputStreamInner;
 use risingwave_common::catalog::DatabaseId;
+use risingwave_pb::common::ActorInfo;
 
 impl RemoteInput {
     /// Create a remote input from compute client and related info. Should provide the corresponding
@@ -359,14 +360,12 @@ pub(crate) fn new_input(
     metrics: Arc<StreamingMetrics>,
     actor_id: ActorId,
     fragment_id: FragmentId,
-    upstream_actor_id: ActorId,
+    upstream_actor_info: &ActorInfo,
     upstream_fragment_id: FragmentId,
 ) -> StreamResult<BoxedInput> {
     let context = &local_barrier_manager.shared_context;
-    let upstream_addr = context
-        .get_actor_info(&upstream_actor_id)?
-        .get_host()?
-        .into();
+    let upstream_actor_id = upstream_actor_info.actor_id;
+    let upstream_addr = upstream_actor_info.get_host()?.into();
 
     let input = if is_local_address(&context.addr, &upstream_addr) {
         LocalInput::new(

--- a/src/stream/src/from_proto/merge.rs
+++ b/src/stream/src/from_proto/merge.rs
@@ -41,13 +41,13 @@ impl MergeExecutorBuilder {
             .map(|actors| actors.actors.iter())
             .into_iter()
             .flatten()
-            .map(|&upstream_actor_id| {
+            .map(|upstream_actor| {
                 new_input(
                     &local_barrier_manager,
                     executor_stats.clone(),
                     actor_context.id,
                     actor_context.fragment_id,
-                    upstream_actor_id,
+                    upstream_actor,
                     upstream_fragment_id,
                 )
             })

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -842,10 +842,6 @@ impl LocalBarrierWorker {
             .get_mut(&DatabaseId::new(request.database_id))
             .expect("should exist");
         if let Some(state) = database_status.state_for_request() {
-            state
-                .local_barrier_manager
-                .shared_context
-                .add_actors(request.broadcast_info.iter().cloned());
             state.transform_to_issued(barrier, request)?;
         }
         Ok(())
@@ -1271,7 +1267,6 @@ pub(crate) mod barrier_test_utils {
                         graphs: vec![PbInitialPartialGraph {
                             partial_graph_id: TEST_PARTIAL_GRAPH_ID.into(),
                             subscriptions: vec![],
-                            actor_infos: vec![],
                         }],
                     }],
                     term_id: "for_test".into(),
@@ -1312,7 +1307,6 @@ pub(crate) mod barrier_test_utils {
                             actor_ids_to_collect: actor_to_collect.into_iter().collect(),
                             table_ids_to_sync: vec![],
                             partial_graph_id: TEST_PARTIAL_GRAPH_ID.into(),
-                            broadcast_info: vec![],
                             actors_to_build: vec![],
                             subscriptions_to_add: vec![],
                             subscriptions_to_remove: vec![],

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -590,12 +590,6 @@ impl DatabaseManagedBarrierState {
         initial_partial_graphs: Vec<InitialPartialGraph>,
     ) -> Self {
         let shared_context = Arc::new(SharedContext::new(database_id, &actor_manager.env, term_id));
-        shared_context.add_actors(
-            initial_partial_graphs
-                .iter()
-                .flat_map(|graph| graph.actor_infos.iter())
-                .cloned(),
-        );
         let (local_barrier_manager, barrier_event_rx, actor_failure_rx) =
             LocalBarrierManager::new(shared_context);
         Self {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Highest Release Version: 2.3

## What's changed and what's your intention?

Previously we broadcast the `ActorInfo` of globally all running actors to the `SharedContext` of each CN, so that the `DispatchExecutor` and `MergeExecutor` can get the host of downstream or upstream actors to establish the exchange connection. 

In https://github.com/risingwavelabs/risingwave/pull/21256, we already unified remote and local output so that the `DispatchExecutor` won't need the `ActorInfo` of downstream actor. In this PR, instead of only providing with upstream actor_ids, we will change to provide the upstream `ActorInfo` directly for `MergeExecutor`, either in build actor info, or `MergeUpdate`, so that `MergeExecutor` also won't need to get `ActorInfo` from `SharedContext`, and in the end, we don't have to broadcast and maintain the global list of `ActorInfo` anymore.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> My PR contains critical fixes that are necessary to be merged into the latest release. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
