### PR TITLE
feat: allow user to force filter pushed into join in streaming query

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -63,6 +63,7 @@ user streaming_allow_jsonb_in_stream_key
 user streaming_enable_bushy_join
 user streaming_enable_delta_join
 user streaming_enable_unaligned_join
+user streaming_force_filter_inside_join
 user streaming_max_parallelism
 user streaming_over_window_cache_policy
 user streaming_parallelism

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -168,6 +168,11 @@ pub struct SessionConfig {
     #[parameter(default = true, alias = "rw_streaming_enable_bushy_join")]
     streaming_enable_bushy_join: bool,
 
+    /// Force filtering to be done inside the join whenever there's a choice between optimizations.
+    /// Defaults to false.
+    #[parameter(default = false, alias = "rw_streaming_force_filter_inside_join")]
+    streaming_force_filter_inside_join: bool,
+
     /// Enable arrangement backfill for streaming queries. Defaults to true.
     /// When set to true, the parallelism of the upstream fragment will be
     /// decoupled from the parallelism of the downstream scan fragment.

--- a/src/frontend/planner_test/tests/testdata/input/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/join.yaml
@@ -347,3 +347,18 @@
   expected_outputs:
   - stream_plan
   - stream_dist_plan
+- name: Force filter pushed down into join
+  sql: |
+    set streaming_force_filter_inside_join = true;
+    create table t (src int, dst int);
+    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+  expected_outputs:
+  - batch_plan
+  - stream_plan
+- name: Pull up filter from join by default
+  sql: |
+    create table t (src int, dst int);
+    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+  expected_outputs:
+    - batch_plan
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/join.yaml
@@ -360,5 +360,5 @@
     create table t (src int, dst int);
     select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
   expected_outputs:
-    - batch_plan
-    - stream_plan
+  - batch_plan
+  - stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/join.yaml
@@ -350,15 +350,17 @@
 - name: Force filter pushed down into join
   sql: |
     set streaming_force_filter_inside_join = true;
-    create table t (src int, dst int);
-    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+    create table t(v1 int, v2 int);
+    create table t2(v3 int, v4 int);
+    select * from t, t2 where t.v1 = t2.v3 and t.v2 > t2.v4 + 1000;
   expected_outputs:
   - batch_plan
   - stream_plan
 - name: Pull up filter from join by default
   sql: |
-    create table t (src int, dst int);
-    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+    create table t(v1 int, v2 int);
+    create table t2(v3 int, v4 int);
+    select * from t, t2 where t.v1 = t2.v3 and t.v2 > t2.v4 + 1000;
   expected_outputs:
   - batch_plan
   - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/join.yaml
@@ -756,3 +756,43 @@
     ├── distribution key: [ 0, 1, 3, 4, 5, 6 ]
     └── read pk prefix len hint: 6
 
+- name: Force filter pushed down into join
+  sql: |
+    set streaming_force_filter_inside_join = true;
+    create table t (src int, dst int);
+    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchHashJoin { type: Inner, predicate: t.src = t.dst AND (t.dst < t.src), output: [t.src, t.dst] }
+      ├─BatchExchange { order: [], dist: HashShard(t.src) }
+      │ └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t.dst) }
+        └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [src, dst, t._row_id(hidden), t._row_id#1(hidden)], stream_key: [t._row_id, t._row_id#1, src], pk_columns: [t._row_id, t._row_id#1, src], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(t.src, t._row_id, t._row_id) }
+      └─StreamHashJoin { type: Inner, predicate: t.src = t.dst AND (t.dst < t.src), output: [t.src, t.dst, t._row_id, t._row_id] }
+        ├─StreamExchange { dist: HashShard(t.src) }
+        │ └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+        └─StreamExchange { dist: HashShard(t.dst) }
+          └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: Pull up filter from join by default
+  sql: |
+    create table t (src int, dst int);
+    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchHashJoin { type: Inner, predicate: t.src = t.dst AND (t.dst < t.src), output: [t.src, t.dst] }
+      ├─BatchExchange { order: [], dist: HashShard(t.src) }
+      │ └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t.dst) }
+        └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [src, dst, t._row_id(hidden), t._row_id#1(hidden)], stream_key: [t._row_id, t._row_id#1, src], pk_columns: [t._row_id, t._row_id#1, src], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.src, t.dst, t._row_id, t._row_id] }
+      └─StreamFilter { predicate: (t.dst < t.src) }
+        └─StreamHashJoin { type: Inner, predicate: t.src = t.dst, output: all }
+          ├─StreamExchange { dist: HashShard(t.src) }
+          │ └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+          └─StreamExchange { dist: HashShard(t.dst) }
+            └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/join.yaml
@@ -759,40 +759,46 @@
 - name: Force filter pushed down into join
   sql: |
     set streaming_force_filter_inside_join = true;
-    create table t (src int, dst int);
-    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+    create table t(v1 int, v2 int);
+    create table t2(v3 int, v4 int);
+    select * from t, t2 where t.v1 = t2.v3 and t.v2 > t2.v4 + 1000;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: Inner, predicate: t.src = t.dst AND (t.dst < t.src), output: [t.src, t.dst] }
-      ├─BatchExchange { order: [], dist: HashShard(t.src) }
-      │ └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
-      └─BatchExchange { order: [], dist: HashShard(t.dst) }
-        └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: t.v1 = t2.v3 AND (t.v2 > $expr1), output: [t.v1, t.v2, t2.v3, t2.v4] }
+      ├─BatchExchange { order: [], dist: HashShard(t.v1) }
+      │ └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t2.v3) }
+        └─BatchProject { exprs: [t2.v3, t2.v4, (t2.v4 + 1000:Int32) as $expr1] }
+          └─BatchScan { table: t2, columns: [t2.v3, t2.v4], distribution: SomeShard }
   stream_plan: |-
-    StreamMaterialize { columns: [src, dst, t._row_id(hidden), t._row_id#1(hidden)], stream_key: [t._row_id, t._row_id#1, src], pk_columns: [t._row_id, t._row_id#1, src], pk_conflict: NoCheck }
-    └─StreamExchange { dist: HashShard(t.src, t._row_id, t._row_id) }
-      └─StreamHashJoin { type: Inner, predicate: t.src = t.dst AND (t.dst < t.src), output: [t.src, t.dst, t._row_id, t._row_id] }
-        ├─StreamExchange { dist: HashShard(t.src) }
-        │ └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-        └─StreamExchange { dist: HashShard(t.dst) }
-          └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+    StreamMaterialize { columns: [v1, v2, v3, v4, t._row_id(hidden), t2._row_id(hidden)], stream_key: [t._row_id, t2._row_id, v1], pk_columns: [t._row_id, t2._row_id, v1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(t.v1, t._row_id, t2._row_id) }
+      └─StreamHashJoin { type: Inner, predicate: t.v1 = t2.v3 AND (t.v2 > $expr1), output: [t.v1, t.v2, t2.v3, t2.v4, t._row_id, t2._row_id] }
+        ├─StreamExchange { dist: HashShard(t.v1) }
+        │ └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+        └─StreamExchange { dist: HashShard(t2.v3) }
+          └─StreamProject { exprs: [t2.v3, t2.v4, (t2.v4 + 1000:Int32) as $expr1, t2._row_id] }
+            └─StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: Pull up filter from join by default
   sql: |
-    create table t (src int, dst int);
-    select t1.src, t2.dst from t t1, t t2 where t1.src = t2.dst and t1.dst < t2.src;
+    create table t(v1 int, v2 int);
+    create table t2(v3 int, v4 int);
+    select * from t, t2 where t.v1 = t2.v3 and t.v2 > t2.v4 + 1000;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: Inner, predicate: t.src = t.dst AND (t.dst < t.src), output: [t.src, t.dst] }
-      ├─BatchExchange { order: [], dist: HashShard(t.src) }
-      │ └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
-      └─BatchExchange { order: [], dist: HashShard(t.dst) }
-        └─BatchScan { table: t, columns: [t.src, t.dst], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: t.v1 = t2.v3 AND (t.v2 > $expr1), output: [t.v1, t.v2, t2.v3, t2.v4] }
+      ├─BatchExchange { order: [], dist: HashShard(t.v1) }
+      │ └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t2.v3) }
+        └─BatchProject { exprs: [t2.v3, t2.v4, (t2.v4 + 1000:Int32) as $expr1] }
+          └─BatchScan { table: t2, columns: [t2.v3, t2.v4], distribution: SomeShard }
   stream_plan: |-
-    StreamMaterialize { columns: [src, dst, t._row_id(hidden), t._row_id#1(hidden)], stream_key: [t._row_id, t._row_id#1, src], pk_columns: [t._row_id, t._row_id#1, src], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.src, t.dst, t._row_id, t._row_id] }
-      └─StreamFilter { predicate: (t.dst < t.src) }
-        └─StreamHashJoin { type: Inner, predicate: t.src = t.dst, output: all }
-          ├─StreamExchange { dist: HashShard(t.src) }
-          │ └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-          └─StreamExchange { dist: HashShard(t.dst) }
-            └─StreamTableScan { table: t, columns: [t.src, t.dst, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+    StreamMaterialize { columns: [v1, v2, v3, v4, t._row_id(hidden), t2._row_id(hidden)], stream_key: [t._row_id, t2._row_id, v1], pk_columns: [t._row_id, t2._row_id, v1], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.v1, t.v2, t2.v3, t2.v4, t._row_id, t2._row_id] }
+      └─StreamFilter { predicate: (t.v2 > $expr1) }
+        └─StreamHashJoin { type: Inner, predicate: t.v1 = t2.v3, output: all }
+          ├─StreamExchange { dist: HashShard(t.v1) }
+          │ └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+          └─StreamExchange { dist: HashShard(t2.v3) }
+            └─StreamProject { exprs: [t2.v3, t2.v4, (t2.v4 + 1000:Int32) as $expr1, t2._row_id] }
+              └─StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -941,7 +941,9 @@ impl LogicalJoin {
         // For inner joins, pull non-equal conditions to a filter operator on top of it by default.
         // We do so as the filter operator can apply the non-equal condition batch-wise (vectorized)
         // as opposed to the HashJoin, which applies the condition row-wise.
-        // However, the default behavior of pulling up non-equal conditions can be overidden by
+        // However, the default behavior of pulling up non-equal conditions can be overidden by the
+        // session variable `streaming_force_filter_inside_join` as it can save unnecessary
+        // materialization of rows only to be filtered later.
 
         let stream_hash_join = StreamHashJoin::new(logical_join.core.clone(), predicate.clone());
 

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -941,7 +941,7 @@ impl LogicalJoin {
         // For inner joins, pull non-equal conditions to a filter operator on top of it by default.
         // We do so as the filter operator can apply the non-equal condition batch-wise (vectorized)
         // as opposed to the HashJoin, which applies the condition row-wise.
-        // However, the default behavior of pulling up non-equal conditions can be overiden by
+        // However, the default behavior of pulling up non-equal conditions can be overidden by
 
         let stream_hash_join = StreamHashJoin::new(logical_join.core.clone(), predicate.clone());
 

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -941,7 +941,7 @@ impl LogicalJoin {
         // For inner joins, pull non-equal conditions to a filter operator on top of it by default.
         // We do so as the filter operator can apply the non-equal condition batch-wise (vectorized)
         // as opposed to the HashJoin, which applies the condition row-wise.
-        // However, the default behavior of pulling up non-equal conditions can be overidden by the
+        // However, the default behavior of pulling up non-equal conditions can be overridden by the
         // session variable `streaming_force_filter_inside_join` as it can save unnecessary
         // materialization of rows only to be filtered later.
 

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -954,7 +954,7 @@ impl LogicalJoin {
 
         let pull_filter = self.join_type() == JoinType::Inner
             && stream_hash_join.eq_join_predicate().has_non_eq()
-            && stream_hash_join.inequality_pairs().is_empty() 
+            && stream_hash_join.inequality_pairs().is_empty()
             && (!force_filter_inside_join);
         if pull_filter {
             let default_indices = (0..self.internal_column_num()).collect::<Vec<_>>();

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -938,14 +938,24 @@ impl LogicalJoin {
         let logical_join = self.clone_with_left_right(left, right);
 
         // Convert to Hash Join for equal joins
-        // For inner joins, pull non-equal conditions to a filter operator on top of it
+        // For inner joins, pull non-equal conditions to a filter operator on top of it by default.
         // We do so as the filter operator can apply the non-equal condition batch-wise (vectorized)
         // as opposed to the HashJoin, which applies the condition row-wise.
+        // However, the default behavior of pulling up non-equal conditions can be overiden by
 
         let stream_hash_join = StreamHashJoin::new(logical_join.core.clone(), predicate.clone());
+
+        let force_filter_inside_join = self
+            .base
+            .ctx()
+            .session_ctx()
+            .config()
+            .streaming_force_filter_inside_join();
+
         let pull_filter = self.join_type() == JoinType::Inner
             && stream_hash_join.eq_join_predicate().has_non_eq()
-            && stream_hash_join.inequality_pairs().is_empty();
+            && stream_hash_join.inequality_pairs().is_empty() 
+            && (!force_filter_inside_join);
         if pull_filter {
             let default_indices = (0..self.internal_column_num()).collect::<Vec<_>>();
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).


## What's changed and what's your intention?

We have a known issue #20028  that building rows into arrays, especially certain data types, this building process takes quite some time. Filtering unnecessary rows earlier in the join can reduce the cost.

Apart from building rows into arrays, materializing possibly many rows only to get them filtered in the next executor is just wasteful.

However, it could be generally hard to decide which one is better, as the existing comment suggest that
```
// We do so as the filter operator can apply the non-equal condition batch-wise (vectorized)
// as opposed to the HashJoin, which applies the condition row-wise.
```
vectorization may help.

Since the overall efficiency could depend on the join selectivity, array building efficiency and vectorization benefits,
we make it a session variable instead of deciding automatically by the optimizer.

We make its default behavior the same as the current one.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
