### PR TITLE
feat(stream): actor create exchange via channel

### DIFF
--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -369,7 +369,7 @@ pub(crate) fn new_input(
 
     let input = if is_local_address(&context.addr, &upstream_addr) {
         LocalInput::new(
-            context.take_receiver((upstream_actor_id, actor_id))?,
+            local_barrier_manager.register_local_upstream_output(actor_id, upstream_actor_id),
             upstream_actor_id,
         )
         .boxed_input()

--- a/src/stream/src/executor/exchange/output.rs
+++ b/src/stream/src/executor/exchange/output.rs
@@ -19,7 +19,7 @@ use super::error::ExchangeChannelClosed;
 use super::permit::Sender;
 use crate::error::StreamResult;
 use crate::executor::DispatcherMessageBatch as Message;
-use crate::task::{ActorId, SharedContext};
+use crate::task::ActorId;
 
 /// `LocalOutput` sends data to a local channel.
 #[derive(Educe)]
@@ -56,16 +56,4 @@ impl Output {
     pub fn actor_id(&self) -> ActorId {
         self.actor_id
     }
-}
-
-/// Create a [`Output`] instance for the current actor id and the
-/// downstream actor id. Used by dispatchers.
-pub fn new_output(
-    context: &SharedContext,
-    actor_id: ActorId,
-    down_id: ActorId,
-) -> StreamResult<Output> {
-    let tx = context.take_sender(&(actor_id, down_id))?;
-
-    Ok(Output::new(down_id, tx))
 }

--- a/src/stream/src/executor/exchange/permit.rs
+++ b/src/stream/src/executor/exchange/permit.rs
@@ -16,6 +16,7 @@
 
 use std::sync::Arc;
 
+use risingwave_common::config::StreamingConfig;
 use risingwave_pb::task_service::permits;
 use tokio::sync::{AcquireError, Semaphore, SemaphorePermit, mpsc};
 
@@ -53,6 +54,14 @@ pub fn channel(
             max_chunk_permits,
         },
         Receiver { rx, permits },
+    )
+}
+
+pub fn channel_from_config(config: &StreamingConfig) -> (Sender, Receiver) {
+    channel(
+        config.developer.exchange_initial_permits,
+        config.developer.exchange_batched_permits,
+        config.developer.exchange_concurrent_barriers,
     )
 }
 

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -159,7 +159,9 @@ async fn test_merger_sum_aggr() {
                 shared_context.clone(),
                 metrics,
                 config::default::developer::stream_chunk_size(),
-            );
+            )
+            .await
+            .unwrap();
             let actor = Actor::new(
                 dispatcher,
                 vec![],

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -154,7 +154,7 @@ async fn test_merger_sum_aggr() {
                 ))],
                 0,
                 0,
-                local_barrier_manager.shared_context.clone(),
+                local_barrier_manager.clone(),
                 metrics,
             );
             let actor = Actor::new(

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -683,7 +683,6 @@ mod tests {
     use risingwave_pb::task_service::{
         GetDataRequest, GetDataResponse, GetStreamRequest, GetStreamResponse, PbPermits,
     };
-    use risingwave_rpc_client::ComputeClientPool;
     use tokio::time::sleep;
     use tokio_stream::wrappers::ReceiverStream;
     use tonic::{Request, Response, Status, Streaming};
@@ -1114,7 +1113,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_stream_exchange_client() {
-        const BATCHED_PERMITS: usize = 1024;
         let rpc_called = Arc::new(AtomicBool::new(false));
         let server_run = Arc::new(AtomicBool::new(false));
         let addr = "127.0.0.1:12348".parse().unwrap();
@@ -1142,16 +1140,12 @@ mod tests {
         let test_env = LocalBarrierTestEnv::for_test().await;
 
         let remote_input = {
-            let pool = ComputeClientPool::for_test();
             RemoteInput::new(
-                pool,
+                &test_env.local_barrier_manager,
                 addr.into(),
                 (0, 0),
                 (0, 0),
-                test_env.local_barrier_manager.shared_context.database_id,
                 Arc::new(StreamingMetrics::unused()),
-                BATCHED_PERMITS,
-                "for_test".into(),
             )
             .await
             .unwrap()

--- a/src/stream/src/executor/receiver.rs
+++ b/src/stream/src/executor/receiver.rs
@@ -169,6 +169,7 @@ impl Execute for ReceiverExecutor {
                                 upstream_actor,
                                 new_upstream_fragment_id,
                             )
+                            .await
                             .context("failed to create upstream input")?;
 
                             // Poll the first barrier from the new upstream. It must be the same as
@@ -261,6 +262,7 @@ mod tests {
             &helper_make_local_actor(old),
             upstream_fragment_id,
         )
+        .await
         .unwrap();
 
         let receiver = ReceiverExecutor::new(

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -546,10 +546,10 @@ impl LocalBarrierWorker {
                             }
                             DatabaseStatus::Running(database) => {
                                 let (upstream_actor_id, actor_id) = ids;
-                                database.new_actor_output_request(
+                                database.new_actor_remote_output_request(
                                     actor_id,
                                     upstream_actor_id,
-                                    NewOutputRequest::Remote(result_sender),
+                                    result_sender,
                                 );
                                 return;
                             }
@@ -922,10 +922,10 @@ impl LocalBarrierWorker {
                     );
                     for ((upstream_actor_id, actor_id), result_sender) in pending_requests.drain(..)
                     {
-                        database.new_actor_output_request(
+                        database.new_actor_remote_output_request(
                             actor_id,
                             upstream_actor_id,
-                            NewOutputRequest::Remote(result_sender),
+                            result_sender,
                         );
                     }
                     *status = DatabaseStatus::Running(database);
@@ -1121,7 +1121,7 @@ impl<T> EventSender<T> {
 
 pub(crate) enum NewOutputRequest {
     Local(permit::Sender),
-    Remote(oneshot::Sender<StreamResult<permit::Receiver>>),
+    Remote(permit::Sender),
 }
 
 impl LocalBarrierManager {

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -29,7 +29,7 @@ use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_storage::StateStoreImpl;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
@@ -38,7 +38,8 @@ use crate::error::{StreamError, StreamResult};
 use crate::executor::Barrier;
 use crate::executor::monitor::StreamingMetrics;
 use crate::task::{
-    ActorId, LocalBarrierManager, PartialGraphId, SharedContext, StreamActorManager, UpDownActorIds,
+    ActorId, LocalBarrierManager, NewOutputRequest, PartialGraphId, SharedContext,
+    StreamActorManager, UpDownActorIds,
 };
 
 struct IssuedState {
@@ -196,6 +197,7 @@ pub(crate) struct InflightActorState {
     /// Whether the actor has been issued a stop barrier
     is_stopping: bool,
 
+    new_output_request_tx: UnboundedSender<(ActorId, NewOutputRequest)>,
     join_handle: JoinHandle<()>,
     monitor_task_handle: Option<JoinHandle<()>>,
 }
@@ -205,6 +207,7 @@ impl InflightActorState {
         actor_id: ActorId,
         initial_partial_graph_id: PartialGraphId,
         initial_barrier: &Barrier,
+        new_output_request_tx: UnboundedSender<(ActorId, NewOutputRequest)>,
         join_handle: JoinHandle<()>,
         monitor_task_handle: Option<JoinHandle<()>>,
     ) -> Self {
@@ -217,6 +220,7 @@ impl InflightActorState {
             )]),
             status: InflightActorStatus::IssuedFirst(vec![initial_barrier.clone()]),
             is_stopping: false,
+            new_output_request_tx,
             join_handle,
             monitor_task_handle,
         }
@@ -568,6 +572,7 @@ impl ManagedBarrierState {
 pub(crate) struct DatabaseManagedBarrierState {
     database_id: DatabaseId,
     pub(super) actor_states: HashMap<ActorId, InflightActorState>,
+    actor_pending_new_output_requests: HashMap<ActorId, Vec<(ActorId, NewOutputRequest)>>,
 
     pub(super) graph_states: HashMap<PartialGraphId, PartialGraphManagedBarrierState>,
 
@@ -595,6 +600,7 @@ impl DatabaseManagedBarrierState {
         Self {
             database_id,
             actor_states: Default::default(),
+            actor_pending_new_output_requests: Default::default(),
             graph_states: initial_partial_graphs
                 .into_iter()
                 .map(|graph| {
@@ -777,12 +783,20 @@ impl DatabaseManagedBarrierState {
             assert!(!is_stop_actor(actor_id));
             assert!(new_actors.insert(actor_id));
             assert!(request.actor_ids_to_collect.contains(&actor_id));
+            let (new_output_request_tx, new_output_request_rx) = mpsc::unbounded_channel();
+            if let Some(pending_requests) = self.actor_pending_new_output_requests.remove(&actor_id)
+            {
+                for request in pending_requests {
+                    let _ = new_output_request_tx.send(request);
+                }
+            }
             let (join_handle, monitor_join_handle) = self.actor_manager.spawn_actor(
                 actor,
                 fragment_id,
                 node,
                 (*subscriptions).clone(),
                 self.local_barrier_manager.clone(),
+                new_output_request_rx,
             );
             assert!(
                 self.actor_states
@@ -792,6 +806,7 @@ impl DatabaseManagedBarrierState {
                             actor_id,
                             partial_graph_id,
                             barrier,
+                            new_output_request_tx,
                             join_handle,
                             monitor_join_handle
                         )
@@ -804,7 +819,11 @@ impl DatabaseManagedBarrierState {
         if cfg!(test) {
             for actor_id in &request.actor_ids_to_collect {
                 if !self.actor_states.contains_key(actor_id) {
-                    let join_handle = self.actor_manager.runtime.spawn(async { pending().await });
+                    let (tx, rx) = unbounded_channel();
+                    let join_handle = self.actor_manager.runtime.spawn(async move {
+                        let _ = rx;
+                        pending().await
+                    });
                     assert!(
                         self.actor_states
                             .try_insert(
@@ -813,6 +832,7 @@ impl DatabaseManagedBarrierState {
                                     *actor_id,
                                     partial_graph_id,
                                     barrier,
+                                    tx,
                                     join_handle,
                                     None,
                                 )
@@ -844,6 +864,22 @@ impl DatabaseManagedBarrierState {
         Ok(())
     }
 
+    pub(super) fn new_actor_output_request(
+        &mut self,
+        actor_id: ActorId,
+        upstream_actor_id: ActorId,
+        request: NewOutputRequest,
+    ) {
+        if let Some(actor) = self.actor_states.get_mut(&upstream_actor_id) {
+            let _ = actor.new_output_request_tx.send((actor_id, request));
+        } else {
+            self.actor_pending_new_output_requests
+                .entry(upstream_actor_id)
+                .or_default()
+                .push((actor_id, request));
+        }
+    }
+
     pub(super) fn poll_next_event(
         &mut self,
         cx: &mut Context<'_>,
@@ -855,11 +891,6 @@ impl DatabaseManagedBarrierState {
         // yield some pending collected epochs
         for (partial_graph_id, graph_state) in &mut self.graph_states {
             if let Some(barrier) = graph_state.may_have_collected_all() {
-                if let Some(actors_to_stop) = barrier.all_stop_actors() {
-                    self.local_barrier_manager
-                        .shared_context
-                        .drop_actors(actors_to_stop);
-                }
                 return Poll::Ready(ManagedBarrierStateEvent::BarrierCollected {
                     partial_graph_id: *partial_graph_id,
                     barrier,
@@ -870,11 +901,6 @@ impl DatabaseManagedBarrierState {
             match event.expect("non-empty when tx in local_barrier_manager") {
                 LocalBarrierEvent::ReportActorCollected { actor_id, epoch } => {
                     if let Some((partial_graph_id, barrier)) = self.collect(actor_id, epoch) {
-                        if let Some(actors_to_stop) = barrier.all_stop_actors() {
-                            self.local_barrier_manager
-                                .shared_context
-                                .drop_actors(actors_to_stop);
-                        }
                         return Poll::Ready(ManagedBarrierStateEvent::BarrierCollected {
                             partial_graph_id,
                             barrier,
@@ -895,6 +921,17 @@ impl DatabaseManagedBarrierState {
                     if let Err(err) = self.register_barrier_sender(actor_id, barrier_sender) {
                         return Poll::Ready(ManagedBarrierStateEvent::ActorError { actor_id, err });
                     }
+                }
+                LocalBarrierEvent::RegisterLocalUpstreamOutput {
+                    actor_id,
+                    upstream_actor_id,
+                    tx,
+                } => {
+                    self.new_actor_output_request(
+                        actor_id,
+                        upstream_actor_id,
+                        NewOutputRequest::Local(tx),
+                    );
                 }
             }
         }

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -572,7 +572,8 @@ impl ManagedBarrierState {
 pub(crate) struct DatabaseManagedBarrierState {
     database_id: DatabaseId,
     pub(super) actor_states: HashMap<ActorId, InflightActorState>,
-    actor_pending_new_output_requests: HashMap<ActorId, Vec<(ActorId, NewOutputRequest)>>,
+    pub(super) actor_pending_new_output_requests:
+        HashMap<ActorId, Vec<(ActorId, NewOutputRequest)>>,
 
     pub(super) graph_states: HashMap<PartialGraphId, PartialGraphManagedBarrierState>,
 
@@ -783,7 +784,7 @@ impl DatabaseManagedBarrierState {
             assert!(!is_stop_actor(actor_id));
             assert!(new_actors.insert(actor_id));
             assert!(request.actor_ids_to_collect.contains(&actor_id));
-            let (new_output_request_tx, new_output_request_rx) = mpsc::unbounded_channel();
+            let (new_output_request_tx, new_output_request_rx) = unbounded_channel();
             if let Some(pending_requests) = self.actor_pending_new_output_requests.remove(&actor_id)
             {
                 for request in pending_requests {

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::config::StreamingConfig;
-use risingwave_common::util::addr::HostAddr;
-use risingwave_rpc_client::ComputeClientPoolRef;
-
 use crate::executor::exchange::permit::{Receiver, Sender};
 
 mod barrier_manager;
@@ -24,10 +20,7 @@ mod stream_manager;
 
 pub use barrier_manager::*;
 pub use env::*;
-use risingwave_common::catalog::DatabaseId;
 pub use stream_manager::*;
-
-use crate::executor::exchange::permit;
 
 pub type ConsumableChannelPair = (Option<Sender>, Option<Receiver>);
 pub type ActorId = u32;
@@ -56,91 +49,5 @@ impl PartialGraphId {
 impl From<PartialGraphId> for u32 {
     fn from(val: PartialGraphId) -> u32 {
         val.0
-    }
-}
-
-/// Stores the information which may be modified from the data plane.
-///
-/// The data structure is created in `LocalBarrierWorker` and is shared by actors created
-/// between two recoveries. In every recovery, the `LocalBarrierWorker` will create a new instance of
-/// `SharedContext`, and the original one becomes stale. The new one is shared by actors created after
-/// recovery.
-pub struct SharedContext {
-    pub(crate) database_id: DatabaseId,
-    term_id: String,
-
-    /// Stores the local address.
-    ///
-    /// It is used to test whether an actor is local or not,
-    /// thus determining whether we should setup local channel only or remote rpc connection
-    /// between two actors/actors.
-    pub(crate) addr: HostAddr,
-
-    /// Compute client pool for streaming gRPC exchange.
-    // TODO: currently the client pool won't be cleared. Should remove compute clients when
-    // disconnected.
-    pub(crate) compute_client_pool: ComputeClientPoolRef,
-
-    pub(crate) config: StreamingConfig,
-}
-
-impl std::fmt::Debug for SharedContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedContext")
-            .field("addr", &self.addr)
-            .finish_non_exhaustive()
-    }
-}
-
-impl SharedContext {
-    pub fn new(database_id: DatabaseId, env: &StreamEnvironment, term_id: String) -> Self {
-        Self {
-            database_id,
-            term_id,
-            addr: env.server_address().clone(),
-            config: env.config().as_ref().to_owned(),
-            compute_client_pool: env.client_pool(),
-        }
-    }
-
-    pub fn term_id(&self) -> String {
-        self.term_id.clone()
-    }
-
-    #[cfg(test)]
-    pub fn for_test() -> Self {
-        use std::sync::Arc;
-
-        use risingwave_common::config::StreamingDeveloperConfig;
-        use risingwave_rpc_client::ComputeClientPool;
-
-        Self {
-            database_id: TEST_DATABASE_ID,
-            term_id: "for_test".into(),
-            addr: LOCAL_TEST_ADDR.clone(),
-            config: StreamingConfig {
-                developer: StreamingDeveloperConfig {
-                    exchange_initial_permits: permit::for_test::INITIAL_PERMITS,
-                    exchange_batched_permits: permit::for_test::BATCHED_PERMITS,
-                    exchange_concurrent_barriers: permit::for_test::CONCURRENT_BARRIERS,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            compute_client_pool: Arc::new(ComputeClientPool::for_test()),
-        }
-    }
-
-    /// Create a new channel pair.
-    pub fn new_channel(&self) -> (Sender, Receiver) {
-        permit::channel(
-            self.config.developer.exchange_initial_permits,
-            self.config.developer.exchange_batched_permits,
-            self.config.developer.exchange_concurrent_barriers,
-        )
-    }
-
-    pub fn config(&self) -> &StreamingConfig {
-        &self.config
     }
 }

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
-
-use anyhow::anyhow;
-use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 use risingwave_common::config::StreamingConfig;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_rpc_client::ComputeClientPoolRef;
 
-use crate::error::StreamResult;
-use crate::executor::exchange::permit::{self, Receiver, Sender};
+use crate::executor::exchange::permit::{Receiver, Sender};
 
 mod barrier_manager;
 mod env;
@@ -32,10 +27,13 @@ pub use env::*;
 use risingwave_common::catalog::DatabaseId;
 pub use stream_manager::*;
 
+use crate::executor::exchange::permit;
+
 pub type ConsumableChannelPair = (Option<Sender>, Option<Receiver>);
 pub type ActorId = u32;
 pub type FragmentId = u32;
 pub type DispatcherId = u64;
+/// (`upstream_actor_id`, `downstream_actor_id`)
 pub type UpDownActorIds = (ActorId, ActorId);
 pub type UpDownFragmentIds = (FragmentId, FragmentId);
 
@@ -71,25 +69,6 @@ pub struct SharedContext {
     pub(crate) database_id: DatabaseId,
     term_id: String,
 
-    /// Stores the senders and receivers for later `Processor`'s usage.
-    ///
-    /// Each actor has several senders and several receivers. Senders and receivers are created
-    /// during `update_actors` and stored in a channel map. Upon `build_actors`, all these channels
-    /// will be taken out and built into the executors and outputs.
-    /// One sender or one receiver can be uniquely determined by the upstream and downstream actor
-    /// id.
-    ///
-    /// There are three cases when we need local channels to pass around messages:
-    /// 1. pass `Message` between two local actors
-    /// 2. The RPC client at the downstream actor forwards received `Message` to one channel in
-    ///    `ReceiverExecutor` or `MergerExecutor`.
-    /// 3. The RPC `Output` at the upstream actor forwards received `Message` to
-    ///    `ExchangeServiceImpl`.
-    ///
-    /// The channel serves as a buffer because `ExchangeServiceImpl`
-    /// is on the server-side and we will also introduce backpressure.
-    channel_map: Mutex<HashMap<UpDownActorIds, ConsumableChannelPair>>,
-
     /// Stores the local address.
     ///
     /// It is used to test whether an actor is local or not,
@@ -118,7 +97,6 @@ impl SharedContext {
         Self {
             database_id,
             term_id,
-            channel_map: Default::default(),
             addr: env.server_address().clone(),
             config: env.config().as_ref().to_owned(),
             compute_client_pool: env.client_pool(),
@@ -139,7 +117,6 @@ impl SharedContext {
         Self {
             database_id: TEST_DATABASE_ID,
             term_id: "for_test".into(),
-            channel_map: Default::default(),
             addr: LOCAL_TEST_ADDR.clone(),
             config: StreamingConfig {
                 developer: StreamingDeveloperConfig {
@@ -154,45 +131,16 @@ impl SharedContext {
         }
     }
 
-    /// Get the channel pair for the given actor ids. If the channel pair does not exist, create one
-    /// with the configured permits.
-    fn get_or_insert_channels(
-        &self,
-        ids: UpDownActorIds,
-    ) -> MappedMutexGuard<'_, ConsumableChannelPair> {
-        MutexGuard::map(self.channel_map.lock(), |map| {
-            map.entry(ids).or_insert_with(|| {
-                let (tx, rx) = permit::channel(
-                    self.config.developer.exchange_initial_permits,
-                    self.config.developer.exchange_batched_permits,
-                    self.config.developer.exchange_concurrent_barriers,
-                );
-                (Some(tx), Some(rx))
-            })
-        })
-    }
-
-    pub fn take_sender(&self, ids: &UpDownActorIds) -> StreamResult<Sender> {
-        self.get_or_insert_channels(*ids)
-            .0
-            .take()
-            .ok_or_else(|| anyhow!("sender for {ids:?} has already been taken").into())
-    }
-
-    pub fn take_receiver(&self, ids: UpDownActorIds) -> StreamResult<Receiver> {
-        self.get_or_insert_channels(ids)
-            .1
-            .take()
-            .ok_or_else(|| anyhow!("receiver for {ids:?} has already been taken").into())
+    /// Create a new channel pair.
+    pub fn new_channel(&self) -> (Sender, Receiver) {
+        permit::channel(
+            self.config.developer.exchange_initial_permits,
+            self.config.developer.exchange_batched_permits,
+            self.config.developer.exchange_concurrent_barriers,
+        )
     }
 
     pub fn config(&self) -> &StreamingConfig {
         &self.config
-    }
-
-    pub(super) fn drop_actors(&self, actors: &HashSet<ActorId>) {
-        self.channel_map
-            .lock()
-            .retain(|(up_id, _), _| !actors.contains(up_id));
     }
 }

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -613,7 +613,7 @@ impl StreamActorManager {
                 actor.dispatchers,
                 actor_id,
                 fragment_id,
-                local_barrier_manager.shared_context.clone(),
+                local_barrier_manager.clone(),
                 self.streaming_metrics.clone(),
             )
             .await?;

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -306,7 +306,7 @@ impl StreamActorManager {
         }
     }
 
-    fn create_snapshot_backfill_input(
+    async fn create_snapshot_backfill_input(
         &self,
         upstream_node: &StreamNode,
         actor_context: &ActorContextRef,
@@ -330,6 +330,7 @@ impl StreamActorManager {
             upstream_merge,
             chunk_size,
         )
+        .await
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -345,12 +346,14 @@ impl StreamActorManager {
     ) -> StreamResult<Executor> {
         let [upstream_node, _]: &[_; 2] = stream_node.input.as_slice().try_into().unwrap();
         let chunk_size = env.config().developer.chunk_size;
-        let upstream = self.create_snapshot_backfill_input(
-            upstream_node,
-            actor_context,
-            local_barrier_manager,
-            chunk_size,
-        )?;
+        let upstream = self
+            .create_snapshot_backfill_input(
+                upstream_node,
+                actor_context,
+                local_barrier_manager,
+                chunk_size,
+            )
+            .await?;
 
         let table_desc: &StorageTableDesc = node.get_table_desc()?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, upstream and downstream actors create exchange channel via `SharedContext`, which is shared via `Arc<Mutex<..>>` and served as a buffer to hold the pending channel tx or rx. It works well in the current scenario, where the upstream and downstream actors are included in a same checkpoint and requires no failure isolation. However, to support partial checkpoint on jobs with streaming dependencies, we will have to isolate the failure between upstream and downstream actors if they are from different streaming jobs, and the current mechanism using `SharedContext` won't work anymore.

In this PR, we will change to not using `SharedContext` to create the exchange channel between upstream and downstream actors. Instead, the request for exchange will be handled via channel. In input executor (`MergeExecutor` and `ReceiverExecutor`), for remote input, it create remote exchange channel in the same way as original, while for local input, it will generate a channel locally, and  send the channel tx in a request to local barrier worker, which will be later sent to `DispatcherExecutor` of the upstream actor. In `DispatcherExecutor`, when handling barriers that needs to have new outputs, it will wait for the `NewOutputRequest` from all new downstream actors, before dispatching the barriers to downstream. `DispatchExecutor`s receive the `NewOutputRequest` via a request channel. The channel rx of `NewOutputRequest ` is passed the `DispatchExecutor` when the actor is initially built.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
