### PR TITLE
feat(ctl): add an IO-bound rule for await tree analyze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12697,8 +12697,8 @@ dependencies = [
 
 [[package]]
 name = "rw-diagnose-tools"
-version = "0.1.0"
-source = "git+https://github.com/risingwavelabs/rw-diagnose-tools?rev=725249f#725249f5420ffdcff7796d2e71cdbc03434168f4"
+version = "0.1.1"
+source = "git+https://github.com/risingwavelabs/rw-diagnose-tools?rev=380d1b7b23a77ee0bbb0d2b9d552de58db4490cc#380d1b7b23a77ee0bbb0d2b9d552de58db4490cc"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -31,7 +31,7 @@ risingwave_pb = { workspace = true }
 risingwave_rpc_client = { workspace = true }
 risingwave_storage = { workspace = true }
 risingwave_stream = { workspace = true }
-rw-diagnose-tools = { git = "https://github.com/risingwavelabs/rw-diagnose-tools", rev = "725249f" }
+rw-diagnose-tools = { git = "https://github.com/risingwavelabs/rw-diagnose-tools", rev = "380d1b7b23a77ee0bbb0d2b9d552de58db4490cc" }
 sea-orm = { workspace = true }
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

See https://github.com/risingwavelabs/rw-diagnose-tools/compare/main%40%7B1day%7D...main for more impl information.
This PR makes some changes:
1. Add another rule to detect actors blocked by IO operations, such as `store_flush` and `store_get`
2. Refactor the code, place output part (`println`) in riseclt instead of `rw-diagnose-tools`.
3. Support analyze await tree dump file from meta dashboard, the format of which is slightly different from the format of dump file by risectl.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
