### PR TITLE
ci: label ci/main-cron/run-all for cherry-pick PRs

### DIFF
--- a/.github/workflows/run-main-cron.yml
+++ b/.github/workflows/run-main-cron.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - 'release-*'
-    types: [synchronize]
+    types: [opened]
 
 jobs:
   label-run-main-cron:

--- a/.github/workflows/run-main-cron.yml
+++ b/.github/workflows/run-main-cron.yml
@@ -1,0 +1,29 @@
+name: Label ci/main-cron/run-all for cherry-pick PRs
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - 'release-*'
+    types: ["labeled"]
+
+jobs:
+  label-run-main-cron:
+    if: |
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'cherry-pick'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Label PR
+        run: |
+          pr_number="${{ github.event.pull_request.number }}"
+          echo "PR number: $pr_number"
+          echo "Labeling PR #$pr_number with ci/main-cron/run-all"
+          gh pr edit "$pr_number" --add-label "ci/main-cron/run-all"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-main-cron.yml
+++ b/.github/workflows/run-main-cron.yml
@@ -8,13 +8,10 @@ on:
   pull_request:
     branches:
       - 'release-*'
-    types: ["labeled"]
+    types: [synchronize]
 
 jobs:
   label-run-main-cron:
-    if: |
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'cherry-pick'
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
Label `ci/main-cron/run-all` to run main-cron test for cherry-pick PRs

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
