### PR TITLE
feat(compactor): optimize compactor pull policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12145,6 +12145,7 @@ dependencies = [
  "sled",
  "spin 0.10.0",
  "sync-point",
+ "sysinfo",
  "tempfile",
  "thiserror 1.0.63",
  "thiserror-ext",

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -865,6 +865,14 @@ pub struct StorageConfig {
     #[serde(default = "default::storage::compactor_max_task_multiplier")]
     pub compactor_max_task_multiplier: f32,
 
+    /// Allows the compactor to use more tasks than `max_pull_task_count` if the CPU usage is
+    /// lower than `compactor_cpu_usage_threshold`.
+    #[serde(default = "default::storage::compactor_absolute_max_task_multiplier")]
+    pub compactor_absolute_max_task_multiplier: f32,
+
+    #[serde(default = "default::storage::compactor_cpu_usage_threshold")]
+    pub compactor_cpu_usage_threshold: f32,
+
     /// The percentage of memory available when compactor is deployed separately.
     /// `non_reserved_memory_bytes` = `system_memory_available_bytes` * `compactor_memory_available_proportion`
     #[serde(default = "default::storage::compactor_memory_available_proportion")]
@@ -1834,6 +1842,14 @@ pub mod default {
 
         pub fn compactor_max_task_multiplier() -> f32 {
             3.0000
+        }
+
+        pub fn compactor_absolute_max_task_multiplier() -> f32 {
+            9.0000
+        }
+
+        pub fn compactor_cpu_usage_threshold() -> f32 {
+            0.8
         }
 
         pub fn compactor_memory_available_proportion() -> f64 {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -50,6 +50,7 @@ serde_bytes = "0.11"
 sled = "0.34.7"
 spin = "0.10"
 sync-point = { path = "../utils/sync-point" }
+sysinfo = { version = "0.34", default-features = false, features = ["system"] }
 tempfile = "3"
 thiserror = "1"
 thiserror-ext = { workspace = true }

--- a/src/storage/src/opts.rs
+++ b/src/storage/src/opts.rs
@@ -126,6 +126,9 @@ pub struct StorageOpts {
 
     pub compactor_max_sst_key_count: u64,
     pub compactor_max_task_multiplier: f32,
+    pub compactor_absolute_max_task_multiplier: f32, // allow boost when cpu usage is low
+    pub compactor_cpu_usage_threshold: f32,
+
     pub compactor_max_sst_size: u64,
     /// enable `FastCompactorRunner`.
     pub enable_fast_compaction: bool,
@@ -231,6 +234,10 @@ impl From<(&RwConfig, &SystemParamsReader, &StorageMemoryConfig)> for StorageOpt
             backup_storage_directory: p.backup_storage_directory().to_owned(),
             compactor_max_sst_key_count: c.storage.compactor_max_sst_key_count,
             compactor_max_task_multiplier: c.storage.compactor_max_task_multiplier,
+            compactor_absolute_max_task_multiplier: c
+                .storage
+                .compactor_absolute_max_task_multiplier,
+            compactor_cpu_usage_threshold: c.storage.compactor_cpu_usage_threshold,
             compactor_max_sst_size: c.storage.compactor_max_sst_size,
             enable_fast_compaction: c.storage.enable_fast_compaction,
             check_compaction_result: c.storage.check_compaction_result,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

A fixed algorithm based on the **number of CPU cores** may lead to the situation where CPU resources cannot be fully utilized in an IO-bound task scenario. On the other hand, directly estimating with CPU usage is likely to cause an overload. Therefore, a new idea is introduced, which allows for boosting when the CPU usage is low.

- Refactor pull task logic with an encapsulated structure
- A new policy that allows for boosting when the CPU usage is low.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
