### PR TITLE
feat(storage): define vector read write trait

### DIFF
--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -680,7 +680,7 @@ impl StateStoreReadVector for HummockStorageReadSnapshot {
         &self,
         _vec: Vector,
         _options: VectorNearestOptions,
-        _on_nearest_item_fn: impl OnNearestItem<O>,
+        _on_nearest_item_fn: impl OnNearestItemFn<O>,
     ) -> StorageResult<Vec<O>> {
         unimplemented!()
     }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -33,6 +33,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(iter_from_coroutine)]
+#![feature(get_mut_unchecked)]
 
 pub mod hummock;
 pub mod memory;
@@ -52,6 +53,7 @@ pub mod mem_table;
 #[cfg(test)]
 #[cfg(feature = "failpoints")]
 mod storage_failpoints;
+pub mod vector;
 
 pub use store::{StateStore, StateStoreIter, StateStoreReadIter};
 pub use store_impl::StateStoreImpl;

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -724,7 +724,7 @@ impl<R: RangeKv> StateStoreReadVector for RangeKvStateStoreReadSnapshot<R> {
         &self,
         _vec: Vector,
         _options: VectorNearestOptions,
-        _on_nearest_item_fn: impl OnNearestItem<O>,
+        _on_nearest_item_fn: impl OnNearestItemFn<O>,
     ) -> StorageResult<Vec<O>> {
         unimplemented!()
     }

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -211,7 +211,7 @@ impl<S: StateStoreReadVector> StateStoreReadVector for MonitoredTableStateStore<
         &self,
         vec: Vector,
         options: VectorNearestOptions,
-        on_nearest_item_fn: impl OnNearestItem<O>,
+        on_nearest_item_fn: impl OnNearestItemFn<O>,
     ) -> impl StorageFuture<'_, Vec<O>> {
         // TODO: monitor
         self.inner.nearest(vec, options, on_nearest_item_fn)

--- a/src/storage/src/monitor/traced_store.rs
+++ b/src/storage/src/monitor/traced_store.rs
@@ -340,7 +340,7 @@ impl<S: StateStoreReadVector> StateStoreReadVector for TracedStateStore<S, Table
         &self,
         vec: Vector,
         options: VectorNearestOptions,
-        on_nearest_item_fn: impl OnNearestItem<O>,
+        on_nearest_item_fn: impl OnNearestItemFn<O>,
     ) -> impl StorageFuture<'_, Vec<O>> {
         self.inner.nearest(vec, options, on_nearest_item_fn)
     }

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -156,7 +156,7 @@ impl StateStoreReadVector for PanicStateStore {
         &self,
         _vec: Vector,
         _options: VectorNearestOptions,
-        _on_nearest_item_fn: impl OnNearestItem<O>,
+        _on_nearest_item_fn: impl OnNearestItemFn<O>,
     ) -> StorageResult<Vec<O>> {
         panic!()
     }

--- a/src/storage/src/vector/mod.rs
+++ b/src/storage/src/vector/mod.rs
@@ -1,0 +1,56 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+pub type VectorItem = f32;
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VectorInner<T>(T);
+
+pub type Vector = VectorInner<Arc<[VectorItem]>>;
+pub type VectorRef<'a> = VectorInner<&'a [VectorItem]>;
+pub type VectorMutRef<'a> = VectorInner<&'a mut [VectorItem]>;
+
+impl Vector {
+    pub fn new(inner: &[VectorItem]) -> Self {
+        Self(Arc::from(inner))
+    }
+
+    pub fn to_ref(&self) -> VectorRef<'_> {
+        VectorInner(self.0.as_ref())
+    }
+
+    pub fn clone_from_ref(r: VectorRef<'_>) -> Self {
+        Self(Vec::from(r.0).into())
+    }
+
+    pub fn get_mut(&mut self) -> Option<VectorMutRef<'_>> {
+        Arc::get_mut(&mut self.0).map(VectorInner)
+    }
+
+    /// # Safety
+    ///
+    /// safe under the same condition to [`Arc::get_mut_unchecked`]
+    pub unsafe fn get_mut_unchecked(&mut self) -> VectorMutRef<'_> {
+        // safety: under unsafe function
+        unsafe { VectorInner(Arc::get_mut_unchecked(&mut self.0)) }
+    }
+}
+
+pub type VectorDistance = f32;
+
+pub trait OnNearestItemFn<O> =
+    for<'i> Fn(VectorRef<'i>, VectorDistance, &'i [u8]) -> O + Send + 'static;
+
+pub enum DistanceMeasurement {}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

As titled

```
pub trait StateStore: StateStoreReadLog + StaticSendSync + Clone {
    type Local: LocalStateStore;
    type ReadSnapshot: StateStoreRead + StateStoreReadVector + Clone;
    type VectorWriter: StateStoreWriteVector;

    ...

    fn new_vector_writer(
        &self,
        options: NewVectorWriterOptions,
    ) -> impl Future<Output = Self::VectorWriter> + Send + '_;
}

pub trait StateStoreWriteVector: StateStoreWriteEpochControl + StaticSendSync {
    fn insert(&mut self, vec: Vector, info: Bytes) -> StorageResult<()>;
}

pub struct VectorNearestOptions {
    pub top_n: usize,
    pub measure: DistanceMeasurement,
}

pub trait StateStoreReadVector: StaticSendSync {
    fn nearest<O: Send + 'static>(
        &self,
        vec: Vector,
        options: VectorNearestOptions,
        on_nearest_item_fn: impl OnNearestItemFn<O>,
    ) -> impl StorageFuture<'_, Vec<O>>;
}
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
