### PR TITLE
fix(source): handling the case of reading empty files 

### DIFF
--- a/src/stream/src/executor/source/fs_fetch_executor.rs
+++ b/src/stream/src/executor/source/fs_fetch_executor.rs
@@ -411,7 +411,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                             None => {
                                 if let Some(ref delete_file_name) = reading_file {
                                     splits_on_fetch -= 1;
-                                    state_store_handler.delete(delete_file_name).await?;
+                                    state_store_handler.delete(delete_file_name.clone()).await?;
                                 }
                             }
                         },

--- a/src/stream/src/executor/source/fs_fetch_executor.rs
+++ b/src/stream/src/executor/source/fs_fetch_executor.rs
@@ -259,7 +259,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
             self.rate_limit_rps,
         )
         .await?;
-        let mut reading_file: Arc<str> = "".into();
+        let mut reading_file: Option<Arc<str>> = None;
 
         while let Some(msg) = stream.next().await {
             match msg {
@@ -339,7 +339,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                         .rows()
                                         .map(|row| {
                                             let filename = row.datum_at(0).unwrap().into_utf8();
-
+                                            reading_file = Some(filename.into());
                                             let size = row.datum_at(2).unwrap().into_int64();
                                             OpendalFsSplit::<Src>::new(
                                                 filename.to_owned(),
@@ -381,7 +381,7 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                 .unwrap();
                                 debug_assert_eq!(mapping.len(), 1);
                                 if let Some((split_id, _offset)) = mapping.into_iter().next() {
-                                    reading_file = split_id.clone();
+                                    reading_file = Some(split_id.clone());
                                     let row = state_store_handler.get(split_id.clone()).await?
                                         .unwrap_or_else(|| {
                                             panic!("The fs_split (file_name) {:?} should be in the state table.",
@@ -409,8 +409,10 @@ impl<S: StateStore, Src: OpendalSource> FsFetchExecutor<S, Src> {
                                 yield Message::Chunk(chunk);
                             }
                             None => {
-                                splits_on_fetch -= 1;
-                                state_store_handler.delete(reading_file.clone()).await?;
+                                if let Some(ref delete_file_name) = reading_file {
+                                    splits_on_fetch -= 1;
+                                    state_store_handler.delete(delete_file_name).await?;
+                                }
                             }
                         },
                     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
cherry pick https://github.com/risingwavelabs/risingwave/pull/21416/files into release-2.3
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
