### PR TITLE
refactor(frontend): reduce memory usage of `LogicalJoin::to_stream`

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -925,7 +925,6 @@ impl LogicalJoin {
         Ok((left, right))
     }
 
-    #[inline(never)]
     fn to_stream_hash_join(
         &self,
         predicate: EqJoinPredicate,
@@ -1000,7 +999,6 @@ impl LogicalJoin {
         }
     }
 
-    #[inline(never)]
     fn to_stream_temporal_join_with_index_selection(
         &self,
         predicate: EqJoinPredicate,
@@ -1241,7 +1239,6 @@ impl LogicalJoin {
         ))
     }
 
-    #[inline(never)]
     fn to_stream_nested_loop_temporal_join(
         &self,
         predicate: EqJoinPredicate,
@@ -1295,7 +1292,6 @@ impl LogicalJoin {
         Ok(StreamTemporalJoin::new(new_logical_join, new_predicate, true).into())
     }
 
-    #[inline(never)]
     fn to_stream_dynamic_filter(
         &self,
         predicate: Condition,
@@ -1407,7 +1403,6 @@ impl LogicalJoin {
             .into())
     }
 
-    #[inline(never)]
     fn to_stream_asof_join(
         &self,
         predicate: EqJoinPredicate,


### PR DESCRIPTION
related: https://github.com/risingwavelabs/risingwave/issues/21355#issuecomment-2808083547

by returning PlanRef in function calls directly. Otherwise, `LogicalJoin::to_stream` needs to allocate stack memory for these temporary variables.

`LogicalJoin::to_stream` is somehow an important path (especially in deep plan), so it may worth the micro optimization

Signed-off-by: xxchan <xxchan22f@gmail.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
