### PR TITLE
revert: "test: run fe stack overflow test only in release mode"

### DIFF
--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -86,11 +86,6 @@ cluster_start
 risedev slt -p 4566 -d dev './e2e_test/streaming/**/*.slt' --junit "streaming-${profile}"
 risedev slt -p 4566 -d dev './e2e_test/backfill/sink/different_pk_and_dist_key.slt'
 
-if [ "$profile" != "ci-dev" ]; then
-    echo "--- Run release mode only tests"
-    risedev slt -p 4566 -d dev './e2e_test/release_mode_only/*.slt'
-fi
-
 echo "--- Kill cluster"
 cluster_stop
 

--- a/e2e_test/streaming/bug_fixes/stack_overflow_17342.slt
+++ b/e2e_test/streaming/bug_fixes/stack_overflow_17342.slt
@@ -1,3 +1,5 @@
+# If this test failed, may take a look at https://github.com/risingwavelabs/risingwave/issues/21355
+
 statement ok
 SET streaming_parallelism TO 1;
 

--- a/e2e_test/streaming/bug_fixes/stack_overflow_17342.slt
+++ b/e2e_test/streaming/bug_fixes/stack_overflow_17342.slt
@@ -1,5 +1,3 @@
-# Why this is release mode only: https://github.com/risingwavelabs/risingwave/issues/21355#issuecomment-2806876248
-
 statement ok
 SET streaming_parallelism TO 1;
 


### PR DESCRIPTION
Reverts risingwavelabs/risingwave#21424


https://github.com/risingwavelabs/risingwave/pull/21424#issuecomment-2812700084

Although I think if the test fail in dev mode, it's a not big deal. But this might be a good way to track increased memory usage in frontend. (until we cannot manage it...)

related #21355