### PR TITLE
fix(risedev): workaround ctrl-c handling for `risedev psql`

### DIFF
--- a/risedev
+++ b/risedev
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ -z "$(which cargo-binstall)" ] && [ -z "$RISINGWAVE_CI" ]; then
     echo "Installing cargo-binstall..."
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
@@ -18,12 +20,20 @@ if [ -z "$RISEDEV_CMD" ]; then
     export RISEDEV_CMD="$0"
 fi
 
-if [ $# -eq 0 ] || [ "$1" == "-h" ] || [ "$1" ==  "--help" ]; then
+if [ $# -eq 0 ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     cargo make --list-all-steps --hide-uninteresting
     exit 0
 fi
 
 cargo make --silent --allow-private configure-if-not-configured
+
+# WORKAROUND: `cargo make` does not handle SIGINT and will exit without waiting for the child processes
+# to finish. This can be confusing and not friendly for users.
+# Here we trap SIGINT to an empty command to ignore it, so that the consecutive `cargo make` will also
+# ignore SIGINT. However, all child processes spawned by `cargo make` can still receive and handle SIGINT.
+# As a result, `cargo make` will behave similar to `bash`.
+# To test this, run `risedev psql`, press ^C, and compare the behavior with `cargo make psql`.
+trap '' INT
 # We marked many tasks as private, so we can have a more concise output when listing all tasks.
 # But we allow private tasks to be executed.
 cargo make --allow-private "$@"

--- a/risedev
+++ b/risedev
@@ -33,7 +33,10 @@ cargo make --silent --allow-private configure-if-not-configured
 # ignore SIGINT. However, all child processes spawned by `cargo make` can still receive and handle SIGINT.
 # As a result, `cargo make` will behave similar to `bash`.
 # To test this, run `risedev psql`, press ^C, and compare the behavior with `cargo make psql`.
-trap '' INT
+if [ "$1" == "psql" ]; then
+    trap '' INT
+fi
+
 # We marked many tasks as private, so we can have a more concise output when listing all tasks.
 # But we allow private tasks to be executed.
 cargo make --allow-private "$@"


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

By ignoring `SIGINT` in the `risedev` wrapper, `cargo-make` will also inherit to ignore it, preventing it from being killed when users send <kbd>Ctrl-C</kbd> to the `psql` shell.

<img width="419" alt="image" src="https://github.com/user-attachments/assets/dd8a5f2e-408c-49b8-84b0-dafe9e488c22" />


Full explanation: https://www.notion.so/risingwave-labs/Story-on-CI-Graceful-Cancellation-1d7f0d69cb76803d900bd1512bf8b479?pvs=4#1d7f0d69cb7680fd8e62dacb796ff9c5

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
