### PR TITLE
feat(meta,frontend,stream): support backfill order recovery by resuming all backfill nodes after recovery

### DIFF
--- a/e2e_test/backfill/backfill_order_control_recovery.slt
+++ b/e2e_test/backfill/backfill_order_control_recovery.slt
@@ -1,0 +1,57 @@
+# Test that after recovery, backfill order control can still allow the job to resume.
+statement ok
+SET RW_IMPLICIT_FLUSH TO TRUE;
+
+statement ok
+create table t1 (v1 int);
+
+statement ok
+create table t2 (v1 int);
+
+statement ok
+create table t3 (v1 int);
+
+statement ok
+insert into t1 values (1);
+
+statement ok
+insert into t2 values (1);
+
+statement ok
+insert into t3 values (1);
+
+statement ok
+set backfill_rate_limit = 0;
+
+statement ok
+set background_ddl=true;
+
+statement ok
+create materialized view m1
+with (backfill_order = FIXED(t1 -> t2, t2 -> t3))
+ as select v1 from t1
+union
+select v1 from t2
+union
+select v1 from t3;
+
+statement ok
+recover;
+
+statement ok
+alter materialized view m1 set backfill_rate_limit = default;
+
+statement ok
+wait;
+
+statement ok
+drop materialized view m1 cascade;
+
+statement ok
+drop table if exists t1 cascade;
+
+statement ok
+drop table if exists t2 cascade;
+
+statement ok
+drop table if exists t3 cascade;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -30,6 +30,8 @@ message AddMutation {
   // TODO: we may allow multiple mutations in a single barrier.
   bool pause = 4;
   repeated SubscriptionUpstreamInfo subscriptions_to_add = 5;
+  // nodes which should start backfill
+  common.Uint32Vector backfill_nodes_to_start = 6;
 }
 
 message StopMutation {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -661,9 +661,6 @@ message StreamScanNode {
   catalog.Table arrangement_table = 10;
 
   optional uint64 snapshot_backfill_epoch = 11;
-
-  // Whether this node should pause backfilling.
-  bool backfill_paused = 12;
 }
 
 // Config options for CDC backfill

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -283,13 +283,6 @@ impl StreamTableScan {
     ) -> SchedulerResult<PbStreamNode> {
         use risingwave_pb::stream_plan::*;
 
-        let backfill_paused = self
-            .core
-            .ctx
-            .with_options()
-            .backfill_order_strategy()
-            .should_pause_initially();
-
         let stream_key = self
             .stream_key()
             .unwrap_or(&[])
@@ -398,7 +391,6 @@ impl StreamTableScan {
             state_table: Some(catalog),
             arrangement_table,
             rate_limit: self.base.ctx().overwrite_options().backfill_rate_limit,
-            backfill_paused,
             ..Default::default()
         }));
 

--- a/src/meta/model/src/streaming_job.rs
+++ b/src/meta/model/src/streaming_job.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
+use sea_orm::FromJsonQueryResult;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +32,9 @@ pub struct Model {
     pub max_parallelism: i32,
     pub specific_resource_group: Option<String>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, FromJsonQueryResult, Serialize, Deserialize, Default)]
+pub struct BackfillOrders(pub HashMap<u32, Vec<u32>>);
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {

--- a/src/meta/src/barrier/backfill_order_control.rs
+++ b/src/meta/src/barrier/backfill_order_control.rs
@@ -131,13 +131,6 @@ impl BackfillOrderState {
     }
 }
 
-// Getters
-impl BackfillOrderState {
-    pub fn get_current_nodes(&self) -> Vec<FragmentId> {
-        self.current_backfill_nodes.keys().cloned().collect()
-    }
-}
-
 // state transitions
 impl BackfillOrderState {
     pub fn finish_actor(&mut self, actor_id: ActorId) -> Vec<FragmentId> {

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -125,6 +125,8 @@ impl CreatingStreamingJobControl {
             // we assume that when handling snapshot backfill, the cluster must not be paused
             pause: false,
             subscriptions_to_add: Default::default(),
+            // TODO: support backfill-order-control for snapshot backfill
+            backfill_nodes_to_start: Default::default(),
         });
 
         control_stream_manager.add_partial_graph(database_id, Some(job_id));

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -26,7 +26,7 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_hummock_sdk::change_log::build_table_change_log_delta;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::catalog::{CreateType, Table};
-use risingwave_pb::common::ActorInfo;
+use risingwave_pb::common::{ActorInfo, Uint32Vector};
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
 use risingwave_pb::stream_plan::barrier::BarrierKind as PbBarrierKind;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
@@ -44,6 +44,7 @@ use tracing::warn;
 
 use super::info::{CommandFragmentChanges, InflightDatabaseInfo, InflightStreamingJobInfo};
 use crate::barrier::InflightSubscriptionInfo;
+use crate::barrier::backfill_order_control::get_root_nodes;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::BarrierInfo;
 use crate::barrier::rpc::ControlStreamManager;
@@ -708,6 +709,7 @@ impl Command {
                         stream_job_fragments: table_fragments,
                         init_split_assignment: split_assignment,
                         upstream_fragment_downstreams,
+                        fragment_backfill_ordering,
                         ..
                     },
                 job_type,
@@ -734,6 +736,10 @@ impl Command {
                     } else {
                         Default::default()
                     };
+                let backfill_nodes_to_start: Vec<_> = match fragment_backfill_ordering {
+                    Some(backfill_order) => get_root_nodes(backfill_order, table_fragments),
+                    None => table_fragments.fragment_ids().collect(),
+                };
                 let add = Some(Mutation::Add(AddMutation {
                     actor_dispatchers: edges
                         .dispatchers
@@ -748,6 +754,9 @@ impl Command {
                     // If the cluster is already paused, the new actors should be paused too.
                     pause: is_currently_paused,
                     subscriptions_to_add,
+                    backfill_nodes_to_start: Some(Uint32Vector {
+                        data: backfill_nodes_to_start,
+                    }),
                 }));
 
                 if let CreateStreamingJobType::SinkIntoTable(ReplaceStreamJobPlan {
@@ -986,6 +995,7 @@ impl Command {
                     upstream_mv_table_id: upstream_mv_table_id.table_id,
                     subscriber_id: *subscription_id,
                 }],
+                backfill_nodes_to_start: Some(Uint32Vector { data: vec![] }),
             })),
             Command::DropSubscription {
                 upstream_mv_table_id,

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -583,12 +583,6 @@ impl CreateMviewProgressTracker {
 
         let backfill_order_state = fragment_backfill_ordering
             .map(|order| BackfillOrderState::new(order, &table_fragments));
-        if let Some(ref state) = backfill_order_state {
-            self.queue_backfill(state.get_current_nodes());
-        } else {
-            // queue all nodes
-            self.queue_backfill(table_fragments.fragment_ids())
-        }
         let progress = Progress::new(
             actors,
             upstream_mv_count,

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -31,7 +31,7 @@ use risingwave_common::util::epoch::Epoch;
 use risingwave_common::util::tracing::TracingContext;
 use risingwave_connector::source::SplitImpl;
 use risingwave_meta_model::WorkerId;
-use risingwave_pb::common::{HostAddress, WorkerNode};
+use risingwave_pb::common::{HostAddress, Uint32Vector, WorkerNode};
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_plan::{
@@ -486,6 +486,13 @@ impl ControlStreamManager {
             actor_splits: build_actor_connector_splits(&source_split_assignments),
             pause: is_paused,
             subscriptions_to_add: Default::default(),
+            // TODO(kwannoel): recover using backfill order plan
+            backfill_nodes_to_start: Some(Uint32Vector {
+                data: background_jobs
+                    .values()
+                    .flat_map(|(_, fragments)| fragments.fragment_ids())
+                    .collect_vec(),
+            }),
         });
 
         fn resolve_jobs_committed_epoch(

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3642,17 +3642,6 @@ impl fmt::Display for BackfillOrderStrategy {
     }
 }
 
-impl BackfillOrderStrategy {
-    /// Returns whether all backfill nodes should pause initially.
-    /// Meta will resume them in the order specified by the backfill order.
-    pub fn should_pause_initially(&self) -> bool {
-        matches!(
-            self,
-            BackfillOrderStrategy::Auto | BackfillOrderStrategy::Fixed(_)
-        )
-    }
-}
-
 impl Statement {
     pub fn to_redacted_string(&self, keywords: RedactSqlOptionKeywordsRef) -> String {
         REDACT_SQL_OPTION_KEYWORDS.sync_scope(keywords, || self.to_string())

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -144,8 +144,8 @@ where
 
         // Poll the upstream to get the first barrier.
         let first_barrier = expect_first_barrier(&mut upstream).await?;
-        let mut paused = first_barrier.is_pause_on_startup();
-        let mut backfill_paused = true;
+        let mut global_pause = first_barrier.is_pause_on_startup();
+        let mut backfill_paused = first_barrier.is_backfill_pause_on_startup(self.fragment_id);
         let first_epoch = first_barrier.epoch;
         let is_newly_added = first_barrier.is_newly_added(self.actor_id);
         // The first barrier message should be propagated.
@@ -234,7 +234,7 @@ where
                     let left_upstream = upstream.by_ref().map(Either::Left);
 
                     // Check if stream paused
-                    let paused = paused
+                    let paused = global_pause
                         || backfill_paused
                         || matches!(self.rate_limiter.rate_limit(), RateLimit::Pause);
                     // Create the snapshot stream
@@ -501,10 +501,10 @@ where
                     use crate::executor::Mutation;
                     match mutation {
                         Mutation::Pause => {
-                            paused = true;
+                            global_pause = true;
                         }
                         Mutation::Resume => {
-                            paused = false;
+                            global_pause = false;
                         }
                         Mutation::StartFragmentBackfill { fragment_ids } if backfill_paused => {
                             if fragment_ids.contains(&self.fragment_id) {

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -94,7 +94,6 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
                     params.executor_stats.clone(),
                     params.env.config().developer.chunk_size,
                     node.rate_limit.into(),
-                    node.backfill_paused,
                     params.fragment_id,
                 )
                 .boxed()
@@ -139,7 +138,6 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
                             params.executor_stats.clone(),
                             params.env.config().developer.chunk_size,
                             node.rate_limit.into(),
-                            node.backfill_paused,
                             params.fragment_id,
                         )
                         .boxed()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

We don't actually recover the backfill order plan in this PR.
We only resume all backfill nodes, meaning we lose the backfill ordering, and all backfill will execute concurrently.
We don't want to persist the backfill plan yet, since the specification could still change.
After `auto backfill order`, `source backfill order` is supported, we will persist the backfill ordering plan.

In this PR we also fill in the initial backfill nodes in the `AddMutation` of the initial barrier, such that backfilling starts from the initial barrier, rather than from the second barrier.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
