### PR TITLE
chore(ci): add `exit_status: -1` as buildkite auto-retry condition

### DIFF
--- a/ci/scripts/gen-integration-test-yaml.py
+++ b/ci/scripts/gen-integration-test-yaml.py
@@ -77,6 +77,9 @@ auto-retry: &auto-retry
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     - signal_reason: agent_stop
       limit: 3
+    - exit_status: -1
+      signal_reason: none
+      limit: 3
 
 steps: {pipeline_steps}
 YAML

--- a/ci/workflows/docker-arm-fast.yml
+++ b/ci/workflows/docker-arm-fast.yml
@@ -3,7 +3,9 @@ auto-retry: &auto-retry
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     - signal_reason: agent_stop
       limit: 3
-
+    - exit_status: -1
+      signal_reason: none
+      limit: 3
 steps:
   - label: "docker-build-push: aarch64"
     if: build.env("SKIP_TARGET_AARCH64") != "true"

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -3,6 +3,9 @@ auto-retry: &auto-retry
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     - signal_reason: agent_stop
       limit: 3
+    - exit_status: -1
+      signal_reason: none
+      limit: 3
 
 steps:
   - label: "docker-build-push: amd64"

--- a/ci/workflows/integration-tests.yml
+++ b/ci/workflows/integration-tests.yml
@@ -1,9 +1,3 @@
-auto-retry: &auto-retry
-  automatic:
-    # Agent terminated because the AWS EC2 spot instance killed by AWS.
-    - signal_reason: agent_stop
-      limit: 3
-
 steps:
   # You may update `gen-integration-test-yaml.py` to add integration test case
   - label: "gen and upload integration test pipeline"

--- a/ci/workflows/main-cron-bisect.yml
+++ b/ci/workflows/main-cron-bisect.yml
@@ -3,6 +3,9 @@ auto-retry: &auto-retry
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     - signal_reason: agent_stop
       limit: 3
+    - exit_status: -1
+      signal_reason: none
+      limit: 3
 
 steps:
   - label: "find regressed step"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -4,6 +4,9 @@ anchors:
         # Agent terminated because the AWS EC2 spot instance killed by AWS.
         - signal_reason: agent_stop
           limit: 3
+        - exit_status: -1
+          signal_reason: none
+          limit: 3
   - plugins:
     # we need to override args, so didn't include image here in the anchor
     - docker-compose: &docker-compose

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -4,6 +4,9 @@ anchors:
         # Agent terminated because the AWS EC2 spot instance killed by AWS.
         - signal_reason: agent_stop
           limit: 3
+        - exit_status: -1
+          signal_reason: none
+          limit: 3
   - plugins:
     - cargo-cache: &cargo-cache
         nienbo/cache#v2.4.20:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

It's observed that `agent_lost` is not retried in recent main-cron runs (https://buildkite.com/risingwavelabs/main-cron/builds/4973#019653ee-6c34-45fc-8f1b-41218534b599).

According to the doc (https://buildkite.com/resources/changelog/193-signal-and-signal-reason-in-automatic-retry-rules/), we may also include `exit_status: -1` as a retry condition.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
