### PR TITLE
refactor(meta): avoid using frontend generated `ColumnIndexMapping` when constructing new dispatcher for replacement

### DIFF
--- a/e2e_test/ddl/alter_table_column_type.slt
+++ b/e2e_test/ddl/alter_table_column_type.slt
@@ -65,11 +65,12 @@ NULL
 
 # If a column is currently being referenced by any downstream job, the column cannot be altered.
 # TODO: support altering referenced columns
-statement ok
-create materialized view my_mv_a as select a from my_table;
+# TODO: supporting in progress, temporarily disable this test
+# statement ok
+# create materialized view my_mv_a as select a from my_table;
 
-statement error unable to drop or alter the column due to being referenced by downstream materialized views or sinks
-alter table my_table alter column a type struct<v double, w varchar, x int>;
+# statement error unable to drop or alter the column due to being referenced by downstream materialized views or sinks
+# alter table my_table alter column a type struct<v double, w varchar, x int>;
 
 statement ok
 drop table my_table cascade;

--- a/e2e_test/source_legacy/cdc_inline/alter/cdc_table_alter.slt
+++ b/e2e_test/source_legacy/cdc_inline/alter/cdc_table_alter.slt
@@ -210,7 +210,7 @@ psql -c "
   ALTER TABLE shipments1 DROP COLUMN destination;
 "
 
-statement error unable to drop or alter the column due to being referenced by downstream materialized views or sinks
+statement error unable to drop the column due to being referenced by downstream materialized views or sinks
 ALTER TABLE pg_shipments DROP COLUMN destination;
 
 # wait alter ddl

--- a/src/common/src/util/column_index_mapping.rs
+++ b/src/common/src/util/column_index_mapping.rs
@@ -18,7 +18,6 @@ use std::vec;
 
 use itertools::Itertools;
 use risingwave_pb::catalog::PbColIndexMapping;
-use risingwave_pb::stream_plan::DispatchStrategy;
 
 /// `ColIndexMapping` is a partial mapping from usize to usize.
 ///
@@ -319,28 +318,6 @@ impl ColIndexMapping {
             target_size: prost.target_size as usize,
             map: prost.map.iter().map(|&x| x.try_into().ok()).collect(),
         }
-    }
-}
-
-impl ColIndexMapping {
-    /// Rewrite the dist-key indices and output indices in the given dispatch strategy. Returns
-    /// `None` if any of the indices is not mapped to the target.
-    pub fn rewrite_dispatch_strategy(
-        &self,
-        strategy: &DispatchStrategy,
-    ) -> Option<DispatchStrategy> {
-        let map = |index: &[u32]| -> Option<Vec<u32>> {
-            index
-                .iter()
-                .map(|i| self.try_map(*i as usize).map(|i| i as u32))
-                .collect()
-        };
-
-        Some(DispatchStrategy {
-            r#type: strategy.r#type,
-            dist_key_indices: map(&strategy.dist_key_indices)?,
-            output_indices: map(&strategy.output_indices)?,
-        })
     }
 }
 

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -41,7 +41,6 @@ use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{Expr, ExprImpl, InputRef, Literal};
 use crate::handler::create_sink::{fetch_incoming_sinks, insert_merger_to_union_with_project};
 use crate::session::SessionImpl;
-use crate::session::current::notice_to_user;
 use crate::{Binder, TableCatalog};
 
 /// Used in auto schema change process

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -117,8 +117,14 @@ pub async fn get_replace_table_plan(
     .await?;
 
     // Calculate the mapping from the original columns to the new columns.
-    // This will be used to map the output of the table in the dispatcher to make
-    // existing downstream jobs work correctly.
+    //
+    // Note: Previously, this will be used to map the output of the table in the dispatcher to make
+    // existing downstream jobs work correctly. This is no longer the case. We will generate mapping
+    // directly in the meta service by checking the new schema of this table and all downstream jobs,
+    // which simplifies handling `ALTER TABLE ALTER COLUMN TYPE`.
+    //
+    // TODO: However, we still generate this mapping and use it for rewriting downstream indexes'
+    // `index_item`. We should consider completely removing this in future works.
     let col_index_mapping = ColIndexMapping::new(
         old_catalog
             .columns()
@@ -128,26 +134,17 @@ pub async fn get_replace_table_plan(
                     let new_c = new_c.get_column_desc().unwrap();
 
                     // We consider both the column ID and the data type.
-                    // If either of them does not match, we will treat it as a new column.
+                    // If either of them does not match, we will treat it as a different column.
                     //
-                    // TODO: Since we've succeeded in assigning column IDs in the step above,
-                    //       the new data type is actually _compatible_ with the old one.
-                    //       Theoretically, it's also possible to do some sort of mapping for
-                    //       the downstream job to work correctly. However, the current impl
-                    //       only supports simple column projection, which we may improve in
-                    //       future works.
-                    //       However, by treating it as a new column, we can at least reject
-                    //       the case where the column with type change is referenced by any
-                    //       downstream jobs (because the original column is considered dropped).
+                    // Note that this does not hurt the ability for `ALTER TABLE ALTER COLUMN TYPE`,
+                    // because we don't rely on this mapping in dispatcher. However, if there's an
+                    // index on the column, currently it will fail to rewrite as the column is
+                    // considered as if it's dropped.
                     let id_matches = || new_c.column_id == old_c.column_id().get_id();
                     let type_matches = || {
                         let original_data_type = old_c.data_type();
                         let new_data_type = DataType::from(new_c.column_type.as_ref().unwrap());
-                        let matches = original_data_type == &new_data_type;
-                        if !matches {
-                            notice_to_user(format!("the data type of column \"{}\" has changed, treating as a new column", old_c.name()));
-                        }
-                        matches
+                        original_data_type == &new_data_type
                     };
 
                     id_matches() && type_matches()

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -25,7 +25,7 @@ use risingwave_pb::catalog::{PbSink, PbSource, PbTable};
 use risingwave_pb::common::worker_node::{PbResource, Property as AddNodeProperty, State};
 use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, WorkerNode, WorkerType};
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
-use risingwave_pb::stream_plan::{PbDispatchStrategy, PbStreamScanType};
+use risingwave_pb::stream_plan::{PbDispatcherType, PbStreamScanType};
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 use tokio::sync::oneshot;
 use tokio::time::{Instant, sleep};
@@ -506,7 +506,7 @@ impl MetadataManager {
         &self,
         job_id: u32,
     ) -> MetaResult<(
-        Vec<(PbDispatchStrategy, Fragment)>,
+        Vec<(PbDispatcherType, Fragment)>,
         HashMap<ActorId, WorkerId>,
     )> {
         let (fragments, actors) = self

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -726,7 +726,7 @@ impl DdlController {
         fragment_graph: StreamFragmentGraph,
     ) -> MetaResult<(ReplaceStreamJobContext, StreamJobFragmentsToCreate)> {
         let (mut replace_table_ctx, mut stream_job_fragments) = self
-            .build_replace_job(stream_ctx, streaming_job, fragment_graph, None, tmp_id as _)
+            .build_replace_job(stream_ctx, streaming_job, fragment_graph, tmp_id as _)
             .await?;
 
         let target_table = streaming_job.table().unwrap();
@@ -1407,13 +1407,7 @@ impl DdlController {
         let mut drop_table_connector_ctx = None;
         let result: MetaResult<_> = try {
             let (mut ctx, mut stream_job_fragments) = self
-                .build_replace_job(
-                    ctx,
-                    &streaming_job,
-                    fragment_graph,
-                    col_index_mapping.as_ref(),
-                    tmp_id as _,
-                )
+                .build_replace_job(ctx, &streaming_job, fragment_graph, tmp_id as _)
                 .await?;
             drop_table_connector_ctx = ctx.drop_table_connector_ctx.clone();
 
@@ -1845,7 +1839,6 @@ impl DdlController {
         stream_ctx: StreamContext,
         stream_job: &StreamingJob,
         mut fragment_graph: StreamFragmentGraph,
-        col_index_mapping: Option<&ColIndexMapping>,
         tmp_job_id: TableId,
     ) -> MetaResult<(ReplaceStreamJobContext, StreamJobFragmentsToCreate)> {
         match &stream_job {
@@ -1904,20 +1897,9 @@ impl DdlController {
 
         let job_type = StreamingJobType::from(stream_job);
 
-        // Map the column indices in the dispatchers with the given mapping.
-        let (mut downstream_fragments, downstream_actor_location) =
+        // Extract the downstream fragments from the fragment graph.
+        let (downstream_fragments, downstream_actor_location) =
             self.metadata_manager.get_downstream_fragments(id).await?;
-        if let Some(mapping) = &col_index_mapping {
-            for (d, _f) in &mut downstream_fragments {
-                *d = mapping.rewrite_dispatch_strategy(d).ok_or_else(|| {
-                    // The `rewrite` only fails if some column is dropped (missing) or altered (type changed).
-                    // TODO: support altering referenced columns
-                    MetaError::invalid_parameter(
-                        "unable to drop or alter the column due to being referenced by downstream materialized views or sinks",
-                    )
-                })?;
-            }
-        }
 
         // build complete graph based on the table job type
         let complete_graph = match &job_type {

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -224,11 +224,7 @@ impl BuildingFragment {
                 NodeBody::SourceBackfill(backfill) => (
                     backfill.upstream_source_id.into(),
                     // FIXME: only pass required columns instead of all columns here
-                    backfill
-                        .columns
-                        .iter()
-                        .map(|c| c.column_desc.as_ref().unwrap().column_id)
-                        .collect(),
+                    backfill.column_ids(),
                 ),
                 _ => return,
             };
@@ -956,14 +952,16 @@ impl CompleteStreamFragmentGraph {
         {
             for (&id, fragment) in &mut graph.fragments {
                 let uses_shuffled_backfill = fragment.has_shuffled_backfill();
-                for (&upstream_table_id, output_columns) in &fragment.upstream_table_columns {
-                    let (up_fragment_id, edge) = match job_type {
-                        StreamingJobType::Table(TableJobType::SharedCdcSource) => {
-                            let source_fragment = upstream_root_fragments
-                                .get(&upstream_table_id)
-                                .context("upstream source fragment not found")?;
-                            let source_job_id = GlobalFragmentId::new(source_fragment.fragment_id);
 
+                for (&upstream_table_id, required_columns) in &fragment.upstream_table_columns {
+                    let upstream_fragment = upstream_root_fragments
+                        .get(&upstream_table_id)
+                        .context("upstream fragment not found")?;
+                    let upstream_root_fragment_id =
+                        GlobalFragmentId::new(upstream_fragment.fragment_id);
+
+                    let edge = match job_type {
+                        StreamingJobType::Table(TableJobType::SharedCdcSource) => {
                             // we traverse all fragments in the graph, and we should find out the
                             // CdcFilter fragment and add an edge between upstream source fragment and it.
                             assert_ne!(
@@ -972,13 +970,14 @@ impl CompleteStreamFragmentGraph {
                             );
 
                             tracing::debug!(
-                                ?source_job_id,
-                                ?output_columns,
+                                ?upstream_root_fragment_id,
+                                ?required_columns,
                                 identity = ?fragment.inner.get_node().unwrap().get_identity(),
                                 current_frag_id=?id,
                                 "CdcFilter with upstream source fragment"
                             );
-                            let edge = StreamFragmentEdge {
+
+                            StreamFragmentEdge {
                                 id: EdgeId::UpstreamExternal {
                                     upstream_table_id,
                                     downstream_fragment_id: id,
@@ -990,23 +989,15 @@ impl CompleteStreamFragmentGraph {
                                     dist_key_indices: vec![], // not used for `NoShuffle`
                                     output_indices: (0..CDC_SOURCE_COLUMN_NUM as _).collect(),
                                 },
-                            };
-
-                            (source_job_id, edge)
+                            }
                         }
+
+                        // handle MV on MV/Source
                         StreamingJobType::MaterializedView
                         | StreamingJobType::Sink
                         | StreamingJobType::Index => {
-                            // handle MV on MV/Source
-
-                            // Build the extra edges between the upstream `Materialize` and the downstream `StreamScan`
-                            // of the new materialized view.
-                            let upstream_fragment = upstream_root_fragments
-                                .get(&upstream_table_id)
-                                .context("upstream materialized view fragment not found")?;
-                            let upstream_root_fragment_id =
-                                GlobalFragmentId::new(upstream_fragment.fragment_id);
-
+                            // Build the extra edges between the upstream `Materialize` and
+                            // the downstream `StreamScan` of the new job.
                             if upstream_fragment.fragment_type_mask & FragmentTypeFlag::Mview as u32
                                 != 0
                             {
@@ -1017,18 +1008,13 @@ impl CompleteStreamFragmentGraph {
                                         nodes.get_node_body().unwrap().as_materialize().unwrap();
                                     let all_column_ids = mview_node.column_ids();
                                     let dist_key_indices = mview_node.dist_key_indices();
-                                    let output_indices = output_columns
-                                        .iter()
-                                        .map(|c| {
-                                            all_column_ids
-                                                .iter()
-                                                .position(|&id| id == *c)
-                                                .map(|i| i as u32)
-                                        })
-                                        .collect::<Option<Vec<_>>>()
-                                        .context(
-                                            "BUG: column not found in the upstream materialized view",
-                                        )?;
+                                    let output_indices = gen_output_indices(
+                                        required_columns,
+                                        all_column_ids,
+                                    )
+                                    .context(
+                                        "BUG: column not found in the upstream materialized view",
+                                    )?;
                                     (dist_key_indices, output_indices)
                                 };
                                 let dispatch_strategy = mv_on_mv_dispatch_strategy(
@@ -1036,44 +1022,33 @@ impl CompleteStreamFragmentGraph {
                                     dist_key_indices,
                                     output_indices,
                                 );
-                                let edge = StreamFragmentEdge {
+
+                                StreamFragmentEdge {
                                     id: EdgeId::UpstreamExternal {
                                         upstream_table_id,
                                         downstream_fragment_id: id,
                                     },
                                     dispatch_strategy,
-                                };
-
-                                (upstream_root_fragment_id, edge)
-                            } else if upstream_fragment.fragment_type_mask
+                                }
+                            }
+                            // Build the extra edges between the upstream `Source` and
+                            // the downstream `SourceBackfill` of the new job.
+                            else if upstream_fragment.fragment_type_mask
                                 & FragmentTypeFlag::Source as u32
                                 != 0
                             {
-                                let source_fragment = upstream_root_fragments
-                                    .get(&upstream_table_id)
-                                    .context("upstream source fragment not found")?;
-                                let source_job_id =
-                                    GlobalFragmentId::new(source_fragment.fragment_id);
-
                                 let output_indices = {
                                     let nodes = &upstream_fragment.nodes;
                                     let source_node =
                                         nodes.get_node_body().unwrap().as_source().unwrap();
 
                                     let all_column_ids = source_node.column_ids().unwrap();
-                                    output_columns
-                                        .iter()
-                                        .map(|c| {
-                                            all_column_ids
-                                                .iter()
-                                                .position(|&id| id == *c)
-                                                .map(|i| i as u32)
-                                        })
-                                        .collect::<Option<Vec<_>>>()
-                                        .context("column not found in the upstream source node")?
+                                    gen_output_indices(required_columns, all_column_ids).context(
+                                        "BUG: column not found in the upstream source node",
+                                    )?
                                 };
 
-                                let edge = StreamFragmentEdge {
+                                StreamFragmentEdge {
                                     id: EdgeId::UpstreamExternal {
                                         upstream_table_id,
                                         downstream_fragment_id: id,
@@ -1085,9 +1060,7 @@ impl CompleteStreamFragmentGraph {
                                         dist_key_indices: vec![], // not used for `NoShuffle`
                                         output_indices,
                                     },
-                                };
-
-                                (source_job_id, edge)
+                                }
                             } else {
                                 bail!(
                                     "the upstream fragment should be a MView or Source, got fragment type: {:b}",
@@ -1105,14 +1078,14 @@ impl CompleteStreamFragmentGraph {
 
                     // put the edge into the extra edges
                     extra_downstreams
-                        .entry(up_fragment_id)
+                        .entry(upstream_root_fragment_id)
                         .or_insert_with(HashMap::new)
                         .try_insert(id, edge.clone())
                         .unwrap();
                     extra_upstreams
                         .entry(id)
                         .or_insert_with(HashMap::new)
-                        .try_insert(up_fragment_id, edge)
+                        .try_insert(upstream_root_fragment_id, edge)
                         .unwrap();
                 }
             }
@@ -1140,48 +1113,69 @@ impl CompleteStreamFragmentGraph {
             for (dispatcher_type, fragment) in &downstream_fragments {
                 let id = GlobalFragmentId::new(fragment.fragment_id);
 
-                let mut res = None;
+                // Similar to `extract_upstream_table_columns_except_cross_db_backfill`.
+                let output_columns = || {
+                    let mut res = None;
 
-                stream_graph_visitor::visit_stream_node(&fragment.nodes, |node_body| {
-                    let columns = match node_body {
-                        NodeBody::StreamScan(stream_scan) => {
-                            stream_scan.upstream_column_ids.clone()
-                        }
-                        _ => return,
-                    };
-                    res = Some(columns);
-                });
+                    stream_graph_visitor::visit_stream_node(&fragment.nodes, |node_body| {
+                        let columns = match node_body {
+                            NodeBody::StreamScan(stream_scan) => {
+                                stream_scan.upstream_column_ids.clone()
+                            }
+                            NodeBody::SourceBackfill(source_backfill) => {
+                                // FIXME: only pass required columns instead of all columns here
+                                source_backfill.column_ids()
+                            }
+                            _ => return,
+                        };
+                        res = Some(columns);
+                    });
 
-                let output_columns = res.context("failed to locate downstream scan")?;
+                    res.context("failed to locate downstream scan")
+                };
 
-                let nodes = graph
-                    .fragments
-                    .get(&table_fragment_id)
-                    .unwrap()
-                    .node
-                    .as_ref()
-                    .unwrap();
+                let table_fragment = graph.fragments.get(&table_fragment_id).unwrap();
+                let nodes = table_fragment.node.as_ref().unwrap();
 
-                let (dist_key_indices, output_indices) = {
-                    let mview_node = nodes.get_node_body().unwrap().as_materialize().unwrap();
-                    let all_column_ids = mview_node.column_ids();
-                    let dist_key_indices = mview_node.dist_key_indices();
-                    let output_indices = output_columns
-                        .iter()
-                        .map(|c| {
-                            all_column_ids
-                                .iter()
-                                .position(|&id| id == *c)
-                                .map(|i| i as u32)
-                        })
-                        .collect::<Option<Vec<_>>>()
-                        .ok_or_else(|| {
-                            MetaError::invalid_parameter(
-                                "unable to drop or alter the column due to \
-                                 being referenced by downstream materialized views or sinks",
-                            )
-                        })?;
-                    (dist_key_indices, output_indices)
+                let (dist_key_indices, output_indices) = match job_type {
+                    StreamingJobType::Table(TableJobType::General) => {
+                        let mview_node = nodes.get_node_body().unwrap().as_materialize().unwrap();
+                        let all_column_ids = mview_node.column_ids();
+                        let dist_key_indices = mview_node.dist_key_indices();
+                        let output_indices = gen_output_indices(&output_columns()?, all_column_ids)
+                            .ok_or_else(|| {
+                                MetaError::invalid_parameter(
+                                    "unable to drop the column due to \
+                                     being referenced by downstream materialized views or sinks",
+                                )
+                            })?;
+                        (dist_key_indices, output_indices)
+                    }
+                    StreamingJobType::Table(TableJobType::SharedCdcSource) => {
+                        assert_eq!(*dispatcher_type, DispatcherType::NoShuffle);
+                        (
+                            vec![], // not used for `NoShuffle`
+                            (0..CDC_SOURCE_COLUMN_NUM as _).collect(),
+                        )
+                    }
+                    StreamingJobType::Source => {
+                        let source_node = nodes.get_node_body().unwrap().as_source().unwrap();
+                        let all_column_ids = source_node.column_ids().unwrap();
+                        let output_indices = gen_output_indices(&output_columns()?, all_column_ids)
+                            .ok_or_else(|| {
+                                MetaError::invalid_parameter(
+                                    "unable to drop the column due to \
+                                     being referenced by downstream materialized views or sinks",
+                                )
+                            })?;
+                        assert_eq!(*dispatcher_type, DispatcherType::NoShuffle);
+                        (
+                            vec![], // not used for `NoShuffle`
+                            output_indices,
+                        )
+                    }
+
+                    _ => bail!("unsupported job type for replacement: {job_type:?}"),
                 };
 
                 let edge = StreamFragmentEdge {
@@ -1225,6 +1219,19 @@ impl CompleteStreamFragmentGraph {
             extra_upstreams,
         })
     }
+}
+
+/// Generate the `output_indices` for [`DispatchStrategy`].
+fn gen_output_indices(required_columns: &Vec<i32>, upstream_columns: Vec<i32>) -> Option<Vec<u32>> {
+    required_columns
+        .iter()
+        .map(|c| {
+            upstream_columns
+                .iter()
+                .position(|&id| id == *c)
+                .map(|i| i as u32)
+        })
+        .collect()
 }
 
 fn mv_on_mv_dispatch_strategy(

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -27,7 +27,7 @@ use risingwave_common::catalog::{
 use risingwave_common::hash::VnodeCount;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::stream_graph_visitor::{
-    self, visit_stream_node, visit_stream_node_cont, visit_stream_node_cont_mut,
+    self, visit_stream_node_cont, visit_stream_node_cont_mut,
 };
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::catalog::Table;
@@ -852,7 +852,7 @@ pub struct FragmentGraphUpstreamContext {
 
 pub struct FragmentGraphDownstreamContext {
     original_root_fragment_id: FragmentId,
-    downstream_fragments: Vec<(DispatchStrategy, Fragment)>,
+    downstream_fragments: Vec<(DispatcherType, Fragment)>,
     downstream_actor_location: HashMap<ActorId, WorkerId>,
 }
 
@@ -895,7 +895,7 @@ impl CompleteStreamFragmentGraph {
     pub fn with_downstreams(
         graph: StreamFragmentGraph,
         original_root_fragment_id: FragmentId,
-        downstream_fragments: Vec<(DispatchStrategy, Fragment)>,
+        downstream_fragments: Vec<(DispatcherType, Fragment)>,
         existing_actor_location: HashMap<ActorId, WorkerId>,
         job_type: StreamingJobType,
     ) -> MetaResult<Self> {
@@ -917,7 +917,7 @@ impl CompleteStreamFragmentGraph {
         upstream_root_fragments: HashMap<TableId, Fragment>,
         upstream_actor_location: HashMap<ActorId, WorkerId>,
         original_root_fragment_id: FragmentId,
-        downstream_fragments: Vec<(DispatchStrategy, Fragment)>,
+        downstream_fragments: Vec<(DispatcherType, Fragment)>,
         downstream_actor_location: HashMap<ActorId, WorkerId>,
         job_type: StreamingJobType,
     ) -> MetaResult<Self> {
@@ -1137,7 +1137,7 @@ impl CompleteStreamFragmentGraph {
 
             // Build the extra edges between the `Materialize` and the downstream `StreamScan` of the
             // existing materialized views.
-            for (dispatch_strategy, fragment) in &downstream_fragments {
+            for (dispatcher_type, fragment) in &downstream_fragments {
                 let id = GlobalFragmentId::new(fragment.fragment_id);
 
                 let mut res = None;
@@ -1190,8 +1190,8 @@ impl CompleteStreamFragmentGraph {
                         downstream_fragment_id: id,
                     }),
                     dispatch_strategy: DispatchStrategy {
+                        r#type: *dispatcher_type as i32,
                         output_indices,
-                        r#type: dispatch_strategy.r#type,
                         dist_key_indices,
                     },
                 };

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -239,6 +239,15 @@ impl stream_plan::MaterializeNode {
     }
 }
 
+impl stream_plan::SourceBackfillNode {
+    pub fn column_ids(&self) -> Vec<i32> {
+        self.columns
+            .iter()
+            .map(|c| c.column_desc.as_ref().unwrap().column_id)
+            .collect()
+    }
+}
+
 // Encapsulating the use of parallelism.
 impl common::WorkerNode {
     pub fn compute_node_parallelism(&self) -> usize {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, when performing schema change, the frontend will generate a `ColumnIndexMapping` between the old and the new schema. It will be used by the meta node to rewrite the `output_indices` field of the dispatchers, to maintain the same schema from the view of existing downstream jobs.

Things start to get complicated since we support altering the column type (https://github.com/risingwavelabs/risingwave/issues/19755): instead of using a simple `output_indices` to transform the data chunks in the dispatcher, we need to introduce some sort of expression evaluation to transform between between two different but compatible composite types.

Note that altering type can be called multiple times on a column. Instead of rewriting the transforming expression with an enhanced `FieldIndexMapping`, it's obvious that generating the transformation between the latest upstream & downstream schema each time can be much easier to implement. This is the motivation behind this PR.

However, we still cannot deprecate the frontend generated `ColumnIndexMapping` now, because it's also used to rewrite the index expressions. ~Considering that the persisted information is all about column index instead of ID, I still haven't come up with a solution to easily update the functional indexes after altering column type.~ UPDATE: it will be removed in an upcoming PR after we eliminate the need for using it to rewrite index expressions:
- #21681
- #21685

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
