### PR TITLE
fix(agg): fix the error of append-only approx_count_distinct

### DIFF
--- a/src/expr/impl/src/aggregate/approx_count_distinct/append_only.rs
+++ b/src/expr/impl/src/aggregate/approx_count_distinct/append_only.rs
@@ -18,7 +18,7 @@ use risingwave_expr::Result;
 
 use super::Bucket;
 
-#[derive(Clone, Copy, Default, Debug, EstimateSize)]
+#[derive(Clone, Copy, Default, Debug, EstimateSize, PartialEq, Eq)]
 pub struct AppendOnlyBucket(pub u8);
 
 impl Bucket for AppendOnlyBucket {

--- a/src/expr/impl/src/aggregate/approx_count_distinct/mod.rs
+++ b/src/expr/impl/src/aggregate/approx_count_distinct/mod.rs
@@ -212,7 +212,7 @@ impl AggregateFunction for AppendOnlyApproxCountDistinct {
 /// The estimation error for `HyperLogLog` is 1.04/sqrt(num of registers). With 2^16 registers this
 /// is ~1/256, or about 0.4%. The memory usage for the default choice of parameters is about
 /// (1024 + 24) bits * 2^16 buckets, which is about 8.58 MB.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct Registers<B: Bucket> {
     registers: Box<[B]>,
     // FIXME: Currently we only store the count result (i64) as the state of updatable register.
@@ -223,7 +223,7 @@ struct Registers<B: Bucket> {
 type UpdatableRegisters = Registers<UpdatableBucket>;
 type AppendOnlyRegisters = Registers<AppendOnlyBucket>;
 
-trait Bucket: Debug + Default + Clone + EstimateSize + Send + Sync + 'static {
+trait Bucket: Debug + Default + Clone + EstimateSize + Send + Sync + PartialEq + Eq + 'static {
     /// Increments or decrements the bucket at `index` depending on the state of `retract`.
     /// Returns an Error if `index` is invalid or if inserting will cause an overflow in the bucket.
     fn update(&mut self, index: u8, retract: bool) -> Result<()>;
@@ -298,7 +298,7 @@ impl<B: Bucket> Registers<B> {
             if zero_registers == 0.0 {
                 raw_estimate
             } else {
-                m * (m.log2() - (zero_registers.log2()))
+                m * (m.ln() - (zero_registers.ln()))
             }
         } else {
             raw_estimate
@@ -334,14 +334,22 @@ mod tests {
     use risingwave_common::array::{Array, DataChunk, I32Array, StreamChunk};
     use risingwave_expr::aggregate::{AggCall, build_append_only};
 
+    use crate::aggregate::approx_count_distinct::AppendOnlyRegisters;
+
     #[test]
-    fn test() {
+    fn test_append_only() {
         let approx_count_distinct = build_append_only(&AggCall::from_pretty(
             "(approx_count_distinct:int8 $0:int4)",
         ))
         .unwrap();
 
-        for range in [0..20000, 20000..30000, 30000..35000] {
+        for range in [
+            0..100,
+            0..20000,
+            20000..30000,
+            30000..35000,
+            1000000..3000000,
+        ] {
             let col = I32Array::from_iter(range.clone()).into_ref();
             let input = StreamChunk::from(DataChunk::new(vec![col], range.len()));
             let mut state = approx_count_distinct.create_state().unwrap();
@@ -358,12 +366,18 @@ mod tests {
                 .unwrap()
                 .into_int64() as usize;
             let actual = range.len();
-            // FIXME: the error is too large?
-            // assert!((actual as f32 * 0.9..actual as f32 * 1.1).contains(&(count as f32)));
-            let expected_range = actual as f32 * 0.5..actual as f32 * 1.5;
-            if !expected_range.contains(&(count as f32)) {
-                panic!("approximate count {} not in {:?}", count, expected_range);
-            }
+
+            let state_encoded = approx_count_distinct.encode_state(&state).unwrap();
+            let state_decoded = approx_count_distinct.decode_state(state_encoded).unwrap();
+            assert_eq!(
+                state.downcast_ref::<AppendOnlyRegisters>(),
+                state_decoded.downcast_ref::<AppendOnlyRegisters>()
+            );
+
+            // When the register number is 65536, the standard deviation is 0.406%.
+            // There is a 99.7% probability that the actual count is within 3 standard deviations.
+            // So this is expected to be a flaky test with 0.3% probability to fail.
+            assert!((actual as f32 * 0.988..actual as f32 * 1.012).contains(&(count as f32)));
         }
     }
 }

--- a/src/expr/impl/src/aggregate/approx_count_distinct/updatable.rs
+++ b/src/expr/impl/src/aggregate/approx_count_distinct/updatable.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 struct SparseCount {
     inner: Vec<(u8, u64)>,
 }
@@ -87,7 +87,7 @@ impl EstimateSize for SparseCount {
     }
 }
 
-#[derive(Clone, Debug, EstimateSize)]
+#[derive(Clone, Debug, EstimateSize, PartialEq, Eq)]
 pub(super) struct UpdatableBucket<const DENSE_BITS: usize = 16> {
     dense_counts: [u64; DENSE_BITS],
     sparse_counts: SparseCount,

--- a/src/expr/impl/src/aggregate/approx_count_distinct/updatable.rs
+++ b/src/expr/impl/src/aggregate/approx_count_distinct/updatable.rs
@@ -182,10 +182,10 @@ mod tests {
         agg.update(1.into(), false).unwrap();
         agg.update(2.into(), false).unwrap();
         agg.update(3.into(), false).unwrap();
-        assert_eq!(agg.calculate_result(), 4);
+        assert_eq!(agg.calculate_result(), 3);
 
         agg.update(3.into(), false).unwrap();
-        assert_eq!(agg.calculate_result(), 4);
+        assert_eq!(agg.calculate_result(), 3);
 
         agg.update(3.into(), true).unwrap();
         agg.update(3.into(), true).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The PR replaces the base-2 logarithm used in the linear-counting branch with the natural logarithm. In the original HyperLogLog paper the bias-correction for small cardinalities is `E = m × ln(m / V)` where V is the number of zero registers. Using log₂ instead of ln multiplies the estimate by 1/ln 2 ≈ 1.44. Consequently every time the algorithm fell into the “small-range” path (roughly n ≲ 2.5 m, i.e. < 163 840 for m = 65 536) it over-estimated the true cardinality by about 44 %. That matches the 40 %-plus inflation we observed around 20 000 distinct values. Restoring ln brings the estimator back to the theoretical error envelope (≈ 0.4 % standard deviation for m = 65 536) and eliminates the systematic high bias at low counts.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
