### PR TITLE
fix(cdc): fix the race case where cleanup process of stale dbz engine may accidentally remove the handler of the active one from registry during recovery

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/JniDbzSourceHandler.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/JniDbzSourceHandler.java
@@ -52,6 +52,10 @@ public class JniDbzSourceHandler {
         }
     }
 
+    public long getSourceId() {
+        return config.getSourceId();
+    }
+
     public static void runJniDbzSourceThread(byte[] getEventStreamRequestBytes, long channelPtr)
             throws Exception {
 
@@ -102,7 +106,7 @@ public class JniDbzSourceHandler {
     public void start() {
         try {
             // register handler to the registry
-            JniDbzSourceRegistry.register(config.getSourceId(), this);
+            JniDbzSourceRegistry.register(this);
 
             // Start the engine
             var startOk = runner.start();
@@ -110,8 +114,6 @@ public class JniDbzSourceHandler {
                 LOG.error(
                         "Failed to send handshake message to channel. sourceId={}",
                         config.getSourceId());
-                // remove the handler from registry
-                JniDbzSourceRegistry.unregister(config.getSourceId());
                 return;
             }
 
@@ -154,7 +156,7 @@ public class JniDbzSourceHandler {
             }
         } finally {
             // remove the handler from registry
-            JniDbzSourceRegistry.unregister(config.getSourceId());
+            JniDbzSourceRegistry.unregister(this);
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Note: ~~This is a theoretical problem but I have not yet reproduced.~~ However, we encountered a bug in a customer's cluster that appears to be caused by this issue.

UPDATE: Reproduced locally. Can observe such logs after this PR:

```
2025-04-23T16:37:49.32772+08:00  INFO risingwave_connector_node: engine#7 start ok: true thread="Thread-1" class="com.risingwave.connector.source.core.DbzCdcEngineRunner"

2025-04-23T16:37:51.566743+08:00  INFO risingwave_connector_node: Replacing existing source handler for source ID 7 thread="Thread-32" class="com.risingwave.connector.source.core.JniDbzSourceRegistry"
2025-04-23T16:37:51.566858+08:00  INFO risingwave_connector_node: engine#7 start ok: true thread="Thread-32" class="com.risingwave.connector.source.core.DbzCdcEngineRunner"

2025-04-23T16:37:51.679962+08:00  INFO risingwave_connector_node: Source handler for source ID 7 does not match the one in the registry (it may have been replaced) thread="Thread-1" class="com.risingwave.connector.source.core.JniDbzSourceRegistry"
```

----

When a CDC source executor is dropped, its corresponding `DbzEngine` in Java is dropped asynchronously via channel closed notification. This makes it possible that we have multiple `Engine` (or `Handler`) for the same source during recovery.

However, in `JniDbzSourceRegistry`, handlers are simply indexed by source ID. There could be a race case where the cleanup process of the stale engine may accidentally unregister the handler of the new/active one from the registry in its `finally` block.

https://github.com/risingwavelabs/risingwave/blob/a2bd1249d035fa55429131cfbc5413e8349cc7ab/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/JniDbzSourceHandler.java#L157-L160

0. trigger **soft** recovery (by `RECOVER` for example)
1. old executors are dropped
2. new executors are created
3. new CDC handler is created and registered, overriding the old one in the registry
4. old CDC handler is cleaned up asynchronously, unregister by id, accidentally remove the new one
5. when committing CDC offset on checkpoints, we fail to obtain the handler from the registry with ID, observe replication lags
	```
	Failed to commit offset to upstream for source: 3001.: Null pointer in call_method obj argument
	```
	https://github.com/risingwavelabs/risingwave/blob/a2bd1249d035fa55429131cfbc5413e8349cc7ab/src/connector/src/source/cdc/jni_source.rs#L19-L39

Note that we don't have this issue before v2.3. This is because we didn't unregister at all before https://github.com/risingwavelabs/risingwave/pull/20353#discussion_r1950548653. While it addressed such resource leakage, it also revealed this issue.

----

This PR fixes this issue by simply comparing the object equality of the handler before removing it from the map.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
