### PR TITLE
fix(connector): use `insert on conflict do update` for postgres sink

### DIFF
--- a/e2e_test/sink/postgres_sink.slt
+++ b/e2e_test/sink/postgres_sink.slt
@@ -269,7 +269,61 @@ select * from postgres_query('$PGHOST', '$PGPORT', '$PGUSER', '${PGPASSWORD:post
 1 Varcharvalue1 Textvalue1 123 456 789 12.34 56.78 90.12 t 2023-05-22 12:34:56 2023-05-22 12:34:56 1 day {"key": "value"}
 2 Varcharvalue4 Textvalue2 234 400 890 NaN 67.89 1.23 f 2023-05-23 23:45:01 2023-05-23 23:45:01 2 days {"key": "value2"}
 
+################### test duplicate inserts should work
+
+statement ok
+CREATE TABLE rw_types_table_dup (
+    id BIGINT PRIMARY KEY,
+    varchar_column VARCHAR,
+    text_column TEXT,
+    smallint_column SMALLINT,
+    integer_column INTEGER,
+    bigint_column BIGINT,
+    decimal_column DECIMAL,
+    real_column REAL,
+    double_column DOUBLE PRECISION,
+    boolean_column BOOLEAN,
+    date_column DATE,
+    time_column TIME,
+    interval_column INTERVAL,
+    jsonb_column JSONB,
+    timestamp_column TIMESTAMP
+);
+
+statement ok
+INSERT INTO rw_types_table (id, varchar_column, text_column, integer_column, smallint_column, bigint_column, decimal_column, real_column, double_column, boolean_column, date_column, time_column, timestamp_column, interval_column, jsonb_column) VALUES
+    (1, 'Varcharvalue4', 'Textvalue1', 123, 456, 789, 12.34, 56.78, 90.12, TRUE, '2023-05-22', '12:34:56', '2023-05-22 12:34:56', '1 day', '{"key": "value"}'),
+    (2, 'Varcharvalue6', 'Textvalue2', 234, 567, 890, 'NAN'::decimal, 67.89, 01.23, FALSE, '2023-05-23', '23:45:01', '2023-05-23 23:45:01', '2 days', '{"key": "value2"}');
+
+statement ok
+flush;
+
+statement ok
+CREATE SINK postgres_rw_types_sink_dup FROM rw_types_table_dup WITH (
+    connector='postgres',
+    host='$PGHOST',
+    port='$PGPORT',
+    user='$PGUSER',
+    password='$PGPASSWORD',
+    database='sink_test',
+    table='pg_types_table',
+    type='upsert',
+    primary_key='id',
+);
+
+query I
+select * from postgres_query('$PGHOST', '$PGPORT', '$PGUSER', '${PGPASSWORD:postgres}', 'sink_test', 'select * from pg_types_table order by id;');
+----
+1 Varcharvalue4 Textvalue1 123 456 789 12.34 56.78 90.12 t 2023-05-22 12:34:56 2023-05-22 12:34:56 1 day {"key": "value"}
+2 Varcharvalue6 Textvalue2 234 567 890 NaN 67.89 1.23 f 2023-05-23 23:45:01 2023-05-23 23:45:01 2 days {"key": "value2"}
+
 ################### cleanup sink
+
+statement ok
+DROP SINK postgres_rw_types_sink_dup;
+
+statement ok
+DROP TABLE rw_types_table_dup;
 
 statement ok
 DROP SINK postgres_rw_types_sink;

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -606,7 +606,7 @@ fn create_insert_sql(
     let columns: String = schema
         .fields()
         .iter()
-        .map(|field| field.name.clone())
+        .map(|field| quote_identifier(&field.name))
         .join(", ");
     let parameters: String = (0..number_of_rows)
         .map(|i| {
@@ -715,7 +715,7 @@ mod tests {
         check(
             sql,
             expect![[
-                r#"INSERT INTO "test_schema"."test_table" (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)"#
+                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6)"#
             ]],
         );
     }
@@ -769,7 +769,7 @@ mod tests {
         check(
             sql,
             expect![[
-                r#"INSERT INTO "test_schema"."test_table" (a, b) VALUES ($1, $2), ($3, $4), ($5, $6) on conflict ("b") do update set "a" = EXCLUDED."a""#
+                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6) on conflict ("b") do update set "a" = EXCLUDED."a""#
             ]],
         );
     }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -424,6 +424,7 @@ impl PostgresSinkWriter {
             &self.pk_indices,
             parameters,
             remaining,
+            true,
         )
         .await?;
         transaction.commit().await?;
@@ -463,6 +464,7 @@ impl PostgresSinkWriter {
             &self.pk_indices,
             delete_parameters,
             delete_remaining_parameter,
+            false,
         )
         .await?;
         let (insert_parameters, insert_remaining_parameter) = insert_parameter_buffer.into_parts();
@@ -474,6 +476,7 @@ impl PostgresSinkWriter {
             &self.pk_indices,
             insert_parameters,
             insert_remaining_parameter,
+            false,
         )
         .await?;
         transaction.commit().await?;
@@ -489,6 +492,7 @@ impl PostgresSinkWriter {
         pk_indices: &[usize],
         parameters: Vec<Vec<Option<ScalarAdapter>>>,
         remaining_parameter: Vec<Option<ScalarAdapter>>,
+        append_only: bool,
     ) -> Result<()> {
         let column_length = match op {
             Op::Insert => schema.len(),
@@ -506,7 +510,13 @@ impl PostgresSinkWriter {
                 schema.fields(),
             );
             let statement = match op {
-                Op::Insert => create_insert_sql(schema, table_name, rows_length),
+                Op::Insert => {
+                    if append_only {
+                        create_insert_sql(schema, table_name, rows_length)
+                    } else {
+                        create_upsert_sql(schema, table_name, pk_indices, rows_length)
+                    }
+                }
                 Op::Delete => create_delete_sql(schema, table_name, pk_indices, rows_length),
                 _ => unreachable!(),
             };
@@ -523,7 +533,13 @@ impl PostgresSinkWriter {
                 "flattened parameters are unaligned"
             );
             let statement = match op {
-                Op::Insert => create_insert_sql(schema, table_name, rows_length),
+                Op::Insert => {
+                    if append_only {
+                        create_insert_sql(schema, table_name, rows_length)
+                    } else {
+                        create_upsert_sql(schema, table_name, pk_indices, rows_length)
+                    }
+                }
                 Op::Delete => create_delete_sql(schema, table_name, pk_indices, rows_length),
                 _ => unreachable!(),
             };
@@ -602,6 +618,46 @@ fn create_delete_sql(
     format!("DELETE FROM {table_name} WHERE {pk} in ({parameters})")
 }
 
+fn create_upsert_sql(
+    schema: &Schema,
+    table_name: &str,
+    pk_indices: &[usize],
+    number_of_rows: usize,
+) -> String {
+    let number_of_columns = schema.len();
+    let columns: String = schema
+        .fields()
+        .iter()
+        .map(|field| field.name.clone())
+        .collect_vec()
+        .join(", ");
+    let parameters: String = (0..number_of_rows)
+        .map(|i| {
+            let row_parameters = (0..number_of_columns)
+                .map(|j| format!("${}", i * number_of_columns + j + 1))
+                .join(", ");
+            format!("({row_parameters})")
+        })
+        .collect_vec()
+        .join(", ");
+    let pk_columns = pk_indices
+        .iter()
+        .map(|i| schema.fields()[*i].name.clone())
+        .collect_vec()
+        .join(", ");
+    let update_parameters: String = (0..number_of_columns)
+        .filter(|i| !pk_indices.contains(i))
+        .map(|i| {
+            let column = schema.fields()[i].name.clone();
+            format!("{column} = EXCLUDED.{column}")
+        })
+        .collect_vec()
+        .join(", ");
+    format!(
+        "INSERT INTO {table_name} ({columns}) VALUES {parameters} on conflict ({pk_columns}) do update set {update_parameters}"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::Display;
@@ -660,6 +716,28 @@ mod tests {
         check(
             sql,
             expect!["DELETE FROM test_table WHERE (a, b) in (($1, $2), ($3, $4), ($5, $6))"],
+        );
+    }
+
+    #[test]
+    fn test_create_upsert_sql() {
+        let schema = Schema::new(vec![
+            Field {
+                data_type: DataType::Int32,
+                name: "a".to_owned(),
+            },
+            Field {
+                data_type: DataType::Int32,
+                name: "b".to_owned(),
+            },
+        ]);
+        let table_name = "test_table";
+        let sql = create_upsert_sql(&schema, table_name, &[1], 3);
+        check(
+            sql,
+            expect![
+                "INSERT INTO test_table (a, b) VALUES ($1, $2), ($3, $4), ($5, $6) on conflict (b) do update set a = EXCLUDED.a"
+            ],
         );
     }
 }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -526,7 +526,10 @@ impl PostgresSinkWriter {
                 }
                 _ => unreachable!(),
             };
-            let statement = transaction.prepare(&statement_str).await?;
+            let statement = transaction
+                .prepare(&statement_str)
+                .await
+                .with_context(|| format!("failed to run statement: {}", statement_str))?;
             for parameter in parameters {
                 transaction
                     .execute_raw(&statement, parameter)
@@ -555,7 +558,10 @@ impl PostgresSinkWriter {
                 _ => unreachable!(),
             };
             tracing::trace!("binding statement: {:?}", statement_str);
-            let statement = transaction.prepare(&statement_str).await?;
+            let statement = transaction
+                .prepare(&statement_str)
+                .await
+                .with_context(|| format!("failed to run statement: {}", statement_str))?;
             tracing::trace!("binding parameters: {:?}", remaining_parameter);
             transaction
                 .execute_raw(&statement, remaining_parameter)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

If there is either:
- recovery
- multiple sinks writing to same table

There can be duplicate entries for the same PK. We should use `on conflict do update` for non append only sinks.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
