### PR TITLE
fix(connector): use the right schema for delete parameters

### DIFF
--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -448,10 +448,8 @@ impl PostgresSinkWriter {
             &self.schema_types,
             chunk.cardinality() * chunk.data_types().len(),
         );
-        let mut delete_parameter_buffer = ParameterBuffer::new(
-            &self.pk_types,
-            chunk.cardinality() * self.pk_indices.len(),
-        );
+        let mut delete_parameter_buffer =
+            ParameterBuffer::new(&self.pk_types, chunk.cardinality() * self.pk_indices.len());
         // 1d flattened array of parameters to be deleted.
         for (op, row) in chunk.rows() {
             match op {

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -285,6 +285,7 @@ impl<'a> ParameterBuffer<'a> {
     }
 
     fn add_row(&mut self, row: impl Row) {
+        assert_eq!(row.len(), self.column_length);
         if self.current_parameter_buffer.len() + self.column_length >= Self::MAX_PARAMETERS {
             self.new_buffer();
         }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -546,7 +546,7 @@ impl PostgresSinkWriter {
             let statement = transaction
                 .prepare(&statement_str)
                 .await
-                .with_context(|| format!("failed to run statement: {}", statement_str))?;
+                .with_context(|| format!("failed to prepare statement: {}", statement_str))?;
             Ok((statement_str, statement))
         }
 
@@ -582,7 +582,7 @@ impl PostgresSinkWriter {
                 transaction
                     .execute_raw(&statement, parameter)
                     .await
-                    .with_context(|| format!("failed to run statement: {}", statement_str,))?;
+                    .with_context(|| format!("failed to execute statement: {}", statement_str,))?;
             }
         }
         if !remaining_parameter.is_empty() {
@@ -609,7 +609,7 @@ impl PostgresSinkWriter {
             transaction
                 .execute_raw(&statement, remaining_parameter)
                 .await
-                .with_context(|| format!("failed to run statement: {}", statement_str))?;
+                .with_context(|| format!("failed to execute statement: {}", statement_str))?;
         }
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

We use all fields of a schema instead of just pk fields previously to generate delete statements. This PR fixes that.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
