### PR TITLE
feat(ci): support workflow for docker image building

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -47,16 +47,11 @@ jobs:
           echo "enable_alpha_build=${{ github.event.inputs.enable_alpha_build }}"
       - name: 'Verify release branch'
         id: verify_release_branch
-        # FIXME
-        # if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
+        if: github.event.inputs.enable_patch_build && github.event.inputs.enable_alpha_build
         run: |
           # Get current branch name
           echo "GITHUB_REF=$GITHUB_REF"
-          
-          # BRANCH_NAME=$(basename $GITHUB_REF)
-          # FIXME
-          BRANCH_NAME=release-8888.8888
-          
+          BRANCH_NAME=$(basename $GITHUB_REF)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           
@@ -69,18 +64,14 @@ jobs:
           fi
       - name: 'Get base version'
         id: get_base_version
-        # FIXME
-        # if: github.event.inputs.enable_alpha_build == 'false'
+        if: !github.event.inputs.enable_alpha_build
         run: |
-          # FIXME
-          VERSION=8888.8888.0
-          # VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
-          # Check its not an alpha build
+          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
+          echo "VERSION=$VERSION"
           if [[ $VERSION == *"alpha"* ]]; then
-            echo "Error: Branch $BRANCH_NAME is has an alpha version: $VERSION"
+            echo "Error: Branch $BRANCH_NAME has an alpha version"
             exit 1
           fi
-          echo "VERSION=$VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: 'Generate image tag'
         id: generate_image_tag

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: 'Generate image tag + build Docker image: v<X.Y.Z>:<label>:<commit_sha>:<branch>'
+        description: 'Generate image tag + build Docker image: v<X.Y.Z>--<label>--<commit_sha>--<branch>'
         required: true
         type: string
         default: 'unlabeled'
@@ -38,7 +38,7 @@ jobs:
           echo "LABEL=$LABEL" >> $GITHUB_ENV
 
           # Build the image tag
-          IMAGE_TAG="v$VERSION:$LABEL:$COMMIT_SHA:$BRANCH_NAME"
+          IMAGE_TAG="v$VERSION--$LABEL--$COMMIT_SHA--$BRANCH_NAME"
           echo "IMAGE_TAG=$IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -47,7 +47,7 @@ jobs:
           echo "enable_alpha_build=${{ github.event.inputs.enable_alpha_build }}"
       - name: 'Verify release branch'
         id: verify_release_branch
-        if: github.event.inputs.enable_patch_build && github.event.inputs.enable_alpha_build
+        if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
         run: |
           # Get current branch name
           echo "GITHUB_REF=$GITHUB_REF"
@@ -64,7 +64,7 @@ jobs:
           fi
       - name: 'Get base version'
         id: get_base_version
-        if: ! github.event.inputs.enable_alpha_build
+        if: github.event.inputs.enable_alpha_build != 'true'
         run: |
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           echo "VERSION=$VERSION"

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -45,6 +45,7 @@ jobs:
         # if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
         run: |
           # Get current branch name
+          echo "GITHUB_REF=$GITHUB_REF"
           BRANCH_NAME=$(echo $GITHUB_REF | cut -d '/' -f 3)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: 'Generate image tag + build Docker image: v<X.Y.Z>-<label>-<commit_sha>-<branch>'
+        description: 'Generate image tag + build Docker image: v<X.Y.Z>:<label>:<commit_sha>:<branch>'
         required: true
         type: string
         default: 'unlabeled'
@@ -38,7 +38,7 @@ jobs:
           echo "LABEL=$LABEL" >> $GITHUB_ENV
 
           # Build the image tag
-          IMAGE_TAG="v$VERSION-$LABEL-$COMMIT_SHA-$BRANCH_NAME"
+          IMAGE_TAG="v$VERSION:$LABEL:$COMMIT_SHA:$BRANCH_NAME"
           echo "IMAGE_TAG=$IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -103,7 +103,7 @@ jobs:
         uses: buildkite/trigger-pipeline-action@v2.0.0
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: 'docker'
+          pipeline: 'risingwavelabs/docker'
           branch: ${{ env.BRANCH_NAME }}
           message: ':github: Triggering Docker build'
           build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}" }'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -62,41 +62,37 @@ jobs:
             echo "Error: Branch $BRANCH_NAME is not a release branch"
             exit 1
           fi
-      - name: 'Verify patch base version'
-        id: verify_patch_base_version
+      - name: 'Get base version'
+        id: get_base_version
         # FIXME
-        # if: github.event.inputs.enable_patch_build == 'true'
+        # if: github.event.inputs.enable_alpha_build == 'false'
         run: |
-          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
+          # FIXME
+          VERSION=2.1.0
+          # VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           # Check its not an alpha build
           if [[ $VERSION == *"alpha"* ]]; then
             echo "Error: Branch $BRANCH_NAME is has an alpha version: $VERSION"
             exit 1
           fi
+          echo "VERSION=$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: 'Generate image tag'
         id: generate_image_tag
         run: |
-          # Get the version from Cargo.toml
-          # FIXME
-          # VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
-          VERSION=2.1.0
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          
           # Get the commit SHA
           COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+          echo "COMMIT_SHA=$COMMIT_SHA"
 
           # Get the tag from the input
           TAG=${{ github.event.inputs.tag }}
-          # Check if the tag is empty
-          if [ -z "$TAG" ]; then
-            TAG="untagged"
-          fi
+          echo "TAG=$TAG"
 
           # Generate the image tag
           IMAGE_TAG="v$VERSION-$TAG-$COMMIT_SHA"
+          echo "IMAGE_TAG=$IMAGE_TAG"
           
           # Write the image tag to environment file
-          echo "IMAGE_TAG=$IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 #      - name: 'Trigger Docker build Workflow via Buildkite'
 #        uses: buildkite/trigger-pipeline-action@v2.0.0

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -54,7 +54,7 @@ jobs:
           BRANCH_NAME=$(basename $GITHUB_REF)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-          
+
           # Check for semver
           if [[ "$BRANCH_NAME" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
             echo "Branch $BRANCH_NAME is a valid release branch"
@@ -66,7 +66,7 @@ jobs:
         id: get_base_version
         if: github.event.inputs.enable_alpha_build != 'true'
         run: |
-          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
+          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
           echo "VERSION=$VERSION"
           if [[ $VERSION == *"alpha"* ]]; then
             echo "Error: Branch $GITHUB_REF has an alpha version"

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -42,12 +42,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: 'Verify release branch'
         id: verify_release_branch
+        # FIXME
         # if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
         run: |
           # Get current branch name
           echo "GITHUB_REF=$GITHUB_REF"
+          
           # BRANCH_NAME=$(basename $GITHUB_REF)
+          # FIXME
           BRANCH_NAME=release-2.1
+          
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           
@@ -58,14 +62,15 @@ jobs:
             echo "Error: Branch $BRANCH_NAME is not a release branch"
             exit 1
           fi
-      - name: 'Verify patch branch'
-        id: verify_patch_branch
+      - name: 'Verify patch base version'
+        id: verify_patch_base_version
+        # FIXME
         # if: github.event.inputs.enable_patch_build == 'true'
         run: |
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           # Check its not an alpha build
           if [[ $VERSION == *"alpha"* ]]; then
-            echo "Error: Branch $BRANCH_NAME is not a release branch"
+            echo "Error: Branch $BRANCH_NAME is has an alpha version: $VERSION"
             exit 1
           fi
       - name: 'Generate image tag'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -64,7 +64,7 @@ jobs:
           fi
       - name: 'Get base version'
         id: get_base_version
-        if: !github.event.inputs.enable_alpha_build
+        if: ! github.event.inputs.enable_alpha_build
         run: |
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           echo "VERSION=$VERSION"

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,6 +1,6 @@
+# To test: gh workflow run 'Build Docker Image' --ref kwannoel/workflow-update-branch
 name: Build Docker Image
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -45,8 +45,8 @@ jobs:
         # if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
         run: |
           # Get current branch name
-          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
-          BRANCH_NAME=$(echo $GITHUB_REF_NAME | cut -d '/' -f 3)
+          echo "GITHUB_REF=$GITHUB_REF"
+          BRANCH_NAME=$(echo $GITHUB_REF | cut -d '/' -f 2)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           # Get current branch name
           echo "GITHUB_REF=$GITHUB_REF"
-          BRANCH_NAME=$(basename $GITHUB_REF)
+          # BRANCH_NAME=$(basename $GITHUB_REF)
+          BRANCH_NAME=release-2.1
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           # Get current branch name
           echo "GITHUB_REF=$GITHUB_REF"
-          BRANCH_NAME=$(echo $GITHUB_REF | cut -d '/' -f 2)
+          BRANCH_NAME=$(basename $GITHUB_REF)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -105,6 +105,5 @@ jobs:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
           pipeline: 'docker'
           branch: ${{ env.BRANCH_NAME }}
-          message: 'Triggering Docker build'
-          env:
-            IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          message: ':github: Triggering Docker build'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}" }'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -40,6 +40,11 @@ jobs:
     # should match: vX.Y.Z
     steps:
       - uses: actions/checkout@v4
+      - name: 'Print inputs'
+        run: |
+          echo "TAG=${{ github.event.inputs.tag }}"
+          echo "enable_patch_build=${{ github.event.inputs.enable_patch_build }}"
+          echo "enable_alpha_build=${{ github.event.inputs.enable_alpha_build }}"
       - name: 'Verify release branch'
         id: verify_release_branch
         # FIXME
@@ -91,7 +96,7 @@ jobs:
           # Generate the image tag
           IMAGE_TAG="v$VERSION-$TAG-$COMMIT_SHA"
           echo "IMAGE_TAG=$IMAGE_TAG"
-          
+
           # Write the image tag to environment file
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 #      - name: 'Trigger Docker build Workflow via Buildkite'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,5 +1,6 @@
 name: Build Docker Image
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -48,5 +48,5 @@ jobs:
           pipeline: 'risingwavelabs/docker'
           branch: ${{ env.BRANCH_NAME }}
           commit: HEAD
-          message: ':github: Triggering Docker build'
+          message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
           build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}" }'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,98 +3,43 @@ name: Build Docker Image
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag for the Docker image: vX.Y.Z-<tag>-<commit_sha>'
+      label:
+        description: 'Generate image tag + build Docker image: v<X.Y.Z>-<label>-<commit_sha>-<branch>'
         required: true
         type: string
-        default: 'untagged'
-      # By default, images should be built for the latest commit of a release-branch.
-      # This is disabled by default.
-      # Only in special circumstances when we need an urgent patch,
-      # before some commit is merged into a release branch,
-      # we can set the `enable_patch_build` input to `true`.
-      enable_patch_build:
-        description: 'Allow patch builds on release branches, default: false'
-        required: true
-        type: boolean
-        default: false
-      # By default, images should be built for the latest commit of a release-branch.
-      # This should only be used to build test images,
-      # and never for production.
-      # Images will be tagged with <commit_sha>-<tag>, to enforce that the image is not used in production.
-      # Since the `commit_sha` will never match semver (vX.Y.Z).
-      enable_alpha_build:
-        description: 'Allow custom build for any branch, default: false'
-        required: true
-        type: boolean
-        default: false
+        default: 'unlabeled'
 
 jobs:
-  # Generate image tag using:
-  # - version inside Cargo.toml,
-  # - the commit SHA,
-  # - and the tag provided by the user.
   generate_image_tag:
     runs-on: ubuntu-latest
-    # Checks that the branch is a release branch, by checking that the semver
-    # should match: vX.Y.Z
     steps:
       - uses: actions/checkout@v4
-      - name: 'Print inputs'
-        run: |
-          echo "TAG=${{ github.event.inputs.tag }}"
-          echo "enable_patch_build=${{ github.event.inputs.enable_patch_build }}"
-          echo "enable_alpha_build=${{ github.event.inputs.enable_alpha_build }}"
-      - name: 'Verify release branch'
-        id: verify_release_branch
-        if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
+      - name: 'Build image tag'
+        id: get_release_branch
         run: |
           # Get current branch name
-          echo "GITHUB_REF=$GITHUB_REF"
-          BRANCH_NAME=$(basename $GITHUB_REF)
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-          # Check for semver
-          if [[ "$BRANCH_NAME" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
-            echo "Branch $BRANCH_NAME is a valid release branch"
-          else
-            echo "Error: Branch $BRANCH_NAME is not a release branch"
-            exit 1
-          fi
-      - name: 'Get base version'
-        id: get_base_version
-        if: github.event.inputs.enable_alpha_build != 'true'
-        run: |
+          # Get version from Cargo.toml, e.g. v2.3.0-alpha
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
           echo "VERSION=$VERSION"
-          if [[ $VERSION == *"alpha"* ]]; then
-            echo "Error: Branch $GITHUB_REF has an alpha version"
-            exit 1
-          fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - name: 'Generate image tag'
-        id: generate_image_tag
-        run: |
+
           # Get the commit SHA
           COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
           echo "COMMIT_SHA=$COMMIT_SHA"
+          echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
 
-          # Get the tag from the input
-          TAG=${{ github.event.inputs.tag }}
-          echo "TAG=$TAG"
+          # Get the label from the input
+          LABEL=${{ github.event.inputs.label }}
+          echo "LABEL=$LABEL"
+          echo "LABEL=$LABEL" >> $GITHUB_ENV
 
-          # Generate the image tag
-          if [[ ${{ github.event.inputs.enable_alpha_build }} == 'true' ]]; then
-            # If alpha build is enabled, use the commit SHA and tag
-            IMAGE_TAG="$COMMIT_SHA-$TAG"
-          else
-            # Use the version from Cargo.toml, commit SHA, and tag
-            IMAGE_TAG="v$VERSION-$TAG-$COMMIT_SHA"
-          fi
+          # Build the image tag
+          IMAGE_TAG="v$VERSION-$LABEL-$COMMIT_SHA-$BRANCH_NAME"
           echo "IMAGE_TAG=$IMAGE_TAG"
-
-          # Write the image tag to environment file
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'
         uses: buildkite/trigger-pipeline-action@v2.0.0
@@ -102,5 +47,6 @@ jobs:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
           pipeline: 'risingwavelabs/docker'
           branch: ${{ env.BRANCH_NAME }}
+          commit: HEAD
           message: ':github: Triggering Docker build'
           build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}" }'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -77,7 +77,9 @@ jobs:
         id: generate_image_tag
         run: |
           # Get the version from Cargo.toml
-          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
+          # FIXME
+          # VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
+          VERSION=2.1.0
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           
           # Get the commit SHA

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -45,8 +45,8 @@ jobs:
         # if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
         run: |
           # Get current branch name
-          echo "GITHUB_REF=$GITHUB_REF"
-          BRANCH_NAME=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+          BRANCH_NAME=$(echo $GITHUB_REF_NAME | cut -d '/' -f 3)
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -69,7 +69,7 @@ jobs:
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           echo "VERSION=$VERSION"
           if [[ $VERSION == *"alpha"* ]]; then
-            echo "Error: Branch $BRANCH_NAME has an alpha version"
+            echo "Error: Branch $GITHUB_REF has an alpha version"
             exit 1
           fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -10,11 +10,11 @@ on:
         default: 'unlabeled'
 
 jobs:
-  generate_image_tag:
+  build_image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: 'Build image tag'
+      - name: 'Generate image tag'
         id: get_release_branch
         run: |
           # Get current branch name

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -22,6 +22,11 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
+          echo "Replace / with - in branch name, for docker manifest requirement"
+          NO_SLASH_BRANCH_NAME=${BRANCH_NAME//\//-}
+          echo "NO_SLASH_BRANCH_NAME=$NO_SLASH_BRANCH_NAME"
+          echo "NO_SLASH_BRANCH_NAME=$NO_SLASH_BRANCH_NAME" >> $GITHUB_ENV
+
           # Get version from Cargo.toml, e.g. v2.3.0-alpha
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
           echo "VERSION=$VERSION"
@@ -38,7 +43,7 @@ jobs:
           echo "LABEL=$LABEL" >> $GITHUB_ENV
 
           # Build the image tag
-          IMAGE_TAG="v$VERSION--$LABEL--$COMMIT_SHA--$BRANCH_NAME"
+          IMAGE_TAG="v$VERSION--$LABEL--$COMMIT_SHA--$NO_SLASH_BRANCH_NAME"
           echo "IMAGE_TAG=$IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
       - name: 'Trigger Docker build Workflow via Buildkite'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -85,7 +85,13 @@ jobs:
           echo "TAG=$TAG"
 
           # Generate the image tag
-          IMAGE_TAG="v$VERSION-$TAG-$COMMIT_SHA"
+          if [[ ${{ github.event.inputs.enable_alpha_build }} == 'true' ]]; then
+            # If alpha build is enabled, use the commit SHA and tag
+            IMAGE_TAG="$COMMIT_SHA-$TAG"
+          else
+            # Use the version from Cargo.toml, commit SHA, and tag
+            IMAGE_TAG="v$VERSION-$TAG-$COMMIT_SHA"
+          fi
           echo "IMAGE_TAG=$IMAGE_TAG"
 
           # Write the image tag to environment file

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -99,12 +99,12 @@ jobs:
 
           # Write the image tag to environment file
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-#      - name: 'Trigger Docker build Workflow via Buildkite'
-#        uses: buildkite/trigger-pipeline-action@v2.0.0
-#        with:
-#          buildkite_api_access_token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
-#          pipeline: 'docker'
-#          branch: ${{ env.BRANCH_NAME }}
-#          message: 'Triggering Docker build'
-#          env:
-#            IMAGE_TAG: ${{ env.IMAGE_TAG }}
+      - name: 'Trigger Docker build Workflow via Buildkite'
+        uses: buildkite/trigger-pipeline-action@v2.0.0
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          pipeline: 'docker'
+          branch: ${{ env.BRANCH_NAME }}
+          message: 'Triggering Docker build'
+          env:
+            IMAGE_TAG: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -55,7 +55,7 @@ jobs:
           
           # BRANCH_NAME=$(basename $GITHUB_REF)
           # FIXME
-          BRANCH_NAME=release-2.1
+          BRANCH_NAME=release-8888.8888
           
           echo "BRANCH_NAME=$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
@@ -73,7 +73,7 @@ jobs:
         # if: github.event.inputs.enable_alpha_build == 'false'
         run: |
           # FIXME
-          VERSION=2.1.0
+          VERSION=8888.8888.0
           # VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           # Check its not an alpha build
           if [[ $VERSION == *"alpha"* ]]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,98 @@
+name: Build Docker Image
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the Docker image: vX.Y.Z-<tag>-<commit_sha>'
+        required: true
+        type: string
+        default: 'untagged'
+      # By default, images should be built for the latest commit of a release-branch.
+      # This is disabled by default.
+      # Only in special circumstances when we need an urgent patch,
+      # before some commit is merged into a release branch,
+      # we can set the `enable_patch_build` input to `true`.
+      enable_patch_build:
+        description: 'Allow patch builds on release branches, default: false'
+        required: true
+        type: boolean
+        default: false
+      # By default, images should be built for the latest commit of a release-branch.
+      # This should only be used to build test images,
+      # and never for production.
+      # Images will be tagged with <commit_sha>-<tag>, to enforce that the image is not used in production.
+      # Since the `commit_sha` will never match semver (vX.Y.Z).
+      enable_alpha_build:
+        description: 'Allow custom build for any branch, default: false'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  # Generate image tag using:
+  # - version inside Cargo.toml,
+  # - the commit SHA,
+  # - and the tag provided by the user.
+  generate_image_tag:
+    runs-on: ubuntu-latest
+    # Checks that the branch is a release branch, by checking that the semver
+    # should match: vX.Y.Z
+    steps:
+      - name: 'Verify release branch'
+        id: verify_release_branch
+        if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
+        run: |
+          # Get current branch name
+          BRANCH_NAME=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          echo "BRANCH_NAME=$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          
+          # Check for semver
+          if [[ "$BRANCH_NAME" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            echo "Branch $BRANCH_NAME is a valid release branch"
+          else
+            echo "Error: Branch $BRANCH_NAME is not a release branch"
+            exit 1
+          fi
+      - name: 'Verify patch branch'
+        id: verify_patch_branch
+        if: github.event.inputs.enable_patch_build == 'true'
+        run: |
+          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
+          # Check its not an alpha build
+          if [[ $VERSION == *"alpha"* ]]; then
+            echo "Error: Branch $BRANCH_NAME is not a release branch"
+            exit 1
+          fi
+      - name: 'Generate image tag'
+        id: generate_image_tag
+        run: |
+          # Get the version from Cargo.toml
+          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          
+          # Get the commit SHA
+          COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+
+          # Get the tag from the input
+          TAG=${{ github.event.inputs.tag }}
+          # Check if the tag is empty
+          if [ -z "$TAG" ]; then
+            TAG="untagged"
+          fi
+
+          # Generate the image tag
+          IMAGE_TAG="v$VERSION-$TAG-$COMMIT_SHA"
+          
+          # Write the image tag to environment file
+          echo "IMAGE_TAG=$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+#      - name: 'Trigger Docker build Workflow via Buildkite'
+#        uses: buildkite/trigger-pipeline-action@v2.0.0
+#        with:
+#          buildkite_api_access_token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
+#          pipeline: 'docker'
+#          branch: ${{ env.BRANCH_NAME }}
+#          message: 'Triggering Docker build'
+#          env:
+#            IMAGE_TAG: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -39,9 +39,10 @@ jobs:
     # Checks that the branch is a release branch, by checking that the semver
     # should match: vX.Y.Z
     steps:
+      - uses: actions/checkout@v4
       - name: 'Verify release branch'
         id: verify_release_branch
-        if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
+        # if: github.event.inputs.enable_patch_build == 'false' && github.event.inputs.enable_alpha_build == 'false'
         run: |
           # Get current branch name
           BRANCH_NAME=$(echo $GITHUB_REF | cut -d '/' -f 3)
@@ -57,7 +58,7 @@ jobs:
           fi
       - name: 'Verify patch branch'
         id: verify_patch_branch
-        if: github.event.inputs.enable_patch_build == 'true'
+        # if: github.event.inputs.enable_patch_build == 'true'
         run: |
           VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2) 
           # Check its not an alpha build

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -8,6 +8,9 @@ auto-retry: &auto-retry
       limit: 3
 
 steps:
+  - label: "print image tag"
+    command: |
+      echo "IMAGE_TAG: $IMAGE_TAG"
   - label: "docker-build-push: amd64"
     if: build.env("SKIP_TARGET_AMD64") != "true"
     command: "ci/scripts/docker.sh"

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -10,7 +10,7 @@ auto-retry: &auto-retry
 steps:
   - label: "print image tag"
     command: |
-      echo "IMAGE_TAG: $IMAGE_TAG"
+      echo "IMAGE_TAG: ${IMAGE_TAG:-unset}"
   - label: "docker-build-push: amd64"
     if: build.env("SKIP_TARGET_AMD64") != "true"
     command: "ci/scripts/docker.sh"

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -8,9 +8,6 @@ auto-retry: &auto-retry
       limit: 3
 
 steps:
-  - label: "print image tag"
-    command: |
-      echo "IMAGE_TAG: ${IMAGE_TAG:-unset}"
   - label: "docker-build-push: amd64"
     if: build.env("SKIP_TARGET_AMD64") != "true"
     command: "ci/scripts/docker.sh"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Closes https://github.com/risingwavelabs/risingwave/issues/21601.

This PR reduces margin for human error due to manual tagging of images. It also makes tagging entirely optional. We can automatically generate semantically correct tagging after this PR:
```
v<X.Y.Z[-alpha]>--<label>--<commit_sha>--<git-branch>
```

We use `--`, to clearly delimit different sections. Since hyphens `-` can be used within each segment as well. It will only be a problem if developer uses `-` as a prefix or suffix. I think that's unlikely.

Test workflow dispatch via cli (actual use will just be via github UI for workflows, see screenshot below):
```sh
 gh workflow run 'Build Docker Image' --ref kwannoel/workflow-update-branch --field label='mylabel'
```

[example run](https://github.com/risingwavelabs/risingwave/actions/runs/14808598756/job/41580436686)

After this PR is merged, we can have a similar UX to this (we won't actual fill in a version, just an arbitrary tag, ignore that part):

![Screenshot 2025-04-29 at 4 52 32 PM](https://github.com/user-attachments/assets/2b2c6263-1940-4f89-b243-4dfa45f1cc97)

This gives us a "form-filling experience", as requested by @BugenZhao. It's inspired by the work by @arkbriar for image building in our other repositories.

Subsequently, I will add docs for how to use this workflow in our internal and developer docs.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
