### PR TITLE
refactor(storage): break down log epoch list into non-checkpoint and checkpoint

### DIFF
--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -167,7 +167,7 @@ impl CreatingStreamingJobControl {
 
     fn resolve_upstream_log_epochs(
         snapshot_backfill_upstream_tables: &HashSet<TableId>,
-        upstream_table_log_epochs: &HashMap<TableId, Vec<Vec<u64>>>,
+        upstream_table_log_epochs: &HashMap<TableId, Vec<(Vec<u64>, u64)>>,
         committed_epoch: u64,
         upstream_curr_epoch: u64,
     ) -> MetaResult<Vec<BarrierInfo>> {
@@ -175,18 +175,22 @@ impl CreatingStreamingJobControl {
         let table_id = snapshot_backfill_upstream_tables.iter().next().unwrap();
         let mut epochs_iter = upstream_table_log_epochs[table_id].iter();
         loop {
-            let epochs = epochs_iter.next().expect("not reach committed epoch yet");
-            if *epochs.last().unwrap() < committed_epoch {
+            let (_, checkpoint_epoch) = epochs_iter.next().expect("not reach committed epoch yet");
+            if *checkpoint_epoch < committed_epoch {
                 continue;
             }
-            assert_eq!(*epochs.last().unwrap(), committed_epoch);
+            assert_eq!(*checkpoint_epoch, committed_epoch);
             break;
         }
         let mut ret = vec![];
         let mut prev_epoch = committed_epoch;
         let mut pending_non_checkpoint_barriers = vec![];
-        for epochs in epochs_iter {
-            for (i, epoch) in epochs.iter().enumerate() {
+        for (non_checkpoint_epochs, checkpoint_epoch) in epochs_iter {
+            for (i, epoch) in non_checkpoint_epochs
+                .iter()
+                .chain([checkpoint_epoch])
+                .enumerate()
+            {
                 assert!(*epoch > prev_epoch);
                 pending_non_checkpoint_barriers.push(prev_epoch);
                 ret.push(BarrierInfo {
@@ -213,7 +217,7 @@ impl CreatingStreamingJobControl {
         job_id: TableId,
         definition: &String,
         snapshot_backfill_upstream_tables: &HashSet<TableId>,
-        upstream_table_log_epochs: &HashMap<TableId, Vec<Vec<u64>>>,
+        upstream_table_log_epochs: &HashMap<TableId, Vec<(Vec<u64>, u64)>>,
         backfill_epoch: u64,
         committed_epoch: u64,
         upstream_curr_epoch: u64,
@@ -253,7 +257,7 @@ impl CreatingStreamingJobControl {
 
     fn recover_consuming_log_store(
         snapshot_backfill_upstream_tables: &HashSet<TableId>,
-        upstream_table_log_epochs: &HashMap<TableId, Vec<Vec<u64>>>,
+        upstream_table_log_epochs: &HashMap<TableId, Vec<(Vec<u64>, u64)>>,
         committed_epoch: u64,
         upstream_curr_epoch: u64,
         stream_job_fragments: StreamJobFragments,
@@ -289,7 +293,7 @@ impl CreatingStreamingJobControl {
         job_id: TableId,
         definition: String,
         snapshot_backfill_upstream_tables: HashSet<TableId>,
-        upstream_table_log_epochs: &HashMap<TableId, Vec<Vec<u64>>>,
+        upstream_table_log_epochs: &HashMap<TableId, Vec<(Vec<u64>, u64)>>,
         backfill_epoch: u64,
         committed_epoch: u64,
         upstream_curr_epoch: u64,

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -106,7 +106,8 @@ struct BarrierWorkerRuntimeInfoSnapshot {
     active_streaming_nodes: ActiveStreamingWorkerNodes,
     database_job_infos: HashMap<DatabaseId, HashMap<TableId, InflightStreamingJobInfo>>,
     state_table_committed_epochs: HashMap<TableId, u64>,
-    state_table_log_epochs: HashMap<TableId, Vec<Vec<u64>>>,
+    /// `table_id` -> (Vec<non-checkpoint epoch>, checkpoint epoch)
+    state_table_log_epochs: HashMap<TableId, Vec<(Vec<u64>, u64)>>,
     subscription_infos: HashMap<DatabaseId, InflightSubscriptionInfo>,
     stream_actors: HashMap<ActorId, StreamActor>,
     fragment_relations: FragmentDownstreamRelation,
@@ -204,7 +205,8 @@ impl BarrierWorkerRuntimeInfoSnapshot {
 struct DatabaseRuntimeInfoSnapshot {
     job_infos: HashMap<TableId, InflightStreamingJobInfo>,
     state_table_committed_epochs: HashMap<TableId, u64>,
-    state_table_log_epochs: HashMap<TableId, Vec<Vec<u64>>>,
+    /// `table_id` -> (Vec<non-checkpoint epoch>, checkpoint epoch)
+    state_table_log_epochs: HashMap<TableId, Vec<(Vec<u64>, u64)>>,
     subscription_info: InflightSubscriptionInfo,
     stream_actors: HashMap<ActorId, StreamActor>,
     fragment_relations: FragmentDownstreamRelation,

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -106,7 +106,7 @@ struct BarrierWorkerRuntimeInfoSnapshot {
     active_streaming_nodes: ActiveStreamingWorkerNodes,
     database_job_infos: HashMap<DatabaseId, HashMap<TableId, InflightStreamingJobInfo>>,
     state_table_committed_epochs: HashMap<TableId, u64>,
-    /// `table_id` -> (Vec<non-checkpoint epoch>, checkpoint epoch)
+    /// `table_id` -> (`Vec<non-checkpoint epoch>`, checkpoint epoch)
     state_table_log_epochs: HashMap<TableId, Vec<(Vec<u64>, u64)>>,
     subscription_infos: HashMap<DatabaseId, InflightSubscriptionInfo>,
     stream_actors: HashMap<ActorId, StreamActor>,
@@ -205,7 +205,7 @@ impl BarrierWorkerRuntimeInfoSnapshot {
 struct DatabaseRuntimeInfoSnapshot {
     job_infos: HashMap<TableId, InflightStreamingJobInfo>,
     state_table_committed_epochs: HashMap<TableId, u64>,
-    /// `table_id` -> (Vec<non-checkpoint epoch>, checkpoint epoch)
+    /// `table_id` -> (`Vec<non-checkpoint epoch>`, checkpoint epoch)
     state_table_log_epochs: HashMap<TableId, Vec<(Vec<u64>, u64)>>,
     subscription_info: InflightSubscriptionInfo,
     stream_actors: HashMap<ActorId, StreamActor>,

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -458,7 +458,7 @@ impl ControlStreamManager {
         database_id: DatabaseId,
         jobs: HashMap<TableId, InflightStreamingJobInfo>,
         state_table_committed_epochs: &mut HashMap<TableId, u64>,
-        state_table_log_epochs: &mut HashMap<TableId, Vec<Vec<u64>>>,
+        state_table_log_epochs: &mut HashMap<TableId, Vec<(Vec<u64>, u64)>>,
         edges: &mut FragmentEdgeBuildResult,
         stream_actors: &HashMap<ActorId, StreamActor>,
         source_splits: &mut HashMap<ActorId, Vec<SplitImpl>>,

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -488,7 +488,8 @@ impl HummockVersion {
                         .map(|item| EpochNewChangeLogCommon {
                             new_value: std::mem::take(&mut item.new_value),
                             old_value: std::mem::take(&mut item.old_value),
-                            epochs: item.epochs.clone(),
+                            non_checkpoint_epochs: item.non_checkpoint_epochs.clone(),
+                            checkpoint_epoch: item.checkpoint_epoch,
                         });
                 table_change_log.insert(*table_id, TableChangeLogCommon::new(change_log_iter));
             }
@@ -1178,9 +1179,10 @@ impl From<HummockVersionDelta> for LocalHummockVersionDelta {
                         ChangeLogDeltaCommon {
                             truncate_epoch: v.truncate_epoch,
                             new_log: EpochNewChangeLogCommon {
-                                epochs: v.new_log.epochs,
                                 new_value: Vec::new(),
                                 old_value: Vec::new(),
+                                non_checkpoint_epochs: v.new_log.non_checkpoint_epochs,
+                                checkpoint_epoch: v.new_log.checkpoint_epoch,
                             },
                         },
                     )
@@ -1206,9 +1208,10 @@ impl From<HummockVersion> for LocalHummockVersion {
                     let epoch_new_change_logs: Vec<EpochNewChangeLogCommon<()>> = v
                         .change_log_into_iter()
                         .map(|epoch_new_change_log| EpochNewChangeLogCommon {
-                            epochs: epoch_new_change_log.epochs,
                             new_value: Vec::new(),
                             old_value: Vec::new(),
+                            non_checkpoint_epochs: epoch_new_change_log.non_checkpoint_epochs,
+                            checkpoint_epoch: epoch_new_change_log.checkpoint_epoch,
                         })
                         .collect();
                     (k, TableChangeLogCommon::new(epoch_new_change_logs))

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -1037,10 +1037,10 @@ impl HummockVersionReader {
 
         if let Some(max_epoch_change_log) = change_log.last() {
             let (_, max_epoch) = epoch_range;
-            if !max_epoch_change_log.epochs.contains(&max_epoch) {
+            if !max_epoch_change_log.epochs().contains(&max_epoch) {
                 warn!(
                     max_epoch,
-                    change_log_epochs = ?change_log.iter().flat_map(|epoch_log| epoch_log.epochs.iter()).collect_vec(),
+                    change_log_epochs = ?change_log.iter().flat_map(|epoch_log| epoch_log.epochs()).collect_vec(),
                     table_id = options.table_id.table_id,
                     "max_epoch does not exist"
                 );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously in L0 log store, we use a simple `Vec<u64>` to represent a group of epochs, where the last epoch is the checkpoint epoch, and the epochs at the front are non-checkpoint epochs in between. As suggested by @kwannoel , related code has poor readability. In this PR, we will explicitly break down the `Vec<u64>` into `(Vec<u64>, u64)`, which represents `(non-checkpoint epochs, checkpoint epoch)` to improve readability.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
