### PR TITLE
fix(frontend): correctly handle case-sensitive identifier (column name) during def purification

### DIFF
--- a/e2e_test/ddl/show_purify.slt
+++ b/e2e_test/ddl/show_purify.slt
@@ -36,3 +36,16 @@ public.ctas	CREATE TABLE ctas (v1 NUMERIC, v2 TIMESTAMP, v3 TIMESTAMP WITH TIME 
 
 statement ok
 drop table ctas;
+
+# Test quote & case-sensitivity when purifying definition.
+
+statement ok
+create table accounts ("accountId" string, data jsonb, primary key ("accountId"));
+
+query TT
+show create table accounts;
+----
+public.accounts	CREATE TABLE accounts ("accountId" CHARACTER VARYING, data JSONB, PRIMARY KEY ("accountId"))
+
+statement ok
+drop table accounts;

--- a/src/frontend/src/catalog/purify.rs
+++ b/src/frontend/src/catalog/purify.rs
@@ -97,7 +97,7 @@ pub fn try_purify_table_source_create_sql_ast(
 
             // Generate a new `ColumnDef` from the catalog.
             ColumnDef {
-                name: column.name().into(),
+                name: Ident::from_real_value(column.name()),
                 data_type: Some(column.data_type().to_ast()),
                 collation: None,
                 options: Vec::new(), // pk will be specified with table constraints
@@ -159,7 +159,14 @@ pub fn try_purify_table_source_create_sql_ast(
                     column.name()
                 );
             }
-            pk_columns.push(column.name().into());
+            // Find the name in `Ident` form from `column_defs` to preserve quote style best.
+            let name_ident = column_defs
+                .iter()
+                .find(|c| c.name.real_value() == column.name())
+                .unwrap()
+                .name
+                .clone();
+            pk_columns.push(name_ident);
         }
 
         let pk_constraint = TableConstraint::Unique {

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -179,12 +179,27 @@ impl Ident {
         }
     }
 
+    /// Convert a real value back to Ident. Behaves the same as SQL function `quote_ident`.
+    pub fn from_real_value(value: &str) -> Self {
+        let needs_quotes = value
+            .chars()
+            .any(|c| !matches!(c, 'a'..='z' | '0'..='9' | '_'));
+
+        if needs_quotes {
+            Self::with_quote_unchecked('"', value.replace('"', "\"\""))
+        } else {
+            Self::new_unchecked(value)
+        }
+    }
+
     pub fn quote_style(&self) -> Option<char> {
         self.quote_style
     }
 }
 
 impl From<&str> for Ident {
+    // FIXME: the result is wrong if value contains quote or is case sensitive,
+    //        should use `Ident::from_real_value` instead.
     fn from(value: &str) -> Self {
         Ident {
             value: value.to_owned(),


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

When purifying definition for tables/sources, we may need to convert a persisted `name: String` back to AST `name: Ident`. `impl From<&str> for Ident` was called for this process. However, its implementation is wrong due to not taking quote style or case-sensitivity into consideration, leading to issues like #21627.

This PR adds a new method `Ident::from_real_value` which provides correct conversion impl from `String` to `Ident`, thus fixes #21627.

Theoretically, we should replace `impl From<&str> for Ident` with this impl but there seemed to be a lot of issues to be addressed as attempted in https://github.com/risingwavelabs/risingwave/pull/19032. Therefore, simply left a `FIXME` in this PR.

The test case added has been tested to fail in release v2.3.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
