### PR TITLE
fix: Fix the issue of source split loss in sink into table

### DIFF
--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -150,7 +150,6 @@ impl CommandContext {
                 job_type,
                 cross_db_snapshot_backfill_info,
             } => {
-                let mut is_sink_into_table = false;
                 match job_type {
                     CreateStreamingJobType::SinkIntoTable(
                         replace_plan @ ReplaceStreamJobPlan {
@@ -161,7 +160,6 @@ impl CommandContext {
                             ..
                         },
                     ) => {
-                        is_sink_into_table = true;
                         barrier_manager_context
                             .metadata_manager
                             .catalog_controller


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

# Refactor CommandContext for SourceChange::CreateJob Handling

## Summary

This pull request refactors the handling of `SourceChange::CreateJob` within the `CommandContext` implementation. Key changes include:

- Removal of the conditional check for `is_sink_into_table`, streamlining the logic.
- Unconditional creation of the `source_change` variable, improving code clarity.
- `source_change` is now constructed using `added_source_fragments` and `added_backfill_fragments`.
- The application of `source_change` to `barrier_manager_context.source_manager` is now performed in a single operation.

These changes eliminate unnecessary conditional logic, enhancing the simplicity and readability of the code. Overall, this refactor aims to improve maintainability while preserving the existing functionality.


## Checklist

- [x] I have written necessary rustdoc comments.
