### PR TITLE
feat: print backtrace in pg_protocol in debug mode

### DIFF
--- a/ci/scripts/e2e-iceberg-test.sh
+++ b/ci/scripts/e2e-iceberg-test.sh
@@ -34,6 +34,10 @@ PGPASSWORD=postgres psql -h db -p 5432 -U postgres -c "DROP DATABASE IF EXISTS m
 risedev ci-start ci-iceberg-test
 
 
+unset BUILDKITE_PARALLEL_JOB
+unset BUILDKITE_PARALLEL_JOB_COUNT
+
+
 echo "--- Running tests"
 cd e2e_test/iceberg
 # Don't remove the `--quiet` option since poetry has a bug when printing output, see

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -246,7 +246,7 @@ steps:
           run: iceberg-test-env
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 22
-    parallelism: 2
+    parallelism: 20
     retry: *auto-retry
 
   - label: "end-to-end pulsar sink test"

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -381,7 +381,17 @@ where
             // Note: all messages will be processed through this code path, making it the
             //       only necessary place to log errors.
             if let Err(error) = &result {
-                tracing::error!(error = %error.as_report(), "error when process message");
+                if cfg!(debug_assertions) {
+                    // Print backtrace in debug mode.
+                    // Print it here is the last resort.
+                    // It's useful only when:
+                    // - no additional context is added to the error
+                    // - backtrace is captured in the error
+                    // - backtrace is not printed in the middle
+                    tracing::error!(error = ?error.as_report(), "error when process message");
+                } else {
+                    tracing::error!(error = %error.as_report(), "error when process message");
+                }
             }
 
             // Log to optionally-enabled target `PGWIRE_QUERY_LOG`.


### PR DESCRIPTION
While troubleshooting https://github.com/risingwavelabs/risingwave/issues/21751 , the error contains limited context, making it quite hard to debug.
```
2025-05-03T16:14:54.873906933Z ERROR handle_query: pgwire::pg_protocol: error when process message error=Failed to run the query: Scheduler error: Unexpected => try_lock failed because the operation would block mode="simple query" session_id=4 sql=SELECT count(*) FROM iceberg_t1_source
```

Signed-off-by: xxchan <xxchan22f@gmail.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
