### PR TITLE
feat(sqlsmith): support generation of jsonb_* table function

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,57 @@
+# To test: gh workflow run 'Build Docker Image' --ref kwannoel/workflow-update-branch
+name: Build Docker Image
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Generate image tag + build Docker image: v<X.Y.Z>--<label>--<commit_sha>--<branch>'
+        required: true
+        type: string
+        default: 'unlabeled'
+
+jobs:
+  build_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Generate image tag'
+        id: get_release_branch
+        run: |
+          # Get current branch name
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          echo "BRANCH_NAME=$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          echo "Replace / with - in branch name, for docker manifest requirement"
+          NO_SLASH_BRANCH_NAME=${BRANCH_NAME//\//-}
+          echo "NO_SLASH_BRANCH_NAME=$NO_SLASH_BRANCH_NAME"
+          echo "NO_SLASH_BRANCH_NAME=$NO_SLASH_BRANCH_NAME" >> $GITHUB_ENV
+
+          # Get version from Cargo.toml, e.g. v2.3.0-alpha
+          VERSION=$(grep -m 1 '^version' Cargo.toml | cut -d '"' -f 2)
+          echo "VERSION=$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          # Get the commit SHA
+          COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+          echo "COMMIT_SHA=$COMMIT_SHA"
+          echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
+
+          # Get the label from the input
+          LABEL=${{ github.event.inputs.label }}
+          echo "LABEL=$LABEL"
+          echo "LABEL=$LABEL" >> $GITHUB_ENV
+
+          # Build the image tag
+          IMAGE_TAG="v$VERSION--$LABEL--$COMMIT_SHA--$NO_SLASH_BRANCH_NAME"
+          echo "IMAGE_TAG=$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+      - name: 'Trigger Docker build Workflow via Buildkite'
+        uses: buildkite/trigger-pipeline-action@v2.0.0
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          pipeline: 'risingwavelabs/docker'
+          branch: ${{ env.BRANCH_NAME }}
+          commit: HEAD
+          message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}" }'

--- a/src/tests/sqlsmith/src/sql_gen/table_functions.rs
+++ b/src/tests/sqlsmith/src/sql_gen/table_functions.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use chrono::{Duration, NaiveDateTime};
-use rand::distr::Alphanumeric;
 use rand::Rng;
+use rand::distr::Alphanumeric;
 use risingwave_sqlparser::ast::{
     DataType as AstDataType, Expr, FunctionArg, ObjectName, TableAlias, TableFactor, Value,
 };
@@ -104,7 +104,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         (relation, table)
     }
 
-    /// Generates `JSONB_ARRARY_ELEMENTS`.
+    /// Generates `JSONB_ARRAY_ELEMENTS`.
     /// `JSONB_ARRAY_ELEMENTS(jsonb)`
     fn gen_jsonb_array_elements(&mut self) -> (TableFactor, Table) {
         let table_name = self.gen_table_name_with_prefix("jsonb_array_elements");
@@ -114,12 +114,17 @@ impl<R: Rng> SqlGenerator<'_, R> {
         let jsonb_expr = self.gen_jsonb(depth, JsonTopLevelKind::Array);
 
         let table = Table::new(table_name, vec![]);
-        let relation = create_tvf("jsonb_array_elements", alias, create_args(vec![jsonb_expr]), false);
+        let relation = create_tvf(
+            "jsonb_array_elements",
+            alias,
+            create_args(vec![jsonb_expr]),
+            false,
+        );
 
         (relation, table)
     }
 
-    /// Generates `JSONB_ARRARY_ELEMENTS_TEXT`.
+    /// Generates `JSONB_ARRAY_ELEMENTS_TEXT`.
     /// `JSONB_ARRAY_ELEMENTS_TEXT(jsonb)`
     fn gen_jsonb_array_elements_text(&mut self) -> (TableFactor, Table) {
         let table_name = self.gen_table_name_with_prefix("jsonb_array_elements_text");
@@ -129,7 +134,12 @@ impl<R: Rng> SqlGenerator<'_, R> {
         let jsonb_expr = self.gen_jsonb(depth, JsonTopLevelKind::Array);
 
         let table = Table::new(table_name, vec![]);
-        let relation = create_tvf("jsonb_array_elements_text", alias, create_args(vec![jsonb_expr]), false);
+        let relation = create_tvf(
+            "jsonb_array_elements_text",
+            alias,
+            create_args(vec![jsonb_expr]),
+            false,
+        );
 
         (relation, table)
     }
@@ -159,7 +169,12 @@ impl<R: Rng> SqlGenerator<'_, R> {
         let jsonb_expr = self.gen_jsonb(depth, JsonTopLevelKind::Object);
 
         let table = Table::new(table_name, vec![]);
-        let relation = create_tvf("jsonb_each_text", alias, create_args(vec![jsonb_expr]), false);
+        let relation = create_tvf(
+            "jsonb_each_text",
+            alias,
+            create_args(vec![jsonb_expr]),
+            false,
+        );
 
         (relation, table)
     }
@@ -174,7 +189,12 @@ impl<R: Rng> SqlGenerator<'_, R> {
         let jsonb_expr = self.gen_jsonb(depth, JsonTopLevelKind::Object);
 
         let table = Table::new(table_name, vec![]);
-        let relation = create_tvf("jsonb_object_keys", alias, create_args(vec![jsonb_expr]), false);
+        let relation = create_tvf(
+            "jsonb_object_keys",
+            alias,
+            create_args(vec![jsonb_expr]),
+            false,
+        );
 
         (relation, table)
     }
@@ -243,12 +263,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         }
     }
 
-    fn gen_json_value(
-        &mut self,
-        depth: usize,
-        max_depth: usize,
-        kind: JsonTopLevelKind,
-    ) -> String {
+    fn gen_json_value(&mut self, depth: usize, max_depth: usize, kind: JsonTopLevelKind) -> String {
         if depth >= max_depth {
             return match self.rng.random_range(0..=3) {
                 0 => format!("\"{}\"", self.gen_random_string()),
@@ -264,7 +279,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 _ => unreachable!(),
             };
         }
-    
+
         match if depth == 0 {
             match kind {
                 JsonTopLevelKind::Array => 4,
@@ -296,8 +311,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 let fields: Vec<String> = (0..len)
                     .map(|_| {
                         let key = self.gen_random_string();
-                        let val =
-                            self.gen_json_value(depth + 1, max_depth, JsonTopLevelKind::Any);
+                        let val = self.gen_json_value(depth + 1, max_depth, JsonTopLevelKind::Any);
                         format!("\"{}\":{}", key, val)
                     })
                     .collect();
@@ -305,7 +319,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
             }
             _ => unreachable!(),
         }
-    }    
+    }
 
     fn gen_random_string(&mut self) -> String {
         let len = self.rng.random_range(3..8);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Add support for generating jsonb_* table functions in Sqlsmith, including `jsonb_array_elements`, `jsonb_array_elements_text`, `jsonb_each`, `jsonb_each_text` and `jsonb_objective_keys`. 

Since some functions (e.g., jsonb_array_elements, jsonb_each) require a specific top-level Jsonb structure—such as an array or object, we first determine the expected top-level type. Then, we recursively generate the Jsonb value under depth control. 

Fixes part of #4540 

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
