### PR TITLE
feat(frontend): support sink_decouple for sink into table

### DIFF
--- a/e2e_test/sink/sink_into_table/decoupled.slt
+++ b/e2e_test/sink/sink_into_table/decoupled.slt
@@ -1,0 +1,70 @@
+statement ok
+DROP TABLE IF EXISTS s1_target cascade;
+
+statement ok
+DROP TABLE IF EXISTS fact;
+
+statement ok
+DROP TABLE IF EXISTS dim;
+
+statement ok
+set sink_decouple = true;
+
+statement ok
+create table fact(v0 int primary key, v1 int, v2 varchar, v3 varchar);
+
+# correspond to 1
+statement ok
+INSERT INTO fact
+  SELECT
+    x as v0,
+    1 as v1,
+    'abcdefgakjandjkw' as v2,
+    'jkb1ku1bu' as v3
+  FROM generate_series(1, 200000) t(x);
+
+# correspond to 2
+statement ok
+INSERT INTO fact
+  SELECT
+    x as v0,
+    2 as v1,
+    'abcdefgakjandjkw' as v2,
+    'jkb1ku1bu' as v3
+  FROM generate_series(200001, 400000) t(x);
+
+statement ok
+create table dim(v1 int);
+
+statement ok
+INSERT INTO dim VALUES(1), (2);
+
+statement ok
+create table s1_target(v0 int primary key, v1 int, v2 varchar, v3 varchar, dim_v1 int);
+
+statement ok
+CREATE SINK s1 INTO s1_target as
+SELECT v0, fact.v1 as v1, v2, v3, dim.v1 as dim_v1
+FROM fact
+JOIN dim ON fact.v1 = dim.v1;
+
+statement ok
+create materialized view m1 as
+  select v0, count(*)
+  from s1_target
+  group by v0;
+
+statement ok
+DELETE FROM dim;
+
+statement ok
+flush;
+
+statement ok
+DROP TABLE s1_target cascade;
+
+statement ok
+DROP TABLE fact cascade;
+
+statement ok
+DROP TABLE dim cascade;

--- a/src/connector/src/sink/trivial.rs
+++ b/src/connector/src/sink/trivial.rs
@@ -72,8 +72,9 @@ impl<T: TrivialSinkName> Sink for TrivialSink<T> {
     const SINK_NAME: &'static str = T::SINK_NAME;
 
     // Disable sink decoupling for all trivial sinks because it introduces overhead without any benefit
-    fn is_sink_decouple(_user_specified: &SinkDecouple) -> Result<bool> {
-        Ok(false)
+    fn is_sink_decouple(user_specified: &SinkDecouple) -> Result<bool> {
+        // TODO(kwannoel): also enable by default, once it's shown to be stable
+        Ok(T::SINK_NAME == TABLE_SINK && matches!(user_specified, SinkDecouple::Enable))
     }
 
     async fn new_log_sinker(&self, _writer_env: SinkWriterParam) -> Result<Self::LogSinker> {

--- a/src/connector/src/sink/trivial.rs
+++ b/src/connector/src/sink/trivial.rs
@@ -71,7 +71,8 @@ impl<T: TrivialSinkName> Sink for TrivialSink<T> {
 
     const SINK_NAME: &'static str = T::SINK_NAME;
 
-    // Disable sink decoupling for all trivial sinks because it introduces overhead without any benefit
+    /// Enable sink decoupling for sink-into-table.
+    /// Disable sink decoupling for blackhole sink. It introduces overhead without any benefit
     fn is_sink_decouple(user_specified: &SinkDecouple) -> Result<bool> {
         // TODO(kwannoel): also enable by default, once it's shown to be stable
         Ok(T::SINK_NAME == TABLE_SINK && matches!(user_specified, SinkDecouple::Enable))

--- a/src/frontend/planner_test/tests/testdata/input/sink_into_table.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/sink_into_table.yaml
@@ -21,3 +21,11 @@
     explain create sink s into t1 as select b from t2;
   expected_outputs:
     - explain_output
+- id: create decoupled sink into table
+  sql: |
+    create table t1 (a int primary key, b int);
+    create table t2 (a int, b int primary key);
+    set sink_decouple = true;
+    explain create sink s into t1 from t2;
+  expected_outputs:
+    - explain_output

--- a/src/frontend/planner_test/tests/testdata/output/sink_into_table.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink_into_table.yaml
@@ -29,3 +29,15 @@
     StreamProject { exprs: [t2.b, null:Int32] }
     └─StreamSink { type: upsert, columns: [b], downstream_pk: [t2.b] }
       └─StreamTableScan { table: t2, columns: [b] }
+- id: create decoupled sink into table
+  sql: |
+    create table t1 (a int primary key, b int);
+    create table t2 (a int, b int primary key);
+    set sink_decouple = true;
+    explain create sink s into t1 from t2;
+  explain_output: |
+    StreamProject { exprs: [t2.a, t2.b] }
+    └─StreamSink { type: upsert, columns: [a, b], downstream_pk: [t2.a] }
+      └─StreamSyncLogStore { buffer_size: 2048, pause_duration_ms: 64 }
+        └─StreamExchange { dist: HashShard(t2.a) }
+          └─StreamTableScan { table: t2, columns: [a, b] }

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -430,8 +430,6 @@ impl StreamSink {
         };
 
         // sink into table should have logstore for sink_decouple
-        println!("any target table: {:?}", target_table.is_some());
-        println!("sink decouple: {:?}", sink_decouple);
         let input = if sink_decouple && target_table.is_some() {
             StreamSyncLogStore::new(input).into()
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

https://github.com/risingwavelabs/risingwave/issues/19285

Use it when sink_decouple is set to true for sink into table. This is supported by placing a logstore before the sink.
```
upstream -> logstore -> sink -> rw table
```

We don't enable `sink_decouple` by default for `sink into table`. But it's available if the user specifies `sink_decouple=true`.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
