### PR TITLE
fix: print `AlterSinkOperation::SetSinkProps` correctly

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -858,6 +858,8 @@ category = "RiseDev - Build"
 dependencies = ["prepare"]
 condition = { env_set = [
     "ENABLE_BUILD_RW_CONNECTOR",
+], env_not_set = [
+    "USE_SYSTEM_RISINGWAVE",
 ], files_modified = { input = [
     "./java/connector-node/**/*",
 ], output = [

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -478,7 +478,7 @@ impl fmt::Display for AlterSinkOperation {
                 write!(f, "SET SINK_RATE_LIMIT TO {}", rate_limit)
             }
             AlterSinkOperation::SetSinkProps { changed_props } => {
-                write!(f, "CONNECTOR WITH {:?}", changed_props)
+                write!(f, "CONNECTOR WITH ({})", display_comma_separated(changed_props))
             }
         }
     }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -478,7 +478,11 @@ impl fmt::Display for AlterSinkOperation {
                 write!(f, "SET SINK_RATE_LIMIT TO {}", rate_limit)
             }
             AlterSinkOperation::SetSinkProps { changed_props } => {
-                write!(f, "CONNECTOR WITH ({})", display_comma_separated(changed_props))
+                write!(
+                    f,
+                    "CONNECTOR WITH ({})",
+                    display_comma_separated(changed_props)
+                )
             }
         }
     }

--- a/src/sqlparser/tests/testdata/alter.yaml
+++ b/src/sqlparser/tests/testdata/alter.yaml
@@ -9,3 +9,5 @@
   formatted_sql: ALTER SYSTEM SET a = DEFAULT
 - input: ALTER SOURCE t ADD COLUMN id INT;
   formatted_sql: ALTER SOURCE t ADD COLUMN id INT
+- input: ALTER SINK t_sink CONNECTOR WITH (properties.allow.auto.create.topics = 'true');
+  formatted_sql:  ALTER SINK t_sink CONNECTOR WITH (properties.allow.auto.create.topics = 'true')


### PR DESCRIPTION
…eses for changed properties

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

as title 

introduced in https://github.com/risingwavelabs/risingwave/pull/20691

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
