### PR TITLE
fix(ci): increase wait time for doris to be ready in `e2e-doris-sink` test

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ What sets RisingWave apart is its integrated storage engine:
 
 * **Online serving:** Row-based storage optimized for point and range queries with single-digit millisecond latency.
 * **Offline persistence:** Built-in Apache Iceberg™ integration for low-cost, durable storage with open access for external query engines.
-  
+
 With RisingWave, real-time data isn’t just processed — it’s stored, queried, and shared across your entire stack.
 
 ## Key design decisions

--- a/ci/scripts/e2e-doris-sink-test.sh
+++ b/ci/scripts/e2e-doris-sink-test.sh
@@ -25,10 +25,9 @@ download_and_prepare_rw "$profile" source
 
 echo "--- starting risingwave cluster"
 risedev ci-start ci-sink-test
-sleep 1
 
 echo "--- create doris table"
-sleep 2
+sleep 10 # Wait for doris to start. TODO: shall we use `service_healthy` condition in docker-compose.yml?
 mysql -uroot -P 9030 -h doris-server -e "CREATE database demo;use demo;
 CREATE table demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 datev2,v8 datetime,v9 boolean,v10 json) UNIQUE KEY(\`v1\`)
 DISTRIBUTED BY HASH(\`v1\`) BUCKETS 1


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

In #21730, we removed the unnecessary `apt install` line before issuing DDL to the Doris server. Then, we started to encounter #21806. I believe this is because we need to allow the server some time to be ready for connection.

A better approach might be to wait for the service to be ready before executing the CI script, by requiring `service_healthy` condition in `depends_on` list in `docker-compose.yml`. However, this may increase the startup time of other CI steps.

https://docs.docker.com/compose/how-tos/startup-order/

Close #21806

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
