### PR TITLE
feat(frontend): plan backfill order strategy after the planner phase, instead of binding phase

### DIFF
--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -25,7 +25,6 @@ use risingwave_sqlparser::ast::{Expr as AstExpr, SelectItem, SetExpr, Statement}
 
 use crate::error::Result;
 
-mod backfill_order_strategy;
 mod bind_context;
 mod bind_param;
 mod create;
@@ -45,7 +44,6 @@ mod struct_field;
 mod update;
 mod values;
 
-pub use backfill_order_strategy::bind_backfill_order_strategy;
 pub use bind_context::{BindContext, Clause, LateralBindContext};
 pub use create_view::BoundCreateView;
 pub use delete::BoundDelete;

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -21,7 +21,6 @@ use risingwave_pb::catalog::PbTable;
 use risingwave_pb::serverless_backfill_controller::{
     ProvisionRequest, node_group_controller_service_client,
 };
-use risingwave_pb::stream_plan::BackfillOrderStrategy as PbBackfillOrderStrategy;
 use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, Query};
 use thiserror_ext::AsReport;
 
@@ -160,19 +159,13 @@ pub async fn handle_create_mv(
     columns: Vec<Ident>,
     emit_mode: Option<EmitMode>,
 ) -> Result<RwPgResponse> {
-    let (dependent_relations, dependent_udfs, bound_query, backfill_order_strategy) = {
+    let (dependent_relations, dependent_udfs, bound_query) = {
         let mut binder = Binder::new_for_stream(handler_args.session.as_ref());
         let bound_query = binder.bind_query(query)?;
-        let backfill_order_strategy = bind_backfill_order_strategy(
-            handler_args.session.as_ref(),
-            handler_args.with_options.backfill_order_strategy(),
-        )?;
-
         (
             binder.included_relations().clone(),
             binder.included_udfs().clone(),
             bound_query,
-            backfill_order_strategy,
         )
     };
     handle_create_mv_bound(
@@ -184,7 +177,6 @@ pub async fn handle_create_mv(
         dependent_udfs,
         columns,
         emit_mode,
-        backfill_order_strategy,
     )
     .await
 }
@@ -228,7 +220,6 @@ pub async fn handle_create_mv_bound(
     dependent_udfs: HashSet<FunctionId>, // TODO(rc): merge with `dependent_relations`
     columns: Vec<Ident>,
     emit_mode: Option<EmitMode>,
-    backfill_order_strategy: PbBackfillOrderStrategy,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
 
@@ -319,8 +310,15 @@ It only indicates the physical clustering of the data, which may improve the per
             return Err(RwError::from(ProtocolError("The session config arrangement backfill must be enabled to use the resource_group option".to_owned())));
         }
 
+        let context: OptimizerContextRef = context.into();
+
         let (plan, table) =
-            gen_create_mv_plan_bound(&session, context.into(), query, name, columns, emit_mode)?;
+            gen_create_mv_plan_bound(&session, context.clone(), query, name, columns, emit_mode)?;
+
+        let backfill_order_strategy = bind_backfill_order_strategy(
+            context.session_ctx().as_ref(),
+            context.with_options().backfill_order_strategy(),
+        )?;
 
         // TODO(rc): To be consistent with UDF dependency check, we should collect relation dependencies
         // during binding instead of visiting the optimized plan.

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -26,11 +26,12 @@ use thiserror_ext::AsReport;
 
 use super::RwPgResponse;
 use crate::WithOptions;
-use crate::binder::{Binder, BoundQuery, BoundSetExpr, bind_backfill_order_strategy};
+use crate::binder::{Binder, BoundQuery, BoundSetExpr};
 use crate::catalog::check_column_name_not_reserved;
 use crate::error::ErrorCode::{InvalidInputSyntax, ProtocolError};
 use crate::error::{ErrorCode, Result, RwError};
 use crate::handler::HandlerArgs;
+use crate::optimizer::backfill_order_strategy::plan_backfill_order_strategy;
 use crate::optimizer::plan_node::Explain;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::{OptimizerContext, OptimizerContextRef, PlanRef, RelationCollectorVisitor};
@@ -315,7 +316,7 @@ It only indicates the physical clustering of the data, which may improve the per
         let (plan, table) =
             gen_create_mv_plan_bound(&session, context.clone(), query, name, columns, emit_mode)?;
 
-        let backfill_order_strategy = bind_backfill_order_strategy(
+        let backfill_order_strategy = plan_backfill_order_strategy(
             context.session_ctx().as_ref(),
             context.with_options().backfill_order_strategy(),
         )?;

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -25,7 +25,6 @@ use risingwave_common::bail_not_implemented;
 use risingwave_common::catalog::{FunctionId, Schema};
 use risingwave_common::session_config::QueryMode;
 use risingwave_common::types::{DataType, Datum};
-use risingwave_pb::stream_plan::BackfillOrderStrategy;
 use risingwave_sqlparser::ast::{SetExpr, Statement};
 
 use super::extended_handle::{PortalResult, PrepareStatement, PreparedResult};
@@ -145,10 +144,6 @@ pub async fn handle_execute(
                 with_options: crate::WithOptions::try_from(with_options.as_slice())?,
             };
 
-            // FIXME(kwannoel): We should probably bind it.
-            let strategy = None;
-            let backfill_order_strategy = BackfillOrderStrategy { strategy };
-
             create_mv::handle_create_mv_bound(
                 handler_args,
                 if_not_exists,
@@ -158,7 +153,6 @@ pub async fn handle_execute(
                 dependent_udfs,
                 columns,
                 emit_mode,
-                backfill_order_strategy,
             )
             .await
         }

--- a/src/frontend/src/optimizer/backfill_order_strategy.rs
+++ b/src/frontend/src/optimizer/backfill_order_strategy.rs
@@ -35,7 +35,7 @@ use crate::session::SessionImpl;
 /// We only bind tables, materialized views and sources.
 /// Queries won't bind duplicate relations in the same query context.
 /// But backfill order strategy can have duplicate relations.
-pub fn bind_backfill_order_strategy(
+pub fn plan_backfill_order_strategy(
     session: &SessionImpl,
     backfill_order_strategy: BackfillOrderStrategy,
 ) -> Result<PbBackfillOrderStrategy> {

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -35,6 +35,7 @@ pub use plan_visitor::{
     SysTableVisitor,
 };
 
+pub mod backfill_order_strategy;
 mod logical_optimization;
 mod optimizer_context;
 pub mod plan_expr_rewriter;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR is in preparation for https://github.com/risingwavelabs/risingwave/pull/21814. To auto-derive backfill order, we need the stream plan, which is produced only after the planning phase.

So we do two things here:
1. Refactor the planning for backfill order strategy after binding.
2. Move the module for backfill order strategy planning into the **optimizer**. This makes more sense, since this is no longer purely binding user input. Rather we are optimizing the backfill order.

We intentionally keep this PR separate from #21814, since we refactor file paths. To keep diffs clean, we should have the files in separate PRs.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
