### PR TITLE
feat(frontend): auto derive backfill order

### DIFF
--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -319,6 +319,7 @@ It only indicates the physical clustering of the data, which may improve the per
         let backfill_order_strategy = plan_backfill_order_strategy(
             context.session_ctx().as_ref(),
             context.with_options().backfill_order_strategy(),
+            plan.clone(),
         )?;
 
         // TODO(rc): To be consistent with UDF dependency check, we should collect relation dependencies

--- a/src/frontend/src/optimizer/backfill_order_strategy.rs
+++ b/src/frontend/src/optimizer/backfill_order_strategy.rs
@@ -364,11 +364,14 @@ mod common {
     }
 }
 
-// FIXME(kwannoel): we can flatten the strategy earlier
-/// We don't use query binder directly because its binding rules are different from a query.
-/// We only bind tables, materialized views and sources.
-/// Queries won't bind duplicate relations in the same query context.
-/// But backfill order strategy can have duplicate relations.
+/// We only bind tables and materialized views.
+/// We need to bind sources and indices in the future as well.
+/// For auto backfill strategy,
+/// if a cycle forms due to the same relation being scanned twice in the derived order,
+/// we won't generate any backfill order strategy.
+/// For fixed backfill strategy,
+/// for scans on the same relation id, even though they may be in different fragments,
+/// they will all share the same backfill order.
 pub fn plan_backfill_order_strategy(
     session: &SessionImpl,
     backfill_order_strategy: BackfillOrderStrategy,

--- a/src/frontend/src/optimizer/backfill_order_strategy.rs
+++ b/src/frontend/src/optimizer/backfill_order_strategy.rs
@@ -12,21 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
-
-use risingwave_common::catalog::ObjectId;
-use risingwave_pb::common::Uint32Vector;
 use risingwave_pb::stream_plan::BackfillOrderStrategy as PbBackfillOrderStrategy;
-use risingwave_sqlparser::ast::{BackfillOrderStrategy, ObjectName};
+use risingwave_sqlparser::ast::BackfillOrderStrategy;
 
-use crate::catalog::CatalogError;
-use crate::catalog::root_catalog::SchemaPath;
-use crate::catalog::schema_catalog::SchemaCatalog;
+use crate::PlanRef;
 use crate::error::Result;
 use crate::optimizer::backfill_order_strategy::auto::plan_auto_strategy;
 use crate::optimizer::backfill_order_strategy::fixed::plan_fixed_strategy;
 use crate::session::SessionImpl;
-use crate::{Binder, PlanRef};
 
 mod auto {
     use std::collections::{HashMap, HashSet};
@@ -236,7 +229,9 @@ mod fixed {
     use risingwave_pb::stream_plan::backfill_order_strategy::Strategy as PbStrategy;
     use risingwave_sqlparser::ast::ObjectName;
 
-    use crate::optimizer::backfill_order_strategy::{bind_backfill_relation_id_by_name, has_cycle};
+    use crate::optimizer::backfill_order_strategy::common::{
+        bind_backfill_relation_id_by_name, has_cycle,
+    };
     use crate::session::SessionImpl;
 
     pub(super) fn plan_fixed_strategy(
@@ -260,6 +255,106 @@ mod fixed {
     }
 }
 
+mod common {
+    use std::collections::{HashMap, HashSet};
+
+    use risingwave_common::catalog::ObjectId;
+    use risingwave_pb::common::Uint32Vector;
+    use risingwave_sqlparser::ast::ObjectName;
+
+    use crate::Binder;
+    use crate::catalog::CatalogError;
+    use crate::catalog::root_catalog::SchemaPath;
+    use crate::catalog::schema_catalog::SchemaCatalog;
+    use crate::session::SessionImpl;
+
+    /// Check if the backfill order has a cycle.
+    pub(super) fn has_cycle(order: &HashMap<ObjectId, Uint32Vector>) -> bool {
+        fn dfs(
+            node: ObjectId,
+            order: &HashMap<ObjectId, Uint32Vector>,
+            visited: &mut HashSet<ObjectId>,
+            stack: &mut HashSet<ObjectId>,
+        ) -> bool {
+            if stack.contains(&node) {
+                return true; // Cycle detected
+            }
+
+            if visited.insert(node) {
+                stack.insert(node);
+                if let Some(downstreams) = order.get(&node) {
+                    for neighbor in &downstreams.data {
+                        if dfs(*neighbor, order, visited, stack) {
+                            return true;
+                        }
+                    }
+                }
+                stack.remove(&node);
+            }
+            false
+        }
+
+        let mut visited = HashSet::new();
+        let mut stack = HashSet::new();
+        for &start in order.keys() {
+            if dfs(start, order, &mut visited, &mut stack) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub(super) fn bind_backfill_relation_id_by_name(
+        session: &SessionImpl,
+        name: ObjectName,
+    ) -> crate::error::Result<ObjectId> {
+        let (db_name, schema_name, rel_name) = Binder::resolve_db_schema_qualified_name(name)?;
+        let db_name = db_name.unwrap_or(session.database());
+
+        let reader = session.env().catalog_reader().read_guard();
+
+        match schema_name {
+            Some(name) => {
+                let schema_catalog = reader.get_schema_by_name(&db_name, &name)?;
+                bind_table(schema_catalog, &rel_name)
+            }
+            None => {
+                let search_path = session.config().search_path();
+                let user_name = session.user_name();
+                let schema_path = SchemaPath::Path(&search_path, &user_name);
+                let result: crate::error::Result<Option<(ObjectId, &str)>> =
+                    schema_path.try_find(|schema_name| {
+                        if let Ok(schema_catalog) = reader.get_schema_by_name(&db_name, schema_name)
+                            && let Ok(relation_id) = bind_table(schema_catalog, &rel_name)
+                        {
+                            Ok(Some(relation_id))
+                        } else {
+                            Ok(None)
+                        }
+                    });
+                if let Some((relation_id, _schema_name)) = result? {
+                    return Ok(relation_id);
+                }
+                Err(CatalogError::NotFound("table", rel_name.to_owned()).into())
+            }
+        }
+    }
+
+    fn bind_table(schema_catalog: &SchemaCatalog, name: &String) -> crate::error::Result<ObjectId> {
+        if let Some(table) = schema_catalog.get_created_table_or_any_internal_table_by_name(name) {
+            Ok(table.id().table_id)
+        } else {
+            Err(CatalogError::NotFound("table", name.to_owned()).into())
+        }
+        // TODO: support source catalog
+        // else if let Some(source) = schema_catalog.get_source_by_name(name) {
+        //     Ok(source.id)
+        // }
+        // Err(CatalogError::NotFound("table or source", name.to_owned()).into())
+    }
+}
+
 // FIXME(kwannoel): we can flatten the strategy earlier
 /// We don't use query binder directly because its binding rules are different from a query.
 /// We only bind tables, materialized views and sources.
@@ -278,86 +373,4 @@ pub fn plan_backfill_order_strategy(
     Ok(PbBackfillOrderStrategy {
         strategy: pb_strategy,
     })
-}
-
-/// Check if the backfill order has a cycle.
-fn has_cycle(order: &HashMap<ObjectId, Uint32Vector>) -> bool {
-    fn dfs(
-        node: ObjectId,
-        order: &HashMap<ObjectId, Uint32Vector>,
-        visited: &mut HashSet<ObjectId>,
-        stack: &mut HashSet<ObjectId>,
-    ) -> bool {
-        if stack.contains(&node) {
-            return true; // Cycle detected
-        }
-
-        if visited.insert(node) {
-            stack.insert(node);
-            if let Some(downstreams) = order.get(&node) {
-                for neighbor in &downstreams.data {
-                    if dfs(*neighbor, order, visited, stack) {
-                        return true;
-                    }
-                }
-            }
-            stack.remove(&node);
-        }
-        false
-    }
-
-    let mut visited = HashSet::new();
-    let mut stack = HashSet::new();
-    for &start in order.keys() {
-        if dfs(start, order, &mut visited, &mut stack) {
-            return true;
-        }
-    }
-
-    false
-}
-
-fn bind_backfill_relation_id_by_name(session: &SessionImpl, name: ObjectName) -> Result<ObjectId> {
-    let (db_name, schema_name, rel_name) = Binder::resolve_db_schema_qualified_name(name)?;
-    let db_name = db_name.unwrap_or(session.database());
-
-    let reader = session.env().catalog_reader().read_guard();
-
-    match schema_name {
-        Some(name) => {
-            let schema_catalog = reader.get_schema_by_name(&db_name, &name)?;
-            bind_table(schema_catalog, &rel_name)
-        }
-        None => {
-            let search_path = session.config().search_path();
-            let user_name = session.user_name();
-            let schema_path = SchemaPath::Path(&search_path, &user_name);
-            let result: Result<Option<(ObjectId, &str)>> = schema_path.try_find(|schema_name| {
-                if let Ok(schema_catalog) = reader.get_schema_by_name(&db_name, schema_name)
-                    && let Ok(relation_id) = bind_table(schema_catalog, &rel_name)
-                {
-                    Ok(Some(relation_id))
-                } else {
-                    Ok(None)
-                }
-            });
-            if let Some((relation_id, _schema_name)) = result? {
-                return Ok(relation_id);
-            }
-            Err(CatalogError::NotFound("table", rel_name.to_owned()).into())
-        }
-    }
-}
-
-fn bind_table(schema_catalog: &SchemaCatalog, name: &String) -> Result<ObjectId> {
-    if let Some(table) = schema_catalog.get_created_table_or_any_internal_table_by_name(name) {
-        Ok(table.id().table_id)
-    } else {
-        Err(CatalogError::NotFound("table", name.to_owned()).into())
-    }
-    // TODO: support source catalog
-    // else if let Some(source) = schema_catalog.get_source_by_name(name) {
-    //     Ok(source.id)
-    // }
-    // Err(CatalogError::NotFound("table or source", name.to_owned()).into())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds the `backfill_order = auto` option when creating materialized views. It focuses on filling right-side tables first (usually smaller lookup tables) and constructs a partial order, which allows for concurrent backfill on incomparable elements (elements which have no dependencies on each other).

We handle the common cases of:
- stream scan
- join
- union

And leave the rest for further improvement.

For tests, please checkout the downstream PR: https://github.com/risingwavelabs/risingwave/pull/21838

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
