### PR TITLE
refactor(frontend,proto): remove unused `auto` variant for backfill order strategy

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1050,17 +1050,8 @@ message StreamContext {
   string timezone = 1;
 }
 
-message BackfillOrderAuto {}
-
-message BackfillOrderFixed {
+message BackfillOrder {
   map<uint32, common.Uint32Vector> order = 1;
-}
-
-message BackfillOrderStrategy {
-  oneof strategy {
-    BackfillOrderAuto auto = 1;
-    BackfillOrderFixed fixed = 2;
-  }
 }
 
 // Representation of a graph of stream fragments.
@@ -1126,5 +1117,5 @@ message StreamFragmentGraph {
   uint32 max_parallelism = 7;
 
   // The backfill order strategy for the fragments.
-  BackfillOrderStrategy backfill_order_strategy = 8;
+  BackfillOrder backfill_order = 8;
 }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -31,7 +31,7 @@ use crate::catalog::check_column_name_not_reserved;
 use crate::error::ErrorCode::{InvalidInputSyntax, ProtocolError};
 use crate::error::{ErrorCode, Result, RwError};
 use crate::handler::HandlerArgs;
-use crate::optimizer::backfill_order_strategy::plan_backfill_order_strategy;
+use crate::optimizer::backfill_order_strategy::plan_backfill_order;
 use crate::optimizer::plan_node::Explain;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::{OptimizerContext, OptimizerContextRef, PlanRef, RelationCollectorVisitor};
@@ -316,7 +316,7 @@ It only indicates the physical clustering of the data, which may improve the per
         let (plan, table) =
             gen_create_mv_plan_bound(&session, context.clone(), query, name, columns, emit_mode)?;
 
-        let backfill_order_strategy = plan_backfill_order_strategy(
+        let backfill_order = plan_backfill_order(
             context.session_ctx().as_ref(),
             context.with_options().backfill_order_strategy(),
             plan.clone(),
@@ -338,7 +338,7 @@ It only indicates the physical clustering of the data, which may improve the per
         let graph = build_graph_with_strategy(
             plan,
             Some(GraphJobType::MaterializedView),
-            Some(backfill_order_strategy),
+            Some(backfill_order),
         )?;
 
         (table, graph, dependencies, resource_group)

--- a/src/frontend/src/stream_fragmenter/graph/fragment_graph.rs
+++ b/src/frontend/src/stream_fragmenter/graph/fragment_graph.rs
@@ -19,8 +19,7 @@ use risingwave_pb::stream_plan::stream_fragment_graph::{
     StreamFragment as StreamFragmentProto, StreamFragmentEdge as StreamFragmentEdgeProto,
 };
 use risingwave_pb::stream_plan::{
-    BackfillOrderStrategy, DispatchStrategy, FragmentTypeFlag,
-    StreamFragmentGraph as StreamFragmentGraphProto, StreamNode,
+    DispatchStrategy, FragmentTypeFlag, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode,
 };
 use thiserror_ext::AsReport;
 
@@ -110,7 +109,7 @@ impl StreamFragmentGraph {
             table_ids_cnt: 0,
             parallelism: None,
             max_parallelism: 0,
-            backfill_order_strategy: Some(BackfillOrderStrategy { strategy: None }),
+            backfill_order: Default::default(),
         }
     }
 

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -30,9 +30,8 @@ use risingwave_common::session_config::SessionConfig;
 use risingwave_common::session_config::parallelism::ConfigParallelism;
 use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::{
-    BackfillOrderStrategy, DispatchStrategy, DispatcherType, ExchangeNode, FragmentTypeFlag,
-    NoOpNode, StreamContext, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode,
-    StreamScanType,
+    BackfillOrder, DispatchStrategy, DispatcherType, ExchangeNode, FragmentTypeFlag, NoOpNode,
+    StreamContext, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamScanType,
 };
 
 use self::rewrite::build_delta_join_without_arrange;
@@ -153,7 +152,7 @@ pub fn build_graph(
 pub fn build_graph_with_strategy(
     plan_node: PlanRef,
     job_type: Option<GraphJobType>,
-    backfill_order_strategy: Option<BackfillOrderStrategy>,
+    backfill_order: Option<BackfillOrder>,
 ) -> SchedulerResult<StreamFragmentGraphProto> {
     let ctx = plan_node.plan_base().ctx();
     let plan_node = reorganize_elements_id(plan_node);
@@ -186,7 +185,7 @@ pub fn build_graph_with_strategy(
         timezone: ctx.get_session_timezone(),
     });
 
-    fragment_graph.backfill_order_strategy = backfill_order_strategy;
+    fragment_graph.backfill_order = backfill_order;
 
     Ok(fragment_graph)
 }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -181,7 +181,7 @@ pub struct CreateStreamingJobCommandInfo {
     pub create_type: CreateType,
     pub streaming_job: StreamingJob,
     pub internal_tables: Vec<Table>,
-    pub fragment_backfill_ordering: Option<FragmentBackfillOrder>,
+    pub fragment_backfill_ordering: FragmentBackfillOrder,
 }
 
 impl StreamJobFragments {
@@ -736,12 +736,10 @@ impl Command {
                     } else {
                         Default::default()
                     };
-                let backfill_nodes_to_pause: Vec<_> = match fragment_backfill_ordering {
-                    Some(backfill_order) => get_nodes_with_backfill_dependencies(backfill_order)
+                let backfill_nodes_to_pause: Vec<_> =
+                    get_nodes_with_backfill_dependencies(fragment_backfill_ordering)
                         .into_iter()
-                        .collect(),
-                    None => Default::default(),
-                };
+                        .collect();
                 let add = Some(Mutation::Add(AddMutation {
                     actor_dispatchers: edges
                         .dispatchers

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -48,7 +48,7 @@ enum BackfillState {
 pub(super) struct Progress {
     // `states` and `done_count` decides whether the progress is done. See `is_done`.
     states: HashMap<ActorId, BackfillState>,
-    backfill_order_state: Option<BackfillOrderState>,
+    backfill_order_state: BackfillOrderState,
     done_count: usize,
 
     /// Tells whether the backfill is from source or mv.
@@ -75,7 +75,7 @@ impl Progress {
         upstream_mv_count: HashMap<TableId, usize>,
         upstream_total_key_count: u64,
         definition: String,
-        backfill_order_state: Option<BackfillOrderState>,
+        backfill_order_state: BackfillOrderState,
     ) -> Self {
         let mut states = HashMap::new();
         let mut backfill_upstream_types = HashMap::new();
@@ -129,9 +129,7 @@ impl Progress {
                 tracing::debug!("actor {} done", actor);
                 new = *new_consumed_rows;
                 self.done_count += 1;
-                if let Some(backfill_order_state) = &mut self.backfill_order_state {
-                    next_backfill_nodes = backfill_order_state.finish_actor(actor);
-                }
+                next_backfill_nodes = self.backfill_order_state.finish_actor(actor);
                 tracing::debug!(
                     "{} actors out of {} complete",
                     self.done_count,
@@ -371,7 +369,7 @@ impl CreateMviewProgressTracker {
             calculate_total_key_count(&upstream_mv_count, version_stats);
         Progress {
             states,
-            backfill_order_state: None,
+            backfill_order_state: Default::default(),
             backfill_upstream_types,
             done_count: 0, // Fill only after first barrier pass
             upstream_mv_count,
@@ -574,14 +572,14 @@ impl CreateMviewProgressTracker {
             self.actor_map.insert(*actor, creating_mv_id);
         }
 
-        let backfill_order_state = fragment_backfill_ordering
-            .map(|order| BackfillOrderState::new(order, &table_fragments));
+        let backfill_order_state =
+            BackfillOrderState::new(fragment_backfill_ordering, &table_fragments);
         let progress = Progress::new(
             actors,
             upstream_mv_count,
             upstream_total_key_count,
             definition.clone(),
-            backfill_order_state.clone(),
+            backfill_order_state,
         );
         if job_type == StreamingJobType::Sink && create_type == CreateType::Background {
             // We return the original tracking job immediately.

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -724,7 +724,7 @@ impl StreamFragmentGraph {
     /// Initially the mapping that comes from frontend is between `table_ids`.
     /// We should remap it to fragment level, since we track progress by actor, and we can get
     /// a fragment <-> actor mapping
-    pub fn create_fragment_backfill_ordering(&self) -> Option<FragmentBackfillOrder> {
+    pub fn create_fragment_backfill_ordering(&self) -> FragmentBackfillOrder {
         let mapping = self.collect_backfill_mapping();
         let mut fragment_ordering: HashMap<u32, Vec<u32>> = HashMap::new();
         for (rel_id, downstream_rel_ids) in &self.backfill_order.order {
@@ -739,7 +739,7 @@ impl StreamFragmentGraph {
                 fragment_ordering.insert(*fragment_id, downstream_fragment_ids);
             }
         }
-        Some(fragment_ordering)
+        fragment_ordering
     }
 }
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -98,7 +98,7 @@ pub struct CreateStreamingJobContext {
 
     pub streaming_job: StreamingJob,
 
-    pub fragment_backfill_ordering: Option<FragmentBackfillOrder>,
+    pub fragment_backfill_ordering: FragmentBackfillOrder,
 }
 
 impl CreateStreamingJobContext {

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -36,10 +36,9 @@ use risingwave_pb::plan_common::{ColumnCatalog, ColumnDesc, ExprContext, Field};
 use risingwave_pb::stream_plan::stream_fragment_graph::{StreamFragment, StreamFragmentEdge};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    AggCallState, BackfillOrderStrategy, DispatchStrategy, DispatcherType, ExchangeNode,
-    FilterNode, FragmentTypeFlag, MaterializeNode, ProjectNode, SimpleAggNode, SourceNode,
-    StreamContext, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamSource,
-    agg_call_state,
+    AggCallState, DispatchStrategy, DispatcherType, ExchangeNode, FilterNode, FragmentTypeFlag,
+    MaterializeNode, ProjectNode, SimpleAggNode, SourceNode, StreamContext,
+    StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamSource, agg_call_state,
 };
 
 use crate::MetaResult;
@@ -423,7 +422,7 @@ fn make_stream_graph() -> StreamFragmentGraphProto {
         table_ids_cnt: 3,
         parallelism: None,
         max_parallelism: VirtualNode::COUNT_FOR_TEST as _,
-        backfill_order_strategy: Some(BackfillOrderStrategy { strategy: None }),
+        backfill_order: Default::default(),
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR is intentionally separated from the previous one, since it involves refactoring and adds noise.
From the previous PR, I realize we only need to pass a backfill order to the meta node, rather than different backfill order strategies.

That's because for `auto` (the variant we are removing), we will directly derive a fixed order for it in the frontend, and send it to the meta node.

Therefore we can simplify the proto definition. There's no risk of breaking backwards compatbility, since this is not persisted, and hasn't made it into any release branch just yet.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
