### PR TITLE
refactor(storage): no default sstable info

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -204,7 +204,18 @@ pub async fn sst_dump_via_sstable_store(
         object_id,
         file_size,
         meta_offset,
-        ..Default::default()
+        // below are default unused value
+        sst_id: 0,
+        key_range: Default::default(),
+        table_ids: vec![],
+        stale_key_count: 0,
+        total_key_count: 0,
+        min_epoch: 0,
+        max_epoch: 0,
+        uncompressed_file_size: 0,
+        range_tombstone_count: 0,
+        bloom_filter_kind: Default::default(),
+        sst_size: 0,
     }
     .into();
     let sstable_cache = sstable_store

--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -284,7 +284,9 @@ impl IntraCompactionPicker {
                 stats,
             ) {
                 let mut overlap = overlap_strategy.create_overlap_info();
-                select_ssts.iter().for_each(|ssts| overlap.update(ssts));
+                select_ssts
+                    .iter()
+                    .for_each(|sst| overlap.update(&sst.key_range));
 
                 assert!(
                     overlap

--- a/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
@@ -60,7 +60,7 @@ impl MinOverlappingPicker {
                 continue;
             }
             let mut overlap_info = self.overlap_strategy.create_overlap_info();
-            overlap_info.update(sst);
+            overlap_info.update(&sst.key_range);
             let overlap_files_range = overlap_info.check_multiple_overlap(target_tables);
 
             if overlap_files_range.is_empty() {
@@ -274,7 +274,7 @@ impl NonOverlapSubLevelPicker {
 
             // reset the `basic_overlap_info` with basic sst
             let mut basic_overlap_info = self.overlap_strategy.create_overlap_info();
-            basic_overlap_info.update(sst);
+            basic_overlap_info.update(&sst.key_range);
 
             let mut overlap_files_range =
                 basic_overlap_info.check_multiple_include(&target_level.table_infos);
@@ -313,7 +313,7 @@ impl NonOverlapSubLevelPicker {
                     if level_handler.is_pending_compact(&other.sst_id) {
                         break 'expand_new_level;
                     }
-                    basic_overlap_info.update(other);
+                    basic_overlap_info.update(&other.key_range);
 
                     add_files_size += other.sst_size;
                     add_files_count += 1;
@@ -569,7 +569,7 @@ impl NonOverlapSubLevelPicker {
             }
 
             for sst in ssts {
-                overlap_info.as_mut().unwrap().update(sst);
+                overlap_info.as_mut().unwrap().update(&sst.key_range);
             }
         }
     }
@@ -1025,7 +1025,7 @@ pub mod tests {
         let overlap_strategy = Arc::new(RangeOverlapStrategy::default());
         let mut overlap_info = overlap_strategy.create_overlap_info();
         for sst in &select_files {
-            overlap_info.update(sst);
+            overlap_info.update(&sst.key_range);
         }
         let range = overlap_info.check_multiple_overlap(&levels[0].table_infos);
         assert!(range.is_empty());

--- a/src/meta/src/hummock/compaction/picker/trivial_move_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/trivial_move_compaction_picker.rs
@@ -90,7 +90,7 @@ impl TrivialMovePicker {
 
                 continue;
             }
-            overlap_info.update(sst);
+            overlap_info.update(&sst.key_range);
             let overlap_files_range = overlap_info.check_multiple_overlap(target_tables);
 
             if overlap_files_range.is_empty() {

--- a/src/storage/hummock_sdk/src/sstable_info.rs
+++ b/src/storage/hummock_sdk/src/sstable_info.rs
@@ -22,7 +22,8 @@ use crate::key_range::KeyRange;
 use crate::version::{ObjectIdReader, SstableIdReader};
 use crate::{HummockSstableId, HummockSstableObjectId};
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(any(test, feature = "test"), derive(Default))]
 pub struct SstableInfoInner {
     pub object_id: u64,
     pub sst_id: u64,
@@ -233,7 +234,8 @@ impl ObjectIdReader for SstableInfoInner {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(any(test, feature = "test"), derive(Default))]
 pub struct SstableInfo(Arc<SstableInfoInner>);
 
 impl From<&PbSstableInfo> for SstableInfo {

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -1083,9 +1083,17 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct GroupDeltasCommon<T> {
     pub group_deltas: Vec<GroupDeltaCommon<T>>,
+}
+
+impl<T> Default for GroupDeltasCommon<T> {
+    fn default() -> Self {
+        Self {
+            group_deltas: vec![],
+        }
+    }
 }
 
 pub type GroupDeltas = GroupDeltasCommon<SstableInfo>;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fields in `SstableInfo` is important for data correctness, and we should fill them carefully. Having `Default` impl for `SstableInfo` can easily implicitly fill in unexpected default value.

In this PR, we will remove the `derive(Default)` for `SstableInfo` when we are not in test build. Current usages of the default implementation are removed and changed accordingly. When dealing with `OverlapStrategy`, we used to pass the whole `SstableInfo`, but actually only its `key_range` is used. We will change to only pass the `KeyRange`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
