### PR TITLE
refactor: unify `hummock+memory` with `hummock+memory-shared`

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -534,9 +534,8 @@ fn total_storage_memory_limit_bytes(storage_memory_config: &StorageMemoryConfig)
 
 /// Checks whether an embedded compactor starts with a compute node.
 fn embedded_compactor_enabled(state_store_url: &str, disable_remote_compactor: bool) -> bool {
-    // We treat `hummock+memory-shared` as a shared storage, so we won't start the compactor
-    // along with the compute node.
-    state_store_url == "hummock+memory"
+    // Always start an embedded compactor if the state store is in-memory.
+    state_store_url.starts_with("hummock+memory")
         || state_store_url.starts_with("hummock+disk")
         || disable_remote_compactor
 }

--- a/src/object_store/src/object/mem.rs
+++ b/src/object_store/src/object/mem.rs
@@ -245,13 +245,18 @@ static SHARED: LazyLock<spin::Mutex<InMemObjectStore>> =
     LazyLock::new(|| spin::Mutex::new(InMemObjectStore::new()));
 
 impl InMemObjectStore {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             objects: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Create a shared reference to the in-memory object store in this process.
+    /// Create a new in-memory object store for testing, isolated with others.
+    pub fn for_test() -> Self {
+        Self::new()
+    }
+
+    /// Get a reference to the in-memory object store shared in this process.
     ///
     /// Note: Should only be used for `risedev playground`, when there're multiple compute-nodes or
     /// compactors in the same process.
@@ -327,7 +332,7 @@ mod tests {
     async fn test_upload() {
         let block = Bytes::from("123456");
 
-        let s3 = InMemObjectStore::new();
+        let s3 = InMemObjectStore::for_test();
         s3.upload("/abc", block).await.unwrap();
 
         // No such object.
@@ -351,7 +356,7 @@ mod tests {
         let blocks = vec![Bytes::from("123"), Bytes::from("456"), Bytes::from("789")];
         let obj = Bytes::from("123456789");
 
-        let store = InMemObjectStore::new();
+        let store = InMemObjectStore::for_test();
         let mut uploader = store.streaming_upload("/abc").await.unwrap();
 
         for block in blocks {
@@ -375,7 +380,7 @@ mod tests {
     async fn test_metadata() {
         let block = Bytes::from("123456");
 
-        let obj_store = InMemObjectStore::new();
+        let obj_store = InMemObjectStore::for_test();
         obj_store.upload("/abc", block).await.unwrap();
 
         let err = obj_store.metadata("/not_exist").await.unwrap_err();
@@ -398,7 +403,7 @@ mod tests {
     #[tokio::test]
     async fn test_list() {
         let payload = Bytes::from("123456");
-        let store = InMemObjectStore::new();
+        let store = InMemObjectStore::for_test();
         assert!(list_all("", &store).await.is_empty());
 
         let paths = vec!["001/002/test.obj", "001/003/test.obj"];

--- a/src/object_store/src/object/mod.rs
+++ b/src/object_store/src/object/mod.rs
@@ -1018,7 +1018,7 @@ pub async fn build_remote_object_store(
                 )
             }
         }
-        "memory" => {
+        "memory" | "memory-shared" /* backward compatible, memory is always shared now */ => {
             if ident == "Meta Backup" {
                 tracing::warn!(
                     "You're using in-memory remote object store for {}. This is not recommended for production environment.",
@@ -1030,20 +1030,6 @@ pub async fn build_remote_object_store(
                     ident
                 );
             }
-            ObjectStoreImpl::InMem(InMemObjectStore::new().monitored(metrics, config))
-        }
-        "memory-shared" => {
-            if ident == "Meta Backup" {
-                tracing::warn!(
-                    "You're using shared in-memory remote object store for {}. This should never be used in production environment.",
-                    ident
-                );
-            } else {
-                tracing::warn!(
-                    "You're using shared in-memory remote object store for {}. This should never be used in benchmarks and production environment.",
-                    ident
-                );
-            }
             ObjectStoreImpl::InMem(InMemObjectStore::shared().monitored(metrics, config))
         }
         #[cfg(madsim)]
@@ -1052,7 +1038,7 @@ pub async fn build_remote_object_store(
         }
         other => {
             unimplemented!(
-                "{} remote object store only supports s3, minio, gcs, oss, cos, azure blob, hdfs, disk, memory, and memory-shared.",
+                "{} remote object store only supports s3, minio, gcs, oss, cos, azure blob, hdfs, disk, memory.",
                 other
             )
         }

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -256,7 +256,7 @@ impl Task for MetaNodeService {
             cmd.env("MALLOC_CONF", conf); // unprefixed for linux
         }
 
-        Self::apply_command_args(&mut cmd, &self.config, HummockInMemoryStrategy::Isolated)?;
+        Self::apply_command_args(&mut cmd, &self.config, HummockInMemoryStrategy::Allowed)?;
 
         if let MetaBackend::Env = self.config.meta_backend {
             if is_env_set("RISEDEV_CLEAN_START") {

--- a/src/risedevtool/src/task/utils.rs
+++ b/src/risedevtool/src/task/utils.rs
@@ -142,13 +142,9 @@ pub fn add_tempo_endpoint(provide_tempo: &[TempoConfig], cmd: &mut Command) -> R
 }
 
 /// Strategy for whether to enable in-memory hummock if no minio and s3 is provided.
-// TODO: dead, remove this.
 pub enum HummockInMemoryStrategy {
-    /// Enable isolated in-memory hummock. Used by single-node configuration.
-    Isolated,
-    /// Enable in-memory hummock shared in a single process. Used by risedev playground and
-    /// deterministic end-to-end tests.
-    Shared,
+    /// Enable in-memory hummock. Used by single-node configuration.
+    Allowed,
     /// Disallow in-memory hummock. Always requires minio or s3.
     Disallowed,
 }
@@ -168,13 +164,9 @@ pub fn add_hummock_backend(
         provide_opendal,
     ) {
         ([], [], []) => match hummock_in_memory_strategy {
-            HummockInMemoryStrategy::Isolated => {
+            HummockInMemoryStrategy::Allowed => {
                 cmd.arg("--state-store").arg("hummock+memory");
                 (false, false)
-            }
-            HummockInMemoryStrategy::Shared => {
-                cmd.arg("--state-store").arg("hummock+memory-shared");
-                (true, false)
             }
             HummockInMemoryStrategy::Disallowed => {
                 return Err(anyhow!(

--- a/src/storage/backup/src/storage.rs
+++ b/src/storage/backup/src/storage.rs
@@ -190,7 +190,7 @@ pub async fn unused() -> ObjectStoreMetaSnapshotStorage {
     ObjectStoreMetaSnapshotStorage::new(
         "",
         Arc::new(ObjectStoreImpl::InMem(MonitoredObjectStore::new(
-            InMemObjectStore::new(),
+            InMemObjectStore::for_test(),
             Arc::new(ObjectStoreMetrics::unused()),
             Arc::new(ObjectStoreConfig::default()),
         ))),

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -56,7 +56,7 @@ use risingwave_storage::monitor::{
 };
 
 pub async fn mock_sstable_store() -> SstableStoreRef {
-    let store = InMemObjectStore::new().monitored(
+    let store = InMemObjectStore::for_test().monitored(
         Arc::new(ObjectStoreMetrics::unused()),
         Arc::new(ObjectStoreConfig::default()),
     );

--- a/src/storage/benches/bench_multi_builder.rs
+++ b/src/storage/benches/bench_multi_builder.rs
@@ -262,7 +262,7 @@ fn bench_table_scan(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    let store = InMemObjectStore::new().monitored(
+    let store = InMemObjectStore::for_test().monitored(
         Arc::new(ObjectStoreMetrics::unused()),
         Arc::new(ObjectStoreConfig::default()),
     );

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -57,7 +57,7 @@ pub const TEST_KEYS_COUNT: usize = 10;
 
 pub async fn mock_sstable_store() -> SstableStoreRef {
     mock_sstable_store_with_object_store(Arc::new(ObjectStoreImpl::InMem(
-        InMemObjectStore::new().monitored(
+        InMemObjectStore::for_test().monitored(
             Arc::new(ObjectStoreMetrics::unused()),
             Arc::new(ObjectStoreConfig::default()),
         ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Follow up of https://github.com/risingwavelabs/risingwave/pull/21353.

This PR unifies `hummock+memory` with `hummock+memory-shared`: we will always use the singleton in-memory object store in the process. This is because I cannot find an actual use case for differentiating them after removing the distributed in-memory e2e tests.

This PR also fixes a bug that in `playground` (or `single-node` with `--in-memory`) mode, we specify the state store url as non-shared while still starting a compactor, which cannot access the objects as a result.

```
2025-05-13T17:30:23.558657+08:00 ERROR rw-standalone-compactor risingwave_object_store::object: read failed error=NotFound error: no object at path 'hummock_001/13964.data'
2025-05-13T17:30:23.558679+08:00 ERROR rw-standalone-compactor risingwave_object_store::object: read failed error=NotFound error: no object at path 'hummock_001/13917.data'
2025-05-13T17:30:23.558793+08:00  WARN           rw-compaction risingwave_storage::hummock::compactor::compactor_runner: Compaction task 6264 failed with error error=Foyer error: NotFound error: no object at path 'hummock_001/14027.data'
```

After this PR, an embedded compactor will be started by the compute node service. So there's no need to start a compactor service separately any more.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
