### PR TITLE
fix: make batch scan adhere to runtime param batch_parallelism

### DIFF
--- a/src/batch/src/worker_manager/worker_node_manager.rs
+++ b/src/batch/src/worker_manager/worker_node_manager.rs
@@ -372,6 +372,7 @@ impl WorkerNodeSelector {
                 let workers = self.apply_worker_node_mask(self.manager.list_serving_worker_nodes());
                 // If it's a singleton, set max_parallelism=1 for place_vnode.
                 let max_parallelism = mapping.to_single().map(|_| 1);
+                // TODO: use runtime parameter batch_parallelism
                 let masked_mapping =
                     place_vnode(Some(&mapping), &workers, max_parallelism, mapping.len())
                         .ok_or_else(|| BatchError::EmptyWorkerNodes)?;

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -348,10 +348,17 @@ pub async fn start_service_as_election_leader(
     let metadata_manager = MetadataManager::new(cluster_controller, catalog_controller);
 
     let serving_vnode_mapping = Arc::new(ServingVnodeMapping::default());
+    let max_serving_parallelism = env
+        .session_params_manager_impl_ref()
+        .get_params()
+        .await
+        .batch_parallelism()
+        .map(|p| p.get());
     serving::on_meta_start(
         env.notification_manager_ref(),
         &metadata_manager,
         serving_vnode_mapping.clone(),
+        max_serving_parallelism,
     )
     .await;
 
@@ -626,6 +633,7 @@ pub async fn start_service_as_election_leader(
             env.notification_manager_ref(),
             metadata_manager.clone(),
             serving_vnode_mapping,
+            env.session_params_manager_impl_ref(),
         )
         .await,
     );

--- a/src/meta/src/controller/session_params.rs
+++ b/src/meta/src/controller/session_params.rs
@@ -27,7 +27,7 @@ use tokio::sync::RwLock;
 use tracing::info;
 
 use crate::controller::SqlMetaStore;
-use crate::manager::NotificationManagerRef;
+use crate::manager::{LocalNotification, NotificationManagerRef};
 use crate::{MetaError, MetaResult};
 
 pub type SessionParamsControllerRef = Arc<SessionParamsController>;
@@ -110,6 +110,7 @@ impl SessionParamsController {
                 name
             )));
         };
+        let old_batch_parallelism = params_guard.batch_parallelism();
         // FIXME: use a real reporter
         let reporter = &mut ();
         let new_param = if let Some(value) = value {
@@ -121,8 +122,13 @@ impl SessionParamsController {
         let mut param: session_parameter::ActiveModel = param.into();
         param.value = Set(new_param.clone());
         param.update(&self.db).await?;
-
+        let new_batch_parallelism = params_guard.batch_parallelism();
         self.notify_workers(name.clone(), new_param.clone());
+        if old_batch_parallelism != new_batch_parallelism {
+            self.notification_manager
+                .notify_local_subscribers(LocalNotification::BatchParallelismChange)
+                .await;
+        }
 
         Ok(new_param)
     }

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -45,6 +45,7 @@ pub enum LocalNotification {
     WorkerNodeDeleted(WorkerNode),
     WorkerNodeActivated(WorkerNode),
     SystemParamsChange(SystemParamsReader),
+    BatchParallelismChange,
     FragmentMappingsUpsert(Vec<FragmentId>),
     FragmentMappingsDelete(Vec<FragmentId>),
 }

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -26,6 +26,7 @@ use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
 use crate::controller::fragment::FragmentParallelismInfo;
+use crate::controller::session_params::SessionParamsControllerRef;
 use crate::manager::{LocalNotification, MetadataManager, NotificationManagerRef};
 use crate::model::FragmentId;
 
@@ -47,6 +48,7 @@ impl ServingVnodeMapping {
         &self,
         streaming_parallelisms: HashMap<FragmentId, FragmentParallelismInfo>,
         workers: &[WorkerNode],
+        max_serving_parallelism: Option<u64>,
     ) -> (HashMap<FragmentId, WorkerSlotMapping>, Vec<FragmentId>) {
         let mut serving_vnode_mappings = self.serving_vnode_mappings.write();
         let mut upserted: HashMap<FragmentId, WorkerSlotMapping> = HashMap::default();
@@ -58,7 +60,8 @@ impl ServingVnodeMapping {
                     FragmentDistributionType::Unspecified => unreachable!(),
                     FragmentDistributionType::Single => Some(1),
                     FragmentDistributionType::Hash => None,
-                };
+                }
+                .or_else(|| max_serving_parallelism.map(|p| p as usize));
                 place_vnode(old_mapping, workers, max_parallelism, info.vnode_count)
             };
             match new_mapping {
@@ -111,15 +114,25 @@ pub async fn on_meta_start(
     notification_manager: NotificationManagerRef,
     metadata_manager: &MetadataManager,
     serving_vnode_mapping: ServingVnodeMappingRef,
+    max_serving_parallelism: Option<u64>,
 ) {
     let (serving_compute_nodes, streaming_parallelisms) =
         fetch_serving_infos(metadata_manager).await;
-    let (mappings, _) =
-        serving_vnode_mapping.upsert(streaming_parallelisms, &serving_compute_nodes);
+    let (mappings, failed) = serving_vnode_mapping.upsert(
+        streaming_parallelisms,
+        &serving_compute_nodes,
+        max_serving_parallelism,
+    );
     tracing::debug!(
         "Initialize serving vnode mapping snapshot for fragments {:?}.",
         mappings.keys()
     );
+    if !failed.is_empty() {
+        tracing::warn!(
+            "Fail to update serving vnode mapping for fragments {:?}.",
+            failed
+        );
+    }
     notification_manager.notify_frontend_without_version(
         Operation::Snapshot,
         Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings {
@@ -158,6 +171,7 @@ pub async fn start_serving_vnode_mapping_worker(
     notification_manager: NotificationManagerRef,
     metadata_manager: MetadataManager,
     serving_vnode_mapping: ServingVnodeMappingRef,
+    session_params: SessionParamsControllerRef,
 ) -> (JoinHandle<()>, Sender<()>) {
     let (local_notification_tx, mut local_notification_rx) = tokio::sync::mpsc::unbounded_channel();
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
@@ -165,6 +179,35 @@ pub async fn start_serving_vnode_mapping_worker(
         .insert_local_sender(local_notification_tx)
         .await;
     let join_handle = tokio::spawn(async move {
+        let reset = || async {
+            let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager).await;
+            let max_serving_parallelism = session_params
+                .get_params()
+                .await
+                .batch_parallelism()
+                .map(|p| p.get());
+            let (mappings, failed) = serving_vnode_mapping.upsert(
+                streaming_parallelisms,
+                &workers,
+                max_serving_parallelism,
+            );
+            tracing::debug!(
+                "Update serving vnode mapping snapshot for fragments {:?}.",
+                mappings.keys()
+            );
+            if !failed.is_empty() {
+                tracing::warn!(
+                    "Fail to update serving vnode mapping for fragments {:?}.",
+                    failed
+                );
+            }
+            notification_manager.notify_frontend_without_version(
+                Operation::Snapshot,
+                Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings {
+                    mappings: to_fragment_worker_slot_mapping(&mappings),
+                }),
+            );
+        };
         loop {
             tokio::select! {
                 notification = local_notification_rx.recv() => {
@@ -175,10 +218,10 @@ pub async fn start_serving_vnode_mapping_worker(
                                     if w.r#type() != WorkerType::ComputeNode || !w.property.as_ref().is_some_and(|p| p.is_serving) {
                                         continue;
                                     }
-                                    let (workers, streaming_parallelisms) = fetch_serving_infos(&metadata_manager).await;
-                                    let (mappings, _) = serving_vnode_mapping.upsert(streaming_parallelisms, &workers);
-                                    tracing::debug!("Update serving vnode mapping snapshot for fragments {:?}.", mappings.keys());
-                                    notification_manager.notify_frontend_without_version(Operation::Snapshot, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_fragment_worker_slot_mapping(&mappings) }));
+                                    reset().await;
+                                }
+                                LocalNotification::BatchParallelismChange => {
+                                    reset().await;
                                 }
                                 LocalNotification::FragmentMappingsUpsert(fragment_ids) => {
                                     if fragment_ids.is_empty() {
@@ -194,13 +237,18 @@ pub async fn start_serving_vnode_mapping_worker(
                                             }
                                         }
                                     }).collect();
-                                    let (upserted, failed) = serving_vnode_mapping.upsert(filtered_streaming_parallelisms, &workers);
+                                    let max_serving_parallelism = session_params
+                                        .get_params()
+                                        .await
+                                        .batch_parallelism()
+                                        .map(|p|p.get());
+                                    let (upserted, failed) = serving_vnode_mapping.upsert(filtered_streaming_parallelisms, &workers, max_serving_parallelism);
                                     if !upserted.is_empty() {
                                         tracing::debug!("Update serving vnode mapping for fragments {:?}.", upserted.keys());
                                         notification_manager.notify_frontend_without_version(Operation::Update, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_fragment_worker_slot_mapping(&upserted) }));
                                     }
                                     if !failed.is_empty() {
-                                        tracing::debug!("Fail to update serving vnode mapping for fragments {:?}.", failed);
+                                        tracing::warn!("Fail to update serving vnode mapping for fragments {:?}.", failed);
                                         notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(&failed)}));
                                     }
                                 }

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -1593,8 +1593,18 @@ impl ScaleController {
                 .running_fragment_parallelisms(Some(reschedules.keys().cloned().collect()))
                 .await?;
             let serving_worker_slot_mapping = Arc::new(ServingVnodeMapping::default());
-            let (upserted, failed) =
-                serving_worker_slot_mapping.upsert(streaming_parallelisms, &workers);
+            let max_serving_parallelism = self
+                .env
+                .session_params_manager_impl_ref()
+                .get_params()
+                .await
+                .batch_parallelism()
+                .map(|p| p.get());
+            let (upserted, failed) = serving_worker_slot_mapping.upsert(
+                streaming_parallelisms,
+                &workers,
+                max_serving_parallelism,
+            );
             if !upserted.is_empty() {
                 tracing::debug!(
                     "Update serving vnode mapping for fragments {:?}.",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, the runtime parameter `batch_parallelism` [doesn't apply to the batch scan](https://github.com/risingwavelabs/risingwave/blob/b34ead99cea83cf861952bba326ca2c1bff2efe0/src/frontend/src/scheduler/plan_fragmenter.rs#L1008). Therefore the batch scan will use all available serving parallleism up to 256. The might cause problem when high QPS introduces too many batch tasks in serving nodes.

This PR makes batch scan adhere to `batch_parallelism`, in order to limit batch scan task parallelism to lower number when necessary. The implementation idea is to utilize only partial parallelism of all when `place_vnode` in meta node.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
