### PR TITLE
feat(storage): filter out GC objects by listing time travel versions and deltas

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -562,6 +562,19 @@ pub struct MetaDeveloperConfig {
     #[serde(default = "default::developer::hummock_time_travel_filter_out_objects_batch_size")]
     pub hummock_time_travel_filter_out_objects_batch_size: usize,
 
+    #[serde(default = "default::developer::hummock_time_travel_filter_out_objects_v1")]
+    pub hummock_time_travel_filter_out_objects_v1: bool,
+
+    #[serde(
+        default = "default::developer::hummock_time_travel_filter_out_objects_list_version_batch_size"
+    )]
+    pub hummock_time_travel_filter_out_objects_list_version_batch_size: usize,
+
+    #[serde(
+        default = "default::developer::hummock_time_travel_filter_out_objects_list_delta_batch_size"
+    )]
+    pub hummock_time_travel_filter_out_objects_list_delta_batch_size: usize,
+
     #[serde(default)]
     pub compute_client_config: RpcClientConfig,
 
@@ -2225,6 +2238,18 @@ pub mod default {
         }
 
         pub fn hummock_time_travel_filter_out_objects_batch_size() -> usize {
+            1000
+        }
+
+        pub fn hummock_time_travel_filter_out_objects_v1() -> bool {
+            false
+        }
+
+        pub fn hummock_time_travel_filter_out_objects_list_version_batch_size() -> usize {
+            10
+        }
+
+        pub fn hummock_time_travel_filter_out_objects_list_delta_batch_size() -> usize {
             1000
         }
 

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -108,6 +108,9 @@ meta_time_travel_vacuum_interval_sec = 30
 meta_hummock_time_travel_epoch_version_insert_batch_size = 1000
 meta_hummock_gc_history_insert_batch_size = 1000
 meta_hummock_time_travel_filter_out_objects_batch_size = 1000
+meta_hummock_time_travel_filter_out_objects_v1 = false
+meta_hummock_time_travel_filter_out_objects_list_version_batch_size = 10
+meta_hummock_time_travel_filter_out_objects_list_delta_batch_size = 1000
 
 [meta.developer.meta_compute_client_config]
 connect_timeout_secs = 5

--- a/src/meta/node/src/lib.rs
+++ b/src/meta/node/src/lib.rs
@@ -391,6 +391,18 @@ pub fn start(
                     .meta
                     .developer
                     .hummock_time_travel_filter_out_objects_batch_size,
+                hummock_time_travel_filter_out_objects_v1: config
+                    .meta
+                    .developer
+                    .hummock_time_travel_filter_out_objects_v1,
+                hummock_time_travel_filter_out_objects_list_version_batch_size: config
+                    .meta
+                    .developer
+                    .hummock_time_travel_filter_out_objects_list_version_batch_size,
+                hummock_time_travel_filter_out_objects_list_delta_batch_size: config
+                    .meta
+                    .developer
+                    .hummock_time_travel_filter_out_objects_list_delta_batch_size,
                 min_delta_log_num_for_hummock_version_checkpoint: config
                     .meta
                     .min_delta_log_num_for_hummock_version_checkpoint,

--- a/src/meta/src/hummock/manager/checkpoint.rs
+++ b/src/meta/src/hummock/manager/checkpoint.rs
@@ -18,7 +18,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::atomic::Ordering;
 
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::object_size_map;
-use risingwave_hummock_sdk::version::{GroupDeltaCommon, HummockVersion};
+use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{HummockObjectId, HummockVersionId, get_stale_object_ids};
 use risingwave_pb::hummock::hummock_version_checkpoint::{PbStaleObjects, StaleObjects};
 use risingwave_pb::hummock::{
@@ -153,52 +153,17 @@ impl HummockManager {
             .hummock_version_deltas
             .range((Excluded(old_checkpoint_id), Included(new_checkpoint_id)))
         {
-            for group_deltas in version_delta.group_deltas.values() {
-                object_sizes.extend(
-                    group_deltas
-                        .group_deltas
-                        .iter()
-                        .flat_map(|delta| {
-                            match delta {
-                                GroupDeltaCommon::IntraLevel(level_delta) => {
-                                    Some(level_delta.inserted_table_infos.iter())
-                                }
-                                GroupDeltaCommon::NewL0SubLevel(inserted_table_infos) => {
-                                    Some(inserted_table_infos.iter())
-                                }
-                                GroupDeltaCommon::GroupConstruct(_)
-                                | GroupDeltaCommon::GroupDestroy(_)
-                                | GroupDeltaCommon::GroupMerge(_) => None,
-                            }
-                            .into_iter()
-                            .flatten()
-                            .map(|t| (t.object_id, t.file_size))
-                        })
-                        .chain(
-                            version_delta
-                                .change_log_delta
-                                .values()
-                                .flat_map(|change_log| {
-                                    let new_log = &change_log.new_log;
-                                    new_log
-                                        .new_value
-                                        .iter()
-                                        .chain(new_log.old_value.iter())
-                                        .map(|t| (t.object_id, t.file_size))
-                                }),
-                        )
-                        .map(|(object_id, size)| {
-                            // DO NOT REMOVE THIS LINE
-                            // This is to ensure that when adding new variant to `HummockObjectId`,
-                            // the compiler will warn us if we forget to handle it here.
-                            match HummockObjectId::Sstable(0.into()) {
-                                HummockObjectId::Sstable(_) => {}
-                            };
-                            (HummockObjectId::Sstable(object_id), size)
-                        }),
-                );
+            // DO NOT REMOVE THIS LINE
+            // This is to ensure that when adding new variant to `HummockObjectId`,
+            // the compiler will warn us if we forget to handle it here.
+            match HummockObjectId::Sstable(0.into()) {
+                HummockObjectId::Sstable(_) => {}
+            };
+            for sst in version_delta.newly_added_sst_infos(false) {
+                let object_id = HummockObjectId::Sstable(sst.object_id);
+                object_sizes.insert(object_id, sst.file_size);
+                versions_object_ids.insert(object_id);
             }
-            versions_object_ids.extend(version_delta.newly_added_object_ids(false));
         }
 
         // Object ids that once exist in any hummock version but not exist in the latest hummock version

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -344,12 +344,7 @@ impl HummockManager {
         let after_metadata_backup = object_ids.len();
         // filter by time travel archive
         let object_ids = self
-            .filter_out_objects_by_time_travel(
-                object_ids.into_iter(),
-                self.env
-                    .opts
-                    .hummock_time_travel_filter_out_objects_batch_size,
-            )
+            .filter_out_objects_by_time_travel(object_ids.into_iter())
             .await?;
         let after_time_travel = object_ids.len();
         // filter by object id watermark, i.e. minimum id of uncommitted objects reported by compute nodes.
@@ -529,14 +524,7 @@ impl HummockManager {
         let object_ids = object_ids
             .into_iter()
             .filter(|s| !version_pinned.contains(s) && !backup_pinned.contains(s));
-        let object_ids = self
-            .filter_out_objects_by_time_travel(
-                object_ids,
-                self.env
-                    .opts
-                    .hummock_time_travel_filter_out_objects_batch_size,
-            )
-            .await?;
+        let object_ids = self.filter_out_objects_by_time_travel(object_ids).await?;
         // Retry is not necessary. Full GC will handle these objects eventually.
         self.delete_objects(object_ids.into_iter().collect())
             .await?;

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use anyhow::anyhow;
+use futures::TryStreamExt;
 use risingwave_common::catalog::TableId;
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::epoch::Epoch;
@@ -24,12 +25,10 @@ use risingwave_hummock_sdk::time_travel::{
     IncompleteHummockVersion, IncompleteHummockVersionDelta, refill_version,
 };
 use risingwave_hummock_sdk::version::{GroupDeltaCommon, HummockVersion, HummockVersionDelta};
-use risingwave_hummock_sdk::{
-    CompactionGroupId, HummockEpoch, HummockObjectId, HummockSstableId, HummockSstableObjectId,
-};
+use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, HummockObjectId, HummockSstableId};
 use risingwave_meta_model::hummock_sstable_info::SstableInfoV2Backend;
 use risingwave_meta_model::{
-    hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_delta,
+    HummockVersionId, hummock_epoch_to_version, hummock_sstable_info, hummock_time_travel_delta,
     hummock_time_travel_version,
 };
 use risingwave_pb::hummock::{PbHummockVersion, PbHummockVersionDelta};
@@ -273,42 +272,76 @@ impl HummockManager {
     pub(crate) async fn filter_out_objects_by_time_travel(
         &self,
         objects: impl Iterator<Item = HummockObjectId>,
-        batch_size: usize,
     ) -> Result<HashSet<HummockObjectId>> {
-        // The input object count is much smaller than time travel pinned object count in meta store.
-        // So search input object in meta store.
         let mut result: HashSet<_> = objects.collect();
-        let mut remain_sst: VecDeque<_> = result
-            .iter()
-            .map(|object_id| {
-                let HummockObjectId::Sstable(sst_id) = object_id;
-                *sst_id
-            })
-            .collect();
-        while !remain_sst.is_empty() {
-            let batch = remain_sst
-                .drain(..std::cmp::min(remain_sst.len(), batch_size))
-                .map(|object_id| object_id.as_raw().inner());
-            let reject_object_ids: Vec<risingwave_meta_model::HummockSstableObjectId> =
-                hummock_sstable_info::Entity::find()
-                    .filter(hummock_sstable_info::Column::ObjectId.is_in(batch))
-                    .select_only()
-                    .column(hummock_sstable_info::Column::ObjectId)
-                    .into_tuple()
-                    .all(&self.env.meta_store_ref().conn)
-                    .await?;
-            for reject in reject_object_ids {
-                // DO NOT REMOVE THIS LINE
-                // This is to ensure that when adding new variant to `HummockObjectId`,
-                // the compiler will warn us if we forget to handle it here.
-                match HummockObjectId::Sstable(0.into()) {
-                    HummockObjectId::Sstable(_) => {}
+        const MAX_BATCH_TIME_TRAVEL_VERSION_COUNT: u64 = 10;
+
+        // filtered out object id pinned by time travel hummock version
+        {
+            let mut prev_version_id: Option<HummockVersionId> = None;
+            loop {
+                let query = hummock_time_travel_version::Entity::find();
+                let query = if let Some(prev_version_id) = prev_version_id {
+                    query.filter(hummock_time_travel_version::Column::VersionId.gt(prev_version_id))
+                } else {
+                    query
                 };
-                let reject: u64 = reject.try_into().unwrap();
-                let object_id = HummockObjectId::Sstable(HummockSstableObjectId::from(reject));
-                result.remove(&object_id);
+                let mut version_stream = query
+                    .order_by_asc(hummock_time_travel_version::Column::VersionId)
+                    .limit(MAX_BATCH_TIME_TRAVEL_VERSION_COUNT)
+                    .stream(&self.env.meta_store_ref().conn)
+                    .await?;
+                let mut next_prev_version_id = None;
+                while let Some(model) = version_stream.try_next().await? {
+                    let version =
+                        HummockVersion::from_persisted_protobuf(&model.version.to_protobuf());
+                    for object_id in version.get_object_ids(false) {
+                        result.remove(&object_id);
+                    }
+                    next_prev_version_id = Some(model.version_id);
+                }
+                if let Some(next_prev_version_id) = next_prev_version_id {
+                    prev_version_id = Some(next_prev_version_id);
+                } else {
+                    break;
+                }
             }
         }
+
+        // filtered out object ids pinned by time travel hummock version delta
+        {
+            let mut prev_version_id: Option<HummockVersionId> = None;
+            loop {
+                let query = hummock_time_travel_delta::Entity::find();
+                let query = if let Some(prev_version_id) = prev_version_id {
+                    query.filter(hummock_time_travel_delta::Column::VersionId.gt(prev_version_id))
+                } else {
+                    query
+                };
+                let mut version_stream = query
+                    .order_by_asc(hummock_time_travel_delta::Column::VersionId)
+                    .limit(MAX_BATCH_TIME_TRAVEL_VERSION_COUNT)
+                    .stream(&self.env.meta_store_ref().conn)
+                    .await?;
+                let mut next_prev_version_id = None;
+                while let Some(model) = version_stream.try_next().await? {
+                    let version_delta = HummockVersionDelta::from_persisted_protobuf(
+                        &model.version_delta.to_protobuf(),
+                    );
+                    // set exclude_table_change_log to true because in time travel delta we ignore the table change log
+                    for object_id in version_delta.newly_added_object_ids(true) {
+                        result.remove(&object_id);
+                    }
+                    next_prev_version_id = Some(model.version_id);
+                }
+                if let Some(next_prev_version_id) = next_prev_version_id {
+                    prev_version_id = Some(next_prev_version_id);
+                } else {
+                    break;
+                }
+            }
+        }
+
         Ok(result)
     }
 

--- a/src/meta/src/hummock/manager/time_travel.rs
+++ b/src/meta/src/hummock/manager/time_travel.rs
@@ -349,7 +349,7 @@ impl HummockManager {
                 while let Some(model) = version_stream.try_next().await? {
                     let version =
                         HummockVersion::from_persisted_protobuf(&model.version.to_protobuf());
-                    for object_id in version.get_object_ids(false) {
+                    for object_id in version.get_object_ids(true) {
                         result.remove(&object_id);
                     }
                     next_prev_version_id = Some(model.version_id);

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -121,6 +121,9 @@ pub struct MetaOpts {
     pub hummock_time_travel_epoch_version_insert_batch_size: usize,
     pub hummock_gc_history_insert_batch_size: usize,
     pub hummock_time_travel_filter_out_objects_batch_size: usize,
+    pub hummock_time_travel_filter_out_objects_v1: bool,
+    pub hummock_time_travel_filter_out_objects_list_version_batch_size: usize,
+    pub hummock_time_travel_filter_out_objects_list_delta_batch_size: usize,
     /// The minimum delta log number a new checkpoint should compact, otherwise the checkpoint
     /// attempt is rejected. Greater value reduces object store IO, meanwhile it results in
     /// more loss of in memory `HummockVersionCheckpoint::stale_objects` state when meta node is
@@ -290,6 +293,9 @@ impl MetaOpts {
             hummock_time_travel_epoch_version_insert_batch_size: 1000,
             hummock_gc_history_insert_batch_size: 1000,
             hummock_time_travel_filter_out_objects_batch_size: 1000,
+            hummock_time_travel_filter_out_objects_v1: false,
+            hummock_time_travel_filter_out_objects_list_version_batch_size: 10,
+            hummock_time_travel_filter_out_objects_list_delta_batch_size: 1000,
             min_delta_log_num_for_hummock_version_checkpoint: 1,
             min_sst_retention_time_sec: 3600 * 24 * 7,
             full_gc_interval_sec: 3600 * 24 * 7,

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -594,7 +594,9 @@ where
             .map(|sst| sst.sst_id())
             .collect()
     }
+}
 
+impl<T> HummockVersionDeltaCommon<T> {
     pub fn newly_added_sst_infos(
         &self,
         exclude_table_change_log: bool,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

When doing GC, we will filter out the objects pinned by time travel. Previously we do the filtering by reading the `hummock_sstable_info` meta store table. This works for the current code that only has sst object to track. However, we will have vector index file in the future, and therefore reading `hummock_sstable_info` is not enough.

In this PR, we will change to list the whole `hummock_time_travel_version`  and `hummock_time_travel_version_delta` table to figure out the object id pinned by time travel version, so that in the future we can support GC of objects other than sst.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
