### PR TITLE
refactor(meta): generate general hummock object id on meta

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -429,11 +429,11 @@ message HummockPinnedSnapshot {
   uint64 minimal_pinned_snapshot = 2;
 }
 
-message GetNewSstIdsRequest {
+message GetNewObjectIdsRequest {
   uint32 number = 1;
 }
 
-message GetNewSstIdsResponse {
+message GetNewObjectIdsResponse {
   common.Status status = 1;
   // inclusive
   uint64 start_id = 2;
@@ -814,7 +814,7 @@ service HummockManagerService {
   rpc GetAssignedCompactTaskNum(GetAssignedCompactTaskNumRequest) returns (GetAssignedCompactTaskNumResponse);
   rpc TriggerCompactionDeterministic(TriggerCompactionDeterministicRequest) returns (TriggerCompactionDeterministicResponse);
   rpc DisableCommitEpoch(DisableCommitEpochRequest) returns (DisableCommitEpochResponse);
-  rpc GetNewSstIds(GetNewSstIdsRequest) returns (GetNewSstIdsResponse);
+  rpc GetNewObjectIds(GetNewObjectIdsRequest) returns (GetNewObjectIdsResponse);
   rpc TriggerManualCompaction(TriggerManualCompactionRequest) returns (TriggerManualCompactionResponse);
   rpc TriggerFullGC(TriggerFullGCRequest) returns (TriggerFullGCResponse);
   rpc RiseCtlGetPinnedVersionsSummary(RiseCtlGetPinnedVersionsSummaryRequest) returns (RiseCtlGetPinnedVersionsSummaryResponse);

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -263,7 +263,7 @@ pub async fn compute_node_serve(
             let (handle, shutdown_sender) = start_compactor(
                 compactor_context,
                 hummock_meta_client.clone(),
-                storage.sstable_object_id_manager().clone(),
+                storage.object_id_manager().clone(),
                 storage.compaction_catalog_manager_ref().clone(),
             );
             sub_tasks.push((handle, shutdown_sender));

--- a/src/meta/service/src/hummock_service.rs
+++ b/src/meta/service/src/hummock_service.rs
@@ -169,18 +169,18 @@ impl HummockManagerService for HummockServiceImpl {
         Ok(Response::new(resp))
     }
 
-    async fn get_new_sst_ids(
+    async fn get_new_object_ids(
         &self,
-        request: Request<GetNewSstIdsRequest>,
-    ) -> Result<Response<GetNewSstIdsResponse>, Status> {
-        let sst_id_range = self
+        request: Request<GetNewObjectIdsRequest>,
+    ) -> Result<Response<GetNewObjectIdsResponse>, Status> {
+        let object_id_range = self
             .hummock_manager
-            .get_new_sst_ids(request.into_inner().number)
+            .get_new_object_ids(request.into_inner().number)
             .await?;
-        Ok(Response::new(GetNewSstIdsResponse {
+        Ok(Response::new(GetNewObjectIdsResponse {
             status: None,
-            start_id: sst_id_range.start_id.inner(),
-            end_id: sst_id_range.end_id.inner(),
+            start_id: object_id_range.start_id.inner(),
+            end_id: object_id_range.end_id.inner(),
         }))
     }
 

--- a/src/meta/src/hummock/manager/sequence.rs
+++ b/src/meta/src/hummock/manager/sequence.rs
@@ -17,7 +17,9 @@ use std::fmt::Display;
 use std::sync::LazyLock;
 
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
-use risingwave_hummock_sdk::{HummockSstableId, HummockSstableObjectId, TypedPrimitive};
+use risingwave_hummock_sdk::{
+    HummockRawObjectId, HummockSstableId, HummockSstableObjectId, TypedPrimitive,
+};
 use risingwave_meta_model::hummock_sequence;
 use risingwave_meta_model::hummock_sequence::{
     COMPACTION_GROUP_ID, COMPACTION_TASK_ID, META_BACKUP_ID, SSTABLE_OBJECT_ID,
@@ -116,6 +118,13 @@ pub async fn next_sstable_id(
     env: &MetaSrvEnv,
     num: impl TryInto<u32> + Display + Copy,
 ) -> Result<HummockSstableId> {
+    next_unique_id(env, num).await
+}
+
+pub async fn next_raw_object_id(
+    env: &MetaSrvEnv,
+    num: impl TryInto<u32> + Display + Copy,
+) -> Result<HummockRawObjectId> {
     next_unique_id(env, num).await
 }
 

--- a/src/meta/src/hummock/manager/utils.rs
+++ b/src/meta/src/hummock/manager/utils.rs
@@ -54,12 +54,12 @@ macro_rules! commit_multi_var_with_provided_txn {
     };
 }
 
-use risingwave_hummock_sdk::SstObjectIdRange;
+use risingwave_hummock_sdk::ObjectIdRange;
 pub(crate) use {commit_multi_var, commit_multi_var_with_provided_txn};
 
 use crate::hummock::HummockManager;
 use crate::hummock::error::Result;
-use crate::hummock::sequence::next_sstable_object_id;
+use crate::hummock::sequence::next_raw_object_id;
 
 impl HummockManager {
     #[cfg(test)]
@@ -111,8 +111,8 @@ impl HummockManager {
         );
     }
 
-    pub async fn get_new_sst_ids(&self, number: u32) -> Result<SstObjectIdRange> {
-        let start_id = next_sstable_object_id(&self.env, number).await?;
-        Ok(SstObjectIdRange::new(start_id, start_id + number as u64))
+    pub async fn get_new_object_ids(&self, number: u32) -> Result<ObjectIdRange> {
+        let start_id = next_raw_object_id(&self.env, number).await?;
+        Ok(ObjectIdRange::new(start_id, start_id + number as u64))
     }
 }

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -30,8 +30,7 @@ use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_hummock_sdk::{
-    HummockContextId, HummockEpoch, HummockVersionId, LocalSstableInfo, SstObjectIdRange,
-    SyncResult,
+    HummockContextId, HummockEpoch, HummockVersionId, LocalSstableInfo, ObjectIdRange, SyncResult,
 };
 use risingwave_pb::common::{HostAddress, WorkerType};
 use risingwave_pb::hummock::compact_task::{TaskStatus, TaskType};
@@ -124,16 +123,16 @@ impl HummockMetaClient for MockHummockMetaClient {
         Ok(self.hummock_manager.get_current_version().await)
     }
 
-    async fn get_new_sst_ids(&self, number: u32) -> Result<SstObjectIdRange> {
+    async fn get_new_object_ids(&self, number: u32) -> Result<ObjectIdRange> {
         fail_point!("get_new_sst_ids_err", |_| Err(anyhow!(
             "failpoint get_new_sst_ids_err"
         )
         .into()));
         self.hummock_manager
-            .get_new_sst_ids(number)
+            .get_new_object_ids(number)
             .await
             .map_err(mock_err)
-            .map(|range| SstObjectIdRange {
+            .map(|range| ObjectIdRange {
                 start_id: range.start_id + self.sst_offset,
                 end_id: range.end_id + self.sst_offset,
             })

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -378,7 +378,7 @@ pub async fn setup_compute_env(
 }
 
 pub async fn get_sst_ids(hummock_manager: &HummockManager, number: u32) -> Vec<u64> {
-    let range = hummock_manager.get_new_sst_ids(number).await.unwrap();
+    let range = hummock_manager.get_new_object_ids(number).await.unwrap();
     (range.start_id.inner()..range.end_id.inner()).collect_vec()
 }
 

--- a/src/rpc_client/src/compactor_client.rs
+++ b/src/rpc_client/src/compactor_client.rs
@@ -19,7 +19,7 @@ use risingwave_common::monitor::EndpointExt;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::hummock::hummock_manager_service_client::HummockManagerServiceClient;
 use risingwave_pb::hummock::{
-    GetNewSstIdsRequest, GetNewSstIdsResponse, ReportCompactionTaskRequest,
+    GetNewObjectIdsRequest, GetNewObjectIdsResponse, ReportCompactionTaskRequest,
     ReportCompactionTaskResponse,
 };
 use risingwave_pb::meta::system_params_service_client::SystemParamsServiceClient;
@@ -120,9 +120,9 @@ impl GrpcCompactorProxyClient {
 
     pub async fn get_new_sst_ids(
         &self,
-        request: GetNewSstIdsRequest,
-    ) -> std::result::Result<tonic::Response<GetNewSstIdsResponse>, tonic::Status> {
-        retry_rpc!(self, get_new_sst_ids, request, GetNewSstIdsResponse)
+        request: GetNewObjectIdsRequest,
+    ) -> std::result::Result<tonic::Response<GetNewObjectIdsResponse>, tonic::Status> {
+        retry_rpc!(self, get_new_object_ids, request, GetNewObjectIdsResponse)
     }
 
     pub async fn report_compaction_task(

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use risingwave_hummock_sdk::version::HummockVersion;
-use risingwave_hummock_sdk::{HummockEpoch, HummockVersionId, SstObjectIdRange, SyncResult};
+use risingwave_hummock_sdk::{HummockEpoch, HummockVersionId, ObjectIdRange, SyncResult};
 use risingwave_pb::hummock::{
     PbHummockVersion, SubscribeCompactionEventRequest, SubscribeCompactionEventResponse,
 };
@@ -36,7 +36,7 @@ pub type HummockMetaClientChangeLogInfo = Vec<u64>;
 pub trait HummockMetaClient: Send + Sync + 'static {
     async fn unpin_version_before(&self, unpin_version_before: HummockVersionId) -> Result<()>;
     async fn get_current_version(&self) -> Result<HummockVersion>;
-    async fn get_new_sst_ids(&self, number: u32) -> Result<SstObjectIdRange>;
+    async fn get_new_object_ids(&self, number: u32) -> Result<ObjectIdRange>;
     // We keep `commit_epoch` only for test/benchmark.
     async fn commit_epoch_with_change_log(
         &self,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -45,7 +45,7 @@ use risingwave_error::tonic::ErrorIsFromTonicServerImpl;
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
 use risingwave_hummock_sdk::{
-    CompactionGroupId, HummockEpoch, HummockVersionId, SstObjectIdRange, SyncResult,
+    CompactionGroupId, HummockEpoch, HummockVersionId, ObjectIdRange, SyncResult,
 };
 use risingwave_pb::backup_service::backup_service_client::BackupServiceClient;
 use risingwave_pb::backup_service::*;
@@ -1626,12 +1626,12 @@ impl HummockMetaClient for MetaClient {
         ))
     }
 
-    async fn get_new_sst_ids(&self, number: u32) -> Result<SstObjectIdRange> {
+    async fn get_new_object_ids(&self, number: u32) -> Result<ObjectIdRange> {
         let resp = self
             .inner
-            .get_new_sst_ids(GetNewSstIdsRequest { number })
+            .get_new_object_ids(GetNewObjectIdsRequest { number })
             .await?;
-        Ok(SstObjectIdRange::new(resp.start_id, resp.end_id))
+        Ok(ObjectIdRange::new(resp.start_id, resp.end_id))
     }
 
     async fn commit_epoch_with_change_log(
@@ -2237,7 +2237,7 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, get_assigned_compact_task_num, GetAssignedCompactTaskNumRequest, GetAssignedCompactTaskNumResponse }
             ,{ hummock_client, trigger_compaction_deterministic, TriggerCompactionDeterministicRequest, TriggerCompactionDeterministicResponse }
             ,{ hummock_client, disable_commit_epoch, DisableCommitEpochRequest, DisableCommitEpochResponse }
-            ,{ hummock_client, get_new_sst_ids, GetNewSstIdsRequest, GetNewSstIdsResponse }
+            ,{ hummock_client, get_new_object_ids, GetNewObjectIdsRequest, GetNewObjectIdsResponse }
             ,{ hummock_client, trigger_manual_compaction, TriggerManualCompactionRequest, TriggerManualCompactionResponse }
             ,{ hummock_client, trigger_full_gc, TriggerFullGcRequest, TriggerFullGcResponse }
             ,{ hummock_client, rise_ctl_get_pinned_versions_summary, RiseCtlGetPinnedVersionsSummaryRequest, RiseCtlGetPinnedVersionsSummaryResponse }

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -45,7 +45,7 @@ use risingwave_storage::hummock::compactor::{
 };
 use risingwave_storage::hummock::hummock_meta_client::MonitoredHummockMetaClient;
 use risingwave_storage::hummock::utils::HummockMemoryCollector;
-use risingwave_storage::hummock::{MemoryLimiter, SstableObjectIdManager, SstableStore};
+use risingwave_storage::hummock::{MemoryLimiter, ObjectIdManager, SstableStore};
 use risingwave_storage::monitor::{
     CompactorMetrics, GLOBAL_COMPACTOR_METRICS, GLOBAL_HUMMOCK_METRICS, monitor_cache,
 };
@@ -243,7 +243,7 @@ pub async fn compactor_serve(
     // limited at first.
     let _observer_join_handle = observer_manager.start().await;
 
-    let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+    let object_id_manager = Arc::new(ObjectIdManager::new(
         hummock_meta_client.clone(),
         storage_opts.sstable_id_remote_fetch_number,
     ));
@@ -272,7 +272,7 @@ pub async fn compactor_serve(
         risingwave_storage::hummock::compactor::start_compactor(
             compactor_context.clone(),
             hummock_meta_client.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
             compaction_catalog_manager_ref,
         ),
     ];

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -160,6 +160,12 @@ impl HummockSstableObjectId {
     }
 }
 
+impl From<HummockRawObjectId> for HummockSstableObjectId {
+    fn from(id: HummockRawObjectId) -> Self {
+        Self(id.0)
+    }
+}
+
 pub type HummockRefCount = u64;
 pub type HummockContextId = u32;
 pub type HummockEpoch = u64;
@@ -433,17 +439,17 @@ impl HummockReadEpoch {
         }
     }
 }
-pub struct SstObjectIdRange {
+pub struct ObjectIdRange {
     // inclusive
-    pub start_id: HummockSstableObjectId,
+    pub start_id: HummockRawObjectId,
     // exclusive
-    pub end_id: HummockSstableObjectId,
+    pub end_id: HummockRawObjectId,
 }
 
-impl SstObjectIdRange {
+impl ObjectIdRange {
     pub fn new(
-        start_id: impl Into<HummockSstableObjectId>,
-        end_id: impl Into<HummockSstableObjectId>,
+        start_id: impl Into<HummockRawObjectId>,
+        end_id: impl Into<HummockRawObjectId>,
     ) -> Self {
         Self {
             start_id: start_id.into(),
@@ -451,7 +457,7 @@ impl SstObjectIdRange {
         }
     }
 
-    pub fn peek_next_sst_object_id(&self) -> Option<HummockSstableObjectId> {
+    fn peek_next_object_id(&self) -> Option<HummockRawObjectId> {
         if self.start_id < self.end_id {
             return Some(self.start_id);
         }
@@ -459,8 +465,8 @@ impl SstObjectIdRange {
     }
 
     /// Pops and returns next SST id.
-    pub fn get_next_sst_object_id(&mut self) -> Option<HummockSstableObjectId> {
-        let next_id = self.peek_next_sst_object_id();
+    pub fn get_next_object_id(&mut self) -> Option<HummockRawObjectId> {
+        let next_id = self.peek_next_object_id();
         self.start_id += 1;
         next_id
     }

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -283,7 +283,7 @@ pub(crate) mod tests {
                 compact_ctx.clone(),
                 compact_task.clone(),
                 rx,
-                Box::new(object_id_manager.clone()),
+                object_id_manager.clone(),
                 compaction_catalog_agent_ref.clone(),
             )
             .await;
@@ -599,7 +599,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(object_id_manager.clone()),
+            object_id_manager.clone(),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -799,7 +799,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(object_id_manager.clone()),
+            object_id_manager.clone(),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -1003,7 +1003,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(object_id_manager.clone()),
+            object_id_manager.clone(),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -1188,7 +1188,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(object_id_manager.clone()),
+            object_id_manager.clone(),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -1296,18 +1296,18 @@ pub(crate) mod tests {
             0,
             compact_ctx.clone(),
             task.clone(),
-            Box::new(SharedComapctorObjectIdManager::for_test(
-                VecDeque::from_iter([5, 6, 7, 8, 9, 10, 11, 12, 13]),
-            )),
+            SharedComapctorObjectIdManager::for_test(VecDeque::from_iter([
+                5, 6, 7, 8, 9, 10, 11, 12, 13,
+            ])),
         );
 
         let fast_compact_runner = FastCompactorRunner::new(
             compact_ctx.clone(),
             task.clone(),
             compaction_catalog_agent_ref.clone(),
-            Box::new(SharedComapctorObjectIdManager::for_test(
-                VecDeque::from_iter([22, 23, 24, 25, 26, 27, 28, 29]),
-            )),
+            SharedComapctorObjectIdManager::for_test(VecDeque::from_iter([
+                22, 23, 24, 25, 26, 27, 28, 29,
+            ])),
             Arc::new(TaskProgress::default()),
         );
         let (_, ret1, _) = slow_compact_runner
@@ -2044,7 +2044,7 @@ pub(crate) mod tests {
                 compact_ctx,
                 compact_task.clone(),
                 rx,
-                Box::new(object_id_manager.clone()),
+                object_id_manager.clone(),
                 compaction_catalog_agent_ref.clone(),
             )
             .await;
@@ -2283,7 +2283,7 @@ pub(crate) mod tests {
                     compact_ctx.clone(),
                     compact_task.clone(),
                     rx,
-                    Box::new(object_id_manager.clone()),
+                    object_id_manager.clone(),
                     compaction_catalog_agent_ref.clone(),
                 )
                 .await;

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -75,8 +75,8 @@ pub(crate) mod tests {
     use risingwave_storage::hummock::{
         BlockedXor16FilterBuilder, CachePolicy, CompressionAlgorithm, FilterBuilder,
         HummockStorage as GlobalHummockStorage, HummockStorage, LocalHummockStorage, MemoryLimiter,
-        SharedComapctorObjectIdManager, Sstable, SstableBuilder, SstableBuilderOptions,
-        SstableIteratorReadOptions, SstableObjectIdManager, SstableWriterOptions,
+        ObjectIdManager, SharedComapctorObjectIdManager, Sstable, SstableBuilder,
+        SstableBuilderOptions, SstableIteratorReadOptions, SstableWriterOptions,
     };
     use risingwave_storage::monitor::{CompactorMetrics, StoreLocalStatistic};
     use risingwave_storage::opts::StorageOpts;
@@ -238,7 +238,7 @@ pub(crate) mod tests {
         .await;
 
         let compact_ctx = get_compactor_context(&storage);
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             storage
                 .storage_opts()
@@ -283,7 +283,7 @@ pub(crate) mod tests {
                 compact_ctx.clone(),
                 compact_task.clone(),
                 rx,
-                Box::new(sstable_object_id_manager.clone()),
+                Box::new(object_id_manager.clone()),
                 compaction_catalog_agent_ref.clone(),
             )
             .await;
@@ -502,7 +502,7 @@ pub(crate) mod tests {
             global_storage.storage_opts().clone(),
             global_storage.sstable_store(),
         );
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             global_storage
                 .storage_opts()
@@ -599,7 +599,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(sstable_object_id_manager.clone()),
+            Box::new(object_id_manager.clone()),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -695,7 +695,7 @@ pub(crate) mod tests {
         .await;
 
         let compact_ctx = get_compactor_context(&storage);
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             storage
                 .storage_opts()
@@ -799,7 +799,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(sstable_object_id_manager.clone()),
+            Box::new(object_id_manager.clone()),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -919,7 +919,7 @@ pub(crate) mod tests {
         ));
 
         let compact_ctx = get_compactor_context(&storage);
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             storage
                 .storage_opts()
@@ -1003,7 +1003,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(sstable_object_id_manager.clone()),
+            Box::new(object_id_manager.clone()),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -1113,7 +1113,7 @@ pub(crate) mod tests {
         )
         .await;
         let compact_ctx = get_compactor_context(&storage);
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             storage
                 .storage_opts()
@@ -1188,7 +1188,7 @@ pub(crate) mod tests {
             compact_ctx,
             compact_task.clone(),
             rx,
-            Box::new(sstable_object_id_manager.clone()),
+            Box::new(object_id_manager.clone()),
             compaction_catalog_agent_ref.clone(),
         )
         .await;
@@ -1344,7 +1344,7 @@ pub(crate) mod tests {
             &[existing_table_id],
         )
         .await;
-        hummock_manager_ref.get_new_sst_ids(10).await.unwrap();
+        hummock_manager_ref.get_new_object_ids(10).await.unwrap();
         let compact_ctx = get_compactor_context(&storage);
         let compaction_catalog_agent_ref =
             CompactionCatalogAgent::for_test(vec![existing_table_id]);
@@ -1527,7 +1527,7 @@ pub(crate) mod tests {
             &[existing_table_id],
         )
         .await;
-        hummock_manager_ref.get_new_sst_ids(10).await.unwrap();
+        hummock_manager_ref.get_new_object_ids(10).await.unwrap();
         let compact_ctx = get_compactor_context(&storage);
         let compaction_catalog_agent_ref =
             CompactionCatalogAgent::for_test(vec![existing_table_id]);
@@ -1655,7 +1655,7 @@ pub(crate) mod tests {
             &[existing_table_id],
         )
         .await;
-        hummock_manager_ref.get_new_sst_ids(10).await.unwrap();
+        hummock_manager_ref.get_new_object_ids(10).await.unwrap();
         let compact_ctx = get_compactor_context(&storage);
         let compaction_catalog_agent_ref =
             CompactionCatalogAgent::for_test(vec![existing_table_id]);
@@ -1897,7 +1897,7 @@ pub(crate) mod tests {
             CompactionCatalogAgent::for_test(vec![table_id_1.table_id(), table_id_2.table_id()]);
 
         let compact_ctx = get_compactor_context(&storage);
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             storage
                 .storage_opts()
@@ -2014,7 +2014,7 @@ pub(crate) mod tests {
             hummock_manager_ref: HummockManagerRef,
             compact_ctx: CompactorContext,
             compaction_catalog_agent_ref: CompactionCatalogAgentRef,
-            sstable_object_id_manager: Arc<SstableObjectIdManager>,
+            object_id_manager: Arc<ObjectIdManager>,
         ) {
             // compact left group
             let manual_compcation_option = ManualCompactionOption {
@@ -2044,7 +2044,7 @@ pub(crate) mod tests {
                 compact_ctx,
                 compact_task.clone(),
                 rx,
-                Box::new(sstable_object_id_manager.clone()),
+                Box::new(object_id_manager.clone()),
                 compaction_catalog_agent_ref.clone(),
             )
             .await;
@@ -2092,7 +2092,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2102,7 +2102,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2130,7 +2130,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2140,7 +2140,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2174,7 +2174,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2235,7 +2235,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2245,7 +2245,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2255,7 +2255,7 @@ pub(crate) mod tests {
             hummock_manager_ref: HummockManagerRef,
             compact_ctx: CompactorContext,
             compaction_catalog_agent_ref: CompactionCatalogAgentRef,
-            sstable_object_id_manager: Arc<SstableObjectIdManager>,
+            object_id_manager: Arc<ObjectIdManager>,
         ) {
             loop {
                 let manual_compcation_option = ManualCompactionOption {
@@ -2283,7 +2283,7 @@ pub(crate) mod tests {
                     compact_ctx.clone(),
                     compact_task.clone(),
                     rx,
-                    Box::new(sstable_object_id_manager.clone()),
+                    Box::new(object_id_manager.clone()),
                     compaction_catalog_agent_ref.clone(),
                 )
                 .await;
@@ -2333,7 +2333,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 
@@ -2343,7 +2343,7 @@ pub(crate) mod tests {
             hummock_manager_ref.clone(),
             compact_ctx.clone(),
             compaction_catalog_agent_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
         )
         .await;
 

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -36,7 +36,7 @@ use risingwave_storage::compaction_catalog_manager::CompactionCatalogAgentRef;
 use risingwave_storage::hummock::compactor::CompactorContext;
 use risingwave_storage::hummock::compactor::compactor_runner::compact_with_agent;
 use risingwave_storage::hummock::test_utils::{ReadOptions, *};
-use risingwave_storage::hummock::{CachePolicy, GetObjectId, SstableObjectIdManager};
+use risingwave_storage::hummock::{CachePolicy, GetObjectId, ObjectIdManager};
 use risingwave_storage::store::*;
 use serial_test::serial;
 
@@ -49,15 +49,14 @@ use crate::test_utils::gen_key_from_bytes;
 #[tokio::test]
 #[cfg(feature = "sync_point")]
 #[serial]
-async fn test_syncpoints_sstable_object_id_manager() {
+async fn test_syncpoints_object_id_manager() {
     let (_env, hummock_manager_ref, _cluster_manager_ref, worker_id) =
         setup_compute_env(8080).await;
     let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
         hummock_manager_ref.clone(),
         worker_id as _,
     ));
-    let sstable_object_id_manager =
-        Arc::new(SstableObjectIdManager::new(hummock_meta_client.clone(), 5));
+    let object_id_manager = Arc::new(ObjectIdManager::new(hummock_meta_client.clone(), 5));
 
     // Block filling cache after fetching ids.
     sync_point::hook("MAP_NEXT_SST_OBJECT_ID.BEFORE_FILL_CACHE", || async {
@@ -70,9 +69,9 @@ async fn test_syncpoints_sstable_object_id_manager() {
     });
 
     // Start the task that fetches new ids.
-    let mut sstable_object_id_manager_clone = sstable_object_id_manager.clone();
+    let mut object_id_manager_clone = object_id_manager.clone();
     let leader_task = tokio::spawn(async move {
-        sstable_object_id_manager_clone
+        object_id_manager_clone
             .get_new_sst_object_id()
             .await
             .unwrap();
@@ -87,9 +86,9 @@ async fn test_syncpoints_sstable_object_id_manager() {
     // Start tasks that waits to be notified.
     let mut follower_tasks = vec![];
     for _ in 0..3 {
-        let mut sstable_object_id_manager_clone = sstable_object_id_manager.clone();
+        let mut object_id_manager_clone = object_id_manager.clone();
         let follower_task = tokio::spawn(async move {
-            sstable_object_id_manager_clone
+            object_id_manager_clone
                 .get_new_sst_object_id()
                 .await
                 .unwrap();
@@ -122,8 +121,7 @@ async fn test_syncpoints_test_failpoints_fetch_ids() {
         hummock_manager_ref.clone(),
         worker_id as _,
     ));
-    let sstable_object_id_manager =
-        Arc::new(SstableObjectIdManager::new(hummock_meta_client.clone(), 5));
+    let object_id_manager = Arc::new(ObjectIdManager::new(hummock_meta_client.clone(), 5));
 
     // Block fetching ids.
     sync_point::hook("MAP_NEXT_SST_OBJECT_ID.BEFORE_FETCH", || async {
@@ -134,10 +132,10 @@ async fn test_syncpoints_test_failpoints_fetch_ids() {
     });
 
     // Start the task that fetches new ids.
-    let mut sstable_object_id_manager_clone = sstable_object_id_manager.clone();
+    let mut object_id_manager_clone = object_id_manager.clone();
     let leader_task = tokio::spawn(async move {
         fail::cfg("get_new_sst_ids_err", "return").unwrap();
-        sstable_object_id_manager_clone
+        object_id_manager_clone
             .get_new_sst_object_id()
             .await
             .unwrap_err();
@@ -150,9 +148,9 @@ async fn test_syncpoints_test_failpoints_fetch_ids() {
     // Start tasks that waits to be notified.
     let mut follower_tasks = vec![];
     for _ in 0..3 {
-        let mut sstable_object_id_manager_clone = sstable_object_id_manager.clone();
+        let mut object_id_manager_clone = object_id_manager.clone();
         let follower_task = tokio::spawn(async move {
-            sstable_object_id_manager_clone
+            object_id_manager_clone
                 .get_new_sst_object_id()
                 .await
                 .unwrap();
@@ -180,7 +178,7 @@ pub async fn compact_once(
     hummock_manager_ref: HummockManagerRef,
     compact_ctx: CompactorContext,
     compaction_catalog_agent_ref: CompactionCatalogAgentRef,
-    sstable_object_id_manager: Arc<SstableObjectIdManager>,
+    object_id_manager: Arc<ObjectIdManager>,
 ) {
     // 2. get compact task
     let manual_compcation_option = ManualCompactionOption {
@@ -206,7 +204,7 @@ pub async fn compact_once(
         compact_ctx,
         compact_task.clone(),
         rx,
-        Box::new(sstable_object_id_manager),
+        Box::new(object_id_manager),
         compaction_catalog_agent_ref.clone(),
     )
     .await;
@@ -261,7 +259,7 @@ async fn test_syncpoints_get_in_delete_range_boundary() {
         .await
         .unwrap();
 
-    let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+    let object_id_manager = Arc::new(ObjectIdManager::new(
         hummock_meta_client.clone(),
         storage
             .storage_opts()
@@ -327,7 +325,7 @@ async fn test_syncpoints_get_in_delete_range_boundary() {
         hummock_manager_ref.clone(),
         compact_ctx.clone(),
         compaction_catalog_agent_ref.clone(),
-        sstable_object_id_manager.clone(),
+        object_id_manager.clone(),
     )
     .await;
 
@@ -368,7 +366,7 @@ async fn test_syncpoints_get_in_delete_range_boundary() {
         hummock_manager_ref.clone(),
         compact_ctx.clone(),
         compaction_catalog_agent_ref.clone(),
-        sstable_object_id_manager.clone(),
+        object_id_manager.clone(),
     )
     .await;
 
@@ -410,7 +408,7 @@ async fn test_syncpoints_get_in_delete_range_boundary() {
         hummock_manager_ref.clone(),
         compact_ctx.clone(),
         compaction_catalog_agent_ref.clone(),
-        sstable_object_id_manager.clone(),
+        object_id_manager.clone(),
     )
     .await;
 
@@ -445,7 +443,7 @@ async fn test_syncpoints_get_in_delete_range_boundary() {
         hummock_manager_ref.clone(),
         compact_ctx.clone(),
         compaction_catalog_agent_ref.clone(),
-        sstable_object_id_manager.clone(),
+        object_id_manager.clone(),
     )
     .await;
 

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -69,7 +69,7 @@ async fn test_syncpoints_object_id_manager() {
     });
 
     // Start the task that fetches new ids.
-    let mut object_id_manager_clone = object_id_manager.clone();
+    let object_id_manager_clone = object_id_manager.clone();
     let leader_task = tokio::spawn(async move {
         object_id_manager_clone
             .get_new_sst_object_id()
@@ -86,7 +86,7 @@ async fn test_syncpoints_object_id_manager() {
     // Start tasks that waits to be notified.
     let mut follower_tasks = vec![];
     for _ in 0..3 {
-        let mut object_id_manager_clone = object_id_manager.clone();
+        let object_id_manager_clone = object_id_manager.clone();
         let follower_task = tokio::spawn(async move {
             object_id_manager_clone
                 .get_new_sst_object_id()
@@ -132,7 +132,7 @@ async fn test_syncpoints_test_failpoints_fetch_ids() {
     });
 
     // Start the task that fetches new ids.
-    let mut object_id_manager_clone = object_id_manager.clone();
+    let object_id_manager_clone = object_id_manager.clone();
     let leader_task = tokio::spawn(async move {
         fail::cfg("get_new_sst_ids_err", "return").unwrap();
         object_id_manager_clone
@@ -148,7 +148,7 @@ async fn test_syncpoints_test_failpoints_fetch_ids() {
     // Start tasks that waits to be notified.
     let mut follower_tasks = vec![];
     for _ in 0..3 {
-        let mut object_id_manager_clone = object_id_manager.clone();
+        let object_id_manager_clone = object_id_manager.clone();
         let follower_task = tokio::spawn(async move {
             object_id_manager_clone
                 .get_new_sst_object_id()
@@ -204,7 +204,7 @@ pub async fn compact_once(
         compact_ctx,
         compact_task.clone(),
         rx,
-        Box::new(object_id_manager),
+        object_id_manager,
         compaction_catalog_agent_ref.clone(),
     )
     .await;

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -52,7 +52,7 @@ use crate::hummock::{
 use crate::monitor::StoreLocalStatistic;
 
 pub struct RemoteBuilderFactory<W: SstableWriterFactory, F: FilterBuilder> {
-    pub object_id_getter: Box<dyn GetObjectId>,
+    pub object_id_getter: Arc<dyn GetObjectId>,
     pub limiter: Arc<MemoryLimiter>,
     pub options: SstableBuilderOptions,
     pub policy: CachePolicy,

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -78,7 +78,7 @@ impl CompactorRunner {
         split_index: usize,
         context: CompactorContext,
         task: CompactTask,
-        object_id_getter: Box<dyn GetObjectId>,
+        object_id_getter: Arc<dyn GetObjectId>,
     ) -> Self {
         let mut options: SstableBuilderOptions = context.storage_opts.as_ref().into();
         options.compression_algorithm = match task.compression_algorithm {
@@ -325,7 +325,7 @@ pub async fn compact_with_agent(
     compactor_context: CompactorContext,
     mut compact_task: CompactTask,
     mut shutdown_rx: Receiver<()>,
-    object_id_getter: Box<dyn GetObjectId>,
+    object_id_getter: Arc<dyn GetObjectId>,
     compaction_catalog_agent_ref: CompactionCatalogAgentRef,
 ) -> (
     (
@@ -583,7 +583,7 @@ pub async fn compact(
     compactor_context: CompactorContext,
     compact_task: CompactTask,
     shutdown_rx: Receiver<()>,
-    object_id_getter: Box<dyn GetObjectId>,
+    object_id_getter: Arc<dyn GetObjectId>,
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
 ) -> (
     (

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -362,7 +362,7 @@ impl CompactorRunner {
         context: CompactorContext,
         task: CompactTask,
         compaction_catalog_agent_ref: CompactionCatalogAgentRef,
-        object_id_getter: Box<dyn GetObjectId>,
+        object_id_getter: Arc<dyn GetObjectId>,
         task_progress: Arc<TaskProgress>,
     ) -> Self {
         let mut options: SstableBuilderOptions = context.storage_opts.as_ref().into();

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -96,7 +96,7 @@ use crate::monitor::CompactorMetrics;
 pub struct Compactor {
     /// The context of the compactor.
     context: CompactorContext,
-    object_id_getter: Box<dyn GetObjectId>,
+    object_id_getter: Arc<dyn GetObjectId>,
     task_config: TaskConfig,
     options: SstableBuilderOptions,
     get_id_time: Arc<AtomicU64>,
@@ -110,7 +110,7 @@ impl Compactor {
         context: CompactorContext,
         options: SstableBuilderOptions,
         task_config: TaskConfig,
-        object_id_getter: Box<dyn GetObjectId>,
+        object_id_getter: Arc<dyn GetObjectId>,
     ) -> Self {
         Self {
             context,
@@ -233,7 +233,7 @@ impl Compactor {
         compaction_filter: impl CompactionFilter,
         compaction_catalog_agent_ref: CompactionCatalogAgentRef,
         task_progress: Option<Arc<TaskProgress>>,
-        object_id_getter: Box<dyn GetObjectId>,
+        object_id_getter: Arc<dyn GetObjectId>,
     ) -> HummockResult<(Vec<LocalSstableInfo>, CompactionStatistics)> {
         let builder_factory = RemoteBuilderFactory::<F, B> {
             object_id_getter,
@@ -525,7 +525,7 @@ pub fn start_compactor(
                                         context.clone(),
                                         compact_task,
                                         rx,
-                                        Box::new(object_id_manager.clone()),
+                                        object_id_manager.clone(),
                                         compaction_catalog_manager_ref.clone(),
                                     )
                                     .await;
@@ -703,7 +703,7 @@ pub fn start_shared_compactor(
                                         context.clone(),
                                         compact_task,
                                         rx,
-                                        Box::new(shared_compactor_object_id_manager),
+                                        shared_compactor_object_id_manager,
                                         compaction_catalog_agent_ref.clone(),
                                     )
                                     .await;

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -78,7 +78,7 @@ pub use self::compaction_utils::{
 pub use self::task_progress::TaskProgress;
 use super::multi_builder::CapacitySplitTableBuilder;
 use super::{
-    GetObjectId, HummockResult, SstableBuilderOptions, SstableObjectIdManager, Xor16FilterBuilder,
+    GetObjectId, HummockResult, ObjectIdManager, SstableBuilderOptions, Xor16FilterBuilder,
 };
 use crate::compaction_catalog_manager::{
     CompactionCatalogAgentRef, CompactionCatalogManager, CompactionCatalogManagerRef,
@@ -282,7 +282,7 @@ impl Compactor {
 pub fn start_compactor(
     compactor_context: CompactorContext,
     hummock_meta_client: Arc<dyn HummockMetaClient>,
-    sstable_object_id_manager: Arc<SstableObjectIdManager>,
+    object_id_manager: Arc<ObjectIdManager>,
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
 ) -> (JoinHandle<()>, Sender<()>) {
     type CompactionShutdownMap = Arc<Mutex<HashMap<u64, Sender<()>>>>;
@@ -343,7 +343,7 @@ pub fn start_compactor(
             pin_mut!(response_event_stream);
 
             let executor = compactor_context.compaction_executor.clone();
-            let sstable_object_id_manager = sstable_object_id_manager.clone();
+            let object_id_manager = object_id_manager.clone();
 
             // This inner loop is to consume stream or report task progress.
             let mut event_loop_iteration_now = Instant::now();
@@ -474,7 +474,7 @@ pub fn start_compactor(
                             .compaction_event_consumed_latency
                             .observe(consumed_latency_ms as _);
 
-                        let sstable_object_id_manager = sstable_object_id_manager.clone();
+                        let object_id_manager = object_id_manager.clone();
                         let compaction_catalog_manager_ref = compaction_catalog_manager_ref.clone();
 
                         match event {
@@ -525,7 +525,7 @@ pub fn start_compactor(
                                         context.clone(),
                                         compact_task,
                                         rx,
-                                        Box::new(sstable_object_id_manager.clone()),
+                                        Box::new(object_id_manager.clone()),
                                         compaction_catalog_manager_ref.clone(),
                                     )
                                     .await;

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -195,7 +195,7 @@ async fn compact_shared_buffer<const IS_NEW_VALUE: bool>(
             sub_compaction_sstable_size as usize,
             table_vnode_partition.clone(),
             use_block_based_filter,
-            Box::new(object_id_manager.clone()),
+            object_id_manager.clone(),
         );
         let mut forward_iters = Vec::with_capacity(payload.len());
         for imm in &payload {
@@ -555,7 +555,7 @@ impl SharedBufferCompactRunner {
         sub_compaction_sstable_size: usize,
         table_vnode_partition: BTreeMap<u32, u32>,
         use_block_based_filter: bool,
-        object_id_getter: Box<dyn GetObjectId>,
+        object_id_getter: Arc<dyn GetObjectId>,
     ) -> Self {
         let mut options: SstableBuilderOptions = context.storage_opts.as_ref().into();
         options.capacity = sub_compaction_sstable_size;

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -45,7 +45,7 @@ use crate::hummock::shared_buffer::shared_buffer_batch::{
 use crate::hummock::utils::MemoryTracker;
 use crate::hummock::{
     BlockedXor16FilterBuilder, CachePolicy, GetObjectId, HummockError, HummockResult,
-    SstableBuilderOptions, SstableObjectIdManagerRef,
+    ObjectIdManagerRef, SstableBuilderOptions,
 };
 use crate::mem_table::ImmutableMemtable;
 use crate::opts::StorageOpts;
@@ -55,7 +55,7 @@ const GC_DELETE_KEYS_FOR_FLUSH: bool = false;
 /// Flush shared buffer to level0. Resulted SSTs are grouped by compaction group.
 pub async fn compact(
     context: CompactorContext,
-    sstable_object_id_manager: SstableObjectIdManagerRef,
+    object_id_manager: ObjectIdManagerRef,
     payload: Vec<ImmutableMemtable>,
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
 ) -> HummockResult<UploadTaskOutput> {
@@ -84,7 +84,7 @@ pub async fn compact(
         } else {
             compact_shared_buffer::<true>(
                 context.clone(),
-                sstable_object_id_manager.clone(),
+                object_id_manager.clone(),
                 compaction_catalog_manager_ref.clone(),
                 non_log_store_new_value_payload,
             )
@@ -99,7 +99,7 @@ pub async fn compact(
         } else {
             compact_shared_buffer::<true>(
                 context.clone(),
-                sstable_object_id_manager.clone(),
+                object_id_manager.clone(),
                 compaction_catalog_manager_ref.clone(),
                 log_store_new_value_payload,
             )
@@ -114,7 +114,7 @@ pub async fn compact(
         } else {
             compact_shared_buffer::<false>(
                 context.clone(),
-                sstable_object_id_manager.clone(),
+                object_id_manager.clone(),
                 compaction_catalog_manager_ref.clone(),
                 old_value_payload,
             )
@@ -146,7 +146,7 @@ pub async fn compact(
 /// When `IS_NEW_VALUE` is false, we are compacting with old value, and the payload imms should have `old_values` not `None`
 async fn compact_shared_buffer<const IS_NEW_VALUE: bool>(
     context: CompactorContext,
-    sstable_object_id_manager: SstableObjectIdManagerRef,
+    object_id_manager: ObjectIdManagerRef,
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
     mut payload: Vec<ImmutableMemtable>,
 ) -> HummockResult<Vec<LocalSstableInfo>> {
@@ -195,7 +195,7 @@ async fn compact_shared_buffer<const IS_NEW_VALUE: bool>(
             sub_compaction_sstable_size as usize,
             table_vnode_partition.clone(),
             use_block_based_filter,
-            Box::new(sstable_object_id_manager.clone()),
+            Box::new(object_id_manager.clone()),
         );
         let mut forward_iters = Vec::with_capacity(payload.len());
         for imm in &payload {

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -54,7 +54,7 @@ use crate::hummock::local_version::recent_versions::RecentVersions;
 use crate::hummock::store::version::{
     HummockReadVersion, StagingData, StagingSstableInfo, VersionUpdate,
 };
-use crate::hummock::{HummockResult, MemoryLimiter, SstableObjectIdManager, SstableStoreRef};
+use crate::hummock::{HummockResult, MemoryLimiter, ObjectIdManager, SstableStoreRef};
 use crate::mem_table::ImmutableMemtable;
 use crate::monitor::HummockStateStoreMetrics;
 use crate::opts::StorageOpts;
@@ -217,11 +217,11 @@ async fn flush_imms(
     payload: Vec<ImmutableMemtable>,
     compactor_context: CompactorContext,
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
-    sstable_object_id_manager: Arc<SstableObjectIdManager>,
+    object_id_manager: Arc<ObjectIdManager>,
 ) -> HummockResult<UploadTaskOutput> {
     compact(
         compactor_context,
-        sstable_object_id_manager,
+        object_id_manager,
         payload,
         compaction_catalog_manager_ref,
     )
@@ -235,7 +235,7 @@ impl HummockEventHandler {
         pinned_version: PinnedVersion,
         compactor_context: CompactorContext,
         compaction_catalog_manager_ref: CompactionCatalogManagerRef,
-        sstable_object_id_manager: Arc<SstableObjectIdManager>,
+        object_id_manager: Arc<ObjectIdManager>,
         state_store_metrics: Arc<HummockStateStoreMetrics>,
     ) -> Self {
         let upload_compactor_context = compactor_context.clone();
@@ -273,7 +273,7 @@ impl HummockEventHandler {
                 let wait_poll_latency = wait_poll_latency.clone();
                 let upload_compactor_context = upload_compactor_context.clone();
                 let compaction_catalog_manager_ref = compaction_catalog_manager_ref.clone();
-                let sstable_object_id_manager = sstable_object_id_manager.clone();
+                let object_id_manager = object_id_manager.clone();
                 spawn({
                     let future = async move {
                         let _timer = upload_task_latency.start_timer();
@@ -284,7 +284,7 @@ impl HummockEventHandler {
                                 .collect(),
                             upload_compactor_context.clone(),
                             compaction_catalog_manager_ref.clone(),
-                            sstable_object_id_manager.clone(),
+                            object_id_manager.clone(),
                         )
                         .await?;
                         assert!(

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use risingwave_hummock_sdk::version::HummockVersion;
-use risingwave_hummock_sdk::{SstObjectIdRange, SyncResult};
+use risingwave_hummock_sdk::{ObjectIdRange, SyncResult};
 use risingwave_pb::hummock::{PbHummockVersion, SubscribeCompactionEventRequest};
 use risingwave_pb::iceberg_compaction::SubscribeIcebergCompactionEventRequest;
 use risingwave_rpc_client::error::Result;
@@ -58,10 +58,10 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
         self.meta_client.get_current_version().await
     }
 
-    async fn get_new_sst_ids(&self, number: u32) -> Result<SstObjectIdRange> {
+    async fn get_new_object_ids(&self, number: u32) -> Result<ObjectIdRange> {
         self.stats.get_new_sst_ids_counts.inc();
         let timer = self.stats.get_new_sst_ids_latency.start_timer();
-        let res = self.meta_client.get_new_sst_ids(number).await;
+        let res = self.meta_client.get_new_object_ids(number).await;
         timer.observe_duration();
         res
     }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -54,7 +54,9 @@ pub use recent_filter::*;
 pub mod block_stream;
 mod time_travel_version_cache;
 
+mod object_id_manager;
 pub use error::*;
+pub use object_id_manager::*;
 pub use risingwave_common::cache::{CacheableEntry, LookupResult, LruCache};
 pub use validator::*;
 use value::*;

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -47,11 +47,9 @@ use risingwave_hummock_sdk::key::{FullKey, KeyPayloadType, UserKey, UserKeyRange
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
 
 mod filter;
-mod sstable_object_id_manager;
 mod utils;
 
 pub use filter::FilterBuilder;
-pub use sstable_object_id_manager::*;
 pub use utils::CompressionAlgorithm;
 use utils::{get_length_prefixed_slice, put_length_prefixed_slice};
 use xxhash_rust::{xxh32, xxh64};

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -58,7 +58,7 @@ use crate::hummock::utils::{wait_for_epoch, wait_for_update};
 use crate::hummock::write_limiter::{WriteLimiter, WriteLimiterRef};
 use crate::hummock::{
     HummockEpoch, HummockError, HummockResult, HummockStorageIterator, HummockStorageRevIterator,
-    MemoryLimiter, SstableObjectIdManager, SstableObjectIdManagerRef, SstableStoreRef,
+    MemoryLimiter, ObjectIdManager, ObjectIdManagerRef, SstableStoreRef,
 };
 use crate::mem_table::ImmutableMemtable;
 use crate::monitor::{CompactorMetrics, HummockStateStoreMetrics};
@@ -94,7 +94,7 @@ pub struct HummockStorage {
 
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
 
-    sstable_object_id_manager: SstableObjectIdManagerRef,
+    object_id_manager: ObjectIdManagerRef,
 
     buffer_tracker: BufferTracker,
 
@@ -155,7 +155,7 @@ impl HummockStorage {
         compactor_metrics: Arc<CompactorMetrics>,
         await_tree_config: Option<await_tree::Config>,
     ) -> HummockResult<Self> {
-        let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
+        let object_id_manager = Arc::new(ObjectIdManager::new(
             hummock_meta_client.clone(),
             options.sstable_id_remote_fetch_number,
         ));
@@ -210,7 +210,7 @@ impl HummockStorage {
             pinned_version,
             compactor_context.clone(),
             compaction_catalog_manager_ref.clone(),
-            sstable_object_id_manager.clone(),
+            object_id_manager.clone(),
             state_store_metrics.clone(),
         );
 
@@ -219,7 +219,7 @@ impl HummockStorage {
         let instance = Self {
             context: compactor_context,
             compaction_catalog_manager_ref: compaction_catalog_manager_ref.clone(),
-            sstable_object_id_manager,
+            object_id_manager,
             buffer_tracker: hummock_event_handler.buffer_tracker().clone(),
             version_update_notifier_tx: hummock_event_handler.version_update_notifier_tx(),
             hummock_event_sender: event_tx.clone(),
@@ -567,8 +567,8 @@ impl HummockStorage {
         self.context.sstable_store.clone()
     }
 
-    pub fn sstable_object_id_manager(&self) -> &SstableObjectIdManagerRef {
-        &self.sstable_object_id_manager
+    pub fn object_id_manager(&self) -> &ObjectIdManagerRef {
+        &self.object_id_manager
     }
 
     pub fn compaction_catalog_manager_ref(&self) -> CompactionCatalogManagerRef {

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -32,7 +32,7 @@ use tracing::{Instrument, error};
 use super::{MonitoredStateStoreGetStats, MonitoredStateStoreIterStats, MonitoredStorageMetrics};
 use crate::error::StorageResult;
 use crate::hummock::sstable_store::SstableStoreRef;
-use crate::hummock::{HummockStorage, SstableObjectIdManagerRef};
+use crate::hummock::{HummockStorage, ObjectIdManagerRef};
 use crate::monitor::monitored_storage_metrics::StateStoreIterStats;
 use crate::monitor::{StateStoreIterLogStats, StateStoreIterStatsTrait};
 use crate::store::*;
@@ -368,8 +368,8 @@ impl MonitoredStateStore<HummockStorage> {
         self.inner.sstable_store()
     }
 
-    pub fn sstable_object_id_manager(&self) -> SstableObjectIdManagerRef {
-        self.inner.sstable_object_id_manager().clone()
+    pub fn object_id_manager(&self) -> ObjectIdManagerRef {
+        self.inner.object_id_manager().clone()
     }
 }
 

--- a/src/storage/src/monitor/traced_store.rs
+++ b/src/storage/src/monitor/traced_store.rs
@@ -31,7 +31,7 @@ use thiserror_ext::AsReport;
 
 use crate::error::StorageResult;
 use crate::hummock::sstable_store::SstableStoreRef;
-use crate::hummock::{HummockStorage, SstableObjectIdManagerRef};
+use crate::hummock::{HummockStorage, ObjectIdManagerRef};
 use crate::store::*;
 use crate::store_impl::AsHummock;
 
@@ -409,8 +409,8 @@ impl TracedStateStore<HummockStorage> {
         self.inner.sstable_store()
     }
 
-    pub fn sstable_object_id_manager(&self) -> &SstableObjectIdManagerRef {
-        self.inner.sstable_object_id_manager()
+    pub fn object_id_manager(&self) -> &ObjectIdManagerRef {
+        self.inner.object_id_manager()
     }
 }
 

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -269,7 +269,9 @@ async fn init_metadata_for_replay(
         .await?;
 
     // shift the sst id to avoid conflict with the original meta node
-    let _ = new_meta_client.get_new_sst_ids(SST_ID_SHIFT_COUNT).await?;
+    let _ = new_meta_client
+        .get_new_object_ids(SST_ID_SHIFT_COUNT)
+        .await?;
 
     tracing::info!("Finished initializing the new Meta");
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Currently in hummock, we only have the sst object file, and the structs and rpc related to generating unique object id are all for sstable object id. As we will support more object types for vector index, in this PR, we will generalize them to support generating the unique general object id type.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
