### PR TITLE
feat(sqlsmith): support testing EOWC

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -133,6 +133,7 @@ pub fn create_table_statement_to_table(statement: &Statement) -> Table {
             columns,
             constraints,
             append_only,
+            source_watermarks,
             ..
         } => {
             let column_name_to_index_mapping: HashMap<_, _> = columns
@@ -170,6 +171,7 @@ pub fn create_table_statement_to_table(statement: &Statement) -> Table {
                 columns.iter().map(|c| c.clone().into()).collect(),
                 pk_indices,
                 *append_only,
+                source_watermarks.to_vec(),
             )
         }
         _ => panic!(

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -122,6 +122,7 @@ pub fn create_table_statement_to_table(statement: &Statement) -> Table {
             name,
             columns,
             constraints,
+            append_only,
             ..
         } => {
             let column_name_to_index_mapping: HashMap<_, _> = columns
@@ -158,6 +159,7 @@ pub fn create_table_statement_to_table(statement: &Statement) -> Table {
                 name.0[0].real_value(),
                 columns.iter().map(|c| c.clone().into()).collect(),
                 pk_indices,
+                *append_only,
             )
         }
         _ => panic!(

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -44,6 +44,7 @@ pub struct Table {
     pub columns: Vec<Column>,
     pub pk_indices: Vec<usize>,
     pub is_base_table: bool,
+    pub is_append_only: bool,
 }
 
 impl Table {
@@ -53,15 +54,22 @@ impl Table {
             columns,
             pk_indices: vec![],
             is_base_table: false,
+            is_append_only: false,
         }
     }
 
-    pub fn new_for_base_table(name: String, columns: Vec<Column>, pk_indices: Vec<usize>) -> Self {
+    pub fn new_for_base_table(
+        name: String,
+        columns: Vec<Column>,
+        pk_indices: Vec<usize>,
+        is_append_only: bool,
+    ) -> Self {
         Self {
             name,
             columns,
             pk_indices,
             is_base_table: true,
+            is_append_only,
         }
     }
 

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -22,7 +22,8 @@ use rand::Rng;
 use risingwave_common::types::DataType;
 use risingwave_frontend::bind_data_type;
 use risingwave_sqlparser::ast::{
-    ColumnDef, EmitMode, Expr, Ident, ObjectName, SetExpr, SourceWatermark, Statement, TableFactor,
+    ColumnDef, EmitMode, Expr, FunctionArg, FunctionArgExpr, Ident, ObjectName, SetExpr,
+    SourceWatermark, Statement, TableFactor,
 };
 
 mod agg;
@@ -215,38 +216,13 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let query = Box::new(query);
         let table = Table::new(name.to_owned(), schema);
         let name = ObjectName(vec![Ident::new_unchecked(name)]);
-        let uses_append_only_table = if let SetExpr::Select(ref select) = query.body {
-            select.from.iter().any(|table_with_joins| {
-                if let TableFactor::Table { name, .. } = &table_with_joins.relation {
-                    append_only_tables
-                        .iter()
-                        .any(|t| t.name == name.base_name())
-                } else {
-                    false
-                }
-            })
-        } else {
-            false
-        };
 
-        let uses_group_by_with_watermarks = if let SetExpr::Select(ref select) = query.body {
-            select.group_by.iter().any(|group_expr| {
-                if let Expr::Identifier(group_ident) = group_expr {
-                    append_only_tables.iter().any(|table| {
-                        table.source_watermarks.iter().any(|watermark| {
-                            matches!(&watermark.expr, Expr::Identifier(w_ident) if w_ident.real_value() == group_ident.real_value())
-                        })
-                    })
-                } else {
-                    false
-                }
-            })
-        } else {
-            false
-        };
+        let uses_append_only_table = self.uses_append_only_table(&query.body, &append_only_tables);
+        let uses_valid_window_function =
+            self.uses_valid_window_function(&query.body, &append_only_tables);
 
         // Randomly choose emit mode if allowed
-        let emit_mode = if uses_append_only_table && uses_group_by_with_watermarks {
+        let emit_mode = if uses_append_only_table && uses_valid_window_function {
             match self.rng.random_range(0..3) {
                 0 => Some(EmitMode::Immediately),
                 1 => Some(EmitMode::OnWindowClose),
@@ -267,6 +243,70 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             emit_mode,
         };
         (mview, table)
+    }
+
+    /// Check whether the current query reads from at least one append-only table.
+    ///
+    /// This function looks for `FROM table_name` in the SELECT clause, and matches
+    /// it against the list of known append-only tables. If any match is found,
+    /// returns `true`.
+    ///
+    /// This is required for enabling `EMIT ON WINDOW CLOSE`, because such mode
+    /// only supports append-only sources.
+    fn uses_append_only_table(&self, query: &SetExpr, append_only_tables: &[Table]) -> bool {
+        if let SetExpr::Select(select) = query {
+            select.from.iter().any(|table_with_joins| {
+                // Only handle plain base tables (not TVF or subquery)
+                if let TableFactor::Table { name, .. } = &table_with_joins.relation {
+                    // Match table name with known append-only table list
+                    append_only_tables
+                        .iter()
+                        .any(|t| t.name == name.base_name())
+                } else {
+                    false
+                }
+            })
+        } else {
+            false
+        }
+    }
+
+    /// Check whether the query uses a valid HOP or TUMBLE table function
+    /// whose time column matches a watermark column in an append-only table.
+    ///
+    /// This is the key condition for enabling `EMIT ON WINDOW CLOSE`.
+    /// Specifically, this function checks that:
+    ///   - The FROM clause uses a table function (TVF): `TUMBLE(...)` or `HOP(...)`
+    ///   - The second argument of the function is a time column
+    ///   - That column must match the `WATERMARK FOR ...` column in one of the append-only tables
+    fn uses_valid_window_function(&self, query: &SetExpr, append_only_tables: &[Table]) -> bool {
+        if let SetExpr::Select(select) = query {
+            select.from.iter().any(|table_with_joins| {
+                if let TableFactor::TableFunction { name, args, .. } = &table_with_joins.relation {
+                    let fn_name = name.real_value().to_lowercase();
+                    // Must be either HOP or TUMBLE
+                    if (fn_name == "hop" || fn_name == "tumble") && args.len() >= 2 {
+                        // Second argument is the time column
+                        if let FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(
+                            ident,
+                        ))) = &args[1]
+                        {
+                            let time_col = ident.real_value();
+                            // Match against any append-only table's watermark column
+                            return append_only_tables.iter().any(|table| {
+                                table
+                                    .source_watermarks
+                                    .iter()
+                                    .any(|wm| wm.column.real_value() == time_col)
+                            });
+                        }
+                    }
+                }
+                false
+            })
+        } else {
+            false
+        }
     }
 
     /// 50/50 chance to be true/false.

--- a/src/tests/sqlsmith/tests/testdata/alltypes.sql
+++ b/src/tests/sqlsmith/tests/testdata/alltypes.sql
@@ -37,3 +37,25 @@ CREATE TABLE alltypes2 (
     c15 integer [],
     c16 varchar []
 );
+
+CREATE TABLE alltypes3 (
+    c1 boolean,
+    c2 smallint,
+    c3 integer,
+    c4 bigint,
+    c5 real,
+    c6 double precision,
+    c7 numeric,
+    c8 date,
+    c9 varchar,
+    c10 time without time zone,
+    c11 timestamp without time zone,
+    -- TODO(Noel): Many timestamptz expressions are unsupported in RW, leave this out for now.
+    -- c12 timestamp with time zone,
+    c13 interval,
+    c14 struct < a integer >,
+    c15 integer [],
+    c16 varchar [],
+    WATERMARK FOR c11 AS c11 - INTERVAL '5 seconds',
+    PRIMARY KEY (c4)
+) APPEND ONLY;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

This PR adds support for the EMIT ON WINDOW CLOSE (EOWC) feature in materialized view generation.

EOWC requires the following conditions to be satisfied:

1. The query must read from append-only tables.

2. The input table must define a watermark column (via WATERMARK FOR ... AS ...).

3. The query must contain a windowing table function (such as HOP or TUMBLE) that uses the watermark column as its time argument.

The generator now checks all of these conditions before enabling EOWC in the emitted materialized view.

Fixes #10241  

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
