### PR TITLE
feat(iceberg): refine enable config load for iceberg

### DIFF
--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -48,8 +48,8 @@ pub const PRIVATE_LINK_TARGETS_KEY: &str = "privatelink.targets";
 const AWS_MSK_IAM_AUTH: &str = "AWS_MSK_IAM";
 
 /// The environment variable to disable using default credential from environment.
-/// It's recommended to set this variable to `false` in cloud hosting environment.
-const DISABLE_DEFAULT_CREDENTIAL: &str = "DISABLE_DEFAULT_CREDENTIAL";
+/// It's recommended to set this variable to `true` in cloud hosting environment.
+pub const DISABLE_DEFAULT_CREDENTIAL: &str = "DISABLE_DEFAULT_CREDENTIAL";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct AwsPrivateLinkItem {

--- a/src/connector/src/connector_common/connection.rs
+++ b/src/connector/src/connector_common/connection.rs
@@ -23,6 +23,7 @@ use rdkafka::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use risingwave_common::bail;
 use risingwave_common::secret::LocalSecretManager;
+use risingwave_common::util::env_var::env_var_is_true;
 use risingwave_pb::catalog::PbConnection;
 use serde_derive::Deserialize;
 use serde_with::serde_as;
@@ -30,6 +31,7 @@ use tonic::async_trait;
 use url::Url;
 use with_options::WithOptions;
 
+use crate::connector_common::common::DISABLE_DEFAULT_CREDENTIAL;
 use crate::connector_common::{
     AwsAuthProps, IcebergCommon, KafkaConnectionProps, KafkaPrivateLinkCommon,
 };
@@ -212,6 +214,10 @@ pub struct IcebergConnection {
     #[serde(rename = "catalog.jdbc.password")]
     pub jdbc_password: Option<String>,
 
+    /// Enable config load. This parameter set to true will load warehouse credentials from environment. Only allowed to be used in BYOC and self-hosted environment.
+    #[serde(default, deserialize_with = "deserialize_optional_bool_from_string")]
+    pub enable_config_load: Option<bool>,
+
     /// This is only used by iceberg engine to enable the hosted catalog.
     #[serde(
         rename = "hosted_catalog",
@@ -317,6 +323,12 @@ impl Connection for IcebergConnection {
             }
         }
 
+        if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL)
+            && matches!(self.enable_config_load, Some(true))
+        {
+            bail!("`enable_config_load` can't be enabled in this environment");
+        }
+
         if self.hosted_catalog.unwrap_or(false) {
             // If `hosted_catalog` is set, we don't need to test the catalog, but just ensure no catalog fields are set.
             if self.catalog_type.is_some() {
@@ -367,7 +379,7 @@ impl Connection for IcebergConnection {
             path_style_access: self.path_style_access,
             database_name: Some("test_database".to_owned()),
             table_name: "test_table".to_owned(),
-            enable_config_load: Some(false),
+            enable_config_load: self.enable_config_load,
             hosted_catalog: self.hosted_catalog,
         };
 

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -31,11 +31,13 @@ use iceberg::io::{
 use iceberg_catalog_glue::{AWS_ACCESS_KEY_ID, AWS_REGION_NAME, AWS_SECRET_ACCESS_KEY};
 use phf::{Set, phf_set};
 use risingwave_common::bail;
+use risingwave_common::util::env_var::env_var_is_true;
 use serde_derive::Deserialize;
 use serde_with::serde_as;
 use url::Url;
 use with_options::WithOptions;
 
+use crate::connector_common::common::DISABLE_DEFAULT_CREDENTIAL;
 use crate::connector_common::iceberg::storage_catalog::StorageCatalogConfig;
 use crate::deserialize_optional_bool_from_string;
 use crate::enforce_secret::EnforceSecret;
@@ -124,7 +126,7 @@ pub struct IcebergCommon {
         deserialize_with = "deserialize_optional_bool_from_string"
     )]
     pub path_style_access: Option<bool>,
-    /// enable config load.
+    /// Enable config load. This parameter set to true will load warehouse credentials from environment. Only allowed to be used in BYOC and self-hosted environment.
     #[serde(default, deserialize_with = "deserialize_optional_bool_from_string")]
     pub enable_config_load: Option<bool>,
 
@@ -160,13 +162,21 @@ impl IcebergCommon {
             .unwrap_or_else(|| "risingwave".to_owned())
     }
 
+    pub fn enable_config_load(&self) -> bool {
+        // If the env var is set to true, we disable the default config load. (Cloud environment)
+        if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL) {
+            return false;
+        }
+        self.enable_config_load.unwrap_or(false)
+    }
+
     /// For both V1 and V2.
     fn build_jni_catalog_configs(
         &self,
         java_catalog_props: &HashMap<String, String>,
     ) -> ConnectorResult<(HashMap<String, String>, HashMap<String, String>)> {
         let mut iceberg_configs = HashMap::new();
-        let enable_config_load = self.enable_config_load.unwrap_or(false);
+        let enable_config_load = self.enable_config_load();
         let file_io_props = {
             let catalog_type = self.catalog_type().to_owned();
 
@@ -424,14 +434,14 @@ impl IcebergCommon {
                             .secret_key(self.secret_key.clone())
                             .region(self.region.clone())
                             .endpoint(self.endpoint.clone())
-                            .enable_config_load(self.enable_config_load)
+                            .enable_config_load(Some(self.enable_config_load()))
                             .build(),
                     ),
                     "gs" | "gcs" => StorageCatalogConfig::Gcs(
                         storage_catalog::StorageCatalogGcsConfig::builder()
                             .warehouse(warehouse)
                             .credential(self.gcs_credential.clone())
-                            .enable_config_load(self.enable_config_load)
+                            .enable_config_load(Some(self.enable_config_load()))
                             .build(),
                     ),
                     "azblob" => StorageCatalogConfig::Azblob(

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -530,7 +530,7 @@ IcebergConfig:
     default: Default::default
   - name: enable_config_load
     field_type: bool
-    comments: enable config load.
+    comments: Enable config load. This parameter set to true will load warehouse credentials from environment. Only allowed to be used in BYOC and self-hosted environment.
     required: false
     default: Default::default
   - name: hosted_catalog

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -176,7 +176,7 @@ IcebergProperties:
     default: Default::default
   - name: enable_config_load
     field_type: bool
-    comments: enable config load.
+    comments: Enable config load. This parameter set to true will load warehouse credentials from environment. Only allowed to be used in BYOC and self-hosted environment.
     required: false
     default: Default::default
   - name: hosted_catalog


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Respect the env variable `DISABLE_DEFAULT_CREDENTIAL` introduced by https://github.com/risingwavelabs/risingwave/pull/17933
- In a cloud environment, DISABLE_DEFAULT_CREDENTIAL should be set to true. However, for a self-hosted environment, we allow users to enable config load to load warehouse credentials from the environment.
- Support `enable_config_load` for iceberg sink, source, iceberg engine and connection.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

- Support `enable_config_load` for iceberg sink, source, iceberg engine and connection.
- This parameter set to true will load warehouse credentials from the environment. Only allowed to be used in a self-hosted environment.

</details>
