### PR TITLE
 fix(sink): Fix sink into table in the recovery of the new version of table graph (sql backend)

### DIFF
--- a/src/meta/src/controller/catalog/util.rs
+++ b/src/meta/src/controller/catalog/util.rs
@@ -428,27 +428,19 @@ impl CatalogController {
                         if let Some(NodeBody::Union(_)) = node.node_body {
                             node.input.retain_mut(|input| match &mut input.node_body {
                                 Some(NodeBody::Project(_)) => {
-                                    let body = input.input.iter().exactly_one().unwrap();
+                                    let body = input
+                                        .input
+                                        .iter()
+                                        .exactly_one()
+                                        .expect("Project node must have exactly one input");
                                     let Some(NodeBody::Merge(merge_node)) = &body.node_body else {
                                         unreachable!("expect merge node");
                                     };
-                                    if all_fragment_ids
+                                    all_fragment_ids
                                         .contains(&(merge_node.upstream_fragment_id as i32))
-                                    {
-                                        true
-                                    } else {
-                                        false
-                                    }
                                 }
-                                Some(NodeBody::Merge(merge_node)) => {
-                                    if all_fragment_ids
-                                        .contains(&(merge_node.upstream_fragment_id as i32))
-                                    {
-                                        true
-                                    } else {
-                                        false
-                                    }
-                                }
+                                Some(NodeBody::Merge(merge_node)) => all_fragment_ids
+                                    .contains(&(merge_node.upstream_fragment_id as i32)),
                                 _ => false,
                             });
                         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The specific issue is that the changes in PR [#17203](https://github.com/risingwavelabs/risingwave/pull/17203) introduced a structure of merge -> project -> union (previously it was merge -> union). We adapted to the new structure, but only in the etcd version from PR [#17960](https://github.com/risingwavelabs/risingwave/pull/17960), which caused the SQL version to remain unchanged (still matching the merge -> union structure). This led to an incorrect judgment that resulted in the entire union branch being deleted.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
