### PR TITLE
fix(cdc/batch): special char during debezium props substitution and `postgres_query`

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:15-alpine
     environment:
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=post\tgres
       - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
     ports:
       - 5432

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres:15-alpine
     environment:
       - POSTGRES_USER=postgres
+      # Test with a password containing special characters #21943, for example 0x5c.
+      # Note that 0x5c 0x74 are TWO characters. It is NOT 0x09.
       - POSTGRES_PASSWORD=post\tgres
       - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
     ports:

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -27,7 +27,7 @@ download_and_prepare_rw "$profile" source
 
 prepare_pg() {
   # set up PG sink destination
-  export PGPASSWORD=postgres
+  export PGPASSWORD='post\tgres'
   psql -h db -U postgres -c "CREATE ROLE test LOGIN SUPERUSER PASSWORD 'connector';" || true
   dropdb -h db -U postgres test || true
   createdb -h db -U postgres test
@@ -63,7 +63,7 @@ echo "--- test sink: jdbc:postgres switch to postgres native"
 # check sink destination postgres
 risedev slt './e2e_test/sink/remote/jdbc.load.slt'
 sleep 1
-sqllogictest -h db -p 5432 -d test './e2e_test/sink/remote/jdbc.check.pg.slt' --label 'pg-native'
+SLT_PASSWORD=$PGPASSWORD sqllogictest -h db -p 5432 -d test './e2e_test/sink/remote/jdbc.check.pg.slt' --label 'pg-native'
 sleep 1
 
 echo "--- killing risingwave cluster: ci-1cn-1fe-switch-to-pg-native"
@@ -75,7 +75,7 @@ echo "--- starting risingwave cluster"
 risedev ci-start ci-inline-source-test
 
 echo "--- check connectivity for postgres"
-PGPASSWORD=postgres psql -h db -U postgres -d postgres -p 5432 -c "SELECT 1;"
+PGPASSWORD='post\tgres' psql -h db -U postgres -d postgres -p 5432 -c "SELECT 1;"
 
 echo "--- dumping risedev-env"
 echo "risedev-env:"
@@ -102,7 +102,7 @@ echo "--- testing remote sinks"
 # check sink destination postgres
 risedev slt './e2e_test/sink/remote/jdbc.load.slt'
 sleep 1
-sqllogictest -h db -p 5432 -d test './e2e_test/sink/remote/jdbc.check.pg.slt' --label 'jdbc'
+SLT_PASSWORD=$PGPASSWORD sqllogictest -h db -p 5432 -d test './e2e_test/sink/remote/jdbc.check.pg.slt' --label 'jdbc'
 sleep 1
 
 # check sink destination mysql using shell

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -60,7 +60,7 @@ echo "--- e2e, ci-1cn-1fe, mysql & postgres cdc"
 mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source_legacy/cdc/mysql_cdc.sql
 
 # import data to postgres
-export PGHOST=db PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres PGDATABASE=cdc_test
+export PGHOST=db PGPORT=5432 PGUSER=postgres PGPASSWORD='post\tgres' PGDATABASE=cdc_test
 createdb
 psql < ./e2e_test/source_legacy/cdc/postgres_cdc.sql
 

--- a/ci/scripts/regress-test.sh
+++ b/ci/scripts/regress-test.sh
@@ -39,7 +39,7 @@ locale-gen C
 dpkg-reconfigure --frontend=noninteractive locales
 # All the above is required because otherwise psql would throw some warning
 # that goes into the output file and thus diverges from the expected output file.
-export PGPASSWORD='postgres';
+export PGPASSWORD='post\tgres';
 
 # Load extensions. This shall only be done once per database, so not part of test runner.
 psql -h db -p 5432 -d postgres -U postgres \

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
@@ -337,8 +337,8 @@ public class DbzConnectorConfig {
         try (var input = getClass().getClassLoader().getResourceAsStream(fileName)) {
             assert input != null;
             var inputStr = IOUtils.toString(input, StandardCharsets.UTF_8);
-            var resolvedStr = substitutor.replace(inputStr);
-            dbProps.load(new StringReader(resolvedStr));
+            dbProps.load(new StringReader(inputStr));
+            dbProps.replaceAll((k, v) -> substitutor.replace(v));
         } catch (IOException e) {
             throw new RuntimeException("failed to load config file " + fileName, e);
         }

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/DbzConnectorConfig.java
@@ -337,6 +337,7 @@ public class DbzConnectorConfig {
         try (var input = getClass().getClassLoader().getResourceAsStream(fileName)) {
             assert input != null;
             var inputStr = IOUtils.toString(input, StandardCharsets.UTF_8);
+            // load before substitution, so that we do not need to escape the substituted text
             dbProps.load(new StringReader(inputStr));
             dbProps.replaceAll((k, v) -> substitutor.replace(v));
         } catch (IOException e) {

--- a/risedev.yml
+++ b/risedev.yml
@@ -803,7 +803,7 @@ profile:
         port: 5432
         address: db
         user: postgres
-        password: postgres
+        password: post\tgres
         user-managed: true
 
   ci-redis:

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -30,7 +30,7 @@ pub use risingwave_pb::expr::table_function::PbType as TableFunctionType;
 use thiserror_ext::AsReport;
 use tokio_postgres::types::Type as TokioPgType;
 
-use super::{Expr, ExprImpl, ExprRewriter, Literal, RwResult, infer_type};
+use super::{ErrorCode, Expr, ExprImpl, ExprRewriter, Literal, RwResult, infer_type};
 use crate::catalog::catalog_service::CatalogReadGuard;
 use crate::catalog::function_catalog::{FunctionCatalog, FunctionKind};
 use crate::catalog::root_catalog::SchemaPath;
@@ -379,19 +379,20 @@ impl TableFunction {
         {
             let schema = tokio::task::block_in_place(|| {
                 FRONTEND_RUNTIME.block_on(async {
-                    let (client, connection) = tokio_postgres::connect(
-                        format!(
-                            "host={} port={} user={} password={} dbname={}",
-                            evaled_args[0],
-                            evaled_args[1],
-                            evaled_args[2],
-                            evaled_args[3],
-                            evaled_args[4]
-                        )
-                        .as_str(),
-                        tokio_postgres::NoTls,
-                    )
-                    .await?;
+                    let mut conf = tokio_postgres::Config::new();
+                    let (client, connection) = conf
+                        .host(&evaled_args[0])
+                        .port(evaled_args[1].parse().map_err(|_| {
+                            ErrorCode::InvalidParameterValue(format!(
+                                "port number: {}",
+                                evaled_args[1]
+                            ))
+                        })?)
+                        .user(&evaled_args[2])
+                        .password(evaled_args[3].clone())
+                        .dbname(&evaled_args[4])
+                        .connect(tokio_postgres::NoTls)
+                        .await?;
 
                     tokio::spawn(async move {
                         if let Err(e) = connection.await {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fixes #21932 by parsing the properties file first and do substitution in-memory. This avoid the substituted text from being handled by the properties-parser.

Also fixes a similar issue in `postgres_query` (batch PostgreSQL source). We shall pass parameters structurally rather than via a interpolated connection string, which would also require complicated escaping to be parsed back losslessly.

Also identified issues in our dev/test tools:
* `risedev` (using `cargo-make`/`envmnt`) environment variable passing [#21974](https://github.com/risingwavelabs/risingwave/issues/21974). Dodged the issue by testing with `\t` rather than `\n`.
* `sqllogictest` substitution: https://gist.github.com/xiangjinwu/f93c11de855cfa38fc484cafad224ecd

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [x] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
