### PR TITLE
feat(meta): Try introducing an in-memory actor cache

### DIFF
--- a/src/meta/model/src/actor.rs
+++ b/src/meta/model/src/actor.rs
@@ -20,7 +20,7 @@ use crate::{
     ActorId, ActorUpstreamActors, ConnectorSplits, ExprContext, FragmentId, VnodeBitmap, WorkerId,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize, Hash)]
 #[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum ActorStatus {
     #[sea_orm(string_value = "INACTIVE")]

--- a/src/meta/model/src/fragment.rs
+++ b/src/meta/model/src/fragment.rs
@@ -35,7 +35,9 @@ pub struct Model {
     pub vnode_count: i32,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize, Hash,
+)]
 #[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum DistributionType {
     #[sea_orm(string_value = "SINGLE")]

--- a/src/meta/model/src/object.rs
+++ b/src/meta/model/src/object.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DatabaseId, ObjectId, SchemaId, UserId};
 
 #[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Copy, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
+    Clone, Debug, PartialEq, Eq, Copy, EnumIter, DeriveActiveEnum, Serialize, Deserialize, Hash,
 )]
 #[sea_orm(rs_type = "String", db_type = "string(None)")]
 pub enum ObjectType {

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -42,8 +42,8 @@ use risingwave_meta_model::{
     ActorId, ColumnCatalogArray, ConnectionId, CreateType, DatabaseId, FragmentId, I32Array,
     IndexId, JobStatus, ObjectId, Property, SchemaId, SecretId, SinkFormatDesc, SinkId, SourceId,
     StreamNode, StreamSourceInfo, StreamingParallelism, SubscriptionId, TableId, UserId, ViewId,
-    connection, database, fragment, function, index, object, object_dependency, schema, secret,
-    sink, source, streaming_job, subscription, table, user_privilege, view,
+    WorkerId, actor, connection, database, fragment, function, index, object, object_dependency,
+    schema, secret, sink, source, streaming_job, subscription, table, user_privilege, view,
 };
 use risingwave_pb::catalog::connection::Info as ConnectionInfo;
 use risingwave_pb::catalog::subscription::SubscriptionState;
@@ -140,12 +140,14 @@ pub struct ReleaseContext {
 impl CatalogController {
     pub async fn new(env: MetaSrvEnv) -> MetaResult<Self> {
         let meta_store = env.meta_store();
+        let actor_info = ActorInfo::init_from_db(&meta_store.conn).await?;
         let catalog_controller = Self {
             env,
             inner: RwLock::new(CatalogControllerInner {
                 db: meta_store.conn,
                 creating_table_finish_notifier: HashMap::new(),
                 dropped_tables: HashMap::new(),
+                actors: actor_info,
             }),
         };
 
@@ -164,6 +166,146 @@ impl CatalogController {
     }
 }
 
+pub struct ActorInfo {
+    pub models: HashMap<ActorId, actor::Model>,
+
+    pub actors_by_fragment_id: HashMap<FragmentId, Vec<ActorId>>,
+    pub actors_by_worker_id: HashMap<WorkerId, Vec<ActorId>>,
+}
+
+impl ActorInfo {
+    pub fn add_actor(&mut self, actor: actor::Model) {
+        debug_assert!(!self.models.contains_key(&actor.actor_id));
+        self.actors_by_fragment_id
+            .entry(actor.fragment_id)
+            .or_default()
+            .push(actor.actor_id);
+        self.actors_by_worker_id
+            .entry(actor.worker_id)
+            .or_default()
+            .push(actor.actor_id);
+        self.models.insert(actor.actor_id, actor);
+    }
+
+    pub fn drop_actor(&mut self, actor_id: ActorId) -> bool {
+        if let Some(actor) = self.models.remove(&actor_id) {
+            // Remove from fragment index
+            if let Some(fragment_actors) = self.actors_by_fragment_id.get_mut(&actor.fragment_id) {
+                fragment_actors.retain(|&id| id != actor_id);
+            }
+            // Remove from worker index
+            if let Some(worker_actors) = self.actors_by_worker_id.get_mut(&actor.worker_id) {
+                worker_actors.retain(|&id| id != actor_id);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn drop_actors_by_fragments(&mut self, fragment_ids: &[FragmentId]) {
+        for fragment_id in fragment_ids {
+            if let Some(actor_ids) = self.actors_by_fragment_id.remove(fragment_id) {
+                for actor_id in actor_ids {
+                    // Remove from main models map
+                    if let Some(actor) = self.models.remove(&actor_id) {
+                        // Remove from worker index
+                        if let Some(worker_actors) =
+                            self.actors_by_worker_id.get_mut(&actor.worker_id)
+                        {
+                            worker_actors.retain(|&id| id != actor_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn get_actors_by_fragment(&self, fragment_id: FragmentId) -> Option<&Vec<ActorId>> {
+        self.actors_by_fragment_id.get(&fragment_id)
+    }
+
+    pub fn get_actors_by_worker(&self, worker_id: WorkerId) -> Option<&Vec<ActorId>> {
+        self.actors_by_worker_id.get(&worker_id)
+    }
+
+    pub fn get_actor(&self, actor_id: ActorId) -> Option<&actor::Model> {
+        self.models.get(&actor_id)
+    }
+
+    pub fn actor_exists(&self, actor_id: ActorId) -> bool {
+        self.models.contains_key(&actor_id)
+    }
+
+    pub fn get_all_actors(&self) -> &HashMap<ActorId, actor::Model> {
+        &self.models
+    }
+
+    pub fn actor_count(&self) -> usize {
+        self.models.len()
+    }
+
+    /// Mutate an existing actor, re-indexing if its `fragment_id` or `worker_id` changes.
+    pub fn mutate_actor<F>(&mut self, actor_id: ActorId, mutator: F) -> bool
+    where
+        F: FnOnce(&mut actor::Model),
+    {
+        if let Some(actor) = self.models.get_mut(&actor_id) {
+            let old_worker = actor.worker_id;
+            let old_fragment = actor.fragment_id;
+
+            mutator(actor);
+
+            debug_assert_eq!(actor.fragment_id, old_fragment);
+
+            if actor.worker_id != old_worker {
+                debug_assert!(self.actors_by_worker_id.contains_key(&old_worker));
+                if let Some(vec) = self.actors_by_worker_id.get_mut(&old_worker) {
+                    vec.retain(|&id| id != actor_id);
+                }
+                self.actors_by_worker_id
+                    .entry(actor.worker_id)
+                    .or_default()
+                    .push(actor_id);
+            }
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl ActorInfo {
+    pub async fn init_from_db(db: &DatabaseConnection) -> MetaResult<Self> {
+        tracing::info!("initializing actor info");
+        let actors: Vec<_> = Actor::find().all(db).await?;
+
+        let actors: HashMap<_, _> = actors
+            .into_iter()
+            .map(|actor| (actor.actor_id, actor))
+            .collect();
+
+        let mut actors_by_fragment_id = HashMap::new();
+        let mut actors_by_worker_id = HashMap::new();
+        for actor in actors.values() {
+            actors_by_fragment_id
+                .entry(actor.fragment_id)
+                .or_insert(vec![])
+                .push(actor.actor_id);
+            actors_by_worker_id
+                .entry(actor.worker_id)
+                .or_insert(vec![])
+                .push(actor.actor_id);
+        }
+
+        Ok(Self {
+            models: actors,
+            actors_by_fragment_id,
+            actors_by_worker_id,
+        })
+    }
+}
+
 pub struct CatalogControllerInner {
     pub(crate) db: DatabaseConnection,
     /// Registered finish notifiers for creating tables.
@@ -175,6 +317,9 @@ pub struct CatalogControllerInner {
         HashMap<DatabaseId, HashMap<ObjectId, Vec<Sender<Result<NotificationVersion, String>>>>>,
     /// Tables have been dropped from the meta store, but the corresponding barrier remains unfinished.
     pub dropped_tables: HashMap<TableId, PbTable>,
+
+    /// Internal actor cache
+    pub actors: ActorInfo,
 }
 
 impl CatalogController {
@@ -385,7 +530,7 @@ impl CatalogController {
         &self,
         database_id: Option<DatabaseId>,
     ) -> MetaResult<()> {
-        let inner = self.inner.write().await;
+        let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
         let filter_condition = object::Column::ObjType.eq(ObjectType::Subscription).and(
             object::Column::Oid.not_in_subquery(
@@ -405,11 +550,26 @@ impl CatalogController {
         } else {
             filter_condition
         };
+
+        let object_ids: Vec<ObjectId> = Object::find()
+            .select_only()
+            .column(object::Column::Oid)
+            .filter(filter_condition.clone())
+            .into_tuple()
+            .all(&txn)
+            .await?;
+
+        let dirty_fragment_ids = self.get_fragment_ids_by_job_ids(&txn, &object_ids).await?;
+
         Object::delete_many()
             .filter(filter_condition)
             .exec(&txn)
             .await?;
+
         txn.commit().await?;
+
+        inner.actors.drop_actors_by_fragments(&dirty_fragment_ids);
+
         // We don't need to notify the frontend, because the Init subscription is not send to frontend.
         Ok(())
     }
@@ -419,7 +579,7 @@ impl CatalogController {
         &self,
         database_id: Option<DatabaseId>,
     ) -> MetaResult<Vec<SourceId>> {
-        let inner = self.inner.write().await;
+        let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
         let filter_condition = streaming_job::Column::JobStatus.eq(JobStatus::Initial).or(
@@ -571,6 +731,10 @@ impl CatalogController {
             .all(&txn)
             .await?;
 
+        let dirty_fragment_ids = self
+            .get_fragment_ids_by_job_ids(&txn, &dirty_job_ids)
+            .await?;
+
         let to_delete_objs: HashSet<ObjectId> = dirty_job_ids
             .clone()
             .into_iter()
@@ -585,6 +749,8 @@ impl CatalogController {
         assert!(res.rows_affected > 0);
 
         txn.commit().await?;
+
+        inner.actors.drop_actors_by_fragments(&dirty_fragment_ids);
 
         let object_group = build_object_group_for_delete(
             to_notify_objs
@@ -749,7 +915,10 @@ impl CatalogControllerInner {
         let sink_num = Sink::find().count(&self.db).await?;
         let function_num = Function::find().count(&self.db).await?;
         let streaming_job_num = StreamingJob::find().count(&self.db).await?;
-        let actor_num = Actor::find().count(&self.db).await?;
+        let actor_num_from_db = Actor::find().count(&self.db).await?;
+        let actor_num = self.actors.models.len() as u64;
+
+        debug_assert_eq!(actor_num_from_db, actor_num);
 
         Ok(CatalogStats {
             table_num: table_num_map.remove(&TableType::Table).unwrap_or(0),

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -64,6 +64,7 @@ use sea_orm::{
 use thiserror_ext::AsReport;
 
 use crate::controller::ObjectModel;
+use crate::controller::catalog::ActorInfo;
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::model::{FragmentActorDispatchers, FragmentDownstreamRelation};
 use crate::{MetaError, MetaResult};
@@ -275,7 +276,7 @@ pub struct PartialFragmentStateTables {
     pub state_table_ids: I32Array,
 }
 
-#[derive(Clone, DerivePartialModel, FromQueryResult)]
+#[derive(Clone, DerivePartialModel, FromQueryResult, Eq, PartialEq, Hash, Debug)]
 #[sea_orm(entity = "Actor")]
 pub struct PartialActorLocation {
     pub actor_id: ActorId,
@@ -284,7 +285,7 @@ pub struct PartialActorLocation {
     pub status: ActorStatus,
 }
 
-#[derive(FromQueryResult)]
+#[derive(FromQueryResult, Debug, Eq, PartialEq, Clone)]
 pub struct FragmentDesc {
     pub fragment_id: FragmentId,
     pub job_id: ObjectId,
@@ -1204,6 +1205,7 @@ pub async fn insert_fragment_relations(
 
 pub async fn get_fragment_actor_dispatchers<C>(
     db: &C,
+    actor_cache: &ActorInfo,
     fragment_ids: Vec<FragmentId>,
 ) -> MetaResult<FragmentActorDispatchers>
 where
@@ -1216,21 +1218,50 @@ where
     let mut fragment_actor_cache: HashMap<FragmentId, FragmentActorInfo> = HashMap::new();
     let get_fragment_actors = |fragment_id: FragmentId| async move {
         let result: MetaResult<FragmentActorInfo> = try {
-            let mut fragment_actors = Fragment::find_by_id(fragment_id)
-                .find_with_related(Actor)
-                .filter(actor::Column::Status.eq(ActorStatus::Running))
-                .all(db)
-                .await?;
-            if fragment_actors.is_empty() {
-                return Err(anyhow!("failed to find fragment: {}", fragment_id).into());
-            }
-            assert_eq!(
-                fragment_actors.len(),
-                1,
-                "find multiple fragment {:?}",
-                fragment_actors
-            );
-            let (fragment, actors) = fragment_actors.pop().unwrap();
+            let (fragment, actors) = {
+                let fragment = Fragment::find_by_id(fragment_id)
+                    .one(db)
+                    .await?
+                    .ok_or_else(|| anyhow!("failed to find fragment: {}", fragment_id))?;
+
+                let fragment_ids = actor_cache
+                    .actors_by_fragment_id
+                    .get(&fragment_id)
+                    .cloned()
+                    .unwrap_or_default();
+
+                let fragment_actors_from_cache: Vec<actor::Model> = fragment_ids
+                    .iter()
+                    .filter_map(|id| actor_cache.models.get(id))
+                    .filter(|m| m.status == ActorStatus::Running)
+                    .cloned()
+                    .collect();
+
+                {
+                    let db_pairs = Fragment::find_by_id(fragment_id)
+                        .find_with_related(Actor)
+                        .filter(actor::Column::Status.eq(ActorStatus::Running))
+                        .all(db)
+                        .await?;
+                    let fragment_actors_from_db: Vec<actor::Model> =
+                        db_pairs.into_iter().flat_map(|(_, acts)| acts).collect();
+
+                    let set_db: HashSet<ActorId> =
+                        fragment_actors_from_db.iter().map(|a| a.actor_id).collect();
+                    let set_cache: HashSet<ActorId> = fragment_actors_from_cache
+                        .iter()
+                        .map(|a| a.actor_id)
+                        .collect();
+
+                    debug_assert_eq!(
+                        set_db, set_cache,
+                        "Actor lists mismatch between DB and cache"
+                    );
+                }
+
+                (fragment, fragment_actors_from_cache)
+            };
+
             (
                 fragment.distribution_type,
                 Arc::new(
@@ -1486,12 +1517,111 @@ pub fn resolve_no_shuffle_actor_dispatcher(
 /// `get_fragment_mappings` returns the fragment vnode mappings of the given job.
 pub async fn get_fragment_mappings<C>(
     db: &C,
+    actor_cache: &ActorInfo,
     job_id: ObjectId,
 ) -> MetaResult<Vec<PbFragmentWorkerSlotMapping>>
 where
     C: ConnectionTrait,
 {
-    let job_actors: Vec<(
+    let fragment_info: Vec<(FragmentId, DistributionType)> = Fragment::find()
+        .select_only()
+        .columns([
+            fragment::Column::FragmentId,
+            fragment::Column::DistributionType,
+        ])
+        .filter(fragment::Column::JobId.eq(job_id))
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    let job_actors_from_cache: Vec<(
+        FragmentId,
+        DistributionType,
+        ActorId,
+        Option<VnodeBitmap>,
+        WorkerId,
+        ActorStatus,
+    )> = fragment_info
+        .into_iter()
+        .flat_map(|(fragment_id, distribution_type)| {
+            actor_cache
+                .actors_by_fragment_id
+                .get(&fragment_id)
+                .into_iter()
+                .flat_map(move |actor_ids| {
+                    actor_ids.iter().map(move |&actor_id| {
+                        let model = &actor_cache.models[&actor_id];
+                        (
+                            fragment_id,
+                            distribution_type,
+                            actor_id,
+                            model.vnode_bitmap.clone(),
+                            model.worker_id,
+                            model.status.clone(),
+                        )
+                    })
+                })
+        })
+        .collect();
+
+    {
+        let job_actors_from_db: Vec<(
+            FragmentId,
+            DistributionType,
+            ActorId,
+            Option<VnodeBitmap>,
+            WorkerId,
+            ActorStatus,
+        )> = Actor::find()
+            .select_only()
+            .columns([
+                fragment::Column::FragmentId,
+                fragment::Column::DistributionType,
+            ])
+            .columns([
+                actor::Column::ActorId,
+                actor::Column::VnodeBitmap,
+                actor::Column::WorkerId,
+                actor::Column::Status,
+            ])
+            .join(JoinType::InnerJoin, actor::Relation::Fragment.def())
+            .filter(fragment::Column::JobId.eq(job_id))
+            .into_tuple()
+            .all(db)
+            .await?;
+
+        // index by ActorId so we can compare without hashing VnodeBitmap
+        let map_db: HashMap<ActorId, _> = job_actors_from_db
+            .into_iter()
+            .map(|(fid, dist, aid, vnode, wid, status)| (aid, (fid, dist, vnode, wid, status)))
+            .collect();
+        let map_cache: HashMap<ActorId, _> = job_actors_from_cache
+            .iter()
+            .cloned()
+            .map(|(fid, dist, aid, vnode, wid, status)| (aid, (fid, dist, vnode, wid, status)))
+            .collect();
+
+        debug_assert_eq!(
+            map_db, map_cache,
+            "Job actors mismatch between DB and cache"
+        );
+    }
+
+    let job_actors = job_actors_from_cache;
+
+    Ok(rebuild_fragment_mapping_from_actors(job_actors))
+}
+
+/// `get_fragment_mappings_txn` returns the fragment vnode mappings of the given job.
+pub async fn get_fragment_mappings_txn<C>(
+    db: &C,
+    _actor_cache: &ActorInfo,
+    job_id: ObjectId,
+) -> MetaResult<Vec<PbFragmentWorkerSlotMapping>>
+where
+    C: ConnectionTrait,
+{
+    let job_actors_from_db: Vec<(
         FragmentId,
         DistributionType,
         ActorId,
@@ -1515,6 +1645,8 @@ where
         .into_tuple()
         .all(db)
         .await?;
+
+    let job_actors = job_actors_from_db;
 
     Ok(rebuild_fragment_mapping_from_actors(job_actors))
 }
@@ -1640,18 +1772,43 @@ pub fn rebuild_fragment_mapping_from_actors(
 /// `get_fragment_actor_ids` returns the fragment actor ids of the given fragments.
 pub async fn get_fragment_actor_ids<C>(
     db: &C,
+    actor_cache: &ActorInfo,
     fragment_ids: Vec<FragmentId>,
 ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>>
 where
     C: ConnectionTrait,
 {
-    let fragment_actors: Vec<(FragmentId, ActorId)> = Actor::find()
-        .select_only()
-        .columns([actor::Column::FragmentId, actor::Column::ActorId])
-        .filter(actor::Column::FragmentId.is_in(fragment_ids))
-        .into_tuple()
-        .all(db)
-        .await?;
+    let fragment_actors_from_cache: Vec<(FragmentId, ActorId)> = fragment_ids
+        .iter()
+        .flat_map(|&fid| {
+            actor_cache
+                .actors_by_fragment_id
+                .get(&fid)
+                .into_iter()
+                .flat_map(move |ids| ids.iter().copied().map(move |aid| (fid, aid)))
+        })
+        .collect();
+
+    {
+        let fragment_actors_from_db: Vec<(FragmentId, ActorId)> = Actor::find()
+            .select_only()
+            .columns([actor::Column::FragmentId, actor::Column::ActorId])
+            .filter(actor::Column::FragmentId.is_in(fragment_ids))
+            .into_tuple()
+            .all(db)
+            .await?;
+
+        let set_db: HashSet<(FragmentId, ActorId)> = fragment_actors_from_db.into_iter().collect();
+        let set_cache: HashSet<(FragmentId, ActorId)> =
+            fragment_actors_from_cache.iter().cloned().collect();
+
+        debug_assert_eq!(
+            set_db, set_cache,
+            "Fragment–actor pairs mismatch between DB and cache"
+        );
+    }
+
+    let fragment_actors = fragment_actors_from_cache;
 
     Ok(fragment_actors.into_iter().into_group_map())
 }
@@ -1662,6 +1819,7 @@ where
 /// - All fragments
 pub async fn get_fragments_for_jobs<C>(
     db: &C,
+    actor_cache: &ActorInfo,
     streaming_jobs: Vec<ObjectId>,
 ) -> MetaResult<(
     HashMap<SourceId, BTreeSet<FragmentId>>,
@@ -1686,15 +1844,33 @@ where
         .into_tuple()
         .all(db)
         .await?;
-    let actors: Vec<ActorId> = Actor::find()
-        .select_only()
-        .column(actor::Column::ActorId)
-        .filter(
-            actor::Column::FragmentId.is_in(fragments.iter().map(|(id, _, _)| *id).collect_vec()),
-        )
-        .into_tuple()
-        .all(db)
-        .await?;
+
+    let fragment_ids: Vec<FragmentId> = fragments.iter().map(|(id, _, _)| *id).collect();
+    let actors_from_cache: Vec<ActorId> = fragment_ids
+        .iter()
+        .filter_map(|fid| actor_cache.actors_by_fragment_id.get(fid))
+        .flat_map(|ids| ids.iter().copied())
+        .collect();
+
+    {
+        let actors_from_db: Vec<ActorId> = Actor::find()
+            .select_only()
+            .column(actor::Column::ActorId)
+            .filter(actor::Column::FragmentId.is_in(fragment_ids))
+            .into_tuple()
+            .all(db)
+            .await?;
+
+        let set_db: HashSet<ActorId> = actors_from_db.into_iter().collect();
+        let set_cache: HashSet<ActorId> = actors_from_cache.iter().copied().collect();
+
+        debug_assert_eq!(
+            set_db, set_cache,
+            "Actor lists mismatch between DB and cache"
+        );
+    }
+
+    let actors = actors_from_cache;
 
     let fragment_ids = fragments
         .iter()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Please note that this PR is still in a very unstable phase and requires extensive testing to ensure stability. The "ready" status is only for testing CI.

This PR is part of the plan to deprecate the Actor table in the metastore. It changes the access to the Actor table (including direct access like `Actor::find` and indirect access like `find_also_related(Actor)`) to access the actor cache within the catalog controller instead, and it will compare the results in debug mode.

In future PRs, it will combine the algorithm from PR #21803 to generate a complete list of actors at startup, replacing the need to read from the metastore.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
