### PR TITLE
feat: fd control for kafka source

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -1157,6 +1157,10 @@ pub struct StreamingDeveloperConfig {
     #[serde(default = "default::developer::stream_chunk_size")]
     pub chunk_size: usize,
 
+    /// The maximum number of file descriptors that can be used by kafka source/sink.
+    #[serde(default = "default::developer::kafka_max_fd_count")]
+    pub kafka_max_fd_count: usize,
+
     /// The initial permits that a channel holds, i.e., the maximum row count can be buffered in
     /// the channel.
     #[serde(default = "default::developer::stream_exchange_initial_permits")]
@@ -2167,6 +2171,10 @@ pub mod default {
 
         pub fn stream_chunk_size() -> usize {
             256
+        }
+
+        pub fn kafka_max_fd_count() -> usize {
+            40000
         }
 
         pub fn stream_exchange_initial_permits() -> usize {

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -166,6 +166,7 @@ stream_enable_executor_row_count = false
 stream_connector_message_buffer_size = 16
 stream_unsafe_extreme_cache_size = 10
 stream_chunk_size = 256
+stream_kafka_max_fd_count = 40000
 stream_exchange_initial_permits = 2048
 stream_exchange_batched_permits = 256
 stream_exchange_concurrent_barriers = 1

--- a/src/connector/src/error.rs
+++ b/src/connector/src/error.rs
@@ -24,6 +24,7 @@ use crate::parser::AccessError;
 use crate::schema::InvalidOptionError;
 use crate::schema::schema_registry::{ConcurrentRequestError, WireFormatError};
 use crate::sink::SinkError;
+use crate::source::kafka::fd_control::FdControlError;
 use crate::source::mqtt::MqttError;
 use crate::source::nats::NatsJetStreamError;
 
@@ -84,6 +85,7 @@ def_anyhow_newtype! {
     openssl::error::ErrorStack => "OpenSSL error",
     risingwave_common::secret::SecretError => "Secret error",
     EnforceSecretError => transparent,
+    FdControlError => transparent,
 }
 
 pub type ConnectorResult<T, E = ConnectorError> = std::result::Result<T, E>;

--- a/src/connector/src/source/kafka/fd_control.rs
+++ b/src/connector/src/source/kafka/fd_control.rs
@@ -1,0 +1,36 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use tokio::sync::{OnceCell, Semaphore, SemaphorePermit};
+
+static KAFKA_FD_CONTROL: OnceCell<Arc<Semaphore>> = OnceCell::const_new();
+
+pub fn init_kafka_fd_control(initial_count: usize) {
+    let semaphore = Arc::new(Semaphore::new(initial_count));
+    match KAFKA_FD_CONTROL.set(semaphore) {
+        Ok(()) => {
+            tracing::info!("Kafka FD quota initialized with {} permits", initial_count);
+        }
+        Err(e) => {
+            tracing::warn!("get fd quota failed, maybe already initialized: {:?}", e);
+        }
+    }
+}
+
+pub async fn try_reserve_fds(permits: u32) -> Option<SemaphorePermit<'static>> {
+    let x = KAFKA_FD_CONTROL.get().unwrap();
+    x.try_acquire_many(permits).ok()
+}

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -32,6 +32,7 @@ pub use client_context::*;
 pub use enumerator::*;
 pub use source::*;
 pub use split::*;
+pub mod fd_control;
 use with_options::WithOptions;
 
 use crate::connector_common::{KafkaCommon, RdKafkaPropertiesCommon};

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -232,7 +232,7 @@ impl KafkaSplitReader {
     async fn into_data_stream(self) {
         // Keep the FD permit alive for the entire duration of the stream
         let _fd_permit = self._fd_permit;
-        
+
         if self.offsets.values().all(|(start_offset, stop_offset)| {
             match (start_offset, stop_offset) {
                 (Some(start), Some(stop)) if (*start + 1) >= *stop => true,

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -30,6 +30,7 @@ use risingwave_common::catalog::{ColumnId, DatabaseId, Field, Schema, TableId};
 use risingwave_common::config::MetricLevel;
 use risingwave_common::must_match;
 use risingwave_common::operator::{unique_executor_id, unique_operator_id};
+use risingwave_connector::source::kafka::fd_control::init_kafka_fd_control;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -175,6 +176,8 @@ impl LocalStreamManager {
             // Since this is a special config, we have to check it here.
             risingwave_storage::hummock::utils::disable_sanity_check();
         }
+
+        init_kafka_fd_control(env.config().developer.kafka_max_fd_count);
 
         let await_tree_reg = await_tree_config.clone().map(await_tree::Registry::new);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

replace https://github.com/risingwavelabs/risingwave/pull/21734

expose the fd can be used in kafka related sdks in the developer config, default to `40,000`, thanks for the idea @hzxa21 

and count down the fd permit only in kafka source, which can report `not enough fd` error and tell the users to spread the actors across more compute nodes. 

* FD usage for Kafka Consumer (in Chinese) [ref](https://chatgpt.com/s/dr_68364431530c81919cf94dd7d79be4fa)

Kafka Sink now does not count into this, because of the sdk constraints, the producers cannot access metadata [ref](https://docs.rs/rdkafka/latest/rdkafka/producer/base_producer/struct.ThreadedProducer.html#method.send). Need to find another way in the future. 

* FD usage for Kafka Producer (in Chinese) [ref](https://chatgpt.com/s/dr_683643ee23548191894594f6f8ec9e2f)


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
