### PR TITLE
feat(expr): `l2_distance` between 2 `vector`s

### DIFF
--- a/e2e_test/batch/types/vector.slt.part
+++ b/e2e_test/batch/types/vector.slt.part
@@ -15,6 +15,22 @@ SELECT * FROM items ORDER BY id;
 1 [1,2,3]
 2 [4,5,6]
 
+query
+SELECT * FROM items ORDER BY l2_distance(embedding, '[3,1,2]') LIMIT 5;
+----
+1 [1,2,3]
+2 [4,5,6]
+
+query
+SELECT * FROM items WHERE id != 1 ORDER BY l2_distance(embedding, (SELECT embedding FROM items WHERE id = 1)) LIMIT 5;
+----
+2 [4,5,6]
+
+query
+SELECT * FROM items WHERE l2_distance(embedding, '[3,1,2]') < 5;
+----
+1 [1,2,3]
+
 statement ok
 DROP TABLE items;
 

--- a/e2e_test/batch/types/vector.slt.part
+++ b/e2e_test/batch/types/vector.slt.part
@@ -16,18 +16,18 @@ SELECT * FROM items ORDER BY id;
 2 [4,5,6]
 
 query
-SELECT * FROM items ORDER BY l2_distance(embedding, '[3,1,2]') LIMIT 5;
+SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 5;
 ----
 1 [1,2,3]
 2 [4,5,6]
 
 query
-SELECT * FROM items WHERE id != 1 ORDER BY l2_distance(embedding, (SELECT embedding FROM items WHERE id = 1)) LIMIT 5;
+SELECT * FROM items WHERE id != 1 ORDER BY embedding <-> (SELECT embedding FROM items WHERE id = 1) LIMIT 5;
 ----
 2 [4,5,6]
 
 query
-SELECT * FROM items WHERE l2_distance(embedding, '[3,1,2]') < 5;
+SELECT * FROM items WHERE embedding <-> '[3,1,2]' < 5;
 ----
 1 [1,2,3]
 

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -307,6 +307,9 @@ message ExprNode {
     MAP_DELETE = 710;
     MAP_FILTER = 711;
 
+    // Vector functions
+    L2_DISTANCE = 750;
+
     // Internal function for schema change
     COMPOSITE_CAST = 800;
 

--- a/src/expr/impl/src/scalar/mod.rs
+++ b/src/expr/impl/src/scalar/mod.rs
@@ -98,3 +98,4 @@ mod trim;
 mod trim_array;
 mod tumble;
 mod upper;
+mod vector_dist;

--- a/src/expr/impl/src/scalar/vector_dist.rs
+++ b/src/expr/impl/src/scalar/vector_dist.rs
@@ -18,8 +18,8 @@ use risingwave_expr::{ExprError, Result, function};
 
 #[function("l2_distance(vector, vector) -> float8"/*, type_infer = "unreachable"*/)]
 fn l2_distance(lhs: VectorRef<'_>, rhs: VectorRef<'_>) -> Result<F64> {
-    let lhs = lhs.into_inner();
-    let rhs = rhs.into_inner();
+    let lhs = lhs.into_slice();
+    let rhs = rhs.into_slice();
     if lhs.len() != rhs.len() {
         return Err(ExprError::InvalidParam {
             name: "l2_distance",
@@ -33,7 +33,7 @@ fn l2_distance(lhs: VectorRef<'_>, rhs: VectorRef<'_>) -> Result<F64> {
     }
     let mut sum = 0.0f32;
     for (l, r) in lhs.iter().zip_eq_fast(rhs.iter()) {
-        let diff = l.unwrap().into_float32().0 - r.unwrap().into_float32().0;
+        let diff = l - r;
         sum += diff * diff;
     }
     Ok((sum as f64).sqrt().into())

--- a/src/expr/impl/src/scalar/vector_dist.rs
+++ b/src/expr/impl/src/scalar/vector_dist.rs
@@ -1,0 +1,40 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::{F64, VectorRef};
+use risingwave_common::util::iter_util::ZipEqFast;
+use risingwave_expr::{ExprError, Result, function};
+
+#[function("l2_distance(vector, vector) -> float8"/*, type_infer = "unreachable"*/)]
+fn l2_distance(lhs: VectorRef<'_>, rhs: VectorRef<'_>) -> Result<F64> {
+    let lhs = lhs.into_inner();
+    let rhs = rhs.into_inner();
+    if lhs.len() != rhs.len() {
+        return Err(ExprError::InvalidParam {
+            name: "l2_distance",
+            reason: format!(
+                "different vector dimensions {} and {}",
+                lhs.len(),
+                rhs.len()
+            )
+            .into(),
+        });
+    }
+    let mut sum = 0.0f32;
+    for (l, r) in lhs.iter().zip_eq_fast(rhs.iter()) {
+        let diff = l.unwrap().into_float32().0 - r.unwrap().into_float32().0;
+        sum += diff * diff;
+    }
+    Ok((sum as f64).sqrt().into())
+}

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -205,6 +205,8 @@ impl Binder {
                 "?" => ExprType::JsonbExists,
                 "?|" => ExprType::JsonbExistsAny,
                 "?&" => ExprType::JsonbExistsAll,
+                // vector
+                "<->" => ExprType::L2Distance,
                 _ => bail_not_implemented!(issue = 112, "binary op: {:?}", name),
             },
             _ => bail_not_implemented!(issue = 112, "binary op: {:?}", op),

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -434,6 +434,8 @@ impl Binder {
                 ("map_delete", raw_call(ExprType::MapDelete)),
                 ("map_insert", raw_call(ExprType::MapInsert)),
                 ("map_length", raw_call(ExprType::MapLength)),
+                // vector
+                ("l2_distance", raw_call(ExprType::L2Distance)),
                 // Functions that return a constant value
                 ("pi", pi()),
                 // greatest and least

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -270,6 +270,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::MapFilter
             | Type::MapInsert
             | Type::MapLength
+            | Type::L2Distance
             | Type::VnodeUser
             | Type::RwEpochToTs
             | Type::CheckNotNull

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -108,6 +108,7 @@ impl Strong {
             | ExprType::Ceil
             | ExprType::Floor
             | ExprType::Extract
+            | ExprType::L2Distance
             | ExprType::Greatest
             | ExprType::Least => self.any_null(func_call),
             // ALL: This kind of expression is null if and only if all of its arguments are null.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Adding an expression for the vector index poc. The implementation may be optimized further.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
