### PR TITLE
refactor(common): remove `PartialOrd` for `DataType` (retained for `DataTypeName`)

### DIFF
--- a/src/common/src/types/map_type.rs
+++ b/src/common/src/types/map_type.rs
@@ -19,7 +19,7 @@ use anyhow::Context;
 use super::*;
 
 /// Refer to [`super::super::array::MapArray`] for the invariants of a map value.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MapType(Box<(DataType, DataType)>);
 
 impl From<MapType> for DataType {

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -178,6 +178,8 @@ pub enum DataType {
     Map(MapType),
 }
 
+impl !PartialOrd for DataType {}
+
 // For DataType::List
 impl std::str::FromStr for Box<DataType> {
     type Err = BoxedError;

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -110,9 +110,7 @@ pub type F64 = ordered_float::OrderedFloat<f64>;
 ///   but without data fields.
 /// - `FromStr` is only used internally for tests.
 ///   The generated implementation isn't efficient, and doesn't handle whitespaces, etc.
-#[derive(
-    Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, EnumDiscriminants, FromStr,
-)]
+#[derive(Debug, Display, Clone, PartialEq, Eq, Hash, EnumDiscriminants, FromStr)]
 #[strum_discriminants(derive(Hash, Ord, PartialOrd))]
 #[strum_discriminants(name(DataTypeName))]
 #[strum_discriminants(vis(pub))]

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -25,7 +25,7 @@ use crate::catalog::ColumnId;
 use crate::util::iter_util::ZipEqFast;
 
 /// A cheaply cloneable struct type.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct StructType(Arc<StructTypeInner>);
 
 impl Debug for StructType {
@@ -45,7 +45,7 @@ impl Debug for StructType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct StructTypeInner {
     /// The name and data type of each field.
     ///

--- a/src/expr/core/src/sig/mod.rs
+++ b/src/expr/core/src/sig/mod.rs
@@ -414,7 +414,7 @@ impl FuncName {
 }
 
 /// An extended data type that can be used to declare a function's argument or result type.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SigDataType {
     /// Exact data type
     Exact(DataType),

--- a/src/frontend/planner_test/tests/testdata/output/backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/backfill.yaml
@@ -151,14 +151,14 @@
         ├─StreamExchange { dist: HashShard(fact1.v1) }
         │ └─StreamUnion { all: true }
         │   ├─StreamExchange { dist: HashShard(fact1._row_id, dim1._row_id, fact1.v1, 0:Int32) }
-        │   │ └─StreamProject { exprs: [fact1.v1, fact1.v1, fact1._row_id, dim1._row_id, 0:Int32] }
+        │   │ └─StreamProject { exprs: [fact1.v1, fact1._row_id, dim1._row_id, fact1.v1, 0:Int32] }
         │   │   └─StreamHashJoin { type: LeftOuter, predicate: fact1.v1 = dim1.v1, output: [fact1.v1, fact1._row_id, dim1._row_id] }
         │   │     ├─StreamExchange { dist: HashShard(fact1.v1) }
         │   │     │ └─StreamTableScan { table: fact1, columns: [fact1.v1, fact1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [fact1._row_id], pk: [_row_id], dist: UpstreamHashShard(fact1._row_id) }
         │   │     └─StreamExchange { dist: HashShard(dim1.v1) }
         │   │       └─StreamTableScan { table: dim1, columns: [dim1.v1, dim1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [dim1._row_id], pk: [_row_id], dist: UpstreamHashShard(dim1._row_id) }
         │   └─StreamExchange { dist: HashShard(fact2._row_id, dim2._row_id, fact2.v1, 1:Int32) }
-        │     └─StreamProject { exprs: [fact2.v1, fact2.v1, fact2._row_id, dim2._row_id, 1:Int32] }
+        │     └─StreamProject { exprs: [fact2.v1, fact2._row_id, dim2._row_id, fact2.v1, 1:Int32] }
         │       └─StreamHashJoin { type: LeftOuter, predicate: fact2.v1 = dim2.v1, output: [fact2.v1, fact2._row_id, dim2._row_id] }
         │         ├─StreamExchange { dist: HashShard(fact2.v1) }
         │         │ └─StreamTableScan { table: fact2, columns: [fact2.v1, fact2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [fact2._row_id], pk: [_row_id], dist: UpstreamHashShard(fact2._row_id) }
@@ -167,14 +167,14 @@
         └─StreamExchange { dist: HashShard(fact3.v1) }
           └─StreamUnion { all: true }
             ├─StreamExchange { dist: HashShard(fact3._row_id, dim3._row_id, fact3.v1, 0:Int32) }
-            │ └─StreamProject { exprs: [fact3.v1, fact3.v1, fact3._row_id, dim3._row_id, 0:Int32] }
+            │ └─StreamProject { exprs: [fact3.v1, fact3._row_id, dim3._row_id, fact3.v1, 0:Int32] }
             │   └─StreamHashJoin { type: LeftOuter, predicate: fact3.v1 = dim3.v1, output: [fact3.v1, fact3._row_id, dim3._row_id] }
             │     ├─StreamExchange { dist: HashShard(fact3.v1) }
             │     │ └─StreamTableScan { table: fact3, columns: [fact3.v1, fact3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [fact3._row_id], pk: [_row_id], dist: UpstreamHashShard(fact3._row_id) }
             │     └─StreamExchange { dist: HashShard(dim3.v1) }
             │       └─StreamTableScan { table: dim3, columns: [dim3.v1, dim3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [dim3._row_id], pk: [_row_id], dist: UpstreamHashShard(dim3._row_id) }
             └─StreamExchange { dist: HashShard(fact4._row_id, dim4._row_id, fact4.v1, 1:Int32) }
-              └─StreamProject { exprs: [fact4.v1, fact4.v1, fact4._row_id, dim4._row_id, 1:Int32] }
+              └─StreamProject { exprs: [fact4.v1, fact4._row_id, dim4._row_id, fact4.v1, 1:Int32] }
                 └─StreamHashJoin { type: LeftOuter, predicate: fact4.v1 = dim4.v1, output: [fact4.v1, fact4._row_id, dim4._row_id] }
                   ├─StreamExchange { dist: HashShard(fact4.v1) }
                   │ └─StreamTableScan { table: fact4, columns: [fact4.v1, fact4._row_id], stream_scan_type: ArrangementBackfill, stream_key: [fact4._row_id], pk: [_row_id], dist: UpstreamHashShard(fact4._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
@@ -415,10 +415,10 @@
     create table t (t timestamp with time zone, a int);
     select * from t where (t > NOW() - INTERVAL '1 hour' OR t is NULL OR a < 1) AND (t < NOW() - INTERVAL '1 hour' OR a > 1);
   stream_plan: |-
-    StreamMaterialize { columns: [t, a, $src(hidden), t._row_id(hidden), $src#1(hidden)], stream_key: [t._row_id, $src, $src#1], pk_columns: [t._row_id, $src, $src#1], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [t, a, t._row_id(hidden), $src(hidden), $src#1(hidden)], stream_key: [t._row_id, $src, $src#1], pk_columns: [t._row_id, $src, $src#1], pk_conflict: NoCheck }
     └─StreamUnion { all: true }
       ├─StreamExchange { dist: HashShard(t._row_id, $src, 0:Int32) }
-      │ └─StreamProject { exprs: [t.t, t.a, $src, t._row_id, 0:Int32] }
+      │ └─StreamProject { exprs: [t.t, t.a, t._row_id, $src, 0:Int32] }
       │   └─StreamDynamicFilter { predicate: (t.t < $expr2), output: [t.t, t.a, t._row_id, $src], cleaned_by_watermark: true }
       │     ├─StreamFilter { predicate: Not((t.a > 1:Int32)) }
       │     │ └─StreamShare { id: 13 }
@@ -443,7 +443,7 @@
       │       └─StreamProject { exprs: [SubtractWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]] }
       │         └─StreamNow { output: [now] }
       └─StreamExchange { dist: HashShard(t._row_id, $src, 1:Int32) }
-        └─StreamProject { exprs: [t.t, t.a, $src, t._row_id, 1:Int32] }
+        └─StreamProject { exprs: [t.t, t.a, t._row_id, $src, 1:Int32] }
           └─StreamFilter { predicate: (t.a > 1:Int32) }
             └─StreamShare { id: 13 }
               └─StreamUnion { all: true }

--- a/src/frontend/planner_test/tests/testdata/output/union.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/union.yaml
@@ -436,41 +436,41 @@
     select * from t1 union all select * from t2 union all select * from t3 union all select * from t4 union all select * from t5;
   stream_dist_plan: |+
     Fragment 0
-    StreamMaterialize { columns: [a, b, c, t1.a(hidden), null:Int64(hidden), null:Decimal(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, null:Decimal, null:Int64, null:Serial, $src], pk_columns: [t1.a, null:Decimal, null:Int64, null:Serial, $src], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [a, b, c, null:Decimal(hidden), null:Int64(hidden), t1.a(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, null:Decimal, null:Int64, null:Serial, $src], pk_columns: [t1.a, null:Decimal, null:Int64, null:Serial, $src], pk_conflict: NoCheck }
     ├── tables: [ Materialize: 4294967294 ]
     └── StreamUnion { all: true }
-        ├── StreamExchange Hash([3, 5, 4, 6, 7]) from 1
-        ├── StreamExchange Hash([3, 5, 4, 6, 7]) from 2
-        ├── StreamExchange Hash([3, 5, 4, 6, 7]) from 3
-        ├── StreamExchange Hash([3, 5, 4, 6, 7]) from 4
-        └── StreamExchange Hash([3, 5, 4, 6, 7]) from 5
+        ├── StreamExchange Hash([5, 3, 4, 6, 7]) from 1
+        ├── StreamExchange Hash([5, 3, 4, 6, 7]) from 2
+        ├── StreamExchange Hash([5, 3, 4, 6, 7]) from 3
+        ├── StreamExchange Hash([5, 3, 4, 6, 7]) from 4
+        └── StreamExchange Hash([5, 3, 4, 6, 7]) from 5
 
     Fragment 1
-    StreamProject { exprs: [t1.a, t1.b, t1.c, t1.a, null:Int64, null:Decimal, null:Serial, 0:Int32] }
+    StreamProject { exprs: [t1.a, t1.b, t1.c, null:Decimal, null:Int64, t1.a, null:Serial, 0:Int32] }
     └── StreamTableScan { table: t1, columns: [t1.a, t1.b, t1.c], stream_scan_type: ArrangementBackfill, stream_key: [t1.a], pk: [a], dist: UpstreamHashShard(t1.a) } { tables: [ StreamScan: 0 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 2
-    StreamProject { exprs: [t2.a, t2.b, t2.c, null:Int32, null:Int64, t2.b, null:Serial, 1:Int32] }
+    StreamProject { exprs: [t2.a, t2.b, t2.c, t2.b, null:Int64, null:Int32, null:Serial, 1:Int32] }
     └── StreamTableScan { table: t2, columns: [t2.a, t2.b, t2.c], stream_scan_type: ArrangementBackfill, stream_key: [t2.b], pk: [b], dist: UpstreamHashShard(t2.b) } { tables: [ StreamScan: 1 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 3
-    StreamProject { exprs: [t3.a, t3.b, t3.c, null:Int32, t3.c, null:Decimal, null:Serial, 2:Int32] }
+    StreamProject { exprs: [t3.a, t3.b, t3.c, null:Decimal, t3.c, null:Int32, null:Serial, 2:Int32] }
     └── StreamTableScan { table: t3, columns: [t3.a, t3.b, t3.c], stream_scan_type: ArrangementBackfill, stream_key: [t3.c], pk: [c], dist: UpstreamHashShard(t3.c) } { tables: [ StreamScan: 2 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 4
-    StreamProject { exprs: [t4.a, t4.b, t4.c, null:Int32, null:Int64, null:Decimal, t4._row_id, 3:Int32] }
+    StreamProject { exprs: [t4.a, t4.b, t4.c, null:Decimal, null:Int64, null:Int32, t4._row_id, 3:Int32] }
     └── StreamTableScan { table: t4, columns: [t4.a, t4.b, t4.c, t4._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t4._row_id], pk: [_row_id], dist: UpstreamHashShard(t4._row_id) } { tables: [ StreamScan: 3 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 5
-    StreamProject { exprs: [t5.a, t5.b, t5.c, t5.a, null:Int64, t5.b, null:Serial, 4:Int32] }
+    StreamProject { exprs: [t5.a, t5.b, t5.c, t5.b, null:Int64, t5.a, null:Serial, 4:Int32] }
     └── StreamTableScan { table: t5, columns: [t5.a, t5.b, t5.c], stream_scan_type: ArrangementBackfill, stream_key: [t5.a, t5.b], pk: [a, b], dist: UpstreamHashShard(t5.a, t5.b) } { tables: [ StreamScan: 4 ] }
         ├── Upstream
         └── BatchPlanNode
@@ -485,7 +485,7 @@
 
     Table 4 { columns: [ vnode, a, b, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3, 4 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
 
-    Table 4294967294 { columns: [ a, b, c, t1.a, null:Int64, null:Decimal, null:Serial, $src, _rw_timestamp ], primary key: [ $3 ASC, $5 ASC, $4 ASC, $6 ASC, $7 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7 ], distribution key: [ 3, 5, 4, 6, 7 ], read pk prefix len hint: 5 }
+    Table 4294967294 { columns: [ a, b, c, null:Decimal, null:Int64, t1.a, null:Serial, $src, _rw_timestamp ], primary key: [ $5 ASC, $3 ASC, $4 ASC, $6 ASC, $7 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7 ], distribution key: [ 5, 3, 4, 6, 7 ], read pk prefix len hint: 5 }
 
 - name: test merged union stream key (4 columns, row_id + src_col + a + b)
   sql: |
@@ -497,41 +497,41 @@
     select * from t1 union all select * from t2 union all select * from t3 union all select * from t4 union all select * from t5;
   stream_dist_plan: |+
     Fragment 0
-    StreamMaterialize { columns: [a, b, c, t1.a(hidden), null:Decimal(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, null:Decimal, null:Serial, $src], pk_columns: [t1.a, null:Decimal, null:Serial, $src], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [a, b, c, null:Decimal(hidden), t1.a(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, null:Decimal, null:Serial, $src], pk_columns: [t1.a, null:Decimal, null:Serial, $src], pk_conflict: NoCheck }
     ├── tables: [ Materialize: 4294967294 ]
     └── StreamUnion { all: true }
-        ├── StreamExchange Hash([3, 4, 5, 6]) from 1
-        ├── StreamExchange Hash([3, 4, 5, 6]) from 2
-        ├── StreamExchange Hash([3, 4, 5, 6]) from 3
-        ├── StreamExchange Hash([3, 4, 5, 6]) from 4
-        └── StreamExchange Hash([3, 4, 5, 6]) from 5
+        ├── StreamExchange Hash([4, 3, 5, 6]) from 1
+        ├── StreamExchange Hash([4, 3, 5, 6]) from 2
+        ├── StreamExchange Hash([4, 3, 5, 6]) from 3
+        ├── StreamExchange Hash([4, 3, 5, 6]) from 4
+        └── StreamExchange Hash([4, 3, 5, 6]) from 5
 
     Fragment 1
-    StreamProject { exprs: [t1.a, t1.b, t1.c, t1.a, null:Decimal, null:Serial, 0:Int32] }
+    StreamProject { exprs: [t1.a, t1.b, t1.c, null:Decimal, t1.a, null:Serial, 0:Int32] }
     └── StreamTableScan { table: t1, columns: [t1.a, t1.b, t1.c], stream_scan_type: ArrangementBackfill, stream_key: [t1.a], pk: [a], dist: UpstreamHashShard(t1.a) } { tables: [ StreamScan: 0 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 2
-    StreamProject { exprs: [t2.a, t2.b, t2.c, null:Int32, t2.b, null:Serial, 1:Int32] }
+    StreamProject { exprs: [t2.a, t2.b, t2.c, t2.b, null:Int32, null:Serial, 1:Int32] }
     └── StreamTableScan { table: t2, columns: [t2.a, t2.b, t2.c], stream_scan_type: ArrangementBackfill, stream_key: [t2.b], pk: [b], dist: UpstreamHashShard(t2.b) } { tables: [ StreamScan: 1 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 3
-    StreamProject { exprs: [t3.a, t3.b, t3.c, null:Int32, null:Decimal, t3._row_id, 2:Int32] }
+    StreamProject { exprs: [t3.a, t3.b, t3.c, null:Decimal, null:Int32, t3._row_id, 2:Int32] }
     └── StreamTableScan { table: t3, columns: [t3.a, t3.b, t3.c, t3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t3._row_id], pk: [_row_id], dist: UpstreamHashShard(t3._row_id) } { tables: [ StreamScan: 2 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 4
-    StreamProject { exprs: [t4.a, t4.b, t4.c, null:Int32, null:Decimal, t4._row_id, 3:Int32] }
+    StreamProject { exprs: [t4.a, t4.b, t4.c, null:Decimal, null:Int32, t4._row_id, 3:Int32] }
     └── StreamTableScan { table: t4, columns: [t4.a, t4.b, t4.c, t4._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t4._row_id], pk: [_row_id], dist: UpstreamHashShard(t4._row_id) } { tables: [ StreamScan: 3 ] }
         ├── Upstream
         └── BatchPlanNode
 
     Fragment 5
-    StreamProject { exprs: [t5.a, t5.b, t5.c, t5.a, t5.b, null:Serial, 4:Int32] }
+    StreamProject { exprs: [t5.a, t5.b, t5.c, t5.b, t5.a, null:Serial, 4:Int32] }
     └── StreamTableScan { table: t5, columns: [t5.a, t5.b, t5.c], stream_scan_type: ArrangementBackfill, stream_key: [t5.a, t5.b], pk: [a, b], dist: UpstreamHashShard(t5.a, t5.b) } { tables: [ StreamScan: 4 ] }
         ├── Upstream
         └── BatchPlanNode
@@ -547,10 +547,10 @@
     Table 4 { columns: [ vnode, a, b, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3, 4 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
 
     Table 4294967294
-    ├── columns: [ a, b, c, t1.a, null:Decimal, null:Serial, $src, _rw_timestamp ]
-    ├── primary key: [ $3 ASC, $4 ASC, $5 ASC, $6 ASC ]
+    ├── columns: [ a, b, c, null:Decimal, t1.a, null:Serial, $src, _rw_timestamp ]
+    ├── primary key: [ $4 ASC, $3 ASC, $5 ASC, $6 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4, 5, 6 ]
-    ├── distribution key: [ 3, 4, 5, 6 ]
+    ├── distribution key: [ 4, 3, 5, 6 ]
     └── read pk prefix len hint: 4
 
 - name: test merged union stream key (3 columns, src_col + a + b)
@@ -674,10 +674,10 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchScan { table: t3, columns: [t3.b], distribution: SomeShard }
   stream_plan: |-
-    StreamMaterialize { columns: [b, t1.a(hidden), t1.b(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, t1.b, null:Serial, $src], pk_columns: [t1.a, t1.b, null:Serial, $src], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [b, t1.b(hidden), t1.a(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, t1.b, null:Serial, $src], pk_columns: [t1.a, t1.b, null:Serial, $src], pk_conflict: NoCheck }
     └─StreamUnion { all: true }
       ├─StreamExchange { dist: HashShard(t1.a, t1.b, null:Serial, 0:Int32) }
-      │ └─StreamProject { exprs: [t1.b, t1.a, t1.b, null:Serial, 0:Int32], noop_update_hint: true }
+      │ └─StreamProject { exprs: [t1.b, t1.b, t1.a, null:Serial, 0:Int32], noop_update_hint: true }
       │   └─StreamHashAgg { group_key: [t1.a, t1.b], aggs: [count] }
       │     └─StreamExchange { dist: HashShard(t1.a, t1.b) }
       │       └─StreamUnion { all: true }
@@ -688,18 +688,18 @@
       │           └─StreamProject { exprs: [t2.a, t2.b, t2._row_id, 1:Int32] }
       │             └─StreamTableScan { table: t2, columns: [t2.a, t2.b, t2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
       └─StreamExchange { dist: HashShard(null:Int32, null:Decimal, t3._row_id, 1:Int32) }
-        └─StreamProject { exprs: [t3.b, null:Int32, null:Decimal, t3._row_id, 1:Int32] }
+        └─StreamProject { exprs: [t3.b, null:Decimal, null:Int32, t3._row_id, 1:Int32] }
           └─StreamTableScan { table: t3, columns: [t3.b, t3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t3._row_id], pk: [_row_id], dist: UpstreamHashShard(t3._row_id) }
   stream_dist_plan: |+
     Fragment 0
-    StreamMaterialize { columns: [b, t1.a(hidden), t1.b(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, t1.b, null:Serial, $src], pk_columns: [t1.a, t1.b, null:Serial, $src], pk_conflict: NoCheck }
+    StreamMaterialize { columns: [b, t1.b(hidden), t1.a(hidden), null:Serial(hidden), $src(hidden)], stream_key: [t1.a, t1.b, null:Serial, $src], pk_columns: [t1.a, t1.b, null:Serial, $src], pk_conflict: NoCheck }
     ├── tables: [ Materialize: 4294967294 ]
     └── StreamUnion { all: true }
-        ├── StreamExchange Hash([1, 2, 3, 4]) from 1
-        └── StreamExchange Hash([1, 2, 3, 4]) from 5
+        ├── StreamExchange Hash([2, 1, 3, 4]) from 1
+        └── StreamExchange Hash([2, 1, 3, 4]) from 5
 
     Fragment 1
-    StreamProject { exprs: [t1.b, t1.a, t1.b, null:Serial, 0:Int32], noop_update_hint: true }
+    StreamProject { exprs: [t1.b, t1.b, t1.a, null:Serial, 0:Int32], noop_update_hint: true }
     └── StreamHashAgg { group_key: [t1.a, t1.b], aggs: [count] } { tables: [ HashAggState: 0 ] }
         └── StreamExchange Hash([0, 1]) from 2
 
@@ -723,7 +723,7 @@
         └── BatchPlanNode
 
     Fragment 5
-    StreamProject { exprs: [t3.b, null:Int32, null:Decimal, t3._row_id, 1:Int32] }
+    StreamProject { exprs: [t3.b, null:Decimal, null:Int32, t3._row_id, 1:Int32] }
     └── StreamTableScan { table: t3, columns: [t3.b, t3._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t3._row_id], pk: [_row_id], dist: UpstreamHashShard(t3._row_id) }
         ├── tables: [ StreamScan: 3 ]
         ├── Upstream
@@ -756,10 +756,10 @@
     └── vnode column idx: 0
 
     Table 4294967294
-    ├── columns: [ b, t1.a, t1.b, null:Serial, $src, _rw_timestamp ]
-    ├── primary key: [ $1 ASC, $2 ASC, $3 ASC, $4 ASC ]
+    ├── columns: [ b, t1.b, t1.a, null:Serial, $src, _rw_timestamp ]
+    ├── primary key: [ $2 ASC, $1 ASC, $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
-    ├── distribution key: [ 1, 2, 3, 4 ]
+    ├── distribution key: [ 2, 1, 3, 4 ]
     └── read pk prefix len hint: 4
 
 - name: test corresponding union error - corresponding list

--- a/src/frontend/src/optimizer/plan_node/logical_union.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_union.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use std::cmp::max;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::hash::RandomState;
 
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
@@ -236,9 +237,9 @@ impl ToStream for LogicalUnion {
             // If all inputs have the same stream key column types, we have a small merged_stream_key. Otherwise, we will have a large merged_stream_key.
 
             let (merged_stream_key_types, types_offset) = {
-                let mut max_types_counter = BTreeMap::default();
+                let mut max_types_counter = HashMap::<_, _, RandomState>::default();
                 for (new_input, _) in &rewrites {
-                    let mut types_counter = BTreeMap::default();
+                    let mut types_counter = HashMap::<_, _, RandomState>::default();
                     for x in new_input.expect_stream_key() {
                         types_counter
                             .entry(new_input.schema().fields[*x].data_type())
@@ -254,7 +255,7 @@ impl ToStream for LogicalUnion {
                 }
 
                 let mut merged_stream_key_types = vec![];
-                let mut types_offset = BTreeMap::default();
+                let mut types_offset = HashMap::<_, _, RandomState>::default();
                 let mut offset = 0;
                 for (key, val) in max_types_counter {
                     let _ = types_offset.insert(key.clone(), offset);
@@ -288,7 +289,7 @@ impl ToStream for LogicalUnion {
                         .collect_vec();
                     // merged_stream_key
                     let mut input_stream_keys = input_stream_key_nulls.clone();
-                    let mut types_counter = BTreeMap::default();
+                    let mut types_counter = HashMap::<_, _, RandomState>::default();
                     for stream_key_idx in new_input.expect_stream_key() {
                         let data_type =
                             new_input.schema().fields[*stream_key_idx].data_type.clone();

--- a/src/frontend/src/optimizer/plan_node/logical_union.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_union.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 use std::cmp::max;
-use std::collections::HashMap;
-use std::hash::RandomState;
 
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
@@ -176,6 +174,9 @@ impl ToStream for LogicalUnion {
         &self,
         ctx: &mut RewriteStreamContext,
     ) -> Result<(PlanRef, ColIndexMapping)> {
+        type FixedState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
+        type TypeMap<T> = std::collections::HashMap<DataType, T, FixedState>;
+
         let original_schema = self.base.schema().clone();
         let original_schema_len = original_schema.len();
         let mut rewrites = vec![];
@@ -237,9 +238,9 @@ impl ToStream for LogicalUnion {
             // If all inputs have the same stream key column types, we have a small merged_stream_key. Otherwise, we will have a large merged_stream_key.
 
             let (merged_stream_key_types, types_offset) = {
-                let mut max_types_counter = HashMap::<_, _, RandomState>::default();
+                let mut max_types_counter = TypeMap::default();
                 for (new_input, _) in &rewrites {
-                    let mut types_counter = HashMap::<_, _, RandomState>::default();
+                    let mut types_counter = TypeMap::default();
                     for x in new_input.expect_stream_key() {
                         types_counter
                             .entry(new_input.schema().fields[*x].data_type())
@@ -255,7 +256,7 @@ impl ToStream for LogicalUnion {
                 }
 
                 let mut merged_stream_key_types = vec![];
-                let mut types_offset = HashMap::<_, _, RandomState>::default();
+                let mut types_offset = TypeMap::default();
                 let mut offset = 0;
                 for (key, val) in max_types_counter {
                     let _ = types_offset.insert(key.clone(), offset);
@@ -289,7 +290,7 @@ impl ToStream for LogicalUnion {
                         .collect_vec();
                     // merged_stream_key
                     let mut input_stream_keys = input_stream_key_nulls.clone();
-                    let mut types_counter = HashMap::<_, _, RandomState>::default();
+                    let mut types_counter = TypeMap::default();
                     for stream_key_idx in new_input.expect_stream_key() {
                         let data_type =
                             new_input.schema().fields[*stream_key_idx].data_type.clone();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

To prevent misuse. See #22054 for the motivation to fix it now.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
