### PR TITLE
refactor(stream): use `ManagedLruCache::remove` instead of `put(None)` as deletion marker

### DIFF
--- a/src/stream/src/executor/project/materialized_exprs.rs
+++ b/src/stream/src/executor/project/materialized_exprs.rs
@@ -73,7 +73,7 @@ impl<S: StateStore> Execute for MaterializedExprsExecutor<S> {
 
 struct StateTableWrapper<S: StateStore> {
     inner: StateTable<S>,
-    cache: ManagedLruCache<OwnedRow, Option<OwnedRow>>,
+    cache: ManagedLruCache<OwnedRow, OwnedRow>,
 }
 
 impl<S: StateStore> StateTableWrapper<S> {
@@ -103,23 +103,16 @@ impl<S: StateStore> StateTableWrapper<S> {
 
         // Store the record and update the cache
         self.inner.insert(&owned_row);
-        self.cache.put(pk, Some(owned_row));
+        self.cache.put(pk, owned_row);
     }
 
     async fn remove_by_pk(&mut self, pk: impl Row) -> StreamExecutorResult<Option<OwnedRow>> {
         // Try to get from cache first
         let pk_owned = pk.into_owned_row();
-        if let Some(row) = self.cache.get(&pk_owned) {
+        if let Some(row) = self.cache.remove(&pk_owned) {
             // Cache hit, delete from cache and state table
-            if let Some(row) = row {
-                let cloned_row = row.clone();
-                self.inner.delete(row);
-                // Mark as deleted in cache
-                self.cache.put(pk_owned, None);
-                Ok(Some(cloned_row))
-            } else {
-                Ok(None)
-            }
+            self.inner.delete(&row);
+            Ok(Some(row))
         } else {
             // Cache miss, get from state table
             let row = self.inner.get_row(pk_owned).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

According to #22048, we use `lru.put(key, None)` to represent deletion before #21429. But now it's not necessary any more, this PR changes this to using `lru.remove(key)`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
