### PR TITLE
bench(sql_bench): add aligned and unaligned join benchmarks

### DIFF
--- a/develop/sql_bench/benchmarks/aligned-join.yaml
+++ b/develop/sql_bench/benchmarks/aligned-join.yaml
@@ -1,0 +1,51 @@
+# Benchmark configuration
+benchmark_name: sample_benchmark
+
+# SQL to set up the initial schema and data (run once)
+setup_sql: |
+  set streaming_enable_unaligned_join = false;
+  create table dim(v1 int);
+  INSERT INTO dim VALUES(1), (2);
+  create table fact(v0 int primary key, v1 int, v2 varchar, v3 varchar);
+  create materialized view m1 as
+    select v0, count(*), sum(v0), string_agg(v2, ',')
+    from fact join dim on fact.v1 = dim.v1
+    group by v0;
+
+
+  INSERT INTO fact
+    SELECT
+      x as v0,
+      1 as v1,
+      'abcdefgakjandjkw' as v2,
+      'jkb1ku1bu' as v3
+    FROM generate_series(1, 2000000) t(x);
+  INSERT INTO fact
+    SELECT
+      x as v0,
+      2 as v1,
+      'abcdefgakjandjkw' as v2,
+      'jkb1ku1bu' as v3
+    FROM generate_series(2000001, 4000000) t(x);
+  flush;
+
+# SQL to prepare the data before each run
+prepare_sql: |
+
+# SQL to clean up after each run
+conclude_sql: |
+  INSERT INTO dim VALUES(1), (2);
+  flush;
+
+# SQL to clean up everything after all runs are complete
+cleanup_sql: |
+  DROP MATERIALIZED VIEW IF EXISTS m1;
+  DROP TABLE IF EXISTS dim;
+  DROP TABLE IF EXISTS fact;
+# SQL to benchmark (optimized version)
+benchmark_sql: |
+  DELETE FROM dim;
+  flush;
+
+# Number of times to run the benchmark
+runs: 3

--- a/develop/sql_bench/benchmarks/unaligned-join.yaml
+++ b/develop/sql_bench/benchmarks/unaligned-join.yaml
@@ -1,0 +1,51 @@
+# Benchmark configuration
+benchmark_name: sample_benchmark
+
+# SQL to set up the initial schema and data (run once)
+setup_sql: |
+  set streaming_enable_unaligned_join = true;
+  create table dim(v1 int);
+  INSERT INTO dim VALUES(1), (2);
+  create table fact(v0 int primary key, v1 int, v2 varchar, v3 varchar);
+  create materialized view m1 as
+    select v0, count(*), sum(v0), string_agg(v2, ',')
+    from fact join dim on fact.v1 = dim.v1
+    group by v0;
+
+
+  INSERT INTO fact
+    SELECT
+      x as v0,
+      1 as v1,
+      'abcdefgakjandjkw' as v2,
+      'jkb1ku1bu' as v3
+    FROM generate_series(1, 2000000) t(x);
+  INSERT INTO fact
+    SELECT
+      x as v0,
+      2 as v1,
+      'abcdefgakjandjkw' as v2,
+      'jkb1ku1bu' as v3
+    FROM generate_series(2000001, 4000000) t(x);
+  flush;
+
+# SQL to prepare the data before each run
+prepare_sql: |
+
+# SQL to clean up after each run
+conclude_sql: |
+  INSERT INTO dim VALUES(1), (2);
+  flush;
+
+# SQL to clean up everything after all runs are complete
+cleanup_sql: |
+  DROP MATERIALIZED VIEW IF EXISTS m1;
+  DROP TABLE IF EXISTS dim;
+  DROP TABLE IF EXISTS fact;
+# SQL to benchmark (optimized version)
+benchmark_sql: |
+  DELETE FROM dim;
+  flush;
+
+# Number of times to run the benchmark
+runs: 3


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Added two benchmark YAML files to test and compare the performance of aligned and unaligned joins:

1. `aligned-join.yaml` - Tests join performance with `streaming_enable_unaligned_join = false`
2. `unaligned-join.yaml` - Tests join performance with `streaming_enable_unaligned_join = true`

Both benchmarks create identical test scenarios with a fact table containing 4 million rows and a dimension table, then measure the barrier latency from processing deletes from the dimension table. This will help us quantify the performance difference between aligned and unaligned join implementations.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>