### PR TITLE
feat(mqtt): fix MQTT data loss

### DIFF
--- a/e2e_test/sink/mqtt_sink.slt
+++ b/e2e_test/sink/mqtt_sink.slt
@@ -47,35 +47,6 @@ WITH
       force_append_only='true',
   );
 
-# First the (retained) topics are primed, so that they will be listened
-# to when the mqtt source initializes. Otherwise it would take 30 seconds
-# for the next enumerator tick
-
-statement ok
-INSERT INTO mqtt (device_id, temperature)
-VALUES ( '12',  56.0 );
-
-statement ok
-FLUSH;
-
-statement ok
-INSERT INTO mqtt (device_id, temperature)
-VALUES ( '13',  20.0 );
-
-statement ok
-FLUSH;
-
-statement ok
-INSERT INTO mqtt_nested (info, temperature)
-VALUES( ROW('12', '/nested/12'), 56.0 );
-
-statement ok
-FLUSH;
-
-statement ok
-INSERT INTO mqtt_nested (info, temperature)
-VALUES( ROW('13', null), 22.0 );
-
 statement ok
 CREATE TABLE mqtt_source
 (
@@ -86,7 +57,7 @@ INCLUDE partition AS mqtt_topic
 WITH (
     connector ='mqtt',
     url ='tcp://mqtt-server',
-    topic = '/device/+',
+    topic = '/device/fixed/12,/device/fixed/13,/device/wildcard/#',
     qos = 'at_least_once',
 ) FORMAT PLAIN ENCODE JSON;
 
@@ -106,28 +77,35 @@ WITH (
 
 statement ok
 INSERT INTO mqtt (device_id, temperature)
-VALUES ( '12',  59.0 );
+VALUES ( 'fixed/12',  59.0 );
 
 statement ok
 FLUSH;
 
 statement ok
 INSERT INTO mqtt (device_id, temperature)
-VALUES ( '12',  60.0 );
+VALUES ( 'fixed/12',  60.0 );
 
 statement ok
 FLUSH;
 
 statement ok
 INSERT INTO mqtt (device_id, temperature)
-VALUES ( '13',  22.0 );
+VALUES ( 'fixed/13',  22.0 );
 
 statement ok
 FLUSH;
 
 statement ok
 INSERT INTO mqtt (device_id, temperature)
-VALUES ( '13',  24.0 );
+VALUES ( 'fixed/13',  24.0 );
+
+statement ok
+FLUSH;
+
+statement ok
+INSERT INTO mqtt (device_id, temperature)
+VALUES ( 'wildcard/14',  31.0 );
 
 statement ok
 FLUSH;
@@ -151,20 +129,20 @@ sleep 15s
 query IT rowsort
 SELECT device_id, temperature FROM mqtt ORDER BY device_id, temperature;
 ----
-12 56
-12 59
-12 60
-13 20
-13 22
-13 24
+fixed/12 59
+fixed/12 60
+fixed/13 22
+fixed/13 24
+wildcard/14 31
 
 query ITT rowsort
 SELECT device_id, temperature, mqtt_topic FROM mqtt_source ORDER BY device_id, temperature;
 ----
-12 59 /device/12
-12 60 /device/12
-13 22 /device/13
-13 24 /device/13
+fixed/12 59 /device/fixed/12
+fixed/12 60 /device/fixed/12
+fixed/13 22 /device/fixed/13
+fixed/13 24 /device/fixed/13
+wildcard/14 31 /device/wildcard/14
 
 query IT rowsort
 SELECT (info).device_id device_id, temperature from mqtt_nested_source ORDER BY device_id, temperature ;

--- a/e2e_test/sink/mqtt_sink.slt
+++ b/e2e_test/sink/mqtt_sink.slt
@@ -24,7 +24,7 @@ WITH
     url='tcp://mqtt-server',
     type = 'append-only',
     topic.field = 'topic',
-    retain = 'true',
+    retain = 'false',
     qos = 'at_least_once',
   ) FORMAT PLAIN ENCODE JSON (
       force_append_only='true',
@@ -41,7 +41,7 @@ WITH
     type = 'append-only',
     topic = '/nested/fallback',
     topic.field = 'info.topic',
-    retain = 'true',
+    retain = 'false',
     qos = 'at_least_once',
   ) FORMAT PLAIN ENCODE JSON (
       force_append_only='true',
@@ -113,7 +113,21 @@ FLUSH;
 
 statement ok
 INSERT INTO mqtt (device_id, temperature)
+VALUES ( '12',  60.0 );
+
+statement ok
+FLUSH;
+
+statement ok
+INSERT INTO mqtt (device_id, temperature)
 VALUES ( '13',  22.0 );
+
+statement ok
+FLUSH;
+
+statement ok
+INSERT INTO mqtt (device_id, temperature)
+VALUES ( '13',  24.0 );
 
 statement ok
 FLUSH;
@@ -125,6 +139,13 @@ VALUES( ROW('12', '/nested/12'), 56.0 );
 statement ok
 FLUSH;
 
+statement ok
+INSERT INTO mqtt_nested (info, temperature)
+VALUES( ROW('13', null), 24.0 );
+
+statement ok
+FLUSH;
+
 sleep 15s
 
 query IT rowsort
@@ -132,18 +153,20 @@ SELECT device_id, temperature FROM mqtt ORDER BY device_id, temperature;
 ----
 12 56
 12 59
+12 60
 13 20
 13 22
+13 24
 
 query ITT rowsort
 SELECT device_id, temperature, mqtt_topic FROM mqtt_source ORDER BY device_id, temperature;
 ----
-12 56 /device/12
 12 59 /device/12
-13 20 /device/13
+12 60 /device/12
 13 22 /device/13
+13 24 /device/13
 
 query IT rowsort
 SELECT (info).device_id device_id, temperature from mqtt_nested_source ORDER BY device_id, temperature ;
 ----
-13 22
+13 24

--- a/src/connector/src/source/mqtt/enumerator/mod.rs
+++ b/src/connector/src/source/mqtt/enumerator/mod.rs
@@ -12,16 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-
 use async_trait::async_trait;
-use risingwave_common::bail;
-use rumqttc::Outgoing;
-use rumqttc::v5::{ConnectionError, Event, Incoming};
-use thiserror_ext::AsReport;
-use tokio::sync::RwLock;
 
 use super::MqttProperties;
 use super::source::MqttSplit;
@@ -29,13 +20,7 @@ use crate::error::ConnectorResult;
 use crate::source::{SourceEnumeratorContextRef, SplitEnumerator};
 
 pub struct MqttSplitEnumerator {
-    #[expect(dead_code)]
     topic: String,
-    #[expect(dead_code)]
-    client: rumqttc::v5::AsyncClient,
-    topics: Arc<RwLock<HashSet<String>>>,
-    connected: Arc<AtomicBool>,
-    stopped: Arc<AtomicBool>,
 }
 
 #[async_trait]
@@ -45,95 +30,56 @@ impl SplitEnumerator for MqttSplitEnumerator {
 
     async fn new(
         properties: Self::Properties,
-        context: SourceEnumeratorContextRef,
+        _context: SourceEnumeratorContextRef,
     ) -> ConnectorResult<MqttSplitEnumerator> {
-        let (client, mut eventloop) = properties.common.build_client(context.info.source_id, 0)?;
-
-        let topic = properties.topic.clone();
-        let mut topics = HashSet::new();
-        if !topic.contains('#') && !topic.contains('+') {
-            topics.insert(topic.clone());
-        }
-
-        client
-            .subscribe(topic.clone(), rumqttc::v5::mqttbytes::QoS::AtMostOnce)
-            .await?;
-
-        let topics = Arc::new(RwLock::new(topics));
-
-        let connected = Arc::new(AtomicBool::new(false));
-        let connected_clone = connected.clone();
-
-        let stopped = Arc::new(AtomicBool::new(false));
-        let stopped_clone = stopped.clone();
-
-        let topics_clone = topics.clone();
-        tokio::spawn(async move {
-            while !stopped_clone.load(std::sync::atomic::Ordering::Relaxed) {
-                match eventloop.poll().await {
-                    Ok(Event::Outgoing(Outgoing::Subscribe(_))) => {
-                        connected_clone.store(true, std::sync::atomic::Ordering::Relaxed);
-                    }
-                    Ok(Event::Incoming(Incoming::Publish(p))) => {
-                        let topic = String::from_utf8_lossy(&p.topic).to_string();
-                        let exist = {
-                            let topics = topics_clone.read().await;
-                            topics.contains(&topic)
-                        };
-
-                        if !exist {
-                            let mut topics = topics_clone.write().await;
-                            topics.insert(topic);
-                        }
-                    }
-                    Ok(_)
-                    | Err(ConnectionError::Timeout(_))
-                    | Err(ConnectionError::RequestsDone) => {}
-                    Err(err) => {
-                        tracing::error!(
-                            "Failed to fetch splits to topic {}: {}",
-                            topic,
-                            err.as_report(),
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(500)).await
-                    }
-                }
-            }
-        });
-
         Ok(Self {
-            client,
-            topics,
             topic: properties.topic,
-            connected,
-            stopped,
         })
     }
 
     async fn list_splits(&mut self) -> ConnectorResult<Vec<MqttSplit>> {
-        if !self.connected.load(std::sync::atomic::Ordering::Relaxed) {
-            let start = std::time::Instant::now();
-            loop {
-                if self.connected.load(std::sync::atomic::Ordering::Relaxed) {
-                    break;
-                }
-
-                if start.elapsed().as_secs() > 10 {
-                    bail!("Failed to connect to mqtt broker");
-                }
-
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            }
-        }
-
-        let topics = self.topics.read().await;
-        Ok(topics.iter().cloned().map(MqttSplit::new).collect())
+        Ok(vec![MqttSplit::new(self.topic.clone())])
     }
 }
 
-impl Drop for MqttSplitEnumerator {
-    fn drop(&mut self) {
-        self.stopped
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::super::MqttProperties;
+    use super::MqttSplitEnumerator;
+    use crate::connector_common::MqttCommon;
+    use crate::source::mqtt::source::MqttSplit;
+    use crate::source::{SourceEnumeratorContext, SplitEnumerator};
+
+    #[tokio::test]
+    async fn test_mqtt_enumerator() {
+        let common = MqttCommon {
+            url: "mqtt://broker".to_owned(),
+            qos: None,
+            user: None,
+            password: None,
+            client_prefix: None,
+            clean_start: true,
+            inflight_messages: None,
+            max_packet_size: None,
+            ca: None,
+            client_cert: None,
+            client_key: None,
+        };
+        let props = MqttProperties {
+            common,
+            topic: "test".to_owned(),
+            qos: None,
+            unknown_fields: HashMap::new(),
+        };
+        let context = Arc::new(SourceEnumeratorContext::dummy());
+        let mut enumerator = MqttSplitEnumerator::new(props, context).await.unwrap();
+
+        assert_eq!(
+            enumerator.list_splits().await.unwrap(),
+            vec![MqttSplit::new("test".to_owned())]
+        );
     }
 }

--- a/src/connector/src/source/mqtt/source/reader.rs
+++ b/src/connector/src/source/mqtt/source/reader.rs
@@ -64,8 +64,8 @@ impl SplitReader for MqttSplitReader {
             .subscribe_many(
                 splits
                     .iter()
-                    .cloned()
-                    .map(|split| Filter::new(split.topic, qos)),
+                    .flat_map(|split| split.topic.split(","))
+                    .map(|topic| Filter::new(topic.to_owned(), qos)),
             )
             .await?;
 

--- a/src/connector/src/source/mqtt/split.rs
+++ b/src/connector/src/source/mqtt/split.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::ConnectorResult;
 use crate::source::{SplitId, SplitMetaData};
 
-/// The states of a NATS split, which will be persisted to checkpoint.
+/// The states of a MQTT split, which will be persisted to checkpoint.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Hash)]
 pub struct MqttSplit {
     pub(crate) topic: String,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR does 2 things, separated in commits (it can be helpful to review them separatedly).

1. It fixes the MQTT data loss (https://github.com/risingwavelabs/risingwave/issues/19707) by moving the processing to a single split (and client)
2. It allows multiple MQTT topics to be specified by separating with `,`s

I intentionally chose to keep 1 split, even when using multiple MQTT topics to prevent message duplication in the case of overlapping topics. e.g. subscribing to `/a/#` and `/a/b/#` should only result in 1 message on topic `a/b/c`. Splitting multiple topics could result in message duplication, if one client subscribed to `/a/#` and the other subscribed to `/a/b/#`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

MQTT sources now allow for multiple topics by separating with `,`s

</details>
