### PR TITLE
fix: respect RUST_LOG when RISINGWAVE_KAFKA_LOG_LEVEL is not set

### DIFF
--- a/src/connector/src/connector_common/connection.rs
+++ b/src/connector/src/connector_common/connection.rs
@@ -102,7 +102,7 @@ impl Connection for KafkaConnection {
 }
 
 pub fn read_kafka_log_level() -> Option<RDKafkaLogLevel> {
-    let log_level = std::env::var("RISINGWAVE_KAFKA_LOG_LEVEL")?;
+    let log_level = std::env::var("RISINGWAVE_KAFKA_LOG_LEVEL").ok()?;
     match log_level.to_uppercase().as_str() {
         "DEBUG" => Some(RDKafkaLogLevel::Debug),
         "INFO" => Some(RDKafkaLogLevel::Info),

--- a/src/connector/src/connector_common/connection.rs
+++ b/src/connector/src/connector_common/connection.rs
@@ -102,8 +102,7 @@ impl Connection for KafkaConnection {
 }
 
 pub fn read_kafka_log_level() -> Option<RDKafkaLogLevel> {
-    let log_level =
-        std::env::var("RISINGWAVE_KAFKA_LOG_LEVEL").unwrap_or_else(|_| "INFO".to_owned());
+    let log_level = std::env::var("RISINGWAVE_KAFKA_LOG_LEVEL")?;
     match log_level.to_uppercase().as_str() {
         "DEBUG" => Some(RDKafkaLogLevel::Debug),
         "INFO" => Some(RDKafkaLogLevel::Info),
@@ -113,13 +112,7 @@ pub fn read_kafka_log_level() -> Option<RDKafkaLogLevel> {
         "EMERG" => Some(RDKafkaLogLevel::Emerg),
         "ALERT" => Some(RDKafkaLogLevel::Alert),
         "NOTICE" => Some(RDKafkaLogLevel::Notice),
-        _ => {
-            tracing::info!(
-                "Invalid RISINGWAVE_KAFKA_LOG_LEVEL: {}, using INFO instead",
-                log_level
-            );
-            None
-        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Signed-off-by: xxchan <xxchan22f@gmail.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
