### PR TITLE
feat(catalog): add fragment backfill progress view

### DIFF
--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -95,6 +95,7 @@ if [[ "$profile" == "ci-release" ]]; then
   # only run in release-mode. It's too slow for dev-mode.
   risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_order_control.slt'
   risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_order_control_recovery.slt'
+  risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_progress.slt'
 fi
 
 echo "--- Kill cluster"

--- a/e2e_test/backfill/backfill_progress.slt
+++ b/e2e_test/backfill/backfill_progress.slt
@@ -42,10 +42,10 @@ statement ok
 set streaming_parallelism=1;
 
 statement ok
-create materialized view m1 as 
-  select x.v1, x.v2 
+create materialized view m1 as
+  select x.v1, x.v2
   from
-    t x 
+    t x
       join t y on x.v1 = y.v1
       join t2 on x.v1 = t2.v1
       join t3 on t3.v1 = t2.v1

--- a/e2e_test/backfill/backfill_progress.slt
+++ b/e2e_test/backfill/backfill_progress.slt
@@ -1,0 +1,70 @@
+statement ok
+drop table if exists t;
+
+statement ok
+drop table if exists t2;
+
+statement ok
+drop table if exists t3;
+
+query I
+select job_id from rw_catalog.rw_fragment_backfill_progress;
+----
+
+statement ok
+create table t(v1 int, v2 int);
+
+statement ok
+create table t2(v1 int, v2 int);
+
+statement ok
+create table t3(v1 int, v2 int);
+
+statement ok
+insert into t select * from generate_series(1, 10000);
+
+statement ok
+insert into t2 select * from generate_series(1, 10000);
+
+statement ok
+insert into t3 select * from generate_series(1, 10000);
+
+statement ok
+flush;
+
+statement ok
+set backfill_rate_limit=1;
+
+statement ok
+set background_ddl=true;
+
+statement ok
+set streaming_parallelism=1;
+
+statement ok
+create materialized view m1 as 
+  select x.v1, x.v2 
+  from
+    t x 
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+
+# Can't validate, because the progress varies. Just make sure it doesn't panic.
+statement ok
+select job_id from rw_catalog.rw_fragment_backfill_progress;
+
+statement ok
+set streaming_parallelism=default;
+
+statement ok
+drop materialized view m1;
+
+statement ok
+drop table t;
+
+statement ok
+drop table t2;
+
+statement ok
+drop table t3;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
@@ -62,6 +62,7 @@ mod iceberg_namespace_properties;
 mod iceberg_tables;
 mod rw_actor_id_to_ddl;
 mod rw_actor_splits;
+mod rw_fragment_backfill_progress;
 mod rw_fragment_id_to_ddl;
 mod rw_internal_table_info;
 mod rw_resource_groups;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_backfill_progress.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_backfill_progress.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::Fields;
+use risingwave_frontend_macro::system_catalog;
+
+/// Provides fragment level backfill progress.
+#[system_catalog(
+view,
+"rw_catalog.rw_fragment_backfill_progress",
+"select 
+  progress.job_id,
+  progress.fragment_id,
+  concat(
+    progress.current_row_count::numeric / stats.total_key_count::numeric * 100,
+    '%',
+    ' ',
+    '(',
+    progress.current_row_count,
+    '/',
+    stats.total_key_count,
+    ')'
+  ) as progress
+FROM internal_backfill_progress() progress
+JOIN rw_table_scan scan_info ON progress.job_id = scan_info.job_id AND progress.fragment_id = scan_info.fragment_id
+JOIN rw_table_stats stats ON scan_info.backfill_target_table_id = stats.id
+"
+)]
+#[derive(Fields)]
+struct RwFragmentBackfillProgress {
+    job_id: i32,
+    #[primary_key]
+    fragment_id: i32,
+    progress: String,
+}
+

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_backfill_progress.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_backfill_progress.rs
@@ -19,7 +19,7 @@ use risingwave_frontend_macro::system_catalog;
 #[system_catalog(
 view,
 "rw_catalog.rw_fragment_backfill_progress",
-"select 
+"select
   progress.job_id,
   progress.fragment_id,
   concat(job_schemas.name, '.', job_tables.name) as job_name,
@@ -52,4 +52,3 @@ struct RwFragmentBackfillProgress {
     upstream_table_name: String,
     progress: String,
 }
-


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

In this PR, we introduced the fragment backfill progress view. This view will display the backfill progress per fragment, in a similar format to `show jobs`.

### Motivation

After backfill order is introduced, we need to also provide a way for users to observe the backfill progress per backfill node. Currently users can only view this progress at a job level, and not at a fragment level via show jobs.

The user flow will be something like:
1. `DESCRIBE FRAGMENTS creating_job_name` or `explain <query>`
2. After seeing the fragment_ids of their stream job / backfill table names, they can run `select * from rw_catalog.rw_fragment_backfill_progress where job_id = ...` to check the progress of their fragments.

### Implementation

We have several pieces which we use to support this.
1. A table function to query the current row count: https://github.com/risingwavelabs/risingwave/pull/22122
2. A rw_stream_scan table to query the upstream table ids. https://github.com/risingwavelabs/risingwave/pull/22123, used for (3) to filter out only backfill table stats. It also queries the fragment id of the backfill node so we can join (1) and (3).
3. Reusing rw_table_stats to query total row count for backfill tables so we can compute a (%) progress.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

The system catalog `rw_fragment_backfill_progress` provides a fragment level backfill progress, to allow you to track how each of the backfill partitions are progressing.

Here's an example of how it can be used:
```
drop materialized view if exists mv1;
drop table if exists t1;
drop table if exists t2;
drop table if exists t3;

create table t1 (a int, b int);
create table t2 (a int, b int);
create table t3 (a int, b int);

insert into t1 select i, i from generate_series(1, 10000) as t(i);
insert into t2 select i, i from generate_series(1, 10000) as t(i);
insert into t3 select i, i from generate_series(1, 10000) as t(i);

set background_ddl=true;
set backfill_rate_limit=1;

flush;
flush;
flush;
flush;
flush;
flush;

create materialized view mv1 with (backfill_order= FIXED(t1->t2, t2->t3))
as select t1.a, t2.b, t3.b as c, t4.a as d from t1 join t2 on t1.a = t2.a join t3 on t2.a = t3.a join t1 as t4 on t3.a = t4.a;

select * from rw_catalog.rw_fragment_backfill_progress;
```

Output:
```
 job_id | fragment_id |  job_name  | upstream_table_name |      progress      
--------+-------------+------------+---------------------+--------------------
      9 |          11 | public.mv1 | public.t3           | 0% (0/10000)
      9 |          10 | public.mv1 | public.t2           | 0% (0/10000)
      9 |          12 | public.mv1 | public.t1           | 0.4700% (47/10000)
      9 |           9 | public.mv1 | public.t1           | 0.4700% (47/10000)

 job_id | fragment_id |  job_name  | upstream_table_name |       progress        
--------+-------------+------------+---------------------+-----------------------
      9 |          10 | public.mv1 | public.t2           | 0% (0/10000)
      9 |          11 | public.mv1 | public.t3           | 0% (0/10000)
      9 |          12 | public.mv1 | public.t1           | 51.4600% (5146/10000)
      9 |           9 | public.mv1 | public.t1           | 92.1500% (9215/10000)
(4 rows)

-- t1 all done, now t2

 job_id | fragment_id |  job_name  | upstream_table_name |      progress      
--------+-------------+------------+---------------------+--------------------
      9 |           9 | public.mv1 | public.t1           | 100% (10000/10000)
      9 |          10 | public.mv1 | public.t2           | 0.0400% (4/10000)
      9 |          11 | public.mv1 | public.t3           | 0% (0/10000)
      9 |          12 | public.mv1 | public.t1           | 100% (10000/10000)
(4 rows)
```