### PR TITLE
feat(sqlsmith): support generation of select * except

### DIFF
--- a/src/tests/sqlsmith/config.yml
+++ b/src/tests/sqlsmith/config.yml
@@ -14,3 +14,6 @@ config:
   using_join:
     weight: 25
     enabled: true
+  except:
+    weight: 10
+    enabled: true

--- a/src/tests/sqlsmith/src/config.rs
+++ b/src/tests/sqlsmith/src/config.rs
@@ -26,6 +26,7 @@ pub enum Feature {
     Join,
     NaturalJoin,
     UsingJoin,
+    Except,
 }
 
 impl fmt::Display for Feature {
@@ -36,6 +37,7 @@ impl fmt::Display for Feature {
             Feature::Join => "join",
             Feature::NaturalJoin => "natural join",
             Feature::UsingJoin => "using join",
+            Feature::Except => "except",
         };
         write!(f, "{}", s)
     }

--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -23,7 +23,8 @@ use rand::Rng;
 use rand::prelude::{IndexedRandom, SliceRandom};
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{
-    Cte, Distinct, Expr, Ident, Query, Select, SelectItem, SetExpr, TableWithJoins, Value, With, SetOperator, Corresponding
+    Corresponding, Cte, Distinct, Expr, Ident, Query, Select, SelectItem, SetExpr, SetOperator,
+    TableWithJoins, Value, With,
 };
 
 use crate::config::Feature;
@@ -157,7 +158,8 @@ impl<R: Rng> SqlGenerator<'_, R> {
             self.restore_context(left_ctxt);
 
             let right_ctxt = self.new_local_context();
-            let (right_expr, right_schema) = self.gen_set_expr(with_tables.clone(), num_select_items);
+            let (right_expr, right_schema) =
+                self.gen_set_expr(with_tables.clone(), num_select_items);
             self.restore_context(right_ctxt);
 
             if !self.schemas_compatible(&left_schema, &right_schema) {
@@ -180,7 +182,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
             )
         } else {
             let (select, schema) = self.gen_select_stmt(with_tables, num_select_items);
-            return (SetExpr::Select(Box::new(select)), schema);
+            (SetExpr::Select(Box::new(select)), schema)
         }
     }
 
@@ -188,7 +190,9 @@ impl<R: Rng> SqlGenerator<'_, R> {
         if left.len() != right.len() {
             return false;
         }
-        left.iter().zip(right.iter()).all(|(l, r)| l.data_type == r.data_type)
+        left.iter()
+            .zip(right.iter())
+            .all(|(l, r)| l.data_type == r.data_type)
     }
 
     fn gen_limit(&mut self, has_order_by: bool) -> Option<Expr> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds support for SELECT * EXCEPT (...) in SQLSmith.

Previously, we avoided generating SELECT * queries due to the risk of implicitly including system-generated columns (e.g., window_start from tumble/hop functions), which could lead to binding errors. 

Now, with a stricter generation policy that restricts tumble/hop to only operate on base tables, such implicit columns are no longer propagated. As a result, SELECT * and SELECT * EXCEPT (...) can be safely generated. The implementation randomly excludes a subset of columns from the current schema to construct a valid EXCEPT list. 

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
