### PR TITLE
fix(mssql-cdc): support `uuid` and `varchar` as primary key data type

### DIFF
--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc.slt.serial
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc.slt.serial
@@ -286,6 +286,7 @@ statement ok
 CREATE TABLE test_pk_uuid (
     "id" CHARACTER VARYING,
     "NAME" CHARACTER VARYING,
+    PRIMARY KEY ("id")
 ) from mssql_source table 'mydb.dbo.test_pk_uuid';
 
 statement ok

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc.slt.serial
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc.slt.serial
@@ -283,6 +283,12 @@ statement ok
 DROP table shared_sqlserver_all_data_types;
 
 statement ok
+CREATE TABLE test_pk_uuid (
+    "id" CHARACTER VARYING,
+    "NAME" CHARACTER VARYING,
+) from mssql_source table 'mydb.dbo.test_pk_uuid';
+
+statement ok
 CREATE TABLE shared_sqlserver_all_data_types (
     id INT,
     c_bit BOOLEAN,
@@ -358,6 +364,11 @@ query I
 select cnt from shared_orders_cnt;
 ----
 3
+
+query I
+select count(*) from test_pk_uuid;
+----
+2000
 
 query I
 select cnt from shared_single_type_cnt;

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_insert.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_insert.sql
@@ -28,6 +28,6 @@ WHILE @i <= 2000
 BEGIN
     INSERT INTO test_pk_uuid (id, NAME)
     VALUES (NEWID(), CONCAT('TEST_NAME', @i), 0);
-    
+
     SET @i = @i + 1;
 END

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_insert.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_insert.sql
@@ -21,3 +21,13 @@ INSERT INTO sqlserver_all_data_types VALUES (11, 'False', 0, 0, 0, 0, 0, 0, 0, '
 INSERT INTO sqlserver_all_data_types VALUES (12, 'True', 255, -32768, -2147483648, -9223372036854775808, -10.0, -9999.999999, -10000.0, 'aa', 'aa', N'🌹', N'🌹', NULL, 0xff, '6f9619ff-8b86-d011-b42d-00c04fc964ff', '1990-01-01', '13:59:59.123', '2000-01-01 11:00:00.123', '1990-01-01 00:00:01.123', '<Person> <Name>Jane Doe</Name> <Age>28</Age> </Person>');
 
 INSERT INTO sqlserver_all_data_types VALUES (13, 'True', 127, 32767, 2147483647, 9223372036854775807, -10.0, 9999.999999, 10000.0, 'zzzz', 'zzzz', N'🌹👍', N'🌹👍', 0xffffffff, 0xffffffff, '6F9619FF-8B86-D011-B42D-00C04FC964FF', '2999-12-31', '23:59:59.999', '2099-12-31 23:59:59.999', '2999-12-31 23:59:59.999', '<Name>Jane Doe</Name>')
+
+DECLARE @i INT = 1;
+
+WHILE @i <= 2000
+BEGIN
+    INSERT INTO test_pk_uuid (id, NAME)
+    VALUES (NEWID(), CONCAT('TEST_NAME', @i), 0);
+    
+    SET @i = @i + 1;
+END

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_insert.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_insert.sql
@@ -22,12 +22,3 @@ INSERT INTO sqlserver_all_data_types VALUES (12, 'True', 255, -32768, -214748364
 
 INSERT INTO sqlserver_all_data_types VALUES (13, 'True', 127, 32767, 2147483647, 9223372036854775807, -10.0, 9999.999999, 10000.0, 'zzzz', 'zzzz', N'🌹👍', N'🌹👍', 0xffffffff, 0xffffffff, '6F9619FF-8B86-D011-B42D-00C04FC964FF', '2999-12-31', '23:59:59.999', '2099-12-31 23:59:59.999', '2999-12-31 23:59:59.999', '<Name>Jane Doe</Name>')
 
-DECLARE @i INT = 1;
-
-WHILE @i <= 2000
-BEGIN
-    INSERT INTO test_pk_uuid (id, NAME)
-    VALUES (NEWID(), CONCAT('TEST_NAME', @i), 0);
-
-    SET @i = @i + 1;
-END

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
@@ -86,3 +86,9 @@ CREATE TABLE orders_without_cdc (
   product_id INT,
   order_status SMALLINT
 );
+
+
+CREATE TABLE test_pk_uuid (
+  id UNIQUEIDENTIFIER PRIMARY KEY,
+  NAME NVARCHAR(50),
+);

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
@@ -103,7 +103,7 @@ EXEC sys.sp_cdc_enable_table
 WHILE @i <= 2000
 BEGIN
     INSERT INTO test_pk_uuid (id, NAME)
-    VALUES (NEWID(), CONCAT('TEST_NAME', @i), 0);
+    VALUES (NEWID(), CONCAT('TEST_NAME', @i));
 
     SET @i = @i + 1;
 END

--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
@@ -92,3 +92,18 @@ CREATE TABLE test_pk_uuid (
   id UNIQUEIDENTIFIER PRIMARY KEY,
   NAME NVARCHAR(50),
 );
+
+EXEC sys.sp_cdc_enable_table
+  @source_schema = 'dbo',
+  @source_name = 'test_pk_uuid',
+  @role_name = NULL;
+
+  DECLARE @i INT = 1;
+
+WHILE @i <= 2000
+BEGIN
+    INSERT INTO test_pk_uuid (id, NAME)
+    VALUES (NEWID(), CONCAT('TEST_NAME', @i), 0);
+
+    SET @i = @i + 1;
+END

--- a/src/connector/src/parser/sql_server.rs
+++ b/src/connector/src/parser/sql_server.rs
@@ -315,7 +315,7 @@ impl<'a> tiberius::IntoSql<'a> for ScalarImplTiberiusWrapper {
             ScalarImpl::Utf8(v) => String::from(v).into_sql(),
             // ScalarImpl::Bytea(v) => (*v.clone()).into_sql(),
             value => {
-                // Utf8, Serial, Interval, Jsonb, Int256, Struct, List are not supported yet
+                // Serial, Interval, Jsonb, Int256, Struct, List are not supported yet
                 unimplemented!("the sql server decoding for {:?} is unsupported", value);
             }
         }

--- a/src/connector/src/parser/sql_server.rs
+++ b/src/connector/src/parser/sql_server.rs
@@ -312,6 +312,7 @@ impl<'a> tiberius::IntoSql<'a> for ScalarImplTiberiusWrapper {
             ScalarImpl::Timestamp(v) => TimestampTiberiusWrapper::from(v).into_sql(),
             ScalarImpl::Timestamptz(v) => TimestamptzTiberiusWrapper::from(v).into_sql(),
             ScalarImpl::Time(v) => TimeTiberiusWrapper::from(v).into_sql(),
+            ScalarImpl::Utf8(v) => String::from(v).into_sql(),
             // ScalarImpl::Bytea(v) => (*v.clone()).into_sql(),
             value => {
                 // Utf8, Serial, Interval, Jsonb, Int256, Struct, List are not supported yet


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
- When upstream pk is `varchar` or `uuid`(both will convert to `utf-8`), we should not panic.
- add test
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
