### PR TITLE
feat(frontend): support fragment level progress for snapshot backfill

### DIFF
--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -95,7 +95,7 @@ if [[ "$profile" == "ci-release" ]]; then
   # only run in release-mode. It's too slow for dev-mode.
   risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_order_control.slt'
   risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_order_control_recovery.slt'
-  risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_progress.slt'
+  risedev slt -p 4566 -d dev './e2e_test/backfill/backfill_progress/test.slt'
 fi
 
 echo "--- Kill cluster"

--- a/e2e_test/backfill/backfill_progress/create_materialized_view.slt
+++ b/e2e_test/backfill/backfill_progress/create_materialized_view.slt
@@ -10,11 +10,18 @@ create materialized view m1 as
       join t2 on x.v1 = t2.v1
       join t3 on t3.v1 = t2.v1
 
-sleep 5s
 
-query I
+sleep 2s
+
+
+query ? retry 3 backoff 1s
 select
-  regexp_match(progress, '([0-9]+)\.[0-9]+%')[1]::numeric >= (5::numeric * 10::numeric / 10000::numeric)
+  case when regexp_match(progress, '([0-9]+\.[0-9]+)%')[1]::numeric
+    >= (2::numeric * 10::numeric / 1000::numeric)
+  then 't'
+  else
+    progress
+  end
 from rw_catalog.rw_fragment_backfill_progress;
 ----
 t
@@ -28,3 +35,72 @@ set streaming_parallelism=default;
 
 statement ok
 drop materialized view m1;
+
+system ok
+risedev psql -c '
+set streaming_parallelism=1;
+set backfill_rate_limit=10;
+create materialized view m1 as
+  select x.v1, x.v2
+  from
+    t x
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+' >/dev/null 2>&1 &
+
+
+sleep 2s
+
+
+query ? retry 3 backoff 1s
+select
+  case when regexp_match(progress, '([0-9]+\.[0-9]+)%')[1]::numeric
+    >= (2::numeric * 10::numeric / 1000::numeric)
+  then 't'
+  else
+    progress
+  end
+from rw_catalog.rw_fragment_backfill_progress;
+----
+t
+t
+t
+t
+
+
+# We must let the mv finish, for snapshot backfill
+# seems like the drop to cancel statement doesn't work for it.
+statement ok
+alter materialized view m1 set backfill_rate_limit=default;
+
+
+statement ok
+set background_ddl=false;
+
+statement ok
+drop materialized view if exists m1_validate;
+
+statement ok
+create materialized view m1_validate as
+  select x.v1, x.v2
+  from
+    t x
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+
+query I retry 3 backoff 2s
+select * from m1_validate except select * from m1
+----
+
+query I retry 3 backoff 2s
+select * from m1 except select * from m1_validate
+----
+
+
+statement ok
+drop materialized view m1;
+
+statement ok
+drop materialized view m1_validate;

--- a/e2e_test/backfill/backfill_progress/create_materialized_view.slt
+++ b/e2e_test/backfill/backfill_progress/create_materialized_view.slt
@@ -1,0 +1,30 @@
+statement ok
+set backfill_rate_limit=10;
+
+statement ok
+create materialized view m1 as
+  select x.v1, x.v2
+  from
+    t x
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+
+sleep 5s
+
+query I
+select 
+  regexp_match(progress, '([0-9]+)\.[0-9]+%')[1]::numeric >= (5::numeric * 10::numeric / 10000::numeric) 
+from rw_catalog.rw_fragment_backfill_progress;
+----
+t
+t
+t
+t
+
+
+statement ok
+set streaming_parallelism=default;
+
+statement ok
+drop materialized view m1;

--- a/e2e_test/backfill/backfill_progress/create_materialized_view.slt
+++ b/e2e_test/backfill/backfill_progress/create_materialized_view.slt
@@ -13,8 +13,8 @@ create materialized view m1 as
 sleep 5s
 
 query I
-select 
-  regexp_match(progress, '([0-9]+)\.[0-9]+%')[1]::numeric >= (5::numeric * 10::numeric / 10000::numeric) 
+select
+  regexp_match(progress, '([0-9]+)\.[0-9]+%')[1]::numeric >= (5::numeric * 10::numeric / 10000::numeric)
 from rw_catalog.rw_fragment_backfill_progress;
 ----
 t

--- a/e2e_test/backfill/backfill_progress/create_materialized_view_snapshot.slt
+++ b/e2e_test/backfill/backfill_progress/create_materialized_view_snapshot.slt
@@ -38,6 +38,7 @@ drop materialized view m1;
 
 system ok
 risedev psql -c '
+set streaming_use_snapshot_backfill=true;
 set streaming_parallelism=1;
 set backfill_rate_limit=100;
 create materialized view m1 as

--- a/e2e_test/backfill/backfill_progress/create_materialized_view_snapshot.slt
+++ b/e2e_test/backfill/backfill_progress/create_materialized_view_snapshot.slt
@@ -1,0 +1,97 @@
+statement ok
+set backfill_rate_limit=100;
+
+statement ok
+create materialized view m1 as
+  select x.v1, x.v2
+  from
+    t x
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+
+query ? retry 3 backoff 1s
+select
+  case when regexp_match(progress, '([0-9]+\.[0-9]+)%')[1]::numeric
+    >= (99::numeric / 1000::numeric)
+  then 't'
+  else
+    progress
+  end
+from rw_catalog.rw_fragment_backfill_progress;
+----
+t
+t
+t
+t
+
+
+statement ok
+set streaming_parallelism=default;
+
+# Make sure its created
+statement ok retry 3 backoff 5s
+select * from m1;
+
+statement ok
+drop materialized view m1;
+
+system ok
+risedev psql -c '
+set streaming_parallelism=1;
+set backfill_rate_limit=100;
+create materialized view m1 as
+  select x.v1, x.v2
+  from
+    t x
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+' >/dev/null 2>&1 &
+
+
+query ? retry 3 backoff 1s
+select
+  case when regexp_match(progress, '([0-9]+\.[0-9]+)%')[1]::numeric
+    >= (2::numeric * 50::numeric / 1000::numeric)
+  then 't'
+  else
+    progress
+  end
+from rw_catalog.rw_fragment_backfill_progress;
+----
+t
+t
+t
+t
+
+
+statement ok
+set background_ddl=false;
+
+statement ok
+drop materialized view if exists m1_validate;
+
+statement ok
+create materialized view m1_validate as
+  select x.v1, x.v2
+  from
+    t x
+      join t y on x.v1 = y.v1
+      join t2 on x.v1 = t2.v1
+      join t3 on t3.v1 = t2.v1
+
+query I retry 3 backoff 5s
+select * from m1_validate except select * from m1
+----
+
+query I retry 3 backoff 5s
+select * from m1 except select * from m1_validate
+----
+
+
+statement ok
+drop materialized view m1;
+
+statement ok
+drop materialized view m1_validate;

--- a/e2e_test/backfill/backfill_progress/test.slt
+++ b/e2e_test/backfill/backfill_progress/test.slt
@@ -10,9 +10,8 @@ drop table if exists t2;
 statement ok
 drop table if exists t3;
 
-query I
+statement count 0
 select job_id from rw_catalog.rw_fragment_backfill_progress;
-----
 
 statement ok
 create table t(v1 int, v2 int);
@@ -24,13 +23,13 @@ statement ok
 create table t3(v1 int, v2 int);
 
 statement ok
-insert into t select * from generate_series(1, 10000);
+insert into t select id as v1, id as v2 from generate_series(1, 1000) gen(id);
 
 statement ok
-insert into t2 select * from generate_series(1, 10000);
+insert into t2 select id as v1, id as v2 from generate_series(1, 1000) gen(id);
 
 statement ok
-insert into t3 select * from generate_series(1, 10000);
+insert into t3 select id as v1, id as v2 from generate_series(1, 1000) gen(id);
 
 statement ok
 flush;
@@ -41,10 +40,10 @@ set background_ddl=true;
 statement ok
 set streaming_parallelism=1;
 
-statement ok
-set streaming_use_snapshot_backfill=true;
+# statement ok
+# set streaming_use_snapshot_backfill=true;
 
-include ./create_materialized_view.slt
+# include ./create_materialized_view.slt
 
 statement ok
 set streaming_use_snapshot_backfill=false;

--- a/e2e_test/backfill/backfill_progress/test.slt
+++ b/e2e_test/backfill/backfill_progress/test.slt
@@ -40,10 +40,13 @@ set background_ddl=true;
 statement ok
 set streaming_parallelism=1;
 
-# statement ok
-# set streaming_use_snapshot_backfill=true;
+statement ok
+set streaming_use_snapshot_backfill=true;
 
-# include ./create_materialized_view.slt
+include ./create_materialized_view_snapshot.slt
+
+statement ok
+set background_ddl=true;
 
 statement ok
 set streaming_use_snapshot_backfill=false;

--- a/e2e_test/backfill/backfill_progress/test.slt
+++ b/e2e_test/backfill/backfill_progress/test.slt
@@ -1,4 +1,7 @@
 statement ok
+drop materialized view if exists mv1;
+
+statement ok
 drop table if exists t;
 
 statement ok
@@ -33,38 +36,26 @@ statement ok
 flush;
 
 statement ok
-set backfill_rate_limit=1;
-
-statement ok
 set background_ddl=true;
 
 statement ok
 set streaming_parallelism=1;
 
 statement ok
-create materialized view m1 as
-  select x.v1, x.v2
-  from
-    t x
-      join t y on x.v1 = y.v1
-      join t2 on x.v1 = t2.v1
-      join t3 on t3.v1 = t2.v1
+set streaming_use_snapshot_backfill=true;
 
-# Can't validate, because the progress varies. Just make sure it doesn't panic.
+include ./create_materialized_view.slt
+
 statement ok
-select job_id from rw_catalog.rw_fragment_backfill_progress;
+set streaming_use_snapshot_backfill=false;
+
+include ./create_materialized_view.slt
+
+statement ok
+set backfill_rate_limit=default
+
+statement ok
+set background_ddl=false;
 
 statement ok
 set streaming_parallelism=default;
-
-statement ok
-drop materialized view m1;
-
-statement ok
-drop table t;
-
-statement ok
-drop table t2;
-
-statement ok
-drop table t3;

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -593,6 +593,7 @@ impl TableFunction {
                 ("fragment_id".to_owned(), DataType::Int32),
                 ("backfill_state_table_id".to_owned(), DataType::Int32),
                 ("current_row_count".to_owned(), DataType::Int64),
+                ("min_epoch".to_owned(), DataType::Int64),
             ])),
             function_type: TableFunctionType::InternalBackfillProgress,
             user_defined: None,

--- a/src/frontend/src/optimizer/logical_optimization.rs
+++ b/src/frontend/src/optimizer/logical_optimization.rs
@@ -149,7 +149,7 @@ static TABLE_FUNCTION_CONVERT: LazyLock<OptimizationStage> = LazyLock::new(|| {
 static TABLE_FUNCTION_TO_FILE_SCAN: LazyLock<OptimizationStage> = LazyLock::new(|| {
     OptimizationStage::new(
         "Table Function To FileScan",
-        vec![TableFunctionToInternalBackfillProgressRule::create()],
+        vec![TableFunctionToFileScanRule::create()],
         ApplyOrder::TopDown,
     )
 });

--- a/src/frontend/src/optimizer/logical_optimization.rs
+++ b/src/frontend/src/optimizer/logical_optimization.rs
@@ -133,6 +133,8 @@ static TABLE_FUNCTION_CONVERT: LazyLock<OptimizationStage> = LazyLock::new(|| {
     OptimizationStage::new(
         "Table Function Convert",
         vec![
+            // Apply file scan rule first
+            TableFunctionToFileScanRule::create(),
             // Apply internal backfill progress rule first
             TableFunctionToInternalBackfillProgressRule::create(),
             // Apply postgres query rule next

--- a/src/frontend/src/optimizer/rule/table_function_to_file_scan_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_file_scan_rule.rs
@@ -19,7 +19,7 @@ use risingwave_connector::source::iceberg::{FileScanBackend, extract_bucket_and_
 
 use super::Rule;
 use crate::expr::{Expr, TableFunctionType};
-use crate::optimizer::PlanRef;
+use crate::optimizer::{BoxedRule, PlanRef};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{LogicalFileScan, LogicalTableFunction};
 
@@ -130,5 +130,11 @@ impl Rule for TableFunctionToFileScanRule {
         } else {
             unreachable!("TableFunction return type should be struct")
         }
+    }
+}
+
+impl TableFunctionToFileScanRule {
+    pub fn create() -> BoxedRule {
+        Box::new(TableFunctionToFileScanRule {})
     }
 }

--- a/src/frontend/src/optimizer/rule/table_function_to_file_scan_rule.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_file_scan_rule.rs
@@ -19,9 +19,9 @@ use risingwave_connector::source::iceberg::{FileScanBackend, extract_bucket_and_
 
 use super::Rule;
 use crate::expr::{Expr, TableFunctionType};
-use crate::optimizer::{BoxedRule, PlanRef};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{LogicalFileScan, LogicalTableFunction};
+use crate::optimizer::{BoxedRule, PlanRef};
 
 /// Transform a special `TableFunction` (with `FILE_SCAN` table function type) into a `LogicalFileScan`
 pub struct TableFunctionToFileScanRule {}

--- a/src/frontend/src/optimizer/rule/table_function_to_internal_backfill_progress.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_internal_backfill_progress.rs
@@ -65,7 +65,7 @@ impl TableFunctionToInternalBackfillProgressRule {
                 Field::new("fragment_id", DataType::Int32),
                 Field::new("backfill_state_table_id", DataType::Int32),
                 Field::new("current_row_count", DataType::Int64),
-                Field::new("snapshot_backfill_epoch", DataType::Int64),
+                Field::new("min_epoch", DataType::Int64),
             ];
             let plan = LogicalValues::new(vec![], Schema::new(fields), ctx.clone());
             return Ok(plan.into());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdaf7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR improves the backfill progress tracking for snapshot backfill by:

1. Restructuring the backfill progress test files for better organization
2. Adding support for tracking progress in snapshot backfill mode by:
   - Tracking the minimum epoch in backfill progress
   - Enhancing the `rw_fragment_backfill_progress` view to show 100% completion when the minimum epoch exceeds the backfill epoch
   - Adding `is_snapshot_backfill` and `backfill_epoch` fields to the table scan information
3. Extending the test cases to verify both regular and snapshot backfill progress

These changes provide more accurate progress reporting for snapshot backfill operations, showing 100% completion when the backfill has processed all data up to the snapshot epoch.

## Checklist

- [ ] I have written necessary rustdoc comments.