### PR TITLE
fix: add timeout and retry for kinesis client

### DIFF
--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -21,6 +21,7 @@ use anyhow::{Context, anyhow};
 use async_nats::jetstream::consumer::DeliverPolicy;
 use async_nats::jetstream::{self};
 use aws_sdk_kinesis::Client as KinesisClient;
+use aws_sdk_kinesis::config::{AsyncSleep, Sleep, SharedAsyncSleep};
 use pulsar::authentication::oauth2::{OAuth2Authentication, OAuth2Params};
 use pulsar::{Authentication, Pulsar, TokioExecutor};
 use rdkafka::ClientConfig;
@@ -565,6 +566,7 @@ impl PulsarCommon {
     }
 }
 
+#[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
 pub struct KinesisCommon {
     #[serde(rename = "stream", alias = "kinesis.stream.name")]
@@ -595,6 +597,87 @@ pub struct KinesisCommon {
         alias = "kinesis.assumerole.external_id"
     )]
     pub assume_role_external_id: Option<String>,
+
+    // sdk options
+    #[serde(
+        rename = "kinesis.sdk.connect_timeout_ms",
+        default = "kinesis_default_connect_timeout_ms"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_connect_timeout_ms: u64,
+    #[serde(
+        rename = "kinesis.sdk.read_timeout_ms",
+        default = "kinesis_default_read_timeout_ms"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_read_timeout_ms: u64,
+    #[serde(
+        rename = "kinesis.sdk.operation_timeout_ms",
+        default = "kinesis_default_operation_timeout_ms"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_operation_timeout_ms: u64,
+    #[serde(
+        rename = "kinesis.sdk.operation_attempt_timeout_ms",
+        default = "kinesis_default_operation_attempt_timeout_ms"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_operation_attempt_timeout_ms: u64,
+    #[serde(
+        rename = "kinesis.sdk.max_retry_limit",
+        default = "kinesis_default_max_retry_limit"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_max_retry_limit: u32,
+    #[serde(
+        rename = "kinesis.sdk.init_backoff_ms",
+        default = "kinesis_default_init_backoff_ms"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_init_backoff_ms: u64,
+    #[serde(
+        rename = "kinesis.sdk.max_backoff_ms",
+        default = "kinesis_default_max_backoff_ms"
+    )]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sdk_max_backoff_ms: u64,
+}
+
+const fn kinesis_default_connect_timeout_ms() -> u64 {
+    10000
+}
+
+const fn kinesis_default_read_timeout_ms() -> u64 {
+    10000
+}
+
+const fn kinesis_default_operation_timeout_ms() -> u64 {
+    10000
+}
+
+const fn kinesis_default_operation_attempt_timeout_ms() -> u64 {
+    10000
+}
+
+const fn kinesis_default_init_backoff_ms() -> u64 {
+    1000
+}
+
+const fn kinesis_default_max_backoff_ms() -> u64 {
+    20000
+}
+
+const fn kinesis_default_max_retry_limit() -> u32 {
+    3
+}
+
+#[derive(Debug)]
+pub struct KinesisAsyncSleepImpl;
+
+impl AsyncSleep for KinesisAsyncSleepImpl {
+    fn sleep(&self, duration: Duration) -> Sleep {
+        Sleep::new(async move { tokio::time::sleep(duration).await })
+    }
 }
 
 impl KinesisCommon {
@@ -612,6 +695,26 @@ impl KinesisCommon {
         };
         let aws_config = config.build_config().await?;
         let mut builder = aws_sdk_kinesis::config::Builder::from(&aws_config);
+        {
+            // for timeout and retry config
+            let sleep_impl = SharedAsyncSleep::new(KinesisAsyncSleepImpl);
+            builder.set_sleep_impl(Some(sleep_impl));
+            let timeout_config = aws_smithy_types::timeout::TimeoutConfig::builder()
+                .connect_timeout(Duration::from_millis(self.sdk_connect_timeout_ms))
+                .read_timeout(Duration::from_millis(self.sdk_read_timeout_ms))
+                .operation_timeout(Duration::from_millis(self.sdk_operation_timeout_ms))
+                .operation_attempt_timeout(Duration::from_millis(
+                    self.sdk_operation_attempt_timeout_ms,
+                ))
+                .build();
+            builder.set_timeout_config(Some(timeout_config));
+
+            let retry_config = aws_smithy_types::retry::RetryConfig::standard()
+                .with_initial_backoff(Duration::from_millis(self.sdk_init_backoff_ms))
+                .with_max_backoff(Duration::from_millis(self.sdk_max_backoff_ms))
+                .with_max_attempts(self.sdk_max_retry_limit);
+            builder.set_retry_config(Some(retry_config));
+        }
         if let Some(endpoint) = &config.endpoint {
             builder = builder.endpoint_url(endpoint);
         }

--- a/src/connector/src/source/kinesis/mod.rs
+++ b/src/connector/src/source/kinesis/mod.rs
@@ -65,9 +65,11 @@ impl crate::source::UnknownFields for KinesisProperties {
 
 #[cfg(test)]
 mod test {
-    use maplit::hashmap;
+    use maplit::{btreemap, hashmap};
 
     use super::*;
+    use crate::source::ConnectorProperties;
+    use crate::WithOptionsSecResolved;
 
     #[test]
     fn test_parse_kinesis_timestamp_offset() {
@@ -81,5 +83,49 @@ mod test {
         let kinesis_props: KinesisProperties =
             serde_json::from_value(serde_json::to_value(props).unwrap()).unwrap();
         assert_eq!(kinesis_props.start_timestamp_millis, Some(123456789));
+    }
+
+    #[test]
+    fn test_kinesis_props() {
+        let with_options = btreemap! {
+            "connector".to_owned() => "kinesis".to_owned(),
+            "scan.startup.mode".to_owned() => "latest".to_owned(),
+            "stream".to_owned() => "sample_stream".to_owned(),
+            "aws.region".to_owned() => "us-east-1".to_owned(),
+            "endpoint".to_owned() => "https://kinesis.us-east-1.amazonaws.com".to_owned(),
+            "aws.credentials.access_key_id".to_owned() => "access_key".to_owned(),
+            "aws.credentials.secret_access_key".to_owned() => "secret_key".to_owned(),
+        };
+        let connector_props = ConnectorProperties::extract(
+            WithOptionsSecResolved::without_secrets(with_options),
+            true,
+        )
+        .unwrap();
+        let ConnectorProperties::Kinesis(kinesis_props) = connector_props else {
+            panic!()
+        };
+
+        assert_eq!(kinesis_props.common.sdk_connect_timeout_ms, 10000);
+
+        let with_options = btreemap! {
+            "connector".to_owned() => "kinesis".to_owned(),
+            "scan.startup.mode".to_owned() => "latest".to_owned(),
+            "stream".to_owned() => "sample_stream".to_owned(),
+            "aws.region".to_owned() => "us-east-1".to_owned(),
+            "endpoint".to_owned() => "https://kinesis.us-east-1.amazonaws.com".to_owned(),
+            "aws.credentials.access_key_id".to_owned() => "access_key".to_owned(),
+            "aws.credentials.secret_access_key".to_owned() => "secret_key".to_owned(),
+            "kinesis.sdk.connect_timeout_ms".to_owned() => "20000".to_owned(),
+        };
+        let connector_props = ConnectorProperties::extract(
+            WithOptionsSecResolved::without_secrets(with_options),
+            true,
+        )
+        .unwrap();
+        let ConnectorProperties::Kinesis(kinesis_props) = connector_props else {
+            panic!()
+        };
+
+        assert_eq!(kinesis_props.common.sdk_connect_timeout_ms, 20000);
     }
 }

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -366,6 +366,13 @@ mod tests {
                 endpoint: None,
                 session_token: None,
                 assume_role_external_id: None,
+                sdk_connect_timeout_ms: 1000,
+                sdk_read_timeout_ms: 1000,
+                sdk_operation_timeout_ms: 1000,
+                sdk_operation_attempt_timeout_ms: 1000,
+                sdk_max_retry_limit: 3,
+                sdk_init_backoff_ms: 100,
+                sdk_max_backoff_ms: 1000,
             },
 
             scan_startup_mode: None,


### PR DESCRIPTION
- Introduced new fields in KinesisCommon for SDK connection, read, operation timeouts, and retry configurations.
- Implemented default values for these new fields.
- Updated Kinesis reader tests to utilize the new SDK configuration options.
- Enhanced the Kinesis connection builder to apply timeout and retry settings based on the new configurations.

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

redo changes: https://github.com/risingwavelabs/risingwave/pull/21616 & https://github.com/risingwavelabs/risingwave/pull/22143

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
