### PR TITLE
refactor(s3 connector): expose `enable_config_load` to user for s3 source and sink

### DIFF
--- a/src/connector/src/connector_common/mod.rs
+++ b/src/connector/src/connector_common/mod.rs
@@ -19,9 +19,10 @@ pub use mqtt_common::{MqttCommon, QualityOfService as MqttQualityOfService};
 
 mod common;
 pub use common::{
-    AwsAuthProps, AwsPrivateLinkItem, KafkaCommon, KafkaConnectionProps, KafkaPrivateLinkCommon,
-    KinesisCommon, MongodbCommon, NatsCommon, PRIVATE_LINK_BROKER_REWRITE_MAP_KEY,
-    PRIVATE_LINK_TARGETS_KEY, PulsarCommon, PulsarOauthCommon, RdKafkaPropertiesCommon,
+    AwsAuthProps, AwsPrivateLinkItem, DISABLE_DEFAULT_CREDENTIAL, KafkaCommon,
+    KafkaConnectionProps, KafkaPrivateLinkCommon, KinesisCommon, MongodbCommon, NatsCommon,
+    PRIVATE_LINK_BROKER_REWRITE_MAP_KEY, PRIVATE_LINK_TARGETS_KEY, PulsarCommon, PulsarOauthCommon,
+    RdKafkaPropertiesCommon,
 };
 mod connection;
 pub use connection::{

--- a/src/connector/src/sink/file_sink/s3.rs
+++ b/src/connector/src/sink/file_sink/s3.rs
@@ -93,7 +93,7 @@ impl<S: OpendalSinkBackend> FileSink<S> {
         if let Some(assume_role) = config.common.assume_role {
             builder = builder.role_arn(&assume_role);
         }
-        // Default behavior is disable load config from environment.
+        // Default behavior is disable loading config from environment.
         if config.common.disable_config_load.unwrap_or(true) {
             builder = builder.disable_config_load();
         }

--- a/src/connector/src/source/filesystem/opendal_source/mod.rs
+++ b/src/connector/src/source/filesystem/opendal_source/mod.rs
@@ -53,6 +53,9 @@ pub struct FsSourceCommon {
     #[serde(rename = "refresh.interval.sec")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub refresh_interval_sec: Option<u64>,
+
+    #[serde(rename = "compression_format", default = "Default::default")]
+    pub compression_format: CompressionFormat,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, WithOptions)]
@@ -115,7 +118,11 @@ impl OpendalSource for OpendalS3 {
     type Properties = OpendalS3Properties;
 
     fn new_enumerator(properties: Self::Properties) -> ConnectorResult<OpendalEnumerator<Self>> {
-        OpendalEnumerator::new_s3_source(properties.s3_properties, properties.assume_role)
+        OpendalEnumerator::new_s3_source(
+            &properties.s3_properties,
+            properties.assume_role,
+            properties.fs_common.compression_format,
+        )
     }
 }
 

--- a/src/connector/src/source/filesystem/opendal_source/s3_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/s3_source.rs
@@ -52,7 +52,7 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
             builder = builder.role_arn(&assume_role);
         }
 
-        // Default behavior is disable load config from environment.
+        // Default behavior is disable loading config from environment.
         if s3_properties.disable_config_load.unwrap_or(true) {
             builder = builder.disable_config_load();
         }

--- a/src/connector/src/source/filesystem/opendal_source/s3_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/s3_source.rs
@@ -53,7 +53,7 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
         }
 
         // Default behavior is disable loading config from environment.
-        if s3_properties.disable_config_load.unwrap_or(true) {
+        if !s3_properties.enable_config_load.unwrap_or(false) {
             builder = builder.disable_config_load();
         }
 

--- a/src/connector/src/source/filesystem/opendal_source/s3_source.rs
+++ b/src/connector/src/source/filesystem/opendal_source/s3_source.rs
@@ -42,27 +42,21 @@ impl<Src: OpendalSource> OpendalEnumerator<Src> {
 
         if let Some(access) = s3_properties.access {
             builder = builder.access_key_id(&access);
-        } else {
-            tracing::error!(
-                "access key id of aws s3 is not set, bucket {}",
-                s3_properties.bucket_name
-            );
         }
 
         if let Some(secret) = s3_properties.secret {
             builder = builder.secret_access_key(&secret);
-        } else {
-            tracing::error!(
-                "secret access key of aws s3 is not set, bucket {}",
-                s3_properties.bucket_name
-            );
         }
 
         if let Some(assume_role) = assume_role {
             builder = builder.role_arn(&assume_role);
         }
 
-        builder = builder.disable_config_load();
+        // Default behavior is disable load config from environment.
+        if s3_properties.disable_config_load.unwrap_or(true) {
+            builder = builder.disable_config_load();
+        }
+
         let (prefix, matcher) = if let Some(pattern) = s3_properties.match_pattern.as_ref() {
             let prefix = get_prefix(pattern);
             let matcher = glob::Pattern::new(pattern)

--- a/src/connector/src/source/filesystem/s3/mod.rs
+++ b/src/connector/src/source/filesystem/s3/mod.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 pub mod enumerator;
-
 use phf::{Set, phf_set};
 use serde::Deserialize;
 
+use crate::deserialize_optional_bool_from_string;
 use crate::enforce_secret::EnforceSecret;
 use crate::source::SourceProperties;
 use crate::source::filesystem::file_common::CompressionFormat;
@@ -39,8 +39,8 @@ pub struct S3PropertiesCommon {
     pub access: Option<String>,
     #[serde(rename = "s3.credentials.secret", default)]
     pub secret: Option<String>,
-    #[serde(rename = "s3.disable.config.load", default)]
-    pub disable_config_load: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_optional_bool_from_string")]
+    pub enable_config_load: Option<bool>,
     #[serde(rename = "s3.endpoint_url")]
     pub endpoint_url: Option<String>,
     #[serde(rename = "compression_format", default = "Default::default")]

--- a/src/connector/src/source/filesystem/s3/mod.rs
+++ b/src/connector/src/source/filesystem/s3/mod.rs
@@ -39,6 +39,8 @@ pub struct S3PropertiesCommon {
     pub access: Option<String>,
     #[serde(rename = "s3.credentials.secret", default)]
     pub secret: Option<String>,
+    #[serde(rename = "s3.disable.config.load", default)]
+    pub disable_config_load: Option<bool>,
     #[serde(rename = "s3.endpoint_url")]
     pub endpoint_url: Option<String>,
     #[serde(rename = "compression_format", default = "Default::default")]

--- a/src/connector/src/source/filesystem/s3/mod.rs
+++ b/src/connector/src/source/filesystem/s3/mod.rs
@@ -20,7 +20,6 @@ use crate::connector_common::DISABLE_DEFAULT_CREDENTIAL;
 use crate::deserialize_optional_bool_from_string;
 use crate::enforce_secret::EnforceSecret;
 use crate::source::SourceProperties;
-use crate::source::filesystem::file_common::CompressionFormat;
 use crate::source::util::dummy::{
     DummyProperties, DummySourceReader, DummySplit, DummySplitEnumerator,
 };
@@ -45,8 +44,6 @@ pub struct S3PropertiesCommon {
     pub enable_config_load: Option<bool>,
     #[serde(rename = "s3.endpoint_url")]
     pub endpoint_url: Option<String>,
-    #[serde(rename = "compression_format", default = "Default::default")]
-    pub compression_format: CompressionFormat,
 }
 
 impl S3PropertiesCommon {

--- a/src/connector/src/source/filesystem/s3/mod.rs
+++ b/src/connector/src/source/filesystem/s3/mod.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 pub mod enumerator;
 use phf::{Set, phf_set};
+use risingwave_common::util::env_var::env_var_is_true;
 use serde::Deserialize;
 
+use crate::connector_common::DISABLE_DEFAULT_CREDENTIAL;
 use crate::deserialize_optional_bool_from_string;
 use crate::enforce_secret::EnforceSecret;
 use crate::source::SourceProperties;
@@ -45,6 +47,16 @@ pub struct S3PropertiesCommon {
     pub endpoint_url: Option<String>,
     #[serde(rename = "compression_format", default = "Default::default")]
     pub compression_format: CompressionFormat,
+}
+
+impl S3PropertiesCommon {
+    pub fn enable_config_load(&self) -> bool {
+        // If the env var is set to true, we disable the default config load. (Cloud environment)
+        if env_var_is_true(DISABLE_DEFAULT_CREDENTIAL) {
+            return false;
+        }
+        self.enable_config_load.unwrap_or(false)
+    }
 }
 
 impl EnforceSecret for S3PropertiesCommon {

--- a/src/connector/src/source/reader/reader.rs
+++ b/src/connector/src/source/reader/reader.rs
@@ -97,8 +97,11 @@ impl SourceReader {
             }
             ConnectorProperties::OpendalS3(prop) => {
                 list_interval_sec = get_list_interval_sec(prop.fs_common.refresh_interval_sec);
-                let lister: OpendalEnumerator<OpendalS3> =
-                    OpendalEnumerator::new_s3_source(prop.s3_properties, prop.assume_role)?;
+                let lister: OpendalEnumerator<OpendalS3> = OpendalEnumerator::new_s3_source(
+                    &prop.s3_properties,
+                    prop.assume_role,
+                    prop.fs_common.compression_format,
+                )?;
                 Ok(build_opendal_fs_list_stream(lister, list_interval_sec))
             }
             ConnectorProperties::Azblob(prop) => {

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1187,6 +1187,11 @@ S3Config:
     default: Default::default
     alias:
     - snowflake.s3_path
+  - name: enable_config_load
+    field_type: bool
+    comments: Enable config load. This parameter set to true will load s3 credentials from the environment. Only allowed to be used in a self-hosted environment.
+    required: false
+    default: Default::default
   - name: s3.credentials.access
     field_type: String
     required: false

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -957,6 +957,10 @@ OpendalS3Properties:
     field_type: String
     required: false
     default: Default::default
+  - name: enable_config_load
+    field_type: bool
+    required: false
+    default: Default::default
   - name: s3.endpoint_url
     field_type: String
     required: false

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -28,6 +28,10 @@ AzblobProperties:
     field_type: CompressionFormat
     required: false
     default: Default::default
+  - name: compression_format
+    field_type: CompressionFormat
+    required: false
+    default: Default::default
 DatagenProperties:
   fields:
   - name: datagen.split.num
@@ -75,6 +79,10 @@ GcsProperties:
   - name: refresh.interval.sec
     field_type: u64
     required: false
+  - name: compression_format
+    field_type: CompressionFormat
+    required: false
+    default: Default::default
   - name: compression_format
     field_type: CompressionFormat
     required: false
@@ -964,10 +972,6 @@ OpendalS3Properties:
   - name: s3.endpoint_url
     field_type: String
     required: false
-  - name: compression_format
-    field_type: CompressionFormat
-    required: false
-    default: Default::default
   - name: s3.assume_role
     field_type: String
     comments: The following are only supported by `s3_v2` (opendal) source.
@@ -976,6 +980,10 @@ OpendalS3Properties:
   - name: refresh.interval.sec
     field_type: u64
     required: false
+  - name: compression_format
+    field_type: CompressionFormat
+    required: false
+    default: Default::default
 PosixFsProperties:
   fields:
   - name: posix_fs.root
@@ -990,6 +998,10 @@ PosixFsProperties:
   - name: refresh.interval.sec
     field_type: u64
     required: false
+  - name: compression_format
+    field_type: CompressionFormat
+    required: false
+    default: Default::default
   - name: compression_format
     field_type: CompressionFormat
     required: false

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -353,8 +353,11 @@ impl SourceScanInfo {
                 Ok(SourceScanInfo::Complete(res))
             }
             (ConnectorProperties::OpendalS3(prop), SourceFetchParameters::Empty) => {
-                let lister: OpendalEnumerator<OpendalS3> =
-                    OpendalEnumerator::new_s3_source(prop.s3_properties, prop.assume_role)?;
+                let lister: OpendalEnumerator<OpendalS3> = OpendalEnumerator::new_s3_source(
+                    &prop.s3_properties,
+                    prop.assume_role,
+                    prop.fs_common.compression_format,
+                )?;
                 let stream = build_opendal_fs_list_for_batch(lister);
 
                 let batch_res: Vec<_> = stream.try_collect().await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
Previously users are required to configure an access key and access ID to access, which is intended to isolate Hummock's S3. However, for on-prem users, it is more reasonable to expose this configuration to them. Users can set `disable_config_load` to allow the S3 source and sink to directly obtain authentication information from the pod's environment. 
This PR places `disable_config_load` within the with option, and the default behavior is set to true.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
