### PR TITLE
fix(sqlsmith): use `ObjectName` for column name to correctly distinguish qualified name

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -444,7 +444,14 @@ CREATE TABLE t4(v1 int PRIMARY KEY, v2 smallint PRIMARY KEY, v3 bool PRIMARY KEY
                             name: "t",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                             ],
@@ -459,11 +466,25 @@ CREATE TABLE t4(v1 int PRIMARY KEY, v2 smallint PRIMARY KEY, v3 bool PRIMARY KEY
                             name: "t2",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                                 Column {
-                                    name: "v2",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v2",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int16,
                                 },
                             ],
@@ -478,11 +499,25 @@ CREATE TABLE t4(v1 int PRIMARY KEY, v2 smallint PRIMARY KEY, v3 bool PRIMARY KEY
                             name: "t3",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                                 Column {
-                                    name: "v2",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v2",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int16,
                                 },
                             ],
@@ -498,15 +533,36 @@ CREATE TABLE t4(v1 int PRIMARY KEY, v2 smallint PRIMARY KEY, v3 bool PRIMARY KEY
                             name: "t4",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                                 Column {
-                                    name: "v2",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v2",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int16,
                                 },
                                 Column {
-                                    name: "v3",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v3",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Boolean,
                                 },
                             ],

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -223,7 +223,14 @@ CREATE TABLE t3(v1 int, v2 bool, v3 smallint);
                             name: "t",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                             ],
@@ -236,11 +243,25 @@ CREATE TABLE t3(v1 int, v2 bool, v3 smallint);
                             name: "t2",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                                 Column {
-                                    name: "v2",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v2",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Boolean,
                                 },
                             ],
@@ -253,15 +274,36 @@ CREATE TABLE t3(v1 int, v2 bool, v3 smallint);
                             name: "t3",
                             columns: [
                                 Column {
-                                    name: "v1",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v1",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int32,
                                 },
                                 Column {
-                                    name: "v2",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v2",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Boolean,
                                 },
                                 Column {
-                                    name: "v3",
+                                    name: ObjectName(
+                                        [
+                                            Ident {
+                                                value: "v3",
+                                                quote_style: None,
+                                            },
+                                        ],
+                                    ),
                                     data_type: Int16,
                                 },
                             ],

--- a/src/tests/sqlsmith/src/sql_gen/dml.rs
+++ b/src/tests/sqlsmith/src/sql_gen/dml.rs
@@ -147,7 +147,7 @@ impl<'a, R: Rng + 'a> SqlGenerator<'a, R> {
             .iter()
             .copied()
             .map(|i| {
-                let id = table.columns[i].name.0.clone();
+                let id = vec![table.columns[i].base_name()];
                 let value = AssignmentValue::Expr(row[i].clone());
                 Assignment { id, value }
             })

--- a/src/tests/sqlsmith/src/sql_gen/dml.rs
+++ b/src/tests/sqlsmith/src/sql_gen/dml.rs
@@ -147,8 +147,7 @@ impl<'a, R: Rng + 'a> SqlGenerator<'a, R> {
             .iter()
             .copied()
             .map(|i| {
-                let name = table.columns[i].name.as_str();
-                let id = vec![name.into()];
+                let id = table.columns[i].name.0.clone();
                 let value = AssignmentValue::Expr(row[i].clone());
                 Assignment { id, value }
             })
@@ -169,7 +168,7 @@ impl<'a, R: Rng + 'a> SqlGenerator<'a, R> {
             .copied()
             .map(|i| {
                 let match_val = row[i].clone();
-                let match_col = Expr::Identifier(table.columns[i].name.as_str().into());
+                let match_col = table.columns[i].name_expr();
 
                 Expr::BinaryOp {
                     left: Box::new(match_col),

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -18,7 +18,7 @@ use rand::seq::IndexedRandom;
 use risingwave_common::types::{DataType, DataTypeName, StructType};
 use risingwave_expr::sig::FUNCTION_REGISTRY;
 use risingwave_frontend::expr::cast_sigs;
-use risingwave_sqlparser::ast::{Expr, Ident, OrderByExpr, Value};
+use risingwave_sqlparser::ast::{Expr, OrderByExpr, Value};
 
 use crate::config::Feature;
 use crate::sql_gen::types::data_type_to_ast_data_type;
@@ -208,7 +208,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
             self.gen_simple_scalar(typ)
         } else {
             let col_def = matched_cols.choose(&mut self.rng).unwrap();
-            Expr::Identifier(Ident::new_unchecked(&col_def.name))
+            col_def.name_expr()
         }
     }
 
@@ -246,7 +246,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         while self.flip_coin() {
             let column = self.bound_columns.choose(&mut self.rng).unwrap();
             order_by.push(OrderByExpr {
-                expr: Expr::Identifier(Ident::new_unchecked(&column.name)),
+                expr: column.name_expr(),
                 asc: if self.rng.random_bool(0.3) {
                     None
                 } else {

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -121,6 +121,10 @@ impl Column {
             Expr::CompoundIdentifier(self.name.0.clone())
         }
     }
+
+    pub fn base_name(&self) -> Ident {
+        self.name.0.last().unwrap().clone()
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -85,9 +85,13 @@ impl Table {
     pub fn get_qualified_columns(&self) -> Vec<Column> {
         self.columns
             .iter()
-            .map(|c| Column {
-                name: format!("{}.{}", self.name, c.name),
-                data_type: c.data_type.clone(),
+            .map(|c| {
+                let mut name = c.name.clone();
+                name.0.insert(0, Ident::new_unchecked(&self.name));
+                Column {
+                    name,
+                    data_type: c.data_type.clone(),
+                }
             })
             .collect()
     }
@@ -96,15 +100,25 @@ impl Table {
 /// Sqlsmith Column definition
 #[derive(Clone, Debug)]
 pub struct Column {
-    pub(crate) name: String,
+    pub(crate) name: ObjectName,
     pub(crate) data_type: DataType,
 }
 
 impl From<ColumnDef> for Column {
     fn from(c: ColumnDef) -> Self {
         Self {
-            name: c.name.real_value(),
+            name: ObjectName(vec![c.name]),
             data_type: bind_data_type(&c.data_type.expect("data type should not be none")).unwrap(),
+        }
+    }
+}
+
+impl Column {
+    pub fn name_expr(&self) -> Expr {
+        if self.name.0.len() == 1 {
+            Expr::Identifier(self.name.0[0].clone())
+        } else {
+            Expr::CompoundIdentifier(self.name.0.clone())
         }
     }
 }
@@ -245,7 +259,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
         columns
             .iter()
-            .filter(|c| watermark_names.contains(&c.name))
+            .filter(|c| watermark_names.contains(&c.name.real_value()))
             .cloned()
             .collect()
     }

--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -23,7 +23,8 @@ use rand::Rng;
 use rand::prelude::{IndexedRandom, SliceRandom};
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{
-    Cte, Distinct, Expr, Ident, Query, Select, SelectItem, SetExpr, TableWithJoins, Value, With,
+    Cte, Distinct, Expr, Ident, ObjectName, Query, Select, SelectItem, SetExpr, TableWithJoins,
+    Value, With,
 };
 
 use crate::config::Feature;
@@ -213,7 +214,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 alias: Ident::new_unchecked(alias.clone()),
             },
             Column {
-                name: alias,
+                name: ObjectName::from_test_str(&alias),
                 data_type: ret_type,
             },
         )
@@ -271,7 +272,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 self.bound_columns.clone_from(&group_by_cols);
                 group_by_cols
                     .into_iter()
-                    .map(|c| Expr::Identifier(Ident::new_unchecked(c.name)))
+                    .map(|c| c.name_expr())
                     .collect_vec()
             }
             9 => self.gen_grouping_sets(),
@@ -287,12 +288,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         let mut new_bound_columns = vec![];
         for _i in 0..grouping_num {
             let group_by_cols = self.gen_random_bound_columns();
-            grouping_sets.push(
-                group_by_cols
-                    .iter()
-                    .map(|c| Expr::Identifier(Ident::new_unchecked(c.name.clone())))
-                    .collect_vec(),
-            );
+            grouping_sets.push(group_by_cols.iter().map(|c| c.name_expr()).collect_vec());
             new_bound_columns.extend(group_by_cols);
         }
         if grouping_sets.is_empty() {
@@ -302,8 +298,8 @@ impl<R: Rng> SqlGenerator<'_, R> {
             let grouping_sets = Expr::GroupingSets(grouping_sets);
             self.bound_columns = new_bound_columns
                 .into_iter()
-                .sorted_by(|a, b| Ord::cmp(&a.name, &b.name))
-                .dedup_by(|a, b| a.name == b.name)
+                .unique_by(|c| c.name.real_value())
+                .sorted_by_key(|c| c.name.real_value())
                 .collect();
 
             // Currently, grouping sets only support one set.

--- a/src/tests/sqlsmith/src/sql_gen/relation.rs
+++ b/src/tests/sqlsmith/src/sql_gen/relation.rs
@@ -24,13 +24,13 @@ use crate::sql_gen::types::BINARY_INEQUALITY_OP_TABLE;
 use crate::sql_gen::{Column, SqlGenerator, SqlGeneratorContext};
 use crate::{BinaryOperator, Expr, Join, JoinConstraint, JoinOperator, Table};
 
-fn create_binary_expr(op: BinaryOperator, left: String, right: String) -> Expr {
-    let left = Box::new(Expr::Identifier(Ident::new_unchecked(left)));
-    let right = Box::new(Expr::Identifier(Ident::new_unchecked(right)));
+fn create_binary_expr(op: BinaryOperator, left: &Column, right: &Column) -> Expr {
+    let left = Box::new(left.name_expr());
+    let right = Box::new(right.name_expr());
     Expr::BinaryOp { left, op, right }
 }
 
-fn create_equi_expr(left: String, right: String) -> Expr {
+fn create_equi_expr(left: &Column, right: &Column) -> Expr {
     create_binary_expr(BinaryOperator::Eq, left, right)
 }
 
@@ -148,7 +148,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         available_join_on_columns.shuffle(&mut self.rng);
         let remaining_columns = available_join_on_columns.split_off(1);
         let (left_column, right_column) = available_join_on_columns.drain(..).next().unwrap();
-        let join_on_expr = create_equi_expr(left_column.name, right_column.name);
+        let join_on_expr = create_equi_expr(&left_column, &right_column);
         Some((join_on_expr, remaining_columns))
     }
 
@@ -164,12 +164,12 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 break;
             }
             let Some(inequality_ops) =
-                BINARY_INEQUALITY_OP_TABLE.get(&(l_col.data_type, r_col.data_type))
+                BINARY_INEQUALITY_OP_TABLE.get(&(l_col.data_type.clone(), r_col.data_type.clone()))
             else {
                 continue;
             };
             let inequality_op = inequality_ops.choose(&mut self.rng).unwrap();
-            let _non_equi_expr = create_binary_expr(inequality_op.clone(), l_col.name, r_col.name);
+            let _non_equi_expr = create_binary_expr(inequality_op.clone(), &l_col, &r_col);
             count += 1;
         }
         expr
@@ -195,7 +195,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         };
 
         for (l_col, r_col) in available_join_on_columns.drain(0..n) {
-            let equi_expr = create_equi_expr(l_col.name, r_col.name);
+            let equi_expr = create_equi_expr(&l_col, &r_col);
             expr = Expr::BinaryOp {
                 left: Box::new(expr),
                 op: BinaryOperator::And,
@@ -268,7 +268,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 right_columns
                     .iter()
                     .find(|r_col| r_col.name == l_col.name)?;
-                Some(Ident::new_unchecked(l_col.name.clone()))
+                Some(l_col.name.0[0].clone())
             })
             .collect();
 

--- a/src/tests/sqlsmith/src/sql_gen/relation.rs
+++ b/src/tests/sqlsmith/src/sql_gen/relation.rs
@@ -268,7 +268,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
                 right_columns
                     .iter()
                     .find(|r_col| r_col.name == l_col.name)?;
-                Some(l_col.name.0[0].clone())
+                Some(l_col.base_name())
             })
             .collect();
 

--- a/src/tests/sqlsmith/src/sql_gen/time_window.rs
+++ b/src/tests/sqlsmith/src/sql_gen/time_window.rs
@@ -50,7 +50,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         let name = Expr::Identifier(source_table_name.as_str().into());
         let size = self.gen_size(1);
         let time_col = time_cols.choose(&mut self.rng).unwrap();
-        let time_col = Expr::Identifier(time_col.name.as_str().into());
+        let time_col = time_col.name_expr();
         let args = create_args(vec![name, time_col, size]);
         let relation = create_tvf("tumble", alias, args, false);
 
@@ -80,7 +80,7 @@ impl<R: Rng> SqlGenerator<'_, R> {
         // We fix slide to "1" here, as slide needs to be divisible by size.
         let (slide_secs, slide) = self.gen_slide();
         let size = self.gen_size(slide_secs);
-        let time_col = Expr::Identifier(time_col.name.as_str().into());
+        let time_col = time_col.name_expr();
         let args = create_args(vec![name, time_col, slide, size]);
 
         let relation = create_tvf("hop", alias, args, false);
@@ -160,7 +160,7 @@ fn find_tables_with_timestamp_cols(tables: Vec<Table>) -> Vec<(String, Vec<Colum
             let columns = table.get_qualified_columns();
             let mut timestamp_cols = vec![];
             for col in columns {
-                let col_name = col.name.clone();
+                let col_name = col.name.base_name();
                 if col_name.contains("window_start") || col_name.contains("window_end") {
                     return None;
                 }


### PR DESCRIPTION


I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

#22085 is a fix to convert `real_value: String` back to `ast::Ident` properly, by quoting the value with `"` if there's any upper case or special character.

However, in sqlsmith, we previously relied on the incorrect behavior by directly interpolating a `.` into the name of `Column` to represent the qualified name. As a result, the fix failed the fuzzing test in main-cron.

This PR fixed the handling of column name in sqlsmith, by storing an `ObjectName` instead.

```
[2m2025-06-12T16:36:47.783799Z[0m [32m INFO[0m [2mrisingwave_sqlsmith::test_runners::utils[0m[2m:[0m [EXECUTING CREATE MVIEW]: CREATE MATERIALIZED VIEW m1 AS WITH with_0 AS (WITH with_1 AS (SELECT tumble_2.auction AS col_0, tumble_2.date_time AS col_1, ((INT '630') # (SMALLINT '994')) AS col_2, tumble_2.bidder AS col_3 FROM tumble(bid, "bid.date_time", INTERVAL '14') AS tumble_2 WHERE false GROUP BY tumble_2.auction, tumble_2.date_time, tumble_2.bidder HAVING false) SELECT TIME '16:36:47' AS col_0, CAST('cIsP9XEFBc' AS CHARACTER VARYING) AS col_1 FROM with_1) SELECT CAST('kP4CxYgYlr' AS CHARACTER VARYING) AS col_0, (575) AS col_1, ((INTERVAL '-2') > TIME '16:35:16') AS col_2, CAST(NULL AS STRUCT<a TIMESTAMP, b REAL, c DOUBLE>) AS col_3 FROM with_0 WHERE true
[2m2025-06-12T16:36:47.784507Z[0m [32m INFO[0m [2mrisingwave_sqlsmith::test_runners::utils[0m[2m:[0m [UNEXPECTED ERROR]: Error {
    kind: Db,
    cause: Some(
        DbError {
            severity: "ERROR",
            parsed_severity: None,
            code: SqlState(
                EXX000,
            ),
            message: "Failed to run the query\n\nCaused by:\n  Item not found: Invalid column: bid.date_time\n",
            ..
        },
    ),
}
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
