### PR TITLE
feat: introduce `as file uri` when ref secret

### DIFF
--- a/proto/secret.proto
+++ b/proto/secret.proto
@@ -25,6 +25,8 @@ message SecretRef {
     TEXT = 1;
     // AS FILE
     FILE = 2;
+    // AS FILE with `file://` prefix
+    FILE_URI = 3;
   }
   uint32 secret_id = 1;
   RefAsType ref_as = 2;

--- a/src/common/secret/src/secret_manager.rs
+++ b/src/common/secret/src/secret_manager.rs
@@ -168,6 +168,11 @@ impl LocalSecretManager {
                     self.get_or_init_secret_file(secret_id, secret_value_bytes.clone())?;
                 Ok(path_str)
             }
+            RefAsType::FileUri => {
+                let path_str =
+                    self.get_or_init_secret_file(secret_id, secret_value_bytes.clone())?;
+                Ok(format!("file://{}", path_str))
+            }
             RefAsType::Unspecified => Err(SecretError::UnspecifiedRefType(secret_id)),
         }
     }

--- a/src/common/secret/src/secret_manager.rs
+++ b/src/common/secret/src/secret_manager.rs
@@ -166,7 +166,7 @@ impl LocalSecretManager {
             RefAsType::File => {
                 let path_str =
                     self.get_or_init_secret_file(secret_id, secret_value_bytes.clone())?;
-                Ok(format!("file://{}", path_str))
+                Ok(path_str)
             }
             RefAsType::Unspecified => Err(SecretError::UnspecifiedRefType(secret_id)),
         }

--- a/src/common/secret/src/secret_manager.rs
+++ b/src/common/secret/src/secret_manager.rs
@@ -166,7 +166,7 @@ impl LocalSecretManager {
             RefAsType::File => {
                 let path_str =
                     self.get_or_init_secret_file(secret_id, secret_value_bytes.clone())?;
-                Ok(path_str)
+                Ok(format!("file://{}", path_str))
             }
             RefAsType::Unspecified => Err(SecretError::UnspecifiedRefType(secret_id)),
         }

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -2174,6 +2174,7 @@ fn bind_webhook_info(
                 ref_as: match secret_ref.ref_as {
                     SecretRefAsType::Text => PbRefAsType::Text,
                     SecretRefAsType::File => PbRefAsType::File,
+                    SecretRefAsType::FileUri => PbRefAsType::FileUri,
                 }
                 .into(),
             }),

--- a/src/frontend/src/utils/with_options.rs
+++ b/src/frontend/src/utils/with_options.rs
@@ -360,6 +360,7 @@ fn resolve_secret_refs_inner(
         let ref_as = match secret_ref.ref_as {
             SecretRefAsType::Text => PbRefAsType::Text,
             SecretRefAsType::File => PbRefAsType::File,
+            SecretRefAsType::FileUri => PbRefAsType::FileUri,
         };
         let pb_secret_ref = PbSecretRef {
             secret_id: secret_catalog.id.secret_id(),

--- a/src/sqlparser/src/ast/value.rs
+++ b/src/sqlparser/src/ast/value.rs
@@ -247,6 +247,7 @@ impl fmt::Display for SecretRefValue {
         match self.ref_as {
             SecretRefAsType::Text => write!(f, "{}", self.secret_name),
             SecretRefAsType::File => write!(f, "{} AS FILE", self.secret_name),
+            SecretRefAsType::FileUri => write!(f, "{} AS FILE URI", self.secret_name),
         }
     }
 }
@@ -256,6 +257,7 @@ impl fmt::Display for SecretRefValue {
 pub enum SecretRefAsType {
     Text,
     File,
+    FileUri,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -559,6 +559,7 @@ define_keywords!(
     UNNEST,
     UPDATE,
     UPPER,
+    URI,
     USAGE,
     USE,
     USER,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3959,7 +3959,9 @@ impl Parser<'_> {
 
     fn parse_secret_ref(&mut self) -> ModalResult<SecretRefValue> {
         let secret_name = self.parse_object_name()?;
-        let ref_as = if self.parse_keywords(&[Keyword::AS, Keyword::FILE]) {
+        let ref_as = if self.parse_keywords(&[Keyword::AS, Keyword::FILE, Keyword::URI]) {
+            SecretRefAsType::FileUri
+        } else if self.parse_keywords(&[Keyword::AS, Keyword::FILE]) {
             SecretRefAsType::File
         } else {
             SecretRefAsType::Text

--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -210,3 +210,7 @@
     sql parser error: Unterminated string literal at line 1, column 76
     LINE 1: CREATE SECRET IF NOT EXISTS secret2 WITH (backend = 'meta') AS 'demo-secret
                                                                                        ^
+- input: CREATE SOURCE IF NOT EXISTS src WITH (kafka.topic = 'abc', kafka.brokers = 'localhost:1001', properties.ssl.key.location = SECRET secret_1 AS FILE) FORMAT PLAIN ENCODE JSON
+  formatted_sql: CREATE SOURCE IF NOT EXISTS src WITH (kafka.topic = 'abc', kafka.brokers = 'localhost:1001', properties.ssl.key.location = secret secret_1 AS FILE) FORMAT PLAIN ENCODE JSON
+- input: CREATE SOURCE IF NOT EXISTS src WITH (kafka.topic = 'abc', kafka.brokers = 'localhost:1001', properties.ssl.key.location = SECRET secret_1 AS FILE URI) FORMAT PLAIN ENCODE JSON
+  formatted_sql: CREATE SOURCE IF NOT EXISTS src WITH (kafka.topic = 'abc', kafka.brokers = 'localhost:1001', properties.ssl.key.location = secret secret_1 AS FILE URI) FORMAT PLAIN ENCODE JSON


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

in current impl, fill_secret returns the absolute path, but most sdk requires `file://<absolute-path>`

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

introduce `AS FILE URI` when referencing a secret, which gives `file://<absolute path>` for a file

</details>
