### PR TITLE
fix(meta): injected project and merge nodes should have unique operator ids by sink into table

### DIFF
--- a/src/common/src/util/stream_graph_visitor.rs
+++ b/src/common/src/util/stream_graph_visitor.rs
@@ -47,9 +47,16 @@ where
 }
 
 /// A utility for visiting the [`NodeBody`] of the [`StreamNode`]s recursively.
-pub fn visit_stream_node(stream_node: &StreamNode, mut f: impl FnMut(&NodeBody)) {
+pub fn visit_stream_node_body(stream_node: &StreamNode, mut f: impl FnMut(&NodeBody)) {
     visit_stream_node_cont(stream_node, |stream_node| {
         f(stream_node.node_body.as_ref().unwrap());
+        true
+    })
+}
+
+pub fn visit_stream_node(stream_node: &StreamNode, mut f: impl FnMut(&StreamNode)) {
+    visit_stream_node_cont(stream_node, |stream_node| {
+        f(stream_node);
         true
     })
 }
@@ -83,7 +90,7 @@ pub fn visit_fragment_mut(fragment: &mut StreamFragment, f: impl FnMut(&mut Node
 /// A utility for visiting the [`NodeBody`] of the [`StreamNode`]s in a
 /// [`StreamFragment`] recursively.
 pub fn visit_fragment(fragment: &StreamFragment, f: impl FnMut(&NodeBody)) {
-    visit_stream_node(fragment.node.as_ref().unwrap(), f)
+    visit_stream_node_body(fragment.node.as_ref().unwrap(), f)
 }
 
 /// Visit the tables of a [`StreamNode`].
@@ -299,7 +306,7 @@ pub fn visit_stream_node_tables_inner<F>(
 }
 
 pub fn visit_stream_node_stream_scan(stream_node: &StreamNode, mut f: impl FnMut(&StreamScanNode)) {
-    visit_stream_node(stream_node, |body| {
+    visit_stream_node_body(stream_node, |body| {
         if let NodeBody::StreamScan(node) = body {
             f(node)
         }

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -22,7 +22,9 @@ use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::hash::{VnodeCount, VnodeCountCompat, WorkerSlotId};
-use risingwave_common::util::stream_graph_visitor::{visit_stream_node, visit_stream_node_mut};
+use risingwave_common::util::stream_graph_visitor::{
+    visit_stream_node_body, visit_stream_node_mut,
+};
 use risingwave_connector::source::SplitImpl;
 use risingwave_meta_model::actor::ActorStatus;
 use risingwave_meta_model::fragment::DistributionType;
@@ -367,7 +369,7 @@ impl CatalogController {
 
         let stream_node = stream_node.to_protobuf();
         let mut upstream_fragments = HashSet::new();
-        visit_stream_node(&stream_node, |body| {
+        visit_stream_node_body(&stream_node, |body| {
             if let NodeBody::Merge(m) = body {
                 assert!(
                     upstream_fragments.insert(m.upstream_fragment_id),
@@ -673,7 +675,7 @@ impl CatalogController {
         } in fragments
         {
             let stream_node = stream_node.to_protobuf();
-            visit_stream_node(&stream_node, |body| {
+            visit_stream_node_body(&stream_node, |body| {
                 if let NodeBody::StreamScan(node) = body {
                     match node.stream_scan_type() {
                         StreamScanType::Unspecified => {}
@@ -1758,7 +1760,7 @@ mod tests {
     use itertools::Itertools;
     use risingwave_common::hash::{ActorMapping, VirtualNode, VnodeCount};
     use risingwave_common::util::iter_util::ZipEqDebug;
-    use risingwave_common::util::stream_graph_visitor::visit_stream_node;
+    use risingwave_common::util::stream_graph_visitor::visit_stream_node_body;
     use risingwave_meta_model::actor::ActorStatus;
     use risingwave_meta_model::fragment::DistributionType;
     use risingwave_meta_model::{
@@ -2027,7 +2029,7 @@ mod tests {
 
             assert_eq!(mview_definition, "");
 
-            visit_stream_node(stream_node, |body| {
+            visit_stream_node_body(stream_node, |body| {
                 if let PbNodeBody::Merge(m) = body {
                     assert!(
                         actor_upstreams

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -20,7 +20,9 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VnodeCountCompat;
-use risingwave_common::util::stream_graph_visitor::{visit_stream_node, visit_stream_node_mut};
+use risingwave_common::util::stream_graph_visitor::{
+    visit_stream_node_body, visit_stream_node_mut,
+};
 use risingwave_common::{bail, current_cluster_version};
 use risingwave_connector::sink::file_sink::fs::FsSink;
 use risingwave_connector::sink::{CONNECTOR_TYPE_KEY, SinkError};
@@ -2008,7 +2010,7 @@ impl CatalogController {
             let mut rate_limit = None;
             let mut node_name = None;
 
-            visit_stream_node(&stream_node, |node| {
+            visit_stream_node_body(&stream_node, |node| {
                 match node {
                     // source rate limit
                     PbNodeBody::Source(node) => {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -21,7 +21,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::hash::{
     IsSingleton, VirtualNode, VnodeCount, VnodeCountCompat, WorkerSlotId,
 };
-use risingwave_common::util::stream_graph_visitor::{self, visit_stream_node};
+use risingwave_common::util::stream_graph_visitor::{self, visit_stream_node_body};
 use risingwave_connector::source::SplitImpl;
 use risingwave_meta_model::{DispatcherType, SourceId, StreamingParallelism, WorkerId};
 use risingwave_pb::catalog::Table;
@@ -610,7 +610,7 @@ impl StreamJobFragments {
         for (fragment_id, fragment) in &self.fragments {
             {
                 {
-                    visit_stream_node(&fragment.nodes, |body| {
+                    visit_stream_node_body(&fragment.nodes, |body| {
                         if let NodeBody::Union(_) = body {
                             if let Some(union_fragment_id) = union_fragment_id.as_mut() {
                                 // The union fragment should be unique.

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -29,7 +29,7 @@ use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::secret::{LocalSecretManager, SecretEncryption};
 use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::stream_graph_visitor::{
-    visit_stream_node, visit_stream_node_cont_mut,
+    visit_stream_node, visit_stream_node_body, visit_stream_node_cont_mut,
 };
 use risingwave_common::{bail, bail_not_implemented, must_match};
 use risingwave_connector::WithOptionsSecResolved;
@@ -892,7 +892,7 @@ impl DdlController {
         for fragment in stream_job_fragments.fragments.values() {
             {
                 {
-                    visit_stream_node(&fragment.nodes, |node| {
+                    visit_stream_node_body(&fragment.nodes, |node| {
                         if let NodeBody::Merge(merge_node) = node {
                             let upstream_fragment_id = merge_node.upstream_fragment_id;
                             if let Some(external_upstream_fragment_downstreams) = replace_table_ctx
@@ -967,6 +967,12 @@ impl DdlController {
 
         let upstream_fragment_id = sink_fragment.fragment_id;
 
+        let mut max_operator_id = 0;
+
+        visit_stream_node(&union_fragment.nodes, |node| {
+            max_operator_id = max_operator_id.max(node.operator_id);
+        });
+
         {
             {
                 visit_stream_node_cont_mut(&mut union_fragment.nodes, |node| {
@@ -990,9 +996,11 @@ impl DdlController {
                                     {
                                         merge_stream_node.identity =
                                             format!("MergeExecutor(from sink {})", sink_id);
+                                        merge_stream_node.operator_id = max_operator_id + 1;
 
                                         input_project_node.identity =
                                             format!("ProjectExecutor(from sink {})", sink_id);
+                                        input_project_node.operator_id = max_operator_id + 2;
                                     }
 
                                     **merge_node = {

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -1112,7 +1112,7 @@ impl CompleteStreamFragmentGraph {
                 let output_columns = {
                     let mut res = None;
 
-                    stream_graph_visitor::visit_stream_node(&fragment.nodes, |node_body| {
+                    stream_graph_visitor::visit_stream_node_body(&fragment.nodes, |node_body| {
                         let columns = match node_body {
                             NodeBody::StreamScan(stream_scan) => stream_scan.upstream_columns(),
                             NodeBody::SourceBackfill(source_backfill) => {

--- a/src/tests/simulation/tests/integration_tests/scale/dynamic_filter.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/dynamic_filter.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use itertools::Itertools;
-use risingwave_common::util::stream_graph_visitor::visit_stream_node;
+use risingwave_common::util::stream_graph_visitor::visit_stream_node_body;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_simulation::cluster::{Cluster, Configuration};
 use risingwave_simulation::ctl_ext::predicate::identity_contains;
@@ -47,7 +47,7 @@ async fn test_dynamic_filter() -> Result<()> {
         .await?;
 
     let mut upstream_fragment_ids = HashSet::new();
-    visit_stream_node(
+    visit_stream_node_body(
         dynamic_filter_fragment.inner.nodes.as_ref().unwrap(),
         |node| {
             if let NodeBody::Merge(merge) = node {


### PR DESCRIPTION
…r ids

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

A unique operator id is required for us to accurately track the profiling metrics for newly injected project and merge nodes inside explain analyze.

1. Traverse the union fragment to find the max operator id. Use that +1, +2 to assign operator ids to the injected project and merge nodes.
2. Refactor function name `visit_stream_node` -> `visit_stream_node_body` to reflect the actual usage.

The operator id just needs to be locally unique to the fragment, since it's globally namespaced by the fragment id.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
