### PR TITLE
fix(frontend): tolerate duplicate operator ids and missing metrics

### DIFF
--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -108,7 +108,7 @@ risedev slt -p 4566 -d dev './e2e_test/ddl/**/*.slt' --junit "batch-ddl-${profil
 risedev slt -p 4566 -d dev './e2e_test/background_ddl/basic.slt' --junit "batch-ddl-${profile}"
 
 if [[ "$mode" != "single-node" && "$mode" != "standalone" ]]; then
-  risedev slt -p 4566 -d dev './e2e_test/visibility_mode/*.slt' --junit "batch-${profile}"
+  risedev slt -p 4566 -d dev './e2e_test/visibility_mode/*.slt' --junit "batch-${profile}" --label "serial"
 fi
 
 risedev slt -p 4566 -d dev './e2e_test/ttl/ttl.slt'

--- a/e2e_test/batch/explain_analyze.slt
+++ b/e2e_test/batch/explain_analyze.slt
@@ -40,7 +40,7 @@ onlyif serial
 statement ok
 set backfill_rate_limit=default;
 
-onlyif serial 
+onlyif serial
 statement ok
 explain analyze (duration_secs 0) materialized view explain_analyze_test.background_mv;
 
@@ -52,7 +52,6 @@ onlyif serial
 statement ok
 drop materialized view explain_analyze_test.background_mv;
 
-skipif serial
 statement ok
 explain analyze (duration_secs 0) table explain_analyze_test.t1;
 

--- a/e2e_test/batch/explain_analyze.slt
+++ b/e2e_test/batch/explain_analyze.slt
@@ -1,0 +1,89 @@
+statement ok
+drop schema if exists explain_analyze_test cascade;
+
+statement ok
+create schema explain_analyze_test;
+
+statement ok
+create table explain_analyze_test.t1(v1 int primary key)
+with (connector='datagen', datagen.rows.per.second='1', fields.id.kind = 'sequence', fields.v1.start = '1', fields.v2.end = '1000000');
+
+statement ok
+create materialized view explain_analyze_test.m1 as select * from explain_analyze_test.t1;
+
+statement ok
+create materialized view explain_analyze_test.m2 as select t1.v1 from explain_analyze_test.m1 join explain_analyze_test.t1 using(v1);
+
+statement ok
+create table explain_analyze_test.t2(v1 int primary key);
+
+statement ok
+create sink explain_analyze_test.s1 into explain_analyze_test.t2 from explain_analyze_test.t1;
+
+onlyif serial
+statement ok
+set background_ddl=true;
+
+onlyif serial
+statement ok
+set backfill_rate_limit=0;
+
+onlyif serial
+statement ok
+create materialized view explain_analyze_test.background_mv as select * from explain_analyze_test.t1;
+
+onlyif serial
+statement ok
+set background_ddl=default;
+
+onlyif serial
+statement ok
+set backfill_rate_limit=default;
+
+onlyif serial 
+statement ok
+explain analyze (duration_secs 0) materialized view explain_analyze_test.background_mv;
+
+onlyif serial
+statement ok
+explain analyze (duration_secs 1) materialized view explain_analyze_test.background_mv;
+
+onlyif serial
+statement ok
+drop materialized view explain_analyze_test.background_mv;
+
+skipif serial
+statement ok
+explain analyze (duration_secs 0) table explain_analyze_test.t1;
+
+statement ok
+explain analyze (duration_secs 1) table explain_analyze_test.t1;
+
+skipif serial
+statement ok
+explain analyze (duration_secs 0) table explain_analyze_test.t2;
+
+skipif serial
+statement ok
+explain analyze (duration_secs 1) table explain_analyze_test.t2;
+
+statement ok
+explain analyze (duration_secs 0) materialized view explain_analyze_test.m1;
+
+statement ok
+explain analyze (duration_secs 1) materialized view explain_analyze_test.m1;
+
+statement ok
+explain analyze (duration_secs 0) materialized view explain_analyze_test.m2;
+
+statement ok
+explain analyze (duration_secs 1) materialized view explain_analyze_test.m2;
+
+statement ok
+explain analyze (duration_secs 0) sink explain_analyze_test.s1;
+
+statement ok
+explain analyze (duration_secs 1) sink explain_analyze_test.s1;
+
+statement ok
+drop schema explain_analyze_test cascade;

--- a/e2e_test/batch/explain_analyze.slt
+++ b/e2e_test/batch/explain_analyze.slt
@@ -58,11 +58,9 @@ explain analyze (duration_secs 0) table explain_analyze_test.t1;
 statement ok
 explain analyze (duration_secs 1) table explain_analyze_test.t1;
 
-skipif serial
 statement ok
 explain analyze (duration_secs 0) table explain_analyze_test.t2;
 
-skipif serial
 statement ok
 explain analyze (duration_secs 1) table explain_analyze_test.t2;
 

--- a/e2e_test/batch/explain_analyze.slt
+++ b/e2e_test/batch/explain_analyze.slt
@@ -55,30 +55,35 @@ drop materialized view explain_analyze_test.background_mv;
 statement ok
 explain analyze (duration_secs 0) table explain_analyze_test.t1;
 
+onlyif serial
 statement ok
 explain analyze (duration_secs 1) table explain_analyze_test.t1;
 
 statement ok
 explain analyze (duration_secs 0) table explain_analyze_test.t2;
 
+onlyif serial
 statement ok
 explain analyze (duration_secs 1) table explain_analyze_test.t2;
 
 statement ok
 explain analyze (duration_secs 0) materialized view explain_analyze_test.m1;
 
+onlyif serial
 statement ok
 explain analyze (duration_secs 1) materialized view explain_analyze_test.m1;
 
 statement ok
 explain analyze (duration_secs 0) materialized view explain_analyze_test.m2;
 
+onlyif serial
 statement ok
 explain analyze (duration_secs 1) materialized view explain_analyze_test.m2;
 
 statement ok
 explain analyze (duration_secs 0) sink explain_analyze_test.s1;
 
+onlyif serial
 statement ok
 explain analyze (duration_secs 1) sink explain_analyze_test.s1;
 

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -510,10 +510,10 @@ mod graph {
     }
 
     impl StreamNode {
-        fn new_for_dispatcher(operator_id: u64) -> Self {
+        fn new_for_dispatcher(fragment_id: u32) -> Self {
             StreamNode {
-                operator_id,
-                fragment_id: 0,
+                operator_id: operator_id_for_dispatch(fragment_id),
+                fragment_id,
                 identity: NodeBodyDiscriminants::Exchange,
                 actor_ids: Default::default(),
                 dependencies: Default::default(),
@@ -615,8 +615,8 @@ mod graph {
             let node = operator_id_to_stream_node.get_mut(&operator_id).unwrap();
             let fragment_id = node.fragment_id;
             if let Some(merge_operator_id) = fragment_id_to_merge_operator_id.get(&fragment_id) {
-                let operator_id_for_dispatch = operator_id_for_dispatch(fragment_id);
-                let mut dispatcher = StreamNode::new_for_dispatcher(operator_id_for_dispatch);
+                let mut dispatcher = StreamNode::new_for_dispatcher(fragment_id);
+                let operator_id_for_dispatch = dispatcher.operator_id;
                 dispatcher.dependencies.push(operator_id);
                 assert!(
                     operator_id_to_stream_node

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -529,7 +529,6 @@ mod graph {
     use std::collections::{HashMap, HashSet};
     use std::time::Duration;
 
-    use fancy_regex::Regex;
     use risingwave_common::operator::{
         unique_executor_id_from_unique_operator_id, unique_operator_id,
     };
@@ -596,9 +595,7 @@ mod graph {
                 node.operator_id,
                 "extracting stream node info"
             );
-            let re = Regex::new(r"[a-zA-Z]+").expect("should be able to compile regex");
-            let result = re.find(&node.identity).unwrap().unwrap();
-            let identity = result.as_str().to_owned();
+            let identity = node.node_body.as_ref().expect("should have node body").to_string();
             let operator_id = unique_operator_id(fragment_id, node.operator_id);
             if let Some(merge_node) = node.node_body.as_ref()
                 && let NodeBody::Merge(box MergeNode {

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -561,15 +561,20 @@ mod graph {
                 fragment_id_to_merge_operator_id.insert(*upstream_fragment_id, operator_id);
             }
             let dependencies = &node.input;
-            let dependency_ids = dependencies.iter().map(|input| unique_operator_id(fragment_id, input.operator_id)).collect::<Vec<_>>();
-            operator_id_to_stream_node
-                .insert(operator_id, StreamNode {
+            let dependency_ids = dependencies
+                .iter()
+                .map(|input| unique_operator_id(fragment_id, input.operator_id))
+                .collect::<Vec<_>>();
+            operator_id_to_stream_node.insert(
+                operator_id,
+                StreamNode {
                     operator_id,
                     fragment_id,
                     identity,
                     actor_ids: actor_ids.clone(),
                     dependencies: dependency_ids,
-                });
+                },
+            );
             for dependency in dependencies {
                 extract_stream_node_info(
                     fragment_id,
@@ -587,14 +592,18 @@ mod graph {
         let mut fragment_id_to_merge_operator_id = HashMap::new();
         for fragment in fragments {
             let actors = fragment.actors;
-            assert!(!actors.is_empty(), "fragment {} should have at least one actor", fragment.id);
+            assert!(
+                !actors.is_empty(),
+                "fragment {} should have at least one actor",
+                fragment.id
+            );
             let actor_ids = actors.iter().map(|actor| actor.id).collect::<HashSet<_>>();
             let node = actors[0].node.as_ref().expect("should have stream node");
             extract_stream_node_info(
                 fragment.id,
                 &mut fragment_id_to_merge_operator_id,
                 &mut operator_id_to_stream_node,
-                &node,
+                node,
                 &actor_ids,
             );
         }

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -546,12 +546,6 @@ mod graph {
             node: &PbStreamNode,
             actor_id: u32,
         ) {
-            tracing::info!(
-                actor_id,
-                fragment_id,
-                node.operator_id,
-                "extracting stream node info"
-            );
             let identity = node
                 .node_body
                 .as_ref()
@@ -567,14 +561,6 @@ mod graph {
                 fragment_id_to_merge_operator_id.insert(*upstream_fragment_id, operator_id);
             }
             let dependencies = &node.input;
-            let dependency_infos = dependencies
-                .iter()
-                .map(|input| {
-                    let operator_id = unique_operator_id(fragment_id, input.operator_id);
-                    (operator_id, input.operator_id)
-                })
-                .collect::<HashMap<_, _>>();
-            tracing::info!(?dependency_infos, "dependency infos");
             let entry = operator_id_to_stream_node
                 .entry(operator_id)
                 .or_insert_with(|| {
@@ -607,7 +593,6 @@ mod graph {
         let mut operator_id_to_stream_node = HashMap::new();
         let mut fragment_id_to_merge_operator_id = HashMap::new();
         for fragment in fragments {
-            tracing::info!(fragment.id, "top-level extracting stream node info");
             let actors = fragment.actors;
             for actor in actors {
                 let actor_id = actor.id;
@@ -662,12 +647,6 @@ mod graph {
             let operator_id = node.operator_id;
             let operator_name = node.identity;
             for actor_id in &node.actor_ids {
-                tracing::info!(
-                    ?operator_name,
-                    ?operator_id,
-                    ?actor_id,
-                    "extracting executor info"
-                );
                 let executor_id =
                     unique_executor_id_from_unique_operator_id(*actor_id, operator_id);
                 assert!(executor_ids.insert(executor_id));

--- a/src/frontend/src/handler/explain_analyze_stream_job.rs
+++ b/src/frontend/src/handler/explain_analyze_stream_job.rs
@@ -245,6 +245,7 @@ mod metrics {
     use crate::handler::explain_analyze_stream_job::graph::{ExecutorId, OperatorId};
     use crate::handler::explain_analyze_stream_job::utils::operator_id_for_dispatch;
 
+    #[expect(dead_code)]
     #[derive(Default, Debug)]
     pub(super) struct ExecutorMetrics {
         pub executor_id: ExecutorId,
@@ -253,6 +254,7 @@ mod metrics {
         pub total_output_pending_ns: u64,
     }
 
+    #[expect(dead_code)]
     #[derive(Default, Debug)]
     pub(super) struct DispatchMetrics {
         pub fragment_id: FragmentId,
@@ -298,11 +300,12 @@ mod metrics {
                 else {
                     continue;
                 };
-                let mut stats: ExecutorMetrics = Default::default();
-                stats.executor_id = *executor_id;
-                stats.epoch = 0;
-                stats.total_output_throughput = *total_output_throughput;
-                stats.total_output_pending_ns = *total_output_pending_ns;
+                let stats = ExecutorMetrics {
+                    executor_id: *executor_id,
+                    epoch: 0,
+                    total_output_throughput: *total_output_throughput,
+                    total_output_pending_ns: *total_output_pending_ns,
+                };
                 assert!(self.executor_stats.insert(*executor_id, stats).is_none());
             }
 
@@ -318,11 +321,12 @@ mod metrics {
                 else {
                     continue;
                 };
-                let mut stats: DispatchMetrics = Default::default();
-                stats.fragment_id = *fragment_id;
-                stats.epoch = 0;
-                stats.total_output_throughput = *total_output_throughput;
-                stats.total_output_pending_ns = *total_output_pending_ns;
+                let stats = DispatchMetrics {
+                    fragment_id: *fragment_id,
+                    epoch: 0,
+                    total_output_throughput: *total_output_throughput,
+                    total_output_pending_ns: *total_output_pending_ns,
+                };
                 assert!(self.dispatch_stats.insert(*fragment_id, stats).is_none());
             }
         }
@@ -651,12 +655,12 @@ mod graph {
     pub(super) fn extract_executor_infos(
         adjacency_list: &HashMap<OperatorId, StreamNode>,
     ) -> (HashSet<u64>, HashMap<u64, HashSet<u64>>) {
-        let mut executor_ids: HashSet<_> = Default::default();
-        let mut operator_to_executor: HashMap<_, _> = Default::default();
-        for (operator_id, node) in adjacency_list.iter() {
+        let mut executor_ids = HashSet::new();
+        let mut operator_to_executor = HashMap::new();
+        for (operator_id, node) in adjacency_list {
             assert_eq!(*operator_id, node.operator_id);
             let operator_id = node.operator_id;
-            let operator_name = node.identity.clone();
+            let operator_name = node.identity;
             for actor_id in &node.actor_ids {
                 tracing::info!(
                     ?operator_name,

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -105,6 +105,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "node_body",
             "#[derive(::enum_as_inner::EnumAsInner, ::strum::Display, ::strum::EnumDiscriminants)]",
         )
+        .type_attribute(
+            "node_body",
+            "#[strum_discriminants(derive(::strum::Display))]",
+        )
         .type_attribute("rex_node", "#[derive(::enum_as_inner::EnumAsInner)]")
         .type_attribute(
             "meta.PausedReason",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The main goal of this PR is to tolerate project and merge nodes injected by sink into table. See https://github.com/risingwavelabs/risingwave/pull/22230. We ensure metrics collection and graph generation can tolerate this case for backwards compatibility. We also add more test coverage, just to validate that explain analyze shouldn't crash.

### Implementation notes

This PR improves the `EXPLAIN ANALYZE` functionality for stream jobs with the following changes:

1. Added a new e2e test for `EXPLAIN ANALYZE` that tests the command on tables, materialized views, and sinks with different duration settings.

2. Enhanced the stream job metrics collection to be more robust:
   - Made output metrics optional to handle cases where metrics are unavailable
   - Improved error handling when collecting metrics from executors
   - Fixed potential underflow issues when calculating metric deltas

3. Improved the operator graph construction:
   - Used node body discriminants for better operator identification. It avoids manual parsing of operator identity.
   - Fixed dispatcher node creation and connection in the graph
   - Enhanced actor ID collection and representation

4. Added a serial label to visibility mode tests to ensure proper test execution. We want to skip background_ddl tests.

5. Optimize graph traversal. Instead of traversing the stream node graph once for each actor, we can just do it once, for the first actor. This is because all actors in the fragment should have the same stream node graph. This makes our graph construction easier to reason about as well.

These changes make the `EXPLAIN ANALYZE` command more reliable and informative, especially when dealing with background DDL operations or when metrics collection might be incomplete.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.