### PR TITLE
fix(frontend): ban snapshot backfill with shared source backfill and delta join

### DIFF
--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -27,7 +27,7 @@ sleep 2s
 statement ok
 set STREAMING_USE_SNAPSHOT_BACKFILL TO true;
 
-statement error error place holder
+statement error Not supported: Snapshot backfill with shared source backfill is not supported
 create materialized view mv_snapshot_backfill_shared_source as (select * from mv_before_produce) union (select * from s_before_produce);
 
 statement ok

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -27,7 +27,7 @@ sleep 2s
 statement ok
 set STREAMING_USE_SNAPSHOT_BACKFILL TO true;
 
-statement error not supported
+statement error error place holder
 create materialized view mv_snapshot_backfill_shared_source as (select * from mv_before_produce) union (select * from s_before_produce);
 
 statement ok

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -24,6 +24,15 @@ create materialized view mv_before_produce as select * from s_before_produce;
 
 sleep 2s
 
+statement ok
+set STREAMING_USE_SNAPSHOT_BACKFILL TO true;
+
+statement error not supported
+create materialized view mv_snapshot_backfill_shared_source as (select * from mv_before_produce) union (select * from s_before_produce);
+
+statement ok
+set STREAMING_USE_SNAPSHOT_BACKFILL TO false;
+
 # All partitions starts with backfill_info: NoDataToBackfill, so it finishes immediately.
 system ok
 internal_table.mjs --name mv_before_produce --type sourcebackfill

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -36,11 +36,11 @@ use risingwave_pb::stream_plan::{
 };
 
 use self::rewrite::build_delta_join_without_arrange;
-use crate::error::Result;
+use crate::error::ErrorCode::NotSupported;
+use crate::error::{Result, RwError};
 use crate::optimizer::PlanRef;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::reorganize_elements_id;
-use crate::scheduler::SchedulerResult;
 use crate::stream_fragmenter::parallelism::derive_parallelism;
 
 /// The mutable state when building fragment graph.
@@ -67,6 +67,9 @@ pub struct BuildFragmentGraphState {
     share_mapping: HashMap<u32, LocalFragmentId>,
     /// operator id to `StreamNode` mapping used by share operator.
     share_stream_node_mapping: HashMap<u32, StreamNode>,
+
+    has_source_backfill: bool,
+    has_snapshot_backfill: bool,
 }
 
 impl BuildFragmentGraphState {
@@ -146,7 +149,7 @@ impl GraphJobType {
 pub fn build_graph(
     plan_node: PlanRef,
     job_type: Option<GraphJobType>,
-) -> SchedulerResult<StreamFragmentGraphProto> {
+) -> Result<StreamFragmentGraphProto> {
     build_graph_with_strategy(plan_node, job_type, None)
 }
 
@@ -154,13 +157,22 @@ pub fn build_graph_with_strategy(
     plan_node: PlanRef,
     job_type: Option<GraphJobType>,
     backfill_order: Option<BackfillOrder>,
-) -> SchedulerResult<StreamFragmentGraphProto> {
+) -> Result<StreamFragmentGraphProto> {
     let ctx = plan_node.plan_base().ctx();
     let plan_node = reorganize_elements_id(plan_node);
 
     let mut state = BuildFragmentGraphState::default();
     let stream_node = plan_node.to_stream_prost(&mut state)?;
-    generate_fragment_graph(&mut state, stream_node).unwrap();
+    generate_fragment_graph(&mut state, stream_node)?;
+    if state.has_source_backfill && state.has_snapshot_backfill {
+        return Err(RwError::from(NotSupported(
+            "Snapshot backfill with shared source backfill is not supported".to_owned(),
+            "`SET streaming_use_shared_source = false` to disable shared source backfill, or \
+                    `SET streaming_use_snapshot_backfill = false` to disable snapshot backfill"
+                .to_owned(),
+        )));
+    }
+
     let mut fragment_graph = state.fragment_graph.to_protobuf();
 
     // Set table ids.
@@ -355,6 +367,7 @@ fn build_fragment(
                     StreamScanType::SnapshotBackfill => {
                         current_fragment.fragment_type_mask |=
                             FragmentTypeFlag::SnapshotBackfillStreamScan as u32;
+                        state.has_snapshot_backfill = true;
                     }
                     StreamScanType::CrossDbSnapshotBackfill => {
                         current_fragment.fragment_type_mask |=
@@ -379,6 +392,7 @@ fn build_fragment(
                 current_fragment.fragment_type_mask |= FragmentTypeFlag::StreamScan as u32;
                 // the backfill algorithm is not parallel safe
                 current_fragment.requires_singleton = true;
+                state.has_source_backfill = true;
             }
 
             NodeBody::CdcFilter(node) => {
@@ -397,6 +411,7 @@ fn build_fragment(
                 let source_id = node.upstream_source_id;
                 state.dependent_table_ids.insert(source_id.into());
                 current_fragment.upstream_table_ids.push(source_id);
+                state.has_source_backfill = true;
             }
 
             NodeBody::Now(_) => {

--- a/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
@@ -24,6 +24,7 @@ use risingwave_pb::stream_plan::{
 };
 
 use super::super::{BuildFragmentGraphState, StreamFragment, StreamFragmentEdge};
+use crate::error::ErrorCode::NotSupported;
 use crate::error::Result;
 use crate::stream_fragmenter::build_and_add_fragment;
 
@@ -358,6 +359,13 @@ pub(crate) fn build_delta_join_without_arrange(
         &node,
         false,
     )?;
+
+    if state.has_snapshot_backfill {
+        return Err(NotSupported(
+            "Delta join with snapshot backfill is not supported".to_owned(),
+            "Please use a different join strategy or disable snapshot backfill by `SET streaming_use_snapshot_backfill = false`.".to_owned(),
+        ).into());
+    }
 
     Ok(union)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

close https://github.com/risingwavelabs/risingwave/issues/22223

For job with snapshot backfill, since its checkpoint is independent to upstream, it should not have any streaming exchange with upstream. However, for delta join and shared source backfill, they must receive upstream messages from exchange channel with upstream. As a result, snapshot backfill join with delta join and shared source backfill will have the panic described in https://github.com/risingwavelabs/risingwave/issues/22223.

In this PR, we will explicitly ban snapshot backfill with delta join and shared source backfill.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
