### PR TITLE
feat(ci): support fast docker workflow in github workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: string
         default: 'unlabeled'
+      fast:
+        description: 'It will build an Arm64 image quickly, in parallel with the normal build'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_image:
@@ -46,6 +51,16 @@ jobs:
           IMAGE_TAG="v$VERSION--$LABEL--$COMMIT_SHA--$NO_SLASH_BRANCH_NAME"
           echo "IMAGE_TAG=$IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+      - name: 'Trigger Docker build fast Workflow via Buildkite'
+        if: ${{ github.event.inputs.fast }}
+        uses: buildkite/trigger-pipeline-action@v2.0.0
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          pipeline: 'risingwavelabs/fast-docker-build-arm'
+          branch: ${{ env.BRANCH_NAME }}
+          commit: HEAD
+          message: ':github: Triggering Docker build with image tag: ${{ env.IMAGE_TAG }}'
+          build_env_vars: '{ "IMAGE_TAG": "${{ env.IMAGE_TAG }}--fast" }'
       - name: 'Trigger Docker build Workflow via Buildkite'
         uses: buildkite/trigger-pipeline-action@v2.0.0
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,12 +343,6 @@ incremental = true
 split-debuginfo = "packed"
 lto = "off"
 
-# Patch profile for production clusters.
-# It will trade-off lto for faster build time.
-[profile.patch-production]
-inherits = "production"
-lto = "off"
-
 [profile.production]
 inherits = "release"
 incremental = false

--- a/ci/workflows/docker-arm-fast.yml
+++ b/ci/workflows/docker-arm-fast.yml
@@ -9,7 +9,7 @@ auto-retry: &auto-retry
 steps:
   - label: "docker-build-push: aarch64"
     if: build.env("SKIP_TARGET_AARCH64") != "true"
-    command: "CARGO_PROFILE=patch-production ci/scripts/docker.sh"
+    command: "CARGO_PROFILE=release ci/scripts/docker.sh"
     key: "build-aarch64"
     plugins:
       - seek-oss/aws-sm#v2.3.2:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

We support fast docker workflow in parallel to the current docker workflow. Just so users can quickly try out a patch. Concurrently we will build the normal image, in case there are any issues, users can switch over.

Note that this workflow only supports fast builds for `ARM64`, because we only have that architecture stack provisioned in our CI. That's mostly fine because our production deployments are typically on that arch.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
