### PR TITLE
feat(log-store): limit the max size of merged flushed chunk

### DIFF
--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -488,7 +488,8 @@ pub struct KvLogStoreFactory<S: StateStore> {
 
     vnodes: Option<Arc<Bitmap>>,
 
-    max_row_count: usize,
+    max_buffer_row_count: usize,
+    chunk_size: usize,
 
     metrics: KvLogStoreMetrics,
 
@@ -498,11 +499,13 @@ pub struct KvLogStoreFactory<S: StateStore> {
 }
 
 impl<S: StateStore> KvLogStoreFactory<S> {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         state_store: S,
         table_catalog: Table,
         vnodes: Option<Arc<Bitmap>>,
-        max_row_count: usize,
+        max_buffer_row_count: usize,
+        chunk_size: usize,
         metrics: KvLogStoreMetrics,
         identity: impl Into<String>,
         pk_info: &'static KvLogStorePkInfo,
@@ -511,7 +514,8 @@ impl<S: StateStore> KvLogStoreFactory<S> {
             state_store,
             table_catalog,
             vnodes,
-            max_row_count,
+            max_buffer_row_count,
+            chunk_size,
             metrics,
             identity: identity.into(),
             pk_info,
@@ -543,9 +547,14 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
             })
             .await;
 
-        let (tx, rx) = new_log_store_buffer(self.max_row_count, self.metrics.clone());
+        let (tx, rx) = new_log_store_buffer(
+            self.max_buffer_row_count,
+            self.chunk_size,
+            self.metrics.clone(),
+        );
 
-        let (read_state, write_state) = new_log_store_state(table_id, local_state_store, serde);
+        let (read_state, write_state) =
+            new_log_store_state(table_id, local_state_store, serde, self.chunk_size);
 
         let (init_epoch_tx, init_epoch_rx) = oneshot::channel();
         let (update_vnode_bitmap_tx, update_vnode_bitmap_rx) = unbounded_channel();
@@ -633,6 +642,7 @@ mod tests {
             table.clone(),
             Some(Arc::new(bitmap)),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -750,6 +760,7 @@ mod tests {
             table.clone(),
             Some(bitmap.clone()),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -845,6 +856,7 @@ mod tests {
             table.clone(),
             Some(bitmap),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -940,6 +952,7 @@ mod tests {
             table.clone(),
             Some(bitmap.clone()),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1061,6 +1074,7 @@ mod tests {
             table.clone(),
             Some(bitmap),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1159,6 +1173,7 @@ mod tests {
             table.clone(),
             Some(vnodes1),
             10 * TEST_DATA_SIZE,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1168,6 +1183,7 @@ mod tests {
             table.clone(),
             Some(vnodes2),
             10 * TEST_DATA_SIZE,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1305,6 +1321,7 @@ mod tests {
             table.clone(),
             Some(vnodes),
             10 * TEST_DATA_SIZE,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1376,6 +1393,7 @@ mod tests {
             table.clone(),
             Some(Arc::new(bitmap)),
             0,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1524,6 +1542,7 @@ mod tests {
             table.clone(),
             Some(bitmap.clone()),
             1024,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1642,6 +1661,7 @@ mod tests {
             table.clone(),
             Some(bitmap.clone()),
             1024,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1710,6 +1730,7 @@ mod tests {
             test_env.storage.clone(),
             table.clone(),
             Some(bitmap.clone()),
+            1024,
             1024,
             KvLogStoreMetrics::for_test(),
             "test",
@@ -1883,6 +1904,7 @@ mod tests {
             table.clone(),
             Some(bitmap.clone()),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -1970,6 +1992,7 @@ mod tests {
             table.clone(),
             Some(bitmap.clone()),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,
@@ -2042,6 +2065,7 @@ mod tests {
             table.clone(),
             Some(bitmap),
             max_row_count,
+            1024,
             KvLogStoreMetrics::for_test(),
             "test",
             pk_info,

--- a/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/reader.rs
@@ -765,12 +765,13 @@ impl<S: StateStoreRead> LogStoreReadState<S> {
             }
         }));
 
+        let chunk_size = self.chunk_size;
         streams_future.map_err(Into::into).map_ok(move |streams| {
             // TODO: set chunk size by config
             Box::pin(merge_log_store_item_stream(
                 streams,
                 serde,
-                1024,
+                chunk_size,
                 read_metrics,
             ))
         })

--- a/src/stream/src/common/log_store_impl/kv_log_store/state.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/state.rs
@@ -36,6 +36,7 @@ pub(crate) struct LogStoreReadState<S: StateStoreRead> {
     pub(super) table_id: TableId,
     pub(super) state_store: Arc<S>,
     pub(super) serde: LogStoreRowSerde,
+    pub(super) chunk_size: usize,
 }
 
 impl<S: StateStoreRead> LogStoreReadState<S> {
@@ -60,6 +61,7 @@ pub(crate) fn new_log_store_state<S: LocalStateStore>(
     table_id: TableId,
     state_store: S,
     serde: LogStoreRowSerde,
+    chunk_size: usize,
 ) -> (
     LogStoreReadState<S::FlushedSnapshotReader>,
     LogStoreWriteState<S>,
@@ -70,6 +72,7 @@ pub(crate) fn new_log_store_state<S: LocalStateStore>(
             table_id,
             state_store: Arc::new(flushed_reader),
             serde: serde.clone(),
+            chunk_size,
         },
         LogStoreWriteState {
             state_store,
@@ -330,6 +333,7 @@ mod tests {
                     })
                     .await,
                 serde.clone(),
+                1024,
             );
             write_state
                 .init(EpochPair::new_test_epoch(epoch1))

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -281,6 +281,7 @@ impl ExecutorBuilder for SinkExecutorBuilder {
                     table,
                     params.vnode_bitmap.clone().map(Arc::new),
                     65536,
+                    params.env.config().developer.chunk_size,
                     metrics,
                     log_store_identity,
                     pk_info,

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -61,7 +61,7 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
 
         let pause_duration_ms = node.pause_duration_ms as _;
         let buffer_max_size = node.buffer_size as usize;
-        let chunk_size = actor_context.streaming_config.developer.chunk_size as u32;
+        let chunk_size = actor_context.streaming_config.developer.chunk_size;
 
         let executor = SyncedKvLogStoreExecutor::new(
             actor_context,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

resolve https://github.com/risingwavelabs/risingwave/issues/22282

In log store, we have logic to merge any contiguous `Flushed` stream chunks into one, so that later we can read all rows of them together in once. However, previously we don't have a limit on the size of merged chunk yet, and they are possible to be merged into a very large chunk when there are too many data in a barrier, and we may exceed the upper bound of valid buffer size of chunk builder and panic like https://github.com/risingwavelabs/risingwave/issues/22282.

In this PR, we will use the system-wide chunk size as the max size of the merged flushed chunk, like what we do for sync log store.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
