### PR TITLE
chore(ci):  disable coverage instrument on `main-cron`

### DIFF
--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 source ci/scripts/common.sh
-export RW_BUILD_INSTRUMENT_COVERAGE=1 # enable coverage instrument
 
 while getopts 'p:' opt; do
     case ${opt} in
@@ -26,6 +25,12 @@ shift $((OPTIND -1))
 if [[ "$profile" != "ci-dev" ]] && [[ "$profile" != "ci-release" ]]; then
     echo "Invalid option: profile must be either ci-dev or ci-release" 1>&2
     exit 1
+fi
+
+# Enable coverage instrumentation only for ci-dev (PR workflow),
+# as ci-release (main-cron workflow) has heavier workload.
+if [[ "$profile" == "ci-dev" ]]; then
+    export RW_BUILD_INSTRUMENT_COVERAGE=1
 fi
 
 echo "--- Build Rust components"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

In the [latest `main-cron` run,](https://buildkite.com/risingwavelabs/main-cron/builds/5725#019788eb-8b2e-46a4-9d29-ca57e78e388e) it appears that test cases related to backfilling are much slower. This could be because it's more resource-intensive, thus significantly affected by the code coverage introduced in #22201.

Given that the results may not be accurate after code optimization, let's disable coverage instrument on `main-cron` first. Later we may investigate if it's meaningful & feasible to re-enable it.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
