### PR TITLE
perf(connector): optimize pg native sink writer with pipelining

### DIFF
--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -19,9 +19,8 @@ use async_trait::async_trait;
 use itertools::Itertools;
 use phf::phf_set;
 use risingwave_common::array::{Op, StreamChunk};
-use risingwave_common::bail;
 use risingwave_common::catalog::Schema;
-use risingwave_common::row::{Row, RowExt};
+use risingwave_common::row::Row;
 use serde_derive::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 use simd_json::prelude::ArrayTrait;
@@ -256,86 +255,17 @@ impl Sink for PostgresSink {
     }
 }
 
-struct ParameterBuffer<'a> {
-    /// A set of parameters to be inserted/deleted.
-    /// Each set is a flattened 2d-array.
-    parameters: Vec<Vec<Option<ScalarAdapter>>>,
-    /// the column dimension (fixed).
-    column_length: usize,
-    /// schema types to serialize into `ScalarAdapter`
-    schema_types: &'a [PgType],
-    /// estimated number of parameters that can be sent in a single query.
-    estimated_parameter_size: usize,
-    /// current parameter buffer to be filled.
-    current_parameter_buffer: Vec<Option<ScalarAdapter>>,
-    /// Parameter upper bound
-    parameter_upper_bound: usize,
-}
-
-impl<'a> ParameterBuffer<'a> {
-    /// The maximum number of parameters that can be sent in a single query.
-    /// See: <https://www.postgresql.org/docs/current/limits.html>
-    /// and <https://github.com/sfackler/rust-postgres/issues/356>
-    const MAX_PARAMETERS: usize = 32768;
-
-    /// `flattened_chunk_size` is the number of datums in a single chunk.
-    fn new(schema_types: &'a [PgType], parameter_upper_bound: usize) -> Self {
-        let estimated_parameter_size = usize::min(Self::MAX_PARAMETERS, parameter_upper_bound);
-        Self {
-            parameters: vec![],
-            column_length: schema_types.len(),
-            schema_types,
-            estimated_parameter_size,
-            current_parameter_buffer: Vec::with_capacity(estimated_parameter_size),
-            parameter_upper_bound,
-        }
-    }
-
-    fn add_row(&mut self, row: impl Row) {
-        assert_eq!(row.len(), self.column_length);
-        if self.current_parameter_buffer.len() + self.column_length > self.parameter_upper_bound {
-            self.new_buffer();
-        }
-        for (i, datum_ref) in row.iter().enumerate() {
-            let pg_datum = datum_ref.map(|s| {
-                let ty = &self.schema_types[i];
-                match ScalarAdapter::from_scalar(s, ty) {
-                    Ok(scalar) => Some(scalar),
-                    Err(e) => {
-                        tracing::error!(error=%e.as_report(), scalar=?s, "Failed to convert scalar to pg value");
-                        None
-                    }
-                }
-            });
-            self.current_parameter_buffer.push(pg_datum.flatten());
-        }
-    }
-
-    fn new_buffer(&mut self) {
-        let filled_buffer = std::mem::replace(
-            &mut self.current_parameter_buffer,
-            Vec::with_capacity(self.estimated_parameter_size),
-        );
-        self.parameters.push(filled_buffer);
-    }
-
-    fn into_parts(self) -> (Vec<Vec<Option<ScalarAdapter>>>, Vec<Option<ScalarAdapter>>) {
-        (self.parameters, self.current_parameter_buffer)
-    }
-}
-
 pub struct PostgresSinkWriter {
-    config: PostgresConfig,
-    pk_indices: Vec<usize>,
-    pk_indices_lookup: HashSet<usize>,
     is_append_only: bool,
     client: tokio_postgres::Client,
     pk_types: Vec<PgType>,
     schema_types: Vec<PgType>,
-    schema: Schema,
+    raw_insert_sql: String,
+    raw_upsert_sql: String,
+    raw_delete_sql: String,
     insert_sql: tokio_postgres::Statement,
-    upsert_sql: tokio_postgres::Statement,
     delete_sql: tokio_postgres::Statement,
+    upsert_sql: tokio_postgres::Statement,
 }
 
 impl PostgresSinkWriter {
@@ -394,26 +324,40 @@ impl PostgresSinkWriter {
             (pk_types, schema_types)
         };
 
-        let insert_sql = create_insert_sql(&schema, &config.schema, &config.table);
-        let upsert_sql = create_upsert_sql(&schema, &config.schema, &config.table, &pk_indices, &pk_indices_lookup);
-        let delete_sql = create_delete_sql(&schema, &config.schema, &config.table, &pk_indices);
+        let raw_insert_sql = create_insert_sql(&schema, &config.schema, &config.table);
+        let raw_upsert_sql = create_upsert_sql(
+            &schema,
+            &config.schema,
+            &config.table,
+            &pk_indices,
+            &pk_indices_lookup,
+        );
+        let raw_delete_sql = create_delete_sql(&schema, &config.schema, &config.table, &pk_indices);
 
-        let insert_sql = client.prepare(&insert_sql).await.context("failed to prepare insert statement")?;
-        let upsert_sql = client.prepare(&upsert_sql).await.context("failed to prepare upsert statement")?;
-        let delete_sql = client.prepare(&delete_sql).await.context("failed to prepare delete statement")?;
+        let insert_sql = client
+            .prepare(&raw_insert_sql)
+            .await
+            .context("failed to prepare insert statement")?;
+        let upsert_sql = client
+            .prepare(&raw_upsert_sql)
+            .await
+            .context("failed to prepare upsert statement")?;
+        let delete_sql = client
+            .prepare(&raw_delete_sql)
+            .await
+            .context("failed to prepare delete statement")?;
 
         let writer = Self {
-            config,
-            pk_indices,
-            pk_indices_lookup,
             is_append_only,
             client,
             pk_types,
             schema_types,
-            schema,
+            raw_insert_sql,
+            raw_upsert_sql,
+            raw_delete_sql,
             insert_sql,
-            upsert_sql,
             delete_sql,
+            upsert_sql,
         };
         Ok(writer)
     }
@@ -429,220 +373,62 @@ impl PostgresSinkWriter {
     }
 
     async fn write_batch_append_only(&mut self, chunk: StreamChunk) -> Result<()> {
-        // 1d flattened array of parameters to be inserted.
-        let mut parameter_buffer = ParameterBuffer::new(
-            &self.schema_types,
-            chunk.cardinality() * chunk.data_types().len(),
-        );
+        let transaction = self.client.transaction().await?;
         for (op, row) in chunk.rows() {
             match op {
                 Op::Insert => {
-                    parameter_buffer.add_row(row);
+                    let pg_row = convert_row_to_pg_row(row, &self.schema_types);
+                    transaction
+                        .execute_raw(&self.insert_sql, &pg_row)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to execute insert statement: {}, parameters: {:?}",
+                                self.raw_insert_sql, pg_row
+                            )
+                        })?;
                 }
-                Op::UpdateInsert | Op::Delete | Op::UpdateDelete => {
-                    bail!(
-                        "append-only sink should not receive update insert, update delete and delete operations"
-                    )
+                _ => {
+                    tracing::error!(
+                        "row ignored, append-only sink should not receive update insert, update delete and delete operations"
+                    );
                 }
             }
         }
-        let (parameters, remaining) = parameter_buffer.into_parts();
-
-        let mut transaction = self.client.transaction().await?;
-        Self::execute_parameter(
-            Op::Insert,
-            &mut transaction,
-            &self.schema,
-            &self.config.schema,
-            &self.config.table,
-            &self.pk_indices,
-            &self.pk_indices_lookup,
-            parameters,
-            remaining,
-            true,
-        )
-        .await?;
-        transaction.commit().await?;
-
         Ok(())
     }
 
     async fn write_batch_non_append_only(&mut self, chunk: StreamChunk) -> Result<()> {
-        // 1d flattened array of parameters to be inserted.
-        let mut insert_parameter_buffer = ParameterBuffer::new(
-            &self.schema_types,
-            // NOTE(kwannoel):
-            // insert on conflict do update may have multiple
-            // rows on the same PK.
-            // In that case they could encounter the following PG error:
-            // ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time
-            // HINT: Ensure that no rows proposed for insertion within the same command have duplicate constrained values
-            // Given that JDBC sink does not batch their insert on conflict do update,
-            // we can keep the behaviour consistent.
-            //
-            // We may opt for an optimization flag to toggle this behaviour in the future.
-            chunk.data_types().len(),
-        );
-        let mut delete_parameter_buffer =
-            ParameterBuffer::new(&self.pk_types, chunk.cardinality() * self.pk_indices.len());
-        // 1d flattened array of parameters to be deleted.
+        let transaction = self.client.transaction().await?;
         for (op, row) in chunk.rows() {
             match op {
-                Op::UpdateInsert | Op::Insert => {
-                    insert_parameter_buffer.add_row(row);
+                Op::Delete | Op::UpdateDelete => {
+                    let pg_row = convert_row_to_pg_row(row, &self.pk_types);
+                    transaction
+                        .execute_raw(&self.delete_sql, &pg_row)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to execute delete statement: {}, parameters: {:?}",
+                                self.raw_delete_sql, pg_row
+                            )
+                        })?;
                 }
-                Op::UpdateDelete | Op::Delete => {
-                    delete_parameter_buffer.add_row(row.project(&self.pk_indices));
+                Op::Insert | Op::UpdateInsert => {
+                    let pg_row = convert_row_to_pg_row(row, &self.schema_types);
+                    transaction
+                        .execute_raw(&self.upsert_sql, &pg_row)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to execute upsert statement: {}, parameters: {:?}",
+                                self.raw_upsert_sql, pg_row
+                            )
+                        })?;
                 }
             }
         }
-
-        let (delete_parameters, delete_remaining_parameter) = delete_parameter_buffer.into_parts();
-        let mut transaction = self.client.transaction().await?;
-        Self::execute_parameter(
-            Op::Delete,
-            &mut transaction,
-            &self.schema,
-            &self.config.schema,
-            &self.config.table,
-            &self.pk_indices,
-            &self.pk_indices_lookup,
-            delete_parameters,
-            delete_remaining_parameter,
-            false,
-        )
-        .await?;
-        let (insert_parameters, insert_remaining_parameter) = insert_parameter_buffer.into_parts();
-        Self::execute_parameter(
-            Op::Insert,
-            &mut transaction,
-            &self.schema,
-            &self.config.schema,
-            &self.config.table,
-            &self.pk_indices,
-            &self.pk_indices_lookup,
-            insert_parameters,
-            insert_remaining_parameter,
-            false,
-        )
-        .await?;
         transaction.commit().await?;
-
-        Ok(())
-    }
-
-    async fn execute_parameter(
-        op: Op,
-        transaction: &mut tokio_postgres::Transaction<'_>,
-        schema: &Schema,
-        schema_name: &str,
-        table_name: &str,
-        pk_indices: &[usize],
-        pk_indices_lookup: &HashSet<usize>,
-        parameters: Vec<Vec<Option<ScalarAdapter>>>,
-        remaining_parameter: Vec<Option<ScalarAdapter>>,
-        append_only: bool,
-    ) -> Result<()> {
-        async fn prepare_statement(
-            transaction: &mut tokio_postgres::Transaction<'_>,
-            op: Op,
-            schema: &Schema,
-            schema_name: &str,
-            table_name: &str,
-            pk_indices: &[usize],
-            pk_indices_lookup: &HashSet<usize>,
-            rows_length: usize,
-            append_only: bool,
-        ) -> Result<(String, tokio_postgres::Statement)> {
-            assert!(rows_length > 0, "parameters are empty");
-            let statement_str = match op {
-                Op::Insert => {
-                    if append_only {
-                        create_insert_sql(schema, schema_name, table_name, rows_length)
-                    } else {
-                        create_upsert_sql(
-                            schema,
-                            schema_name,
-                            table_name,
-                            pk_indices,
-                            pk_indices_lookup,
-                            rows_length,
-                        )
-                    }
-                }
-                Op::Delete => {
-                    create_delete_sql(schema, schema_name, table_name, pk_indices, rows_length)
-                }
-                _ => unreachable!(),
-            };
-            let statement = transaction
-                .prepare(&statement_str)
-                .await
-                .with_context(|| format!("failed to prepare statement: {}", statement_str))?;
-            Ok((statement_str, statement))
-        }
-
-        let column_length = match op {
-            Op::Insert => schema.len(),
-            Op::Delete => pk_indices.len(),
-            _ => unreachable!(),
-        };
-
-        if !parameters.is_empty() {
-            let parameter_length = parameters[0].len();
-            assert_eq!(
-                parameter_length % column_length,
-                0,
-                "flattened parameters are unaligned, parameter_length={} column_length={}",
-                parameter_length,
-                column_length,
-            );
-            let rows_length = parameter_length / column_length;
-            let (statement_str, statement) = prepare_statement(
-                transaction,
-                op,
-                schema,
-                schema_name,
-                table_name,
-                pk_indices,
-                pk_indices_lookup,
-                rows_length,
-                append_only,
-            )
-            .await?;
-            for parameter in parameters {
-                transaction
-                    .execute_raw(&statement, parameter)
-                    .await
-                    .with_context(|| format!("failed to execute statement: {}", statement_str,))?;
-            }
-        }
-        if !remaining_parameter.is_empty() {
-            let parameter_length = remaining_parameter.len();
-            assert_eq!(
-                parameter_length % column_length,
-                0,
-                "flattened parameters are unaligned"
-            );
-            let rows_length = remaining_parameter.len() / column_length;
-            let (statement_str, statement) = prepare_statement(
-                transaction,
-                op,
-                schema,
-                schema_name,
-                table_name,
-                pk_indices,
-                pk_indices_lookup,
-                rows_length,
-                append_only,
-            )
-            .await?;
-            tracing::trace!("binding parameters: {:?}", remaining_parameter);
-            transaction
-                .execute_raw(&statement, remaining_parameter)
-                .await
-                .with_context(|| format!("failed to execute statement: {}", statement_str))?;
-        }
         Ok(())
     }
 }
@@ -666,11 +452,7 @@ impl LogSinker for PostgresSinkWriter {
     }
 }
 
-fn create_insert_sql(
-    schema: &Schema,
-    schema_name: &str,
-    table_name: &str,
-) -> String {
+fn create_insert_sql(schema: &Schema, schema_name: &str, table_name: &str) -> String {
     let normalized_table_name = format!(
         "{}.{}",
         quote_identifier(schema_name),
@@ -741,6 +523,26 @@ fn quote_identifier(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace("\"", "\"\""))
 }
 
+type PgDatum = Option<ScalarAdapter>;
+type PgRow = Vec<PgDatum>;
+
+fn convert_row_to_pg_row(row: impl Row, schema_types: &[PgType]) -> PgRow {
+    let mut buffer = Vec::with_capacity(row.len());
+    for (i, datum_ref) in row.iter().enumerate() {
+        let pg_datum = datum_ref.map(|s| {
+            match ScalarAdapter::from_scalar(s, &schema_types[i]) {
+                Ok(scalar) => Some(scalar),
+                Err(e) => {
+                    tracing::error!(error=%e.as_report(), scalar=?s, "Failed to convert scalar to pg value");
+                    None
+                }
+            }
+        });
+        buffer.push(pg_datum.flatten());
+    }
+    buffer
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::Display;
@@ -770,12 +572,10 @@ mod tests {
         ]);
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_insert_sql(&schema, schema_name, table_name, 3);
+        let sql = create_insert_sql(&schema, schema_name, table_name);
         check(
             sql,
-            expect![[
-                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6)"#
-            ]],
+            expect![[r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2)"#]],
         );
     }
 
@@ -793,20 +593,16 @@ mod tests {
         ]);
         let schema_name = "test_schema";
         let table_name = "test_table";
-        let sql = create_delete_sql(&schema, schema_name, table_name, &[1], 3);
+        let sql = create_delete_sql(&schema, schema_name, table_name, &[1]);
         check(
             sql,
-            expect![[
-                r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in (($1), ($2), ($3))"#
-            ]],
+            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in ($1)"#]],
         );
         let table_name = "test_table";
-        let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1], 3);
+        let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1]);
         check(
             sql,
-            expect![[
-                r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in (($1, $2), ($3, $4), ($5, $6))"#
-            ]],
+            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in ($1, $2)"#]],
         );
     }
 
@@ -825,18 +621,11 @@ mod tests {
         let schema_name = "test_schema";
         let table_name = "test_table";
         let pk_indices_lookup = HashSet::from_iter([1]);
-        let sql = create_upsert_sql(
-            &schema,
-            schema_name,
-            table_name,
-            &[1],
-            &pk_indices_lookup,
-            3,
-        );
+        let sql = create_upsert_sql(&schema, schema_name, table_name, &[1], &pk_indices_lookup);
         check(
             sql,
             expect![[
-                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2), ($3, $4), ($5, $6) on conflict ("b") do update set "a" = EXCLUDED."a""#
+                r#"INSERT INTO "test_schema"."test_table" ("a", "b") VALUES ($1, $2) on conflict ("b") do update set "a" = EXCLUDED."a""#
             ]],
         );
     }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -647,7 +647,7 @@ mod tests {
         let sql = create_delete_sql(&schema, schema_name, table_name, &[1]);
         check(
             sql,
-            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in ($1)"#]],
+            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("b") in (($1))"#]],
         );
         let table_name = "test_table";
         let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1]);

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -539,7 +539,7 @@ fn create_delete_sql(
     let parameters: String = (0..pk_indices.len())
         .map(|i| format!("${}", i + 1))
         .join(", ");
-    format!("DELETE FROM {normalized_table_name} WHERE {pk} in ({parameters})")
+    format!("DELETE FROM {normalized_table_name} WHERE {pk} in (({parameters}))")
 }
 
 fn create_upsert_sql(
@@ -653,7 +653,7 @@ mod tests {
         let sql = create_delete_sql(&schema, schema_name, table_name, &[0, 1]);
         check(
             sql,
-            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in ($1, $2)"#]],
+            expect![[r#"DELETE FROM "test_schema"."test_table" WHERE ("a", "b") in (($1, $2))"#]],
         );
     }
 

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -398,6 +398,10 @@ impl PostgresSinkWriter {
         let upsert_sql = create_upsert_sql(&schema, &config.schema, &config.table, &pk_indices, &pk_indices_lookup);
         let delete_sql = create_delete_sql(&schema, &config.schema, &config.table, &pk_indices);
 
+        let insert_sql = client.prepare(&insert_sql).await.context("failed to prepare insert statement")?;
+        let upsert_sql = client.prepare(&upsert_sql).await.context("failed to prepare upsert statement")?;
+        let delete_sql = client.prepare(&delete_sql).await.context("failed to prepare delete statement")?;
+
         let writer = Self {
             config,
             pk_indices,
@@ -407,7 +411,9 @@ impl PostgresSinkWriter {
             pk_types,
             schema_types,
             schema,
-
+            insert_sql,
+            upsert_sql,
+            delete_sql,
         };
         Ok(writer)
     }

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use futures::StreamExt;
 use futures::stream::FuturesOrdered;
-use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use phf::phf_set;
 use risingwave_common::array::{Op, StreamChunk};
@@ -422,7 +422,8 @@ impl PostgresSinkWriter {
 
     async fn write_batch_non_append_only(&mut self, chunk: StreamChunk) -> Result<()> {
         let transaction = Arc::new(self.client.transaction().await?);
-        let mut futures = FuturesOrdered::new();
+        let mut delete_futures = FuturesOrdered::new();
+        let mut upsert_futures = FuturesOrdered::new();
         for (op, row) in chunk.rows() {
             match op {
                 Op::Delete | Op::UpdateDelete => {
@@ -442,7 +443,7 @@ impl PostgresSinkWriter {
                                 )
                             })
                     };
-                    futures.push_back(future.boxed());
+                    delete_futures.push_back(future);
                 }
                 Op::Insert | Op::UpdateInsert => {
                     let pg_row = convert_row_to_pg_row(row, &self.schema_types);
@@ -460,11 +461,14 @@ impl PostgresSinkWriter {
                                 )
                             })
                     };
-                    futures.push_back(future.boxed());
+                    upsert_futures.push_back(future);
                 }
             }
         }
-        while let Some(result) = futures.next().await {
+        while let Some(result) = delete_futures.next().await {
+            result?;
+        }
+        while let Some(result) = upsert_futures.next().await {
             result?;
         }
         if let Some(transaction) = Arc::into_inner(transaction) {


### PR DESCRIPTION
 I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?
[
We add pipelining in this PR](https://www.postgresql.org/docs/current/libpq-pipeline-mode.html), which can be simply done by concurrently executing a series of futures.

This also removes complicated logic around parameter batching, just do query pipelining.

These fixes are done for PG rust sink.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.