### PR TITLE
fix(connector): jdbc pg should use `NO_GENERATED_KEYS` instead of `SUCCESS_NO_INFO`

### DIFF
--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSink.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSink.java
@@ -259,15 +259,17 @@ public class JDBCSink implements SinkWriter {
                 }
 
                 this.upsertStatement =
-                        conn.prepareStatement(upsertSql.get(), Statement.SUCCESS_NO_INFO);
+                        conn.prepareStatement(upsertSql.get(), Statement.NO_GENERATED_KEYS);
                 // upsert sink will handle DELETE events
                 var deleteSql = jdbcDialect.getDeleteStatement(schemaTableName, pkColumnNames);
-                this.deleteStatement = conn.prepareStatement(deleteSql, Statement.SUCCESS_NO_INFO);
+                this.deleteStatement =
+                        conn.prepareStatement(deleteSql, Statement.NO_GENERATED_KEYS);
             } else {
                 var insertSql =
                         jdbcDialect.getInsertIntoStatement(
                                 schemaTableName, List.of(tableSchema.getColumnNames()));
-                this.insertStatement = conn.prepareStatement(insertSql, Statement.SUCCESS_NO_INFO);
+                this.insertStatement =
+                        conn.prepareStatement(insertSql, Statement.NO_GENERATED_KEYS);
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

`SUCCESS_NO_INFO` is a returned status from calling `executeBatch`, it's not a configuration parameter.
<img width="1453" alt="Screenshot 2025-06-21 at 11 58 19 AM" src="https://github.com/user-attachments/assets/604663cf-a305-4ca7-8989-0f78a94e4014" />

On the other hand, `NO_GENERATED_KEYS` is the correct configuration parameter:
<img width="1453" alt="Screenshot 2025-06-21 at 11 56 29 AM" src="https://github.com/user-attachments/assets/226702a8-6076-4fec-81b0-ea4c5d683dd8" />

[docs](https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/Connection.html#prepareStatement(java.lang.String,int))

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
