### PR TITLE
feat: add `allow_create_stream` to avoid create nats stream by mistake

### DIFF
--- a/e2e_test/source_inline/nats/test.slt.serial
+++ b/e2e_test/source_inline/nats/test.slt.serial
@@ -3,6 +3,18 @@ control substitution on
 statement ok
 set streaming_use_shared_source to false;
 
+statement error set `allow_create_stream` to true to create a stream
+create table t_nats ( i int ) with (
+  connector = 'nats',
+  server_url='nats-server:4222',
+  subject='testsubject',
+  connect_mode='plain',
+  consumer.durable_name = 'demo1',
+  consumer.ack_policy = 'all',
+  stream='teststream',
+  consumer.max_ack_pending = '100000')
+format plain encode json;
+
 system ok
 python3 e2e_test/source_inline/nats/operation.py create_stream "teststream" "testsubject"
 

--- a/integration_tests/nats/README.md
+++ b/integration_tests/nats/README.md
@@ -49,6 +49,7 @@ WITH
     server_url = 'nats-server:4222',
     subject = 'subject1',
     stream = 'my_stream',
+    allow_create_stream = 'true',
     connect_mode = 'plain'
   ) FORMAT PLAIN ENCODE JSON;
 ```

--- a/integration_tests/nats/create_sink.sql
+++ b/integration_tests/nats/create_sink.sql
@@ -13,6 +13,7 @@ WITH
     server_url = 'nats-server:4222',
     subject = 'subject1',
     type = 'append-only',
+    allow_create_stream = 'true',
     force_append_only = 'true',
     connect_mode = 'plain'
   );
@@ -41,6 +42,7 @@ WITH
     connector = 'nats',
     server_url = 'nats-server:4222',
     subject = 'subject2',
+    allow_create_stream = 'true',
     type = 'append-only',
     force_append_only = 'true',
     connect_mode = 'plain'

--- a/integration_tests/nats/create_source.sql
+++ b/integration_tests/nats/create_source.sql
@@ -20,6 +20,7 @@ WITH
     connector = 'nats',
     server_url = 'nats-server:4222',
     subject = 'live_stream_metrics',
+    allow_create_stream = 'true',
     stream = 'risingwave',
     connect_mode = 'plain'
   ) FORMAT PLAIN ENCODE JSON;

--- a/integration_tests/nats/pb/create_source.sql
+++ b/integration_tests/nats/pb/create_source.sql
@@ -5,6 +5,7 @@ WITH
     server_url = 'nats-server:4222',
     subject = 'live_stream_metrics',
     stream = 'risingwave',
+    allow_create_stream = 'true',
     connect_mode = 'plain'
   ) FORMAT PLAIN ENCODE PROTOBUF (
     message = 'livestream.schema.LiveStreamMetrics',

--- a/src/connector/src/connector_common/common.rs
+++ b/src/connector/src/connector_common/common.rs
@@ -956,6 +956,9 @@ impl NatsCommon {
         stream_str: String,
     ) -> ConnectorResult<jetstream::stream::Stream> {
         let subjects: Vec<String> = self.subject.split(',').map(|s| s.to_owned()).collect();
+
+        // In `SourceEnumerator`, we may create a stream
+        // In `SourceReader`, the desired stream MUST exist
         if let Ok(mut stream_instance) = jetstream.get_stream(&stream_str).await {
             tracing::info!(
                 "load existing nats stream ({:?}) with config {:?}",

--- a/src/connector/src/source/nats/enumerator/mod.rs
+++ b/src/connector/src/source/nats/enumerator/mod.rs
@@ -43,7 +43,10 @@ impl SplitEnumerator for NatsSplitEnumerator {
 
         // check if the stream exists or allow create stream
         let jetstream = properties.common.build_context().await?;
-        let _ = properties.common.build_or_get_stream(jetstream, properties.stream.clone()).await?;
+        let _ = properties
+            .common
+            .build_or_get_stream(jetstream, properties.stream.clone())
+            .await?;
         Ok(Self {
             subject: properties.common.subject,
             split_id: Arc::from("0"),

--- a/src/connector/src/source/nats/enumerator/mod.rs
+++ b/src/connector/src/source/nats/enumerator/mod.rs
@@ -40,6 +40,10 @@ impl SplitEnumerator for NatsSplitEnumerator {
         _context: SourceEnumeratorContextRef,
     ) -> ConnectorResult<NatsSplitEnumerator> {
         let client = properties.common.build_client().await?;
+
+        // check if the stream exists or allow create stream
+        let jetstream = properties.common.build_context().await?;
+        let _ = properties.common.build_or_get_stream(jetstream, properties.stream.clone()).await?;
         Ok(Self {
             subject: properties.common.subject,
             split_id: Arc::from("0"),

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -1067,6 +1067,10 @@ NatsConfig:
   - name: max_message_size
     field_type: i32
     required: false
+  - name: allow_create_stream
+    field_type: bool
+    required: false
+    default: Default::default
   - name: r#type
     field_type: String
     required: true

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -689,6 +689,10 @@ NatsProperties:
   - name: max_message_size
     field_type: i32
     required: false
+  - name: allow_create_stream
+    field_type: bool
+    required: false
+    default: Default::default
   - name: consumer.deliver_subject
     field_type: String
     required: false


### PR DESCRIPTION

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

resolve https://github.com/risingwavelabs/risingwave/issues/21797

per request by poc user

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

### Problem

The NATS connector currently creates streams automatically when they don't exist, which can lead to unintended stream creation in production environments. This poses security and operational risks:
Streams may be created with default configurations that don't match production requirements
Typos in stream names could result in unwanted streams being created
No explicit control over when RisingWave should have stream creation permissions

### Solution

This PR introduces a new boolean configuration parameter allow_create_stream that provides explicit control over stream creation behavior:
Default: allow_create_stream = false - RisingWave will NOT create streams automatically
Explicit permission: Users must set allow_create_stream = true to enable stream creation
Clear error messaging: When a stream doesn't exist and creation is disabled, users get a helpful error message

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
