### PR TITLE
feat: introduce rwadmin user for cloud control plane

### DIFF
--- a/e2e_test/ddl/user.slt
+++ b/e2e_test/ddl/user.slt
@@ -26,6 +26,15 @@ DROP USER ddl_user;
 statement ok
 DROP USER IF EXISTS ddl_user;
 
+statement error Permission denied
+ALTER USER rwadmin RENAME TO rwa;
+
+statement error Permission denied
+ALTER USER rwadmin WITH NOLOGIN NOSUPERUSER;
+
+statement error Permission denied
+ALTER USER rwadmin WITH PASSWORD '';
+
 # Test quoting
 statement ok
 CREATE USER "n-m";

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -64,6 +64,10 @@ pub const DEFAULT_SUPER_USER_ID: u32 = 1;
 pub const DEFAULT_SUPER_USER_FOR_PG: &str = "postgres";
 pub const DEFAULT_SUPER_USER_FOR_PG_ID: u32 = 2;
 
+// This is the default superuser for admin, which is used only for cloud control plane.
+pub const DEFAULT_SUPER_USER_FOR_ADMIN: &str = "rwadmin";
+pub const DEFAULT_SUPER_USER_FOR_ADMIN_ID: u32 = 3;
+
 pub const NON_RESERVED_USER_ID: i32 = 11;
 
 pub const MAX_SYS_CATALOG_NUM: i32 = 5000;
@@ -82,7 +86,7 @@ pub fn is_system_schema(schema_name: &str) -> bool {
 
 pub const RW_RESERVED_COLUMN_NAME_PREFIX: &str = "_rw_";
 
-/// When there is no primary key specified while creating source, will use the
+/// When there is no primary key specified while creating source, will use
 /// the message key as primary key in `BYTEA` type with this name.
 /// Note: the field has version to track, please refer to [`default_key_column_name_version_mapping`]
 pub const DEFAULT_KEY_COLUMN_NAME: &str = "_rw_key";

--- a/src/frontend/src/handler/alter_user.rs
+++ b/src/frontend/src/handler/alter_user.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use pgwire::pg_response::StatementType;
+use risingwave_common::catalog::DEFAULT_SUPER_USER_FOR_ADMIN;
 use risingwave_pb::user::UserInfo;
 use risingwave_pb::user::update_user_request::UpdateField;
 use risingwave_sqlparser::ast::{AlterUserStatement, ObjectName, UserOption, UserOptions};
@@ -33,6 +34,21 @@ fn alter_prost_user_info(
     options: &UserOptions,
     session_user: &UserCatalog,
 ) -> Result<(UserInfo, Vec<UpdateField>, Option<String>)> {
+    let change_self_password_only = session_user.id == user_info.id
+        && options.0.len() == 1
+        && matches!(
+            &options.0[0],
+            UserOption::EncryptedPassword(_) | UserOption::Password(_) | UserOption::OAuth(_)
+        );
+
+    if !change_self_password_only && user_info.name == DEFAULT_SUPER_USER_FOR_ADMIN {
+        // The admin superuser cannot be altered except for changing its password by itself.
+        return Err(PermissionDenied(
+            format!("{} cannot be altered", DEFAULT_SUPER_USER_FOR_ADMIN).to_owned(),
+        )
+        .into());
+    }
+
     if !session_user.is_super {
         let require_super = user_info.is_super
             || options
@@ -46,14 +62,7 @@ fn alter_prost_user_info(
             )
             .into());
         }
-
-        let change_self_password = session_user.id == user_info.id
-            && options.0.len() == 1
-            && matches!(
-                &options.0[0],
-                UserOption::EncryptedPassword(_) | UserOption::Password(_)
-            );
-        if !session_user.can_create_user && !change_self_password {
+        if !session_user.can_create_user && !change_self_password_only {
             return Err(PermissionDenied("permission denied to alter user".to_owned()).into());
         }
     }
@@ -144,7 +153,21 @@ fn alter_rename_prost_user_info(
         return Err(PermissionDenied("must be superuser to rename users".to_owned()).into());
     }
 
-    user_info.name = Binder::resolve_user_name(new_name)?;
+    let new_name = Binder::resolve_user_name(new_name)?;
+    if new_name == DEFAULT_SUPER_USER_FOR_ADMIN {
+        return Err(PermissionDenied(
+            format!("{} is reserved for admin", DEFAULT_SUPER_USER_FOR_ADMIN).to_owned(),
+        )
+        .into());
+    }
+    if user_info.name == DEFAULT_SUPER_USER_FOR_ADMIN {
+        return Err(PermissionDenied(
+            format!("{} cannot be renamed", DEFAULT_SUPER_USER_FOR_ADMIN).to_owned(),
+        )
+        .into());
+    }
+
+    user_info.name = new_name;
     user_info.auth_info = None;
     Ok((user_info, vec![UpdateField::Rename, UpdateField::AuthInfo]))
 }

--- a/src/frontend/src/handler/drop_user.rs
+++ b/src/frontend/src/handler/drop_user.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_common::catalog::DEFAULT_SUPER_USER_FOR_ADMIN;
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
@@ -40,6 +41,12 @@ pub async fn handle_drop_user(
                 return Err(ErrorCode::PermissionDenied(
                     "current user cannot be dropped".to_owned(),
                 )
+                .into());
+            }
+            if user_name == DEFAULT_SUPER_USER_FOR_ADMIN {
+                return Err(ErrorCode::PermissionDenied(format!(
+                    "cannot drop the admin superuser \"{user_name}\""
+                ))
                 .into());
             }
             if let Some(current_user) = user_info_reader

--- a/src/meta/model/migration/src/m20230908_072257_init.rs
+++ b/src/meta/model/migration/src/m20230908_072257_init.rs
@@ -931,6 +931,14 @@ impl MigrationTrait for Migration {
                 true.into(),
                 true.into(),
             ])
+            .values_panic([
+                3.into(),
+                "rwadmin".into(),
+                true.into(),
+                true.into(),
+                true.into(),
+                true.into(),
+            ])
             .to_owned();
 
         // Since User table is newly created, we assume that the initial user id of `root` is 1 and `postgres` is 2.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Related #22260 . In this PR, we introduced a new initial super user `rwadmin`, dedicated solely to the cloud control plane. This user cannot be altered or dropped, except for password changes made by the user itself. Note that:
1. For newly initialized clusters, `rwadmin` will be created automatically together with default superusers `root` and `postgres`. 
2. For existing clusters, to ensure security (mainly for non-cloud clusters), `rwadmin` is not automatically created, but we can still use other superusers to create it. Following that, the cloud control plane can utilize it for login and periodically update its password. Cc @wjf3121 

Additionally, I think that in the official quick start documentation, a security reminder should be added that when using RisingWave in a prod environment, the default superusers' password should be changed. @hengm3467 

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
