### PR TITLE
feat(optimizer): push topn to scan when there is an index

### DIFF
--- a/src/frontend/src/optimizer/logical_optimization.rs
+++ b/src/frontend/src/optimizer/logical_optimization.rs
@@ -842,7 +842,7 @@ impl LogicalOptimizer {
         plan = plan.optimize_by_rules(&COMMON_SUB_EXPR_EXTRACT)?;
 
         plan = plan.optimize_by_rules(&PULL_UP_HOP)?;
-        
+
         tracing::info!("Before top-n push down, plan: {}", plan.explain_to_string());
 
         plan = plan.optimize_by_rules(&TOP_N_PUSH_DOWN)?;
@@ -850,7 +850,10 @@ impl LogicalOptimizer {
 
         plan = plan.optimize_by_rules(&TOP_N_AGG_ON_INDEX)?;
 
-        tracing::info!("After topn agg on index, plan: {}", plan.explain_to_string());
+        tracing::info!(
+            "After topn agg on index, plan: {}",
+            plan.explain_to_string()
+        );
 
         plan = plan.optimize_by_rules(&LIMIT_PUSH_DOWN)?;
 

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -180,11 +180,7 @@ impl LogicalTopN {
         core.into()
     }
 
-    pub fn clone_with_input_and_order(
-        &self,
-        input: PlanRef,
-        order: Order,
-    ) -> Self {
+    pub fn clone_with_input_and_order(&self, input: PlanRef, order: Order) -> Self {
         let mut core = self.core.clone();
         core.input = input;
         core.order = order;

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -179,6 +179,17 @@ impl LogicalTopN {
         core.order = prefix.concat(core.order);
         core.into()
     }
+
+    pub fn clone_with_input_and_order(
+        &self,
+        input: PlanRef,
+        order: Order,
+    ) -> Self {
+        let mut core = self.core.clone();
+        core.input = input;
+        core.order = order;
+        core.into()
+    }
 }
 
 impl PlanTreeNodeUnary for LogicalTopN {

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -172,6 +172,8 @@ mod apply_share_eliminate_rule;
 pub use apply_share_eliminate_rule::*;
 mod top_n_on_index_rule;
 pub use top_n_on_index_rule::*;
+mod top_n_push_down_rule;
+pub use top_n_push_down_rule::*;
 mod stream;
 pub use stream::bushy_tree_join_ordering_rule::*;
 pub use stream::filter_with_now_to_join_rule::*;
@@ -350,6 +352,7 @@ macro_rules! for_all_rules {
             , { SourceToIcebergScanRule }
             , { AddLogstoreRule }
             , { EmptyAggRemoveRule }
+            , { TopNPushDownRule }
         }
     };
 }

--- a/src/frontend/src/optimizer/rule/top_n_push_down_rule.rs
+++ b/src/frontend/src/optimizer/rule/top_n_push_down_rule.rs
@@ -15,31 +15,28 @@
 use itertools::Itertools;
 
 use super::{BoxedRule, Rule};
-use crate::{expr::ExprImpl, optimizer::{plan_node::PlanTreeNodeUnary, PlanRef}};
+use crate::expr::ExprImpl;
+use crate::optimizer::PlanRef;
+use crate::optimizer::plan_node::PlanTreeNodeUnary;
 
 pub struct TopNPushDownRule {}
 
 impl Rule for TopNPushDownRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
-        // 只匹配 LogicalTopN
         let top_n = plan.as_logical_top_n()?;
 
-        // 1. offset != 0 时，不下推
         if top_n.offset() != 0 {
             return Some(plan);
         }
 
-        // 2. 没有排序列时，不下推
         let col_orders = &top_n.topn_order().column_orders;
         if col_orders.is_empty() {
             return Some(plan);
         }
 
-        // 3. 必须是 Project 的输入
         let project_input = top_n.input();
         let project = project_input.as_logical_project()?;
 
-        // 4. 如果 Project 中有不支持下推的表达式，也不下推
         for expr in project.exprs() {
             if expr.has_agg_call()
                 || expr.has_subquery()
@@ -53,40 +50,37 @@ impl Rule for TopNPushDownRule {
             }
         }
 
-        // 5. 排序列必须映射到 Project 输出的 InputRef
         let can_pushdown = col_orders.iter().all(|field_order| {
-            matches!(&project.exprs()[field_order.column_index], ExprImpl::InputRef(_))
+            matches!(
+                &project.exprs()[field_order.column_index],
+                ExprImpl::InputRef(_)
+            )
         });
         if !can_pushdown {
             return Some(plan);
         }
 
-        // 6. 构造新的 TopN：下推到 Project 的输入
         let new_orders = top_n
             .topn_order()
-            .clone() // 先 clone 一个 Order
+            .clone()
             .column_orders
             .into_iter()
-            .map(|mut fo| {
-                // fo.column_index 是 Project 输出的下标
-                if let ExprImpl::InputRef(ir) = &project.exprs()[fo.column_index] {
-                    fo.column_index = ir.index as usize; // 替换成 Scan 输出的下标
+            .map(|mut o| {
+                if let ExprImpl::InputRef(input_ref) = &project.exprs()[o.column_index] {
+                    o.column_index = input_ref.index as usize;
                 } else {
                     unreachable!("we only push down when expr is InputRef");
                 }
-                fo
+                o
             })
             .collect_vec();
 
-        // 2. 构造新的 Order
         let mut new_topn_order = top_n.topn_order().clone();
         new_topn_order.column_orders = new_orders;
 
-        // 3. 用 project.input()（底层输入）构造新的 TopN
         let input = project.input().clone();
         let new_topn = top_n.clone_with_input_and_order(input, new_topn_order);
 
-        // 4. 将新的 TopN 插回 Project 上层
         Some(project.clone_with_input(new_topn.into()).into())
     }
 }

--- a/src/frontend/src/optimizer/rule/top_n_push_down_rule.rs
+++ b/src/frontend/src/optimizer/rule/top_n_push_down_rule.rs
@@ -1,0 +1,98 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+
+use super::{BoxedRule, Rule};
+use crate::{expr::ExprImpl, optimizer::{plan_node::PlanTreeNodeUnary, PlanRef}};
+
+pub struct TopNPushDownRule {}
+
+impl Rule for TopNPushDownRule {
+    fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
+        // 只匹配 LogicalTopN
+        let top_n = plan.as_logical_top_n()?;
+
+        // 1. offset != 0 时，不下推
+        if top_n.offset() != 0 {
+            return Some(plan);
+        }
+
+        // 2. 没有排序列时，不下推
+        let col_orders = &top_n.topn_order().column_orders;
+        if col_orders.is_empty() {
+            return Some(plan);
+        }
+
+        // 3. 必须是 Project 的输入
+        let project_input = top_n.input();
+        let project = project_input.as_logical_project()?;
+
+        // 4. 如果 Project 中有不支持下推的表达式，也不下推
+        for expr in project.exprs() {
+            if expr.has_agg_call()
+                || expr.has_subquery()
+                || expr.has_user_defined_function()
+                || expr.has_window_function()
+                || expr.has_table_function()
+                || expr.has_now()
+                || expr.is_parameter()
+            {
+                return Some(plan);
+            }
+        }
+
+        // 5. 排序列必须映射到 Project 输出的 InputRef
+        let can_pushdown = col_orders.iter().all(|field_order| {
+            matches!(&project.exprs()[field_order.column_index], ExprImpl::InputRef(_))
+        });
+        if !can_pushdown {
+            return Some(plan);
+        }
+
+        // 6. 构造新的 TopN：下推到 Project 的输入
+        let new_orders = top_n
+            .topn_order()
+            .clone() // 先 clone 一个 Order
+            .column_orders
+            .into_iter()
+            .map(|mut fo| {
+                // fo.column_index 是 Project 输出的下标
+                if let ExprImpl::InputRef(ir) = &project.exprs()[fo.column_index] {
+                    fo.column_index = ir.index as usize; // 替换成 Scan 输出的下标
+                } else {
+                    unreachable!("we only push down when expr is InputRef");
+                }
+                fo
+            })
+            .collect_vec();
+
+        // 2. 构造新的 Order
+        let mut new_topn_order = top_n.topn_order().clone();
+        new_topn_order.column_orders = new_orders;
+
+        // 3. 用 project.input()（底层输入）构造新的 TopN
+        let input = project.input().clone();
+        let new_topn = top_n.clone_with_input_and_order(input, new_topn_order);
+
+        // 4. 将新的 TopN 插回 Project 上层
+        Some(project.clone_with_input(new_topn.into()).into())
+    }
+}
+
+impl TopNPushDownRule {
+    pub fn create() -> BoxedRule {
+        Box::new(TopNPushDownRule {})
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
close https://github.com/risingwavelabs/risingwave/issues/21342
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
