### PR TITLE
feat(storage): batch add flushed imm to uploader

### DIFF
--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -34,7 +34,7 @@ use risingwave_storage::hummock::iterator::test_utils::{
 };
 use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use risingwave_storage::hummock::store::version::{
-    HummockReadVersion, StagingData, StagingSstableInfo, VersionUpdate, read_filter_for_version,
+    HummockReadVersion, StagingSstableInfo, VersionUpdate, read_filter_for_version,
 };
 use risingwave_storage::hummock::test_utils::*;
 
@@ -69,7 +69,7 @@ async fn test_read_version_basic() {
             TableId::from(table_id),
         );
 
-        read_version.update(VersionUpdate::Staging(StagingData::ImmMem(imm)));
+        read_version.add_imm(imm);
 
         let key = iterator_test_table_key_of(1_usize);
         let key_range = map_table_key_range((
@@ -103,7 +103,8 @@ async fn test_read_version_basic() {
                 TableId::from(table_id),
             );
 
-            read_version.update(VersionUpdate::Staging(StagingData::ImmMem(imm)));
+            read_version.add_imm(imm);
+            let _ = read_version.start_upload_pending_imms();
         }
 
         for e in 1..6 {
@@ -129,9 +130,10 @@ async fn test_read_version_basic() {
     {
         // test clean imm with sst update info
         let staging = read_version.staging();
-        assert_eq!(6, staging.imm.len());
+        assert!(staging.pending_imms.is_empty());
+        assert_eq!(6, staging.uploading_imms.len());
         let batch_id_vec_for_clear = staging
-            .imm
+            .uploading_imms
             .iter()
             .rev()
             .map(|imm| imm.batch_id())
@@ -140,7 +142,7 @@ async fn test_read_version_basic() {
             .collect::<Vec<_>>();
 
         let epoch_id_vec_for_clear = staging
-            .imm
+            .uploading_imms
             .iter()
             .rev()
             .map(|imm| imm.min_epoch())
@@ -214,7 +216,7 @@ async fn test_read_version_basic() {
         ));
 
         {
-            read_version.update(VersionUpdate::Staging(StagingData::Sst(dummy_sst)));
+            read_version.update(VersionUpdate::Sst(dummy_sst));
         }
     }
 
@@ -225,11 +227,12 @@ async fn test_read_version_basic() {
         // imm(0, 1, 2) => sst{sst_object_id: 1}
         // staging => {imm(3, 4, 5), sst[{sst_object_id: 1}, {sst_object_id: 2}]}
         let staging = read_version.staging();
-        assert_eq!(3, read_version.staging().imm.len());
+        assert!(read_version.staging().pending_imms.is_empty());
+        assert_eq!(3, read_version.staging().uploading_imms.len());
         assert_eq!(1, read_version.staging().sst.len());
         assert_eq!(2, read_version.staging().sst[0].sstable_infos().len());
         let remain_batch_id_vec = staging
-            .imm
+            .uploading_imms
             .iter()
             .map(|imm| imm.batch_id())
             .collect::<Vec<_>>();
@@ -315,9 +318,7 @@ async fn test_read_filter_basic() {
             TableId::from(table_id),
         );
 
-        read_version
-            .write()
-            .update(VersionUpdate::Staging(StagingData::ImmMem(imm)));
+        read_version.write().add_imm(imm);
 
         // directly prune_overlap
         let key = Bytes::from(iterator_test_table_key_of(epoch as usize));

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -524,7 +524,7 @@ async fn test_state_store_sync() {
     {
         // after sync 1 epoch
         let read_version = hummock_storage.read_version();
-        assert_eq!(1, read_version.read().staging().imm.len());
+        assert_eq!(1, read_version.read().staging().uploading_imms.len());
         assert!(read_version.read().staging().sst.is_empty());
     }
 
@@ -570,7 +570,7 @@ async fn test_state_store_sync() {
     {
         // after sync all epoch
         let read_version = hummock_storage.read_version();
-        assert!(read_version.read().staging().imm.is_empty());
+        assert!(read_version.read().staging().uploading_imms.is_empty());
         assert!(read_version.read().staging().sst.is_empty());
     }
 

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -1462,6 +1462,7 @@ async fn test_iter_log() {
             table_option: Default::default(),
             is_replicated: false,
             vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
+            upload_on_flush: true,
         })
         .await;
 
@@ -1477,6 +1478,7 @@ async fn test_iter_log() {
             table_option: Default::default(),
             is_replicated: false,
             vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
+            upload_on_flush: true,
         })
         .await;
     // flush for about 10 times per epoch
@@ -1602,6 +1604,7 @@ async fn test_read_log_next_epoch() {
             table_option: Default::default(),
             is_replicated: false,
             vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
+            upload_on_flush: true,
         })
         .await;
     // flush for about 10 times per epoch

--- a/src/storage/hummock_trace/src/opts.rs
+++ b/src/storage/hummock_trace/src/opts.rs
@@ -162,6 +162,7 @@ pub struct TracedNewLocalOptions {
     pub table_option: TracedTableOption,
     pub is_replicated: bool,
     pub vnodes: TracedBitmap,
+    pub upload_on_flush: bool,
 }
 
 #[derive(Encode, Decode, PartialEq, Debug, Clone)]
@@ -182,6 +183,7 @@ impl TracedNewLocalOptions {
             },
             is_replicated: false,
             vnodes: TracedBitmap::from(Bitmap::ones(VirtualNode::COUNT_FOR_TEST)),
+            upload_on_flush: true,
         }
     }
 }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -51,9 +51,7 @@ use crate::hummock::event_handler::{
 };
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::local_version::recent_versions::RecentVersions;
-use crate::hummock::store::version::{
-    HummockReadVersion, StagingData, StagingSstableInfo, VersionUpdate,
-};
+use crate::hummock::store::version::{HummockReadVersion, StagingSstableInfo, VersionUpdate};
 use crate::hummock::{HummockResult, MemoryLimiter, ObjectIdManager, SstableStoreRef};
 use crate::mem_table::ImmutableMemtable;
 use crate::monitor::HummockStateStoreMetrics;
@@ -458,11 +456,7 @@ impl HummockEventHandler {
         trace!("data_flushed. SST size {}", staging_sstable_info.imm_size());
         self.for_each_read_version(
             staging_sstable_info.imm_ids().keys().cloned(),
-            |_, read_version| {
-                read_version.update(VersionUpdate::Staging(StagingData::Sst(
-                    staging_sstable_info.clone(),
-                )))
-            },
+            |_, read_version| read_version.update(VersionUpdate::Sst(staging_sstable_info.clone())),
         )
     }
 
@@ -693,14 +687,14 @@ impl HummockEventHandler {
                 self.uploader
                     .init_instance(instance_id, table_id, init_epoch);
             }
-            HummockEvent::ImmToUploader { instance_id, imm } => {
+            HummockEvent::ImmToUploader { instance_id, imms } => {
                 assert!(
                     self.local_read_version_mapping.contains_key(&instance_id),
-                    "add imm from non-existing read version instance: instance_id: {}, table_id {}",
+                    "add imm from non-existing read version instance: instance_id: {}, table_id {:?}",
                     instance_id,
-                    imm.table_id,
+                    imms.first().map(|imm| imm.table_id),
                 );
-                self.uploader.add_imm(instance_id, imm);
+                self.uploader.add_imms(instance_id, imms);
                 self.uploader.may_flush();
             }
 
@@ -898,7 +892,6 @@ mod tests {
     use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::local_version::pinned_version::PinnedVersion;
     use crate::hummock::local_version::recent_versions::RecentVersions;
-    use crate::hummock::store::version::{StagingData, VersionUpdate};
     use crate::hummock::test_utils::default_opts_for_test;
     use crate::mem_table::ImmutableMemtable;
     use crate::monitor::HummockStateStoreMetrics;
@@ -995,13 +988,11 @@ mod tests {
         });
 
         let imm1 = gen_imm(epoch1).await;
-        read_version
-            .write()
-            .update(VersionUpdate::Staging(StagingData::ImmMem(imm1.clone())));
+        read_version.write().add_imm(imm1.clone());
 
         send_event(HummockEvent::ImmToUploader {
             instance_id: guard.instance_id,
-            imm: imm1,
+            imms: vec![imm1],
         });
 
         send_event(HummockEvent::StartEpoch {
@@ -1015,15 +1006,16 @@ mod tests {
             opts: SealCurrentEpochOptions::for_test(),
         });
 
-        let imm2 = gen_imm(epoch2).await;
-        read_version
-            .write()
-            .update(VersionUpdate::Staging(StagingData::ImmMem(imm2.clone())));
+        {
+            let imm2 = gen_imm(epoch2).await;
+            let mut read_version = read_version.write();
+            read_version.add_imm(imm2);
 
-        send_event(HummockEvent::ImmToUploader {
-            instance_id: guard.instance_id,
-            imm: imm2,
-        });
+            send_event(HummockEvent::ImmToUploader {
+                instance_id: guard.instance_id,
+                imms: read_version.start_upload_pending_imms(),
+            });
+        }
 
         let epoch3 = epoch2.next_epoch();
         send_event(HummockEvent::StartEpoch {
@@ -1148,13 +1140,12 @@ mod tests {
         let write_imm = |read_version: &HummockReadVersionRef,
                          instance: &LocalInstanceGuard,
                          imm: &ImmutableMemtable| {
-            read_version
-                .write()
-                .update(VersionUpdate::Staging(StagingData::ImmMem(imm.clone())));
+            let mut read_version = read_version.write();
+            read_version.add_imm(imm.clone());
 
             send_event(HummockEvent::ImmToUploader {
                 instance_id: instance.instance_id,
-                imm: imm.clone(),
+                imms: read_version.start_upload_pending_imms(),
             });
         };
         let seal_epoch = |instance: &LocalInstanceGuard, next_epoch| {

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -992,7 +992,7 @@ mod tests {
 
         send_event(HummockEvent::ImmToUploader {
             instance_id: guard.instance_id,
-            imms: vec![imm1],
+            imms: read_version.write().start_upload_pending_imms(),
         });
 
         send_event(HummockEvent::StartEpoch {

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use itertools::Itertools;
 use parking_lot::{RwLock, RwLockReadGuard};
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::TableId;
@@ -70,7 +71,7 @@ pub enum HummockEvent {
 
     ImmToUploader {
         instance_id: SharedBufferBatchId,
-        imm: ImmutableMemtable,
+        imms: Vec<ImmutableMemtable>,
     },
 
     StartEpoch {
@@ -137,8 +138,12 @@ impl HummockEvent {
                 format!("InitEpoch {} {}", instance_id, init_epoch)
             }
 
-            HummockEvent::ImmToUploader { instance_id, imm } => {
-                format!("ImmToUploader {} {}", instance_id, imm.batch_id())
+            HummockEvent::ImmToUploader { instance_id, imms } => {
+                format!(
+                    "ImmToUploader {} {:?}",
+                    instance_id,
+                    imms.iter().map(|imm| imm.batch_id()).collect_vec()
+                )
             }
 
             HummockEvent::LocalSealEpoch {

--- a/src/storage/src/hummock/iterator/change_log.rs
+++ b/src/storage/src/hummock/iterator/change_log.rs
@@ -704,6 +704,7 @@ mod tests {
                 table_option: Default::default(),
                 is_replicated: false,
                 vnodes: Bitmap::ones(VirtualNode::COUNT_FOR_TEST).into(),
+                upload_on_flush: true,
             })
             .await;
         let logs = gen_test_data(epoch_count, 10000, 0.05, 0.2);

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -31,7 +31,7 @@ use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_watermark::WatermarkSerdeType;
 use tracing::{Instrument, warn};
 
-use super::version::{StagingData, VersionUpdate};
+use super::version::VersionUpdate;
 use crate::error::StorageResult;
 use crate::hummock::event_handler::hummock_event_handler::HummockEventSender;
 use crate::hummock::event_handler::{HummockEvent, HummockReadVersionRef, LocalInstanceGuard};
@@ -86,6 +86,9 @@ pub struct LocalHummockStorage {
     /// In that case, we use this flag to avoid reading the same data twice,
     /// by ignoring the replicated `ReadVersion`.
     is_replicated: bool,
+
+    /// Whether or not send imm to uploader on every flush.
+    upload_on_flush: bool,
 
     /// Event sender.
     event_sender: HummockEventSender,
@@ -528,6 +531,25 @@ impl StateStoreWriteEpochControl for LocalHummockStorage {
 
     fn seal_current_epoch(&mut self, next_epoch: u64, mut opts: SealCurrentEpochOptions) {
         assert!(!self.mem_table.is_dirty());
+        if !self.is_replicated {
+            if self.upload_on_flush {
+                debug_assert_eq!(self.read_version.write().pending_imm_size(), 0);
+            } else {
+                let pending_imms = self.read_version.write().start_upload_pending_imms();
+                if !pending_imms.is_empty()
+                    && self
+                        .event_sender
+                        .send(HummockEvent::ImmToUploader {
+                            instance_id: self.instance_id(),
+                            imms: pending_imms,
+                        })
+                        .is_err()
+                {
+                    warn!("failed to send ImmToUploader during seal. maybe shutting down");
+                }
+            }
+        }
+
         if let Some(new_level) = &opts.switch_op_consistency_level {
             self.mem_table.op_consistency_level.update(new_level);
             self.op_consistency_level.update(new_level);
@@ -677,14 +699,17 @@ impl LocalHummockStorage {
             );
             self.spill_offset += 1;
             let imm_size = imm.size();
-            self.read_version
-                .write()
-                .update(VersionUpdate::Staging(StagingData::ImmMem(imm.clone())));
+            let mut read_version = self.read_version.write();
+            read_version.add_imm(imm);
 
             // insert imm to uploader
-            if !self.is_replicated {
+            if !self.is_replicated
+                && (self.upload_on_flush
+                    || read_version.pending_imm_size() >= self.mem_table_spill_threshold)
+            {
+                let imms = read_version.start_upload_pending_imms();
                 self.event_sender
-                    .send(HummockEvent::ImmToUploader { instance_id, imm })
+                    .send(HummockEvent::ImmToUploader { instance_id, imms })
                     .map_err(|_| {
                         HummockError::other("failed to send imm to uploader. maybe shutting down")
                     })?;
@@ -735,6 +760,7 @@ impl LocalHummockStorage {
             write_limiter,
             version_update_notifier_tx,
             mem_table_spill_threshold,
+            upload_on_flush: option.upload_on_flush,
         }
     }
 

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -141,11 +141,18 @@ pub enum VersionUpdate {
 #[derive(Clone)]
 pub struct StagingVersion {
     pending_imm_size: usize,
-    // newer data comes last
+    /// It contains the imms added but not sent to the uploader of hummock event handler.
+    /// It is non-empty only when `upload_on_flush` is false.
+    ///
+    /// It will be sent to the uploader when `pending_imm_size` exceed threshold or on `seal_current_epoch`.
+    ///
+    /// newer data comes last
     pub pending_imms: Vec<ImmutableMemtable>,
-    // newer data comes first
-    // Note: Currently, building imm and writing to staging version is not atomic, and therefore
-    // imm of smaller batch id may be added later than one with greater batch id
+    /// It contains the imms already sent to uploader of hummock event handler.
+    /// Note: Currently, building imm and writing to staging version is not atomic, and therefore
+    /// imm of smaller batch id may be added later than one with greater batch id
+    ///
+    /// Newer data comes first.
     pub uploading_imms: VecDeque<ImmutableMemtable>,
 
     // newer data comes first

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -127,15 +127,8 @@ impl StagingSstableInfo {
     }
 }
 
-#[derive(Clone)]
-pub enum StagingData {
-    ImmMem(ImmutableMemtable),
-    Sst(Arc<StagingSstableInfo>),
-}
-
 pub enum VersionUpdate {
-    /// a new staging data entry will be added.
-    Staging(StagingData),
+    Sst(Arc<StagingSstableInfo>),
     CommittedSnapshot(CommittedVersion),
     NewTableWatermark {
         direction: WatermarkDirection,
@@ -147,10 +140,13 @@ pub enum VersionUpdate {
 
 #[derive(Clone)]
 pub struct StagingVersion {
+    pending_imm_size: usize,
+    // newer data comes last
+    pub pending_imms: Vec<ImmutableMemtable>,
     // newer data comes first
     // Note: Currently, building imm and writing to staging version is not atomic, and therefore
     // imm of smaller batch id may be added later than one with greater batch id
-    pub imm: VecDeque<ImmutableMemtable>,
+    pub uploading_imms: VecDeque<ImmutableMemtable>,
 
     // newer data comes first
     pub sst: VecDeque<Arc<StagingSstableInfo>>,
@@ -171,16 +167,21 @@ impl StagingVersion {
         let (left, right) = table_key_range;
         let left = left.as_ref().map(|key| TableKey(key.0.as_ref()));
         let right = right.as_ref().map(|key| TableKey(key.0.as_ref()));
-        let overlapped_imms = self.imm.iter().filter(move |imm| {
-            // retain imm which is overlapped with (min_epoch_exclusive, max_epoch_inclusive]
-            imm.min_epoch() <= max_epoch_inclusive
-                && imm.table_id == table_id
-                && range_overlap(
-                    &(left, right),
-                    &imm.start_table_key(),
-                    Included(&imm.end_table_key()),
-                )
-        });
+        let overlapped_imms = self
+            .pending_imms
+            .iter()
+            .rev() // rev to let newer imm come first
+            .chain(self.uploading_imms.iter())
+            .filter(move |imm| {
+                // retain imm which is overlapped with (min_epoch_exclusive, max_epoch_inclusive]
+                imm.min_epoch() <= max_epoch_inclusive
+                    && imm.table_id == table_id
+                    && range_overlap(
+                        &(left, right),
+                        &imm.start_table_key(),
+                        Included(&imm.end_table_key()),
+                    )
+            });
 
         // TODO: Remove duplicate sst based on sst id
         let overlapped_ssts = self
@@ -205,7 +206,7 @@ impl StagingVersion {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.imm.is_empty() && self.sst.is_empty()
+        self.pending_imms.is_empty() && self.uploading_imms.is_empty() && self.sst.is_empty()
     }
 }
 
@@ -270,7 +271,9 @@ impl HummockReadVersion {
                 }
             },
             staging: StagingVersion {
-                imm: VecDeque::default(),
+                pending_imm_size: 0,
+                pending_imms: Vec::default(),
+                uploading_imms: VecDeque::default(),
                 sst: VecDeque::default(),
             },
 
@@ -294,6 +297,34 @@ impl HummockReadVersion {
         self.table_id
     }
 
+    pub fn add_imm(&mut self, imm: ImmutableMemtable) {
+        if let Some(item) = self
+            .staging
+            .pending_imms
+            .last()
+            .or_else(|| self.staging.uploading_imms.front())
+        {
+            // check batch_id order from newest to old
+            debug_assert!(item.batch_id() < imm.batch_id());
+        }
+
+        self.staging.pending_imm_size += imm.size();
+        self.staging.pending_imms.push(imm);
+    }
+
+    pub fn pending_imm_size(&self) -> usize {
+        self.staging.pending_imm_size
+    }
+
+    pub fn start_upload_pending_imms(&mut self) -> Vec<ImmutableMemtable> {
+        let pending_imms = std::mem::take(&mut self.staging.pending_imms);
+        for imm in &pending_imms {
+            self.staging.uploading_imms.push_front(imm.clone());
+        }
+        self.staging.pending_imm_size = 0;
+        pending_imms
+    }
+
     /// Updates the read version with `VersionUpdate`.
     /// There will be three data types to be processed
     /// `VersionUpdate::Staging`
@@ -305,18 +336,8 @@ impl HummockReadVersion {
     /// `staging_sst` and `staging_imm` in memory according to epoch
     pub fn update(&mut self, info: VersionUpdate) {
         match info {
-            VersionUpdate::Staging(staging) => match staging {
-                // TODO: add a check to ensure that the added batch id of added imm is greater than
-                // the batch id of imm at the front
-                StagingData::ImmMem(imm) => {
-                    if let Some(item) = self.staging.imm.front() {
-                        // check batch_id order from newest to old
-                        debug_assert!(item.batch_id() < imm.batch_id());
-                    }
-
-                    self.staging.imm.push_front(imm)
-                }
-                StagingData::Sst(staging_sst_ref) => {
+            VersionUpdate::Sst(staging_sst_ref) => {
+                {
                     let Some(imms) = staging_sst_ref.imm_ids.get(&self.instance_id) else {
                         warn!(
                             instance_id = self.instance_id,
@@ -327,7 +348,7 @@ impl HummockReadVersion {
 
                     // old data comes first
                     for imm_id in imms.iter().rev() {
-                        let check_err = match self.staging.imm.pop_back() {
+                        let check_err = match self.staging.uploading_imms.pop_back() {
                             None => Some("empty".to_owned()),
                             Some(prev_imm_id) => {
                                 if prev_imm_id.batch_id() == *imm_id {
@@ -346,14 +367,20 @@ impl HummockReadVersion {
                             "should be valid staging_sst.size {},
                                     staging_sst.imm_ids {:?},
                                     staging_sst.epochs {:?},
-                                    local_imm_ids {:?},
+                                    local_pending_imm_ids {:?},
+                                    local_uploading_imm_ids {:?},
                                     instance_id {}
                                     check_err {:?}",
                             staging_sst_ref.imm_size,
                             staging_sst_ref.imm_ids,
                             staging_sst_ref.epochs,
                             self.staging
-                                .imm
+                                .pending_imms
+                                .iter()
+                                .map(|imm| imm.batch_id())
+                                .collect_vec(),
+                            self.staging
+                                .uploading_imms
                                 .iter()
                                 .map(|imm| imm.batch_id())
                                 .collect_vec(),
@@ -364,7 +391,7 @@ impl HummockReadVersion {
 
                     self.staging.sst.push_front(staging_sst_ref);
                 }
-            },
+            }
 
             VersionUpdate::CommittedSnapshot(committed_version) => {
                 if let Some(info) = committed_version
@@ -373,14 +400,28 @@ impl HummockReadVersion {
                     .get(&self.table_id)
                 {
                     let committed_epoch = info.committed_epoch;
-                    self.staging.imm.retain(|imm| {
-                        if self.is_replicated {
-                            imm.min_epoch() > committed_epoch
-                        } else {
-                            assert!(imm.min_epoch() > committed_epoch);
-                            true
-                        }
-                    });
+                    if self.is_replicated {
+                        self.staging
+                            .uploading_imms
+                            .retain(|imm| imm.min_epoch() > committed_epoch);
+                        self.staging
+                            .pending_imms
+                            .retain(|imm| imm.min_epoch() > committed_epoch);
+                    } else {
+                        self.staging
+                            .pending_imms
+                            .iter()
+                            .chain(self.staging.uploading_imms.iter())
+                            .for_each(|imm| {
+                                assert!(
+                                    imm.min_epoch() > committed_epoch,
+                                    "imm of table {} min_epoch {} should be greater than committed_epoch {}",
+                                    imm.table_id,
+                                    imm.min_epoch(),
+                                    committed_epoch
+                                )
+                            });
+                    }
 
                     self.staging.sst.retain(|sst| {
                         sst.epochs.first().expect("epochs not empty") > &committed_epoch

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -968,6 +968,7 @@ impl<R: RangeKv> StateStore for RangeKvStateStore<R> {
                 table_option: Default::default(),
                 is_replicated: false,
                 vnodes: Arc::new(Bitmap::from_bool_slice(&[true])),
+                upload_on_flush: true,
             },
         )
     }

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -644,6 +644,8 @@ pub struct NewLocalOptions {
 
     /// The vnode bitmap for the local state store instance
     pub vnodes: Arc<Bitmap>,
+
+    pub upload_on_flush: bool,
 }
 
 impl From<TracedNewLocalOptions> for NewLocalOptions {
@@ -663,6 +665,7 @@ impl From<TracedNewLocalOptions> for NewLocalOptions {
             table_option: value.table_option.into(),
             is_replicated: value.is_replicated,
             vnodes: Arc::new(value.vnodes.into()),
+            upload_on_flush: value.upload_on_flush,
         }
     }
 }
@@ -680,6 +683,7 @@ impl From<NewLocalOptions> for TracedNewLocalOptions {
             table_option: value.table_option.into(),
             is_replicated: value.is_replicated,
             vnodes: value.vnodes.as_ref().clone().into(),
+            upload_on_flush: value.upload_on_flush,
         }
     }
 }
@@ -690,6 +694,7 @@ impl NewLocalOptions {
         op_consistency_level: OpConsistencyLevel,
         table_option: TableOption,
         vnodes: Arc<Bitmap>,
+        upload_on_flush: bool,
     ) -> Self {
         NewLocalOptions {
             table_id,
@@ -697,6 +702,7 @@ impl NewLocalOptions {
             table_option,
             is_replicated: false,
             vnodes,
+            upload_on_flush,
         }
     }
 
@@ -712,6 +718,7 @@ impl NewLocalOptions {
             table_option,
             is_replicated: true,
             vnodes,
+            upload_on_flush: false,
         }
     }
 
@@ -724,6 +731,7 @@ impl NewLocalOptions {
             },
             is_replicated: false,
             vnodes: Arc::new(Bitmap::ones(VirtualNode::COUNT_FOR_TEST)),
+            upload_on_flush: true,
         }
     }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -544,6 +544,7 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
                 },
                 is_replicated: false,
                 vnodes: serde.vnodes().clone(),
+                upload_on_flush: false,
             })
             .await;
 

--- a/src/stream/src/common/log_store_impl/kv_log_store/state.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/state.rs
@@ -330,6 +330,7 @@ mod tests {
                         table_option: Default::default(),
                         is_replicated: false,
                         vnodes: vnodes.clone(),
+                        upload_on_flush: false,
                     })
                     .await,
                 serde.clone(),

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -428,6 +428,7 @@ where
                 op_consistency_level,
                 table_option,
                 distribution.vnodes().clone(),
+                true,
             )
         };
         let local_state_store = store.new_local(new_local_options).await;

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -536,6 +536,7 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                 },
                 is_replicated: false,
                 vnodes: self.serde.vnodes().clone(),
+                upload_on_flush: false,
             })
             .await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously in `LocalHummockStorage`, we add the newly generated imm to uploader whenever on `flush`. This works for normal state table, where we only flush once in each epoch. However, for state of kv log store, we may flush multiple times on multiple chunks, which generates a large number of imm and meanwhile many `HummockEvent::ImmToUploader`, and causes too much pending events and unable to handle hummock event timely.

In this PR, we add a new option `upload_on_flush` in `NewLocalOptions`. When it's false, we won't always add the imm generated in `flush` to uploader. Instead, we will add them in a batch when their total size reaches `mem_table_spill_threshold`. We will also add the pending imms to uploader on `seal_current_epoch`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
