### PR TITLE
feat(meta): minimal support for `ALTER MATERIALIZED VIEW AS`

### DIFF
--- a/e2e_test/streaming/alter_mv/alter_mv_simple.slt
+++ b/e2e_test/streaming/alter_mv/alter_mv_simple.slt
@@ -1,0 +1,82 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t (n varchar, a int);
+
+statement ok
+create materialized view mv as select n, a from t where a >= 18;
+
+statement ok
+create materialized view mv_count as select count(*) from mv;
+
+statement ok
+insert into t values ('Alice', 18), ('Bob', 19), ('Charlie', 17);
+
+query TI rowsort
+select * from mv;
+----
+Alice   18
+Bob	    19
+
+query I
+select * from mv_count;
+----
+2
+
+statement ok
+alter materialized view mv as select n, a from t where a >= 16;
+
+query TT
+show create materialized view mv;
+----
+public.mv CREATE MATERIALIZED VIEW mv AS SELECT n, a FROM t WHERE a >= 16
+
+# `Charlie` is historical data, so it should not appear in the altered MV.
+query TI rowsort
+select * from mv;
+----
+Alice   18
+Bob	    19
+
+statement ok
+insert into t values ('David', 17);
+
+# `David` is new data, so it should appear in the altered MV.
+query TI rowsort
+select * from mv;
+----
+Alice   18
+Bob	    19
+David   17
+
+query I
+select * from mv_count;
+----
+3
+
+statement ok
+delete from t where n = 'Charlie';
+
+# The delete record of `Charlie` should survive the filtering with `a >= 16`.
+# However, since it's not included in the altered MV, the change should not be propogated to downstream.
+# This is achieved by setting `conflict_behavior` to `Overwrite` after altering MV.
+query I
+select * from mv_count;
+----
+3
+
+statement ok
+delete from t;
+
+query TI
+select * from mv;
+----
+
+query I
+select * from mv_count;
+----
+0
+
+statement ok
+drop table t cascade;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -393,9 +393,14 @@ message ReplaceJobPlan {
     catalog.Source source = 1;
   }
 
+  message ReplaceMaterializedView {
+    catalog.Table table = 1;
+  }
+
   oneof replace_job {
     ReplaceTable replace_table = 3;
     ReplaceSource replace_source = 4;
+    ReplaceMaterializedView replace_materialized_view = 5;
   }
 }
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -33,6 +33,7 @@ use risingwave_pb::common::WorkerType;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::ddl_service::ddl_service_server::DdlService;
 use risingwave_pb::ddl_service::drop_table_request::PbSourceId;
+use risingwave_pb::ddl_service::replace_job_plan::ReplaceMaterializedView;
 use risingwave_pb::ddl_service::*;
 use risingwave_pb::frontend_service::GetTableReplacePlanRequest;
 use risingwave_pb::meta::event_log;
@@ -105,6 +106,9 @@ impl DdlServiceImpl {
             replace_job_plan::ReplaceJob::ReplaceSource(ReplaceSource { source }) => {
                 StreamingJob::Source(source.unwrap())
             }
+            replace_job_plan::ReplaceJob::ReplaceMaterializedView(ReplaceMaterializedView {
+                table,
+            }) => StreamingJob::MaterializedView(table.unwrap()),
         };
 
         ReplaceStreamJobInfo {

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1213,6 +1213,11 @@ impl CatalogController {
                 let source = source::ActiveModel::from(source);
                 source.update(txn).await?;
             }
+            StreamingJob::MaterializedView(table) => {
+                // Update the table catalog with the new one.
+                let table = table::ActiveModel::from(table);
+                table.update(txn).await?;
+            }
             _ => unreachable!(
                 "invalid streaming job type: {:?}",
                 streaming_job.job_type_str()
@@ -1290,7 +1295,7 @@ impl CatalogController {
         // 4. update catalogs and notify.
         let mut objects = vec![];
         match job_type {
-            StreamingJobType::Table(_) => {
+            StreamingJobType::Table(_) | StreamingJobType::MaterializedView => {
                 let (table, table_obj) = Table::find_by_id(original_job_id)
                     .find_also_related(Object)
                     .one(txn)

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -326,9 +326,11 @@ impl StreamingJob {
                     return Err(MetaError::permission_denied("source version is stale"));
                 }
             }
-            StreamingJob::MaterializedView(_)
-            | StreamingJob::Sink(_, _)
-            | StreamingJob::Index(_, _) => {
+            StreamingJob::MaterializedView(_) => {
+                // No version check for materialized view, since `ALTER MATERIALIZED VIEW AS QUERY`
+                // is a full rewrite.
+            }
+            StreamingJob::Sink(_, _) | StreamingJob::Index(_, _) => {
                 bail_not_implemented!("schema change for {}", self.job_type_str())
             }
         }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1514,10 +1514,10 @@ impl DdlController {
         fragment_graph: StreamFragmentGraphProto,
     ) -> MetaResult<NotificationVersion> {
         match &mut streaming_job {
-            StreamingJob::Table(..) | StreamingJob::Source(..) => {}
-            StreamingJob::MaterializedView(..)
-            | StreamingJob::Sink(..)
-            | StreamingJob::Index(..) => {
+            StreamingJob::Table(..)
+            | StreamingJob::Source(..)
+            | StreamingJob::MaterializedView(..) => {}
+            StreamingJob::Sink(..) | StreamingJob::Index(..) => {
                 bail_not_implemented!("schema change for {}", streaming_job.job_type_str())
             }
         }
@@ -1565,6 +1565,7 @@ impl DdlController {
                 .await?;
             drop_table_connector_ctx = ctx.drop_table_connector_ctx.clone();
 
+            // Handle sinks that sink into the table.
             if let StreamingJob::Table(_, table, ..) = &streaming_job {
                 let catalogs = self
                     .metadata_manager
@@ -1997,10 +1998,10 @@ impl DdlController {
         tmp_job_id: TableId,
     ) -> MetaResult<(ReplaceStreamJobContext, StreamJobFragmentsToCreate)> {
         match &stream_job {
-            StreamingJob::Table(..) | StreamingJob::Source(..) => {}
-            StreamingJob::MaterializedView(..)
-            | StreamingJob::Sink(..)
-            | StreamingJob::Index(..) => {
+            StreamingJob::Table(..)
+            | StreamingJob::Source(..)
+            | StreamingJob::MaterializedView(..) => {}
+            StreamingJob::Sink(..) | StreamingJob::Index(..) => {
                 bail_not_implemented!("schema change for {}", stream_job.job_type_str())
             }
         }
@@ -2041,6 +2042,7 @@ impl DdlController {
                 .metadata_manager
                 .get_table_catalog_by_ids(old_internal_table_ids)
                 .await?;
+            // TODO(alter-mv): the current impl is very fragile for alter MV, be more strict here!
             fragment_graph.fit_internal_table_ids(old_internal_tables)?;
         }
 
@@ -2067,8 +2069,9 @@ impl DdlController {
                     job_type,
                 )?
             }
-            StreamingJobType::Table(TableJobType::SharedCdcSource) => {
-                // get the upstream fragment which should be the cdc source
+            StreamingJobType::Table(TableJobType::SharedCdcSource)
+            | StreamingJobType::MaterializedView => {
+                // CDC tables or materialized views can have upstream jobs as well.
                 let (upstream_root_fragments, upstream_actor_location) = self
                     .metadata_manager
                     .get_upstream_root_fragments(fragment_graph.dependent_table_ids())

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -1135,7 +1135,7 @@ impl CompleteStreamFragmentGraph {
                 let nodes = table_fragment.node.as_ref().unwrap();
 
                 let (dist_key_indices, output_mapping) = match job_type {
-                    StreamingJobType::Table(_) => {
+                    StreamingJobType::Table(_) | StreamingJobType::MaterializedView => {
                         let mview_node = nodes.get_node_body().unwrap().as_materialize().unwrap();
                         let all_columns = mview_node.column_descs();
                         let dist_key_indices = mview_node.dist_key_indices();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

> [!WARNING]
> This feature is highly experimental and may be subject to change. It won't be published in the documentation in the near future.

This PR adds minimal support for `ALTER MATERIALIZED VIEW <name> AS <query>` to the meta service. The logic is kept as simple (trivial) as possible.

Thanks to the great extendibility of the design of the graph builder, almost no extra logic is required to support basic replacement of materialized view but adding some `match` arms!

Note that we inherit the very basic algorithm for matching internal tables that's used by replacing table with connector (only source node state table). In this implementation, we simply sort the tables and match them without any additional checks. This assumes that there's neither change on the topological structure of the fragment graph, nor schema change, which is typically correct for `ALTER TABLE` cases but not for `ALTER MV`. As a result, we may encounter all sort of undefined behavior. This will be improved in future works.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
