### PR TITLE
fix(sqlparser): `arr[lo:hi]` and `map{k: v}` broken by `aggregate:` (#22394)

### DIFF
--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -32,7 +32,6 @@ use crate::ast::*;
 use crate::keywords::{self, Keyword};
 use crate::parser_v2::{
     ParserExt as _, dollar_quoted_string, keyword, literal_i64, literal_uint, single_quoted_string,
-    token_number,
 };
 use crate::tokenizer::*;
 use crate::{impl_parse_to, parser_v2};
@@ -648,13 +647,17 @@ impl Parser<'_> {
                 k if keywords::RESERVED_FOR_COLUMN_OR_TABLE_NAME.contains(&k) => {
                     parser_err!("syntax error at or near {token}")
                 }
+                Keyword::AGGREGATE => {
+                    *self = checkpoint;
+                    self.parse_function()
+                }
                 // Here `w` is a word, check if it's a part of a multi-part
                 // identifier, a function call, or a simple identifier:
                 _ => match self.peek_token().token {
-                    Token::LParen | Token::Period | Token::Colon => {
+                    Token::LParen | Token::Period => {
                         *self = checkpoint;
                         if let Ok(object_name) = self.parse_object_name()
-                            && !matches!(self.peek_token().token, Token::LParen | Token::Colon)
+                            && !matches!(self.peek_token().token, Token::LParen)
                         {
                             Ok(Expr::CompoundIdentifier(object_name.0))
                         } else {
@@ -3922,17 +3925,6 @@ impl Parser<'_> {
             Token::SingleQuotedString(s) => Ok(s),
             _ => self.expected_at(checkpoint, "literal string"),
         }
-    }
-
-    /// Parse a map key string
-    pub fn parse_map_key(&mut self) -> PResult<Expr> {
-        alt((
-            Self::parse_function,
-            single_quoted_string.map(|s| Expr::Value(Value::SingleQuotedString(s))),
-            token_number.map(|s| Expr::Value(Value::Number(s))),
-            fail.expect("literal string, number or function"),
-        ))
-        .parse_next(self)
     }
 
     /// Parse a SQL datatype (in the context of a CREATE TABLE statement for example)

--- a/src/sqlparser/tests/testdata/array.yaml
+++ b/src/sqlparser/tests/testdata/array.yaml
@@ -77,3 +77,18 @@
 - input: CREATE TABLE t (params STRUCT<a STRUCT<b int>>[])
   formatted_sql: CREATE TABLE t (params STRUCT<a STRUCT<b INT>>[])
   formatted_ast: 'CreateTable { or_replace: false, temporary: false, if_not_exists: false, name: ObjectName([Ident { value: "t", quote_style: None }]), columns: [ColumnDef { name: Ident { value: "params", quote_style: None }, data_type: Some(Array(Struct([StructField { name: Ident { value: "a", quote_style: None }, data_type: Struct([StructField { name: Ident { value: "b", quote_style: None }, data_type: Int }]) }]))), collation: None, options: [] }], wildcard_idx: None, constraints: [], with_options: [], format_encode: None, source_watermarks: [], append_only: false, on_conflict: None, with_version_column: None, query: None, cdc_table_info: None, include_column_options: [], webhook_info: None, engine: Hummock }'
+- input: SELECT arr[lo:hi] from t;
+  formatted_sql: SELECT arr[lo:hi] FROM t
+  formatted_ast: 'Query(Query { with: None, body: Select(Select { distinct: All, projection: [UnnamedExpr(ArrayRangeIndex { obj: Identifier(Ident { value: "arr", quote_style: None }), start: Some(Identifier(Ident { value: "lo", quote_style: None })), end: Some(Identifier(Ident { value: "hi", quote_style: None })) })], from: [TableWithJoins { relation: Table { name: ObjectName([Ident { value: "t", quote_style: None }]), alias: None, as_of: None }, joins: [] }], lateral_views: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })'
+- input: SELECT MAP{k:v} from t;
+  formatted_sql: 'SELECT MAP {k: v} FROM t'
+  formatted_ast: 'Query(Query { with: None, body: Select(Select { distinct: All, projection: [UnnamedExpr(Map { entries: [(Identifier(Ident { value: "k", quote_style: None }), Identifier(Ident { value: "v", quote_style: None }))] })], from: [TableWithJoins { relation: Table { name: ObjectName([Ident { value: "t", quote_style: None }]), alias: None, as_of: None }, joins: [] }], lateral_views: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })'
+- input: |-
+    SELECT map{
+      aggregate:array_sum(l)
+      :
+      aggregate:array_sum(h)
+    } from t
+    group by k;
+  formatted_sql: 'SELECT MAP {AGGREGATE:array_sum(l): AGGREGATE:array_sum(h)} FROM t GROUP BY k'
+  formatted_ast: 'Query(Query { with: None, body: Select(Select { distinct: All, projection: [UnnamedExpr(Map { entries: [(Function(Function { scalar_as_agg: true, name: ObjectName([Ident { value: "array_sum", quote_style: None }]), arg_list: FunctionArgList { distinct: false, args: [Unnamed(Expr(Identifier(Ident { value: "l", quote_style: None })))], variadic: false, order_by: [], ignore_nulls: false }, within_group: None, filter: None, over: None }), Function(Function { scalar_as_agg: true, name: ObjectName([Ident { value: "array_sum", quote_style: None }]), arg_list: FunctionArgList { distinct: false, args: [Unnamed(Expr(Identifier(Ident { value: "h", quote_style: None })))], variadic: false, order_by: [], ignore_nulls: false }, within_group: None, filter: None, over: None }))] })], from: [TableWithJoins { relation: Table { name: ObjectName([Ident { value: "t", quote_style: None }]), alias: None, as_of: None }, joins: [] }], lateral_views: [], selection: None, group_by: [Identifier(Ident { value: "k", quote_style: None })], having: None }), order_by: [], limit: None, offset: None, fetch: None })'

--- a/src/sqlparser/tests/testdata/select.yaml
+++ b/src/sqlparser/tests/testdata/select.yaml
@@ -259,3 +259,6 @@
     sql parser error: expected end of statement, found: OFFSET
     LINE 1: SELECT * FROM t OFFSET 1 OFFSET 2
                                      ^
+- input: select aggregate:array_sum(v) from (values (3), (2), (1)) as t(v);
+  formatted_sql: SELECT AGGREGATE:array_sum(v) FROM (VALUES (3), (2), (1)) AS t (v)
+  formatted_ast: 'Query(Query { with: None, body: Select(Select { distinct: All, projection: [UnnamedExpr(Function(Function { scalar_as_agg: true, name: ObjectName([Ident { value: "array_sum", quote_style: None }]), arg_list: FunctionArgList { distinct: false, args: [Unnamed(Expr(Identifier(Ident { value: "v", quote_style: None })))], variadic: false, order_by: [], ignore_nulls: false }, within_group: None, filter: None, over: None }))], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { with: None, body: Values(Values([[Value(Number("3"))], [Value(Number("2"))], [Value(Number("1"))]])), order_by: [], limit: None, offset: None, fetch: None }, alias: Some(TableAlias { name: Ident { value: "t", quote_style: None }, columns: [Ident { value: "v", quote_style: None }] }) }, joins: [] }], lateral_views: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })'


### PR DESCRIPTION
Cherry picking #22394 onto branch release-2.3,

This PR/issue was created to resolve #22407