### PR TITLE
refactor(meta): wrap fragment type mask with struct

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1050,26 +1050,6 @@ message StreamActor {
   plan_common.ExprContext expr_context = 10;
 }
 
-// Indicates whether the fragment contains some special kind of nodes.
-enum FragmentTypeFlag {
-  FRAGMENT_TYPE_FLAG_FRAGMENT_UNSPECIFIED = 0;
-  FRAGMENT_TYPE_FLAG_SOURCE = 1;
-  FRAGMENT_TYPE_FLAG_MVIEW = 2;
-  FRAGMENT_TYPE_FLAG_SINK = 4;
-  FRAGMENT_TYPE_FLAG_NOW = 8; // TODO: Remove this and insert a `BarrierRecv` instead.
-  // Include StreamScan and StreamCdcScan
-  FRAGMENT_TYPE_FLAG_STREAM_SCAN = 16;
-  FRAGMENT_TYPE_FLAG_BARRIER_RECV = 32;
-  FRAGMENT_TYPE_FLAG_VALUES = 64;
-  FRAGMENT_TYPE_FLAG_DML = 128;
-  FRAGMENT_TYPE_FLAG_CDC_FILTER = 256;
-  FRAGMENT_TYPE_FLAG_SOURCE_SCAN = 1024;
-  FRAGMENT_TYPE_FLAG_SNAPSHOT_BACKFILL_STREAM_SCAN = 2048;
-  // Note: this flag is not available in old fragments, so only suitable for debugging purpose.
-  FRAGMENT_TYPE_FLAG_FS_FETCH = 4096;
-  FRAGMENT_TYPE_FLAG_CROSS_DB_SNAPSHOT_BACKFILL_STREAM_SCAN = 8192;
-}
-
 // The streaming context associated with a stream plan
 message StreamContext {
   // The timezone associated with the streaming plan. Only applies to MV for now.

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -509,7 +509,7 @@ pub fn max_column_id(columns: &[ColumnCatalog]) -> ColumnId {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use risingwave_pb::plan_common::PbColumnDesc;
 
     use crate::catalog::ColumnDesc;

--- a/src/ctl/src/cmd_impl/meta/cluster_info.rs
+++ b/src/ctl/src/cmd_impl/meta/cluster_info.rs
@@ -16,12 +16,12 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use comfy_table::{Attribute, Cell, Row, Table};
 use itertools::Itertools;
+use risingwave_common::catalog::FragmentTypeFlag;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_connector::source::{SplitImpl, SplitMetaData};
 use risingwave_pb::meta::GetClusterInfoResponse;
 use risingwave_pb::meta::table_fragments::State;
 use risingwave_pb::source::ConnectorSplits;
-use risingwave_pb::stream_plan::FragmentTypeFlag;
 
 use crate::CtlContext;
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_backfill_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_backfill_info.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::catalog::FragmentTypeFlag;
 use risingwave_common::types::Fields;
 use risingwave_common::util::stream_graph_visitor::{
     visit_stream_node_source_backfill, visit_stream_node_stream_scan,
 };
 use risingwave_frontend_macro::system_catalog;
 use risingwave_pb::meta::FragmentDistribution;
-use risingwave_pb::stream_plan::FragmentTypeFlag;
 
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
 use crate::catalog::system_catalog::rw_catalog::common::CatalogBackfillType;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragments.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragments.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::catalog::FragmentTypeFlag;
 use risingwave_common::types::{Fields, JsonbVal};
 use risingwave_frontend_macro::system_catalog;
-use risingwave_pb::stream_plan::FragmentTypeFlag;
 use serde_json::json;
 
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
@@ -39,7 +39,7 @@ pub(super) fn extract_fragment_type_flag(mask: u32) -> Vec<FragmentTypeFlag> {
     for i in 0..32 {
         let bit = 1 << i;
         if mask & bit != 0 {
-            match FragmentTypeFlag::try_from(bit as i32) {
+            match FragmentTypeFlag::try_from(bit) {
                 Err(_) => continue,
                 Ok(flag) => result.push(flag),
             };
@@ -70,8 +70,7 @@ async fn read_rw_fragment(reader: &SysCatalogReaderImpl) -> Result<Vec<RwFragmen
                 .collect(),
             flags: extract_fragment_type_flag(distribution.fragment_type_mask)
                 .into_iter()
-                .flat_map(|t| t.as_str_name().strip_prefix("FRAGMENT_TYPE_FLAG_"))
-                .map(|s| s.into())
+                .map(|t| t.as_str_name().to_owned())
                 .collect(),
             parallelism: distribution.parallelism as i32,
             max_parallelism: distribution.vnode_count as i32,
@@ -82,7 +81,7 @@ async fn read_rw_fragment(reader: &SysCatalogReaderImpl) -> Result<Vec<RwFragmen
 
 #[cfg(test)]
 mod tests {
-    use risingwave_pb::stream_plan::FragmentTypeFlag;
+    use risingwave_common::catalog::FragmentTypeFlag;
 
     use super::extract_fragment_type_flag;
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_rate_limit.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_rate_limit.rs
@@ -39,8 +39,7 @@ async fn read_rw_rate_limit(reader: &SysCatalogReaderImpl) -> Result<Vec<RwRateL
             fragment_id: info.fragment_id as i32,
             fragment_type: extract_fragment_type_flag(info.fragment_type_mask)
                 .into_iter()
-                .flat_map(|t| t.as_str_name().strip_prefix("FRAGMENT_TYPE_FLAG_"))
-                .map(|s| s.into())
+                .map(|t| t.as_str_name().to_owned())
                 .collect(),
             table_id: info.job_id as i32,
             rate_limit: info.rate_limit as i32,

--- a/src/frontend/src/stream_fragmenter/graph/fragment_graph.rs
+++ b/src/frontend/src/stream_fragmenter/graph/fragment_graph.rs
@@ -15,11 +15,12 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use risingwave_common::catalog::FragmentTypeMask;
 use risingwave_pb::stream_plan::stream_fragment_graph::{
     StreamFragment as StreamFragmentProto, StreamFragmentEdge as StreamFragmentEdgeProto,
 };
 use risingwave_pb::stream_plan::{
-    DispatchStrategy, FragmentTypeFlag, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode,
+    DispatchStrategy, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode,
 };
 use thiserror_ext::AsReport;
 
@@ -35,7 +36,7 @@ pub struct StreamFragment {
     pub node: Option<Box<StreamNode>>,
 
     /// Bitwise-OR of type Flags of this fragment.
-    pub fragment_type_mask: u32,
+    pub fragment_type_mask: FragmentTypeMask,
 
     /// Mark whether this fragment requires exactly one actor.
     pub requires_singleton: bool,
@@ -63,7 +64,7 @@ impl StreamFragment {
     pub fn new(fragment_id: LocalFragmentId) -> Self {
         Self {
             fragment_id,
-            fragment_type_mask: FragmentTypeFlag::FragmentUnspecified as u32,
+            fragment_type_mask: FragmentTypeMask::empty(),
             requires_singleton: false,
             node: None,
             table_ids_cnt: 0,
@@ -75,7 +76,7 @@ impl StreamFragment {
         StreamFragmentProto {
             fragment_id: self.fragment_id,
             node: self.node.clone().map(|n| *n),
-            fragment_type_mask: self.fragment_type_mask,
+            fragment_type_mask: self.fragment_type_mask.into(),
             requires_singleton: self.requires_singleton,
             table_ids_cnt: self.table_ids_cnt,
             upstream_table_ids: self.upstream_table_ids.clone(),

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -25,12 +25,12 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 use educe::Educe;
-use risingwave_common::catalog::TableId;
+use risingwave_common::catalog::{FragmentTypeFlag, TableId};
 use risingwave_common::session_config::SessionConfig;
 use risingwave_common::session_config::parallelism::ConfigParallelism;
 use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::{
-    BackfillOrder, DispatchStrategy, DispatcherType, ExchangeNode, FragmentTypeFlag, NoOpNode,
+    BackfillOrder, DispatchStrategy, DispatcherType, ExchangeNode, NoOpNode,
     PbDispatchOutputMapping, StreamContext, StreamFragmentGraph as StreamFragmentGraphProto,
     StreamNode, StreamScanType,
 };
@@ -340,12 +340,14 @@ fn build_fragment(
     recursive::tracker!().recurse(|_t| {
         // Update current fragment based on the node we're visiting.
         match stream_node.get_node_body()? {
-            NodeBody::BarrierRecv(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::BarrierRecv as u32
-            }
+            NodeBody::BarrierRecv(_) => current_fragment
+                .fragment_type_mask
+                .add(FragmentTypeFlag::BarrierRecv),
 
             NodeBody::Source(node) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::Source as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::Source);
 
                 if let Some(source) = node.source_inner.as_ref()
                     && let Some(source_info) = source.info.as_ref()
@@ -358,30 +360,38 @@ fn build_fragment(
             }
 
             NodeBody::Dml(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::Dml as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::Dml);
             }
 
             NodeBody::Materialize(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::Mview as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::Mview);
             }
 
-            NodeBody::Sink(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::Sink as u32
-            }
+            NodeBody::Sink(_) => current_fragment
+                .fragment_type_mask
+                .add(FragmentTypeFlag::Sink),
 
             NodeBody::TopN(_) => current_fragment.requires_singleton = true,
 
             NodeBody::StreamScan(node) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::StreamScan as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::StreamScan);
                 match node.stream_scan_type() {
                     StreamScanType::SnapshotBackfill => {
-                        current_fragment.fragment_type_mask |=
-                            FragmentTypeFlag::SnapshotBackfillStreamScan as u32;
+                        current_fragment
+                            .fragment_type_mask
+                            .add(FragmentTypeFlag::SnapshotBackfillStreamScan);
                         state.has_snapshot_backfill = true;
                     }
                     StreamScanType::CrossDbSnapshotBackfill => {
-                        current_fragment.fragment_type_mask |=
-                            FragmentTypeFlag::CrossDbSnapshotBackfillStreamScan as u32;
+                        current_fragment
+                            .fragment_type_mask
+                            .add(FragmentTypeFlag::CrossDbSnapshotBackfillStreamScan);
                         state.has_cross_db_snapshot_backfill = true;
                     }
                     StreamScanType::Unspecified
@@ -400,14 +410,18 @@ fn build_fragment(
             }
 
             NodeBody::StreamCdcScan(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::StreamScan as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::StreamScan);
                 // the backfill algorithm is not parallel safe
                 current_fragment.requires_singleton = true;
                 state.has_source_backfill = true;
             }
 
             NodeBody::CdcFilter(node) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::CdcFilter as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::CdcFilter);
                 // memorize upstream source id for later use
                 state
                     .dependent_table_ids
@@ -417,7 +431,9 @@ fn build_fragment(
                     .push(node.upstream_source_id);
             }
             NodeBody::SourceBackfill(node) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::SourceScan as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::SourceScan);
                 // memorize upstream source id for later use
                 let source_id = node.upstream_source_id;
                 state.dependent_table_ids.insert(source_id.into());
@@ -427,17 +443,23 @@ fn build_fragment(
 
             NodeBody::Now(_) => {
                 // TODO: Remove this and insert a `BarrierRecv` instead.
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::Now as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::Now);
                 current_fragment.requires_singleton = true;
             }
 
             NodeBody::Values(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::Values as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::Values);
                 current_fragment.requires_singleton = true;
             }
 
             NodeBody::StreamFsFetch(_) => {
-                current_fragment.fragment_type_mask |= FragmentTypeFlag::FsFetch as u32;
+                current_fragment
+                    .fragment_type_mask
+                    .add(FragmentTypeFlag::FsFetch);
             }
 
             _ => {}

--- a/src/meta/src/barrier/backfill_order_control.rs
+++ b/src/meta/src/barrier/backfill_order_control.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use risingwave_pb::stream_plan::FragmentTypeFlag;
+use risingwave_common::catalog::FragmentTypeFlag;
 
 use crate::model::{FragmentId, StreamJobFragments};
 
@@ -67,9 +67,9 @@ impl BackfillOrderState {
         let mut backfill_nodes: HashMap<FragmentId, BackfillNode> = HashMap::new();
 
         for fragment in stream_job_fragments.fragments() {
-            if fragment.fragment_type_mask
-                & (FragmentTypeFlag::StreamScan as u32 | FragmentTypeFlag::SourceScan as u32)
-                > 0
+            if fragment
+                .fragment_type_mask
+                .contains_any([FragmentTypeFlag::StreamScan, FragmentTypeFlag::SourceScan])
             {
                 let fragment_id = fragment.fragment_id;
                 backfill_nodes.insert(

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -14,10 +14,9 @@
 
 use std::sync::Arc;
 
-use risingwave_common::catalog::DatabaseId;
+use risingwave_common::catalog::{DatabaseId, FragmentTypeFlag};
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
-use risingwave_pb::stream_plan::PbFragmentTypeFlag;
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
 
@@ -201,10 +200,9 @@ impl CommandContext {
                             .fill_snapshot_backfill_epoch(
                                 info.stream_job_fragments.fragments.iter().filter_map(
                                     |(fragment_id, fragment)| {
-                                        if (fragment.fragment_type_mask
-                                            & PbFragmentTypeFlag::CrossDbSnapshotBackfillStreamScan as u32)
-                                            != 0
-                                        {
+                                        if fragment.fragment_type_mask.contains(
+                                            FragmentTypeFlag::CrossDbSnapshotBackfillStreamScan,
+                                        ) {
                                             Some(*fragment_id as _)
                                         } else {
                                             None
@@ -223,10 +221,10 @@ impl CommandContext {
                             .fill_snapshot_backfill_epoch(
                                 info.stream_job_fragments.fragments.iter().filter_map(
                                     |(fragment_id, fragment)| {
-                                        if (fragment.fragment_type_mask
-                                            & (PbFragmentTypeFlag::SnapshotBackfillStreamScan as u32 | PbFragmentTypeFlag::CrossDbSnapshotBackfillStreamScan as u32))
-                                            != 0
-                                        {
+                                        if fragment.fragment_type_mask.contains_any([
+                                            FragmentTypeFlag::SnapshotBackfillStreamScan,
+                                            FragmentTypeFlag::CrossDbSnapshotBackfillStreamScan,
+                                        ]) {
                                             Some(*fragment_id as _)
                                         } else {
                                             None

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -27,7 +27,9 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use itertools::Itertools;
-use risingwave_common::catalog::{DEFAULT_SCHEMA_NAME, SYSTEM_SCHEMAS, TableOption};
+use risingwave_common::catalog::{
+    DEFAULT_SCHEMA_NAME, FragmentTypeFlag, SYSTEM_SCHEMAS, TableOption,
+};
 use risingwave_common::current_cluster_version;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont_mut;
@@ -57,7 +59,6 @@ use risingwave_pb::meta::subscribe_response::{
     Info as NotificationInfo, Info, Operation as NotificationOperation, Operation,
 };
 use risingwave_pb::meta::{PbFragmentWorkerSlotMapping, PbObject, PbObjectGroup};
-use risingwave_pb::stream_plan::FragmentTypeFlag;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::telemetry::PbTelemetryEventStage;
 use risingwave_pb::user::PbUserInfo;

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -21,6 +21,7 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
+use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
 use risingwave_common::hash::{VnodeCount, VnodeCountCompat, WorkerSlotId};
 use risingwave_common::util::stream_graph_visitor::{
     visit_stream_node_body, visit_stream_node_mut,
@@ -52,8 +53,8 @@ use risingwave_pb::meta::{FragmentWorkerSlotMapping, PbFragmentWorkerSlotMapping
 use risingwave_pb::source::{ConnectorSplit, PbConnectorSplits};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    PbDispatchOutputMapping, PbDispatcherType, PbFragmentTypeFlag, PbStreamContext, PbStreamNode,
-    PbStreamScanType, StreamScanType,
+    PbDispatchOutputMapping, PbDispatcherType, PbStreamContext, PbStreamNode, PbStreamScanType,
+    StreamScanType,
 };
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::Expr;
@@ -292,7 +293,7 @@ impl CatalogController {
         let fragment = fragment::Model {
             fragment_id: *pb_fragment_id as _,
             job_id,
-            fragment_type_mask: *pb_fragment_type_mask as _,
+            fragment_type_mask: (*pb_fragment_type_mask).into(),
             distribution_type,
             stream_node,
             state_table_ids,
@@ -433,7 +434,7 @@ impl CatalogController {
         let pb_distribution_type = PbFragmentDistributionType::from(distribution_type) as _;
         let pb_fragment = Fragment {
             fragment_id: fragment_id as _,
-            fragment_type_mask: fragment_type_mask as _,
+            fragment_type_mask: fragment_type_mask.into(),
             distribution_type: pb_distribution_type,
             actors: pb_actors,
             state_table_ids: pb_state_table_ids,
@@ -1015,7 +1016,7 @@ impl CatalogController {
 
         let mut sink_actor_mapping = HashMap::new();
         for (actor_id, sink_id, type_mask) in actor_with_type {
-            if type_mask & PbFragmentTypeFlag::Sink as i32 != 0 {
+            if FragmentTypeMask::from(type_mask).contains(FragmentTypeFlag::Sink) {
                 sink_actor_mapping
                     .entry(sink_id)
                     .or_insert_with(|| (sink_name_mapping.get(&sink_id).unwrap().clone(), vec![]))
@@ -1558,11 +1559,10 @@ impl CatalogController {
         // job_id -> fragment
         let mut root_fragments = HashMap::<ObjectId, fragment::Model>::new();
         for fragment in all_fragments {
-            if (fragment.fragment_type_mask & PbFragmentTypeFlag::Mview as i32) != 0
-                || (fragment.fragment_type_mask & PbFragmentTypeFlag::Sink as i32) != 0
-            {
+            let mask = FragmentTypeMask::from(fragment.fragment_type_mask);
+            if mask.contains_any([FragmentTypeFlag::Mview, FragmentTypeFlag::Sink]) {
                 _ = root_fragments.insert(fragment.job_id, fragment);
-            } else if fragment.fragment_type_mask & PbFragmentTypeFlag::Source as i32 != 0 {
+            } else if mask.contains(FragmentTypeFlag::Source) {
                 // look for Source fragment only if there's no MView fragment
                 // (notice try_insert here vs insert above)
                 _ = root_fragments.try_insert(fragment.job_id, fragment);
@@ -1663,7 +1663,9 @@ impl CatalogController {
             .into_tuple()
             .all(&inner.db)
             .await?;
-        fragments.retain(|(_, mask, _)| *mask & PbFragmentTypeFlag::Source as i32 != 0);
+        fragments.retain(|(_, mask, _)| {
+            FragmentTypeMask::from(*mask).contains(FragmentTypeFlag::Source)
+        });
 
         let mut source_fragment_ids = HashMap::new();
         for (fragment_id, _, stream_node) in fragments {
@@ -1691,7 +1693,9 @@ impl CatalogController {
             .into_tuple()
             .all(&inner.db)
             .await?;
-        fragments.retain(|(_, mask, _)| *mask & PbFragmentTypeFlag::SourceScan as i32 != 0);
+        fragments.retain(|(_, mask, _)| {
+            FragmentTypeMask::from(*mask).contains(FragmentTypeFlag::SourceScan)
+        });
 
         let mut source_fragment_ids = HashMap::new();
         for (fragment_id, _, stream_node) in fragments {
@@ -1740,8 +1744,8 @@ impl CatalogController {
             .await?;
 
         fragments.retain(|(_, mask, _)| {
-            *mask & PbFragmentTypeFlag::Mview as i32 != 0
-                || *mask & PbFragmentTypeFlag::Sink as i32 != 0
+            FragmentTypeMask::from(*mask)
+                .contains_any([FragmentTypeFlag::Mview, FragmentTypeFlag::Sink])
         });
 
         Ok(fragments
@@ -1758,6 +1762,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap, HashSet};
 
     use itertools::Itertools;
+    use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
     use risingwave_common::hash::{ActorMapping, VirtualNode, VnodeCount};
     use risingwave_common::util::iter_util::ZipEqDebug;
     use risingwave_common::util::stream_graph_visitor::visit_stream_node_body;
@@ -1774,7 +1779,7 @@ mod tests {
     use risingwave_pb::plan_common::PbExprContext;
     use risingwave_pb::source::{PbConnectorSplit, PbConnectorSplits};
     use risingwave_pb::stream_plan::stream_node::PbNodeBody;
-    use risingwave_pb::stream_plan::{MergeNode, PbFragmentTypeFlag, PbStreamNode, PbUnionNode};
+    use risingwave_pb::stream_plan::{MergeNode, PbStreamNode, PbUnionNode};
 
     use crate::MetaResult;
     use crate::controller::catalog::CatalogController;
@@ -1859,7 +1864,7 @@ mod tests {
 
         let pb_fragment = Fragment {
             fragment_id: TEST_FRAGMENT_ID as _,
-            fragment_type_mask: PbFragmentTypeFlag::Source as _,
+            fragment_type_mask: FragmentTypeMask::from(FragmentTypeFlag::Source as u32),
             distribution_type: PbFragmentDistributionType::Hash as _,
             actors: pb_actors.clone(),
             state_table_ids: vec![TEST_STATE_TABLE_ID as _],
@@ -2063,7 +2068,7 @@ mod tests {
         } = pb_fragment;
 
         assert_eq!(fragment_id, TEST_FRAGMENT_ID as u32);
-        assert_eq!(fragment_type_mask, fragment.fragment_type_mask as u32);
+        assert_eq!(fragment_type_mask, fragment.fragment_type_mask.into());
         assert_eq!(
             pb_distribution_type,
             PbFragmentDistributionType::from(fragment.distribution_type)

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -18,6 +18,7 @@ use std::num::NonZeroUsize;
 use anyhow::anyhow;
 use indexmap::IndexMap;
 use itertools::Itertools;
+use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::util::stream_graph_visitor::{
@@ -46,9 +47,9 @@ use risingwave_pb::meta::subscribe_response::{
 use risingwave_pb::meta::{PbFragmentWorkerSlotMapping, PbObject, PbObjectGroup};
 use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::source::{PbConnectorSplit, PbConnectorSplits};
+use risingwave_pb::stream_plan::PbStreamNode;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
-use risingwave_pb::stream_plan::{FragmentTypeFlag, PbFragmentTypeFlag, PbStreamNode};
 use risingwave_pb::user::PbUserInfo;
 use risingwave_sqlparser::ast::{SqlOption, Statement};
 use risingwave_sqlparser::parser::{Parser, ParserError};
@@ -1429,12 +1430,18 @@ impl CatalogController {
             .await?;
         let mut fragments = fragments
             .into_iter()
-            .map(|(id, mask, stream_node)| (id, mask, stream_node.to_protobuf()))
+            .map(|(id, mask, stream_node)| {
+                (
+                    id,
+                    FragmentTypeMask::from(mask as u32),
+                    stream_node.to_protobuf(),
+                )
+            })
             .collect_vec();
 
         fragments.retain_mut(|(_, fragment_type_mask, stream_node)| {
             let mut found = false;
-            if *fragment_type_mask & PbFragmentTypeFlag::Source as i32 != 0 {
+            if fragment_type_mask.contains(FragmentTypeFlag::Source) {
                 visit_stream_node_mut(stream_node, |node| {
                     if let PbNodeBody::Source(node) = node {
                         if let Some(node_inner) = &mut node.source_inner
@@ -1451,7 +1458,7 @@ impl CatalogController {
                 // so we just scan all fragments for StreamFsFetch node if using fs connector
                 visit_stream_node_mut(stream_node, |node| {
                     if let PbNodeBody::StreamFsFetch(node) = node {
-                        *fragment_type_mask |= PbFragmentTypeFlag::FsFetch as i32;
+                        fragment_type_mask.add(FragmentTypeFlag::FsFetch);
                         if let Some(node_inner) = &mut node.node_inner
                             && node_inner.source_id == source_id as u32
                         {
@@ -1472,7 +1479,7 @@ impl CatalogController {
         for (id, fragment_type_mask, stream_node) in fragments {
             fragment::ActiveModel {
                 fragment_id: Set(id),
-                fragment_type_mask: Set(fragment_type_mask),
+                fragment_type_mask: Set(fragment_type_mask.into()),
                 stream_node: Set(StreamNode::from(&stream_node)),
                 ..Default::default()
             }
@@ -1504,7 +1511,7 @@ impl CatalogController {
         &self,
         job_id: ObjectId,
         // returns true if the mutation is applied
-        mut fragments_mutation_fn: impl FnMut(&mut i32, &mut PbStreamNode) -> bool,
+        mut fragments_mutation_fn: impl FnMut(FragmentTypeMask, &mut PbStreamNode) -> bool,
         // error message when no relevant fragments is found
         err_msg: &'static str,
     ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>> {
@@ -1524,11 +1531,13 @@ impl CatalogController {
             .await?;
         let mut fragments = fragments
             .into_iter()
-            .map(|(id, mask, stream_node)| (id, mask, stream_node.to_protobuf()))
+            .map(|(id, mask, stream_node)| {
+                (id, FragmentTypeMask::from(mask), stream_node.to_protobuf())
+            })
             .collect_vec();
 
         fragments.retain_mut(|(_, fragment_type_mask, stream_node)| {
-            fragments_mutation_fn(fragment_type_mask, stream_node)
+            fragments_mutation_fn(*fragment_type_mask, stream_node)
         });
         if fragments.is_empty() {
             return Err(MetaError::invalid_parameter(format!(
@@ -1557,13 +1566,13 @@ impl CatalogController {
     async fn mutate_fragment_by_fragment_id(
         &self,
         fragment_id: FragmentId,
-        mut fragment_mutation_fn: impl FnMut(&mut i32, &mut PbStreamNode) -> bool,
+        mut fragment_mutation_fn: impl FnMut(FragmentTypeMask, &mut PbStreamNode) -> bool,
         err_msg: &'static str,
     ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
-        let (mut fragment_type_mask, stream_node): (i32, StreamNode) =
+        let (fragment_type_mask, stream_node): (i32, StreamNode) =
             Fragment::find_by_id(fragment_id)
                 .select_only()
                 .columns([
@@ -1575,8 +1584,9 @@ impl CatalogController {
                 .await?
                 .ok_or_else(|| MetaError::catalog_id_not_found("fragment", fragment_id))?;
         let mut pb_stream_node = stream_node.to_protobuf();
+        let fragment_type_mask = FragmentTypeMask::from(fragment_type_mask);
 
-        if !fragment_mutation_fn(&mut fragment_type_mask, &mut pb_stream_node) {
+        if !fragment_mutation_fn(fragment_type_mask, &mut pb_stream_node) {
             return Err(MetaError::invalid_parameter(format!(
                 "fragment id {fragment_id}: {}",
                 err_msg
@@ -1606,9 +1616,11 @@ impl CatalogController {
         rate_limit: Option<u32>,
     ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>> {
         let update_backfill_rate_limit =
-            |fragment_type_mask: &mut i32, stream_node: &mut PbStreamNode| {
+            |fragment_type_mask: FragmentTypeMask, stream_node: &mut PbStreamNode| {
                 let mut found = false;
-                if *fragment_type_mask & PbFragmentTypeFlag::backfill_rate_limit_fragments() != 0 {
+                if fragment_type_mask
+                    .contains_any(FragmentTypeFlag::backfill_rate_limit_fragments())
+                {
                     visit_stream_node_mut(stream_node, |node| match node {
                         PbNodeBody::StreamCdcScan(node) => {
                             node.rate_limit = rate_limit;
@@ -1648,9 +1660,9 @@ impl CatalogController {
         rate_limit: Option<u32>,
     ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>> {
         let update_sink_rate_limit =
-            |fragment_type_mask: &mut i32, stream_node: &mut PbStreamNode| {
+            |fragment_type_mask: FragmentTypeMask, stream_node: &mut PbStreamNode| {
                 let mut found = false;
-                if *fragment_type_mask & PbFragmentTypeFlag::sink_rate_limit_fragments() != 0 {
+                if fragment_type_mask.contains_any(FragmentTypeFlag::sink_rate_limit_fragments()) {
                     visit_stream_node_mut(stream_node, |node| {
                         if let PbNodeBody::Sink(node) = node {
                             node.rate_limit = rate_limit;
@@ -1671,9 +1683,9 @@ impl CatalogController {
         rate_limit: Option<u32>,
     ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>> {
         let update_dml_rate_limit =
-            |fragment_type_mask: &mut i32, stream_node: &mut PbStreamNode| {
+            |fragment_type_mask: FragmentTypeMask, stream_node: &mut PbStreamNode| {
                 let mut found = false;
-                if *fragment_type_mask & PbFragmentTypeFlag::dml_rate_limit_fragments() != 0 {
+                if fragment_type_mask.contains_any(FragmentTypeFlag::dml_rate_limit_fragments()) {
                     visit_stream_node_mut(stream_node, |node| {
                         if let PbNodeBody::Dml(node) = node {
                             node.rate_limit = rate_limit;
@@ -2030,7 +2042,7 @@ impl CatalogController {
         let fragments = fragments
             .into_iter()
             .filter(|(_, fragment_type_mask, _)| {
-                *fragment_type_mask & FragmentTypeFlag::Sink as i32 != 0
+                FragmentTypeMask::from(*fragment_type_mask).contains(FragmentTypeFlag::Sink)
             })
             .filter_map(|(id, _, stream_node)| {
                 let mut stream_node = stream_node.to_protobuf();
@@ -2089,13 +2101,15 @@ impl CatalogController {
         fragment_id: FragmentId,
         rate_limit: Option<u32>,
     ) -> MetaResult<HashMap<FragmentId, Vec<ActorId>>> {
-        let update_rate_limit = |fragment_type_mask: &mut i32, stream_node: &mut PbStreamNode| {
+        let update_rate_limit = |fragment_type_mask: FragmentTypeMask,
+                                 stream_node: &mut PbStreamNode| {
             let mut found = false;
-            if *fragment_type_mask & PbFragmentTypeFlag::dml_rate_limit_fragments() != 0
-                || *fragment_type_mask & PbFragmentTypeFlag::sink_rate_limit_fragments() != 0
-                || *fragment_type_mask & PbFragmentTypeFlag::backfill_rate_limit_fragments() != 0
-                || *fragment_type_mask & PbFragmentTypeFlag::source_rate_limit_fragments() != 0
-            {
+            if fragment_type_mask.contains_any(
+                FragmentTypeFlag::dml_rate_limit_fragments()
+                    .chain(FragmentTypeFlag::sink_rate_limit_fragments())
+                    .chain(FragmentTypeFlag::backfill_rate_limit_fragments())
+                    .chain(FragmentTypeFlag::source_rate_limit_fragments()),
+            ) {
                 visit_stream_node_mut(stream_node, |node| {
                     if let PbNodeBody::Dml(node) = node {
                         node.rate_limit = rate_limit;
@@ -2305,9 +2319,9 @@ impl CatalogController {
                 fragment::Column::FragmentTypeMask,
                 fragment::Column::StreamNode,
             ])
-            .filter(fragment_type_mask_intersects(
-                PbFragmentTypeFlag::rate_limit_fragments(),
-            ))
+            .filter(fragment_type_mask_intersects(FragmentTypeFlag::raw_flag(
+                FragmentTypeFlag::rate_limit_fragments(),
+            ) as _))
             .into_tuple()
             .all(&txn)
             .await?;

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
+use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
 use risingwave_common::hash::{ActorMapping, VnodeBitmapExt, WorkerSlotId, WorkerSlotMapping};
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_common::{bail, hash};
@@ -46,9 +47,7 @@ use risingwave_pb::meta::subscribe_response::Info as NotificationInfo;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, PbFragmentWorkerSlotMapping, PbObject, PbObjectGroup,
 };
-use risingwave_pb::stream_plan::{
-    PbDispatchOutputMapping, PbDispatcher, PbDispatcherType, PbFragmentTypeFlag,
-};
+use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
 use risingwave_sqlparser::ast::Statement as SqlStatement;
@@ -1662,7 +1661,7 @@ where
 
     let mut source_fragment_ids: HashMap<SourceId, BTreeSet<FragmentId>> = HashMap::new();
     for (fragment_id, mask, stream_node) in fragments {
-        if mask & PbFragmentTypeFlag::Source as i32 == 0 {
+        if !FragmentTypeMask::from(mask).contains(FragmentTypeFlag::Source) {
             continue;
         }
         if let Some(source_id) = stream_node.to_protobuf().find_stream_source() {

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -17,7 +17,7 @@ use std::ops::{AddAssign, Deref};
 
 use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
-use risingwave_common::catalog::TableId;
+use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask, TableId};
 use risingwave_common::hash::{
     ActorAlignmentId, IsSingleton, VirtualNode, VnodeCount, VnodeCountCompat,
 };
@@ -39,8 +39,8 @@ use risingwave_pb::meta::{PbTableFragments, PbTableParallelism};
 use risingwave_pb::plan_common::PbExprContext;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    DispatchStrategy, Dispatcher, FragmentTypeFlag, PbDispatchOutputMapping, PbDispatcher,
-    PbStreamActor, PbStreamContext, StreamNode,
+    DispatchStrategy, Dispatcher, PbDispatchOutputMapping, PbDispatcher, PbStreamActor,
+    PbStreamContext, StreamNode,
 };
 
 use super::{ActorId, FragmentId};
@@ -187,7 +187,7 @@ impl StreamActor {
 #[derive(Clone, Debug, Default)]
 pub struct Fragment {
     pub fragment_id: FragmentId,
-    pub fragment_type_mask: u32,
+    pub fragment_type_mask: FragmentTypeMask,
     pub distribution_type: PbFragmentDistributionType,
     pub actors: Vec<StreamActor>,
     pub state_table_ids: Vec<u32>,
@@ -203,7 +203,7 @@ impl Fragment {
     ) -> PbFragment {
         PbFragment {
             fragment_id: self.fragment_id,
-            fragment_type_mask: self.fragment_type_mask,
+            fragment_type_mask: self.fragment_type_mask.into(),
             distribution_type: self.distribution_type as _,
             actors: self
                 .actors
@@ -484,7 +484,7 @@ impl StreamJobFragments {
     /// Returns the actor ids with the given fragment type.
     pub fn filter_actor_ids(
         &self,
-        check_type: impl Fn(u32) -> bool + 'static,
+        check_type: impl Fn(FragmentTypeMask) -> bool + 'static,
     ) -> impl Iterator<Item = ActorId> + '_ {
         self.fragments
             .values()
@@ -495,7 +495,7 @@ impl StreamJobFragments {
     /// Returns mview actor ids.
     pub fn mview_actor_ids(&self) -> Vec<ActorId> {
         Self::filter_actor_ids(self, |fragment_type_mask| {
-            (fragment_type_mask & FragmentTypeFlag::Mview as u32) != 0
+            fragment_type_mask.contains(FragmentTypeFlag::Mview)
         })
         .collect()
     }
@@ -504,17 +504,19 @@ impl StreamJobFragments {
     pub fn tracking_progress_actor_ids(&self) -> Vec<(ActorId, BackfillUpstreamType)> {
         let mut actor_ids = vec![];
         for fragment in self.fragments.values() {
-            if fragment.fragment_type_mask & FragmentTypeFlag::CdcFilter as u32 != 0 {
+            if fragment
+                .fragment_type_mask
+                .contains(FragmentTypeFlag::CdcFilter)
+            {
                 // Note: CDC table job contains a StreamScan fragment (StreamCdcScan node) and a CdcFilter fragment.
                 // We don't track any fragments' progress.
                 return vec![];
             }
-            if (fragment.fragment_type_mask
-                & (FragmentTypeFlag::Values as u32
-                    | FragmentTypeFlag::StreamScan as u32
-                    | FragmentTypeFlag::SourceScan as u32))
-                != 0
-            {
+            if fragment.fragment_type_mask.contains_any([
+                FragmentTypeFlag::Values,
+                FragmentTypeFlag::StreamScan,
+                FragmentTypeFlag::SourceScan,
+            ]) {
                 actor_ids.extend(fragment.actors.iter().map(|actor| {
                     (
                         actor.actor_id,
@@ -536,27 +538,35 @@ impl StreamJobFragments {
     pub fn mview_fragment(&self) -> Option<Fragment> {
         self.fragments
             .values()
-            .find(|fragment| (fragment.fragment_type_mask & FragmentTypeFlag::Mview as u32) != 0)
+            .find(|fragment| {
+                fragment
+                    .fragment_type_mask
+                    .contains(FragmentTypeFlag::Mview)
+            })
             .cloned()
     }
 
     pub fn source_fragment(&self) -> Option<Fragment> {
         self.fragments
             .values()
-            .find(|fragment| (fragment.fragment_type_mask & FragmentTypeFlag::Source as u32) != 0)
+            .find(|fragment| {
+                fragment
+                    .fragment_type_mask
+                    .contains(FragmentTypeFlag::Source)
+            })
             .cloned()
     }
 
     pub fn sink_fragment(&self) -> Option<Fragment> {
         self.fragments
             .values()
-            .find(|fragment| (fragment.fragment_type_mask & FragmentTypeFlag::Sink as u32) != 0)
+            .find(|fragment| fragment.fragment_type_mask.contains(FragmentTypeFlag::Sink))
             .cloned()
     }
 
     pub fn snapshot_backfill_actor_ids(&self) -> HashSet<ActorId> {
         Self::filter_actor_ids(self, |mask| {
-            (mask & FragmentTypeFlag::SnapshotBackfillStreamScan as u32) != 0
+            mask.contains(FragmentTypeFlag::SnapshotBackfillStreamScan)
         })
         .collect()
     }
@@ -801,10 +811,10 @@ pub enum BackfillUpstreamType {
 }
 
 impl BackfillUpstreamType {
-    pub fn from_fragment_type_mask(mask: u32) -> Self {
-        let is_mview = (mask & FragmentTypeFlag::StreamScan as u32) != 0;
-        let is_values = (mask & FragmentTypeFlag::Values as u32) != 0;
-        let is_source = (mask & FragmentTypeFlag::SourceScan as u32) != 0;
+    pub fn from_fragment_type_mask(mask: FragmentTypeMask) -> Self {
+        let is_mview = mask.contains(FragmentTypeFlag::StreamScan);
+        let is_values = mask.contains(FragmentTypeFlag::Values);
+        let is_source = mask.contains(FragmentTypeFlag::SourceScan);
 
         // Note: in theory we can have multiple backfill executors in one fragment, but currently it's not possible.
         // See <https://github.com/risingwavelabs/risingwave/issues/6236>.
@@ -821,7 +831,7 @@ impl BackfillUpstreamType {
         } else if is_source {
             BackfillUpstreamType::Source
         } else {
-            unreachable!("invalid fragment type mask: {}", mask);
+            unreachable!("invalid fragment type mask: {:?}", mask);
         }
     }
 }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, anyhow};
 use await_tree::{InstrumentAwait, span};
 use either::Either;
 use itertools::Itertools;
-use risingwave_common::catalog::AlterDatabaseParam;
+use risingwave_common::catalog::{AlterDatabaseParam, FragmentTypeFlag};
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::secret::{LocalSecretManager, SecretEncryption};
@@ -54,7 +54,7 @@ use risingwave_pb::ddl_service::{
 };
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    FragmentTypeFlag, MergeNode, PbDispatchOutputMapping, PbDispatcherType, PbStreamFragmentGraph,
+    MergeNode, PbDispatchOutputMapping, PbDispatcherType, PbStreamFragmentGraph,
     StreamFragmentGraph as StreamFragmentGraphProto,
 };
 use risingwave_pb::telemetry::{PbTelemetryDatabaseObject, PbTelemetryEventStage};
@@ -749,7 +749,7 @@ impl DdlController {
         let stream_scan_fragment = table_fragments
             .fragments
             .values()
-            .filter(|f| f.fragment_type_mask & FragmentTypeFlag::StreamScan as u32 != 0)
+            .filter(|f| f.fragment_type_mask.contains(FragmentTypeFlag::StreamScan))
             .exactly_one()
             .ok()
             .with_context(|| {

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -25,7 +25,7 @@ use num_integer::Integer;
 use num_traits::abs;
 use risingwave_common::bail;
 use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
-use risingwave_common::catalog::{DatabaseId, TableId};
+use risingwave_common::catalog::{DatabaseId, FragmentTypeFlag, FragmentTypeMask, TableId};
 use risingwave_common::hash::ActorMapping;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_meta_model::{ObjectId, WorkerId, actor, fragment, streaming_job};
@@ -36,9 +36,7 @@ use risingwave_pb::meta::table_fragments::fragment::{
     FragmentDistributionType, PbFragmentDistributionType,
 };
 use risingwave_pb::meta::table_fragments::{self, State};
-use risingwave_pb::stream_plan::{
-    Dispatcher, FragmentTypeFlag, PbDispatcher, PbDispatcherType, StreamNode,
-};
+use risingwave_pb::stream_plan::{Dispatcher, PbDispatcher, PbDispatcherType, StreamNode};
 use thiserror_ext::AsReport;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, oneshot};
@@ -64,7 +62,7 @@ pub struct WorkerReschedule {
 
 pub struct CustomFragmentInfo {
     pub fragment_id: u32,
-    pub fragment_type_mask: u32,
+    pub fragment_type_mask: FragmentTypeMask,
     pub distribution_type: PbFragmentDistributionType,
     pub state_table_ids: Vec<u32>,
     pub node: StreamNode,
@@ -79,16 +77,6 @@ pub struct CustomActorInfo {
     pub dispatcher: Vec<Dispatcher>,
     /// `None` if singleton.
     pub vnode_bitmap: Option<Bitmap>,
-}
-
-impl CustomFragmentInfo {
-    pub fn get_fragment_type_mask(&self) -> u32 {
-        self.fragment_type_mask
-    }
-
-    pub fn distribution_type(&self) -> FragmentDistributionType {
-        self.distribution_type
-    }
 }
 
 use educe::Educe;
@@ -537,7 +525,7 @@ impl ScaleController {
 
                 let fragment = CustomFragmentInfo {
                     fragment_id: fragment_id as _,
-                    fragment_type_mask: fragment_type_mask as _,
+                    fragment_type_mask: fragment_type_mask.into(),
                     distribution_type: distribution_type.into(),
                     state_table_ids: state_table_ids.into_u32_array(),
                     node: stream_node.to_protobuf(),
@@ -713,7 +701,9 @@ impl ScaleController {
                 }
             }
 
-            if (fragment.fragment_type_mask & FragmentTypeFlag::Source as u32) != 0
+            if fragment
+                .fragment_type_mask
+                .contains(FragmentTypeFlag::Source)
                 && fragment.node.find_stream_source().is_some()
             {
                 stream_source_fragment_ids.insert(*fragment_id);
@@ -750,7 +740,7 @@ impl ScaleController {
                 .map(|v| v.unsigned_abs())
                 .sum();
 
-            match fragment.distribution_type() {
+            match fragment.distribution_type {
                 FragmentDistributionType::Hash => {
                     if fragment.actors.len() + added_actor_count <= removed_actor_count {
                         bail!("can't remove all actors from fragment {}", fragment_id);
@@ -774,7 +764,10 @@ impl ScaleController {
             for noshuffle_downstream in no_shuffle_reschedule.keys() {
                 let fragment = fragment_map.get(noshuffle_downstream).unwrap();
                 // SourceScan is always a NoShuffle downstream, rescheduled together with the upstream Source.
-                if (fragment.fragment_type_mask & FragmentTypeFlag::SourceScan as u32) != 0 {
+                if fragment
+                    .fragment_type_mask
+                    .contains(FragmentTypeFlag::SourceScan)
+                {
                     let stream_node = &fragment.node;
                     if let Some((_source_id, upstream_source_fragment_id)) =
                         stream_node.find_source_backfill()
@@ -853,7 +846,7 @@ impl ScaleController {
 
             let fragment = ctx.fragment_map.get(fragment_id).unwrap();
 
-            match fragment.distribution_type() {
+            match fragment.distribution_type {
                 FragmentDistributionType::Single => {
                     // Skip re-balancing action for single distribution (always None)
                     fragment_actor_bitmap
@@ -966,7 +959,7 @@ impl ScaleController {
                 .unwrap_or_default();
 
             // Question: Is it possible to have Hash Distribution Fragment but the Actor's bitmap remains unchanged?
-            if upstream_fragment.distribution_type() == FragmentDistributionType::Single {
+            if upstream_fragment.distribution_type == FragmentDistributionType::Single {
                 assert!(
                     upstream_fragment_bitmap.is_empty(),
                     "single fragment should have no bitmap updates"
@@ -1044,7 +1037,7 @@ impl ScaleController {
                         None => {
                             // single fragment should have no bitmap updates (same as upstream)
                             assert_eq!(
-                                upstream_fragment.distribution_type(),
+                                upstream_fragment.distribution_type,
                                 FragmentDistributionType::Single
                             );
                         }
@@ -1065,7 +1058,7 @@ impl ScaleController {
                 }
             }
 
-            match fragment.distribution_type() {
+            match fragment.distribution_type {
                 FragmentDistributionType::Hash => {}
                 FragmentDistributionType::Single => {
                     // single distribution should update nothing
@@ -1272,7 +1265,7 @@ impl ScaleController {
                 .cloned()
                 .collect();
 
-            let upstream_dispatcher_mapping = match fragment.distribution_type() {
+            let upstream_dispatcher_mapping = match fragment.distribution_type {
                 FragmentDistributionType::Hash => {
                     if !in_degree_types.contains(&DispatcherType::Hash) {
                         None
@@ -1323,7 +1316,7 @@ impl ScaleController {
                 vec![]
             };
 
-            let vnode_bitmap_updates = match fragment.distribution_type() {
+            let vnode_bitmap_updates = match fragment.distribution_type {
                 FragmentDistributionType::Hash => {
                     let mut vnode_bitmap_updates =
                         fragment_actor_bitmap.remove(&fragment_id).unwrap();

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -22,7 +22,8 @@ use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::{
-    CDC_SOURCE_COLUMN_NUM, TableId, generate_internal_table_name_with_type,
+    CDC_SOURCE_COLUMN_NUM, FragmentTypeFlag, FragmentTypeMask, TableId,
+    generate_internal_table_name_with_type,
 };
 use risingwave_common::hash::VnodeCount;
 use risingwave_common::util::iter_util::ZipEqFast;
@@ -39,9 +40,8 @@ use risingwave_pb::stream_plan::stream_fragment_graph::{
 };
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    BackfillOrder, DispatchOutputMapping, DispatchStrategy, DispatcherType, FragmentTypeFlag,
-    PbStreamNode, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamScanNode,
-    StreamScanType,
+    BackfillOrder, DispatchOutputMapping, DispatchStrategy, DispatcherType, PbStreamNode,
+    StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamScanNode, StreamScanType,
 };
 
 use crate::barrier::SnapshotBackfillInfo;
@@ -552,7 +552,9 @@ impl StreamFragmentGraph {
     pub fn dml_fragment_id(&self) -> Option<FragmentId> {
         self.fragments
             .values()
-            .filter(|b| b.fragment_type_mask & FragmentTypeFlag::Dml as u32 != 0)
+            .filter(|b| {
+                FragmentTypeMask::from(b.fragment_type_mask).contains(FragmentTypeFlag::Dml)
+            })
             .map(|b| b.fragment_id)
             .at_most_one()
             .expect("require at most 1 dml node when creating the streaming job")
@@ -592,16 +594,17 @@ impl StreamFragmentGraph {
     pub fn collect_snapshot_backfill_info(
         &self,
     ) -> MetaResult<(Option<SnapshotBackfillInfo>, SnapshotBackfillInfo)> {
-        Self::collect_snapshot_backfill_info_impl(
-            self.fragments
-                .values()
-                .map(|fragment| (fragment.node.as_ref().unwrap(), fragment.fragment_type_mask)),
-        )
+        Self::collect_snapshot_backfill_info_impl(self.fragments.values().map(|fragment| {
+            (
+                fragment.node.as_ref().unwrap(),
+                fragment.fragment_type_mask.into(),
+            )
+        }))
     }
 
     /// Returns `Ok((Some(``snapshot_backfill_info``), ``cross_db_snapshot_backfill_info``))`
     pub fn collect_snapshot_backfill_info_impl(
-        fragments: impl IntoIterator<Item = (&PbStreamNode, u32)>,
+        fragments: impl IntoIterator<Item = (&PbStreamNode, FragmentTypeMask)>,
     ) -> MetaResult<(Option<SnapshotBackfillInfo>, SnapshotBackfillInfo)> {
         let mut prev_stream_scan: Option<(Option<SnapshotBackfillInfo>, StreamScanNode)> = None;
         let mut cross_db_info = SnapshotBackfillInfo {
@@ -616,17 +619,15 @@ impl StreamFragmentGraph {
                     let is_snapshot_backfill = match stream_scan_type {
                         StreamScanType::SnapshotBackfill => {
                             assert!(
-                                (fragment_type_mask
-                                    & (FragmentTypeFlag::SnapshotBackfillStreamScan as u32))
-                                    > 0
+                                fragment_type_mask
+                                    .contains(FragmentTypeFlag::SnapshotBackfillStreamScan)
                             );
                             true
                         }
                         StreamScanType::CrossDbSnapshotBackfill => {
                             assert!(
-                                (fragment_type_mask
-                                    & (FragmentTypeFlag::CrossDbSnapshotBackfillStreamScan as u32))
-                                    > 0
+                                fragment_type_mask
+                                    .contains(FragmentTypeFlag::CrossDbSnapshotBackfillStreamScan)
                             );
                             cross_db_info.upstream_mv_table_id_to_backfill_epoch.insert(
                                 TableId::new(stream_scan.table_id),
@@ -998,8 +999,9 @@ impl CompleteStreamFragmentGraph {
                         | StreamingJobType::Index => {
                             // Build the extra edges between the upstream `Materialize` and
                             // the downstream `StreamScan` of the new job.
-                            if upstream_fragment.fragment_type_mask & FragmentTypeFlag::Mview as u32
-                                != 0
+                            if upstream_fragment
+                                .fragment_type_mask
+                                .contains(FragmentTypeFlag::Mview)
                             {
                                 // Resolve the required output columns from the upstream materialized view.
                                 let (dist_key_indices, output_mapping) = {
@@ -1033,9 +1035,9 @@ impl CompleteStreamFragmentGraph {
                             }
                             // Build the extra edges between the upstream `Source` and
                             // the downstream `SourceBackfill` of the new job.
-                            else if upstream_fragment.fragment_type_mask
-                                & FragmentTypeFlag::Source as u32
-                                != 0
+                            else if upstream_fragment
+                                .fragment_type_mask
+                                .contains(FragmentTypeFlag::Source)
                             {
                                 let output_mapping = {
                                     let nodes = &upstream_fragment.nodes;
@@ -1371,7 +1373,7 @@ impl CompleteStreamFragmentGraph {
         let vnode_count = distribution.vnode_count();
 
         let materialized_fragment_id =
-            if inner.fragment_type_mask & FragmentTypeFlag::Mview as u32 != 0 {
+            if FragmentTypeMask::from(inner.fragment_type_mask).contains(FragmentTypeFlag::Mview) {
                 job_id
             } else {
                 None
@@ -1385,7 +1387,7 @@ impl CompleteStreamFragmentGraph {
 
         Fragment {
             fragment_id: inner.fragment_id,
-            fragment_type_mask: inner.fragment_type_mask,
+            fragment_type_mask: inner.fragment_type_mask.into(),
             distribution_type,
             actors,
             state_table_ids,

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -17,7 +17,7 @@ use std::num::NonZeroUsize;
 use std::vec;
 
 use itertools::Itertools;
-use risingwave_common::catalog::{DatabaseId, SchemaId, TableId};
+use risingwave_common::catalog::{DatabaseId, FragmentTypeFlag, SchemaId, TableId};
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_pb::catalog::PbTable;
@@ -36,10 +36,9 @@ use risingwave_pb::plan_common::{ColumnCatalog, ColumnDesc, ExprContext, Field};
 use risingwave_pb::stream_plan::stream_fragment_graph::{StreamFragment, StreamFragmentEdge};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{
-    AggCallState, DispatchStrategy, DispatcherType, ExchangeNode, FilterNode, FragmentTypeFlag,
-    MaterializeNode, PbDispatchOutputMapping, ProjectNode, SimpleAggNode, SourceNode,
-    StreamContext, StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamSource,
-    agg_call_state,
+    AggCallState, DispatchStrategy, DispatcherType, ExchangeNode, FilterNode, MaterializeNode,
+    PbDispatchOutputMapping, ProjectNode, SimpleAggNode, SourceNode, StreamContext,
+    StreamFragmentGraph as StreamFragmentGraphProto, StreamNode, StreamSource, agg_call_state,
 };
 
 use crate::MetaResult;
@@ -293,7 +292,7 @@ fn make_stream_fragments() -> Vec<StreamFragment> {
     fragments.push(StreamFragment {
         fragment_id: 1,
         node: Some(simple_agg_node),
-        fragment_type_mask: FragmentTypeFlag::FragmentUnspecified as u32,
+        fragment_type_mask: 0,
         requires_singleton: false,
         table_ids_cnt: 0,
         upstream_table_ids: vec![],

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -451,37 +451,6 @@ impl stream_plan::StreamNode {
         None
     }
 }
-
-impl stream_plan::FragmentTypeFlag {
-    /// Fragments that may be affected by `BACKFILL_RATE_LIMIT`.
-    pub fn backfill_rate_limit_fragments() -> i32 {
-        stream_plan::FragmentTypeFlag::SourceScan as i32
-            | stream_plan::FragmentTypeFlag::StreamScan as i32
-    }
-
-    /// Fragments that may be affected by `SOURCE_RATE_LIMIT`.
-    /// Note: for `FsFetch`, old fragments don't have this flag set, so don't use this to check.
-    pub fn source_rate_limit_fragments() -> i32 {
-        stream_plan::FragmentTypeFlag::Source as i32 | stream_plan::FragmentTypeFlag::FsFetch as i32
-    }
-
-    /// Fragments that may be affected by `BACKFILL_RATE_LIMIT`.
-    pub fn sink_rate_limit_fragments() -> i32 {
-        stream_plan::FragmentTypeFlag::Sink as i32
-    }
-
-    /// Note: this doesn't include `FsFetch` created in old versions.
-    pub fn rate_limit_fragments() -> i32 {
-        Self::backfill_rate_limit_fragments()
-            | Self::source_rate_limit_fragments()
-            | Self::sink_rate_limit_fragments()
-    }
-
-    pub fn dml_rate_limit_fragments() -> i32 {
-        stream_plan::FragmentTypeFlag::Dml as i32
-    }
-}
-
 impl stream_plan::Dispatcher {
     pub fn as_strategy(&self) -> stream_plan::DispatchStrategy {
         stream_plan::DispatchStrategy {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously when declaring the `FragmentTypeFlag`, we need to carefully set the raw int value of the enum variant to be a well-formed power of 2 value. In this PR, we will change to use a macro to generate the enum, so that we only need to declare a list of flags, and then the value can be correctly generated.

Besides, previously we operate with `fragment_type_mask` as raw int value, where we have to do raw bit operation on int value, which is unreadable, and can easily make mistake. In this PR, we will wrap the raw int value with a struct `FragmentTypeMask`, and provide method like `add`, `contains` to encapsulate the logic of `|=` and `(mask | flag) != 0`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
