### PR TITLE
fix: kafka offset handling for timestamps beyond latest #22413

### DIFF
--- a/e2e_test/source_inline/kafka/issue_22387.slt
+++ b/e2e_test/source_inline/kafka/issue_22387.slt
@@ -1,0 +1,18 @@
+control substitution on
+
+# Issue Description
+#
+# This issue exists because:
+# When we query a timestamp that is greater than all message timestamps, the Kafka SDK's `offsets_for_times` returns an offset pointing to the partition end.
+# Our handling is to use the current high-watermark as the starting offset, intending to read from the latest (the first message greater than the timestamp).
+# However, for normal latest offset handling, we use high-watermark - 1.
+# As a result, we accessed a non-existent offset in the reader, and Kafka reset the consumer position, causing us to actually consume from the earliest offset.
+
+system ok
+rpk topic create test_topic_issue_22387;
+
+system ok
+python e2e_test/source_inline/kafka/kafka_startup_millis.py --db-name $__DATABASE__ --topic test_topic_issue_22387 --produce-after-table
+
+system ok
+rpk topic delete test_topic_issue_22387;

--- a/e2e_test/source_inline/kafka/kafka_startup_millis.py
+++ b/e2e_test/source_inline/kafka/kafka_startup_millis.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import time
+import sys
+import os
+from confluent_kafka import Producer
+import psycopg2
+
+
+def produce_records(producer, topic, records):
+    """Produce records to Kafka topic"""
+    for record in records:
+        producer.produce(topic, value=json.dumps(record))
+    producer.flush()
+    print(f"Produced {len(records)} records to topic {topic}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Test Kafka startup timestamp functionality')
+    parser.add_argument('--db-name', required=True, help='RisingWave database name')
+    parser.add_argument('--topic', required=True, help='Kafka topic name')
+    parser.add_argument('--produce-after-table', action='store_true', help='Produce more data after building table')
+
+    args = parser.parse_args()
+
+    kafka_broker = os.environ.get("RISEDEV_KAFKA_BOOTSTRAP_SERVERS")
+    # Initialize Kafka producer
+    try:
+        producer = Producer({
+            'bootstrap.servers': kafka_broker
+        })
+        print(f"Connected to Kafka broker: {kafka_broker}")
+    except Exception as e:
+        print(f"Failed to connect to Kafka: {e}")
+        sys.exit(1)
+
+    try:
+        # Step 1: Produce some initial records to the topic
+        initial_records = [
+            {"id": i}
+            for i in range(1, 6)
+        ]
+        produce_records(producer, args.topic, initial_records)
+
+        # Step 2: Sleep 1 second
+        print("Sleeping for 1 second...")
+        time.sleep(1)
+
+        # Step 3: Record timestamp as millis as CURRENT_TIMESTAMP
+        current_timestamp_millis = int(time.time() * 1000)
+        print(f"Recorded CURRENT_TIMESTAMP: {current_timestamp_millis}")
+
+        # Step 4: Produce more data
+        additional_records = [
+            {"id": i}
+            for i in range(6, 9)
+        ]
+
+        if not args.produce_after_table:
+            print("Producing more data before table is created")
+            produce_records(producer, args.topic, additional_records)
+
+        # Connect to RisingWave
+        try:
+            conn = psycopg2.connect(
+                host=os.environ.get("RISEDEV_RW_FRONTEND_LISTEN_ADDRESS"),
+                port=os.environ.get("RISEDEV_RW_FRONTEND_PORT"),
+                user='root',
+                password='',
+                database=args.db_name
+            )
+            cur = conn.cursor()
+            print(f"Connected to RisingWave database: {args.db_name}")
+        except Exception as e:
+            print(f"Failed to connect to RisingWave: {e}")
+            sys.exit(1)
+
+        table_name = f"test_table_{int(time.time())}"
+
+        try:
+            # Step 5: Create a table in RisingWave, starting load from CURRENT_TIMESTAMP
+            create_table_sql = f"""
+            CREATE TABLE {table_name} (
+                id INTEGER,
+                message VARCHAR,
+                timestamp BIGINT
+            ) WITH (
+                connector = 'kafka',
+                topic = '{args.topic}',
+                properties.bootstrap.server = '{kafka_broker}',
+                scan.startup.timestamp_millis = '{current_timestamp_millis}'
+            ) FORMAT PLAIN ENCODE JSON;
+            """
+
+            cur.execute(create_table_sql)
+            conn.commit()
+            print(f"Created table {table_name} with startup timestamp {current_timestamp_millis}")
+
+            if args.produce_after_table:
+                print("Producing more data after table is created")
+                produce_records(producer, args.topic, additional_records)
+
+            # Wait a moment for the table to start consuming
+            time.sleep(3)
+
+            # Step 6: Select count(*) from the table
+            cur.execute(f"SELECT COUNT(*) FROM {table_name}")
+            count_result = cur.fetchone()[0]
+            print(f"Count from table {table_name}: {count_result}")
+
+            # Also show the actual records for verification
+            cur.execute(f"SELECT * FROM {table_name} ORDER BY id")
+            records = cur.fetchall()
+            print(f"Records in table:")
+            for record in records:
+                print(f"  {record}")
+
+            # Expected: Should only see records with timestamps >= current_timestamp_millis
+            expected_count = len([r for r in additional_records])
+            assert count_result == expected_count, f"❌ Test FAILED: Expected count {expected_count}, got {count_result}"
+
+        finally:
+            # Step 7: Drop the table
+            try:
+                cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+                conn.commit()
+                print(f"Dropped table {table_name}")
+            except Exception as e:
+                print(f"Failed to drop table: {e}")
+
+            cur.close()
+            conn.close()
+
+    finally:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_test/source_inline/kafka/protobuf/alter_source.slt
+++ b/e2e_test/source_inline/kafka/protobuf/alter_source.slt
@@ -76,7 +76,7 @@ SELECT age FROM mv_user_gen;
 
 # Test that generated column works before schema refresh
 query II rowsort retry 3 backoff 5s
-SELECT id, t FROM mv_user_gen LIMIT 5;
+SELECT id, t FROM mv_user_gen ORDER BY id LIMIT 5;
 ----
 0 1
 1 2

--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -22,7 +22,8 @@ use moka::future::Cache as MokaCache;
 use moka::ops::compute::Op;
 use rdkafka::admin::{AdminClient, AdminOptions};
 use rdkafka::consumer::{BaseConsumer, Consumer};
-use rdkafka::error::KafkaResult;
+use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::{ClientConfig, Offset, TopicPartitionList};
 use risingwave_common::bail;
 use risingwave_common::metrics::LabelGuardedIntGauge;
@@ -292,13 +293,17 @@ impl KafkaSplitEnumerator {
             )
         })?;
 
+        // Watermark here has nothing to do with watermark in streaming processing. Watermark
+        // here means smallest/largest offset available for reading.
+        let mut watermarks = self.get_watermarks(topic_partitions.as_ref()).await?;
+
         // here we are getting the start offset and end offset for each partition with the given
         // timestamp if the timestamp is None, we will use the low watermark and high
         // watermark as the start and end offset if the timestamp is provided, we will use
         // the watermark to narrow down the range
         let mut expect_start_offset = if let Some(ts) = expect_start_timestamp_millis {
             Some(
-                self.fetch_offset_for_time(topic_partitions.as_ref(), ts)
+                self.fetch_offset_for_time(topic_partitions.as_ref(), ts, &watermarks)
                     .await?,
             )
         } else {
@@ -307,37 +312,24 @@ impl KafkaSplitEnumerator {
 
         let mut expect_stop_offset = if let Some(ts) = expect_stop_timestamp_millis {
             Some(
-                self.fetch_offset_for_time(topic_partitions.as_ref(), ts)
+                self.fetch_offset_for_time(topic_partitions.as_ref(), ts, &watermarks)
                     .await?,
             )
         } else {
             None
         };
 
-        // Watermark here has nothing to do with watermark in streaming processing. Watermark
-        // here means smallest/largest offset available for reading.
-        let mut watermarks = {
-            let mut ret = HashMap::new();
-            for partition in &topic_partitions {
-                let (low, high) = self
-                    .client
-                    .fetch_watermarks(self.topic.as_str(), *partition, self.sync_call_timeout)
-                    .await?;
-                ret.insert(partition, (low - 1, high));
-            }
-            ret
-        };
-
         Ok(topic_partitions
             .iter()
             .map(|partition| {
-                let (low, high) = watermarks.remove(&partition).unwrap();
+                let (low, high) = watermarks.remove(partition).unwrap();
                 let start_offset = {
+                    let earliest_offset = low - 1;
                     let start = expect_start_offset
                         .as_mut()
-                        .map(|m| m.remove(partition).flatten().map(|t| t-1).unwrap_or(low))
-                        .unwrap_or(low);
-                    i64::max(start, low)
+                        .map(|m| m.remove(partition).flatten().unwrap_or(earliest_offset))
+                        .unwrap_or(earliest_offset);
+                    i64::max(start, earliest_offset)
                 };
                 let stop_offset = {
                     let stop = expect_stop_offset
@@ -383,7 +375,8 @@ impl KafkaSplitEnumerator {
                 Ok(map)
             }
             KafkaEnumeratorOffset::Timestamp(time) => {
-                self.fetch_offset_for_time(partitions, time).await
+                self.fetch_offset_for_time(partitions, time, watermarks)
+                    .await
             }
             KafkaEnumeratorOffset::None => partitions
                 .iter()
@@ -412,7 +405,8 @@ impl KafkaSplitEnumerator {
                 Ok(map)
             }
             KafkaEnumeratorOffset::Timestamp(time) => {
-                self.fetch_offset_for_time(partitions, time).await
+                self.fetch_offset_for_time(partitions, time, watermarks)
+                    .await
             }
             KafkaEnumeratorOffset::None => partitions
                 .iter()
@@ -425,6 +419,7 @@ impl KafkaSplitEnumerator {
         &self,
         partitions: &[i32],
         time: i64,
+        watermarks: &HashMap<i32, (i64, i64)>,
     ) -> KafkaResult<HashMap<i32, Option<i64>>> {
         let mut tpl = TopicPartitionList::new();
 
@@ -445,16 +440,48 @@ impl KafkaSplitEnumerator {
                     // XXX(rc): currently in RW source, `offset` means the last consumed offset, so we need to subtract 1
                     result.insert(elem.partition(), Some(offset - 1));
                 }
-                _ => {
-                    let (_, high_watermark) = self
-                        .client
-                        .fetch_watermarks(
-                            self.topic.as_str(),
-                            elem.partition(),
-                            self.sync_call_timeout,
-                        )
-                        .await?;
-                    result.insert(elem.partition(), Some(high_watermark));
+                Offset::End => {
+                    let (_, high_watermark) = watermarks.get(&elem.partition()).unwrap();
+                    tracing::info!(
+                        source_id = self.context.info.source_id,
+                        "no message found before timestamp {} (ms) for partition {}, start from latest",
+                        time,
+                        elem.partition()
+                    );
+                    result.insert(elem.partition(), Some(high_watermark - 1)); // align to Latest
+                }
+                Offset::Invalid => {
+                    // special case for madsim test
+                    // For a read Kafka, it returns `Offset::Latest` when the timestamp is later than the latest message in the partition
+                    // But in madsim, it returns `Offset::Invalid`
+                    // So we align to Latest here
+                    tracing::info!(
+                        source_id = self.context.info.source_id,
+                        "got invalid offset for partition  {} at timestamp {}, align to latest",
+                        elem.partition(),
+                        time
+                    );
+                    let (_, high_watermark) = watermarks.get(&elem.partition()).unwrap();
+                    result.insert(elem.partition(), Some(high_watermark - 1)); // align to Latest
+                }
+                Offset::Beginning => {
+                    let (low, _) = watermarks.get(&elem.partition()).unwrap();
+                    tracing::info!(
+                        source_id = self.context.info.source_id,
+                        "all message in partition {} is after timestamp {} (ms), start from earliest",
+                        elem.partition(),
+                        time,
+                    );
+                    result.insert(elem.partition(), Some(low - 1)); // align to Earliest
+                }
+                err_offset @ Offset::Stored | err_offset @ Offset::OffsetTail(_) => {
+                    tracing::error!(
+                        source_id = self.context.info.source_id,
+                        "got invalid offset for partition {}: {err_offset:?}",
+                        elem.partition(),
+                        err_offset = err_offset,
+                    );
+                    return Err(KafkaError::OffsetFetch(RDKafkaErrorCode::NoOffset));
                 }
             }
         }


### PR DESCRIPTION
…mplement Kafka startup timestamp functionality

- Introduced a new end-to-end test script to validate Kafka's behavior when querying offsets for timestamps greater than available messages.
- Enhanced the Kafka enumerator to correctly handle offsets based on watermarks, ensuring proper alignment with the latest and earliest offsets.
- Updated SQL test to ensure correct ordering in query results.

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

resolve https://github.com/risingwavelabs/risingwave/issues/22431

cherry-pick https://github.com/risingwavelabs/risingwave/pull/22413 to release-2.5

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
