### PR TITLE
feat: decouple streaming now timestamp and epoch

### DIFF
--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -352,6 +352,10 @@ pub mod default {
             30000
         }
 
+        pub fn streaming_now_progress_ratio() -> Option<f32> {
+            None
+        }
+
         pub fn enable_explain_analyze_stats() -> bool {
             true
         }

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -199,6 +199,9 @@ pub struct StreamingDeveloperConfig {
     #[serde(default = "default::developer::streaming_hash_join_entry_state_max_rows")]
     pub hash_join_entry_state_max_rows: usize,
 
+    #[serde(default = "default::developer::streaming_now_progress_ratio")]
+    pub now_progress_ratio: Option<f32>,
+
     /// Enable / Disable profiling stats used by `EXPLAIN ANALYZE`
     #[serde(default = "default::developer::enable_explain_analyze_stats")]
     pub enable_explain_analyze_stats: bool,

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -177,9 +177,10 @@ impl<S: StateStore> NowExecutor<S> {
                         < new_timestamp.timestamp_millis()
                     {
                         info!(
-                            "adjusting progress timestamp from {} to {}. barrier_interval_ms: {}, progress_ratio: {}",
+                            "adjusted next now timestamp from {} to {}. curr_epoch: {}, barrier_interval_ms: {}, progress_ratio: {}",
                             new_timestamp.timestamp_millis(),
                             progress_timestamp,
+                            barrier.get_curr_epoch(),
                             barrier_interval_ms,
                             progress_ratio
                         );

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -560,7 +560,12 @@ mod tests {
     async fn test_now_with_progress_ratio() -> StreamExecutorResult<()> {
         let state_store = create_state_store();
         let progress_ratio = Some(2.0);
-        let (tx, mut now) = create_executor_with_progress_ratio(NowMode::UpdateCurrent, &state_store, progress_ratio).await;
+        let (tx, mut now) = create_executor_with_progress_ratio(
+            NowMode::UpdateCurrent,
+            &state_store,
+            progress_ratio,
+        )
+        .await;
 
         // Init barrier at epoch 1 (timestamp 2021-04-01T00:00:00.001Z)
         tx.send(Barrier::new_test_barrier(test_epoch(1))).unwrap();
@@ -592,7 +597,7 @@ mod tests {
         );
 
         // Send next barrier at epoch 5 (timestamp 2021-04-01T00:00:00.005Z)
-        // With progress_ratio = 2.0 and barrier_interval_ms = 1000, 
+        // With progress_ratio = 2.0 and barrier_interval_ms = 1000,
         // adjusted timestamp should be: 1 + (1000 * 2.0) = 2001ms = 2021-04-01T00:00:02.001Z
         // Since 2001 < 5, the adjusted timestamp should be used
         tx.send(Barrier::with_prev_epoch_for_test(
@@ -612,7 +617,7 @@ mod tests {
             StreamChunk::from_pretty(
                 " TZ
                 - 2021-04-01T00:00:00.001Z
-                + 2021-04-01T00:00:02.001Z"  // adjusted timestamp
+                + 2021-04-01T00:00:02.001Z" // adjusted timestamp
             )
         );
 
@@ -648,7 +653,7 @@ mod tests {
             StreamChunk::from_pretty(
                 " TZ
                 - 2021-04-01T00:00:02.001Z
-                + 2021-04-01T00:00:04.001Z"  // adjusted timestamp
+                + 2021-04-01T00:00:04.001Z" // adjusted timestamp
             )
         );
 
@@ -672,7 +677,7 @@ mod tests {
             StreamChunk::from_pretty(
                 " TZ
                 - 2021-04-01T00:00:04.001Z
-                + 2021-04-01T00:00:06.001Z"  // adjusted timestamp
+                + 2021-04-01T00:00:06.001Z" // adjusted timestamp
             )
         );
 
@@ -696,7 +701,7 @@ mod tests {
             StreamChunk::from_pretty(
                 " TZ
                 - 2021-04-01T00:00:06.001Z
-                + 2021-04-01T00:00:08.001Z"  // adjusted timestamp
+                + 2021-04-01T00:00:08.001Z" // adjusted timestamp
             )
         );
 
@@ -721,7 +726,7 @@ mod tests {
             StreamChunk::from_pretty(
                 " TZ
                 - 2021-04-01T00:00:08.001Z
-                + 2021-04-01T00:00:10.001Z"  // adjusted timestamp
+                + 2021-04-01T00:00:10.001Z" // adjusted timestamp
             )
         );
 
@@ -746,7 +751,7 @@ mod tests {
             StreamChunk::from_pretty(
                 " TZ
                 - 2021-04-01T00:00:10.001Z
-                + 2021-04-01T00:00:12.001Z"  // adjusted timestamp
+                + 2021-04-01T00:00:12.001Z" // adjusted timestamp
             )
         );
 
@@ -869,7 +874,7 @@ mod tests {
     async fn create_executor_with_progress_ratio(
         mode: NowMode,
         state_store: &MemoryStateStore,
-        progress_ratio: Option<f32>
+        progress_ratio: Option<f32>,
     ) -> (UnboundedSender<Barrier>, BoxedMessageStream) {
         let table_id = TableId::new(1);
         let column_descs = vec![ColumnDesc::unnamed(ColumnId::new(0), DataType::Timestamptz)];

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -134,7 +134,8 @@ impl<S: StateStore> NowExecutor<S> {
                 );
             }
             for barrier in barriers {
-                let new_timestamp = barrier.get_curr_epoch().as_timestamptz();
+                let curr_epoch = barrier.get_curr_epoch();
+                let new_timestamp = curr_epoch.as_timestamptz();
                 let pause_mutation =
                     barrier
                         .mutation
@@ -180,7 +181,7 @@ impl<S: StateStore> NowExecutor<S> {
                             "adjusted next now timestamp from {} to {}. curr_epoch: {}, barrier_interval_ms: {}, progress_ratio: {}",
                             new_timestamp.timestamp_millis(),
                             progress_timestamp,
-                            barrier.get_curr_epoch(),
+                            curr_epoch,
                             barrier_interval_ms,
                             progress_ratio
                         );

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -97,8 +97,8 @@ impl<S: StateStore> NowExecutor<S> {
         } = self;
 
         info!(
-            "NowExecutor started. mode: {:?}, progress_ratio: {:?}, barrier_interval_ms: {:?}",
-            mode, progress_ratio, barrier_interval_ms
+            "NowExecutor started. progress_ratio: {:?}, barrier_interval_ms: {:?}",
+            progress_ratio, barrier_interval_ms
         );
 
         let max_chunk_size = crate::config::chunk_size();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

## TL;DR
add a `stream_now_progress_ratio` to decouple now timestamp from the epoch timestamp to avoid introducing excessive changes within one epoch from dynamic filter
``` rust
// stream_now_progress_ratio must be set > 1.0, otherwise it will be ignore
let adjusted_timestamp = prev_now_timestamp + barrier_interval_ms * stream_now_progress_ratio;
let now_timestamp = min(adjusted_timestamp, epoch_timestamp);
```

## Summary
This pull request introduces enhancements to the `NowExecutor` by adding support for a configurable `progress_ratio` to adjust timestamp progression dynamically. It also includes changes to the configuration system to support this new feature. Below are the key changes grouped by theme:

### Configuration Updates
* Added a new `now_progress_ratio` field to `StreamingDeveloperConfig` to allow optional configuration of the progress ratio for the `NowExecutor`. A default function `streaming_now_progress_ratio` returning `None` was also added. (`src/common/src/config.rs`, [[1]](diffhunk://#diff-c81fa6ff8ebe6cc6822331e0f5ae282664862104a8b9189edce5e9336685690fR1300-R1302) [[2]](diffhunk://#diff-c81fa6ff8ebe6cc6822331e0f5ae282664862104a8b9189edce5e9336685690fR2417-R2420)

### `NowExecutor` Enhancements
* Introduced `progress_ratio` and `barrier_interval_ms` as new fields in the `NowExecutor` to enable dynamic timestamp adjustment during execution. These fields are initialized in the constructor and used in the `execute` method to calculate adjusted timestamps. (`src/stream/src/executor/now.rs`, [[1]](diffhunk://#diff-02242739957400ef6800c5c4fcb2889b19700416cdb8035cefc29c4815896069R41-R44) [[2]](diffhunk://#diff-02242739957400ef6800c5c4fcb2889b19700416cdb8035cefc29c4815896069R73-R83) [[3]](diffhunk://#diff-02242739957400ef6800c5c4fcb2889b19700416cdb8035cefc29c4815896069R95-R96) [[4]](diffhunk://#diff-02242739957400ef6800c5c4fcb2889b19700416cdb8035cefc29c4815896069L155-R195)
* Modified the timestamp progression logic in the `execute` method to account for the `progress_ratio`. If the ratio is greater than `1.0`, the timestamp is adjusted to avoid large gaps, ensuring smoother downstream operations. (`src/stream/src/executor/now.rs`, [src/stream/src/executor/now.rsL155-R195](diffhunk://#diff-02242739957400ef6800c5c4fcb2889b19700416cdb8035cefc29c4815896069L155-R195))

Verify it works via the following config locally:
```
[streaming.developer]
stream_now_progress_ratio = 2.0

```

TODO:
- UT

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
