### PR TITLE
feat: make kafka source `group.id.prefix` alter-able

### DIFF
--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -98,6 +98,7 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
     map.try_insert(
         std::any::type_name::<KafkaProperties>().to_owned(),
         [
+            "group.id.prefix".to_owned(),
             "properties.sync.call.timeout".to_owned(),
             "properties.security.protocol".to_owned(),
             "properties.ssl.endpoint.identification.algorithm".to_owned(),

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -150,6 +150,7 @@ pub struct KafkaProperties {
     ///   offsets, and does not join the consumer group. It just reports offsets
     ///   to the group.
     #[serde(rename = "group.id.prefix")]
+    #[with_option(allow_alter_on_fly)]
     pub group_id_prefix: Option<String>,
 
     /// This parameter is used to tell `KafkaSplitReader` to produce `UpsertMessage`s, which

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -246,6 +246,7 @@ KafkaProperties:
       offsets, and does not join the consumer group. It just reports offsets
       to the group.
     required: false
+    allow_alter_on_fly: true
   - name: upsert
     field_type: String
     comments: |-


### PR DESCRIPTION
… related configurations

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

per requested by @xxchan 

thread https://github.com/risingwavelabs/risingwave/pull/22466#pullrequestreview-2977510415

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

make `group.id.prefix` valid in alter table/source connector, not valid for sink

</details>
