### PR TITLE
fix(pgwire): send `ParameterStatus(TimeZone)` on startup to avoid `psycopg[binary]` segfault

### DIFF
--- a/e2e_test/source_inline/requirements.txt
+++ b/e2e_test/source_inline/requirements.txt
@@ -1,3 +1,3 @@
 nats-py==2.9.0
-psycopg
+psycopg[binary]
 psycopg2-binary==2.9.10

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -1687,6 +1687,10 @@ impl Session for SessionImpl {
         }
     }
 
+    fn get_config(&self, key: &str) -> std::result::Result<String, BoxedError> {
+        self.config().get(key).map_err(Into::into)
+    }
+
     fn set_config(&self, key: &str, value: String) -> std::result::Result<String, BoxedError> {
         Self::set_config(self, key, value).map_err(Into::into)
     }

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -447,6 +447,7 @@ pub enum BeParameterStatusMessage<'a> {
     StandardConformingString(&'a str),
     ServerVersion(&'a str),
     ApplicationName(&'a str),
+    TimeZone(&'a str),
 }
 
 #[derive(Debug)]
@@ -513,6 +514,7 @@ impl BeMessage<'_> {
                     }
                     ServerVersion(val) => [b"server_version", val.as_bytes()],
                     ApplicationName(val) => [b"application_name", val.as_bytes()],
+                    TimeZone(val) => [b"TimeZone", val.as_bytes()],
                 };
 
                 // Parameter names and values are passed as null-terminated strings

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -514,6 +514,7 @@ impl BeMessage<'_> {
                     }
                     ServerVersion(val) => [b"server_version", val.as_bytes()],
                     ApplicationName(val) => [b"application_name", val.as_bytes()],
+                    // psycopg3 is case-sensitive, so we use "TimeZone" instead of "timezone" #18079
                     TimeZone(val) => [b"TimeZone", val.as_bytes()],
                 };
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -643,6 +643,9 @@ where
                 self.stream
                     .write_no_flush(&BeMessage::BackendKeyData(session.id()))?;
 
+                self.stream.write_no_flush(&BeMessage::ParameterStatus(
+                    BeParameterStatusMessage::TimeZone(&session.get_config("timezone")?),
+                ))?;
                 self.stream
                     .write_parameter_status_msg_no_flush(&ParameterStatus {
                         application_name: application_name.cloned(),
@@ -1245,9 +1248,6 @@ where
         ))?;
         self.write_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::ServerVersion(PG_VERSION),
-        ))?;
-        self.write_no_flush(&BeMessage::ParameterStatus(
-            BeParameterStatusMessage::TimeZone("UTC"),
         ))?;
         if let Some(application_name) = &status.application_name {
             self.write_no_flush(&BeMessage::ParameterStatus(

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -1246,6 +1246,9 @@ where
         self.write_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::ServerVersion(PG_VERSION),
         ))?;
+        self.write_no_flush(&BeMessage::ParameterStatus(
+            BeParameterStatusMessage::TimeZone("UTC"),
+        ))?;
         if let Some(application_name) = &status.application_name {
             self.write_no_flush(&BeMessage::ParameterStatus(
                 BeParameterStatusMessage::ApplicationName(application_name),

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -126,6 +126,8 @@ pub trait Session: Send + Sync {
 
     fn id(&self) -> SessionId;
 
+    fn get_config(&self, key: &str) -> Result<String, BoxedError>;
+
     fn set_config(&self, key: &str, value: String) -> Result<String, BoxedError>;
 
     fn transaction_status(&self) -> TransactionStatus;
@@ -478,6 +480,13 @@ mod tests {
 
         fn id(&self) -> SessionId {
             (0, 0)
+        }
+
+        fn get_config(&self, key: &str) -> Result<String, BoxedError> {
+            match key {
+                "timezone" => Ok("UTC".to_owned()),
+                _ => Err(format!("Unknown config key: {key}").into()),
+            }
         }
 
         fn set_config(&self, _key: &str, _value: String) -> Result<String, BoxedError> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fixes #18079.

Will refactor in a follow-up to generalize to more parameters as PostgreSQL, rather than treating TimeZone (for `psycopg[binary]`) and application_name (for DataGrip #10339) specially.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
