### PR TITLE
fix(pgwire): send ParameterStatus(TimeZone) on startup to avoid psycopg[binary] segfault (#22504)

### DIFF
--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -105,7 +105,7 @@ risedev slt -p 4566 -d dev './e2e_test/database/prepare.slt'
 risedev slt -p 4566 -d test './e2e_test/database/test.slt'
 
 echo "--- e2e, $mode, python_client"
-python3 -m pip install --break-system-packages psycopg
+python3 -m pip install --break-system-packages 'psycopg[binary]'
 python3 ./e2e_test/python_client/main.py
 
 echo "--- e2e, $mode, subscription"

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -1634,6 +1634,10 @@ impl Session for SessionImpl {
         }
     }
 
+    fn get_config(&self, key: &str) -> std::result::Result<String, BoxedError> {
+        self.config().get(key).map_err(Into::into)
+    }
+
     fn set_config(&self, key: &str, value: String) -> std::result::Result<String, BoxedError> {
         Self::set_config(self, key, value).map_err(Into::into)
     }

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -399,6 +399,7 @@ pub enum BeParameterStatusMessage<'a> {
     StandardConformingString(&'a str),
     ServerVersion(&'a str),
     ApplicationName(&'a str),
+    TimeZone(&'a str),
 }
 
 #[derive(Debug)]
@@ -465,6 +466,8 @@ impl BeMessage<'_> {
                     }
                     ServerVersion(val) => [b"server_version", val.as_bytes()],
                     ApplicationName(val) => [b"application_name", val.as_bytes()],
+                    // psycopg3 is case-sensitive, so we use "TimeZone" instead of "timezone" #18079
+                    TimeZone(val) => [b"TimeZone", val.as_bytes()],
                 };
 
                 // Parameter names and values are passed as null-terminated strings

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -581,6 +581,9 @@ where
                 self.stream
                     .write_no_flush(&BeMessage::BackendKeyData(session.id()))?;
 
+                self.stream.write_no_flush(&BeMessage::ParameterStatus(
+                    BeParameterStatusMessage::TimeZone(&session.get_config("timezone")?),
+                ))?;
                 self.stream
                     .write_parameter_status_msg_no_flush(&ParameterStatus {
                         application_name: application_name.cloned(),
@@ -603,9 +606,13 @@ where
     }
 
     async fn process_password_msg(&mut self, msg: FePasswordMessage) -> PsqlResult<()> {
-        let authenticator = self.session.as_ref().unwrap().user_authenticator();
+        let session = self.session.as_ref().unwrap();
+        let authenticator = session.user_authenticator();
         authenticator.authenticate(&msg.password).await?;
         self.stream.write_no_flush(&BeMessage::AuthenticationOk)?;
+        self.stream.write_no_flush(&BeMessage::ParameterStatus(
+            BeParameterStatusMessage::TimeZone(&session.get_config("timezone")?),
+        ))?;
         self.stream
             .write_parameter_status_msg_no_flush(&ParameterStatus::default())?;
         self.ready_for_query()?;

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -582,7 +582,11 @@ where
                     .write_no_flush(&BeMessage::BackendKeyData(session.id()))?;
 
                 self.stream.write_no_flush(&BeMessage::ParameterStatus(
-                    BeParameterStatusMessage::TimeZone(&session.get_config("timezone")?),
+                    BeParameterStatusMessage::TimeZone(
+                        &session
+                            .get_config("timezone")
+                            .map_err(PsqlError::Uncategorized)?,
+                    ),
                 ))?;
                 self.stream
                     .write_parameter_status_msg_no_flush(&ParameterStatus {
@@ -611,7 +615,11 @@ where
         authenticator.authenticate(&msg.password).await?;
         self.stream.write_no_flush(&BeMessage::AuthenticationOk)?;
         self.stream.write_no_flush(&BeMessage::ParameterStatus(
-            BeParameterStatusMessage::TimeZone(&session.get_config("timezone")?),
+            BeParameterStatusMessage::TimeZone(
+                &session
+                    .get_config("timezone")
+                    .map_err(PsqlError::Uncategorized)?,
+            ),
         ))?;
         self.stream
             .write_parameter_status_msg_no_flush(&ParameterStatus::default())?;

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -126,6 +126,8 @@ pub trait Session: Send + Sync {
 
     fn id(&self) -> SessionId;
 
+    fn get_config(&self, key: &str) -> Result<String, BoxedError>;
+
     fn set_config(&self, key: &str, value: String) -> Result<String, BoxedError>;
 
     fn transaction_status(&self) -> TransactionStatus;
@@ -486,6 +488,13 @@ mod tests {
 
         fn id(&self) -> SessionId {
             (0, 0)
+        }
+
+        fn get_config(&self, key: &str) -> Result<String, BoxedError> {
+            match key {
+                "timezone" => Ok("UTC".to_owned()),
+                _ => Err(format!("Unknown config key: {key}").into()),
+            }
         }
 
         fn set_config(&self, _key: &str, _value: String) -> Result<String, BoxedError> {


### PR DESCRIPTION
Cherry picking #22504 onto branch release-2.3,

This PR/issue was created to resolve #22518.