### PR TITLE
feat: Add CASCADE support for DROP CONNECTION

### DIFF
--- a/e2e_test/source_inline/connection/drop_cascade.slt
+++ b/e2e_test/source_inline/connection/drop_cascade.slt
@@ -1,0 +1,139 @@
+control substitution on
+
+# Test DROP CONNECTION CASCADE functionality
+
+# for non-shared source
+statement ok
+set streaming_use_shared_source to false;
+
+# Create secret for connection
+statement ok
+create secret sec_cascade with (backend = 'meta') as '${RISEDEV_KAFKA_BOOTSTRAP_SERVERS}';
+
+# Create connection that will have dependencies
+statement ok
+create connection conn_cascade with (type = 'kafka', properties.bootstrap.server = secret sec_cascade, properties.security.protocol = 'plaintext');
+
+# Create Kafka topic for testing
+system ok
+rpk topic create connection_cascade_test -p 1
+
+# Create table that depends on the connection
+statement ok
+create table t_cascade (a int, b varchar) with (
+  connector = 'kafka',
+  connection = conn_cascade,
+  topic = 'connection_cascade_test')
+format plain encode json;
+
+# Create data table for sink
+statement ok
+create table data_cascade (a int, b varchar);
+
+statement ok
+insert into data_cascade values (10, 'cascade_test'), (20, 'test_data');
+
+statement ok
+flush;
+
+# Create sink that depends on the connection
+statement ok
+create sink sink_cascade from data_cascade with (
+  connector = 'kafka',
+  connection = conn_cascade,
+  topic = 'connection_cascade_test'
+) format plain encode json (
+  force_append_only='true'
+);
+
+# Wait for sink to be created and data to flow
+sleep 3s
+
+# Verify that normal DROP CONNECTION fails when objects depend on it
+statement error Permission denied: PermissionDenied: connection used by 2 other objects.
+drop connection conn_cascade;
+
+# Test that restrict mode also fails explicitly
+statement error Permission denied: PermissionDenied: connection used by 2 other objects.
+drop connection conn_cascade restrict;
+
+# Test DROP CONNECTION CASCADE - should succeed and drop dependent objects
+statement ok
+drop connection conn_cascade cascade;
+
+# Verify that the dependent table was dropped
+statement error
+select * from t_cascade;
+----
+db error: ERROR: Failed to run the query
+
+Caused by these errors (recent errors listed first):
+  1: Catalog error
+  2: table or source not found: t_cascade
+
+
+# Verify that the dependent sink was dropped
+query T
+select count(*) from rw_sinks where name = 'sink_cascade';
+----
+0
+
+
+# Verify connection is actually dropped
+query T
+select count(*) from rw_connections where name = 'conn_cascade';
+----
+0
+
+
+# Clean up remaining objects
+statement ok
+drop table data_cascade;
+
+statement ok
+drop secret sec_cascade;
+
+# Test DROP CONNECTION IF EXISTS CASCADE with existing connection
+statement ok
+create connection conn_if_exists with (type = 'kafka', properties.bootstrap.server = '${RISEDEV_KAFKA_BOOTSTRAP_SERVERS}', properties.security.protocol = 'plaintext');
+
+statement ok
+drop connection if exists conn_if_exists cascade;
+
+# Verify connection was dropped
+query T
+select count(*) from rw_connections where name = 'conn_if_exists';
+----
+0
+
+# Test dropping non-existent connection with CASCADE - should not error with IF EXISTS
+statement ok
+drop connection if exists non_existent_conn cascade;
+
+# Test DROP CONNECTION CASCADE without IF EXISTS on non-existent connection - should error
+statement error
+drop connection non_existent_conn2 cascade;
+----
+db error: ERROR: Failed to run the query
+
+Caused by these errors (recent errors listed first):
+  1: Catalog error
+  2: connection not found: non_existent_conn2
+
+
+# Test CASCADE with connection that has no dependencies
+statement ok
+create connection conn_no_deps with (type = 'kafka', properties.bootstrap.server = '${RISEDEV_KAFKA_BOOTSTRAP_SERVERS}', properties.security.protocol = 'plaintext');
+
+statement ok
+drop connection conn_no_deps cascade;
+
+# Verify it was dropped
+query T
+select count(*) from rw_connections where name = 'conn_no_deps';
+----
+0
+
+
+statement ok
+set streaming_use_shared_source to true;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -502,6 +502,7 @@ message ListConnectionsResponse {
 
 message DropConnectionRequest {
   uint32 connection_id = 1;
+  bool cascade = 2;
 }
 
 message DropConnectionResponse {

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -200,7 +200,7 @@ pub trait CatalogWriter: Send + Sync {
 
     async fn drop_function(&self, function_id: FunctionId) -> Result<()>;
 
-    async fn drop_connection(&self, connection_id: u32) -> Result<()>;
+    async fn drop_connection(&self, connection_id: u32, cascade: bool) -> Result<()>;
 
     async fn drop_secret(&self, secret_id: SecretId) -> Result<()>;
 
@@ -575,8 +575,11 @@ impl CatalogWriter for CatalogWriterImpl {
         self.wait_version(version).await
     }
 
-    async fn drop_connection(&self, connection_id: u32) -> Result<()> {
-        let version = self.meta_client.drop_connection(connection_id).await?;
+    async fn drop_connection(&self, connection_id: u32, cascade: bool) -> Result<()> {
+        let version = self
+            .meta_client
+            .drop_connection(connection_id, cascade)
+            .await?;
         self.wait_version(version).await
     }
 

--- a/src/frontend/src/handler/drop_connection.rs
+++ b/src/frontend/src/handler/drop_connection.rs
@@ -25,6 +25,7 @@ pub async fn handle_drop_connection(
     handler_args: HandlerArgs,
     connection_name: ObjectName,
     if_exists: bool,
+    cascade: bool,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session;
     let db_name = &session.database();
@@ -59,7 +60,9 @@ pub async fn handle_drop_connection(
     };
 
     let catalog_writer = session.catalog_writer()?;
-    catalog_writer.drop_connection(connection_id).await?;
+    catalog_writer
+        .drop_connection(connection_id, cascade)
+        .await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_CONNECTION))
 }

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -505,11 +505,9 @@ pub async fn handle(
                     | ObjectType::Subscription
                     | ObjectType::Index
                     | ObjectType::Table
-                    | ObjectType::Schema => true,
-                    ObjectType::Database
-                    | ObjectType::User
-                    | ObjectType::Connection
-                    | ObjectType::Secret => {
+                    | ObjectType::Schema
+                    | ObjectType::Connection => true,
+                    ObjectType::Database | ObjectType::User | ObjectType::Secret => {
                         bail_not_implemented!("DROP CASCADE");
                     }
                 }
@@ -558,8 +556,13 @@ pub async fn handle(
                     drop_view::handle_drop_view(handler_args, object_name, if_exists, cascade).await
                 }
                 ObjectType::Connection => {
-                    drop_connection::handle_drop_connection(handler_args, object_name, if_exists)
-                        .await
+                    drop_connection::handle_drop_connection(
+                        handler_args,
+                        object_name,
+                        if_exists,
+                        cascade,
+                    )
+                    .await
                 }
                 ObjectType::Secret => {
                     drop_secret::handle_drop_secret(handler_args, object_name, if_exists).await

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -75,7 +75,7 @@ use tempfile::{Builder, NamedTempFile};
 use crate::FrontendOpts;
 use crate::catalog::catalog_service::CatalogWriter;
 use crate::catalog::root_catalog::Catalog;
-use crate::catalog::{ConnectionId, DatabaseId, SchemaId, SecretId};
+use crate::catalog::{DatabaseId, SchemaId, SecretId};
 use crate::error::{ErrorCode, Result};
 use crate::handler::RwPgResponse;
 use crate::meta_client::FrontendMetaClient;
@@ -589,7 +589,7 @@ impl CatalogWriter for MockCatalogWriter {
         unreachable!()
     }
 
-    async fn drop_connection(&self, _connection_id: ConnectionId) -> Result<()> {
+    async fn drop_connection(&self, _connection_id: u32, _cascade: bool) -> Result<()> {
         unreachable!()
     }
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -846,10 +846,14 @@ impl DdlService for DdlServiceImpl {
         request: Request<DropConnectionRequest>,
     ) -> Result<Response<DropConnectionResponse>, Status> {
         let req = request.into_inner();
+        let drop_mode = DropMode::from_request_setting(req.cascade);
 
         let version = self
             .ddl_controller
-            .run_command(DdlCommand::DropConnection(req.connection_id as _))
+            .run_command(DdlCommand::DropConnection(
+                req.connection_id as _,
+                drop_mode,
+            ))
             .await?;
 
         Ok(Response::new(DropConnectionResponse {

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -230,8 +230,15 @@ impl MetaClient {
         Ok(resp.connections)
     }
 
-    pub async fn drop_connection(&self, connection_id: ConnectionId) -> Result<WaitVersion> {
-        let request = DropConnectionRequest { connection_id };
+    pub async fn drop_connection(
+        &self,
+        connection_id: ConnectionId,
+        cascade: bool,
+    ) -> Result<WaitVersion> {
+        let request = DropConnectionRequest {
+            connection_id,
+            cascade,
+        };
         let resp = self.inner.drop_connection(request).await?;
         Ok(resp
             .version

--- a/src/sqlparser/tests/testdata/drop.yaml
+++ b/src/sqlparser/tests/testdata/drop.yaml
@@ -20,3 +20,11 @@
   formatted_sql: DROP SECRET secret
 - input: DROP SECRET IF EXISTS secret
   formatted_sql: DROP SECRET IF EXISTS secret
+- input: DROP CONNECTION conn
+  formatted_sql: DROP CONNECTION conn
+- input: DROP CONNECTION IF EXISTS conn
+  formatted_sql: DROP CONNECTION IF EXISTS conn
+- input: DROP CONNECTION conn CASCADE
+  formatted_sql: DROP CONNECTION conn CASCADE
+- input: DROP CONNECTION IF EXISTS conn CASCADE
+  formatted_sql: DROP CONNECTION IF EXISTS conn CASCADE


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

**ALL CODE IS GENERATED FROM CLAUDE CODE**

## What's changed and what's your intention?

## PR Description

### Summary
This PR implements CASCADE functionality for the `DROP CONNECTION` statement, allowing users to automatically drop dependent objects when dropping a connection.

### User-Facing Changes

#### New Syntax Support
- **`DROP CONNECTION connection_name CASCADE`** - Drops the connection and all dependent objects (tables, sinks, etc.)
- **`DROP CONNECTION IF EXISTS connection_name CASCADE`** - Same as above, but doesn't error if the connection doesn't exist
- **`DROP CONNECTION connection_name RESTRICT`** - Explicitly prevents dropping if dependencies exist (existing behavior)

#### Behavior Changes
- **Before**: `DROP CONNECTION` would fail with "connection used by X other objects" if any tables, sinks, or other objects depended on the connection
- **After**: 
  - `DROP CONNECTION` (without CASCADE) - Same behavior as before (fails if dependencies exist)
  - `DROP CONNECTION CASCADE` - Automatically drops all dependent objects and then drops the connection
  - `DROP CONNECTION RESTRICT` - Explicitly fails if dependencies exist (same as default behavior)

#### Example Usage
```sql
-- Create connection and dependent objects
CREATE CONNECTION my_conn WITH (type = 'kafka', ...);
CREATE TABLE my_table (...) WITH (connector = 'kafka', connection = my_conn, ...);
CREATE SINK my_sink FROM data WITH (connector = 'kafka', connection = my_conn, ...);

-- This would fail before this PR
DROP CONNECTION my_conn;  -- Error: connection used by 2 other objects

-- New functionality - automatically drops my_table and my_sink first
DROP CONNECTION my_conn CASCADE;  -- ✅ Success
```

### Implementation Details
- Extended the DDL service protocol to support cascade mode
- Updated the frontend handler to process the CASCADE keyword
- Modified the meta controller to handle cascading drops for connections
- Added comprehensive end-to-end tests covering various scenarios

### Testing
- Added comprehensive SQLLogicTest suite in `e2e_test/source_inline/connection/drop_cascade.slt`
- Tests cover CASCADE with dependencies, without dependencies, IF EXISTS variants, and error cases
- Updated parser tests to validate new syntax

This change brings `DROP CONNECTION` in line with other RisingWave objects that already support CASCADE functionality.
## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

refer to the user facing section above

</details>
