### PR TITLE
fix: join encoding type backward compability

### DIFF
--- a/src/stream/src/from_proto/asof_join.rs
+++ b/src/stream/src/from_proto/asof_join.rs
@@ -90,6 +90,9 @@ impl ExecutorBuilder for AsOfJoinExecutorBuilder {
         let join_type_proto = node.get_join_type()?;
         let as_of_desc_proto = node.get_asof_desc()?;
         let asof_desc = AsOfDesc::from_protobuf(as_of_desc_proto)?;
+        let join_encoding_type = node
+            .get_join_encoding_type()
+            .unwrap_or(JoinEncodingTypeProto::MemoryOptimized);
 
         let args = AsOfJoinExecutorDispatcherArgs {
             ctx: params.actor_context,
@@ -113,7 +116,7 @@ impl ExecutorBuilder for AsOfJoinExecutorBuilder {
                 .developer
                 .high_join_amplification_threshold,
             asof_desc,
-            join_encoding_type: node.get_join_encoding_type()?,
+            join_encoding_type,
         };
 
         let exec = args.dispatch()?;

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -134,6 +134,10 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
         let degree_state_table_r =
             StateTable::from_table_catalog(degree_table_r, store, Some(vnodes)).await;
 
+        let join_encoding_type = node
+            .get_join_encoding_type()
+            .unwrap_or(JoinEncodingTypeProto::MemoryOptimized);
+
         let args = HashJoinExecutorDispatcherArgs {
             ctx: params.actor_context,
             info: params.info.clone(),
@@ -160,7 +164,7 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
                 .config()
                 .developer
                 .high_join_amplification_threshold,
-            join_encoding_type: node.get_join_encoding_type()?,
+            join_encoding_type,
         };
 
         let exec = args.dispatch()?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

So old queries on old versions will not go through the optimizer again, right?
It has to be dealt with on the compute node.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
