### PR TITLE
fix(frontend): fix topn on index optimization rule bug

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -505,10 +505,19 @@
     select * from t1 where c = 1 and a = 2 and d = 3 order by b desc limit 10
   expected_outputs:
     - batch_plan
-- name: topn index selection + limit pushdown with point get
+- name: topn index selection + limit pushdown with point get + descending order point get
   sql: |
     create table t1 (a int, b int, c int);
     create index idx1 on t1(a asc, b);
     select * from t1 where a = 1 order by b limit 10;
+  expected_outputs:
+    - batch_plan
+- name: topn index selection + limit pushdown with multi point get + various order combination point get
+  sql: |
+    create table t1 (a int, b int, c int);
+    create index idx1 on t1(a desc nulls first, c desc nulls last);
+    create index idx2 on t1(a desc nulls first, c asc nulls last, b desc nulls first);
+    create index idx3 on t1(a desc nulls last, c asc nulls first, b desc nulls last);
+    select * from t1 where c = 2 and a = 2 order by b desc nulls last limit 10;
   expected_outputs:
     - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -845,7 +845,7 @@
       └─BatchExchange { order: [], dist: Single }
         └─BatchLimit { limit: 10, offset: 0 }
           └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c, idx3.d], scan_ranges: [idx3.a = Int32(2) AND idx3.c = Int32(1) AND idx3.d = Int32(3)], limit: 10, distribution: UpstreamHashShard(idx3.a) }
-- name: topn index selection + limit pushdown with point get
+- name: topn index selection + limit pushdown with point get + descending order point get
   sql: |
     create table t1 (a int, b int, c int);
     create index idx1 on t1(a asc, b);
@@ -856,3 +856,16 @@
       └─BatchExchange { order: [], dist: Single }
         └─BatchLimit { limit: 10, offset: 0 }
           └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
+- name: topn index selection + limit pushdown with multi point get + various order combination point get
+  sql: |
+    create table t1 (a int, b int, c int);
+    create index idx1 on t1(a desc nulls first, c desc nulls last);
+    create index idx2 on t1(a desc nulls first, c asc nulls last, b desc nulls first);
+    create index idx3 on t1(a desc nulls last, c asc nulls first, b desc nulls last);
+    select * from t1 where c = 2 and a = 2 order by b desc nulls last limit 10;
+  batch_plan: |-
+    BatchSort { order: [idx3.b DESC NULLS LAST] }
+    └─BatchTopN { order: [idx3.a DESC NULLS LAST, idx3.c ASC NULLS FIRST, idx3.b DESC NULLS LAST], limit: 10, offset: 0 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchLimit { limit: 10, offset: 0 }
+          └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c], scan_ranges: [idx3.a = Int32(2) AND idx3.c = Int32(2)], limit: 10, distribution: UpstreamHashShard(idx3.a) }

--- a/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
+++ b/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
@@ -60,14 +60,22 @@ impl TopNOnIndexRule {
         let prefix = input_refs
             .into_iter()
             .flat_map(|input_ref| {
-                vec![
+                [
                     ColumnOrder {
                         column_index: input_ref.index,
-                        order_type: OrderType::ascending(),
+                        order_type: OrderType::ascending_nulls_first(),
                     },
                     ColumnOrder {
                         column_index: input_ref.index,
-                        order_type: OrderType::descending(),
+                        order_type: OrderType::ascending_nulls_last(),
+                    },
+                    ColumnOrder {
+                        column_index: input_ref.index,
+                        order_type: OrderType::descending_nulls_first(),
+                    },
+                    ColumnOrder {
+                        column_index: input_ref.index,
+                        order_type: OrderType::descending_nulls_last(),
                     },
                 ]
             })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, the component of a composite index present in the equality constant expression of the WHERE clause was extracted, and the longest common index prefix was constructed in ascending order. However, some indexes might be in descending order.

Previous behavior:

```sql
dev=> create table t(a int, b int, c int);
CREATE_TABLE
dev=> create index t_index_ab on t(a desc, b asc);
CREATE_INDEX
dev=> explain select * from t where a=10 order by b limit 1;
                                        QUERY PLAN                                        
------------------------------------------------------------------------------------------
 BatchTopN { order: [t_index_ab.b ASC], limit: 1, offset: 0 }
 └─BatchExchange { order: [], dist: Single }
   └─BatchTopN { order: [t_index_ab.b ASC], limit: 1, offset: 0 }
     └─BatchScan { table: t_index_ab, columns: [a, b, c], scan_ranges: [a = Int32(10)] }
(4 rows)
```

Now:

```sql
BatchSort { order: [t_index_ab.b ASC] }
 └─BatchTopN { order: [t_index_ab.a DESC, t_index_ab.b ASC], limit: 1, offset: 0 }
   └─BatchExchange { order: [], dist: Single }
     └─BatchLimit { limit: 1, offset: 0 }
       └─BatchScan { table: t_index_ab, columns: [a, b, c], scan_ranges: [a = Int32(10)], limit: 1 }
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
