### PR TITLE
fix(sink): shall not panic when protobuf message not found

### DIFF
--- a/e2e_test/sink/kafka/protobuf.slt
+++ b/e2e_test/sink/kafka/protobuf.slt
@@ -112,6 +112,16 @@ format plain encode protobuf (
   schema.registry = 'http://schemaregistry:8082',
   message = 'test.package.MessageH.MessageI');
 
+statement error fff
+create sink sink_invalid_message from into_kafka with (
+  connector = 'kafka',
+  topic = 'test-rw-sink-append-only-protobuf-csr-a',
+  properties.bootstrap.server = 'message_queue:29092')
+format plain encode protobuf (
+  force_append_only = true,
+  schema.registry = 'http://schemaregistry:8082',
+  message = 'test.package.Message');
+
 statement error
 create sink sink_upsert from into_kafka with (
   connector = 'kafka',

--- a/e2e_test/sink/kafka/protobuf.slt
+++ b/e2e_test/sink/kafka/protobuf.slt
@@ -112,7 +112,7 @@ format plain encode protobuf (
   schema.registry = 'http://schemaregistry:8082',
   message = 'test.package.MessageH.MessageI');
 
-statement error fff
+statement error message test.package.Message not defined in proto
 create sink sink_invalid_message from into_kafka with (
   connector = 'kafka',
   topic = 'test-rw-sink-append-only-protobuf-csr-a',

--- a/src/connector/src/schema/protobuf.rs
+++ b/src/connector/src/schema/protobuf.rs
@@ -99,11 +99,12 @@ pub async fn fetch_from_registry(
             );
         }
     };
+    let message_descriptor = vpb
+        .parent_pool()
+        .get_message_by_name(message_name)
+        .ok_or_else(|| invalid_option_error!("message {message_name} not defined in proto"))?;
 
-    Ok((
-        vpb.parent_pool().get_message_by_name(message_name).unwrap(),
-        vid,
-    ))
+    Ok((message_descriptor, vid))
 }
 
 impl LoadedSchema for FileDescriptor {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Protobuf syntax allows multiple top-level message definitions (unlike Avro). So users need to specify both a path and a message name. (*I want to use `message mypackage.Foo` from file `/path/to/proto/definition`.*) When the message name is not found in the provided path, we shall report errors properly.

The error is already handled for:
* source with schema registry
* source with schema location (e.g. https to pre-compiled binary descriptor file)
* sink with schema location (e.g. https to pre-compiled binary descriptor file)

And we fix the following in this PR:
* sink with schema registry [#15546](https://github.com/risingwavelabs/risingwave/pull/15546)

Eventually we aim to unify the code path for all 4 cases.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
