### PR TITLE
feat(compute): Implement UnionUpstreamSink operator

### DIFF
--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1025,7 +1025,7 @@ impl DdlController {
                                             upstream_actor_id: vec![],
                                             upstream_fragment_id,
                                             upstream_dispatcher_type: PbDispatcherType::Hash as _,
-                                            fields: sink_fields.to_vec(),
+                                            fields: vec![],
                                         }
                                     };
 

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1025,7 +1025,7 @@ impl DdlController {
                                             upstream_actor_id: vec![],
                                             upstream_fragment_id,
                                             upstream_dispatcher_type: PbDispatcherType::Hash as _,
-                                            fields: vec![],
+                                            fields: sink_fields.to_vec(),
                                         }
                                     };
 

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -197,6 +197,7 @@ async fn test_merger_sum_aggr() {
                     outputs,
                     local_barrier_manager.clone(),
                     schema,
+                    100,
                 )
                 .boxed(),
             );

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -41,7 +41,7 @@ pub(crate) enum MergeExecutorUpstream {
 pub(crate) struct MergeExecutorInput {
     upstream: MergeExecutorUpstream,
     actor_context: ActorContextRef,
-    pub(crate) upstream_fragment_id: UpstreamFragmentId,
+    upstream_fragment_id: UpstreamFragmentId,
     local_barrier_manager: LocalBarrierManager,
     executor_stats: Arc<StreamingMetrics>,
     pub(crate) info: ExecutorInfo,
@@ -226,7 +226,7 @@ impl MergeExecutor {
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
-    async fn execute_inner(mut self: Box<Self>) {
+    pub(crate) async fn execute_inner(mut self: Box<Self>) {
         let select_all = self.upstreams;
         let select_all = BufferChunks::new(select_all, self.chunk_size, self.schema);
         let actor_id = self.actor_context.id;

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -41,7 +41,7 @@ pub(crate) enum MergeExecutorUpstream {
 pub(crate) struct MergeExecutorInput {
     upstream: MergeExecutorUpstream,
     actor_context: ActorContextRef,
-    upstream_fragment_id: UpstreamFragmentId,
+    pub(crate) upstream_fragment_id: UpstreamFragmentId,
     local_barrier_manager: LocalBarrierManager,
     executor_stats: Arc<StreamingMetrics>,
     pub(crate) info: ExecutorInfo,
@@ -171,6 +171,7 @@ impl MergeExecutor {
         inputs: Vec<super::exchange::permit::Receiver>,
         local_barrier_manager: crate::task::LocalBarrierManager,
         schema: Schema,
+        chunk_size: usize,
     ) -> Self {
         use super::exchange::input::LocalInput;
         use crate::executor::exchange::input::ActorInput;
@@ -197,7 +198,7 @@ impl MergeExecutor {
             local_barrier_manager,
             metrics.into(),
             barrier_rx,
-            100,
+            chunk_size,
             schema,
         )
     }
@@ -638,6 +639,7 @@ mod tests {
             rxs,
             barrier_test_env.local_barrier_manager.clone(),
             Schema::new(vec![]),
+            100,
         );
         let mut merger = merger.boxed().execute();
         for (idx, epoch) in epochs {

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -104,6 +104,7 @@ mod temporal_join;
 mod top_n;
 mod troublemaker;
 mod union;
+mod upstream_sink_union;
 mod values;
 mod watermark;
 mod watermark_filter;
@@ -163,6 +164,7 @@ pub use top_n::{
 };
 pub use troublemaker::TroublemakerExecutor;
 pub use union::UnionExecutor;
+pub use upstream_sink_union::UpstreamSinkUnionExecutor;
 pub use utils::DummyExecutor;
 pub use values::ValuesExecutor;
 pub use watermark_filter::WatermarkFilterExecutor;

--- a/src/stream/src/executor/project/mod.rs
+++ b/src/stream/src/executor/project/mod.rs
@@ -17,5 +17,5 @@ mod project_scalar;
 mod project_set;
 
 pub use materialized_exprs::{MaterializedExprsArgs, MaterializedExprsExecutor};
-pub use project_scalar::ProjectExecutor;
+pub use project_scalar::{ProjectExecutor, apply_project_exprs};
 pub use project_set::{ProjectSetExecutor, ProjectSetSelectItem};

--- a/src/stream/src/executor/project/project_scalar.rs
+++ b/src/stream/src/executor/project/project_scalar.rs
@@ -87,21 +87,30 @@ impl Execute for ProjectExecutor {
     }
 }
 
+pub async fn apply_project_exprs(
+    exprs: &[NonStrictExpression],
+    chunk: StreamChunk,
+) -> StreamExecutorResult<StreamChunk> {
+    let (data_chunk, ops) = chunk.into_parts();
+    let mut projected_columns = Vec::new();
+
+    for expr in exprs {
+        let evaluated_expr = expr.eval_infallible(&data_chunk).await;
+        projected_columns.push(evaluated_expr);
+    }
+    let (_, vis) = data_chunk.into_parts();
+
+    let new_chunk = StreamChunk::with_visibility(ops, projected_columns, vis);
+
+    Ok(new_chunk)
+}
+
 impl Inner {
     async fn map_filter_chunk(
         &self,
         chunk: StreamChunk,
     ) -> StreamExecutorResult<Option<StreamChunk>> {
-        let (data_chunk, ops) = chunk.into_parts();
-        let mut projected_columns = Vec::new();
-
-        for expr in &self.exprs {
-            let evaluated_expr = expr.eval_infallible(&data_chunk).await;
-            projected_columns.push(evaluated_expr);
-        }
-        let (_, vis) = data_chunk.into_parts();
-
-        let mut new_chunk = StreamChunk::with_visibility(ops, projected_columns, vis);
+        let mut new_chunk = apply_project_exprs(&self.exprs, chunk).await?;
         if self.noop_update_hint {
             new_chunk = new_chunk.eliminate_adjacent_noop_update();
         }

--- a/src/stream/src/executor/upstream_sink_union.rs
+++ b/src/stream/src/executor/upstream_sink_union.rs
@@ -314,8 +314,6 @@ impl UpstreamSinkUnionExecutor {
         let upstreams = DynamicReceivers::new(inputs, Some(barrier_align), None);
         pin_mut!(upstreams);
 
-        // let mut start_time = Instant::now();
-
         while let Some(msg) = upstreams.next().await {
             yield msg?;
         }

--- a/src/stream/src/executor/upstream_sink_union.rs
+++ b/src/stream/src/executor/upstream_sink_union.rs
@@ -1,0 +1,450 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::future::try_join_all;
+use risingwave_expr::expr::NonStrictExpression;
+
+use crate::executor::exchange::input::{Input, new_input};
+use crate::executor::prelude::*;
+use crate::executor::project::apply_project_exprs;
+use crate::executor::{BarrierMutationType, BoxedMessageInput, DynamicReceivers, MergeExecutor};
+use crate::task::{FragmentId, LocalBarrierManager};
+
+/// `MergeProjectExecutor` applies a projection to the output of a merge executor.
+struct MergeProjectExecutor {
+    /// Expressions of the current projection.
+    project_exprs: Vec<NonStrictExpression>,
+
+    /// The stream of messages after handled by merge executor.
+    merge: BoxedMessageStream,
+}
+
+impl MergeProjectExecutor {
+    #[try_stream(ok = Message, error = StreamExecutorError)]
+    async fn execute_inner(mut self) {
+        while let Some(msg) = self.merge.next().await {
+            let msg = msg?;
+            if let Message::Chunk(chunk) = msg {
+                // Apply the projection expressions to the chunk.
+                let new_chunk = apply_project_exprs(&self.project_exprs, chunk).await?;
+                yield Message::Chunk(new_chunk);
+            } else {
+                yield msg;
+            }
+        }
+    }
+}
+
+pub struct SinkHandlerInput {
+    /// The ID of the upstream fragment that this input is associated with.
+    upstream_fragment_id: FragmentId,
+
+    /// The stream of messages from the upstream fragment.
+    executor_stream: BoxedMessageStream,
+}
+
+impl SinkHandlerInput {
+    pub fn new(
+        upstream_fragment_id: FragmentId,
+        merge: Box<MergeExecutor>,
+        project_exprs: Vec<NonStrictExpression>,
+    ) -> Self {
+        let merge_stream = merge.execute();
+        let executor = MergeProjectExecutor {
+            project_exprs,
+            merge: merge_stream,
+        };
+        let executor_stream = executor.execute_inner().boxed();
+        Self {
+            upstream_fragment_id,
+            executor_stream,
+        }
+    }
+}
+
+impl Input for SinkHandlerInput {
+    type InputId = FragmentId;
+
+    fn id(&self) -> Self::InputId {
+        // Return a unique identifier for this input, e.g., based on the upstream fragment ID
+        self.upstream_fragment_id
+    }
+}
+
+impl Stream for SinkHandlerInput {
+    type Item = MessageStreamItem;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.executor_stream.poll_next_unpin(cx)
+    }
+}
+
+#[derive(Debug)]
+pub struct UpstreamInfo {
+    pub upstream_fragment_id: FragmentId,
+    pub merge_schema: Schema,
+    pub project_exprs: Vec<NonStrictExpression>,
+}
+
+type BoxedSinkInput = BoxedMessageInput<FragmentId, BarrierMutationType>;
+
+pub struct UpstreamSinkUnionExecutor {
+    /// The context of the actor.
+    actor_context: ActorContextRef,
+
+    /// Used to create merge executors.
+    local_barrier_manager: LocalBarrierManager,
+
+    /// Streaming metrics.
+    executor_stats: Arc<StreamingMetrics>,
+
+    /// The size of the chunks to be processed.
+    chunk_size: usize,
+
+    /// The initial inputs to the executor.
+    upstream_infos: Vec<UpstreamInfo>,
+}
+
+impl Debug for UpstreamSinkUnionExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpstreamSinkUnionExecutor")
+            .field("upstream_infos", &self.upstream_infos)
+            .finish()
+    }
+}
+
+impl Execute for UpstreamSinkUnionExecutor {
+    fn execute(self: Box<Self>) -> BoxedMessageStream {
+        self.execute_inner().boxed()
+    }
+}
+
+impl UpstreamSinkUnionExecutor {
+    pub fn new(
+        ctx: ActorContextRef,
+        local_barrier_manager: LocalBarrierManager,
+        executor_stats: Arc<StreamingMetrics>,
+        chunk_size: usize,
+        upstream_infos: Vec<(FragmentId, Schema, Vec<NonStrictExpression>)>,
+    ) -> Self {
+        Self {
+            actor_context: ctx,
+            local_barrier_manager,
+            executor_stats,
+            chunk_size,
+            upstream_infos: upstream_infos
+                .into_iter()
+                .map(
+                    |(upstream_fragment_id, merge_schema, project_exprs)| UpstreamInfo {
+                        upstream_fragment_id,
+                        merge_schema,
+                        project_exprs,
+                    },
+                )
+                .collect(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn for_test(
+        actor_id: ActorId,
+        local_barrier_manager: LocalBarrierManager,
+        chunk_size: usize,
+    ) -> Self {
+        let metrics = StreamingMetrics::unused();
+        let actor_ctx = ActorContext::for_test(actor_id);
+        Self {
+            actor_context: actor_ctx,
+            local_barrier_manager,
+            executor_stats: metrics.into(),
+            chunk_size,
+            upstream_infos: vec![],
+        }
+    }
+
+    #[allow(dead_code)]
+    async fn new_sink_input(
+        &self,
+        upstream_info: UpstreamInfo,
+    ) -> StreamExecutorResult<BoxedSinkInput> {
+        let (upstream_fragment_id, merge_schema, project_exprs) = (
+            upstream_info.upstream_fragment_id,
+            upstream_info.merge_schema,
+            upstream_info.project_exprs,
+        );
+
+        let merge_executor = self
+            .new_merge_executor(upstream_fragment_id, merge_schema)
+            .await?;
+
+        Ok(SinkHandlerInput::new(
+            upstream_fragment_id,
+            Box::new(merge_executor),
+            project_exprs,
+        )
+        .boxed_input())
+    }
+
+    async fn new_merge_executor(
+        &self,
+        upstream_fragment_id: FragmentId,
+        schema: Schema,
+    ) -> StreamExecutorResult<MergeExecutor> {
+        let barrier_rx = self
+            .local_barrier_manager
+            .subscribe_barrier(self.actor_context.id);
+
+        let inputs: Vec<_> = try_join_all(
+            self.actor_context
+                .initial_upstream_actors
+                .get(&upstream_fragment_id)
+                .map(|actors| actors.actors.iter())
+                .into_iter()
+                .flatten()
+                .map(|upstream_actor| {
+                    new_input(
+                        &self.local_barrier_manager,
+                        self.executor_stats.clone(),
+                        self.actor_context.id,
+                        self.actor_context.fragment_id,
+                        upstream_actor,
+                        upstream_fragment_id,
+                    )
+                }),
+        )
+        .await?;
+
+        let upstreams =
+            MergeExecutor::new_select_receiver(inputs, &self.executor_stats, &self.actor_context);
+
+        Ok(MergeExecutor::new(
+            self.actor_context.clone(),
+            self.actor_context.fragment_id,
+            upstream_fragment_id,
+            upstreams,
+            self.local_barrier_manager.clone(),
+            self.executor_stats.clone(),
+            barrier_rx,
+            self.chunk_size,
+            schema,
+        ))
+    }
+
+    #[try_stream(ok = Message, error = StreamExecutorError)]
+    async fn execute_inner(mut self: Box<Self>) {
+        let inputs: Vec<_> = {
+            let upstream_infos = std::mem::take(&mut self.upstream_infos);
+            let mut inputs = Vec::with_capacity(upstream_infos.len());
+            for UpstreamInfo {
+                upstream_fragment_id,
+                merge_schema,
+                project_exprs,
+            } in upstream_infos
+            {
+                let merge_executor = self
+                    .new_merge_executor(upstream_fragment_id, merge_schema)
+                    .await?;
+
+                let input = SinkHandlerInput::new(
+                    upstream_fragment_id,
+                    Box::new(merge_executor),
+                    project_exprs,
+                )
+                .boxed_input();
+
+                inputs.push(input);
+            }
+            inputs
+        };
+
+        let execution_stream = self.execute_with_inputs(inputs);
+        pin_mut!(execution_stream);
+        while let Some(msg) = execution_stream.next().await {
+            yield msg?;
+        }
+    }
+
+    #[try_stream(ok = Message, error = StreamExecutorError)]
+    async fn execute_with_inputs(self: Box<Self>, inputs: Vec<BoxedSinkInput>) {
+        let actor_id = self.actor_context.id;
+        let fragment_id = self.actor_context.fragment_id;
+
+        let barrier_align = self
+            .executor_stats
+            .barrier_align_duration
+            .with_guarded_label_values(&[
+                actor_id.to_string().as_str(),
+                fragment_id.to_string().as_str(),
+                "",
+                "UpstreamSinkUnion",
+            ]);
+
+        let upstreams = DynamicReceivers::new(inputs, Some(barrier_align), None);
+        pin_mut!(upstreams);
+
+        // let mut start_time = Instant::now();
+
+        while let Some(msg) = upstreams.next().await {
+            yield msg?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::array::{Op, StreamChunkTestExt};
+    use risingwave_common::catalog::Field;
+
+    use super::*;
+    use crate::executor::MessageInner;
+    use crate::executor::exchange::permit::{Sender, channel_for_test};
+    use crate::executor::test_utils::expr::build_from_pretty;
+    use crate::task::barrier_test_utils::LocalBarrierTestEnv;
+
+    #[tokio::test]
+    async fn test_sink_input() {
+        let test_env = LocalBarrierTestEnv::for_test().await;
+
+        let actor_id = 2;
+
+        let schema = Schema {
+            fields: vec![
+                Field::unnamed(DataType::Int64),
+                Field::unnamed(DataType::Int64),
+            ],
+        };
+
+        let (tx1, rx1) = channel_for_test();
+        let (tx2, rx2) = channel_for_test();
+
+        let merge = MergeExecutor::for_test(
+            actor_id,
+            vec![rx1, rx2],
+            test_env.local_barrier_manager.clone(),
+            schema.clone(),
+            5,
+        );
+
+        let test_expr = build_from_pretty("$1:int8");
+
+        let mut input = SinkHandlerInput::new(
+            1919, // from MergeExecutor::for_test()
+            Box::new(merge),
+            vec![test_expr],
+        )
+        .boxed_input();
+
+        let chunk1 = StreamChunk::from_pretty(
+            " I I
+            + 1 4
+            + 2 5
+            + 3 6",
+        );
+        let chunk2 = StreamChunk::from_pretty(
+            " I I
+            + 7 8
+            - 3 6",
+        );
+
+        tx1.send(MessageInner::Chunk(chunk1).into()).await.unwrap();
+        tx2.send(MessageInner::Chunk(chunk2).into()).await.unwrap();
+
+        let msg = input.next().await.unwrap().unwrap();
+        assert_eq!(
+            *msg.as_chunk().unwrap(),
+            StreamChunk::from_pretty(
+                " I
+                + 4
+                + 5
+                + 6
+                + 8
+                - 6"
+            )
+        );
+    }
+
+    fn new_input_for_test(
+        actor_id: ActorId,
+        local_barrier_manager: LocalBarrierManager,
+    ) -> (BoxedSinkInput, Sender) {
+        let (tx, rx) = channel_for_test();
+        let merge = MergeExecutor::for_test(
+            actor_id,
+            vec![rx],
+            local_barrier_manager,
+            Schema::new(vec![]),
+            10,
+        );
+        let input = SinkHandlerInput::new(actor_id, Box::new(merge), vec![]).boxed_input();
+        (input, tx)
+    }
+
+    fn build_test_chunk(size: u64) -> StreamChunk {
+        let ops = vec![Op::Insert; size as usize];
+        StreamChunk::new(ops, vec![])
+    }
+
+    #[tokio::test]
+    async fn test_fixed_upstreams() {
+        let test_env = LocalBarrierTestEnv::for_test().await;
+
+        let actor_id = 2;
+
+        let b1 = Barrier::with_prev_epoch_for_test(2, 1);
+
+        test_env.inject_barrier(&b1, [actor_id]);
+        test_env.flush_all_events().await;
+
+        let mut inputs = Vec::with_capacity(3);
+        let mut txs = Vec::with_capacity(3);
+        for _ in 0..3 {
+            let (input, tx) = new_input_for_test(actor_id, test_env.local_barrier_manager.clone());
+            inputs.push(input);
+            txs.push(tx);
+        }
+
+        let sink_union = UpstreamSinkUnionExecutor::for_test(
+            actor_id,
+            test_env.local_barrier_manager.clone(),
+            10,
+        );
+        let mut sink_union = Box::new(sink_union).execute_with_inputs(inputs).boxed();
+
+        for tx in txs {
+            tx.send(MessageInner::Chunk(build_test_chunk(10)).into())
+                .await
+                .unwrap();
+            tx.send(MessageInner::Chunk(build_test_chunk(10)).into())
+                .await
+                .unwrap();
+            tx.send(MessageInner::Barrier(b1.clone().into_dispatcher()).into())
+                .await
+                .unwrap();
+        }
+
+        for _ in 0..6 {
+            let msg = sink_union.next().await.unwrap().unwrap();
+            assert!(msg.is_chunk());
+            assert_eq!(msg.as_chunk().unwrap().ops().len(), 10);
+        }
+
+        let msg = sink_union.next().await.unwrap().unwrap();
+        assert!(msg.is_barrier());
+        let barrier = msg.as_barrier().unwrap();
+        assert_eq!(barrier.epoch, b1.epoch);
+    }
+}

--- a/src/stream/src/executor/upstream_sink_union.rs
+++ b/src/stream/src/executor/upstream_sink_union.rs
@@ -321,6 +321,11 @@ mod tests {
 
         let actor_id = 2;
 
+        let b1 = Barrier::with_prev_epoch_for_test(2, 1);
+
+        test_env.inject_barrier(&b1, [actor_id]);
+        test_env.flush_all_events().await;
+
         let schema = Schema {
             fields: vec![
                 Field::unnamed(DataType::Int64),

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -244,8 +244,10 @@ impl StreamActorManager {
             );
         }
 
-        let executor_id = Self::get_executor_id(actor_context, union_node) + (1 << 24); // Ensure the id is unique.
-        let mut info = Self::get_executor_info(union_node, executor_id);
+        // Use the first MergeNode to fill in the info of the new node.
+        let first_merge = merge_projects.first().unwrap().0;
+        let executor_id = Self::get_executor_id(actor_context, first_merge);
+        let mut info = Self::get_executor_info(first_merge, executor_id);
         info.identity = format!("UpstreamSinkUnion {:X}", executor_id);
         let eval_error_report = ActorEvalErrorReport {
             actor_context: actor_context.clone(),

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -349,6 +349,10 @@ impl StreamActorManager {
             merge_projects.push((project_input, union_input));
         }
 
+        if merge_projects.is_empty() {
+            return None;
+        }
+
         let mut remaining_nodes = rev_iter.collect_vec();
 
         merge_projects.reverse();

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -326,8 +326,7 @@ impl StreamActorManager {
                     && let NodeBody::Merge(merge) = project_input.get_node_body().unwrap()
                 {
                     let merge_check = merge.upstream_dispatcher_type()
-                        == risingwave_pb::stream_plan::DispatcherType::Hash
-                        && merge.get_fields().is_empty();
+                        == risingwave_pb::stream_plan::DispatcherType::Hash;
                     if merge_check {
                         is_sink_into = true;
                         tracing::debug!(

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -265,23 +265,24 @@ impl StreamActorManager {
                 let project_input = input_stream_node.get_input();
                 assert_eq!(project_input.len(), 1);
                 let project_input = project_input.first().unwrap();
-                if project.get_select_list().iter().all(|e| {
+                let all_unspecified = project.get_select_list().iter().all(|e| {
                     e.function_type() == risingwave_pb::expr::expr_node::PbType::Unspecified
-                }) {
-                    if let NodeBody::Merge(merge) = project_input.get_node_body().unwrap() {
-                        tracing::debug!(
-                            "sink into table: fragment_id: {}, upstream_fragment_id: {}, project: {:?}",
-                            fragment_id,
-                            merge.upstream_fragment_id,
-                            project.get_select_list()
-                        );
-                        sink_into_streams.push((
-                            merge.upstream_fragment_id,
-                            project_input.get_fields().clone(),
-                            project.get_select_list().clone(),
-                        ));
-                        is_sink_into = true;
-                    }
+                });
+                if all_unspecified
+                    && let NodeBody::Merge(merge) = project_input.get_node_body().unwrap()
+                {
+                    tracing::debug!(
+                        "sink into table: fragment_id: {}, upstream_fragment_id: {}, project: {:?}",
+                        fragment_id,
+                        merge.upstream_fragment_id,
+                        project.get_select_list()
+                    );
+                    sink_into_streams.push((
+                        merge.upstream_fragment_id,
+                        project_input.get_fields().clone(),
+                        project.get_select_list().clone(),
+                    ));
+                    is_sink_into = true;
                 }
             }
             if !is_sink_into {

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -259,25 +259,29 @@ impl StreamActorManager {
 
         let mut sink_into_streams = Vec::new();
         for input_stream_node in &node.input {
+            // Check if the input stream node is for sink-into operation.
             let mut is_sink_into = false;
             if let NodeBody::Project(project) = input_stream_node.get_node_body().unwrap() {
                 let project_input = input_stream_node.get_input();
                 assert_eq!(project_input.len(), 1);
                 let project_input = project_input.first().unwrap();
-                if let NodeBody::Merge(merge) = project_input.get_node_body().unwrap() {
-                    tracing::debug!(
-                        "sink into table: fragment_id: {}, upstream_fragment_id: {}, project: {:?}",
-                        fragment_id,
-                        merge.upstream_fragment_id,
-                        project.get_select_list()
-                    );
-                    assert!(project.get_nondecreasing_exprs().is_empty());
-                    sink_into_streams.push((
-                        merge.upstream_fragment_id,
-                        project_input.get_fields().clone(),
-                        project.get_select_list().clone(),
-                    ));
-                    is_sink_into = true;
+                if project.get_select_list().iter().all(|e| {
+                    e.function_type() == risingwave_pb::expr::expr_node::PbType::Unspecified
+                }) {
+                    if let NodeBody::Merge(merge) = project_input.get_node_body().unwrap() {
+                        tracing::debug!(
+                            "sink into table: fragment_id: {}, upstream_fragment_id: {}, project: {:?}",
+                            fragment_id,
+                            merge.upstream_fragment_id,
+                            project.get_select_list()
+                        );
+                        sink_into_streams.push((
+                            merge.upstream_fragment_id,
+                            project_input.get_fields().clone(),
+                            project.get_select_list().clone(),
+                        ));
+                        is_sink_into = true;
+                    }
                 }
             }
             if !is_sink_into {

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -26,6 +26,7 @@ use risingwave_common::config::MetricLevel;
 use risingwave_common::must_match;
 use risingwave_common::operator::{unique_executor_id, unique_operator_id};
 use risingwave_common::util::runtime::BackgroundShutdownRuntime;
+use risingwave_expr::expr::build_non_strict_from_prost;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -44,7 +45,8 @@ use crate::executor::monitor::StreamingMetrics;
 use crate::executor::subtask::SubtaskHandle;
 use crate::executor::{
     Actor, ActorContext, ActorContextRef, DispatchExecutor, Execute, Executor, ExecutorInfo,
-    MergeExecutorInput, SnapshotBackfillExecutor, TroublemakerExecutor, WrapperExecutor,
+    MergeExecutorInput, SnapshotBackfillExecutor, TroublemakerExecutor, UpstreamSinkUnionExecutor,
+    WrapperExecutor,
 };
 use crate::from_proto::{MergeExecutorBuilder, create_executor};
 use crate::task::{
@@ -254,21 +256,46 @@ impl StreamActorManager {
 
         // Create the input executor before creating itself
         let mut input = Vec::with_capacity(node.input.iter().len());
+
+        let mut sink_into_streams = Vec::new();
         for input_stream_node in &node.input {
-            input.push(
-                self.create_nodes_inner(
-                    fragment_id,
-                    input_stream_node,
-                    env.clone(),
-                    store.clone(),
-                    actor_context,
-                    vnode_bitmap.clone(),
-                    has_stateful || is_stateful,
-                    subtasks,
-                    local_barrier_manager,
-                )
-                .await?,
-            );
+            let mut is_sink_into = false;
+            if let NodeBody::Project(project) = input_stream_node.get_node_body().unwrap() {
+                let project_input = input_stream_node.get_input();
+                assert_eq!(project_input.len(), 1);
+                let project_input = project_input.first().unwrap();
+                if let NodeBody::Merge(merge) = project_input.get_node_body().unwrap() {
+                    tracing::debug!(
+                        "sink into table: fragment_id: {}, upstream_fragment_id: {}, project: {:?}",
+                        fragment_id,
+                        merge.upstream_fragment_id,
+                        project.get_select_list()
+                    );
+                    assert!(project.get_nondecreasing_exprs().is_empty());
+                    sink_into_streams.push((
+                        merge.upstream_fragment_id,
+                        project_input.get_fields().clone(),
+                        project.get_select_list().clone(),
+                    ));
+                    is_sink_into = true;
+                }
+            }
+            if !is_sink_into {
+                input.push(
+                    self.create_nodes_inner(
+                        fragment_id,
+                        input_stream_node,
+                        env.clone(),
+                        store.clone(),
+                        actor_context,
+                        vnode_bitmap.clone(),
+                        has_stateful || is_stateful,
+                        subtasks,
+                        local_barrier_manager,
+                    )
+                    .await?,
+                );
+            }
         }
 
         let op_info = node.get_identity().clone();
@@ -284,6 +311,33 @@ impl StreamActorManager {
             actor_context: actor_context.clone(),
             identity: info.identity.clone().into(),
         };
+
+        if !sink_into_streams.is_empty() {
+            let upstream_infos = sink_into_streams
+                .into_iter()
+                .map(|(upstream_fragment_id, fields, select_list)| {
+                    let merge_schema: Schema = fields.iter().map(Field::from).collect();
+                    let project_exprs = select_list
+                        .iter()
+                        .map(|e| build_non_strict_from_prost(e, eval_error_report.clone()))
+                        .try_collect()
+                        .unwrap();
+                    (upstream_fragment_id, merge_schema, project_exprs)
+                })
+                .collect();
+            let upstream_sink_union_executor = UpstreamSinkUnionExecutor::new(
+                actor_context.clone(),
+                local_barrier_manager.clone(),
+                self.streaming_metrics.clone(),
+                env.config().developer.chunk_size,
+                upstream_infos,
+            );
+            let mut info = info.clone();
+            info.id += 1 << 24; // Ensure the id is unique.
+            info.identity = format!("UpstreamSinkUnion {:X}", info.id);
+            let executor = (info, upstream_sink_union_executor).into();
+            input.push(executor);
+        }
 
         // Build the executor with params.
         let executor_params = ExecutorParams {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Currently, we have only implemented the `UpstreamSinkUnion` operator. In `create_nodes_inner` function, we replaced the previous `Merge` + `Project` operator in a way that is not completely reliable. Soon, once the meta's modification is completed, the hack here will no longer be needed.
In addition, the operator does not currently support dynamic increase and decrease of upstream, but will support it in the future.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
