### PR TITLE
feat: refreshable source, SourceExec part

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -71,6 +71,10 @@ message BarrierCompleteResponse {
   // prev_epoch of barrier
   uint64 epoch = 9;
   uint32 database_id = 10;
+  // Used for refreshable batch source.
+  // SourceExecutor reports the source load is finished, and then
+  // meta will issue a LoadFinished barrier to notify MaterializeExecutor to start diff calculation.
+  repeated uint32 load_finished_source_ids = 11;
 }
 
 message StreamingControlStreamRequest {

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -160,6 +160,10 @@ impl StreamChunk {
         builder.take().expect("chunk should not be empty")
     }
 
+    pub fn empty(data_types: &[DataType]) -> Self {
+        StreamChunkBuilder::build_empty(data_types.to_vec())
+    }
+
     /// Get the reference of the underlying data chunk.
     pub fn data_chunk(&self) -> &DataChunk {
         &self.data

--- a/src/common/src/array/stream_chunk_builder.rs
+++ b/src/common/src/array/stream_chunk_builder.rs
@@ -104,6 +104,10 @@ impl StreamChunkBuilder {
         }
     }
 
+    pub fn build_empty(data_types: Vec<DataType>) -> StreamChunk {
+        Self::new(1, data_types).take_inner()
+    }
+
     /// Get the current number of rows in the builder.
     pub fn size(&self) -> usize {
         self.size
@@ -161,6 +165,10 @@ impl StreamChunkBuilder {
         if self.size == 0 {
             return None;
         }
+        Some(self.take_inner())
+    }
+
+    fn take_inner(&mut self) -> StreamChunk {
         self.size = 0;
 
         let ops = std::mem::replace(&mut self.ops, Vec::with_capacity(self.initial_capacity));
@@ -179,7 +187,7 @@ impl StreamChunkBuilder {
             .collect::<Vec<_>>();
         let vis = std::mem::take(&mut self.vis_builder).finish();
 
-        Some(StreamChunk::with_visibility(ops, columns, vis))
+        StreamChunk::with_visibility(ops, columns, vis)
     }
 
     #[must_use]

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -50,6 +50,7 @@ use crate::error::ConnectorResult as Result;
 use crate::parser::ParserConfig;
 use crate::parser::schema_change::SchemaChangeEnvelope;
 use crate::source::SplitImpl::{CitusCdc, MongodbCdc, MysqlCdc, PostgresCdc, SqlServerCdc};
+use crate::source::batch::BatchSourceSplitImpl;
 use crate::source::monitor::EnumeratorMetrics;
 use crate::with_options::WithOptions;
 use crate::{
@@ -450,7 +451,10 @@ pub type BoxSourceMessageStream =
     BoxStream<'static, crate::error::ConnectorResult<Vec<SourceMessage>>>;
 /// Stream of [`StreamChunk`]s parsed from the messages from the external source.
 pub type BoxSourceChunkStream = BoxStream<'static, crate::error::ConnectorResult<StreamChunk>>;
+/// `StreamChunk` with the latest split state.
+/// The state is constructed in `StreamReaderBuilder::into_retry_stream`
 pub type StreamChunkWithState = (StreamChunk, HashMap<SplitId, SplitImpl>);
+/// See [`StreamChunkWithState`].
 pub type BoxSourceChunkWithStateStream =
     BoxStream<'static, crate::error::ConnectorResult<StreamChunkWithState>>;
 
@@ -699,6 +703,16 @@ impl SplitImpl {
             CitusCdc(split) => split.start_offset().clone().unwrap_or_default(),
             SqlServerCdc(split) => split.start_offset().clone().unwrap_or_default(),
             _ => unreachable!("get_cdc_split_offset() is only for cdc split"),
+        }
+    }
+
+    pub fn into_batch_split(self) -> Option<BatchSourceSplitImpl> {
+        #[expect(clippy::match_single_binding)]
+        match self {
+            // SplitImpl::BatchPosixFs(batch_posix_fs_split) => {
+            //     Some(BatchSourceSplitImpl::BatchPosixFs(batch_posix_fs_split))
+            // }
+            _ => None,
         }
     }
 }

--- a/src/connector/src/source/batch.rs
+++ b/src/connector/src/source/batch.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::source::{SplitImpl, SplitMetaData};
+
+/// # Batch Refreshable Source
+///
+/// A batch refreshable source can be refreshed - reload all data from the source, e.g., re-run a `SELECT *` query from the source.
+/// The reloaded data will be handled by `RefreshableMaterialize` to calculate a diff to send to downstream.
+///
+/// See <https://github.com/risingwavelabs/risingwave/issues/22690> for the whole picture of the user journey.
+///
+/// ## Failover
+///
+/// Batch source is considered stateless. i.e., it's consumption progress is not recorded, and cannot be resumed.
+/// The split metadata just represent "how to load the data".
+///
+/// - On startup, `SourceExecutor` will load data.
+/// - On `RefreshStart` barrier (from `REFRESH TABLE t` SQL command), it will re-load data.
+/// - On recovery, it will *do nothing*, regardless of whether it's in the middle of loading data or not before crash.
+pub trait BatchSourceSplit: SplitMetaData {
+    fn finished(&self) -> bool;
+    /// Mark the source as finished. Called after the source is exhausted.
+    /// Then `SourceExecutor` will report to meta to send a `LoadFinish` barrier,
+    /// and the `RefreshableMaterialize` will begin to calculate the diff.
+    fn finish(&mut self);
+    /// Refresh the source to make it ready for re-run.
+    /// Called when receiving `RefreshStart` barrier.
+    fn refresh(&mut self);
+}
+
+pub enum BatchSourceSplitImpl {}
+
+/// See [`BatchSourceSplit`] for more details.
+impl BatchSourceSplitImpl {
+    pub fn finished(&self) -> bool {
+        unreachable!()
+    }
+
+    pub fn finish(&mut self) {
+        tracing::info!("finishing batch source split");
+        unreachable!()
+    }
+
+    pub fn refresh(&mut self) {
+        tracing::info!("refreshing batch source split");
+        unreachable!()
+    }
+}
+
+impl From<BatchSourceSplitImpl> for SplitImpl {
+    fn from(batch_split: BatchSourceSplitImpl) -> Self {
+        match batch_split {}
+    }
+}

--- a/src/connector/src/source/batch.rs
+++ b/src/connector/src/source/batch.rs
@@ -14,10 +14,14 @@
 
 use crate::source::{SplitImpl, SplitMetaData};
 
-/// # Batch Refreshable Source
+/// # Refreshable Batch Source/Table
 ///
-/// A batch refreshable source can be refreshed - reload all data from the source, e.g., re-run a `SELECT *` query from the source.
+/// A refreshable batch source can be refreshed - reload all data from the source, e.g., re-run a `SELECT *` query from the source.
 /// The reloaded data will be handled by `RefreshableMaterialize` to calculate a diff to send to downstream.
+///
+/// - *Batch* means the source loads all data at once, instead of continuously streaming data.
+/// - *Refreshable* part is handled by the materialize executor. When creating a table with a refreshable batch source, the table can be
+///   refreshed by running `REFRESH TABLE t` SQL command.
 ///
 /// See <https://github.com/risingwavelabs/risingwave/issues/22690> for the whole picture of the user journey.
 ///

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -43,6 +43,7 @@ pub mod prelude {
 }
 
 pub mod base;
+pub mod batch;
 pub mod cdc;
 pub mod data_gen_util;
 pub mod datagen;

--- a/src/connector/src/with_options.rs
+++ b/src/connector/src/with_options.rs
@@ -204,6 +204,14 @@ pub trait WithPropertiesExt: Get + GetKeyIter + Sized {
 
     fn is_refreshable_connector(&self) -> bool {
         false
+        // TODO: enable this when implementation done
+        // self.get(UPSTREAM_SOURCE_KEY)
+        //     .map(|s| s.eq_ignore_ascii_case(BATCH_POSIX_FS_CONNECTOR))
+        //     .unwrap_or(false)
+    }
+
+    fn requires_singleton(&self) -> bool {
+        self.is_new_fs_connector() || self.is_iceberg_connector() || self.is_refreshable_connector()
     }
 }
 

--- a/src/connector/src/with_options.rs
+++ b/src/connector/src/with_options.rs
@@ -202,7 +202,8 @@ pub trait WithPropertiesExt: Get + GetKeyIter + Sized {
             .unwrap_or(false)
     }
 
-    fn is_refreshable_connector(&self) -> bool {
+    /// See [`crate::source::batch::BatchSourceSplit`] for more details.
+    fn is_batch_connector(&self) -> bool {
         false
         // TODO: enable this when implementation done
         // self.get(UPSTREAM_SOURCE_KEY)
@@ -211,7 +212,7 @@ pub trait WithPropertiesExt: Get + GetKeyIter + Sized {
     }
 
     fn requires_singleton(&self) -> bool {
-        self.is_new_fs_connector() || self.is_iceberg_connector() || self.is_refreshable_connector()
+        self.is_new_fs_connector() || self.is_iceberg_connector() || self.is_batch_connector()
     }
 }
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -840,7 +840,7 @@ pub async fn bind_create_source_or_table_with_connector(
 
     if is_create_source {
         // reject refreshable batch source
-        if with_properties.is_refreshable_connector() {
+        if with_properties.is_batch_connector() {
             return Err(ErrorCode::BindError(
             "can't CREATE SOURCE with refreshable batch connector\n\nHint: use CREATE TABLE instead"
                 .to_owned(),

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -839,6 +839,16 @@ pub async fn bind_create_source_or_table_with_connector(
     }
 
     if is_create_source {
+        // reject refreshable batch source
+        if with_properties.is_refreshable_connector() {
+            return Err(ErrorCode::BindError(
+            "can't CREATE SOURCE with refreshable batch connector\n\nHint: use CREATE TABLE instead"
+                .to_owned(),
+        )
+        .into());
+        }
+
+        // reject unsupported formats for CREATE SOURCE
         match format_encode.format {
             Format::Upsert
             | Format::Debezium

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -947,7 +947,7 @@ impl LogicalPlanRoot {
         // Determine if the table should be refreshable based on the connector type
         let refreshable = source_catalog
             .as_ref()
-            .map(|catalog| catalog.with_properties.is_refreshable_connector())
+            .map(|catalog| catalog.with_properties.is_batch_connector())
             .unwrap_or(false);
 
         // Validate that refreshable tables have a user-defined primary key (i.e., does not have rowid)

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -950,6 +950,15 @@ impl LogicalPlanRoot {
             .map(|catalog| catalog.with_properties.is_refreshable_connector())
             .unwrap_or(false);
 
+        // Validate that refreshable tables have a user-defined primary key (i.e., does not have rowid)
+        if refreshable && row_id_index.is_some() {
+            return Err(crate::error::ErrorCode::BindError(
+                "Refreshable tables must have a PRIMARY KEY. Please define a primary key for the table."
+                    .to_owned(),
+            )
+            .into());
+        }
+
         StreamMaterialize::create_for_table(
             stream_plan,
             table_name,

--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -190,14 +190,14 @@ impl Source {
             .is_some_and(|catalog| catalog.with_properties.is_kafka_connector())
     }
 
-    pub fn is_refreshable_connector(&self) -> bool {
+    pub fn is_batch_connector(&self) -> bool {
         self.catalog
             .as_ref()
-            .is_some_and(|catalog| catalog.with_properties.is_refreshable_connector())
+            .is_some_and(|catalog| catalog.with_properties.is_batch_connector())
     }
 
     pub fn requires_singleton(&self) -> bool {
-        self.is_iceberg_connector() || self.is_refreshable_connector()
+        self.is_iceberg_connector() || self.is_batch_connector()
     }
 
     /// Currently, only iceberg source supports time travel.

--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -190,6 +190,16 @@ impl Source {
             .is_some_and(|catalog| catalog.with_properties.is_kafka_connector())
     }
 
+    pub fn is_refreshable_connector(&self) -> bool {
+        self.catalog
+            .as_ref()
+            .is_some_and(|catalog| catalog.with_properties.is_refreshable_connector())
+    }
+
+    pub fn requires_singleton(&self) -> bool {
+        self.is_iceberg_connector() || self.is_refreshable_connector()
+    }
+
     /// Currently, only iceberg source supports time travel.
     pub fn support_time_travel(&self) -> bool {
         self.is_iceberg_connector()

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -352,8 +352,7 @@ fn build_fragment(
                 if let Some(source) = node.source_inner.as_ref()
                     && let Some(source_info) = source.info.as_ref()
                     && ((source_info.is_shared() && !source_info.is_distributed)
-                        || source.with_properties.is_new_fs_connector()
-                        || source.with_properties.is_iceberg_connector())
+                        || source.with_properties.requires_singleton())
                 {
                     current_fragment.requires_singleton = true;
                 }

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -524,6 +524,7 @@ pub async fn start_service_as_election_leader(
         source_manager.clone(),
         sink_manager.clone(),
         scale_controller.clone(),
+        barrier_scheduler.clone(),
     )
     .await;
     tracing::info!("GlobalBarrierManager started");

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -853,7 +853,7 @@ impl DatabaseCheckpointControl {
                         }));
                     });
                 let task = task.get_or_insert_default();
-                node.command_ctx.collect_commit_epoch_info(
+                let load_finished_source_ids = node.command_ctx.collect_commit_epoch_info(
                     &mut task.commit_info,
                     take(&mut node.state.resps),
                     self.collect_backfill_pinned_upstream_log_epoch(),
@@ -861,6 +861,8 @@ impl DatabaseCheckpointControl {
                 self.completing_barrier = Some(node.command_ctx.barrier_info.prev_epoch());
                 task.finished_jobs.extend(finished_jobs);
                 task.notifiers.extend(node.notifiers);
+                task.load_finished_source_ids
+                    .extend(load_finished_source_ids);
                 task.epoch_infos
                     .try_insert(
                         self.database_id,

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -673,14 +673,9 @@ impl CommandContext {
         info: &mut CommitEpochInfo,
         resps: Vec<BarrierCompleteResponse>,
         backfill_pinned_log_epoch: HashMap<TableId, (u64, HashSet<TableId>)>,
-    ) -> Vec<u32> {
-        let (
-            sst_to_context,
-            synced_ssts,
-            new_table_watermarks,
-            old_value_ssts,
-            load_finished_source_ids,
-        ) = collect_resp_info(resps);
+    ) {
+        let (sst_to_context, synced_ssts, new_table_watermarks, old_value_ssts) =
+            collect_resp_info(resps);
 
         let new_table_fragment_infos =
             if let Some(Command::CreateStreamingJob { info, job_type, .. }) = &self.command
@@ -752,17 +747,6 @@ impl CommandContext {
         info.new_table_fragment_infos
             .extend(new_table_fragment_infos);
         info.change_log_delta.extend(table_new_change_log);
-
-        // Handle load finished source IDs for refreshable batch sources
-        if !load_finished_source_ids.is_empty() {
-            tracing::info!(
-                "Received load finished source IDs: {:?}",
-                load_finished_source_ids
-            );
-        }
-
-        // Return load_finished_source_ids for the caller to handle
-        load_finished_source_ids
     }
 }
 

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -54,6 +54,7 @@ pub(super) enum CompletingTask {
     Err(MetaError),
 }
 
+/// Only for checkpoint barrier. For normal barrier, there won't be a task.
 #[derive(Default)]
 pub(super) struct CompleteBarrierTask {
     pub(super) commit_info: CommitEpochInfo,

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -68,6 +68,8 @@ pub(super) struct CompleteBarrierTask {
             Vec<(TableId, u64)>,
         ),
     >,
+    /// Source IDs that have finished loading data and need `LoadFinish` commands
+    pub(super) load_finished_source_ids: Vec<u32>,
 }
 
 impl CompleteBarrierTask {
@@ -101,6 +103,13 @@ impl CompleteBarrierTask {
                 .barrier_wait_commit_latency
                 .start_timer();
             let version_stats = context.commit_epoch(self.commit_info).await?;
+
+            // Handle load finished source IDs for refreshable batch sources
+            // Spawn this asynchronously to avoid deadlock during barrier collection
+            if !self.load_finished_source_ids.is_empty() {
+                context.handle_load_finished_source_ids(self.load_finished_source_ids.clone());
+            }
+
             for command_ctx in self
                 .epoch_infos
                 .values()

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -107,7 +107,9 @@ impl CompleteBarrierTask {
             // Handle load finished source IDs for refreshable batch sources
             // Spawn this asynchronously to avoid deadlock during barrier collection
             if !self.load_finished_source_ids.is_empty() {
-                context.handle_load_finished_source_ids(self.load_finished_source_ids.clone());
+                context
+                    .handle_load_finished_source_ids(self.load_finished_source_ids.clone())
+                    .await?;
             }
 
             for command_ctx in self

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -111,6 +111,11 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
     ) -> MetaResult<()> {
         use risingwave_common::catalog::TableId;
 
+        tracing::info!(
+            "Handling load finished source IDs: {:?}",
+            load_finished_source_ids
+        );
+
         use crate::barrier::Command;
         for associated_source_id in load_finished_source_ids {
             let res: MetaResult<()> = try {

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -76,7 +76,10 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
         database_id: DatabaseId,
     ) -> MetaResult<Option<DatabaseRuntimeInfoSnapshot>>;
 
-    fn handle_load_finished_source_ids(&self, load_finished_source_ids: Vec<u32>);
+    fn handle_load_finished_source_ids(
+        &self,
+        load_finished_source_ids: Vec<u32>,
+    ) -> impl Future<Output = MetaResult<()>> + Send + '_;
 }
 
 pub(super) struct GlobalBarrierWorkerContextImpl {

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -142,6 +142,7 @@ impl GlobalBarrierManager {
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
         scale_controller: ScaleControllerRef,
+        barrier_scheduler: schedule::BarrierScheduler,
     ) -> (Arc<Self>, JoinHandle<()>, oneshot::Sender<()>) {
         let (request_tx, request_rx) = unbounded_channel();
         let hummock_manager_clone = hummock_manager.clone();
@@ -155,6 +156,7 @@ impl GlobalBarrierManager {
             sink_manager,
             scale_controller,
             request_rx,
+            barrier_scheduler,
         )
         .await;
         let manager = Self {

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -302,6 +302,12 @@ impl BarrierScheduler {
         ret
     }
 
+    /// Schedule a command without waiting for it to be executed.
+    pub fn run_command_no_wait(&self, database_id: DatabaseId, command: Command) -> MetaResult<()> {
+        tracing::trace!("run_command_no_wait: {:?}", command);
+        self.push(database_id, vec![(command, Notifier::default())])
+    }
+
     /// Flush means waiting for the next barrier to collect.
     pub async fn flush(&self, database_id: DatabaseId) -> MetaResult<HummockVersionId> {
         let start = Instant::now();
@@ -854,7 +860,10 @@ mod tests {
             unimplemented!()
         }
 
-        fn handle_load_finished_source_ids(&self, _load_finished_source_ids: Vec<u32>) {
+        async fn handle_load_finished_source_ids(
+            &self,
+            _load_finished_source_ids: Vec<u32>,
+        ) -> MetaResult<()> {
             unimplemented!()
         }
     }

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -853,6 +853,10 @@ mod tests {
         ) -> MetaResult<Option<crate::barrier::DatabaseRuntimeInfoSnapshot>> {
             unimplemented!()
         }
+
+        fn handle_load_finished_source_ids(&self, _load_finished_source_ids: Vec<u32>) {
+            unimplemented!()
+        }
     }
 
     #[tokio::test]

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -123,6 +123,10 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
     ) -> MetaResult<Option<DatabaseRuntimeInfoSnapshot>> {
         unreachable!()
     }
+
+    fn handle_load_finished_source_ids(&self, _load_finished_source_ids: Vec<u32>) {
+        unimplemented!()
+    }
 }
 
 #[tokio::test]

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -124,7 +124,10 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
         unreachable!()
     }
 
-    fn handle_load_finished_source_ids(&self, _load_finished_source_ids: Vec<u32>) {
+    async fn handle_load_finished_source_ids(
+        &self,
+        _load_finished_source_ids: Vec<u32>,
+    ) -> MetaResult<()> {
         unimplemented!()
     }
 }

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -36,16 +36,13 @@ pub(super) fn collect_resp_info(
     Vec<LocalSstableInfo>,
     HashMap<TableId, TableWatermarks>,
     Vec<SstableInfo>,
-    Vec<u32>,
 ) {
     let mut sst_to_worker: HashMap<HummockSstableObjectId, u32> = HashMap::new();
     let mut synced_ssts: Vec<LocalSstableInfo> = vec![];
     let mut table_watermarks = Vec::with_capacity(resps.len());
     let mut old_value_ssts = Vec::with_capacity(resps.len());
-    let mut load_finished_source_ids = Vec::new();
 
     for resp in resps {
-        load_finished_source_ids.extend(resp.load_finished_source_ids);
         let ssts_iter = resp.synced_sstables.into_iter().map(|local_sst| {
             let sst_info = local_sst.sst.expect("field not None");
             sst_to_worker.insert(sst_info.object_id.into(), resp.worker_id);
@@ -77,7 +74,6 @@ pub(super) fn collect_resp_info(
                 .collect_vec(),
         ),
         old_value_ssts,
-        load_finished_source_ids,
     )
 }
 
@@ -88,8 +84,7 @@ pub(super) fn collect_creating_job_commit_epoch_info(
     tables_to_commit: impl Iterator<Item = TableId>,
     is_first_time: bool,
 ) {
-    let (sst_to_context, sstables, new_table_watermarks, old_value_sst, _load_finished_source_ids) =
-        collect_resp_info(resps);
+    let (sst_to_context, sstables, new_table_watermarks, old_value_sst) = collect_resp_info(resps);
     assert!(old_value_sst.is_empty());
     commit_info.sst_to_context.extend(sst_to_context);
     commit_info.sstables.extend(sstables);

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -36,13 +36,16 @@ pub(super) fn collect_resp_info(
     Vec<LocalSstableInfo>,
     HashMap<TableId, TableWatermarks>,
     Vec<SstableInfo>,
+    Vec<u32>,
 ) {
     let mut sst_to_worker: HashMap<HummockSstableObjectId, u32> = HashMap::new();
     let mut synced_ssts: Vec<LocalSstableInfo> = vec![];
     let mut table_watermarks = Vec::with_capacity(resps.len());
     let mut old_value_ssts = Vec::with_capacity(resps.len());
+    let mut load_finished_source_ids = Vec::new();
 
     for resp in resps {
+        load_finished_source_ids.extend(resp.load_finished_source_ids);
         let ssts_iter = resp.synced_sstables.into_iter().map(|local_sst| {
             let sst_info = local_sst.sst.expect("field not None");
             sst_to_worker.insert(sst_info.object_id.into(), resp.worker_id);
@@ -74,6 +77,7 @@ pub(super) fn collect_resp_info(
                 .collect_vec(),
         ),
         old_value_ssts,
+        load_finished_source_ids,
     )
 }
 
@@ -84,7 +88,8 @@ pub(super) fn collect_creating_job_commit_epoch_info(
     tables_to_commit: impl Iterator<Item = TableId>,
     is_first_time: bool,
 ) {
-    let (sst_to_context, sstables, new_table_watermarks, old_value_sst) = collect_resp_info(resps);
+    let (sst_to_context, sstables, new_table_watermarks, old_value_sst, _load_finished_source_ids) =
+        collect_resp_info(resps);
     assert!(old_value_sst.is_empty());
     commit_info.sst_to_context.extend(sst_to_context);
     commit_info.sstables.extend(sstables);

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -149,6 +149,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
         sink_manager: SinkCoordinatorManager,
         scale_controller: ScaleControllerRef,
         request_rx: mpsc::UnboundedReceiver<BarrierManagerRequest>,
+        barrier_scheduler: schedule::BarrierScheduler,
     ) -> Self {
         let status = Arc::new(ArcSwap::new(Arc::new(BarrierManagerStatus::Starting)));
 
@@ -160,6 +161,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
             source_manager,
             scale_controller,
             env.clone(),
+            barrier_scheduler,
         ));
 
         Self::new_inner(env, sink_manager, request_rx, context).await

--- a/src/stream/src/executor/source/executor_core.rs
+++ b/src/stream/src/executor/source/executor_core.rs
@@ -64,9 +64,7 @@ where
         source_desc_builder: SourceDescBuilder,
         split_state_store: SourceStateTableHandler<S>,
     ) -> Self {
-        let is_batch_source = source_desc_builder
-            .with_properties()
-            .is_refreshable_connector();
+        let is_batch_source = source_desc_builder.with_properties().is_batch_connector();
         Self {
             source_id,
             source_name,

--- a/src/stream/src/executor/source/executor_core.rs
+++ b/src/stream/src/executor/source/executor_core.rs
@@ -15,6 +15,8 @@
 use std::collections::HashMap;
 
 use risingwave_common::catalog::{ColumnId, TableId};
+use risingwave_connector::WithPropertiesExt;
+use risingwave_connector::source::batch::BatchSourceSplitImpl;
 use risingwave_connector::source::reader::desc::SourceDescBuilder;
 use risingwave_connector::source::{SplitId, SplitImpl, SplitMetaData};
 use risingwave_storage::StateStore;
@@ -46,6 +48,9 @@ pub struct StreamSourceCore<S: StateStore> {
     /// Source messages will only write the cache.
     /// It is read on split change and rebuild stream reader on error.
     pub(crate) updated_splits_in_epoch: HashMap<SplitId, SplitImpl>,
+
+    /// Is refreshable batch source
+    pub(crate) is_batch_source: bool,
 }
 
 impl<S> StreamSourceCore<S>
@@ -59,6 +64,9 @@ where
         source_desc_builder: SourceDescBuilder,
         split_state_store: SourceStateTableHandler<S>,
     ) -> Self {
+        let is_batch_source = source_desc_builder
+            .with_properties()
+            .is_refreshable_connector();
         Self {
             source_id,
             source_name,
@@ -67,6 +75,7 @@ where
             latest_split_info: HashMap::new(),
             split_state_store,
             updated_splits_in_epoch: HashMap::new(),
+            is_batch_source,
         }
     }
 
@@ -75,5 +84,22 @@ where
             .into_iter()
             .map(|split| (split.id(), split))
             .collect();
+    }
+
+    /// # Panics
+    /// If the source is not a batch source.
+    pub fn get_batch_split(&self) -> BatchSourceSplitImpl {
+        debug_assert_eq!(
+            self.latest_split_info.len(),
+            1,
+            "batch source should have only one split"
+        );
+        self.latest_split_info
+            .values()
+            .next()
+            .unwrap()
+            .clone()
+            .into_batch_split()
+            .unwrap()
     }
 }

--- a/src/stream/src/executor/source/reader_stream.rs
+++ b/src/stream/src/executor/source/reader_stream.rs
@@ -193,6 +193,7 @@ impl StreamReaderBuilder {
 
             let (stream, _) = build_stream_result.unwrap();
             let stream = apply_rate_limit(stream, self.rate_limit).boxed();
+            let mut is_error = false;
             #[for_await]
             'consume: for msg in stream {
                 match msg {
@@ -214,9 +215,31 @@ impl StreamReaderBuilder {
                             actor_id = self.actor_ctx.id,
                             "stream source reader error"
                         );
+                        is_error = true;
                         break 'consume;
                     }
                 }
+            }
+            if !is_error {
+                tracing::info!("stream source reader consume finished");
+                latest_splits_info.values_mut().for_each(|split_impl| {
+                    if let Some(mut batch_split) = split_impl.clone().into_batch_split() {
+                        batch_split.finish();
+                        *split_impl = batch_split.into();
+                    }
+                });
+                yield (
+                    StreamChunk::empty(
+                        self.source_desc
+                            .columns
+                            .iter()
+                            .map(|c| c.data_type.clone())
+                            .collect_vec()
+                            .as_slice(),
+                    ),
+                    latest_splits_info.clone(),
+                );
+                break 'build_consume_loop;
             }
             tracing::info!("stream source reader error, retry in 1s");
             tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -46,6 +46,7 @@ use crate::executor::UpdateMutation;
 use crate::executor::prelude::*;
 use crate::executor::source::reader_stream::StreamReaderBuilder;
 use crate::executor::stream_reader::StreamReaderWithPause;
+use crate::task::LocalBarrierManager;
 
 /// A constant to multiply when calculating the maximum time to wait for a barrier. This is due to
 /// some latencies in network and cost in meta.
@@ -70,9 +71,13 @@ pub struct SourceExecutor<S: StateStore> {
     rate_limit_rps: Option<u32>,
 
     is_shared_non_cdc: bool,
+
+    /// Local barrier manager for reporting source load finished events
+    barrier_manager: LocalBarrierManager,
 }
 
 impl<S: StateStore> SourceExecutor<S> {
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         actor_ctx: ActorContextRef,
         stream_source_core: StreamSourceCore<S>,
@@ -81,6 +86,7 @@ impl<S: StateStore> SourceExecutor<S> {
         system_params: SystemParamsReaderRef,
         rate_limit_rps: Option<u32>,
         is_shared_non_cdc: bool,
+        barrier_manager: LocalBarrierManager,
     ) -> Self {
         Self {
             actor_ctx,
@@ -90,6 +96,7 @@ impl<S: StateStore> SourceExecutor<S> {
             system_params,
             rate_limit_rps,
             is_shared_non_cdc,
+            barrier_manager,
         }
     }
 
@@ -193,6 +200,22 @@ impl<S: StateStore> SourceExecutor<S> {
         (column_ids, source_ctx)
     }
 
+    /// Check if this is a batch refreshable source.
+    fn is_batch_source(&self) -> bool {
+        self.stream_source_core.is_batch_source
+    }
+
+    /// Refresh splits
+    fn refresh_batch_splits(&mut self) -> StreamExecutorResult<Vec<SplitImpl>> {
+        debug_assert!(self.is_batch_source());
+        let core = &self.stream_source_core;
+        #[expect(unused_variables, unused_mut)]
+        let mut split = core.get_batch_split();
+        #[expect(unreachable_code)]
+        split.refresh();
+        Ok(vec![split.into()])
+    }
+
     fn is_auto_schema_change_enable(&self) -> bool {
         self.actor_ctx
             .streaming_config
@@ -241,6 +264,12 @@ impl<S: StateStore> SourceExecutor<S> {
                     {
                         should_rebuild_stream = true;
                     }
+                }
+                ApplyMutationAfterBarrier::RefreshBatchSplits(splits) => {
+                    // Just override the latest split info with the refreshed splits. No need to check.
+                    self.stream_source_core.latest_split_info =
+                        splits.into_iter().map(|s| (s.id(), s)).collect();
+                    should_rebuild_stream = true;
                 }
                 ApplyMutationAfterBarrier::ConnectorPropsChange => {
                     should_rebuild_stream = true;
@@ -554,6 +583,8 @@ impl<S: StateStore> SourceExecutor<S> {
             .source_split_change_count
             .with_guarded_label_values(&self.get_metric_labels());
 
+        let mut is_refreshing = false;
+
         while let Some(msg) = stream.next().await {
             let Ok(msg) = msg else {
                 tokio::time::sleep(Duration::from_millis(1000)).await;
@@ -575,6 +606,22 @@ impl<S: StateStore> SourceExecutor<S> {
                     }
 
                     let epoch = barrier.epoch;
+
+                    if self.is_batch_source() && is_refreshing {
+                        #[expect(unused_variables)]
+                        let batch_split = self.stream_source_core.get_batch_split();
+                        #[expect(unreachable_code)]
+                        if batch_split.finished() {
+                            tracing::info!(?epoch, "emitting load finish");
+                            self.barrier_manager.report_source_load_finished(
+                                epoch,
+                                self.actor_ctx.id,
+                                source_id.table_id(),
+                                source_id.table_id(),
+                            );
+                            is_refreshing = false;
+                        }
+                    }
 
                     let mut split_change = None;
 
@@ -657,6 +704,36 @@ impl<S: StateStore> SourceExecutor<S> {
                                     self.rebuild_stream_reader(&source_desc, &mut stream)?;
                                 }
                             }
+                            Mutation::RefreshStart {
+                                table_id: _,
+                                associated_source_id,
+                            } if *associated_source_id == source_id => {
+                                debug_assert!(self.is_batch_source());
+                                is_refreshing = true;
+
+                                // Similar to split_change, we need to update the split info, and rebuild source reader.
+
+                                // For batch sources, trigger re-enumeration of splits to detect file changes
+                                if let Ok(new_splits) = self.refresh_batch_splits() {
+                                    tracing::info!(
+                                        actor_id = self.actor_ctx.id,
+                                         %associated_source_id,
+                                        new_splits_count = new_splits.len(),
+                                        "RefreshStart triggered split re-enumeration"
+                                    );
+                                    split_change = Some((
+                                        &source_desc,
+                                        &mut stream,
+                                        ApplyMutationAfterBarrier::RefreshBatchSplits(new_splits),
+                                    ));
+                                } else {
+                                    tracing::warn!(
+                                        actor_id = self.actor_ctx.id,
+                                        %associated_source_id,
+                                        "Failed to refresh splits during RefreshStart"
+                                    );
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -730,7 +807,8 @@ impl<S: StateStore> SourceExecutor<S> {
                         .updated_splits_in_epoch
                         .extend(latest_state);
 
-                    source_output_row_count.inc_by(chunk.cardinality() as u64);
+                    let card = chunk.cardinality();
+                    source_output_row_count.inc_by(card as u64);
                     let chunk =
                         prune_additional_cols(&chunk, split_idx, offset_idx, &source_desc.columns);
                     yield Message::Chunk(chunk);
@@ -754,6 +832,7 @@ enum ApplyMutationAfterBarrier<'a> {
         should_trim_state: bool,
         split_change_count: &'a LabelGuardedMetric<GenericCounter<AtomicU64>>,
     },
+    RefreshBatchSplits(Vec<SplitImpl>),
     ConnectorPropsChange,
 }
 
@@ -916,6 +995,7 @@ mod tests {
     use super::*;
     use crate::executor::AddMutation;
     use crate::executor::source::{SourceStateTableHandler, default_source_internal_table};
+    use crate::task::LocalBarrierManager;
 
     const MOCK_SOURCE_NAME: &str = "mock_source";
 
@@ -956,6 +1036,7 @@ mod tests {
             split_state_store,
             updated_splits_in_epoch: HashMap::new(),
             source_name: MOCK_SOURCE_NAME.to_owned(),
+            is_batch_source: false,
         };
 
         let system_params_manager = LocalSystemParamsManager::for_test();
@@ -968,6 +1049,7 @@ mod tests {
             system_params_manager.get_params(),
             None,
             false,
+            LocalBarrierManager::for_test(),
         );
         let mut executor = executor.boxed().execute();
 
@@ -1047,6 +1129,7 @@ mod tests {
             split_state_store,
             updated_splits_in_epoch: HashMap::new(),
             source_name: MOCK_SOURCE_NAME.to_owned(),
+            is_batch_source: false,
         };
 
         let system_params_manager = LocalSystemParamsManager::for_test();
@@ -1059,6 +1142,7 @@ mod tests {
             system_params_manager.get_params(),
             None,
             false,
+            LocalBarrierManager::for_test(),
         );
         let mut handler = executor.boxed().execute();
 

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -607,7 +607,9 @@ impl<S: StateStore> SourceExecutor<S> {
 
                     let epoch = barrier.epoch;
 
-                    if self.is_batch_source() && is_refreshing {
+                    // NOTE: We rely on CompleteBarrierTask, which is only for checkpoint barrier,
+                    // so we wait for a checkpoint barrier here.
+                    if barrier.is_checkpoint() && self.is_batch_source() && is_refreshing {
                         #[expect(unused_variables)]
                         let batch_split = self.stream_source_core.get_batch_split();
                         #[expect(unreachable_code)]

--- a/src/stream/src/executor/wrapper/schema_check.rs
+++ b/src/stream/src/executor/wrapper/schema_check.rs
@@ -31,7 +31,8 @@ pub async fn schema_check(info: Arc<ExecutorInfo>, input: impl MessageStream) {
             Message::Chunk(chunk) => risingwave_common::util::schema_check::schema_check(
                 info.schema.fields().iter().map(|f| &f.data_type),
                 chunk.columns(),
-            ),
+            )
+            .map_err(|e| format!("{e}\nchunk:\n{}", chunk.to_pretty())),
             Message::Watermark(watermark) => {
                 let expected = info.schema.fields()[watermark.col_idx].data_type();
                 let found = &watermark.data_type;

--- a/src/stream/src/executor/wrapper/trace.rs
+++ b/src/stream/src/executor/wrapper/trace.rs
@@ -88,6 +88,7 @@ pub async fn trace(
                     prev_epoch = barrier.epoch.prev,
                     curr_epoch = barrier.epoch.curr,
                     kind = ?barrier.kind,
+                    mutation = ?barrier.mutation,
                 );
                 span.record("message", "barrier");
             }

--- a/src/stream/src/from_proto/source/trad_source.rs
+++ b/src/stream/src/from_proto/source/trad_source.rs
@@ -231,6 +231,7 @@ impl ExecutorBuilder for SourceExecutorBuilder {
                         system_params,
                         source.rate_limit,
                         is_shared && !source.with_properties.is_cdc_connector(),
+                        params.local_barrier_manager.clone(),
                     )
                     .boxed()
                 }

--- a/src/stream/src/task/barrier_worker/mod.rs
+++ b/src/stream/src/task/barrier_worker/mod.rs
@@ -76,7 +76,7 @@ use crate::task::barrier_worker::managed_state::{
 /// Note that this option will significantly increase the overhead of tracing.
 pub const ENABLE_BARRIER_AGGREGATION: bool = false;
 
-/// Collect result of some barrier on current compute node. Will be reported to the meta service in [`LocalBarrierWorker::next_completed_epoch`].
+/// Collect result of some barrier on current compute node. Will be reported to the meta service in [`LocalBarrierWorker::on_epoch_completed`].
 #[derive(Debug)]
 pub struct BarrierCompleteResult {
     /// The result returned from `sync` of `StateStore`.
@@ -84,6 +84,9 @@ pub struct BarrierCompleteResult {
 
     /// The updated creation progress of materialized view after this barrier.
     pub create_mview_progress: Vec<PbCreateMviewProgress>,
+
+    /// The source IDs that have finished loading data for refreshable batch sources.
+    pub load_finished_source_ids: Vec<u32>,
 }
 
 /// Lives in [`crate::task::barrier_worker::LocalBarrierWorker`],
@@ -367,6 +370,8 @@ impl LocalBarrierWorker {
                             partial_graph_id,
                             barrier,
                         } => {
+                            // update await_epoch_completed_futures
+                            // handled below in next_completed_epoch
                             self.complete_barrier(database_id, partial_graph_id, barrier.epoch.prev);
                         }
                         ManagedBarrierStateEvent::ActorError{
@@ -629,6 +634,7 @@ mod await_epoch_completed_future {
         barrier: Barrier,
         barrier_await_tree_reg: Option<&await_tree::Registry>,
         create_mview_progress: Vec<PbCreateMviewProgress>,
+        load_finished_source_ids: Vec<u32>,
     ) -> AwaitEpochCompletedFuture {
         let prev_epoch = barrier.epoch.prev;
         let future = async move {
@@ -646,6 +652,7 @@ mod await_epoch_completed_future {
                 result.map(|sync_result| BarrierCompleteResult {
                     sync_result,
                     create_mview_progress,
+                    load_finished_source_ids,
                 }),
             )
         });
@@ -716,7 +723,7 @@ impl LocalBarrierWorker {
             else {
                 return;
             };
-            let (barrier, table_ids, create_mview_progress) =
+            let (barrier, table_ids, create_mview_progress, load_finished_source_ids) =
                 database_state.pop_barrier_to_complete(partial_graph_id, prev_epoch);
 
             let complete_barrier_future = match &barrier.kind {
@@ -748,6 +755,7 @@ impl LocalBarrierWorker {
                         barrier,
                         self.actor_manager.await_tree_reg.as_ref(),
                         create_mview_progress,
+                        load_finished_source_ids,
                     )
                 });
         }
@@ -763,6 +771,7 @@ impl LocalBarrierWorker {
         let BarrierCompleteResult {
             create_mview_progress,
             sync_result,
+            load_finished_source_ids,
         } = result;
 
         let (synced_sstables, table_watermarks, old_value_ssts) = sync_result
@@ -808,6 +817,7 @@ impl LocalBarrierWorker {
                             .map(|sst| sst.sst_info.into())
                             .collect(),
                         database_id: database_id.database_id,
+                        load_finished_source_ids,
                     },
                 )
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Second part of #22690. See the tracking issue for the whole picture of the user journey.

Source part.

Key changes include:

- Added a new `BatchSourceSplit` interface in connector, and use it in SourceExec.
- Added a new `batch_posix_fs` connector for testing purporse
- Added a mechanism to trigger `LoadFinish` barrier: Similar to MV creation progress reporting, SourceExec will report load finish to barrier worker, and reported to meta as part of `BarrierCompleteResponse`. When handling this, meta will trigger a `LoadFinish` barrier.



## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.