### PR TITLE
feat: make `stream_unsafe_cache_size` a session variable

### DIFF
--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -61,6 +61,7 @@ user sink_rate_limit
 user source_rate_limit
 user standard_conforming_strings
 user statement_timeout
+user stream_unsafe_extreme_cache_size
 user streaming_allow_jsonb_in_stream_key
 user streaming_enable_bushy_join
 user streaming_enable_delta_join

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -405,6 +405,7 @@ message SimpleAggNode {
   // Required by the downstream `RowMergeNode`,
   // currently only used by the `approx_percentile`'s two phase plan
   bool must_output_per_barrier = 9;
+  optional uint32 extreme_cache_size = 10;
 }
 
 message HashAggNode {
@@ -419,6 +420,7 @@ message HashAggNode {
   uint32 row_count_index = 7;
   bool emit_on_window_close = 8;
   AggNodeVersion version = 9;
+  optional uint32 extreme_cache_size = 10;
 }
 
 message TopNNode {

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -230,6 +230,9 @@ pub struct SessionConfig {
     #[parameter(default = JoinEncodingType::default())]
     streaming_join_encoding: JoinEncodingType,
 
+    #[parameter(default = 10u32)]
+    stream_unsafe_extreme_cache_size: u32,
+
     /// Enable join ordering for streaming and batch queries. Defaults to true.
     #[parameter(default = true, alias = "rw_enable_join_ordering")]
     enable_join_ordering: bool,

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -217,6 +217,12 @@ impl StreamNode for StreamHashAgg {
             row_count_index: self.row_count_idx as u32,
             emit_on_window_close: self.base.emit_on_window_close(),
             version: PbAggNodeVersion::LATEST as _,
+            extreme_cache_size: Some(
+                self.ctx()
+                    .session_ctx()
+                    .config()
+                    .stream_unsafe_extreme_cache_size(),
+            ),
         }))
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -150,6 +150,12 @@ impl StreamNode for StreamSimpleAgg {
             row_count_index: self.row_count_idx as u32,
             version: PbAggNodeVersion::LATEST as _,
             must_output_per_barrier: self.must_output_per_barrier,
+            extreme_cache_size: Some(
+                self.ctx()
+                    .session_ctx()
+                    .config()
+                    .stream_unsafe_extreme_cache_size(),
+            ),
         }))
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_stateless_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_stateless_simple_agg.rs
@@ -102,6 +102,13 @@ impl StreamNode for StreamStatelessSimpleAgg {
             distinct_dedup_tables: Default::default(),
             version: AggNodeVersion::Issue13465 as _,
             must_output_per_barrier: false, // this is not used
+            extreme_cache_size: Some(
+                self // this is not used
+                    .ctx()
+                    .session_ctx()
+                    .config()
+                    .stream_unsafe_extreme_cache_size(),
+            ),
         }))
     }
 }

--- a/src/stream/src/executor/aggregate/mod.rs
+++ b/src/stream/src/executor/aggregate/mod.rs
@@ -47,9 +47,6 @@ pub struct AggExecutorArgs<S: StateStore, E: AggExecutorExtraArgs> {
     pub actor_ctx: ActorContextRef,
     pub info: ExecutorInfo,
 
-    // system configs
-    pub extreme_cache_size: usize,
-
     // agg common things
     pub agg_calls: Vec<AggCall>,
     pub row_count_index: usize,
@@ -57,6 +54,9 @@ pub struct AggExecutorArgs<S: StateStore, E: AggExecutorExtraArgs> {
     pub intermediate_state_table: StateTable<S>,
     pub distinct_dedup_tables: HashMap<usize, StateTable<S>>,
     pub watermark_epoch: AtomicU64Ref,
+
+    // agg common but for TopNStateCache only
+    pub extreme_cache_size: usize,
 
     // extra
     pub extra: E,

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -92,6 +92,9 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             build_distinct_dedup_table_from_proto(node.get_distinct_dedup_tables(), store, vnodes)
                 .await;
 
+        // 10 is used to be the default.
+        let extreme_cache_size = *node.get_extreme_cache_size().unwrap_or(&10) as usize;
+
         let exec = HashAggExecutorDispatcherArgs {
             args: AggExecutorArgs {
                 version: node.version(),
@@ -100,7 +103,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
                 actor_ctx: params.actor_context,
                 info: params.info.clone(),
 
-                extreme_cache_size: params.env.config().developer.unsafe_extreme_cache_size,
+                extreme_cache_size,
 
                 agg_calls,
                 row_count_index: node.get_row_count_index() as usize,

--- a/src/stream/src/from_proto/simple_agg.rs
+++ b/src/stream/src/from_proto/simple_agg.rs
@@ -55,6 +55,9 @@ impl ExecutorBuilder for SimpleAggExecutorBuilder {
                 .await;
         let must_output_per_barrier = node.get_must_output_per_barrier();
 
+        // 10 is used to be the default.
+        let extreme_cache_size = *node.get_extreme_cache_size().unwrap_or(&10) as usize;
+
         let exec = SimpleAggExecutor::new(AggExecutorArgs {
             version: node.version(),
 
@@ -62,7 +65,7 @@ impl ExecutorBuilder for SimpleAggExecutorBuilder {
             actor_ctx: params.actor_context,
             info: params.info.clone(),
 
-            extreme_cache_size: params.env.config().developer.unsafe_extreme_cache_size,
+            extreme_cache_size,
 
             agg_calls,
             row_count_index: node.get_row_count_index() as usize,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Right now, it is a global configuration variable. This PR makes a session variable.

1. In general cases, the optimal size of cache varies query by query and its data pattern. It is better if we can tune the setting for each query.
2. as a temporary workaround for https://github.com/risingwavelabs/risingwave/issues/22293. Under append-only settings, some aggregation functions only need to store and cache 1 element, but right now we keep 10 elements in cache while storing all the elements. `set stream_extreme_cache_size to 1` does not make sense for other queries.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
