### PR TITLE
refactor(frontend): separate PlanVisitor of different conventions

### DIFF
--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -66,7 +66,7 @@ use crate::handler::create_mv::parse_column_names;
 use crate::handler::create_table::{ColumnIdGenerator, generate_stream_graph_for_replace_table};
 use crate::handler::util::{check_connector_match_connection_type, ensure_connection_type_allowed};
 use crate::optimizer::plan_node::{
-    IcebergPartitionInfo, LogicalSource, PartitionComputeInfo, StreamProject, generic,
+    IcebergPartitionInfo, LogicalSource, PartitionComputeInfo, Stream, StreamProject, generic,
 };
 use crate::optimizer::{OptimizerContext, PlanRef, RelationCollectorVisitor};
 use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
@@ -389,7 +389,7 @@ pub async fn gen_sink_plan(
     // TODO(rc): To be consistent with UDF dependency check, we should collect relation dependencies
     // during binding instead of visiting the optimized plan.
     let dependencies =
-        RelationCollectorVisitor::collect_with(dependent_relations, sink_plan.clone())
+        RelationCollectorVisitor::collect_with::<Stream>(dependent_relations, sink_plan.clone())
             .into_iter()
             .map(|id| id.table_id() as ObjectId)
             .chain(

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -36,7 +36,7 @@ use crate::error::{ErrorCode, Result, RwError};
 use crate::handler::HandlerArgs;
 use crate::handler::flush::do_flush;
 use crate::handler::util::{DataChunkToRowSetAdapter, to_pg_field};
-use crate::optimizer::plan_node::Explain;
+use crate::optimizer::plan_node::{Batch, Explain};
 use crate::optimizer::{
     BatchPlanRoot, ExecutionModeDecider, OptimizerContext, OptimizerContextRef,
     ReadStorageTableVisitor, RelationCollectorVisitor, SysTableVisitor,
@@ -264,8 +264,10 @@ fn gen_batch_query_plan(
     let schema = logical.schema();
     let batch_plan = logical.gen_batch_plan()?;
 
-    let dependent_relations =
-        RelationCollectorVisitor::collect_with(dependent_relations, batch_plan.plan.clone());
+    let dependent_relations = RelationCollectorVisitor::collect_with::<Batch>(
+        dependent_relations,
+        batch_plan.plan.clone(),
+    );
 
     let read_storage_tables = ReadStorageTableVisitor::collect(&batch_plan);
 

--- a/src/frontend/src/optimizer/logical_optimization.rs
+++ b/src/frontend/src/optimizer/logical_optimization.rs
@@ -731,7 +731,7 @@ impl LogicalOptimizer {
         plan = plan.optimize_by_rules(&COMMON_SUB_EXPR_EXTRACT)?;
 
         #[cfg(debug_assertions)]
-        InputRefValidator.validate(plan.clone());
+        InputRefValidator.validate::<Logical>(plan.clone());
 
         if ctx.is_explain_logical() {
             match ctx.explain_format() {
@@ -856,7 +856,7 @@ impl LogicalOptimizer {
         plan = plan.optimize_by_rules(&DAG_TO_TREE)?;
 
         #[cfg(debug_assertions)]
-        InputRefValidator.validate(plan.clone());
+        InputRefValidator.validate::<Logical>(plan.clone());
 
         if ctx.is_explain_logical() {
             match ctx.explain_format() {

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -327,7 +327,7 @@ impl BatchOptimizedLogicalPlanRoot {
 
         let mut plan = self.plan;
 
-        if TemporalJoinValidator::exist_dangling_temporal_scan(plan.clone()) {
+        if TemporalJoinValidator::exist_dangling_temporal_scan::<Logical>(plan.clone()) {
             return Err(ErrorCode::NotSupported(
                 "do not support temporal join for batch queries".to_owned(),
                 "please use temporal join in streaming queries".to_owned(),
@@ -369,7 +369,7 @@ impl BatchOptimizedLogicalPlanRoot {
         }
 
         #[cfg(debug_assertions)]
-        InputRefValidator.validate(plan.clone());
+        InputRefValidator.validate::<Batch>(plan.clone());
         assert!(
             *plan.distribution() == Distribution::Single,
             "{}",
@@ -578,9 +578,9 @@ impl LogicalPlanRoot {
         }
 
         #[cfg(debug_assertions)]
-        InputRefValidator.validate(plan.clone());
+        InputRefValidator.validate::<Stream>(plan.clone());
 
-        if TemporalJoinValidator::exist_dangling_temporal_scan(plan.clone()) {
+        if TemporalJoinValidator::exist_dangling_temporal_scan::<Stream>(plan.clone()) {
             return Err(ErrorCode::NotSupported(
                 "exist dangling temporal scan".to_owned(),
                 "please check your temporal join syntax e.g. consider removing the right outer join if it is being used.".to_owned(),

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -133,10 +133,10 @@ impl LogicalMultiJoinBuilder {
         let left = join.left();
         let right = join.right();
 
-        if TemporalJoinValidator::exist_dangling_temporal_scan(left.clone()) {
+        if TemporalJoinValidator::exist_dangling_temporal_scan::<Logical>(left.clone()) {
             return Self::with_input(plan);
         }
-        if TemporalJoinValidator::exist_dangling_temporal_scan(right.clone()) {
+        if TemporalJoinValidator::exist_dangling_temporal_scan::<Logical>(right.clone()) {
             return Self::with_input(plan);
         }
 

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -1324,18 +1324,46 @@ macro_rules! for_all_plan_nodes {
     };
 }
 
-/// `for_logical_plan_nodes` includes all plan nodes with logical convention.
 #[macro_export]
-macro_rules! for_logical_plan_nodes {
-    ($macro:ident) => {
+macro_rules! for_each_convention_all_plan_nodes {
+    ($macro:path $(,$rest:tt)*) => {
         $crate::for_all_plan_nodes! {
-              $crate::for_logical_plan_nodes, $macro
+            $crate::for_each_convention_all_plan_nodes
+            , $macro
+            $(,$rest)*
         }
     };
     (
         $( { Logical, $logical_name:ident } ),*
         , $( { Batch, $batch_name:ident } ),*
         , $( { Stream, $stream_name:ident } ),*
+        , $macro:path $(,$rest:tt)*
+    ) => {
+        $macro! {
+            {
+                Logical, { $( $logical_name ),* },
+                Batch, { $( $batch_name ),* },
+                Stream, { $( $stream_name ),* }
+            }
+            $(,$rest)*
+        }
+    }
+}
+
+/// `for_logical_plan_nodes` includes all plan nodes with logical convention.
+#[macro_export]
+macro_rules! for_logical_plan_nodes {
+    ($macro:ident) => {
+        $crate::for_each_convention_all_plan_nodes! {
+              $crate::for_logical_plan_nodes, $macro
+        }
+    };
+    (
+        {
+            Logical, { $( $logical_name:ident ),* },
+            Batch, { $( $batch_name:ident ),* },
+            Stream, { $( $stream_name:ident ),* }
+        }
         , $macro:ident
     ) => {
         $macro! {
@@ -1348,14 +1376,16 @@ macro_rules! for_logical_plan_nodes {
 #[macro_export]
 macro_rules! for_batch_plan_nodes {
     ($macro:ident) => {
-        $crate::for_all_plan_nodes! {
+        $crate::for_each_convention_all_plan_nodes! {
               $crate::for_batch_plan_nodes, $macro
         }
     };
     (
-        $( { Logical, $logical_name:ident } ),*
-        , $( { Batch, $batch_name:ident } ),*
-        , $( { Stream, $stream_name:ident } ),*
+        {
+            Logical, { $( $logical_name:ident ),* },
+            Batch, { $( $batch_name:ident ),* },
+            Stream, { $( $stream_name:ident ),* }
+        }
         , $macro:ident
     ) => {
         $macro! {
@@ -1368,14 +1398,16 @@ macro_rules! for_batch_plan_nodes {
 #[macro_export]
 macro_rules! for_stream_plan_nodes {
     ($macro:ident) => {
-        $crate::for_all_plan_nodes! {
+        $crate::for_each_convention_all_plan_nodes! {
               $crate::for_stream_plan_nodes, $macro
         }
     };
     (
-        $( { Logical, $logical_name:ident } ),*
-        , $( { Batch, $batch_name:ident } ),*
-        , $( { Stream, $stream_name:ident } ),*
+        {
+            Logical, { $( $logical_name:ident ),* },
+            Batch, { $( $batch_name:ident ),* },
+            Stream, { $( $stream_name:ident ),* }
+        }
         , $macro:ident
     ) => {
         $macro! {

--- a/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::catalog::SourceId;
 use crate::optimizer::plan_node::{Logical, LogicalShare, LogicalSource, PlanRef};
-use crate::optimizer::plan_visitor::{DefaultBehavior, DefaultValue};
+use crate::optimizer::plan_visitor::{DefaultBehavior, DefaultValue, LogicalPlanVisitor};
 use crate::optimizer::{PlanRewriter, PlanVisitor};
 
 #[derive(Debug, Clone, Default)]
@@ -85,7 +85,7 @@ impl PlanRewriter<Logical> for ShareSourceRewriter {
     }
 }
 
-impl PlanVisitor for SourceCounter {
+impl LogicalPlanVisitor for SourceCounter {
     type Result = ();
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/apply_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/apply_visitor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{DefaultBehavior, Merge};
+use super::{DefaultBehavior, LogicalPlanVisitor, Merge};
 use crate::PlanRef;
 use crate::error::{ErrorCode, RwError};
 use crate::optimizer::plan_node::{LogicalApply, PlanTreeNodeBinary};
@@ -20,7 +20,7 @@ use crate::optimizer::plan_visitor::PlanVisitor;
 
 pub struct HasMaxOneRowApply();
 
-impl PlanVisitor for HasMaxOneRowApply {
+impl LogicalPlanVisitor for HasMaxOneRowApply {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;
@@ -59,7 +59,7 @@ pub struct CheckApplyElimination {
     result: CheckResult,
 }
 
-impl PlanVisitor for CheckApplyElimination {
+impl LogicalPlanVisitor for CheckApplyElimination {
     type Result = ();
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/cardinality_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/cardinality_visitor.rs
@@ -17,7 +17,7 @@ use std::ops::{Mul, Sub};
 
 use risingwave_pb::plan_common::JoinType;
 
-use super::{DefaultBehavior, DefaultValue, PlanVisitor};
+use super::{DefaultBehavior, DefaultValue, LogicalPlanVisitor, PlanVisitor};
 use crate::optimizer::plan_node::generic::TopNLimit;
 use crate::optimizer::plan_node::{
     self, PlanNode, PlanTreeNode, PlanTreeNodeBinary, PlanTreeNodeUnary,
@@ -53,7 +53,7 @@ impl CardinalityVisitor {
     }
 }
 
-impl PlanVisitor for CardinalityVisitor {
+impl LogicalPlanVisitor for CardinalityVisitor {
     type Result = Cardinality;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/distributed_dml_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/distributed_dml_visitor.rs
@@ -16,10 +16,10 @@ use std::rc::Rc;
 
 use risingwave_connector::source::ConnectorProperties;
 
-use super::{DefaultBehavior, Merge};
+use super::{BatchPlanVisitor, DefaultBehavior, Merge};
 use crate::PlanRef;
 use crate::catalog::source_catalog::SourceCatalog;
-use crate::optimizer::plan_node::{BatchSource, LogicalSource, StreamSource};
+use crate::optimizer::plan_node::BatchSource;
 use crate::optimizer::plan_visitor::PlanVisitor;
 
 #[derive(Debug, Clone, Default)]
@@ -49,7 +49,7 @@ impl DistributedDmlVisitor {
     }
 }
 
-impl PlanVisitor for DistributedDmlVisitor {
+impl BatchPlanVisitor for DistributedDmlVisitor {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;
@@ -60,22 +60,6 @@ impl PlanVisitor for DistributedDmlVisitor {
 
     fn visit_batch_source(&mut self, batch_source: &BatchSource) -> bool {
         if let Some(source_catalog) = &batch_source.core.catalog {
-            Self::is_iceberg_source(source_catalog)
-        } else {
-            false
-        }
-    }
-
-    fn visit_logical_source(&mut self, logical_source: &LogicalSource) -> bool {
-        if let Some(source_catalog) = &logical_source.core.catalog {
-            Self::is_iceberg_source(source_catalog)
-        } else {
-            false
-        }
-    }
-
-    fn visit_stream_source(&mut self, stream_source: &StreamSource) -> bool {
-        if let Some(source_catalog) = &stream_source.core.catalog {
             Self::is_iceberg_source(source_catalog)
         } else {
             false

--- a/src/frontend/src/optimizer/plan_visitor/execution_mode_decider.rs
+++ b/src/frontend/src/optimizer/plan_visitor/execution_mode_decider.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{DefaultBehavior, Merge};
+use super::{BatchPlanVisitor, DefaultBehavior, Merge};
 use crate::optimizer::BatchPlanRoot;
 use crate::optimizer::plan_node::{BatchLimit, BatchSeqScan, BatchValues, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
@@ -28,7 +28,7 @@ impl ExecutionModeDecider {
     }
 }
 
-impl PlanVisitor for ExecutionModeDecider {
+impl BatchPlanVisitor for ExecutionModeDecider {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
@@ -15,10 +15,10 @@
 use paste::paste;
 use risingwave_common::catalog::{Field, Schema};
 
-use super::{DefaultBehavior, Merge};
+use super::{BatchPlanVisitor, DefaultBehavior, LogicalPlanVisitor, Merge, StreamPlanVisitor};
 use crate::expr::ExprVisitor;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
-use crate::optimizer::plan_node::{Explain, PlanRef, PlanTreeNodeUnary};
+use crate::optimizer::plan_node::{ConventionMarker, Explain, PlanRef, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
 
 struct ExprVis<'a> {
@@ -45,7 +45,11 @@ pub struct InputRefValidator;
 
 impl InputRefValidator {
     #[track_caller]
-    pub fn validate(mut self, plan: PlanRef) {
+    pub fn validate<C: ConventionMarker>(mut self, plan: PlanRef)
+    where
+        Self: PlanVisitor<C, Result = Option<String>>,
+    {
+        plan.expect_convention::<C>();
         if let Some(err) = self.visit(plan.clone()) {
             panic!(
                 "Input references are inconsistent with the input schema: {}, plan:\n{}",
@@ -68,7 +72,7 @@ macro_rules! visit_filter {
                     };
                     plan.predicate().visit_expr(&mut vis);
                     vis.string.or_else(|| {
-                        self.visit(input)
+                        self.[<visit_$convention>](input)
                     })
                 }
             }
@@ -92,21 +96,49 @@ macro_rules! visit_project {
                             return vis.string;
                         }
                     }
-                    self.visit(input)
+                    self.[<visit_$convention>](input)
                 }
             }
         )*
     };
 }
 
-impl PlanVisitor for InputRefValidator {
+impl StreamPlanVisitor for InputRefValidator {
     type Result = Option<String>;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;
 
-    visit_filter!(logical, batch, stream);
+    visit_filter!(stream);
 
-    visit_project!(logical, batch, stream);
+    visit_project!(stream);
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        Merge(|a: Option<String>, b| a.or(b))
+    }
+}
+
+impl BatchPlanVisitor for InputRefValidator {
+    type Result = Option<String>;
+
+    type DefaultBehavior = impl DefaultBehavior<Self::Result>;
+
+    visit_filter!(batch);
+
+    visit_project!(batch);
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        Merge(|a: Option<String>, b| a.or(b))
+    }
+}
+
+impl LogicalPlanVisitor for InputRefValidator {
+    type Result = Option<String>;
+
+    type DefaultBehavior = impl DefaultBehavior<Self::Result>;
+
+    visit_filter!(logical);
+
+    visit_project!(logical);
 
     fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a: Option<String>, b| a.or(b))

--- a/src/frontend/src/optimizer/plan_visitor/jsonb_stream_key_checker.rs
+++ b/src/frontend/src/optimizer/plan_visitor/jsonb_stream_key_checker.rs
@@ -15,7 +15,7 @@
 use risingwave_common::catalog::{Field, FieldDisplay};
 use risingwave_common::types::DataType;
 
-use super::{DefaultBehavior, Merge};
+use super::{DefaultBehavior, LogicalPlanVisitor, Merge};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::*;
 use crate::optimizer::plan_visitor::PlanVisitor;
@@ -38,7 +38,7 @@ impl StreamKeyChecker {
     }
 }
 
-impl PlanVisitor for StreamKeyChecker {
+impl LogicalPlanVisitor for StreamKeyChecker {
     type Result = Option<String>;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/mod.rs
+++ b/src/frontend/src/optimizer/plan_visitor/mod.rs
@@ -46,7 +46,7 @@ pub use distributed_dml_visitor::*;
 pub use read_storage_table_visitor::*;
 pub use rw_timestamp_validator::*;
 
-use crate::for_all_plan_nodes;
+use crate::for_each_convention_all_plan_nodes;
 use crate::optimizer::plan_node::*;
 
 /// The behavior for the default implementations of `visit_xxx`.
@@ -83,65 +83,83 @@ where
     }
 }
 
+pub trait PlanVisitor<C: ConventionMarker> {
+    type Result;
+    fn visit(&mut self, plan: PlanRef) -> Self::Result;
+}
+
 /// Define `PlanVisitor` trait.
 macro_rules! def_visitor {
-    ($({ $convention:ident, $name:ident }),*) => {
-        /// The visitor for plan nodes. visit all inputs and return the ret value of the left most input,
-        /// and leaf node returns `R::default()`
-        pub trait PlanVisitor {
-            type Result: Default;
-            type DefaultBehavior: DefaultBehavior<Self::Result>;
+    ({
+        $( $convention:ident, { $( $name:ident ),* }),*
+    }) => {
+        paste! {
+            $(
+                /// The visitor for plan nodes. visit all inputs and return the ret value of the left most input,
+                /// and leaf node returns `R::default()`
+                pub trait [<$convention  PlanVisitor>] {
+                    type Result: Default;
+                    type DefaultBehavior: DefaultBehavior<Self::Result>;
 
-            /// The behavior for the default implementations of `visit_xxx`.
-            fn default_behavior() -> Self::DefaultBehavior;
+                    /// The behavior for the default implementations of `visit_xxx`.
+                    fn default_behavior() -> Self::DefaultBehavior;
 
-            paste! {
-                fn visit(&mut self, plan: PlanRef) -> Self::Result {
-                    use risingwave_common::util::recursive::{tracker, Recurse};
-                    use crate::session::current::notice_to_user;
+                    fn [<visit_ $convention:snake>](&mut self, plan: PlanRef) -> Self::Result {
+                        use risingwave_common::util::recursive::{tracker, Recurse};
+                        use crate::session::current::notice_to_user;
 
-                    tracker!().recurse(|t| {
-                        if t.depth_reaches(PLAN_DEPTH_THRESHOLD) {
-                            notice_to_user(PLAN_TOO_DEEP_NOTICE);
+                        tracker!().recurse(|t| {
+                            if t.depth_reaches(PLAN_DEPTH_THRESHOLD) {
+                                notice_to_user(PLAN_TOO_DEEP_NOTICE);
+                            }
+
+                            match plan.node_type() {
+                                $(
+                                    PlanNodeType::[<$convention $name>] => self.[<visit_ $convention:snake _ $name:snake>](plan.downcast_ref::<[<$convention $name>]>().unwrap()),
+                                )*
+                                _ => unreachable!(),
+                            }
+                        })
+                    }
+
+                    $(
+                        #[doc = "Visit [`" [<$convention $name>] "`] , the function should visit the inputs."]
+                        fn [<visit_ $convention:snake _ $name:snake>](&mut self, plan: &[<$convention $name>]) -> Self::Result {
+                            let results = plan.inputs().into_iter().map(|input| self.[<visit_ $convention:snake>](input));
+                            Self::default_behavior().apply(results)
                         }
+                    )*
 
-                        match plan.node_type() {
-                            $(
-                                PlanNodeType::[<$convention $name>] => self.[<visit_ $convention:snake _ $name:snake>](plan.downcast_ref::<[<$convention $name>]>().unwrap()),
-                            )*
-                        }
-                    })
                 }
 
-                $(
-                    #[doc = "Visit [`" [<$convention $name>] "`] , the function should visit the inputs."]
-                    fn [<visit_ $convention:snake _ $name:snake>](&mut self, plan: &[<$convention $name>]) -> Self::Result {
-                        let results = plan.inputs().into_iter().map(|input| self.visit(input));
-                        Self::default_behavior().apply(results)
+                impl<V: [<$convention  PlanVisitor>]> PlanVisitor<$convention> for V {
+                    type Result = V::Result;
+                    fn visit(&mut self, plan: PlanRef) -> Self::Result {
+                        self.[<visit_ $convention:snake>](plan)
                     }
-                )*
-            }
+                }
+            )*
         }
     }
 }
 
-for_all_plan_nodes! { def_visitor }
+for_each_convention_all_plan_nodes! { def_visitor }
 
 macro_rules! impl_has_variant {
-    ( $($variant:ty),* ) => {
+    ( $({$convention:ident $variant_name:ident}),* ) => {
         paste! {
             $(
-                pub fn [<has_ $variant:snake _where>]<P>(plan: PlanRef, pred: P) -> bool
+                pub fn [<has_ $convention:snake _ $variant_name:snake _where>]<P>(plan: PlanRef, pred: P) -> bool
                 where
-                    P: FnMut(&$variant) -> bool,
+                    P: FnMut(&[<$convention $variant_name>]) -> bool,
                 {
                     struct HasWhere<P> {
                         pred: P,
                     }
 
-                    impl<P> PlanVisitor for HasWhere<P>
+                    impl<P> [<$convention PlanVisitor>] for HasWhere<P>
                     where
-                        P: FnMut(&$variant) -> bool,
+                        P: FnMut(&[<$convention $variant_name>]) -> bool,
                     {
                         type Result = bool;
                         type DefaultBehavior = impl DefaultBehavior<Self::Result>;
@@ -150,7 +168,7 @@ macro_rules! impl_has_variant {
                             Merge(|a, b| a | b)
                         }
 
-                        fn [<visit_ $variant:snake>](&mut self, node: &$variant) -> Self::Result {
+                        fn [<visit_ $convention:snake _ $variant_name:snake>](&mut self, node: &[<$convention $variant_name>]) -> Self::Result {
                             (self.pred)(node)
                         }
                     }
@@ -160,8 +178,8 @@ macro_rules! impl_has_variant {
                 }
 
                 #[allow(dead_code)]
-                pub fn [<has_ $variant:snake>](plan: PlanRef) -> bool {
-                    [<has_ $variant:snake _where>](plan, |_| true)
+                pub fn [<has_ $convention:snake _ $variant_name:snake>](plan: PlanRef) -> bool {
+                    [<has_ $convention:snake _$variant_name:snake _where>](plan, |_| true)
                 }
             )*
         }
@@ -169,15 +187,15 @@ macro_rules! impl_has_variant {
 }
 
 impl_has_variant! {
-    LogicalApply,
-    LogicalMaxOneRow,
-    LogicalOverWindow,
-    LogicalScan,
-    LogicalSource,
-    BatchExchange,
-    BatchSeqScan,
-    BatchSource,
-    BatchInsert,
-    BatchDelete,
-    BatchUpdate
+    {Logical Apply},
+    {Logical MaxOneRow},
+    {Logical OverWindow},
+    {Logical Scan},
+    {Logical Source},
+    {Batch Exchange},
+    {Batch SeqScan},
+    {Batch Source},
+    {Batch Insert},
+    {Batch Delete},
+    {Batch Update}
 }

--- a/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{DefaultBehavior, DefaultValue, LogicalPlanVisitor};
 use crate::PlanRef;
 use crate::expr::{CorrelatedId, CorrelatedInputRef, ExprVisitor};
 use crate::optimizer::plan_node::{
@@ -40,7 +40,7 @@ impl PlanCorrelatedIdFinder {
     }
 }
 
-impl PlanVisitor for PlanCorrelatedIdFinder {
+impl LogicalPlanVisitor for PlanCorrelatedIdFinder {
     /// `correlated_input_ref` can only appear in `LogicalProject`, `LogicalFilter`,
     /// `LogicalJoin` or the `filter` clause of `PlanAggCall` of `LogicalAgg` now.
     type Result = ();

--- a/src/frontend/src/optimizer/plan_visitor/read_storage_table_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/read_storage_table_visitor.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use risingwave_common::catalog::TableId;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{BatchPlanVisitor, DefaultBehavior, DefaultValue};
 use crate::optimizer::BatchPlanRoot;
 use crate::optimizer::plan_node::{BatchLogSeqScan, BatchLookupJoin};
 use crate::optimizer::plan_visitor::PlanVisitor;
@@ -34,7 +34,7 @@ impl ReadStorageTableVisitor {
     }
 }
 
-impl PlanVisitor for ReadStorageTableVisitor {
+impl BatchPlanVisitor for ReadStorageTableVisitor {
     type Result = ();
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
@@ -16,9 +16,13 @@ use std::collections::HashSet;
 
 use risingwave_common::catalog::TableId;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{
+    BatchPlanVisitor, DefaultBehavior, DefaultValue, LogicalPlanVisitor, StreamPlanVisitor,
+};
 use crate::PlanRef;
-use crate::optimizer::plan_node::{BatchSource, LogicalScan, StreamSource, StreamTableScan};
+use crate::optimizer::plan_node::{
+    BatchSource, ConventionMarker, LogicalScan, StreamSource, StreamTableScan,
+};
 use crate::optimizer::plan_visitor::PlanVisitor;
 
 /// TODO(rc): maybe we should rename this to `DependencyCollectorVisitor`.
@@ -36,14 +40,56 @@ impl RelationCollectorVisitor {
     /// collected during the binding phase. Note that during visit the collected relations might be
     /// duplicated with the default ones. The collection is necessary, because implicit dependencies
     /// on indices can only be discovered after plan is built.
-    pub fn collect_with(relations: HashSet<TableId>, plan: PlanRef) -> HashSet<TableId> {
+    pub fn collect_with<C: ConventionMarker>(
+        relations: HashSet<TableId>,
+        plan: PlanRef,
+    ) -> HashSet<TableId>
+    where
+        Self: PlanVisitor<C>,
+    {
+        plan.expect_convention::<C>();
         let mut visitor = Self::new_with(relations);
         visitor.visit(plan);
         visitor.relations
     }
 }
 
-impl PlanVisitor for RelationCollectorVisitor {
+impl LogicalPlanVisitor for RelationCollectorVisitor {
+    type Result = ();
+
+    type DefaultBehavior = impl DefaultBehavior<Self::Result>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        DefaultValue
+    }
+
+    fn visit_logical_scan(&mut self, plan: &LogicalScan) {
+        self.relations.insert(plan.table_desc().table_id);
+    }
+}
+
+impl StreamPlanVisitor for RelationCollectorVisitor {
+    type Result = ();
+
+    type DefaultBehavior = impl DefaultBehavior<Self::Result>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        DefaultValue
+    }
+
+    fn visit_stream_table_scan(&mut self, plan: &StreamTableScan) {
+        let logical = plan.core();
+        self.relations.insert(logical.table_desc.table_id);
+    }
+
+    fn visit_stream_source(&mut self, plan: &StreamSource) {
+        if let Some(catalog) = plan.source_catalog() {
+            self.relations.insert(catalog.id.into());
+        }
+    }
+}
+
+impl BatchPlanVisitor for RelationCollectorVisitor {
     type Result = ();
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;
@@ -56,22 +102,7 @@ impl PlanVisitor for RelationCollectorVisitor {
         self.relations.insert(plan.core().table_desc.table_id);
     }
 
-    fn visit_logical_scan(&mut self, plan: &LogicalScan) {
-        self.relations.insert(plan.table_desc().table_id);
-    }
-
-    fn visit_stream_table_scan(&mut self, plan: &StreamTableScan) {
-        let logical = plan.core();
-        self.relations.insert(logical.table_desc.table_id);
-    }
-
     fn visit_batch_source(&mut self, plan: &BatchSource) {
-        if let Some(catalog) = plan.source_catalog() {
-            self.relations.insert(catalog.id.into());
-        }
-    }
-
-    fn visit_stream_source(&mut self, plan: &StreamSource) {
         if let Some(catalog) = plan.source_catalog() {
             self.relations.insert(catalog.id.into());
         }

--- a/src/frontend/src/optimizer/plan_visitor/rw_timestamp_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/rw_timestamp_validator.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::catalog::{RW_TIMESTAMP_COLUMN_ID, RW_TIMESTAMP_COLUMN_NAME};
 
-use super::{DefaultBehavior, Merge};
+use super::{DefaultBehavior, Merge, StreamPlanVisitor};
 use crate::PlanRef;
 use crate::optimizer::plan_node::StreamTableScan;
 use crate::optimizer::plan_visitor::PlanVisitor;
@@ -28,7 +28,7 @@ impl RwTimestampValidator {
     }
 }
 
-impl PlanVisitor for RwTimestampValidator {
+impl StreamPlanVisitor for RwTimestampValidator {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
+++ b/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{DefaultBehavior, DefaultValue, LogicalPlanVisitor};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{LogicalShare, PlanNodeId, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
@@ -34,7 +34,7 @@ impl ShareParentCounter {
     }
 }
 
-impl PlanVisitor for ShareParentCounter {
+impl LogicalPlanVisitor for ShareParentCounter {
     type Result = ();
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{DefaultBehavior, Merge, PlanVisitor};
+use super::{DefaultBehavior, LogicalPlanVisitor, Merge};
 use crate::optimizer::plan_node;
 
 /// Recursively visit the **logical** plan and decide whether it has side effect and cannot be
 /// eliminated trivially.
 pub struct SideEffectVisitor;
 
-impl PlanVisitor for SideEffectVisitor {
+impl LogicalPlanVisitor for SideEffectVisitor {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;

--- a/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{DefaultBehavior, Merge};
+use super::{BatchPlanVisitor, DefaultBehavior, Merge};
 use crate::optimizer::BatchPlanRoot;
-use crate::optimizer::plan_node::{BatchSysSeqScan, LogicalSysScan, StreamTableScan};
+use crate::optimizer::plan_node::BatchSysSeqScan;
 use crate::optimizer::plan_visitor::PlanVisitor;
 
 #[derive(Debug, Clone, Default)]
@@ -27,7 +27,7 @@ impl SysTableVisitor {
     }
 }
 
-impl PlanVisitor for SysTableVisitor {
+impl BatchPlanVisitor for SysTableVisitor {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;
@@ -38,14 +38,5 @@ impl PlanVisitor for SysTableVisitor {
 
     fn visit_batch_sys_seq_scan(&mut self, _batch_seq_scan: &BatchSysSeqScan) -> bool {
         true
-    }
-
-    fn visit_logical_sys_scan(&mut self, _logical_scan: &LogicalSysScan) -> bool {
-        true
-    }
-
-    // Sys scan not allowed for streaming.
-    fn visit_stream_table_scan(&mut self, _stream_table_scan: &StreamTableScan) -> bool {
-        false
     }
 }

--- a/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
@@ -14,11 +14,12 @@
 
 use risingwave_sqlparser::ast::AsOf;
 
-use super::{DefaultBehavior, Merge};
+use super::{BatchPlanVisitor, DefaultBehavior, LogicalPlanVisitor, Merge, StreamPlanVisitor};
 use crate::PlanRef;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
-    BatchSeqScan, LogicalScan, PlanTreeNodeBinary, StreamTableScan, StreamTemporalJoin,
+    BatchSeqScan, ConventionMarker, LogicalScan, PlanTreeNodeBinary, StreamTableScan,
+    StreamTemporalJoin,
 };
 use crate::optimizer::plan_visitor::PlanVisitor;
 
@@ -28,7 +29,10 @@ pub struct TemporalJoinValidator {
 }
 
 impl TemporalJoinValidator {
-    pub fn exist_dangling_temporal_scan(plan: PlanRef) -> bool {
+    pub fn exist_dangling_temporal_scan<C: ConventionMarker>(plan: PlanRef) -> bool
+    where
+        Self: PlanVisitor<C, Result = bool>,
+    {
         let mut decider = TemporalJoinValidator {
             found_non_append_only_temporal_join: false,
         };
@@ -41,7 +45,35 @@ impl TemporalJoinValidator {
     }
 }
 
-impl PlanVisitor for TemporalJoinValidator {
+impl LogicalPlanVisitor for TemporalJoinValidator {
+    type Result = bool;
+
+    type DefaultBehavior = impl DefaultBehavior<Self::Result>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        Merge(|a, b| a | b)
+    }
+
+    fn visit_logical_scan(&mut self, logical_scan: &LogicalScan) -> bool {
+        matches!(logical_scan.as_of(), Some(AsOf::ProcessTime))
+    }
+}
+
+impl BatchPlanVisitor for TemporalJoinValidator {
+    type Result = bool;
+
+    type DefaultBehavior = impl DefaultBehavior<Self::Result>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        Merge(|a, b| a | b)
+    }
+
+    fn visit_batch_seq_scan(&mut self, batch_seq_scan: &BatchSeqScan) -> bool {
+        matches!(batch_seq_scan.core().as_of, Some(AsOf::ProcessTime))
+    }
+}
+
+impl StreamPlanVisitor for TemporalJoinValidator {
     type Result = bool;
 
     type DefaultBehavior = impl DefaultBehavior<Self::Result>;
@@ -54,18 +86,10 @@ impl PlanVisitor for TemporalJoinValidator {
         matches!(stream_table_scan.core().as_of, Some(AsOf::ProcessTime))
     }
 
-    fn visit_batch_seq_scan(&mut self, batch_seq_scan: &BatchSeqScan) -> bool {
-        matches!(batch_seq_scan.core().as_of, Some(AsOf::ProcessTime))
-    }
-
-    fn visit_logical_scan(&mut self, logical_scan: &LogicalScan) -> bool {
-        matches!(logical_scan.as_of(), Some(AsOf::ProcessTime))
-    }
-
     fn visit_stream_temporal_join(&mut self, stream_temporal_join: &StreamTemporalJoin) -> bool {
         if !stream_temporal_join.append_only() {
             self.found_non_append_only_temporal_join = true;
         }
-        self.visit(stream_temporal_join.left())
+        self.visit_stream(stream_temporal_join.left())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, in `PlanVisitor` trait, we include the `visit_$convention_$variant_name` method of all conventions in the trait. However, every time we visit a plan, its convention is fixed. In this PR, we will divide the trait into 3 `$ConventionPlanVisitor` traits, with each trait only has the `visit_$convention_$variant_name` of its own plan nodes, so that we can avoid calling the `visit_xxx` method with the wrong convention. We will also have a `PlanVisitor<C: ConventionMarker>` trait, with a method `fn visit(&mut self, plan: PlanRef) -> Self::Result;`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
