### PR TITLE
feat(expr): `vector || vector` concatenation

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -312,6 +312,7 @@ message ExprNode {
     COSINE_DISTANCE = 751;
     L1_DISTANCE = 752;
     INNER_PRODUCT = 753;
+    VEC_CONCAT = 754;
 
     // Internal function for schema change
     COMPOSITE_CAST = 800;

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -391,6 +391,8 @@ pub mod data_types {
 }
 
 impl DataType {
+    pub const VEC_MAX_SIZE: usize = 16000;
+
     pub fn create_array_builder(&self, capacity: usize) -> ArrayBuilderImpl {
         use crate::array::*;
 

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -140,6 +140,12 @@ impl Binder {
             BinaryOperator::Custom(name) if name == "||" => {
                 let left_type = (!bound_left.is_untyped()).then(|| bound_left.return_type());
                 let right_type = (!bound_right.is_untyped()).then(|| bound_right.return_type());
+                // Dispatching order following PostgreSQL:
+                // 1. array
+                // 2. explicitly string
+                // 3. `T || T` for any T with its own `||` operator
+                // 4. implicitly string (i.e. unknown)
+                // 5. invalid
                 match (left_type, right_type) {
                     // array concatenation
                     (Some(DataType::List { .. }), Some(DataType::List { .. }))
@@ -153,14 +159,23 @@ impl Binder {
                         ExprType::ConcatOp
                     }
 
+                    // jsonb concatenation
                     (Some(DataType::Jsonb), Some(DataType::Jsonb))
                     | (Some(DataType::Jsonb), None)
                     | (None, Some(DataType::Jsonb)) => ExprType::JsonbConcat,
 
-                    // bytea (and varbit, tsvector, tsquery)
+                    // bytea concatenation
                     (Some(DataType::Bytea), Some(DataType::Bytea))
                     | (Some(DataType::Bytea), None)
                     | (None, Some(DataType::Bytea)) => ExprType::ByteaConcatOp,
+
+                    // vector/halfvec concatenation
+                    (Some(DataType::Vector(_)), Some(DataType::Vector(_)))
+                    | (Some(DataType::Vector(_)), None)
+                    | (None, Some(DataType::Vector(_))) => ExprType::VecConcat,
+
+                    // TODO: varbit, tsvector, tsquery
+                    // Once these types are supported, they shall go before the unknown-as-string case below.
 
                     // string concatenation
                     (None, _) | (_, None) => ExprType::ConcatOp,

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -1078,7 +1078,17 @@ pub fn bind_data_type(data_type: &AstDataType) -> Result<DataType> {
         }
         AstDataType::Bytea => DataType::Bytea,
         AstDataType::Jsonb => DataType::Jsonb,
-        AstDataType::Vector(size) => DataType::Vector(*size as _),
+        AstDataType::Vector(size) => match (1..=DataType::VEC_MAX_SIZE).contains(&(*size as _)) {
+            true => DataType::Vector(*size as _),
+            false => {
+                return Err(ErrorCode::BindError(format!(
+                    "vector size {} is out of range [1, {}]",
+                    size,
+                    DataType::VEC_MAX_SIZE
+                ))
+                .into());
+            }
+        },
         AstDataType::Regclass
         | AstDataType::Regproc
         | AstDataType::Uuid

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -274,6 +274,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::CosineDistance
             | Type::L1Distance
             | Type::InnerProduct
+            | Type::VecConcat
             | Type::VnodeUser
             | Type::RwEpochToTs
             | Type::CheckNotNull

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -112,6 +112,7 @@ impl Strong {
             | ExprType::CosineDistance
             | ExprType::L1Distance
             | ExprType::InnerProduct
+            | ExprType::VecConcat
             | ExprType::Greatest
             | ExprType::Least => self.any_null(func_call),
             // ALL: This kind of expression is null if and only if all of its arguments are null.

--- a/src/sqlparser/src/parser_v2/data_type.rs
+++ b/src/sqlparser/src/parser_v2/data_type.rs
@@ -244,7 +244,7 @@ fn non_keyword_datatype<S: TokenStream>(input: &mut StatefulStream<S>) -> ModalR
         "regclass" => Ok(DataType::Regclass),
         "regproc" => Ok(DataType::Regproc),
         "map" => cut_err(map_type_arguments).parse_next(input),
-        "vector" => precision_in_range(1..=16000)
+        "vector" => precision_in_range(..)
             .map(DataType::Vector)
             .parse_next(input),
         _ => Ok(DataType::Custom(type_name)),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Support vector concatenation: `vector || vector -> vector`

Caveat:
Since we require vector types to have a statically defined size, we cannot infer it for `null` or extended mode parameters `$1`.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
