### PR TITLE
feat(frontend): support `trim`, `ltrim`, `rtrim` function on bytea type

### DIFF
--- a/e2e_test/batch/functions/trim.slt.part
+++ b/e2e_test/batch/functions/trim.slt.part
@@ -127,3 +127,40 @@ query T
 select rtrim('\x1234567890'::bytea, '\x9012'::bytea);
 ----
 \x12345678
+
+query T
+SELECT btrim(NULL::bytea, E'\\001');
+----
+NULL
+
+query T
+SELECT btrim('1'::bytea, '1'::bytea);
+----
+\x
+
+query T
+SELECT ltrim('1'::bytea, '1'::bytea);
+----
+\x
+
+query T
+SELECT rtrim('1'::bytea, '1'::bytea);
+----
+\x
+
+
+query T
+SELECT btrim(''::bytea, '1'::bytea);
+----
+\x
+
+query T
+SELECT ltrim(''::bytea, '1'::bytea);
+----
+\x
+
+
+query T
+SELECT rtrim(''::bytea, '1'::bytea);
+----
+\x

--- a/e2e_test/batch/functions/trim.slt.part
+++ b/e2e_test/batch/functions/trim.slt.part
@@ -72,3 +72,58 @@ query T
 select btrim('abcxyzabc', 'bca');
 ----
 xyz
+
+query T
+select trim(both from '\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x345678
+
+query T
+select trim(leading '\x9012'::bytea from '\x1234567890'::bytea);
+----
+\x34567890
+
+query T
+select trim(trailing '\x9012'::bytea from '\x1234567890'::bytea);
+----
+\x12345678
+
+query T
+select trim('\x9012'::bytea from '\x1234567890'::bytea);
+----
+\x345678
+
+query T
+select trim(both from '\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x345678
+
+query T
+select trim(leading from '\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x34567890
+
+query T
+select trim(trailing from '\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x12345678
+
+query T
+select trim(from '\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x345678
+
+query T
+select btrim('\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x345678
+
+query T
+select ltrim('\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x34567890
+
+query T
+select rtrim('\x1234567890'::bytea, '\x9012'::bytea);
+----
+\x12345678

--- a/src/expr/impl/src/scalar/trim.rs
+++ b/src/expr/impl/src/scalar/trim.rs
@@ -88,12 +88,12 @@ fn trim_bound(bytes: &[u8], bytesremoved: &[u8]) -> (usize, usize) {
 /// ```
 #[function("trim(bytea, bytea) -> bytea")]
 pub fn trim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
-    let (mut start, mut end) = trim_bound(bytes, bytesremoved);
+    let (start, end) = trim_bound(bytes, bytesremoved);
 
-    if start == bytes.len() && end == 0 {
-        (start, end) = (0, 0);
-    }
-    bytes[start..end].iter().copied().collect()
+    bytes
+        .get(start..end)
+        .map(|s| s.iter().copied().collect())
+        .unwrap_or_else(|| Box::<[u8]>::from([]))
 }
 
 /// Removes the longest string containing only bytes appearing in bytesremoved

--- a/src/expr/impl/src/scalar/trim.rs
+++ b/src/expr/impl/src/scalar/trim.rs
@@ -88,7 +88,11 @@ fn trim_bound(bytes: &[u8], bytesremoved: &[u8]) -> (usize, usize) {
 /// ```
 #[function("trim(bytea, bytea) -> bytea")]
 pub fn trim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
-    let (start, end) = trim_bound(bytes, bytesremoved);
+    let (mut start, mut end) = trim_bound(bytes, bytesremoved);
+    
+    if start == bytes.len() && end == 0 {
+        (start, end) = (0, 0);
+    }
     bytes[start..end].iter().copied().collect()
 }
 

--- a/src/expr/impl/src/scalar/trim.rs
+++ b/src/expr/impl/src/scalar/trim.rs
@@ -58,6 +58,17 @@ pub fn rtrim_characters(s: &str, characters: &str, writer: &mut impl Write) {
     writer.write_str(s.trim_end_matches(pattern)).unwrap();
 }
 
+///  Removes the longest string containing only bytes appearing in bytesremoved from the start,
+///  end, or both ends (BOTH is the default) of bytes.
+///
+/// # Example
+///
+/// ```slt
+/// query T
+/// SELECT trim('\x9012'::bytea from '\x1234567890'::bytea);
+/// ----
+/// \x345678
+/// ```
 #[function("trim(bytea, bytea) -> bytea")]
 pub fn trim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
     let existed = |b: &u8| bytesremoved.contains(b);
@@ -73,6 +84,17 @@ pub fn trim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
     bytes[start..end].iter().copied().collect()
 }
 
+/// Removes the longest string containing only bytes appearing in bytesremoved
+/// from the start of bytes.
+///
+/// # Example
+///
+/// ```slt
+/// query T
+/// SELECT ltrim('\x1234567890'::bytea, '\x9012'::bytea);
+/// ----
+/// \x34567890
+/// ```
 #[function("ltrim(bytea, bytea) -> bytea")]
 pub fn ltrim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
     let existed = |b: &u8| bytesremoved.contains(b);
@@ -83,6 +105,17 @@ pub fn ltrim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
     bytes[start..].iter().copied().collect()
 }
 
+/// Removes the longest string containing only bytes appearing in bytesremoved
+/// from the end of bytes.
+///
+/// # Example
+///
+/// ```slt
+/// query T
+/// SELECT rtrim('\x1234567890'::bytea, '\x9012'::bytea);
+/// ----
+/// \x12345678
+/// ```
 #[function("rtrim(bytea, bytea) -> bytea")]
 pub fn rtrim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
     let existed = |b: &u8| bytesremoved.contains(b);

--- a/src/expr/impl/src/scalar/trim.rs
+++ b/src/expr/impl/src/scalar/trim.rs
@@ -89,7 +89,7 @@ fn trim_bound(bytes: &[u8], bytesremoved: &[u8]) -> (usize, usize) {
 #[function("trim(bytea, bytea) -> bytea")]
 pub fn trim_bytea(bytes: &[u8], bytesremoved: &[u8]) -> Box<[u8]> {
     let (mut start, mut end) = trim_bound(bytes, bytesremoved);
-    
+
     if start == bytes.len() && end == 0 {
         (start, end) = (0, 0);
     }

--- a/src/expr/impl/src/scalar/trim.rs
+++ b/src/expr/impl/src/scalar/trim.rs
@@ -14,7 +14,7 @@
 
 use std::fmt::Write;
 
-use risingwave_expr::{Result, function};
+use risingwave_expr::function;
 
 #[function("trim(varchar) -> varchar")]
 pub fn trim(s: &str, writer: &mut impl Write) {

--- a/src/tests/regress/data/sql/strings.sql
+++ b/src/tests/regress/data/sql/strings.sql
@@ -744,15 +744,15 @@ SELECT repeat('Pg', -4);
 --@ SELECT SUBSTRING('string'::bytea FROM -10 FOR 2147483646) AS "string";
 --@ SELECT SUBSTRING('string'::bytea FROM -10 FOR -2147483646) AS "error";
 --@ 
---@ SELECT trim(E'\\000'::bytea from E'\\000Tom\\000'::bytea);
---@ SELECT trim(leading E'\\000'::bytea from E'\\000Tom\\000'::bytea);
---@ SELECT trim(trailing E'\\000'::bytea from E'\\000Tom\\000'::bytea);
---@ SELECT btrim(E'\\000trim\\000'::bytea, E'\\000'::bytea);
---@ SELECT btrim(''::bytea, E'\\000'::bytea);
---@ SELECT btrim(E'\\000trim\\000'::bytea, ''::bytea);
---@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'Th\\001omas'::bytea from 2),'escape');
---@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
---@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
+SELECT trim(E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+SELECT trim(leading E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+SELECT trim(trailing E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+SELECT btrim(E'\\000trim\\000'::bytea, E'\\000'::bytea);
+SELECT btrim(''::bytea, E'\\000'::bytea);
+SELECT btrim(E'\\000trim\\000'::bytea, ''::bytea);
+SELECT encode(overlay(E'Th\\000omas'::bytea placing E'Th\\001omas'::bytea from 2),'escape');
+SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
+SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
 
 --@ SELECT bit_count('\x1234567890'::bytea);
 

--- a/src/tests/regress/data/sql/strings.sql
+++ b/src/tests/regress/data/sql/strings.sql
@@ -744,15 +744,15 @@ SELECT repeat('Pg', -4);
 --@ SELECT SUBSTRING('string'::bytea FROM -10 FOR 2147483646) AS "string";
 --@ SELECT SUBSTRING('string'::bytea FROM -10 FOR -2147483646) AS "error";
 --@ 
-SELECT trim(E'\\000'::bytea from E'\\000Tom\\000'::bytea);
-SELECT trim(leading E'\\000'::bytea from E'\\000Tom\\000'::bytea);
-SELECT trim(trailing E'\\000'::bytea from E'\\000Tom\\000'::bytea);
-SELECT btrim(E'\\000trim\\000'::bytea, E'\\000'::bytea);
-SELECT btrim(''::bytea, E'\\000'::bytea);
-SELECT btrim(E'\\000trim\\000'::bytea, ''::bytea);
-SELECT encode(overlay(E'Th\\000omas'::bytea placing E'Th\\001omas'::bytea from 2),'escape');
-SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
-SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
+--@ SELECT trim(E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+--@ SELECT trim(leading E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+--@ SELECT trim(trailing E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+--@ SELECT btrim(E'\\000trim\\000'::bytea, E'\\000'::bytea);
+--@ SELECT btrim(''::bytea, E'\\000'::bytea);
+--@ SELECT btrim(E'\\000trim\\000'::bytea, ''::bytea);
+--@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'Th\\001omas'::bytea from 2),'escape');
+--@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
+--@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
 
 --@ SELECT bit_count('\x1234567890'::bytea);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Support `trim`, `ltrim`, `rtrim` function on bytea type
- Part of #8831.

Support `trim` syntax: 
- trim ( [ LEADING | TRAILING | BOTH ] bytesremoved bytea FROM bytes bytea ) → bytea
- trim ( [ LEADING | TRAILING | BOTH ] [ FROM ] bytes bytea, bytesremoved bytea ) → bytea
- btrim ( bytes bytea, bytesremoved bytea ) → bytea
- ltrim ( bytes bytea, bytesremoved bytea ) → bytea
- rtrim ( bytes bytea, bytesremoved bytea ) → bytea

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Support `trim`, `ltrim`, `btrim` and `rtrim` function on bytea type

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
