### PR TITLE
feat: support more bytea type functions

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -202,6 +202,11 @@ message ExprNode {
     QUOTE_NULLABLE = 331;
     HMAC = 332;
     SECURE_COMPARE = 333;
+    GET_BIT = 334;
+    GET_BYTE = 335;
+    SET_BIT = 336;
+    SET_BYTE = 337;
+    BIT_COUNT = 338;
 
     // Constraints Check
     CHECK_NOT_NULL = 350;

--- a/src/expr/impl/src/scalar/bytea_bits.rs
+++ b/src/expr/impl/src/scalar/bytea_bits.rs
@@ -1,0 +1,90 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_expr::{ExprError, Result, function};
+
+/// Extracts n'th bit from binary string.
+#[function("get_bit(bytea, int8) -> int4")]
+pub fn get_bit(bytes: &[u8], n: i64) -> Result<i32> {
+    let max_sz = (bytes.len() * 8) as i64;
+    if n < 0 || n >= max_sz {
+        return Err(ExprError::InvalidParam {
+            name: "get_bit",
+            reason: format!("index {} out of valid range, 0..{}", n, max_sz - 1).into(),
+        });
+    }
+    let index = n / 8;
+    let byte = bytes[index as usize];
+    Ok(((byte >> (n % 8)) & 1) as i32)
+}
+
+/// Sets n'th bit in binary string to newvalue.
+#[function("set_bit(bytea, int8, int4) -> bytea")]
+pub fn set_bit(bytes: &[u8], n: i64, value: i32) -> Result<Box<[u8]>> {
+    let max_sz = (bytes.len() * 8) as i64;
+    if n < 0 || n >= max_sz {
+        return Err(ExprError::InvalidParam {
+            name: "set_bit",
+            reason: format!("index {} out of valid range, 0..{}", n, max_sz - 1).into(),
+        });
+    }
+    let mut buf = bytes.to_vec();
+    let index = (n / 8) as usize;
+    let bit_pos = (n % 8) as u8;
+
+    if value != 0 {
+        buf[index] |= 1 << bit_pos;
+    } else {
+        buf[index] &= !(1 << bit_pos);
+    }
+    Ok(buf.iter().copied().collect())
+}
+
+/// Extracts n'th byte from binary string.
+#[function("get_byte(bytea, int4) -> int4")]
+pub fn get_byte(bytes: &[u8], n: i32) -> Result<i32> {
+    let max_sz = bytes.len() as i32;
+    if n < 0 || n >= max_sz {
+        return Err(ExprError::InvalidParam {
+            name: "get_byte",
+            reason: format!("index {} out of valid range, 0..{}", n, max_sz - 1).into(),
+        });
+    }
+    Ok(bytes[n as usize].into())
+}
+
+/// Sets n'th byte in binary string to newvalue.
+#[function("set_byte(bytea, int4, int4) -> bytea")]
+pub fn set_byte(bytes: &[u8], n: i32, value: i32) -> Result<Box<[u8]>> {
+    let max_sz = bytes.len() as i32;
+    if n < 0 || n >= max_sz {
+        return Err(ExprError::InvalidParam {
+            name: "set_byte",
+            reason: format!("index {} out of valid range, 0..{}", n, max_sz - 1).into(),
+        });
+    }
+    let mut buf = bytes.to_vec();
+    buf[n as usize] = value as u8;
+    Ok(buf.iter().copied().collect())
+}
+
+/// Returns the number of bits set in the binary string
+#[function("bit_count(bytea) -> int8")]
+pub fn bit_count(bytes: &[u8]) -> i64 {
+    let mut ans = 0;
+    for byte in bytes {
+        ans += byte.count_ones();
+    }
+    ans.into()
+}

--- a/src/expr/impl/src/scalar/mod.rs
+++ b/src/expr/impl/src/scalar/mod.rs
@@ -32,6 +32,7 @@ mod array_to_string;
 mod array_transform;
 mod ascii;
 mod bitwise_op;
+mod bytea_bits;
 mod cardinality;
 mod case;
 mod cast;

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -294,6 +294,11 @@ impl Binder {
                     Ok(FunctionCall::new_unchecked(ExprType::QuoteNullable, inputs, DataType::Varchar).into())
                 }))),
                 ("string_to_array", raw_call(ExprType::StringToArray)),
+                ("get_bit", raw_call(ExprType::GetBit)),
+                ("get_byte", raw_call(ExprType::GetByte)),
+                ("set_bit", raw_call(ExprType::SetBit)),
+                ("set_byte", raw_call(ExprType::SetByte)),
+                ("bit_count", raw_call(ExprType::BitCount)),
                 ("encode", raw_call(ExprType::Encode)),
                 ("decode", raw_call(ExprType::Decode)),
                 ("convert_from", raw_call(ExprType::ConvertFrom)),

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -232,6 +232,11 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::Acosh
             | Type::Decode
             | Type::Encode
+            | Type::GetBit
+            | Type::GetByte
+            | Type::SetBit
+            | Type::SetByte
+            | Type::BitCount
             | Type::Sha1
             | Type::Sha224
             | Type::Sha256

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -231,6 +231,11 @@ impl Strong {
             | ExprType::Sha256
             | ExprType::Sha384
             | ExprType::Sha512
+            | ExprType::GetBit
+            | ExprType::GetByte
+            | ExprType::SetBit
+            | ExprType::SetByte
+            | ExprType::BitCount
             | ExprType::Hmac
             | ExprType::SecureCompare
             | ExprType::Left

--- a/src/tests/regress/data/sql/strings.sql
+++ b/src/tests/regress/data/sql/strings.sql
@@ -663,14 +663,14 @@ SELECT decode(encode('\x1234567890abcdef00', 'escape'), 'escape');
 --
 -- get_bit/set_bit etc
 --
---@ SELECT get_bit('\x1234567890abcdef00'::bytea, 43);
---@ SELECT get_bit('\x1234567890abcdef00'::bytea, 99);  -- error
---@ SELECT set_bit('\x1234567890abcdef00'::bytea, 43, 0);
---@ SELECT set_bit('\x1234567890abcdef00'::bytea, 99, 0);  -- error
---@ SELECT get_byte('\x1234567890abcdef00'::bytea, 3);
---@ SELECT get_byte('\x1234567890abcdef00'::bytea, 99);  -- error
---@ SELECT set_byte('\x1234567890abcdef00'::bytea, 7, 11);
---@ SELECT set_byte('\x1234567890abcdef00'::bytea, 99, 11);  -- error
+SELECT get_bit('\x1234567890abcdef00'::bytea, 43);
+SELECT get_bit('\x1234567890abcdef00'::bytea, 99);  -- error
+SELECT set_bit('\x1234567890abcdef00'::bytea, 43, 0);
+SELECT set_bit('\x1234567890abcdef00'::bytea, 99, 0);  -- error
+SELECT get_byte('\x1234567890abcdef00'::bytea, 3);
+SELECT get_byte('\x1234567890abcdef00'::bytea, 99);  -- error
+SELECT set_byte('\x1234567890abcdef00'::bytea, 7, 11);
+SELECT set_byte('\x1234567890abcdef00'::bytea, 99, 11);  -- error
 
 --
 -- test behavior of escape_string_warning and standard_conforming_strings options
@@ -754,7 +754,7 @@ SELECT repeat('Pg', -4);
 --@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
 --@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
 
---@ SELECT bit_count('\x1234567890'::bytea);
+SELECT bit_count('\x1234567890'::bytea);
 
 --@ SELECT unistr('\0064at\+0000610');
 --@ SELECT unistr('d\u0061t\U000000610');


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Support `get_bit`, `get_byte`, `set_bit`, `set_byte` and `bit_count` functions
- Part of #8831

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->
Support `get_bit`, `get_byte`, `set_bit`, `set_byte` and `bit_count` functions.
</details>

