### PR TITLE
refactor(frontend): simplify optimizer generic table scan

### DIFF
--- a/src/frontend/src/catalog/index_catalog.rs
+++ b/src/frontend/src/catalog/index_catalog.rs
@@ -21,25 +21,17 @@ use itertools::Itertools;
 use risingwave_common::catalog::{Field, IndexId, Schema};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_common::util::sort_util::ColumnOrder;
-use risingwave_pb::catalog::{PbIndex, PbIndexColumnProperties, PbStreamJobStatus};
+use risingwave_pb::catalog::{PbIndex, PbIndexColumnProperties};
 
-use crate::catalog::{DatabaseId, OwnedByUserCatalog, SchemaId, TableCatalog};
-use crate::expr::{Expr, ExprDisplay, ExprImpl, ExprRewriter as _, FunctionCall};
+use crate::catalog::table_catalog::TableType;
+use crate::catalog::{OwnedByUserCatalog, TableCatalog};
+use crate::expr::{ExprDisplay, ExprImpl, ExprRewriter as _, FunctionCall};
 use crate::user::UserId;
 
 #[derive(Clone, Debug, Educe)]
 #[educe(PartialEq, Eq, Hash)]
-pub struct IndexCatalog {
-    pub id: IndexId,
-
+pub struct TableIndex {
     pub name: String,
-
-    /// Only `InputRef` and `FuncCall` type index is supported Now.
-    /// The index of `InputRef` is the column index of the primary table.
-    /// The `index_item` size is equal to the index table columns size
-    /// The input args of `FuncCall` is also the column index of the primary table.
-    pub index_item: Vec<ExprImpl>,
-
     /// The properties of the index columns.
     /// <https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-INDEX-COLUMN-PROPS>
     pub index_column_properties: Vec<PbIndexColumnProperties>,
@@ -62,6 +54,28 @@ pub struct IndexCatalog {
     pub function_mapping: HashMap<FunctionCall, usize>,
 
     pub index_columns_len: u32,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum IndexType {
+    Table(Arc<TableIndex>),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct IndexCatalog {
+    pub id: IndexId,
+
+    pub name: String,
+
+    /// Only `InputRef` and `FuncCall` type index is supported Now.
+    /// The index of `InputRef` is the column index of the primary table.
+    /// The `index_item` size is equal to the index table columns size
+    /// The input args of `FuncCall` is also the column index of the primary table.
+    pub index_item: Vec<ExprImpl>,
+
+    pub index_type: IndexType,
+
+    pub primary_table: Arc<TableCatalog>,
 
     pub created_at_epoch: Option<Epoch>,
 
@@ -75,8 +89,8 @@ pub struct IndexCatalog {
 impl IndexCatalog {
     pub fn build_from(
         index_prost: &PbIndex,
-        index_table: &TableCatalog,
-        primary_table: &TableCatalog,
+        index_table: &Arc<TableCatalog>,
+        primary_table: &Arc<TableCatalog>,
     ) -> Self {
         let index_item: Vec<ExprImpl> = index_prost
             .index_item
@@ -85,51 +99,65 @@ impl IndexCatalog {
             .map(|expr| item_rewriter::CompositeCastEliminator.rewrite_expr(expr))
             .collect();
 
-        let primary_to_secondary_mapping: BTreeMap<usize, usize> = index_item
-            .iter()
-            .enumerate()
-            .filter_map(|(i, expr)| match expr {
-                ExprImpl::InputRef(input_ref) => Some((input_ref.index, i)),
-                ExprImpl::FunctionCall(_) => None,
-                _ => unreachable!(),
-            })
-            .collect();
+        let index_type = match index_table.table_type {
+            TableType::Index => {
+                let primary_to_secondary_mapping: BTreeMap<usize, usize> = index_item
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, expr)| match expr {
+                        ExprImpl::InputRef(input_ref) => Some((input_ref.index, i)),
+                        ExprImpl::FunctionCall(_) => None,
+                        _ => unreachable!(),
+                    })
+                    .collect();
 
-        let secondary_to_primary_mapping = BTreeMap::from_iter(
-            primary_to_secondary_mapping
-                .clone()
-                .into_iter()
-                .map(|(x, y)| (y, x)),
-        );
+                let secondary_to_primary_mapping = BTreeMap::from_iter(
+                    primary_to_secondary_mapping
+                        .clone()
+                        .into_iter()
+                        .map(|(x, y)| (y, x)),
+                );
 
-        let function_mapping: HashMap<FunctionCall, usize> = index_item
-            .iter()
-            .enumerate()
-            .filter_map(|(i, expr)| match expr {
-                ExprImpl::InputRef(_) => None,
-                ExprImpl::FunctionCall(func) => Some((func.deref().clone(), i)),
-                _ => unreachable!(),
-            })
-            .collect();
+                let function_mapping: HashMap<FunctionCall, usize> = index_item
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, expr)| match expr {
+                        ExprImpl::InputRef(_) => None,
+                        ExprImpl::FunctionCall(func) => Some((func.deref().clone(), i)),
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                IndexType::Table(Arc::new(TableIndex {
+                    name: index_prost.name.clone(),
+                    index_column_properties: index_prost.index_column_properties.clone(),
+                    index_columns_len: index_prost.index_columns_len,
+                    index_table: index_table.clone(),
+                    primary_table: primary_table.clone(),
+                    primary_to_secondary_mapping,
+                    secondary_to_primary_mapping,
+                    function_mapping,
+                }))
+            }
+            TableType::Table | TableType::MaterializedView | TableType::Internal => {
+                unreachable!()
+            }
+        };
 
         IndexCatalog {
             id: index_prost.id.into(),
             name: index_prost.name.clone(),
             index_item,
-            index_column_properties: index_prost.index_column_properties.clone(),
-            index_table: Arc::new(index_table.clone()),
-            primary_table: Arc::new(primary_table.clone()),
-            primary_to_secondary_mapping,
-            secondary_to_primary_mapping,
-            function_mapping,
-            index_columns_len: index_prost.index_columns_len,
+            index_type,
+            primary_table: primary_table.clone(),
             created_at_epoch: index_prost.created_at_epoch.map(Epoch::from),
             initialized_at_epoch: index_prost.initialized_at_epoch.map(Epoch::from),
             created_at_cluster_version: index_prost.created_at_cluster_version.clone(),
             initialized_at_cluster_version: index_prost.initialized_at_cluster_version.clone(),
         }
     }
+}
 
+impl TableIndex {
     pub fn primary_table_pk_ref_to_index_table(&self) -> Vec<ColumnOrder> {
         let mapping = self.primary_to_secondary_mapping();
 
@@ -169,38 +197,24 @@ impl IndexCatalog {
     pub fn function_mapping(&self) -> &HashMap<FunctionCall, usize> {
         &self.function_mapping
     }
+}
 
-    pub fn to_prost(&self, schema_id: SchemaId, database_id: DatabaseId) -> PbIndex {
-        PbIndex {
-            id: self.id.index_id,
-            schema_id,
-            database_id,
-            name: self.name.clone(),
-            owner: self.index_table.owner,
-            index_table_id: self.index_table.id.table_id,
-            primary_table_id: self.primary_table.id.table_id,
-            index_item: self
-                .index_item
-                .iter()
-                .map(|expr| expr.to_expr_proto())
-                .collect_vec(),
-            index_column_properties: self.index_column_properties.clone(),
-            index_columns_len: self.index_columns_len,
-            initialized_at_epoch: self.initialized_at_epoch.map(|e| e.0),
-            created_at_epoch: self.created_at_epoch.map(|e| e.0),
-            stream_job_status: PbStreamJobStatus::Creating.into(),
-            initialized_at_cluster_version: self.initialized_at_cluster_version.clone(),
-            created_at_cluster_version: self.created_at_cluster_version.clone(),
+impl IndexCatalog {
+    pub fn index_table(&self) -> &Arc<TableCatalog> {
+        match &self.index_type {
+            IndexType::Table(index) => &index.index_table,
         }
     }
 
     /// Get the column properties of the index column.
     pub fn get_column_properties(&self, column_idx: usize) -> Option<PbIndexColumnProperties> {
-        self.index_column_properties.get(column_idx).cloned()
+        match &self.index_type {
+            IndexType::Table(index) => index.index_column_properties.get(column_idx).cloned(),
+        }
     }
 
     pub fn get_column_def(&self, column_idx: usize) -> Option<String> {
-        if let Some(col) = self.index_table.columns.get(column_idx) {
+        if let Some(col) = self.index_table().columns.get(column_idx) {
             if col.is_hidden {
                 return None;
             }
@@ -224,7 +238,7 @@ impl IndexCatalog {
     }
 
     pub fn display(&self) -> IndexDisplay {
-        let index_table = self.index_table.clone();
+        let index_table = self.index_table().clone();
         let index_columns_with_ordering = index_table
             .pk
             .iter()
@@ -272,7 +286,7 @@ pub struct IndexDisplay {
 
 impl OwnedByUserCatalog for IndexCatalog {
     fn owner(&self) -> UserId {
-        self.index_table.owner
+        self.index_table().owner
     }
 }
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
@@ -15,6 +15,7 @@
 use risingwave_common::types::{Fields, Timestamptz};
 use risingwave_frontend_macro::system_catalog;
 
+use crate::catalog::index_catalog::IndexType;
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
 use crate::error::Result;
 
@@ -47,16 +48,18 @@ fn read_rw_indexes(reader: &SysCatalogReaderImpl) -> Result<Vec<RwIndex>> {
 
     Ok(schemas
         .flat_map(|schema| {
-            schema
-                .iter_index_with_acl(current_user)
-                .map(|index| RwIndex {
+            schema.iter_index_with_acl(current_user).map(|index| {
+                let (index_table, index_columns_len) = match &index.index_type {
+                    IndexType::Table(index) => (&index.index_table, index.index_columns_len),
+                };
+                RwIndex {
                     id: index.id.index_id as i32,
                     name: index.name.clone(),
                     primary_table_id: index.primary_table.id().table_id as i32,
                     key_columns: index
                         .index_item
                         .iter()
-                        .take(index.index_columns_len as usize)
+                        .take(index_columns_len as usize)
                         .map(|index| {
                             let ind = if let Some(input_ref) = index.as_input_ref() {
                                 input_ref.index() + 1
@@ -69,7 +72,7 @@ fn read_rw_indexes(reader: &SysCatalogReaderImpl) -> Result<Vec<RwIndex>> {
                     include_columns: index
                         .index_item
                         .iter()
-                        .skip(index.index_columns_len as usize)
+                        .skip(index_columns_len as usize)
                         .map(|index| {
                             let ind = if let Some(input_ref) = index.as_input_ref() {
                                 input_ref.index() + 1
@@ -80,14 +83,15 @@ fn read_rw_indexes(reader: &SysCatalogReaderImpl) -> Result<Vec<RwIndex>> {
                         })
                         .collect(),
                     schema_id: schema.id() as i32,
-                    owner: index.index_table.owner as i32,
-                    definition: index.index_table.create_sql(),
+                    owner: index.index_table().owner as i32,
+                    definition: index_table.create_sql(),
                     acl: vec![],
                     initialized_at: index.initialized_at_epoch.map(|e| e.as_timestamptz()),
                     created_at: index.created_at_epoch.map(|e| e.as_timestamptz()),
                     initialized_at_cluster_version: index.initialized_at_cluster_version.clone(),
                     created_at_cluster_version: index.created_at_cluster_version.clone(),
-                })
+                }
+            })
         })
         .collect())
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -81,7 +81,7 @@ async fn read_relation_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwRelat
             schema_catalog
                 .iter_index_with_acl(current_user)
                 .for_each(|t| {
-                    table_ids.push(t.index_table.id.table_id);
+                    table_ids.push(t.index_table().id.table_id);
                 });
         }
     }
@@ -163,14 +163,15 @@ async fn read_relation_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwRelat
         schema_catalog
             .iter_index_with_acl(current_user)
             .for_each(|t| {
-                if let Some(fragments) = table_fragments.get(&t.index_table.id.table_id) {
+                if let Some(fragments) = table_fragments.get(&t.index_table().id.table_id) {
+                    let index_table = t.index_table();
                     rows.push(RwRelationInfo {
                         schemaname: schema.clone(),
                         relationname: t.name.clone(),
-                        relationowner: t.index_table.owner as i32,
-                        definition: t.index_table.create_sql(),
+                        relationowner: index_table.owner as i32,
+                        definition: index_table.create_sql(),
                         relationtype: "INDEX".into(),
-                        relationid: t.index_table.id.table_id as i32,
+                        relationid: index_table.id.table_id as i32,
                         relationtimezone: fragments.get_ctx().unwrap().get_timezone().clone(),
                         fragments: Some(json!(fragments.get_fragments()).to_string()),
                         initialized_at: t.initialized_at_epoch.map(|e| e.as_timestamptz()),

--- a/src/frontend/src/expr/function_impl/pg_get_indexdef.rs
+++ b/src/frontend/src/expr/function_impl/pg_get_indexdef.rs
@@ -51,7 +51,7 @@ fn pg_get_indexdef_impl(
                 name: "oid",
                 reason: e.to_report_string().into(),
             })?
-            .index_table
+            .index_table()
             .create_sql()
     } else {
         catalog

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -39,7 +39,7 @@ use crate::optimizer::plan_expr_rewriter::ConstEvalRewriter;
 use crate::optimizer::plan_node::{
     Explain, LogicalProject, LogicalScan, StreamMaterialize, StreamPlanRef as PlanRef,
 };
-use crate::optimizer::property::{Cardinality, Distribution, Order, RequiredDist};
+use crate::optimizer::property::{Distribution, Order, RequiredDist};
 use crate::optimizer::{OptimizerContext, OptimizerContextRef, PlanRoot};
 use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
 use crate::session::SessionImpl;
@@ -75,8 +75,6 @@ pub(crate) fn gen_create_index_plan(
     include: Vec<Ident>,
     distributed_by: Vec<ast::Expr>,
 ) -> Result<(PlanRef, TableCatalog, PbIndex)> {
-    let table_name = table.name.clone();
-
     if table.is_index() {
         return Err(
             ErrorCode::InvalidInputSyntax(format!("\"{}\" is an index", table.name)).into(),
@@ -92,7 +90,7 @@ pub(crate) fn gen_create_index_plan(
     }
 
     let mut binder = Binder::new_for_stream(session);
-    binder.bind_table(Some(&schema_name), &table_name)?;
+    binder.bind_table(Some(&schema_name), &table.name)?;
 
     let mut index_columns_ordered_expr = vec![];
     let mut include_columns_expr = vec![];
@@ -200,7 +198,6 @@ pub(crate) fn gen_create_index_plan(
 
     // Manually assemble the materialization plan for the index MV.
     let materialize = assemble_materialize(
-        table_name,
         index_database_id,
         index_schema_id,
         table.clone(),
@@ -215,7 +212,6 @@ pub(crate) fn gen_create_index_plan(
         } else {
             distributed_columns_expr.len()
         },
-        table.cardinality,
     )?;
 
     let mut index_table = materialize.table().clone();
@@ -321,7 +317,6 @@ fn build_index_item(
 /// Note: distributed by columns must be a prefix of index columns, so we just use
 /// `distributed_by_columns_len` to represent distributed by columns
 fn assemble_materialize(
-    table_name: String,
     database_id: DatabaseId,
     schema_id: SchemaId,
     table_catalog: Arc<TableCatalog>,
@@ -330,7 +325,6 @@ fn assemble_materialize(
     index_columns: &[(ExprImpl, OrderType)],
     include_columns: &[ExprImpl],
     distributed_by_columns_len: usize,
-    cardinality: Cardinality,
 ) -> Result<StreamMaterialize> {
     // Build logical plan and then call gen_create_index_plan
     // LogicalProject(index_columns, include_columns)
@@ -339,15 +333,7 @@ fn assemble_materialize(
     let definition = context.normalized_sql().to_owned();
     let retention_seconds = table_catalog.retention_seconds.and_then(NonZeroU32::new);
 
-    let logical_scan = LogicalScan::create(
-        table_name,
-        table_catalog.clone(),
-        // Index table has no indexes.
-        vec![],
-        context,
-        None,
-        cardinality,
-    );
+    let logical_scan = LogicalScan::create(table_catalog.clone(), context, None);
 
     let exprs = index_columns
         .iter()

--- a/src/frontend/src/handler/drop_index.rs
+++ b/src/frontend/src/handler/drop_index.rs
@@ -41,7 +41,7 @@ pub async fn handle_drop_index(
         let reader = session.env().catalog_reader().read_guard();
         match reader.get_index_by_name(db_name, schema_path, &index_name) {
             Ok((index, _)) => {
-                if !session.is_super_user() && session.user_id() != index.index_table.owner {
+                if !session.is_super_user() && session.user_id() != index.index_table().owner {
                     return Err(PermissionDenied(format!(
                         "must be owner of index \"{}\"",
                         index.name

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -143,7 +143,7 @@ impl Distill for BatchLookupJoin {
 
         let scan: &BatchSeqScan = self.core.right.as_batch_seq_scan().unwrap();
 
-        vec.push(("lookup table", Pretty::display(&scan.core().table_name)));
+        vec.push(("lookup table", Pretty::display(&scan.core().table_name())));
 
         childless_record("BatchLookupJoin", vec)
     }

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -142,7 +142,7 @@ impl Distill for BatchSeqScan {
     fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx().is_explain_verbose();
         let mut vec = Vec::with_capacity(4);
-        vec.push(("table", Pretty::from(self.core.table_name.clone())));
+        vec.push(("table", Pretty::from(self.core.table_name().to_owned())));
         vec.push(("columns", self.core.columns_pretty(verbose)));
 
         if !self.scan_ranges.is_empty() {

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -286,7 +286,7 @@ impl LogicalJoin {
             result_plan = Some(lookup_join);
         }
 
-        let indexes = logical_scan.indexes();
+        let indexes = logical_scan.table_indexes();
         for index in indexes {
             if let Some(index_scan) = logical_scan.to_index_scan_if_index_covered(index) {
                 let index_scan: PlanRef = index_scan.into();
@@ -1032,7 +1032,7 @@ impl LogicalJoin {
         {
             return result_plan.map(|x| x.into());
         }
-        let indexes = logical_scan.indexes();
+        let indexes = logical_scan.table_indexes();
         for index in indexes {
             // Use index table
             if let Some(index_scan) = logical_scan.to_index_scan_if_index_covered(index) {

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashSet};
-use std::rc::Rc;
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -31,7 +30,9 @@ use super::{
     ToStream, generic,
 };
 use crate::TableCatalog;
-use crate::catalog::{ColumnId, IndexCatalog};
+use crate::binder::BoundBaseTable;
+use crate::catalog::ColumnId;
+use crate::catalog::index_catalog::{IndexType, TableIndex};
 use crate::error::Result;
 use crate::expr::{CorrelatedInputRef, ExprImpl, ExprRewriter, ExprVisitor, InputRef};
 use crate::optimizer::ApplyResult;
@@ -91,29 +92,48 @@ impl GenericPlanRef for LogicalScan {
 impl LogicalScan {
     /// Create a [`LogicalScan`] node. Used by planner.
     pub fn create(
-        table_name: String, // explain-only
         table_catalog: Arc<TableCatalog>,
-        indexes: Vec<Rc<IndexCatalog>>,
         ctx: OptimizerContextRef,
         as_of: Option<AsOf>,
-        table_cardinality: Cardinality,
     ) -> Self {
         let output_col_idx: Vec<usize> = (0..table_catalog.columns().len()).collect();
         generic::TableScan::new(
-            table_name,
             output_col_idx,
             table_catalog,
-            indexes,
+            vec![],
             ctx,
             Condition::true_cond(),
             as_of,
-            table_cardinality,
+        )
+        .into()
+    }
+
+    pub fn from_base_table(
+        base_table: &BoundBaseTable,
+        ctx: OptimizerContextRef,
+        as_of: Option<AsOf>,
+    ) -> Self {
+        let table_catalog = base_table.table_catalog.clone();
+        let output_col_idx: Vec<usize> = (0..table_catalog.columns().len()).collect();
+        let mut table_indexes = vec![];
+        for index in &base_table.table_indexes {
+            match &index.index_type {
+                IndexType::Table(index) => table_indexes.push(index.clone()),
+            }
+        }
+        generic::TableScan::new(
+            output_col_idx,
+            table_catalog,
+            table_indexes,
+            ctx,
+            Condition::true_cond(),
+            as_of,
         )
         .into()
     }
 
     pub fn table_name(&self) -> &str {
-        &self.core.table_name
+        &self.core.table_catalog.name
     }
 
     pub fn as_of(&self) -> Option<AsOf> {
@@ -122,7 +142,7 @@ impl LogicalScan {
 
     /// The cardinality of the table **without** applying the predicate.
     pub fn table_cardinality(&self) -> Cardinality {
-        self.core.table_cardinality
+        self.core.table_catalog.cardinality
     }
 
     // FIXME(kwannoel): Fetch from `table_catalog` + lazily instantiate?
@@ -145,9 +165,9 @@ impl LogicalScan {
         self.core.output_column_ids()
     }
 
-    /// Get all indexes on this table
-    pub fn indexes(&self) -> &[Rc<IndexCatalog>] {
-        &self.core.indexes
+    /// Get all table indexes on this table
+    pub fn table_indexes(&self) -> &[Arc<TableIndex>] {
+        &self.core.table_indexes
     }
 
     /// Get the logical scan's filter predicate
@@ -170,7 +190,7 @@ impl LogicalScan {
     }
 
     /// Return indexes can satisfy the required order.
-    pub fn indexes_satisfy_order(&self, required_order: &Order) -> Vec<&Rc<IndexCatalog>> {
+    pub fn indexes_satisfy_order(&self, required_order: &Order) -> Vec<&Arc<TableIndex>> {
         self.indexes_satisfy_order_with_prefix(required_order, &HashSet::new())
             .into_iter()
             .map(|(index, _)| index)
@@ -185,7 +205,7 @@ impl LogicalScan {
         &self,
         required_order: &Order,
         prefix: &HashSet<ColumnOrder>,
-    ) -> Vec<(&Rc<IndexCatalog>, Order)> {
+    ) -> Vec<(&Arc<TableIndex>, Order)> {
         let output_col_map = self
             .output_col_idx()
             .iter()
@@ -195,7 +215,7 @@ impl LogicalScan {
             .collect::<BTreeMap<_, _>>();
         let unmatched_idx = output_col_map.len();
         let mut index_catalog_and_orders = vec![];
-        for index in self.indexes() {
+        for index in self.table_indexes() {
             let s2p_mapping = index.secondary_to_primary_mapping();
             let index_orders: Vec<ColumnOrder> = index
                 .index_table
@@ -241,7 +261,7 @@ impl LogicalScan {
     }
 
     /// If the index can cover the scan, transform it to the index scan.
-    pub fn to_index_scan_if_index_covered(&self, index: &Rc<IndexCatalog>) -> Option<LogicalScan> {
+    pub fn to_index_scan_if_index_covered(&self, index: &Arc<TableIndex>) -> Option<LogicalScan> {
         let p2s_mapping = index.primary_to_secondary_mapping();
         if self
             .required_col_idx()
@@ -249,7 +269,6 @@ impl LogicalScan {
             .all(|x| p2s_mapping.contains_key(x))
         {
             let index_scan = self.core.to_index_scan(
-                &index.name,
                 index.index_table.clone(),
                 p2s_mapping,
                 index.function_mapping(),
@@ -298,14 +317,12 @@ impl LogicalScan {
         predicate = predicate.rewrite_expr(&mut inverse_mapping);
 
         let scan_without_predicate = generic::TableScan::new(
-            self.table_name().to_owned(),
             self.required_col_idx().to_vec(),
             self.core.table_catalog.clone(),
-            self.indexes().to_vec(),
+            self.table_indexes().to_vec(),
             self.ctx(),
             Condition::true_cond(),
             self.as_of(),
-            self.table_cardinality(),
         );
         let project_expr = if self.required_col_idx() != self.output_col_idx() {
             Some(self.output_idx_to_input_ref())
@@ -317,28 +334,24 @@ impl LogicalScan {
 
     fn clone_with_predicate(&self, predicate: Condition) -> Self {
         generic::TableScan::new_inner(
-            self.table_name().to_owned(),
             self.output_col_idx().to_vec(),
             self.table_catalog(),
-            self.indexes().to_vec(),
+            self.table_indexes().to_vec(),
             self.base.ctx().clone(),
             predicate,
             self.as_of(),
-            self.table_cardinality(),
         )
         .into()
     }
 
     pub fn clone_with_output_indices(&self, output_col_idx: Vec<usize>) -> Self {
         generic::TableScan::new_inner(
-            self.table_name().to_owned(),
             output_col_idx,
             self.core.table_catalog.clone(),
-            self.indexes().to_vec(),
+            self.table_indexes().to_vec(),
             self.base.ctx().clone(),
             self.predicate().clone(),
             self.as_of(),
-            self.table_cardinality(),
         )
         .into()
     }
@@ -555,7 +568,7 @@ impl ToBatch for LogicalScan {
     ) -> Result<crate::optimizer::plan_node::BatchPlanRef> {
         let new = self.clone_with_predicate(self.predicate().clone());
 
-        if !new.indexes().is_empty() {
+        if !new.table_indexes().is_empty() {
             let index_selection_rule = IndexSelectionRule::create();
             if let ApplyResult::Ok(applied) = index_selection_rule.apply(new.clone().into()) {
                 if let Some(scan) = applied.as_logical_scan() {

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -91,7 +91,7 @@ impl StreamTableScan {
     }
 
     pub fn table_name(&self) -> &str {
-        &self.core.table_name
+        self.core.table_name()
     }
 
     pub fn core(&self) -> &generic::TableScan {
@@ -100,14 +100,12 @@ impl StreamTableScan {
 
     pub fn to_index_scan(
         &self,
-        index_name: &str,
         index_table_catalog: Arc<TableCatalog>,
         primary_to_secondary_mapping: &BTreeMap<usize, usize>,
         function_mapping: &HashMap<FunctionCall, usize>,
         stream_scan_type: StreamScanType,
     ) -> StreamTableScan {
         let logical_index_scan = self.core.to_index_scan(
-            index_name,
             index_table_catalog,
             primary_to_secondary_mapping,
             function_mapping,
@@ -257,7 +255,7 @@ impl Distill for StreamTableScan {
     fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx().is_explain_verbose();
         let mut vec = Vec::with_capacity(4);
-        vec.push(("table", Pretty::from(self.core.table_name.clone())));
+        vec.push(("table", Pretty::from(self.core.table_name().to_owned())));
         vec.push(("columns", self.core.columns_pretty(verbose)));
 
         if verbose {

--- a/src/frontend/src/optimizer/rule/index_delta_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_delta_join_rule.rs
@@ -54,7 +54,7 @@ impl Rule<Stream> for IndexDeltaJoinRule {
             table_scan: &StreamTableScan,
             stream_scan_type: StreamScanType,
         ) -> Option<PlanRef> {
-            for index in &table_scan.core().indexes {
+            for index in &table_scan.core().table_indexes {
                 // Only full covering index can be used in delta join
                 if !index.full_covering() {
                     continue;
@@ -92,7 +92,6 @@ impl Rule<Stream> for IndexDeltaJoinRule {
                 return Some(
                     table_scan
                         .to_index_scan(
-                            index.index_table.name.as_str(),
                             index.index_table.clone(),
                             p2s_mapping,
                             index.function_mapping(),

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -49,7 +49,7 @@
 use std::cmp::min;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, HashMap};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
@@ -61,7 +61,7 @@ use risingwave_pb::plan_common::JoinType;
 use risingwave_sqlparser::ast::AsOf;
 
 use super::prelude::{PlanRef, *};
-use crate::catalog::IndexCatalog;
+use crate::catalog::index_catalog::TableIndex;
 use crate::expr::{
     Expr, ExprImpl, ExprRewriter, ExprType, ExprVisitor, FunctionCall, InputRef, to_conjunctions,
     to_disjunctions,
@@ -91,7 +91,7 @@ pub struct IndexSelectionRule {}
 impl Rule<Logical> for IndexSelectionRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         let logical_scan: &LogicalScan = plan.as_logical_scan()?;
-        let indexes = logical_scan.indexes();
+        let indexes = logical_scan.table_indexes();
         if indexes.is_empty() {
             return None;
         }
@@ -204,30 +204,24 @@ impl IndexSelectionRule {
     fn gen_index_lookup(
         &self,
         logical_scan: &LogicalScan,
-        index: &IndexCatalog,
+        index: &TableIndex,
     ) -> (PlanRef, IndexCost) {
         // 1. logical_scan ->  logical_join
         //                      /        \
         //                index_scan   primary_table_scan
         let index_scan = LogicalScan::create(
-            index.index_table.name.clone(),
             index.index_table.clone(),
-            vec![],
             logical_scan.ctx(),
             logical_scan.as_of().clone(),
-            index.index_table.cardinality,
         );
         // We use `schema.len` instead of `index_item.len` here,
         // because schema contains system columns like `_rw_timestamp` column which is not represented in the index item.
         let offset = index_scan.table_catalog().columns().len();
 
         let primary_table_scan = LogicalScan::create(
-            index.primary_table.name.clone(),
             index.primary_table.clone(),
-            vec![],
             logical_scan.ctx(),
             logical_scan.as_of().clone(),
-            index.primary_table.cardinality,
         );
 
         let predicate = logical_scan.predicate().clone();
@@ -329,12 +323,9 @@ impl IndexSelectionRule {
         let primary_table_desc = logical_scan.table_desc();
 
         let primary_table_scan = LogicalScan::create(
-            logical_scan.table_name().to_owned(),
             logical_scan.table_catalog(),
-            vec![],
             logical_scan.ctx(),
             logical_scan.as_of().clone(),
-            logical_scan.table_cardinality(),
         );
 
         let conjunctions = primary_table_desc
@@ -518,7 +509,7 @@ impl IndexSelectionRule {
 
         let mut result = vec![];
 
-        for index in logical_scan.indexes() {
+        for index in logical_scan.table_indexes() {
             if let Some(column_index) = column_index {
                 assert_eq!(conjunctions.len(), 1);
                 let p2s_mapping = index.primary_to_secondary_mapping();
@@ -559,7 +550,6 @@ impl IndexSelectionRule {
         }
 
         let primary_access = generic::TableScan::new(
-            logical_scan.table_name().to_owned(),
             primary_table_desc
                 .pk
                 .iter()
@@ -572,7 +562,6 @@ impl IndexSelectionRule {
                 conjunctions: conjunctions.to_vec(),
             },
             logical_scan.as_of().clone(),
-            logical_scan.table_cardinality(),
         );
 
         result.push(primary_access.into());
@@ -583,7 +572,7 @@ impl IndexSelectionRule {
     /// build index access if predicate (refers to primary table) is covered by index
     fn build_index_access(
         &self,
-        index: Rc<IndexCatalog>,
+        index: Arc<TableIndex>,
         predicate: Condition,
         ctx: OptimizerContextRef,
         as_of: Option<AsOf>,
@@ -602,7 +591,6 @@ impl IndexSelectionRule {
 
         Some(
             generic::TableScan::new(
-                index.index_table.name.clone(),
                 index
                     .primary_table_pk_ref_to_index_table()
                     .iter()
@@ -613,7 +601,6 @@ impl IndexSelectionRule {
                 ctx,
                 new_predicate,
                 as_of,
-                index.index_table.cardinality,
             )
             .into(),
         )

--- a/src/frontend/src/optimizer/rule/table_function_to_internal_backfill_progress.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_internal_backfill_progress.rs
@@ -86,14 +86,7 @@ impl TableFunctionToInternalBackfillProgressRule {
     }
 
     fn build_scan(ctx: Rc<OptimizerContext>, table: Arc<TableCatalog>) -> LogicalScan {
-        LogicalScan::create(
-            table.name.clone(),
-            table,
-            vec![],
-            ctx.clone(),
-            None,
-            Default::default(),
-        )
+        LogicalScan::create(table, ctx.clone(), None)
     }
 
     fn build_agg(backfill_info: &BackfillInfo, scan: LogicalScan) -> anyhow::Result<PlanRef> {

--- a/src/frontend/src/optimizer/rule/table_function_to_internal_source_backfill_progress.rs
+++ b/src/frontend/src/optimizer/rule/table_function_to_internal_source_backfill_progress.rs
@@ -82,14 +82,7 @@ impl TableFunctionToInternalSourceBackfillProgressRule {
     }
 
     fn build_scan(ctx: Rc<OptimizerContext>, table: Arc<TableCatalog>) -> LogicalScan {
-        LogicalScan::create(
-            table.name.clone(),
-            table,
-            vec![],
-            ctx.clone(),
-            None,
-            Default::default(),
-        )
+        LogicalScan::create(table, ctx.clone(), None)
     }
 
     fn build_project(

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -78,19 +78,7 @@ impl Planner {
 
     pub(super) fn plan_base_table(&mut self, base_table: &BoundBaseTable) -> Result<PlanRef> {
         let as_of = base_table.as_of.clone();
-        let table_cardinality = base_table.table_catalog.cardinality;
-        let scan = LogicalScan::create(
-            base_table.table_catalog.name().to_owned(),
-            base_table.table_catalog.clone(),
-            base_table
-                .table_indexes
-                .iter()
-                .map(|x| x.as_ref().clone().into())
-                .collect(),
-            self.ctx(),
-            as_of.clone(),
-            table_cardinality,
-        );
+        let scan = LogicalScan::from_base_table(base_table, self.ctx(), as_of.clone());
 
         match base_table.table_catalog.engine {
             Engine::Hummock => {

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -604,18 +604,11 @@ pub(crate) mod tests {
             engine: Engine::Hummock,
             clean_watermark_index_in_pk: None,
         };
-        let batch_plan_node = LogicalScan::create(
-            "".to_owned(),
-            table_catalog.into(),
-            vec![],
-            ctx,
-            None,
-            Cardinality::unknown(),
-        )
-        .to_batch()
-        .unwrap()
-        .to_distributed()
-        .unwrap();
+        let batch_plan_node = LogicalScan::create(table_catalog.into(), ctx, None)
+            .to_batch()
+            .unwrap()
+            .to_distributed()
+            .unwrap();
         let batch_filter = BatchFilter::new(generic::Filter::new(
             Condition {
                 conjunctions: vec![],

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -1241,7 +1241,7 @@ impl BatchPlanFragmenter {
             )
         } else if let Some(scan_node) = node.as_batch_seq_scan() {
             build_table_scan_info(
-                scan_node.core().table_name.to_owned(),
+                scan_node.core().table_name().to_owned(),
                 &scan_node.core().table_desc,
                 scan_node.scan_ranges(),
             )

--- a/src/frontend/src/session/cursor_manager.rs
+++ b/src/frontend/src/session/cursor_manager.rs
@@ -49,7 +49,7 @@ use crate::handler::util::{
 use crate::monitor::{CursorMetrics, PeriodicCursorMetrics};
 use crate::optimizer::PlanRoot;
 use crate::optimizer::plan_node::{BatchFilter, BatchLogSeqScan, BatchSeqScan, generic};
-use crate::optimizer::property::{Cardinality, Order, RequiredDist};
+use crate::optimizer::property::{Order, RequiredDist};
 use crate::scheduler::{DistributedQueryStream, LocalQueryStream, ReadSnapshot};
 use crate::utils::Condition;
 use crate::{OptimizerContext, OptimizerContextRef, PgResponseStream, TableCatalog};
@@ -950,7 +950,6 @@ impl SubscriptionCursor {
             (batch_log_seq_scan.into(), out_fields, out_names)
         } else {
             let core = generic::TableScan::new(
-                table_catalog.name.clone(),
                 output_col_idx,
                 table_catalog.clone(),
                 vec![],
@@ -959,7 +958,6 @@ impl SubscriptionCursor {
                     conjunctions: vec![],
                 },
                 None,
-                Cardinality::default(),
             );
             let scans = match scan {
                 Some(scan) => vec![scan],

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -574,7 +574,7 @@ impl CatalogWriter for MockCatalogWriter {
             schema_catalog.get_index_by_id(&index_id).unwrap().clone()
         };
 
-        let index_table_id = index.index_table.id;
+        let index_table_id = index.index_table().id;
         let (database_id, schema_id) = self.drop_table_or_index_id(index_id.index_id);
         self.catalog
             .write()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

changes:
* do not store `table_name` and `cardinality` in `generic::TableScan`, and instead use the one in `TableCatalog`
* introduced a new enum `IndexType`, with currently only one variant as `Table(TableIndex)` to represent the existing index type that build index as a state table. Moved some fields in the original `IndexCatalog` to `TableIndex`, and store `IndexType` as a field in `IndexCatalog`. Store `TableIndex` instead of `IndexCatalog` in `generic::TableScan`. This is for vector index to be introduced later.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
