### PR TITLE
feat(dashboard): add test data for dashboard rendering

### DIFF
--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -84,7 +84,9 @@ echo "--- Install Python Dependencies"
 python3 -m pip install --break-system-packages -r ./e2e_test/requirements.txt
 
 echo "--- e2e, $mode, dashboard"
+cluster_start
 risedev slt -p 4566 -d dev './e2e_test/dashboard/**/*.slt'
+cluster_stop
 
 echo "--- e2e, $mode, streaming"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::common::table::state_table=warn" \

--- a/ci/scripts/e2e-test-serial.sh
+++ b/ci/scripts/e2e-test-serial.sh
@@ -83,6 +83,9 @@ chmod +x ./target/debug/risingwave_e2e_extended_mode_test
 echo "--- Install Python Dependencies"
 python3 -m pip install --break-system-packages -r ./e2e_test/requirements.txt
 
+echo "--- e2e, $mode, dashboard"
+risedev slt -p 4566 -d dev './e2e_test/dashboard/**/*.slt'
+
 echo "--- e2e, $mode, streaming"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::common::table::state_table=warn" \
 cluster_start

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -31,10 +31,14 @@ TODO: Find a suitable testing framework
 Start a RisingWave cluster, create some tables and materialized views for testing purposes.
 
 ```bash
-./risedev d
-# Nexmark and tpch do not have nested MV-on-MV structures.
+# Start full cluster so prometheus is available.
+./risedev k
+./risedev clean-data
+./risedev d full
 # We maintain our own separate test data for testing the dashboard's rendering
-./risedev slt e2e_test/dashboard/create_graph.slt.part
+# It provides nested MV-on-MV structures (nexmark and tpch only have 1-deep MV-on-MV).
+# It also provides backpressure and lag scenarios.
+./risedev slt e2e_test/dashboard/create_graph.slt.part --label dashboard
 ```
 
 Install dependencies and start the development server.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -29,27 +29,12 @@ TODO: Find a suitable testing framework
 ## Development
 
 Start a RisingWave cluster, create some tables and materialized views for testing purposes.
-For example:
 
 ```bash
 ./risedev d
-./risedev slt  e2e_test/nexmark/create_sources.slt.part
-./risedev psql -c 'CREATE TABLE dimension (v1 int);'
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv AS SELECT auction.* FROM dimension join auction on auction.id-auction.id = dimension.v1;'
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv2 AS SELECT * FROM mv;'
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv3 AS SELECT count(*) FROM mv2;'
-
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv4 AS SELECT * FROM mv;'
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv5 AS SELECT count(*) FROM mv2;'
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv6 AS SELECT mv4.* FROM mv4 join mv2 using(id);'
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv7 AS SELECT max(id) FROM mv;'
-
-./risedev psql -c 'CREATE MATERIALIZED VIEW mv8 AS SELECT mv.* FROM mv join mv6 using(id);'
-./risedev psql -c 'CREATE SCHEMA s1;'
-./risedev psql -c 'CREATE TABLE s1.t1 (v1 int);'
-./risedev psql -c 'CREATE MATERIALIZED VIEW s1.mv1 AS SELECT s1.t1.* FROM s1.t1 join mv on s1.t1.v1 = mv.id;'
-
-./risedev psql -c 'INSERT INTO dimension select 0 from generate_series(1, 20);'
+# Nexmark and tpch do not have nested MV-on-MV structures.
+# We maintain our own separate test data for testing the dashboard's rendering
+./risedev slt e2e_test/dashboard/create_graph.slt.part
 ```
 
 Install dependencies and start the development server.

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -6,6 +6,7 @@ create table t(v1 int, v2 int) with (
     fields.v1.start = 1,
     fields.v1.end = 1000000,
     fields.v2.kind = 'random',
+    fields.v2.seed = '1',
     fields.v2.min = 1,
     fields.v2.max = 100,
     datagen.rows.per.second = 100
@@ -22,6 +23,7 @@ create table t2(v1 int, v2 int) with (
     fields.v1.start = 1,
     fields.v1.end = 1000000,
     fields.v2.kind = 'random',
+    fields.v2.seed = '2',
     fields.v2.min = 1,
     fields.v2.max = 100,
     datagen.rows.per.second = 100
@@ -38,6 +40,7 @@ create table t3(v1 int, v2 int) with (
     fields.v1.start = 1,
     fields.v1.end = 1000000,
     fields.v2.kind = 'random',
+    fields.v2.seed = '3',
     fields.v2.min = 1,
     fields.v2.max = 100,
     datagen.rows.per.second = 100
@@ -54,6 +57,7 @@ create table t4(v1 int, v2 int) with (
     fields.v1.start = 1,
     fields.v1.end = 1000000,
     fields.v2.kind = 'random',
+    fields.v2.seed = '4',
     fields.v2.min = 1,
     fields.v2.max = 100,
     datagen.rows.per.second = 100
@@ -70,6 +74,7 @@ create table t5(v1 int, v2 int) with (
     fields.v1.start = 1,
     fields.v1.end = 1000000,
     fields.v2.kind = 'random',
+    fields.v2.seed = '5',
     fields.v2.min = 1,
     fields.v2.max = 100,
     datagen.rows.per.second = 100

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -1,104 +1,64 @@
 statement ok
-create table t(v1 int primary key, v2 int);
+create table t(v1 int, v2 int);
 
 statement ok
-create table t2(v1 int primary key, v2 int);
+create table t2(v1 int, v2 int);
 
 statement ok
-create table t3(v1 int primary key, v2 int);
+create table t3(v1 int, v2 int);
 
 statement ok
-create table t4(v1 int primary key, v2 int);
+create table t4(v1 int, v2 int);
 
 statement ok
-create table t5(v1 int primary key, v2 int);
+create table t5(v1 int, v2 int);
 
-# Materialized View 1: Join t, t2, t3
 statement ok
-create materialized view mv1 as
-select t.v1 as t_v1, t.v2 as t_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2
-from t join t2 on t.v1 = t2.v1 join t3 on t2.v1 = t3.v1;
+create materialized view mv1 as 
+select t.v1, t.v2, t2.v1 as t2_v1, t2.v2 as t2_v2
+from t join t2 on t.v1 = t2.v1;
 
-# Materialized View 2: Join t, t2, t4
 statement ok
-create materialized view mv2 as
-select t.v1 as t_v1, t.v2 as t_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
-from t join t2 on t.v1 = t2.v1 join t4 on t2.v1 = t4.v1;
+create materialized view mv2 as 
+select t3.v1, t3.v2, t4.v1 as t4_v1, t4.v2 as t4_v2
+from t3 join t4 on t3.v2 = t4.v2;
 
-# Materialized View 3: Join t, t2, t5
 statement ok
-create materialized view mv3 as
-select t.v1 as t_v1, t.v2 as t_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from t join t2 on t.v1 = t2.v1 join t5 on t2.v1 = t5.v1;
+create materialized view mv3 as 
+select mv1.v1, mv1.t2_v1, t5.v1 as t5_v1, t5.v2 as t5_v2
+from mv1 join t5 on mv1.v1 = t5.v1;
 
-# Materialized View 4: Join t, t3, t4
 statement ok
-create materialized view mv4 as
-select t.v1 as t_v1, t.v2 as t_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
-from t join t3 on t.v1 = t3.v1 join t4 on t3.v1 = t4.v1;
+create materialized view mv4 as 
+select mv2.v1, mv2.t4_v1, mv3.t5_v1, mv3.t5_v2
+from mv2 join mv3 on mv2.v1 = mv3.v1;
 
-# Materialized View 5: Join t, t3, t5
 statement ok
-create materialized view mv5 as
-select t.v1 as t_v1, t.v2 as t_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from t join t3 on t.v1 = t3.v1 join t5 on t3.v1 = t5.v1;
+create materialized view mv5 as 
+select t.v1, t.v2, mv4.v1 as mv4_v1, mv4.t4_v1
+from t join mv4 on t.v2 = mv4.v1;
 
-# Materialized View 6: Join t, t4, t5
 statement ok
-create materialized view mv6 as
-select t.v1 as t_v1, t.v2 as t_v2, t4.v1 as t4_v1, t4.v2 as t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from t join t4 on t.v1 = t4.v1 join t5 on t4.v1 = t5.v1;
+create materialized view mv6 as 
+select mv1.v1, mv1.t2_v1, mv2.v1 as mv2_v1, mv2.t4_v1
+from mv1 join mv2 on mv1.t2_v1 = mv2.t4_v1;
 
-# Materialized View 7: Join t2, t3, t4
 statement ok
-create materialized view mv7 as
-select t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
-from t2 join t3 on t2.v1 = t3.v1 join t4 on t3.v1 = t4.v1;
+create materialized view mv7 as 
+select t3.v1, t3.v2, mv3.t5_v1, mv3.t5_v2, t5.v1 as t5_orig_v1
+from t3 join mv3 on t3.v1 = mv3.v1 join t5 on mv3.t5_v1 = t5.v1;
 
-# Materialized View 8: Join t2, t3, t5
 statement ok
-create materialized view mv8 as
-select t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from t2 join t3 on t2.v1 = t3.v1 join t5 on t3.v1 = t5.v1;
+create materialized view mv8 as 
+select mv4.v1, mv4.t4_v1, mv5.v1 as mv5_v1, mv5.mv4_v1
+from mv4 join mv5 on mv4.v1 = mv5.mv4_v1;
 
-# Materialized View 9: Join t2, t4, t5
 statement ok
-create materialized view mv9 as
-select t2.v1 as t2_v1, t2.v2 as t2_v2, t4.v1 as t4_v1, t4.v2 as t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from t2 join t4 on t2.v1 = t4.v1 join t5 on t4.v1 = t5.v1;
+create materialized view mv9 as 
+select t2.v1, t2.v2, mv6.mv2_v1, mv7.t5_v1
+from t2 join mv6 on t2.v1 = mv6.v1 join mv7 on mv6.mv2_v1 = mv7.v1;
 
-# Materialized View 10: Join t3, t4, t5
 statement ok
-create materialized view mv10 as
-select t3.v1 as t3_v1, t3.v2 as t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from t3 join t4 on t3.v1 = t4.v1 join t5 on t4.v1 = t5.v1;
-
-# Materialized View 11: Join mv1 with table t4
-statement ok
-create materialized view mv11 as
-select mv1.t_v1, mv1.t_v2, mv1.t2_v1, mv1.t2_v2, mv1.t3_v1, mv1.t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
-from mv1 join t4 on mv1.t_v1 = t4.v1;
-
-# Materialized View 12: Join mv2 with mv7
-statement ok
-create materialized view mv12 as
-select mv2.t_v1, mv2.t_v2, mv2.t2_v1, mv2.t2_v2, mv2.t4_v1, mv2.t4_v2, mv7.t3_v1, mv7.t3_v2, mv7.t4_v1 as mv7_t4_v1, mv7.t4_v2 as mv7_t4_v2
-from mv2 join mv7 on mv2.t_v1 = mv7.t2_v1;
-
-# Materialized View 13: Join mv3 with mv8
-statement ok
-create materialized view mv13 as
-select mv3.t_v1, mv3.t_v2, mv3.t2_v1, mv3.t2_v2, mv3.t5_v1, mv3.t5_v2, mv8.t3_v1, mv8.t3_v2, mv8.t5_v1 as mv8_t5_v1, mv8.t5_v2 as mv8_t5_v2
-from mv3 join mv8 on mv3.t_v1 = mv8.t2_v1;
-
-# Materialized View 14: Join mv4 with table t5
-statement ok
-create materialized view mv14 as
-select mv4.t_v1, mv4.t_v2, mv4.t3_v1, mv4.t3_v2, mv4.t4_v1, mv4.t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
-from mv4 join t5 on mv4.t_v1 = t5.v1;
-
-# Materialized View 15: Join mv5 with mv9
-statement ok
-create materialized view mv15 as
-select mv5.t_v1, mv5.t_v2, mv5.t3_v1, mv5.t3_v2, mv5.t5_v1, mv5.t5_v2, mv9.t2_v1, mv9.t2_v2, mv9.t4_v1, mv9.t4_v2, mv9.t5_v1 as mv9_t5_v1, mv9.t5_v2 as mv9_t5_v2
-from mv5 join mv9 on mv5.t_v1 = mv9.t2_v1;
+create materialized view mv10 as 
+select mv8.v1, mv8.mv5_v1, mv9.v1 as mv9_v1, mv9.t5_v1
+from mv8 join mv9 on mv8.mv5_v1 = mv9.v1;

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -79,51 +79,51 @@ statement ok
 create table if not exists t5(v1 int, v2 int);
 
 statement ok
-create materialized view mv1 as 
+create materialized view mv1 as
 select t.v1, t.v2, t2.v1 as t2_v1, t2.v2 as t2_v2
 from t join t2 on t.v1 = t2.v1;
 
 statement ok
-create materialized view mv2 as 
+create materialized view mv2 as
 select t3.v1, t3.v2, t4.v1 as t4_v1, t4.v2 as t4_v2
 from t3 join t4 on t3.v2 = t4.v2;
 
 statement ok
-create materialized view mv3 as 
+create materialized view mv3 as
 select mv1.v1, mv1.t2_v1, t5.v1 as t5_v1, t5.v2 as t5_v2
 from mv1 join t5 on mv1.v1 = t5.v1;
 
 statement ok
-create materialized view mv4 as 
+create materialized view mv4 as
 select mv2.v1, mv2.t4_v1, mv3.t5_v1, mv3.t5_v2
 from mv2 join mv3 on mv2.v1 = mv3.v1;
 
 statement ok
-create materialized view mv5 as 
+create materialized view mv5 as
 select t.v1, t.v2, mv4.v1 as mv4_v1, mv4.t4_v1
 from t join mv4 on t.v2 = mv4.v1;
 
 statement ok
-create materialized view mv6 as 
+create materialized view mv6 as
 select mv1.v1, mv1.t2_v1, mv2.v1 as mv2_v1, mv2.t4_v1
 from mv1 join mv2 on mv1.t2_v1 = mv2.t4_v1;
 
 statement ok
-create materialized view mv7 as 
+create materialized view mv7 as
 select t3.v1, t3.v2, mv3.t5_v1, mv3.t5_v2, t5.v1 as t5_orig_v1
 from t3 join mv3 on t3.v1 = mv3.v1 join t5 on mv3.t5_v1 = t5.v1;
 
 statement ok
-create materialized view mv8 as 
+create materialized view mv8 as
 select mv4.v1, mv4.t4_v1, mv5.v1 as mv5_v1, mv5.mv4_v1
 from mv4 join mv5 on mv4.v1 = mv5.mv4_v1;
 
 statement ok
-create materialized view mv9 as 
+create materialized view mv9 as
 select t2.v1, t2.v2, mv6.mv2_v1, mv7.t5_v1
 from t2 join mv6 on t2.v1 = mv6.v1 join mv7 on mv6.mv2_v1 = mv7.v1;
 
 statement ok
-create materialized view mv10 as 
+create materialized view mv10 as
 select mv8.v1, mv8.mv5_v1, mv9.v1 as mv9_v1, mv9.t5_v1
 from mv8 join mv9 on mv8.mv5_v1 = mv9.v1;

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -1,0 +1,104 @@
+statement ok
+create table t(v1 int primary key, v2 int);
+
+statement ok
+create table t2(v1 int primary key, v2 int);
+
+statement ok
+create table t3(v1 int primary key, v2 int);
+
+statement ok
+create table t4(v1 int primary key, v2 int);
+
+statement ok
+create table t5(v1 int primary key, v2 int);
+
+# Materialized View 1: Join t, t2, t3
+statement ok
+create materialized view mv1 as
+select t.v1 as t_v1, t.v2 as t_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2
+from t join t2 on t.v1 = t2.v1 join t3 on t2.v1 = t3.v1;
+
+# Materialized View 2: Join t, t2, t4
+statement ok
+create materialized view mv2 as
+select t.v1 as t_v1, t.v2 as t_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
+from t join t2 on t.v1 = t2.v1 join t4 on t2.v1 = t4.v1;
+
+# Materialized View 3: Join t, t2, t5
+statement ok
+create materialized view mv3 as
+select t.v1 as t_v1, t.v2 as t_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from t join t2 on t.v1 = t2.v1 join t5 on t2.v1 = t5.v1;
+
+# Materialized View 4: Join t, t3, t4
+statement ok
+create materialized view mv4 as
+select t.v1 as t_v1, t.v2 as t_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
+from t join t3 on t.v1 = t3.v1 join t4 on t3.v1 = t4.v1;
+
+# Materialized View 5: Join t, t3, t5
+statement ok
+create materialized view mv5 as
+select t.v1 as t_v1, t.v2 as t_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from t join t3 on t.v1 = t3.v1 join t5 on t3.v1 = t5.v1;
+
+# Materialized View 6: Join t, t4, t5
+statement ok
+create materialized view mv6 as
+select t.v1 as t_v1, t.v2 as t_v2, t4.v1 as t4_v1, t4.v2 as t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from t join t4 on t.v1 = t4.v1 join t5 on t4.v1 = t5.v1;
+
+# Materialized View 7: Join t2, t3, t4
+statement ok
+create materialized view mv7 as
+select t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
+from t2 join t3 on t2.v1 = t3.v1 join t4 on t3.v1 = t4.v1;
+
+# Materialized View 8: Join t2, t3, t5
+statement ok
+create materialized view mv8 as
+select t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from t2 join t3 on t2.v1 = t3.v1 join t5 on t3.v1 = t5.v1;
+
+# Materialized View 9: Join t2, t4, t5
+statement ok
+create materialized view mv9 as
+select t2.v1 as t2_v1, t2.v2 as t2_v2, t4.v1 as t4_v1, t4.v2 as t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from t2 join t4 on t2.v1 = t4.v1 join t5 on t4.v1 = t5.v1;
+
+# Materialized View 10: Join t3, t4, t5
+statement ok
+create materialized view mv10 as
+select t3.v1 as t3_v1, t3.v2 as t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from t3 join t4 on t3.v1 = t4.v1 join t5 on t4.v1 = t5.v1;
+
+# Materialized View 11: Join mv1 with table t4
+statement ok
+create materialized view mv11 as
+select mv1.t_v1, mv1.t_v2, mv1.t2_v1, mv1.t2_v2, mv1.t3_v1, mv1.t3_v2, t4.v1 as t4_v1, t4.v2 as t4_v2
+from mv1 join t4 on mv1.t_v1 = t4.v1;
+
+# Materialized View 12: Join mv2 with mv7
+statement ok
+create materialized view mv12 as
+select mv2.t_v1, mv2.t_v2, mv2.t2_v1, mv2.t2_v2, mv2.t4_v1, mv2.t4_v2, mv7.t3_v1, mv7.t3_v2, mv7.t4_v1 as mv7_t4_v1, mv7.t4_v2 as mv7_t4_v2
+from mv2 join mv7 on mv2.t_v1 = mv7.t2_v1;
+
+# Materialized View 13: Join mv3 with mv8
+statement ok
+create materialized view mv13 as
+select mv3.t_v1, mv3.t_v2, mv3.t2_v1, mv3.t2_v2, mv3.t5_v1, mv3.t5_v2, mv8.t3_v1, mv8.t3_v2, mv8.t5_v1 as mv8_t5_v1, mv8.t5_v2 as mv8_t5_v2
+from mv3 join mv8 on mv3.t_v1 = mv8.t2_v1;
+
+# Materialized View 14: Join mv4 with table t5
+statement ok
+create materialized view mv14 as
+select mv4.t_v1, mv4.t_v2, mv4.t3_v1, mv4.t3_v2, mv4.t4_v1, mv4.t4_v2, t5.v1 as t5_v1, t5.v2 as t5_v2
+from mv4 join t5 on mv4.t_v1 = t5.v1;
+
+# Materialized View 15: Join mv5 with mv9
+statement ok
+create materialized view mv15 as
+select mv5.t_v1, mv5.t_v2, mv5.t3_v1, mv5.t3_v2, mv5.t5_v1, mv5.t5_v2, mv9.t2_v1, mv9.t2_v2, mv9.t4_v1, mv9.t4_v2, mv9.t5_v1 as mv9_t5_v1, mv9.t5_v2 as mv9_t5_v2
+from mv5 join mv9 on mv5.t_v1 = mv9.t2_v1;

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -122,13 +122,3 @@ statement ok
 create materialized view mv8 as
 select mv4.v1, mv4.t4_v1, mv5.v1 as mv5_v1, mv5.mv4_v1
 from mv4 join mv5 on mv4.v1 = mv5.mv4_v1;
-
-statement ok
-create materialized view mv9 as
-select t2.v1, t2.v2, mv6.mv2_v1, mv7.t5_v1
-from t2 join mv6 on t2.v1 = mv6.v1 join mv7 on mv6.mv2_v1 = mv7.v1;
-
-statement ok
-create materialized view mv10 as
-select mv8.v1, mv8.mv5_v1, mv9.v1 as mv9_v1, mv9.t5_v1
-from mv8 join mv9 on mv8.mv5_v1 = mv9.v1;

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -1,17 +1,62 @@
 statement ok
-create table t(v1 int, v2 int);
+create table t(v1 int, v2 int) with (
+    connector = 'datagen',
+    fields.v1.kind = 'sequence',
+    fields.v1.start = 1,
+    fields.v1.end = 1000000,
+    fields.v2.kind = 'random',
+    fields.v2.min = 1,
+    fields.v2.max = 100,
+    datagen.rows.per.second = 100
+);
 
 statement ok
-create table t2(v1 int, v2 int);
+create table t2(v1 int, v2 int) with (
+    connector = 'datagen',
+    fields.v1.kind = 'sequence',
+    fields.v1.start = 1,
+    fields.v1.end = 1000000,
+    fields.v2.kind = 'random',
+    fields.v2.min = 1,
+    fields.v2.max = 100,
+    datagen.rows.per.second = 100
+);
 
 statement ok
-create table t3(v1 int, v2 int);
+create table t3(v1 int, v2 int) with (
+    connector = 'datagen',
+    fields.v1.kind = 'sequence',
+    fields.v1.start = 1,
+    fields.v1.end = 1000000,
+    fields.v2.kind = 'random',
+    fields.v2.min = 1,
+    fields.v2.max = 100,
+    datagen.rows.per.second = 100
+);
 
 statement ok
-create table t4(v1 int, v2 int);
+create table t4(v1 int, v2 int) with (
+    connector = 'datagen',
+    fields.v1.kind = 'sequence',
+    fields.v1.start = 1,
+    fields.v1.end = 1000000,
+    fields.v2.kind = 'random',
+    fields.v2.min = 1,
+    fields.v2.max = 100,
+    datagen.rows.per.second = 100
+);
 
 statement ok
-create table t5(v1 int, v2 int);
+create table t5(v1 int, v2 int) with (
+    connector = 'datagen',
+    fields.v1.kind = 'sequence',
+    fields.v1.start = 1,
+    fields.v1.end = 1000000,
+    fields.v2.kind = 'random',
+    fields.v2.min = 1,
+    fields.v2.max = 100,
+    datagen.rows.per.second = 100
+);
 
 statement ok
 create materialized view mv1 as 

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -1,3 +1,4 @@
+onlyif dashboard
 statement ok
 create table t(v1 int, v2 int) with (
     connector = 'datagen',
@@ -11,6 +12,10 @@ create table t(v1 int, v2 int) with (
 );
 
 statement ok
+create table if not exists t(v1 int, v2 int);
+
+onlyif dashboard
+statement ok
 create table t2(v1 int, v2 int) with (
     connector = 'datagen',
     fields.v1.kind = 'sequence',
@@ -22,6 +27,10 @@ create table t2(v1 int, v2 int) with (
     datagen.rows.per.second = 100
 );
 
+statement ok
+create table if not exists t2(v1 int, v2 int);
+
+onlyif dashboard
 statement ok
 create table t3(v1 int, v2 int) with (
     connector = 'datagen',
@@ -35,6 +44,10 @@ create table t3(v1 int, v2 int) with (
 );
 
 statement ok
+create table if not exists t3(v1 int, v2 int);
+
+onlyif dashboard
+statement ok
 create table t4(v1 int, v2 int) with (
     connector = 'datagen',
     fields.v1.kind = 'sequence',
@@ -47,6 +60,10 @@ create table t4(v1 int, v2 int) with (
 );
 
 statement ok
+create table if not exists t4(v1 int, v2 int);
+
+onlyif dashboard
+statement ok
 create table t5(v1 int, v2 int) with (
     connector = 'datagen',
     fields.v1.kind = 'sequence',
@@ -57,6 +74,9 @@ create table t5(v1 int, v2 int) with (
     fields.v2.max = 100,
     datagen.rows.per.second = 100
 );
+
+statement ok
+create table if not exists t5(v1 int, v2 int);
 
 statement ok
 create materialized view mv1 as 

--- a/e2e_test/dashboard/drop_graph.slt.part
+++ b/e2e_test/dashboard/drop_graph.slt.part
@@ -1,26 +1,5 @@
 # Drop materialized views in reverse dependency order (dependent MVs first, then base MVs)
 statement ok
-drop materialized view mv15;
-
-statement ok
-drop materialized view mv14;
-
-statement ok
-drop materialized view mv13;
-
-statement ok
-drop materialized view mv12;
-
-statement ok
-drop materialized view mv11;
-
-statement ok
-drop materialized view mv10;
-
-statement ok
-drop materialized view mv9;
-
-statement ok
 drop materialized view mv8;
 
 statement ok

--- a/e2e_test/dashboard/drop_graph.slt.part
+++ b/e2e_test/dashboard/drop_graph.slt.part
@@ -1,0 +1,61 @@
+# Drop materialized views in reverse dependency order (dependent MVs first, then base MVs)
+statement ok
+drop materialized view mv15;
+
+statement ok
+drop materialized view mv14;
+
+statement ok
+drop materialized view mv13;
+
+statement ok
+drop materialized view mv12;
+
+statement ok
+drop materialized view mv11;
+
+statement ok
+drop materialized view mv10;
+
+statement ok
+drop materialized view mv9;
+
+statement ok
+drop materialized view mv8;
+
+statement ok
+drop materialized view mv7;
+
+statement ok
+drop materialized view mv6;
+
+statement ok
+drop materialized view mv5;
+
+statement ok
+drop materialized view mv4;
+
+statement ok
+drop materialized view mv3;
+
+statement ok
+drop materialized view mv2;
+
+statement ok
+drop materialized view mv1;
+
+# Drop tables
+statement ok
+drop table t5;
+
+statement ok
+drop table t4;
+
+statement ok
+drop table t3;
+
+statement ok
+drop table t2;
+
+statement ok
+drop table t;

--- a/e2e_test/dashboard/graph.slt
+++ b/e2e_test/dashboard/graph.slt
@@ -9,4 +9,4 @@ include create_graph.slt.part
 sleep 5s
 
 -- Include the cleanup script
-include drop_graph.slt.part 
+include drop_graph.slt.part

--- a/e2e_test/dashboard/graph.slt
+++ b/e2e_test/dashboard/graph.slt
@@ -1,0 +1,12 @@
+-- Market Data Graph Test Suite
+-- This file includes the creation and cleanup of a comprehensive market data graph
+-- with 5 datagen sources and 20 materialized views
+
+-- Include the creation script
+include create_graph.slt.part
+
+-- Wait for data to be processed
+sleep 5s
+
+-- Include the cleanup script
+include drop_graph.slt.part 

--- a/e2e_test/dashboard/graph.slt
+++ b/e2e_test/dashboard/graph.slt
@@ -1,12 +1,5 @@
--- Market Data Graph Test Suite
--- This file includes the creation and cleanup of a comprehensive market data graph
--- with 5 datagen sources and 20 materialized views
-
--- Include the creation script
+# Include the creation script
 include create_graph.slt.part
 
--- Wait for data to be processed
-sleep 5s
-
--- Include the cleanup script
+# Include the cleanup script
 include drop_graph.slt.part


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Added dedicated test data for the dashboard's rendering capabilities. Previously we have some adhoc sql, that's not tested in CI. This PR unifies those SQL into a single slt script, and tests the queries to make sure they can run in CI.

We don't use `nexmark` or `tpch`, since these query sets are 1-deep, (i.e. base tables and MVs only on base tables, no mv-on-mv). So we cannot evaluate the graph rendering for deep graphs. Further, these queries also do not have high backpressure, and we can't really see how high backpressure is visualized for these.

This PR:
- Creates a new test suite in `e2e_test/dashboard/` with scripts to generate a complex graph of materialized views
- Adds `create_graph.slt.part` that creates 5 datagen tables and 10 materialized views with various dependencies
- Adds `drop_graph.slt.part` for proper cleanup of the test resources
- Updates the dashboard README to reference the new test data instead of the previous ad-hoc commands

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.