### PR TITLE
fix(dashboard): normalize backpressure values to 0-1 range

### DIFF
--- a/dashboard/components/utils/backPressure.tsx
+++ b/dashboard/components/utils/backPressure.tsx
@@ -16,10 +16,10 @@ export function backPressureColor(value: number) {
   ].map((c) => tinycolor(c))
 
   value = Math.max(value, 0)
-  value = Math.min(value, 100)
+  value = Math.min(value, 1)
 
   const step = colorRange.length - 1
-  const pos = (value / 100) * step
+  const pos = value * step
   const floor = Math.floor(pos)
   const ceil = Math.ceil(pos)
 
@@ -37,9 +37,9 @@ export function backPressureColor(value: number) {
  */
 export function backPressureWidth(value: number, scale: number) {
   value = Math.max(value, 0)
-  value = Math.min(value, 100)
+  value = Math.min(value, 1)
 
-  return scale * (value / 100) + 2
+  return scale * value + 2
 }
 
 export function epochToUnixMillis(epoch: number) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

There's no need to further normalize the backpressure by dividing by 100. The values received here are not percentages but a float with the rate: `[0.0, 1.0]`.

Before the change, even though backpressure is at 98%, there's no colour transition for that edge or width transition:
<img width="1225" height="521" alt="Screenshot 2025-08-11 at 5 19 25 PM" src="https://github.com/user-attachments/assets/8790f8ac-4041-4ab5-90cd-fb27cda886e6" />

After the change, you can see there's colour transition and width transition at 115% backpressure:
<img width="1225" height="521" alt="Screenshot 2025-08-11 at 5 19 11 PM" src="https://github.com/user-attachments/assets/a87f7db2-7dda-43de-9488-38fab0a8a795" />

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
