### PR TITLE
refactor(pg-cdc): do not require table owner permission for pk access

### DIFF
--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -41,7 +41,7 @@ const DISCOVER_PRIMARY_KEY_QUERY: &str = r#"
     SELECT a.attname as column_name
     FROM pg_index i
     JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-    WHERE i.indrelid = ($1 || '.' || $2)::regclass 
+    WHERE i.indrelid = ($1 || '.' || $2)::regclass
       AND i.indisprimary = true
     ORDER BY array_position(i.indkey, a.attnum)
 "#;

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -36,7 +36,7 @@ use super::maybe_tls_connector::MaybeMakeTlsConnector;
 use crate::error::ConnectorResult;
 
 /// SQL query to discover primary key columns directly from PostgreSQL system tables.
-/// This bypasses `information_schema.table_constraints` to avoid permission issues.
+/// This bypasses querying `information_schema.table_constraints` to avoid permission issues.
 const DISCOVER_PRIMARY_KEY_QUERY: &str = r#"
     SELECT a.attname as column_name
     FROM pg_index i
@@ -78,7 +78,7 @@ pub struct PostgresExternalTable {
 
 impl PostgresExternalTable {
     /// Discover primary key columns directly from PostgreSQL system tables.
-    /// This bypasses `information_schema.table_constraints` to avoid requiring table owner permissions.
+    /// This bypasses querying `information_schema.table_constraints` to avoid requiring table owner permissions.
     async fn discover_primary_key(
         connection: &PgPool,
         schema_name: &str,
@@ -101,7 +101,7 @@ impl PostgresExternalTable {
 
     /// Discover schema with workaround for primary key discovery
     /// This method uses direct PostgreSQL system table queries for primary keys
-    /// to avoid permission issues with `information_schema.table_constraints`
+    /// to avoid permission issues when querying `information_schema.table_constraints`
     async fn discover_pk_and_full_columns(
         username: &str,
         password: &str,

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use postgres_openssl::MakeTlsConnector;
 use risingwave_common::bail;
@@ -89,7 +89,7 @@ impl PostgresExternalTable {
             .bind(table_name)
             .fetch_all(connection)
             .await
-            .map_err(|e| anyhow!("Failed to discover primary key columns: {}", e))?;
+            .context("Failed to discover primary key columns")?;
 
         let pk_columns = rows
             .into_iter()

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -23,9 +23,10 @@ use risingwave_common::catalog::{ColumnDesc, ColumnId};
 use risingwave_common::types::{DataType, ScalarImpl, StructType};
 use sea_schema::postgres::def::{ColumnType as SeaType, TableDef, TableInfo};
 use sea_schema::postgres::discovery::SchemaDiscovery;
+use sea_schema::sea_query::{Alias, IntoIden};
 use serde_derive::Deserialize;
-use sqlx::PgPool;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use sqlx::{PgPool, Row};
 use thiserror_ext::AsReport;
 use tokio_postgres::types::Kind as PgKind;
 use tokio_postgres::{Client as PgClient, NoTls};
@@ -33,6 +34,17 @@ use tokio_postgres::{Client as PgClient, NoTls};
 #[cfg(not(madsim))]
 use super::maybe_tls_connector::MaybeMakeTlsConnector;
 use crate::error::ConnectorResult;
+
+/// SQL query to discover primary key columns directly from PostgreSQL system tables.
+/// This bypasses `information_schema.table_constraints` to avoid permission issues.
+const DISCOVER_PRIMARY_KEY_QUERY: &str = r#"
+    SELECT a.attname as column_name
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+    WHERE i.indrelid = ($1 || '.' || $2)::regclass 
+      AND i.indisprimary = true
+    ORDER BY array_position(i.indkey, a.attnum)
+"#;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -65,6 +77,81 @@ pub struct PostgresExternalTable {
 }
 
 impl PostgresExternalTable {
+    /// Discover primary key columns directly from PostgreSQL system tables.
+    /// This bypasses `information_schema.table_constraints` to avoid requiring table owner permissions.
+    async fn discover_primary_key(
+        connection: &PgPool,
+        schema_name: &str,
+        table_name: &str,
+    ) -> ConnectorResult<Vec<String>> {
+        let rows = sqlx::query(DISCOVER_PRIMARY_KEY_QUERY)
+            .bind(schema_name)
+            .bind(table_name)
+            .fetch_all(connection)
+            .await
+            .map_err(|e| anyhow!("Failed to discover primary key columns: {}", e))?;
+
+        let pk_columns = rows
+            .into_iter()
+            .map(|row| row.get::<String, _>("column_name"))
+            .collect();
+
+        Ok(pk_columns)
+    }
+
+    /// Discover schema with workaround for primary key discovery
+    /// This method uses direct PostgreSQL system table queries for primary keys
+    /// to avoid permission issues with `information_schema.table_constraints`
+    async fn discover_pk_and_full_columns(
+        username: &str,
+        password: &str,
+        host: &str,
+        port: u16,
+        database: &str,
+        schema: &str,
+        table: &str,
+        ssl_mode: &SslMode,
+        ssl_root_cert: &Option<String>,
+    ) -> ConnectorResult<(Vec<sea_schema::postgres::def::ColumnInfo>, Vec<String>)> {
+        let mut options = PgConnectOptions::new()
+            .username(username)
+            .password(password)
+            .host(host)
+            .port(port)
+            .database(database)
+            .ssl_mode(match ssl_mode {
+                SslMode::Disabled => PgSslMode::Disable,
+                SslMode::Preferred => PgSslMode::Prefer,
+                SslMode::Required => PgSslMode::Require,
+                SslMode::VerifyCa => PgSslMode::VerifyCa,
+                SslMode::VerifyFull => PgSslMode::VerifyFull,
+            });
+
+        if (*ssl_mode == SslMode::VerifyCa || *ssl_mode == SslMode::VerifyFull)
+            && let Some(root_cert) = ssl_root_cert
+        {
+            options = options.ssl_root_cert(root_cert.as_str());
+        }
+
+        let connection = PgPool::connect_with(options).await?;
+
+        // Use sea-schema only for column discovery (no permission issues)
+        let schema_discovery = SchemaDiscovery::new(connection.clone(), schema);
+        let empty_map: HashMap<String, Vec<String>> = HashMap::new();
+        let columns = schema_discovery
+            .discover_columns(
+                Alias::new(schema).into_iden(),
+                Alias::new(table).into_iden(),
+                &empty_map,
+            )
+            .await?;
+
+        // Use direct system table query for primary key discovery
+        let pk_columns = Self::discover_primary_key(&connection, schema, table).await?;
+
+        Ok((columns, pk_columns))
+    }
+
     async fn discover_schema(
         username: &str,
         password: &str,
@@ -125,7 +212,8 @@ impl PostgresExternalTable {
         is_append_only: bool,
     ) -> ConnectorResult<Self> {
         tracing::debug!("connect to postgres external table");
-        let table_schema = Self::discover_schema(
+
+        let (columns, pk_names) = Self::discover_pk_and_full_columns(
             username,
             password,
             host,
@@ -137,8 +225,9 @@ impl PostgresExternalTable {
             ssl_root_cert,
         )
         .await?;
+
         let mut column_descs = vec![];
-        for col in &table_schema.columns {
+        for col in &columns {
             let rw_data_type = sea_type_to_rw_type(&col.col_type)?;
             let column_desc = if let Some(ref default_expr) = col.default {
                 // parse the value of "column_default" field in information_schema.columns,
@@ -168,16 +257,13 @@ impl PostgresExternalTable {
             column_descs.push(column_desc);
         }
 
-        if !is_append_only && table_schema.primary_key_constraints.is_empty() {
+        // Check primary key existence using the directly discovered pk_names
+        if !is_append_only && pk_names.is_empty() {
             return Err(anyhow!(
                 "Postgres table should define the primary key for non-append-only tables"
             )
             .into());
         }
-        let mut pk_names = vec![];
-        table_schema.primary_key_constraints.iter().for_each(|pk| {
-            pk_names.extend(pk.columns.clone());
-        });
 
         Ok(Self {
             column_descs,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
If a user has already created a publication, we do not need to perform operations such as `creating publication` or `alter publication add tables`, and table owner permissions are not required. 
In the previous implementation, the primary key was retrieved using SeaORM, which required querying the `information_schema.table_constraints` table, but this table requires higher permissions. This PR changes the primary key retrieval step to query other system tables to avoid this issue.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
