### PR TITLE
refactor(optimizer): introduce `Upsert` stream kind & reject it in many cases

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -108,8 +108,9 @@ impl Source {
             if catalog.append_only {
                 StreamKind::AppendOnly
             } else {
-                // TODO(kind): some source can be upsert, differentiate them.
-                StreamKind::Retract
+                // Always treat source as upsert, as we either don't parse the old record for `Update`, or we don't
+                // trust the old record from external source.
+                StreamKind::Upsert
             }
         } else {
             // `Source` acts only as a barrier receiver. There's no data at all.

--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -108,7 +108,7 @@ impl Source {
             if catalog.append_only {
                 StreamKind::AppendOnly
             } else {
-                // TODO(kind): this could be upsert.
+                // TODO(kind): some source can be upsert, differentiate them.
                 StreamKind::Retract
             }
         } else {

--- a/src/frontend/src/optimizer/plan_node/logical_dedup.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_dedup.rs
@@ -120,7 +120,7 @@ impl ToStream for LogicalDedup {
                 Order::default(),
                 self.dedup_cols().to_vec(),
             );
-            Ok(StreamGroupTopN::new(logical_top_n, None).into())
+            Ok(StreamGroupTopN::new(logical_top_n, None)?.into())
         }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -956,7 +956,7 @@ impl LogicalJoin {
         // session variable `streaming_force_filter_inside_join` as it can save unnecessary
         // materialization of rows only to be filtered later.
 
-        let stream_hash_join = StreamHashJoin::new(core.clone(), predicate.clone());
+        let stream_hash_join = StreamHashJoin::new(core.clone(), predicate.clone())?;
 
         let force_filter_inside_join = self
             .base
@@ -982,7 +982,7 @@ impl LogicalJoin {
                 self.right().schema().len(),
             );
             core.on = eq_cond.eq_cond();
-            let hash_join = StreamHashJoin::new(core, eq_cond).into();
+            let hash_join = StreamHashJoin::new(core, eq_cond)?.into();
             let logical_filter = generic::Filter::new(predicate.non_eq_cond(), hash_join);
             let plan = StreamFilter::new(logical_filter).into();
             if self.output_indices() != &default_indices {
@@ -1243,11 +1243,7 @@ impl LogicalJoin {
 
         let new_predicate = new_predicate.retain_prefix_eq_key(lookup_prefix_len);
 
-        Ok(StreamTemporalJoin::new(
-            new_logical_join,
-            new_predicate,
-            false,
-        ))
+        StreamTemporalJoin::new(new_logical_join, new_predicate, false)
     }
 
     fn to_stream_nested_loop_temporal_join(
@@ -1300,7 +1296,7 @@ impl LogicalJoin {
             new_join_output_indices,
         );
 
-        Ok(StreamTemporalJoin::new(new_logical_join, new_predicate, true).into())
+        Ok(StreamTemporalJoin::new(new_logical_join, new_predicate, true)?.into())
     }
 
     fn to_stream_dynamic_filter(
@@ -1435,7 +1431,7 @@ impl LogicalJoin {
         let inequality_desc =
             Self::get_inequality_desc_from_predicate(predicate.other_cond().clone(), left_len)?;
 
-        Ok(StreamAsOfJoin::new(core, predicate, inequality_desc).into())
+        Ok(StreamAsOfJoin::new(core, predicate, inequality_desc)?.into())
     }
 
     /// Convert the logical join to a Hash join.

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1369,7 +1369,7 @@ impl LogicalJoin {
         );
 
         let core = DynamicFilter::new(comparator, left_ref.index, left, right);
-        let plan = StreamDynamicFilter::new(core).into();
+        let plan = StreamDynamicFilter::new(core)?.into();
         // TODO: `DynamicFilterExecutor` should support `output_indices` in `ChunkBuilder`
         if self
             .output_indices()

--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -729,7 +729,8 @@ impl ToStream for LogicalOverWindow {
                 RequiredDist::shard_by_key(stream_input.schema().len(), &partition_key_indices)
                     .streaming_enforce_if_not_satisfies(stream_input)?;
             let core = self.core.clone_with_input(new_input);
-            Ok(StreamOverWindow::new(core).into())
+
+            Ok(StreamOverWindow::new(core)?.into())
         }
     }
 

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -293,7 +293,7 @@ impl ToStream for LogicalProject {
                     new_input.clone(),
                     impure_exprs,
                     impure_field_names,
-                )
+                )?
                 .into();
 
                 let input_len = new_input.schema().len();

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -150,7 +150,7 @@ impl LogicalTopN {
             self.topn_order().clone(),
             vec![vnode_col_idx],
         );
-        let local_top_n = StreamGroupTopN::new(local_top_n, Some(vnode_col_idx));
+        let local_top_n = StreamGroupTopN::new(local_top_n, Some(vnode_col_idx))?;
 
         let exchange =
             RequiredDist::single().streaming_enforce_if_not_satisfies(local_top_n.into())?;
@@ -327,7 +327,7 @@ impl ToStream for LogicalTopN {
             let input = RequiredDist::hash_shard(self.group_key())
                 .streaming_enforce_if_not_satisfies(input)?;
             let core = self.core.clone_with_input(input);
-            StreamGroupTopN::new(core, None).into()
+            StreamGroupTopN::new(core, None)?.into()
         } else {
             self.gen_dist_stream_top_n_plan(self.input().to_stream(ctx)?)?
         })

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -127,7 +127,7 @@ impl LogicalTopN {
     fn gen_single_stream_top_n_plan(&self, stream_input: StreamPlanRef) -> Result<StreamPlanRef> {
         let input = RequiredDist::single().streaming_enforce_if_not_satisfies(stream_input)?;
         let core = self.core.clone_with_input(input);
-        Ok(StreamTopN::new(core).into())
+        Ok(StreamTopN::new(core)?.into())
     }
 
     fn gen_vnode_two_phase_stream_top_n_plan(
@@ -161,7 +161,7 @@ impl LogicalTopN {
             self.offset(),
             self.topn_order().clone(),
         );
-        let global_top_n = StreamTopN::new(global_top_n);
+        let global_top_n = StreamTopN::new(global_top_n)?;
 
         // use another projection to remove the column we added before.
         assert_eq!(vnode_col_idx, global_top_n.base.schema().len() - 1);

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -39,6 +39,7 @@ pub mod prelude {
     pub use super::super::Stream;
     pub use super::super::generic::{GenericPlanRef, PhysicalPlanRef};
     pub use super::StreamPlanNodeMetadata;
+    pub use crate::error::Result;
     pub use crate::optimizer::property::StreamKind;
     pub(crate) use crate::optimizer::property::reject_upsert_input;
 }

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -40,4 +40,5 @@ pub mod prelude {
     pub use super::super::generic::{GenericPlanRef, PhysicalPlanRef};
     pub use super::StreamPlanNodeMetadata;
     pub use crate::optimizer::property::StreamKind;
+    pub(crate) use crate::optimizer::property::reject_upsert_input;
 }

--- a/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_cdc_table_scan.rs
@@ -46,7 +46,7 @@ impl StreamCdcTableScan {
         let base = PlanBase::new_stream_with_core(
             &core,
             distribution,
-            StreamKind::Retract, // TODO(kind): could this be upsert?
+            StreamKind::Retract,
             false,
             core.watermark_columns(),
             core.columns_monotonicity(),

--- a/src/frontend/src/optimizer/plan_node/stream_dml.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dml.rs
@@ -38,11 +38,11 @@ impl StreamDml {
             input.stream_key().map(|v| v.to_vec()),
             input.functional_dependency().clone(),
             input.distribution().clone(),
-            if append_only {
+            input.stream_kind().merge(if append_only {
                 StreamKind::AppendOnly
             } else {
                 StreamKind::Retract
-            }, // TODO(kind): merge input stream kind
+            }),
             false,                   // TODO(rc): decide EOWC property
             WatermarkColumns::new(), // no watermark if dml is allowed
             MonotonicityMap::new(),  // TODO: derive monotonicity

--- a/src/frontend/src/optimizer/plan_node/stream_dml.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dml.rs
@@ -41,7 +41,9 @@ impl StreamDml {
             input.stream_kind().merge(if append_only {
                 StreamKind::AppendOnly
             } else {
-                StreamKind::Retract
+                // We cannot guarantee that there's no conflict on stream key between upstream
+                // source and DML input, so we must treat it as upsert here.
+                StreamKind::Upsert
             }),
             false,                   // TODO(rc): decide EOWC property
             WatermarkColumns::new(), // no watermark if dml is allowed

--- a/src/frontend/src/optimizer/plan_node/stream_dml.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dml.rs
@@ -31,6 +31,7 @@ pub struct StreamDml {
 }
 
 impl StreamDml {
+    // `append_only` indicates whether only `INSERT` is allowed.
     pub fn new(input: PlanRef, append_only: bool, column_descs: Vec<ColumnDesc>) -> Self {
         let base = PlanBase::new_stream(
             input.ctx(),
@@ -39,6 +40,9 @@ impl StreamDml {
             input.functional_dependency().clone(),
             input.distribution().clone(),
             input.stream_kind().merge(if append_only {
+                // For append-only table. Either there will be a `RowIdGen` following the `Dml` and `Union`,
+                // or there will be a `Materialize` with conflict handling enabled. In both cases there
+                // will be no key conflict, so we can treat the merged stream as append-only here.
                 StreamKind::AppendOnly
             } else {
                 // We cannot guarantee that there's no conflict on stream key between upstream

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -47,11 +47,10 @@ impl StreamDynamicFilter {
                 ExprType::LessThan | ExprType::LessThanOrEqual
             );
 
-        let out_kind = if condition_always_relax && core.left().append_only() {
-            StreamKind::AppendOnly
-        } else {
-            // TODO(kind): check if the impl can handle upsert stream.
-            StreamKind::Retract
+        let out_kind = match core.left().stream_kind() {
+            StreamKind::AppendOnly if condition_always_relax => StreamKind::AppendOnly,
+            StreamKind::AppendOnly | StreamKind::Retract => StreamKind::Retract,
+            StreamKind::Upsert => todo!(), /* TODO(kind): check if the impl can handle upsert stream. */
         };
 
         let base = PlanBase::new_stream_with_core(

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -39,7 +39,7 @@ pub struct StreamDynamicFilter {
 }
 
 impl StreamDynamicFilter {
-    pub fn new(core: DynamicFilter<PlanRef>) -> Self {
+    pub fn new(core: DynamicFilter<PlanRef>) -> Result<Self> {
         let right_non_decreasing = core.right().columns_monotonicity()[0].is_non_decreasing();
         let condition_always_relax = right_non_decreasing
             && matches!(
@@ -47,10 +47,12 @@ impl StreamDynamicFilter {
                 ExprType::LessThan | ExprType::LessThanOrEqual
             );
 
-        let out_kind = match core.left().stream_kind() {
+        // TODO(kind): theoretically, the impl can handle upsert stream.
+        let left_kind = reject_upsert_input!(core.left());
+        let out_kind = match left_kind {
             StreamKind::AppendOnly if condition_always_relax => StreamKind::AppendOnly,
             StreamKind::AppendOnly | StreamKind::Retract => StreamKind::Retract,
-            StreamKind::Upsert => todo!(), /* TODO(kind): check if the impl can handle upsert stream. */
+            StreamKind::Upsert => unreachable!(),
         };
 
         let base = PlanBase::new_stream_with_core(
@@ -62,11 +64,12 @@ impl StreamDynamicFilter {
             MonotonicityMap::new(), // TODO: derive monotonicity
         );
         let cleaned_by_watermark = Self::cleaned_by_watermark(&core);
-        Self {
+
+        Ok(Self {
             base,
             core,
             cleaned_by_watermark,
-        }
+        })
     }
 
     fn derive_watermark_columns(core: &DynamicFilter<PlanRef>) -> WatermarkColumns {
@@ -150,7 +153,7 @@ impl PlanTreeNodeBinary<Stream> for StreamDynamicFilter {
     }
 
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
-        Self::new(self.core.clone_with_left_right(left, right))
+        Self::new(self.core.clone_with_left_right(left, right)).unwrap()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -21,6 +21,7 @@ use super::utils::{Distill, plan_node_name, watermark_pretty};
 use super::{
     ExprRewritable, PlanBase, PlanTreeNodeUnary, StreamNode, StreamPlanRef as PlanRef, generic,
 };
+use crate::error::Result;
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::generic::GenericPlanNode;
 use crate::optimizer::property::{MonotonicityMap, Order};
@@ -36,9 +37,11 @@ pub struct StreamGroupTopN {
 }
 
 impl StreamGroupTopN {
-    pub fn new(core: generic::TopN<PlanRef>, vnode_col_idx: Option<usize>) -> Self {
+    pub fn new(core: generic::TopN<PlanRef>, vnode_col_idx: Option<usize>) -> Result<Self> {
         assert!(!core.group_key.is_empty());
         assert!(core.limit_attr.limit() > 0);
+        reject_upsert_input!(core.input);
+
         let input = &core.input;
 
         // FIXME(rc): Actually only watermark messages on the first group-by column are propagated
@@ -68,17 +71,18 @@ impl StreamGroupTopN {
             Some(stream_key),
             core.functional_dependency(),
             input.distribution().clone(),
-            StreamKind::Retract, // TODO(kind): reject upsert input
+            StreamKind::Retract,
             // TODO: https://github.com/risingwavelabs/risingwave/issues/8348
             false,
             watermark_columns,
             MonotonicityMap::new(), // TODO: derive monotonicity
         );
-        StreamGroupTopN {
+
+        Ok(StreamGroupTopN {
             base,
             core,
             vnode_col_idx,
-        }
+        })
     }
 
     pub fn limit_attr(&self) -> TopNLimit {
@@ -152,7 +156,7 @@ impl PlanTreeNodeUnary<Stream> for StreamGroupTopN {
     fn clone_with_input(&self, input: PlanRef) -> Self {
         let mut core = self.core.clone();
         core.input = input;
-        Self::new(core, self.vnode_col_idx)
+        Self::new(core, self.vnode_col_idx).unwrap()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -99,7 +99,6 @@ impl StreamHashAgg {
                 // in EOWC mode, we produce append only output
                 StreamKind::AppendOnly
             } else {
-                // TODO(kind): reject upsert input
                 StreamKind::Retract
             },
             emit_on_window_close,

--- a/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_approx_percentile.rs
@@ -19,6 +19,7 @@ use risingwave_pb::stream_plan::LocalApproxPercentileNode;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::StreamPlanRef as PlanRef;
+use crate::error::Result;
 use crate::expr::{ExprRewriter, ExprVisitor, InputRef, InputRefDisplay, Literal};
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::generic::{GenericPlanRef, PhysicalPlanRef};
@@ -27,7 +28,7 @@ use crate::optimizer::plan_node::utils::{Distill, childless_record, watermark_pr
 use crate::optimizer::plan_node::{
     ExprRewritable, PlanAggCall, PlanBase, PlanTreeNodeUnary, Stream, StreamNode,
 };
-use crate::optimizer::property::{FunctionalDependencySet, WatermarkColumns};
+use crate::optimizer::property::{FunctionalDependencySet, WatermarkColumns, reject_upsert_input};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
 // Does not contain `core` because no other plan nodes share
@@ -42,7 +43,7 @@ pub struct StreamLocalApproxPercentile {
 }
 
 impl StreamLocalApproxPercentile {
-    pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Self {
+    pub fn new(input: PlanRef, approx_percentile_agg_call: &PlanAggCall) -> Result<Self> {
         let schema = Schema::new(vec![
             Field::with_name(DataType::Int16, "sign"),
             Field::with_name(DataType::Int32, "bucket_id"),
@@ -57,18 +58,18 @@ impl StreamLocalApproxPercentile {
             input.stream_key().map(|k| k.to_vec()),
             functional_dependency,
             input.distribution().clone(),
-            input.stream_kind(), // TODO(kind): reject upsert input
+            reject_upsert_input!(input),
             input.emit_on_window_close(),
             watermark_columns,
             input.columns_monotonicity().clone(),
         );
-        Self {
+        Ok(Self {
             base,
             input,
             quantile: approx_percentile_agg_call.direct_args[0].clone(),
             relative_error: approx_percentile_agg_call.direct_args[1].clone(),
             percentile_col: approx_percentile_agg_call.inputs[0].clone(),
-        }
+        })
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -56,7 +56,9 @@ pub struct StreamMaterialize {
 impl StreamMaterialize {
     pub fn new(input: PlanRef, table: TableCatalog) -> Result<Self> {
         let kind = match table.conflict_behavior() {
-            ConflictBehavior::NoCheck => reject_upsert_input!(input),
+            ConflictBehavior::NoCheck => {
+                reject_upsert_input!(input, "Materialize without conflict handling")
+            }
 
             // When conflict handling is enabled, upsert stream can be converted to retract stream.
             ConflictBehavior::Overwrite

--- a/src/frontend/src/optimizer/plan_node/stream_materialized_exprs.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialized_exprs.rs
@@ -114,7 +114,8 @@ impl StreamMaterializedExprs {
             input.stream_key().map(|v| v.to_vec()),
             fd_set,
             input.distribution().clone(),
-            // TODO(kind): theoretically, the impl can handle upsert stream.
+            // Note: even though we persist the evaluation results, there are still passthrough columns.
+            // We still cannot handle upsert input.
             reject_upsert_input!(input),
             input.emit_on_window_close(),
             input.watermark_columns().clone(),

--- a/src/frontend/src/optimizer/plan_node/stream_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_over_window.rs
@@ -35,8 +35,9 @@ pub struct StreamOverWindow {
 }
 
 impl StreamOverWindow {
-    pub fn new(core: generic::OverWindow<PlanRef>) -> Self {
+    pub fn new(core: generic::OverWindow<PlanRef>) -> Result<Self> {
         assert!(core.funcs_have_same_partition_and_order());
+        reject_upsert_input!(core.input);
 
         let input = &core.input;
         let watermark_columns = WatermarkColumns::new();
@@ -44,13 +45,13 @@ impl StreamOverWindow {
         let base = PlanBase::new_stream_with_core(
             &core,
             input.distribution().clone(),
-            // TODO(kind): reject upsert input
             StreamKind::Retract, // general over window cannot be append-only
             false,
             watermark_columns,
             MonotonicityMap::new(), // TODO: derive monotonicity
         );
-        StreamOverWindow { base, core }
+
+        Ok(StreamOverWindow { base, core })
     }
 
     fn infer_state_table(&self) -> TableCatalog {
@@ -94,7 +95,7 @@ impl PlanTreeNodeUnary<Stream> for StreamOverWindow {
     fn clone_with_input(&self, input: PlanRef) -> Self {
         let mut core = self.core.clone();
         core.input = input;
-        Self::new(core)
+        Self::new(core).unwrap()
     }
 }
 impl_plan_tree_node_for_unary! { Stream, StreamOverWindow }

--- a/src/frontend/src/optimizer/plan_node/stream_row_merge.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_row_merge.rs
@@ -28,7 +28,7 @@ use crate::optimizer::plan_node::utils::{Distill, childless_record};
 use crate::optimizer::plan_node::{
     ExprRewritable, PlanBase, PlanTreeNodeBinary, Stream, StreamNode, StreamPlanRef as PlanRef,
 };
-use crate::optimizer::property::{FunctionalDependencySet, WatermarkColumns};
+use crate::optimizer::property::{FunctionalDependencySet, WatermarkColumns, reject_upsert_input};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
 /// `StreamRowMerge` is used for merging two streams with the same stream key and distribution.
@@ -87,7 +87,7 @@ impl StreamRowMerge {
             lhs_input.stream_key().map(|k| k.to_vec()),
             functional_dependency,
             lhs_input.distribution().clone(),
-            lhs_input.stream_kind(), // TODO(kind): reject upsert input
+            reject_upsert_input!(lhs_input),
             lhs_input.emit_on_window_close(),
             watermark_columns,
             lhs_input.columns_monotonicity().clone(),

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -43,8 +43,9 @@ impl StreamSimpleAgg {
         core: generic::Agg<PlanRef>,
         row_count_idx: usize,
         must_output_per_barrier: bool,
-    ) -> Self {
+    ) -> Result<Self> {
         assert_eq!(core.agg_calls[row_count_idx], PlanAggCall::count_star());
+        reject_upsert_input!(core.input);
 
         let input = core.input.clone();
         let input_dist = input.distribution();
@@ -60,17 +61,18 @@ impl StreamSimpleAgg {
         let base = PlanBase::new_stream_with_core(
             &core,
             dist,
-            StreamKind::Retract, // TODO(kind): reject upsert input
+            StreamKind::Retract,
             false,
             watermark_columns,
             MonotonicityMap::new(),
         );
-        StreamSimpleAgg {
+
+        Ok(StreamSimpleAgg {
             base,
             core,
             row_count_idx,
             must_output_per_barrier,
-        }
+        })
     }
 
     pub fn agg_calls(&self) -> &[PlanAggCall] {
@@ -101,7 +103,7 @@ impl PlanTreeNodeUnary<Stream> for StreamSimpleAgg {
             input,
             ..self.core.clone()
         };
-        Self::new(logical, self.row_count_idx, self.must_output_per_barrier)
+        Self::new(logical, self.row_count_idx, self.must_output_per_barrier).unwrap()
     }
 }
 impl_plan_tree_node_for_unary! { Stream, StreamSimpleAgg }
@@ -155,7 +157,9 @@ impl ExprRewritable<Stream> for StreamSimpleAgg {
     fn rewrite_exprs(&self, r: &mut dyn ExprRewriter) -> PlanRef {
         let mut core = self.core.clone();
         core.rewrite_exprs(r);
-        Self::new(core, self.row_count_idx, self.must_output_per_barrier).into()
+        Self::new(core, self.row_count_idx, self.must_output_per_barrier)
+            .unwrap()
+            .into()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -175,6 +175,15 @@ impl StreamSink {
     pub fn new(input: PlanRef, sink_desc: SinkDesc, log_store_type: SinkLogStoreType) -> Self {
         let base = input.plan_base().clone_with_new_plan_id();
 
+        if let SinkType::AppendOnly = sink_desc.sink_type {
+            let kind = input.stream_kind();
+            assert_matches!(
+                kind,
+                StreamKind::AppendOnly,
+                "{kind} stream cannot be used as input of append-only sink",
+            );
+        }
+
         Self {
             base,
             input,

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -52,7 +52,7 @@ impl StreamTemporalJoin {
         is_nested_loop: bool,
     ) -> Result<Self> {
         assert!(core.join_type == JoinType::Inner || core.join_type == JoinType::LeftOuter);
-        // TODO(kind): theoretically, even if input is upsert, the output can be retract
+        // TODO(kind): theoretically, the impl can handle upsert stream.
         let stream_kind = reject_upsert_input!(core.left);
         let append_only = stream_kind.is_append_only();
         assert!(!is_nested_loop || append_only);

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -50,11 +50,10 @@ impl StreamTemporalJoin {
         core: generic::Join<PlanRef>,
         eq_join_predicate: EqJoinPredicate,
         is_nested_loop: bool,
-    ) -> Self {
+    ) -> Result<Self> {
         assert!(core.join_type == JoinType::Inner || core.join_type == JoinType::LeftOuter);
-        // TODO(kind): reject upsert input
         // TODO(kind): theoretically, even if input is upsert, the output can be retract
-        let stream_kind = core.left.stream_kind();
+        let stream_kind = reject_upsert_input!(core.left);
         let append_only = stream_kind.is_append_only();
         assert!(!is_nested_loop || append_only);
 
@@ -102,13 +101,13 @@ impl StreamTemporalJoin {
             columns_monotonicity,
         );
 
-        Self {
+        Ok(Self {
             base,
             core,
             eq_join_predicate,
             append_only,
             is_nested_loop,
-        }
+        })
     }
 
     /// Get join type
@@ -221,7 +220,7 @@ impl PlanTreeNodeBinary<Stream> for StreamTemporalJoin {
         let mut core = self.core.clone();
         core.left = left;
         core.right = right;
-        Self::new(core, self.eq_join_predicate.clone(), self.is_nested_loop)
+        Self::new(core, self.eq_join_predicate.clone(), self.is_nested_loop).unwrap()
     }
 }
 
@@ -287,6 +286,7 @@ impl ExprRewritable<Stream> for StreamTemporalJoin {
             self.eq_join_predicate.rewrite_exprs(r),
             self.is_nested_loop,
         )
+        .unwrap()
         .into()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -35,22 +35,24 @@ pub struct StreamTopN {
 }
 
 impl StreamTopN {
-    pub fn new(core: generic::TopN<PlanRef>) -> Self {
+    pub fn new(core: generic::TopN<PlanRef>) -> Result<Self> {
         assert!(core.group_key.is_empty());
         assert!(core.limit_attr.limit() > 0);
         let input = &core.input;
         assert_matches!(input.distribution(), Distribution::Single);
+        reject_upsert_input!(input);
         let watermark_columns = WatermarkColumns::new();
 
         let base = PlanBase::new_stream_with_core(
             &core,
             Distribution::Single,
-            StreamKind::Retract, // TODO(kind): reject upsert input
+            StreamKind::Retract,
             false,
             watermark_columns,
             MonotonicityMap::new(),
         );
-        StreamTopN { base, core }
+
+        Ok(StreamTopN { base, core })
     }
 
     pub fn limit_attr(&self) -> TopNLimit {
@@ -83,7 +85,7 @@ impl PlanTreeNodeUnary<Stream> for StreamTopN {
     fn clone_with_input(&self, input: PlanRef) -> Self {
         let mut core = self.core.clone();
         core.input = input;
-        Self::new(core)
+        Self::new(core).unwrap()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -48,6 +48,7 @@ impl StreamUnion {
             core.all,
             "After UnionToDistinctRule, union should become union all"
         );
+        assert!(core.source_col.is_some());
 
         let inputs = &core.inputs;
         let ctx = core.ctx();
@@ -72,6 +73,9 @@ impl StreamUnion {
         let base = PlanBase::new_stream_with_core(
             &core,
             dist,
+            // There's no handling on key conflict in executor implementation. However, we guarantee
+            // that there's a `source_col` as a part of stream key, indicating which input the row
+            // comes from. As a result, there's in fact no key conflict and we can safely call `merge`.
             (inputs.iter().map(|i| i.stream_kind()))
                 .reduce(StreamKind::merge)
                 .unwrap_or(/* empty inputs */ StreamKind::AppendOnly),

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -48,6 +48,7 @@ impl StreamUnion {
             core.all,
             "After UnionToDistinctRule, union should become union all"
         );
+        assert!(!core.inputs.is_empty());
 
         let inputs = &core.inputs;
         let ctx = core.ctx();
@@ -69,10 +70,7 @@ impl StreamUnion {
             watermark_columns.insert(idx, ctx.next_watermark_group_id());
         }
 
-        let kind = if inputs.is_empty() {
-            // No data. Can be interpreted as append-only.
-            StreamKind::AppendOnly
-        } else if core.source_col.is_some() {
+        let kind = if core.source_col.is_some() {
             // There's no handling on key conflict in executor implementation. However, in most cases
             // there's a `source_col` as a part of stream key, indicating which input the row comes from,
             // there won't be actual key conflict and we can safely call `merge`.

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -84,8 +84,9 @@ impl StreamUnion {
                 // Single input. Follow the input's kind.
                 inputs[0].stream_kind()
             } else if inputs.iter().all(|x| x.stream_kind().is_append_only()) {
-                // Special case for append-only table. There must be a `RowIdGen` following the `Union`,
-                // we can treat the merged stream as append-only here.
+                // Special case for append-only table. Either there will be a `RowIdGen` following the `Union`,
+                // or there will be a `Materialize` with conflict handling enabled. In both cases there
+                // will be no key conflict, so we can treat the merged stream as append-only here.
                 StreamKind::AppendOnly
             } else {
                 // Otherwise we must treat it as upsert.

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -72,12 +72,9 @@ impl StreamUnion {
         let base = PlanBase::new_stream_with_core(
             &core,
             dist,
-            if inputs.iter().all(|x| x.append_only()) {
-                StreamKind::AppendOnly
-            } else {
-                // TODO(kind): handle `StreamKind::Upsert`
-                StreamKind::Retract
-            },
+            (inputs.iter().map(|i| i.stream_kind()))
+                .reduce(StreamKind::merge)
+                .unwrap_or(/* empty inputs */ StreamKind::AppendOnly),
             inputs.iter().all(|x| x.emit_on_window_close()),
             watermark_columns,
             MonotonicityMap::new(),

--- a/src/frontend/src/optimizer/property/stream_kind.rs
+++ b/src/frontend/src/optimizer/property/stream_kind.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+
 /// The kind of the changelog stream output by a stream operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum StreamKind {
@@ -33,6 +35,20 @@ pub enum StreamKind {
     /// Stateful operators typically can not process such streams correctly. It must be converted
     /// to `Retract` before being sent to stateful operators in this case.
     Upsert,
+}
+
+impl Display for StreamKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::AppendOnly => "append-only",
+                Self::Retract => "retract",
+                Self::Upsert => "upsert",
+            }
+        )
+    }
 }
 
 impl StreamKind {

--- a/src/frontend/src/optimizer/property/stream_kind.rs
+++ b/src/frontend/src/optimizer/property/stream_kind.rs
@@ -30,7 +30,7 @@ pub enum StreamKind {
     /// When a row is going to be deleted, an incomplete `Delete` record may be emitted, where
     /// only the primary key columns are guaranteed to be set.
     ///
-    /// Stateful operators typically can not process such streams correctly. It will be converted
+    /// Stateful operators typically can not process such streams correctly. It must be converted
     /// to `Retract` before being sent to stateful operators in this case.
     Upsert,
 }

--- a/src/frontend/src/optimizer/property/stream_kind.rs
+++ b/src/frontend/src/optimizer/property/stream_kind.rs
@@ -50,17 +50,26 @@ impl StreamKind {
 /// Reject upsert stream as input.
 macro_rules! reject_upsert_input {
     ($input:expr) => {
-        if let StreamKind::Upsert = $input.stream_kind() {
-            return Err(::anyhow::anyhow!(
+        reject_upsert_input!(
+            $input,
+            std::any::type_name::<Self>().split("::").last().unwrap()
+        )
+    };
+
+    ($input:expr, $curr:expr) => {{
+        use crate::optimizer::property::StreamKind;
+        let kind = $input.stream_kind();
+        if let StreamKind::Upsert = kind {
+            risingwave_common::bail!(
                 "{} yields upsert stream, which is not supported as input of {}",
                 std::any::type_name_of_val(&$input)
                     .split("::")
                     .last()
                     .unwrap(),
-                std::any::type_name::<Self>().split("::").last().unwrap(),
-            )
-            .into());
+                $curr,
+            );
         }
-    };
+        kind
+    }};
 }
 pub(crate) use reject_upsert_input;

--- a/src/frontend/src/optimizer/property/stream_kind.rs
+++ b/src/frontend/src/optimizer/property/stream_kind.rs
@@ -42,6 +42,9 @@ impl StreamKind {
     }
 
     /// Returns the stream kind representing the merge (union) of the two.
+    ///
+    /// Note that there should be no conflict on the stream key between the two streams,
+    /// otherwise it will result in an "inconsistent" stream.
     pub fn merge(self, other: Self) -> Self {
         self.max(other)
     }

--- a/src/frontend/src/optimizer/property/stream_kind.rs
+++ b/src/frontend/src/optimizer/property/stream_kind.rs
@@ -76,16 +76,15 @@ macro_rules! reject_upsert_input {
     };
 
     ($input:expr, $curr:expr) => {{
+        use crate::optimizer::plan_node::Explain;
         use crate::optimizer::property::StreamKind;
+
         let kind = $input.stream_kind();
         if let StreamKind::Upsert = kind {
             risingwave_common::bail!(
-                "{} yields upsert stream, which is not supported as input of {}",
-                std::any::type_name_of_val(&$input)
-                    .split("::")
-                    .last()
-                    .unwrap(),
+                "upsert stream is not supported as input of {}, plan:\n{}",
                 $curr,
+                $input.explain_to_string()
             );
         }
         kind

--- a/src/frontend/src/optimizer/rule/stream/separate_consecutive_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/stream/separate_consecutive_join_rule.rs
@@ -43,7 +43,11 @@ impl Rule<Stream> for SeparateConsecutiveJoinRule {
             join.join_type(),
             join.eq_join_predicate().all_cond(),
         );
-        Some(StreamHashJoin::new(core, join.eq_join_predicate().clone()).into())
+        Some(
+            StreamHashJoin::new(core, join.eq_join_predicate().clone())
+                .unwrap()
+                .into(),
+        )
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Motivation: #22799.

Following #22798, this PR introduces `Upsert` stream kind and reject it in many cases when an operator does not support processing `Upsert` stream as input.

For now, the only source of `Upsert` stream is the `Source` operator for sources that are not append-only. However, since users are not allowed to create bare upsert `SOURCE` currently, but always materializing them with a `TABLE`, there's still no hit for the rejection path.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
