### PR TITLE
feat(dashboard): support querying historical backpressure

### DIFF
--- a/dashboard/components/TimeControls.tsx
+++ b/dashboard/components/TimeControls.tsx
@@ -27,6 +27,7 @@ import {
 } from "@chakra-ui/react"
 import { useState } from "react"
 import {
+  getCurrentTimeInSystemTimezone,
   parseDuration,
   parseTimestampToUnixEpoch,
 } from "../lib/utils/timeUtils"
@@ -54,7 +55,7 @@ export default function TimeControls({
     // Parse timestamp if provided
     if (timestampInput.trim()) {
       try {
-        timestamp = parseTimestampToUnixEpoch(timestampInput, "UTC")
+        timestamp = parseTimestampToUnixEpoch(timestampInput)
         setDisplayTimestamp(new Date(timestamp * 1000).toISOString())
         setTimestampError("")
       } catch (error) {
@@ -99,11 +100,11 @@ export default function TimeControls({
       </Text>
       <VStack spacing={3} align="stretch">
         <FormControl isInvalid={!!timestampError}>
-          <FormLabel fontSize="sm">Timestamp (ISO format)</FormLabel>
+          <FormLabel fontSize="sm">Timestamp (system timezone)</FormLabel>
           <HStack spacing={2}>
             <Input
               size="sm"
-              placeholder="2024-01-15T10:30:00Z"
+              placeholder="2024-01-15T10:30:00 (system timezone)"
               value={timestampInput}
               onChange={(e) => setTimestampInput(e.target.value)}
             />
@@ -111,7 +112,7 @@ export default function TimeControls({
               size="sm"
               variant="outline"
               onClick={() => {
-                const now = new Date().toISOString()
+                const now = getCurrentTimeInSystemTimezone()
                 setTimestampInput(now)
                 setTimestampError("")
               }}

--- a/dashboard/components/TimeControls.tsx
+++ b/dashboard/components/TimeControls.tsx
@@ -100,12 +100,25 @@ export default function TimeControls({
       <VStack spacing={3} align="stretch">
         <FormControl isInvalid={!!timestampError}>
           <FormLabel fontSize="sm">Timestamp (ISO format)</FormLabel>
-          <Input
-            size="sm"
-            placeholder="2024-01-15T10:30:00Z"
-            value={timestampInput}
-            onChange={(e) => setTimestampInput(e.target.value)}
-          />
+          <HStack spacing={2}>
+            <Input
+              size="sm"
+              placeholder="2024-01-15T10:30:00Z"
+              value={timestampInput}
+              onChange={(e) => setTimestampInput(e.target.value)}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                const now = new Date().toISOString()
+                setTimestampInput(now)
+                setTimestampError("")
+              }}
+            >
+              Now
+            </Button>
+          </HStack>
           {timestampError && (
             <Text fontSize="xs" color="red.500">
               {timestampError}

--- a/dashboard/components/TimeControls.tsx
+++ b/dashboard/components/TimeControls.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  HStack,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import { useState } from "react"
+import {
+  parseDuration,
+  parseTimestampToUnixEpoch,
+} from "../lib/utils/timeUtils"
+
+interface TimeControlsProps {
+  onApply: (timestamp?: number, offset?: number) => void
+  title?: string
+}
+
+export default function TimeControls({
+  onApply,
+  title = "Time Controls",
+}: TimeControlsProps) {
+  const [timestampInput, setTimestampInput] = useState("")
+  const [offsetInput, setOffsetInput] = useState("")
+  const [displayTimestamp, setDisplayTimestamp] = useState<string>("")
+  const [displayOffset, setDisplayOffset] = useState<string>("")
+  const [timestampError, setTimestampError] = useState<string>("")
+  const [offsetError, setOffsetError] = useState<string>("")
+
+  const handleApply = () => {
+    let timestamp: number | undefined
+    let offset: number | undefined
+
+    // Parse timestamp if provided
+    if (timestampInput.trim()) {
+      try {
+        timestamp = parseTimestampToUnixEpoch(timestampInput, "UTC")
+        setDisplayTimestamp(new Date(timestamp * 1000).toISOString())
+        setTimestampError("")
+      } catch (error) {
+        setTimestampError("Invalid timestamp format")
+        return
+      }
+    } else {
+      setDisplayTimestamp("")
+    }
+
+    // Parse offset if provided
+    if (offsetInput.trim()) {
+      try {
+        offset = parseDuration(offsetInput)
+        setDisplayOffset(offsetInput)
+        setOffsetError("")
+      } catch (error) {
+        setOffsetError("Invalid offset format (use: 30s, 5m, 2h, 1d)")
+        return
+      }
+    } else {
+      setDisplayOffset("")
+    }
+
+    onApply(timestamp, offset)
+  }
+
+  const handleReset = () => {
+    setTimestampInput("")
+    setOffsetInput("")
+    setDisplayTimestamp("")
+    setDisplayOffset("")
+    setTimestampError("")
+    setOffsetError("")
+    onApply(undefined, undefined)
+  }
+
+  return (
+    <Box>
+      <Text fontWeight="semibold" mb={3}>
+        {title}
+      </Text>
+      <VStack spacing={3} align="stretch">
+        <FormControl isInvalid={!!timestampError}>
+          <FormLabel fontSize="sm">Timestamp (ISO format)</FormLabel>
+          <Input
+            size="sm"
+            placeholder="2024-01-15T10:30:00Z"
+            value={timestampInput}
+            onChange={(e) => setTimestampInput(e.target.value)}
+          />
+          {timestampError && (
+            <Text fontSize="xs" color="red.500">
+              {timestampError}
+            </Text>
+          )}
+        </FormControl>
+
+        <FormControl isInvalid={!!offsetError}>
+          <FormLabel fontSize="sm">Offset</FormLabel>
+          <Input
+            size="sm"
+            placeholder="1h, 30m, 2d"
+            value={offsetInput}
+            onChange={(e) => setOffsetInput(e.target.value)}
+          />
+          {offsetError && (
+            <Text fontSize="xs" color="red.500">
+              {offsetError}
+            </Text>
+          )}
+        </FormControl>
+
+        <HStack spacing={2}>
+          <Button size="sm" colorScheme="blue" onClick={handleApply}>
+            Apply
+          </Button>
+          <Button size="sm" variant="outline" onClick={handleReset}>
+            Reset
+          </Button>
+        </HStack>
+
+        {(displayTimestamp || displayOffset) && (
+          <Box p={2} bg="gray.50" borderRadius="md">
+            <Text fontSize="xs" fontWeight="medium" mb={1}>
+              Applied Settings:
+            </Text>
+            {displayTimestamp && (
+              <Text fontSize="xs" color="gray.600">
+                Timestamp: {displayTimestamp}
+              </Text>
+            )}
+            {displayOffset && (
+              <Text fontSize="xs" color="gray.600">
+                Offset: {displayOffset}
+              </Text>
+            )}
+          </Box>
+        )}
+      </VStack>
+    </Box>
+  )
+}

--- a/dashboard/lib/api/streamingStats.ts
+++ b/dashboard/lib/api/streamingStats.ts
@@ -41,14 +41,32 @@ export interface StreamingStatsCallbacks {
   ) => void
 }
 
+export interface TimeParams {
+  at?: number // Unix timestamp in seconds
+  timeOffset?: number // Time offset in seconds
+}
+
 export function createStreamingStatsRefresh(
   callbacks: StreamingStatsCallbacks,
   initialSnapshot: ChannelStatsSnapshot | undefined,
-  statsType: StatsType
+  statsType: StatsType,
+  timeParams?: TimeParams
 ) {
   return function refresh() {
+    // Build query parameters for time-based requests
+    const queryParams = new URLSearchParams()
+    if (timeParams?.at) {
+      queryParams.append("at", timeParams.at.toString())
+    }
+    if (timeParams?.timeOffset) {
+      queryParams.append("time_offset", timeParams.timeOffset.toString())
+    }
+
+    const queryString = queryParams.toString()
+    const urlSuffix = queryString ? `?${queryString}` : ""
+
     // Try Prometheus first, fall back to embedded if it fails
-    api.get("/metrics/streaming_stats_prometheus").then(
+    api.get(`/metrics/streaming_stats_prometheus${urlSuffix}`).then(
       (res) => {
         let response = GetStreamingPrometheusStatsResponse.fromJSON(res)
         const result = new Map<string, ChannelDeltaStats>()
@@ -83,7 +101,7 @@ export function createStreamingStatsRefresh(
           e
         )
         // Fall back to embedded dashboard
-        api.get("/metrics/streaming_stats").then(
+        api.get(`/metrics/streaming_stats${urlSuffix}`).then(
           (res) => {
             let response = GetStreamingStatsResponse.fromJSON(res)
             let snapshot = new ChannelStatsSnapshot(

--- a/dashboard/lib/utils/timeUtils.ts
+++ b/dashboard/lib/utils/timeUtils.ts
@@ -48,7 +48,7 @@ export function parseDuration(durationStr: string): number {
  */
 export function parseTimestampToUnixEpoch(
   timestamp: string,
-  timezone: string
+  timezone: string = Intl.DateTimeFormat().resolvedOptions().timeZone
 ): number {
   try {
     // Create a date object from the timestamp string
@@ -63,6 +63,42 @@ export function parseTimestampToUnixEpoch(
   } catch (error) {
     throw new Error("Invalid timestamp format")
   }
+}
+
+/**
+ * Get current time in system timezone as ISO string
+ */
+export function getCurrentTimeInSystemTimezone(): string {
+  const now = new Date()
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  // Format the date in the system timezone
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone: timeZone,
+    hour12: false,
+  })
+
+  const formatted = formatter.formatToParts(now)
+  const datePart =
+    formatted.find((part) => part.type === "year")?.value +
+    "-" +
+    formatted.find((part) => part.type === "month")?.value +
+    "-" +
+    formatted.find((part) => part.type === "day")?.value
+  const timePart =
+    formatted.find((part) => part.type === "hour")?.value +
+    ":" +
+    formatted.find((part) => part.type === "minute")?.value +
+    ":" +
+    formatted.find((part) => part.type === "second")?.value
+
+  return `${datePart}T${timePart}`
 }
 
 /**

--- a/dashboard/lib/utils/timeUtils.ts
+++ b/dashboard/lib/utils/timeUtils.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Parse a duration string (e.g., "1h", "30m", "2d") and return the duration in seconds
+ */
+export function parseDuration(durationStr: string): number {
+  const match = durationStr.match(/^(\d+)([smhd])$/)
+  if (!match) {
+    throw new Error(
+      'Invalid duration format. Use format like "30s", "5m", "2h", "1d"'
+    )
+  }
+
+  const value = parseInt(match[1])
+  const unit = match[2]
+
+  switch (unit) {
+    case "s":
+      return value
+    case "m":
+      return value * 60
+    case "h":
+      return value * 60 * 60
+    case "d":
+      return value * 60 * 60 * 24
+    default:
+      throw new Error("Invalid time unit. Use s, m, h, or d")
+  }
+}
+
+/**
+ * Convert a timestamp and timezone to unix epoch time in seconds
+ */
+export function parseTimestampToUnixEpoch(
+  timestamp: string,
+  timezone: string
+): number {
+  try {
+    // Create a date object from the timestamp string
+    const date = new Date(timestamp)
+
+    if (isNaN(date.getTime())) {
+      throw new Error("Invalid timestamp format")
+    }
+
+    // Convert to unix epoch time (seconds)
+    return Math.floor(date.getTime() / 1000)
+  } catch (error) {
+    throw new Error("Invalid timestamp format")
+  }
+}
+
+/**
+ * Format a unix epoch time to a readable string
+ */
+export function formatUnixEpoch(unixEpoch: number): string {
+  return new Date(unixEpoch * 1000).toISOString()
+}

--- a/dashboard/pages/fragment_graph.tsx
+++ b/dashboard/pages/fragment_graph.tsx
@@ -40,6 +40,7 @@ import { parseAsInteger, useQueryState } from "nuqs"
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react"
 import FragmentDependencyGraph from "../components/FragmentDependencyGraph"
 import FragmentGraph from "../components/FragmentGraph"
+import TimeControls from "../components/TimeControls"
 import Title from "../components/Title"
 import useErrorToast from "../hook/useErrorToast"
 import useFetch from "../lib/api/fetch"
@@ -48,7 +49,10 @@ import {
   getRelationIdInfos,
   getStreamingJobs,
 } from "../lib/api/streaming"
-import { createStreamingStatsRefresh } from "../lib/api/streamingStats"
+import {
+  TimeParams,
+  createStreamingStatsRefresh,
+} from "../lib/api/streamingStats"
 import { FragmentBox } from "../lib/layout"
 import { TableFragments, TableFragments_Fragment } from "../proto/gen/meta"
 import {
@@ -337,6 +341,9 @@ export default function Streaming() {
     [key: number]: FragmentStats
   }>()
 
+  // Time parameters state
+  const [timeParams, setTimeParams] = useState<TimeParams>()
+
   useEffect(() => {
     let initialSnapshot: ChannelStatsSnapshot | undefined
 
@@ -347,7 +354,8 @@ export default function Streaming() {
         toast,
       },
       initialSnapshot,
-      "fragment"
+      "fragment",
+      timeParams
     )
 
     refresh() // run once immediately
@@ -355,7 +363,14 @@ export default function Streaming() {
     return () => {
       clearInterval(interval)
     }
-  }, [toast])
+  }, [toast, timeParams])
+
+  const handleTimeParamsChange = (timestamp?: number, offset?: number) => {
+    setTimeParams({
+      at: timestamp,
+      timeOffset: offset,
+    })
+  }
 
   const retVal = (
     <Flex p={3} height="calc(100vh - 20px)" flexDirection="column">
@@ -368,6 +383,7 @@ export default function Streaming() {
           width={SIDEBAR_WIDTH}
           height="full"
         >
+          <TimeControls onApply={handleTimeParamsChange} />
           <FormControl>
             <FormLabel>Streaming Jobs</FormLabel>
             <Input

--- a/dashboard/pages/relation_graph.tsx
+++ b/dashboard/pages/relation_graph.tsx
@@ -72,14 +72,6 @@ export default function StreamingGraph() {
   const { response: relationDeps } = useFetch(getRelationDependencies)
   const [selectedId, setSelectedId] = useQueryState("id", parseAsInteger)
   const { response: fragmentToRelationMap } = useFetch(getFragmentToRelationMap)
-  const [resetEmbeddedBackPressures, setResetEmbeddedBackPressures] =
-    useState<boolean>(false)
-
-  const toggleResetEmbeddedBackPressures = () => {
-    setResetEmbeddedBackPressures(
-      (resetEmbeddedBackPressures) => !resetEmbeddedBackPressures
-    )
-  }
 
   const toast = useErrorToast()
 
@@ -103,11 +95,6 @@ export default function StreamingGraph() {
   useEffect(() => {
     let initialSnapshot: ChannelStatsSnapshot | undefined
 
-    if (resetEmbeddedBackPressures) {
-      setChannelStats(undefined)
-      toggleResetEmbeddedBackPressures()
-    }
-
     const refresh = createStreamingStatsRefresh(
       {
         setChannelStats,
@@ -123,7 +110,7 @@ export default function StreamingGraph() {
     return () => {
       clearInterval(interval)
     }
-  }, [toast, resetEmbeddedBackPressures])
+  }, [toast])
 
   // Convert fragment-level backpressure rate map to relation-level backpressure rate
   const relationChannelStats: Map<string, ChannelDeltaStats> | undefined =
@@ -162,10 +149,6 @@ export default function StreamingGraph() {
         >
           <Box flex={1} overflowY="scroll">
             <VStack width={SIDEBAR_WIDTH} align="start" spacing={1}>
-              <Button onClick={(_) => toggleResetEmbeddedBackPressures()}>
-                Reset Back Pressures
-              </Button>
-
               <Text fontWeight="semibold" mb={3}>
                 Relations
               </Text>


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

90% written by LLM.

Added time-based controls to the dashboard for viewing historical metrics data. This feature allows users to:

1. Specify a timestamp to view metrics at a specific point in time
2. Set a time offset for rate calculations (throughput, backpressure)

The implementation includes:
- A new `TimeControls` component with timestamp and offset inputs
- Time utility functions for parsing and formatting timestamps
- Backend support for time-based parameters in Prometheus queries
- Integration with fragment and relation graph pages

This enhancement helps users analyze historical performance issues and compare metrics across different time periods, making it easier to troubleshoot performance problems that occurred in the past.

---

We also removed the `resetBackpressures` button. It's not really necessary now that we have prometheus metrics.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.