### PR TITLE
feat(state-table): support optionally preload all rows in memory

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -107,6 +107,19 @@ steps:
         - ./ci/plugins/upload-failure-logs
       timeout_in_minutes: 30
       retry: *auto-retry
+    - label: "end-to-end preload-memory test"
+      key: "e2e-preload-memory-test-release"
+      command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true ci/scripts/e2e-test-serial.sh -p ci-release -m ci-3streaming-2serving-3fe"
+      if: |
+        !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-preload-memory-tests"
+      depends_on:
+        - "build"
+      plugins:
+        - docker-compose#v5.5.0: *docker-compose-standard
+        - ./ci/plugins/upload-failure-logs
+      timeout_in_minutes: 30
+      retry: *auto-retry
 
     - label: "slow end-to-end test ({{matrix.backend}} backend)"
       key: "slow-e2e-test-release"
@@ -396,6 +409,20 @@ steps:
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
       || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
       || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/
+    depends_on: "build-simulation"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      # Only upload zipped files, otherwise the logs is too much.
+      - ./ci/plugins/upload-failure-logs-zipped
+    timeout_in_minutes: 60
+    parallelism: 4
+    retry: *auto-retry
+  - label: "preload-memory recovery test (madsim)"
+    key: "preload-memory-recovery-test-deterministic"
+    command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true TEST_NUM=12 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 ci/scripts/deterministic-recovery-test.sh"
+    if: |
+      !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-preload-memory-tests"
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v5.5.0: *docker-compose

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -125,9 +125,9 @@ steps:
     retry: *auto-retry
   - label: "e2e preload-memory test"
     command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true ci/scripts/e2e-test-serial.sh -p ci-dev -m ci-3streaming-2serving-3fe"
-    if: | 
+    if: |
       !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-tests"
+      || build.pull_request.labels includes "ci/run-preload-memory-tests"
       || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
     depends_on:
       - "build"
@@ -550,6 +550,19 @@ steps:
       # - test-collector#v1.0.0:
       #     files: "*-junit.xml"
       #     format: "junit"
+    timeout_in_minutes: 40
+    parallelism: 4
+    retry: *auto-retry
+  - label: "preload memory recovery test (deterministic simulation)"
+    command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true TEST_NUM=4 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 ci/scripts/deterministic-recovery-test.sh"
+    if: |
+      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-preload-memory-tests"
+    depends_on: "build-simulation"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      # Only upload zipped files, otherwise the logs is too much.
+      - ./ci/plugins/upload-failure-logs-zipped
     timeout_in_minutes: 40
     parallelism: 4
     retry: *auto-retry

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -123,6 +123,20 @@ steps:
     timeout_in_minutes: 35
     parallelism: 4
     retry: *auto-retry
+  - label: "e2e preload-memory test"
+    command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true ci/scripts/e2e-test-serial.sh -p ci-dev -m ci-3streaming-2serving-3fe"
+    if: | 
+      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-e2e-tests"
+      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+    depends_on:
+      - "build"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 35
+    parallelism: 4
+    retry: *auto-retry
 
   - label: "slow end-to-end test"
     key: "slow-e2e-test"

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -23,7 +23,7 @@ plotters = { version = "0.3.5", default-features = false, features = [
 ] }
 risingwave_common = { workspace = true }
 risingwave_connector = { workspace = true }
-risingwave_stream = { workspace = true }
+risingwave_stream = { workspace = true, features = ["test"] }
 sea-orm  = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -224,6 +224,22 @@ pub struct StreamingDeveloperConfig {
     /// `IcebergSink`: The maximum number of rows in a row group when writing Parquet files.
     #[serde(default = "default::developer::iceberg_sink_write_parquet_max_row_group_rows")]
     pub iceberg_sink_write_parquet_max_row_group_rows: usize,
+
+
+    /// Whether by default enable preloading all rows in memory for state table.
+    /// If true, all capable state tables will preload its state to memory
+    #[serde(default = "default::streaming::default_enable_mem_preload_state_table")]
+    pub default_enable_mem_preload_state_table: bool,
+
+    /// The list of state table ids to *enable* preloading all rows in memory for state table.
+    /// Only takes effect when `default_enable_mem_preload_state_table` is false.
+    #[serde(default)]
+    pub mem_preload_state_table_ids_whilelist: Vec<u32>,
+
+    /// The list of state table ids to *disable* preloading all rows in memory for state table.
+    /// Only takes effect when `default_enable_mem_preload_state_table` is true.
+    #[serde(default)]
+    pub mem_preload_state_table_ids_blacklist: Vec<u32>,
 }
 
 pub mod default {
@@ -248,6 +264,10 @@ pub mod default {
 
         pub fn unsafe_enable_strict_consistency() -> bool {
             true
+        }
+
+        pub fn default_enable_mem_preload_state_table() -> bool {
+            false
         }
     }
 }

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -245,6 +245,7 @@ pub mod default {
     pub use crate::config::default::developer;
 
     pub mod streaming {
+        use tracing::info;
         use crate::config::AsyncStackTraceOption;
         use crate::util::env_var::env_var_is_true;
 
@@ -267,7 +268,12 @@ pub mod default {
         }
 
         pub fn default_enable_mem_preload_state_table() -> bool {
-            env_var_is_true("DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE")
+            if env_var_is_true("DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE") {
+                info!("enabled mem_preload_state_table globally by env var");
+                true
+            } else {
+                false
+            }
         }
     }
 }

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -233,7 +233,7 @@ pub struct StreamingDeveloperConfig {
     /// The list of state table ids to *enable* preloading all rows in memory for state table.
     /// Only takes effect when `default_enable_mem_preload_state_table` is false.
     #[serde(default)]
-    pub mem_preload_state_table_ids_whilelist: Vec<u32>,
+    pub mem_preload_state_table_ids_whitelist: Vec<u32>,
 
     /// The list of state table ids to *disable* preloading all rows in memory for state table.
     /// Only takes effect when `default_enable_mem_preload_state_table` is true.
@@ -246,6 +246,7 @@ pub mod default {
 
     pub mod streaming {
         use crate::config::AsyncStackTraceOption;
+        use crate::util::env_var::env_var_is_true;
 
         pub fn in_flight_barrier_nums() -> usize {
             // quick fix
@@ -266,7 +267,7 @@ pub mod default {
         }
 
         pub fn default_enable_mem_preload_state_table() -> bool {
-            false
+            env_var_is_true("DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE")
         }
     }
 }

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -225,7 +225,6 @@ pub struct StreamingDeveloperConfig {
     #[serde(default = "default::developer::iceberg_sink_write_parquet_max_row_group_rows")]
     pub iceberg_sink_write_parquet_max_row_group_rows: usize,
 
-
     /// Whether by default enable preloading all rows in memory for state table.
     /// If true, all capable state tables will preload its state to memory
     #[serde(default = "default::streaming::default_enable_mem_preload_state_table")]

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -246,6 +246,7 @@ pub mod default {
 
     pub mod streaming {
         use tracing::info;
+
         use crate::config::AsyncStackTraceOption;
         use crate::util::env_var::env_var_is_true;
 

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -199,7 +199,7 @@ stream_iceberg_fetch_batch_size = 1024
 stream_iceberg_sink_positional_delete_cache_size = 1024
 stream_iceberg_sink_write_parquet_max_row_group_rows = 100000
 stream_default_enable_mem_preload_state_table = false
-stream_mem_preload_state_table_ids_whilelist = []
+stream_mem_preload_state_table_ids_whitelist = []
 stream_mem_preload_state_table_ids_blacklist = []
 
 [streaming.developer.stream_compute_client_config]

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -198,6 +198,9 @@ stream_iceberg_list_interval_sec = 1
 stream_iceberg_fetch_batch_size = 1024
 stream_iceberg_sink_positional_delete_cache_size = 1024
 stream_iceberg_sink_write_parquet_max_row_group_rows = 100000
+stream_default_enable_mem_preload_state_table = false
+stream_mem_preload_state_table_ids_whilelist = []
+stream_mem_preload_state_table_ids_blacklist = []
 
 [streaming.developer.stream_compute_client_config]
 connect_timeout_secs = 5

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -24,7 +24,7 @@ use risingwave_storage::monitor::MonitoredStateStore;
 use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::TableDistribution;
 use risingwave_storage::table::batch_table::BatchTable;
-use risingwave_stream::common::table::state_table::StateTable;
+use risingwave_stream::common::table::state_table::{StateTable, StateTableBuilder};
 
 use crate::CtlContext;
 use crate::common::HummockServiceOpts;
@@ -55,7 +55,7 @@ pub fn print_table_catalog(table: &TableCatalog) {
 
 // TODO: shall we work on `TableDesc` instead?
 pub async fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> StateTable<S> {
-    StateTable::from_table_catalog(
+    StateTableBuilder::new(
         &table.to_internal_table_prost(),
         hummock,
         Some(
@@ -65,6 +65,8 @@ pub async fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -
                 .clone(),
         ),
     )
+    .forbid_preload_all_rows()
+    .build()
     .await
 }
 

--- a/src/license/src/feature.json
+++ b/src/license/src/feature.json
@@ -92,6 +92,11 @@
             "description": "Sink auto schema change.",
             "type": "string",
             "const": "SinkAutoSchemaChange"
+        },
+        {
+            "description": "Support state table memory preload for boosting performance.",
+            "type": "string",
+            "const": "StateTableMemoryPreload"
         }
     ]
 }

--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -494,6 +494,21 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for TableKey<T> {
     }
 }
 
+impl TableKey<Bytes> {
+    pub fn split_vnode_bytes(&self) -> (VirtualNode, Bytes) {
+        debug_assert!(
+            self.0.len() >= VirtualNode::SIZE,
+            "too short table key: {:?}",
+            self.0.as_ref()
+        );
+        let (vnode, _) = self.0.split_first_chunk::<{ VirtualNode::SIZE }>().unwrap();
+        (
+            VirtualNode::from_be_bytes(*vnode),
+            self.0.slice(VirtualNode::SIZE..),
+        )
+    }
+}
+
 impl<T: AsRef<[u8]>> TableKey<T> {
     pub fn split_vnode(&self) -> (VirtualNode, &[u8]) {
         debug_assert!(

--- a/src/storage/src/hummock/iterator/change_log.rs
+++ b/src/storage/src/hummock/iterator/change_log.rs
@@ -586,7 +586,7 @@ mod tests {
         let mem_tables = kvs
             .iter()
             .map(|(key, value)| {
-                let mut t = MemTable::new(OpConsistencyLevel::Inconsistent);
+                let mut t = MemTable::new(233.into(), OpConsistencyLevel::Inconsistent);
                 t.insert(key.clone(), value.clone()).unwrap();
                 t
             })
@@ -634,8 +634,8 @@ mod tests {
                 )
             })
             .collect_vec();
-        let mut new_value_memtable = MemTable::new(OpConsistencyLevel::Inconsistent);
-        let mut old_value_memtable = MemTable::new(OpConsistencyLevel::Inconsistent);
+        let mut new_value_memtable = MemTable::new(233.into(), OpConsistencyLevel::Inconsistent);
+        let mut old_value_memtable = MemTable::new(233.into(), OpConsistencyLevel::Inconsistent);
         for (key, value) in &kvs {
             new_value_memtable
                 .delete(key.clone(), Bytes::new())

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -437,6 +437,7 @@ impl StateStoreWriteEpochControl for LocalHummockStorage {
                 KeyOp::Insert(value) => {
                     if let Some(sanity_check_reader) = &sanity_check_flushed_snapshot_reader {
                         do_insert_sanity_check(
+                            self.table_id,
                             &key,
                             &value,
                             sanity_check_reader,
@@ -453,6 +454,7 @@ impl StateStoreWriteEpochControl for LocalHummockStorage {
                 KeyOp::Delete(old_value) => {
                     if let Some(sanity_check_reader) = &sanity_check_flushed_snapshot_reader {
                         do_delete_sanity_check(
+                            self.table_id,
                             &key,
                             &old_value,
                             sanity_check_reader,
@@ -469,6 +471,7 @@ impl StateStoreWriteEpochControl for LocalHummockStorage {
                 KeyOp::Update((old_value, new_value)) => {
                     if let Some(sanity_check_reader) = &sanity_check_flushed_snapshot_reader {
                         do_update_sanity_check(
+                            self.table_id,
                             &key,
                             &old_value,
                             &new_value,
@@ -744,7 +747,7 @@ impl LocalHummockStorage {
     ) -> Self {
         let stats = hummock_version_reader.stats().clone();
         Self {
-            mem_table: MemTable::new(option.op_consistency_level.clone()),
+            mem_table: MemTable::new(option.table_id, option.op_consistency_level.clone()),
             spill_offset: 0,
             epoch: None,
             table_id: option.table_id,

--- a/src/storage/src/mem_table.rs
+++ b/src/storage/src/mem_table.rs
@@ -18,6 +18,7 @@ use std::ops::Bound::{Included, Unbounded};
 use std::ops::RangeBounds;
 
 use bytes::Bytes;
+use risingwave_common::catalog::TableId;
 use risingwave_common_estimate_size::{EstimateSize, KvSize};
 use risingwave_hummock_sdk::key::TableKey;
 use thiserror::Error;
@@ -45,6 +46,7 @@ pub enum KeyOp {
 /// `MemTable` is a buffer for modify operations without encoding
 #[derive(Clone)]
 pub struct MemTable {
+    table_id: TableId,
     pub(crate) buffer: MemTableStore,
     pub(crate) op_consistency_level: OpConsistencyLevel,
     pub(crate) kv_size: KvSize,
@@ -52,8 +54,9 @@ pub struct MemTable {
 
 #[derive(Error, Debug)]
 pub enum MemTableError {
-    #[error("Inconsistent operation {key:?}, prev: {prev:?}, new: {new:?}")]
+    #[error("Inconsistent operation on table {table_id} {key:?}, prev: {prev:?}, new: {new:?}")]
     InconsistentOperation {
+        table_id: TableId,
         key: TableKey<Bytes>,
         prev: KeyOp,
         new: KeyOp,
@@ -123,8 +126,9 @@ pub type MemTableHummockIterator<'a> = FromRustIterator<'a, MemTableIteratorBuil
 pub type MemTableHummockRevIterator<'a> = FromRustIterator<'a, MemTableRevIteratorBuilder>;
 
 impl MemTable {
-    pub fn new(op_consistency_level: OpConsistencyLevel) -> Self {
+    pub fn new(table_id: TableId, op_consistency_level: OpConsistencyLevel) -> Self {
         Self {
+            table_id,
             buffer: BTreeMap::new(),
             op_consistency_level,
             kv_size: KvSize::new(),
@@ -133,7 +137,10 @@ impl MemTable {
 
     pub fn drain(&mut self) -> Self {
         self.kv_size.set(0);
-        std::mem::replace(self, Self::new(self.op_consistency_level.clone()))
+        std::mem::replace(
+            self,
+            Self::new(self.table_id, self.op_consistency_level.clone()),
+        )
     }
 
     pub fn is_dirty(&self) -> bool {
@@ -172,6 +179,7 @@ impl MemTable {
                     KeyOp::Insert(_) | KeyOp::Update(_) => {
                         let new_op = KeyOp::Insert(value);
                         let err = MemTableError::InconsistentOperation {
+                            table_id: self.table_id,
                             key: e.key().clone(),
                             prev: e.get().clone(),
                             new: new_op.clone(),
@@ -223,6 +231,7 @@ impl MemTable {
                     KeyOp::Insert(old_op_new_value) => {
                         if sanity_check_enabled() && !value_checker(old_op_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
+                                table_id: self.table_id,
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
                                 new: KeyOp::Delete(old_value),
@@ -236,6 +245,7 @@ impl MemTable {
                     KeyOp::Delete(_) => {
                         let new_op = KeyOp::Delete(old_value);
                         let err = MemTableError::InconsistentOperation {
+                            table_id: self.table_id,
                             key: e.key().clone(),
                             prev: e.get().clone(),
                             new: new_op.clone(),
@@ -256,6 +266,7 @@ impl MemTable {
                     KeyOp::Update((old_op_old_value, old_op_new_value)) => {
                         if sanity_check_enabled() && !value_checker(old_op_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
+                                table_id: self.table_id,
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
                                 new: KeyOp::Delete(old_value),
@@ -306,6 +317,7 @@ impl MemTable {
                     KeyOp::Insert(old_op_new_value) => {
                         if sanity_check_enabled() && !value_checker(old_op_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
+                                table_id: self.table_id,
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
                                 new: KeyOp::Update((old_value, new_value)),
@@ -320,6 +332,7 @@ impl MemTable {
                     KeyOp::Update((old_op_old_value, old_op_new_value)) => {
                         if sanity_check_enabled() && !value_checker(old_op_new_value, &old_value) {
                             return Err(Box::new(MemTableError::InconsistentOperation {
+                                table_id: self.table_id,
                                 key: e.key().clone(),
                                 prev: e.get().clone(),
                                 new: KeyOp::Update((old_value, new_value)),
@@ -334,6 +347,7 @@ impl MemTable {
                     KeyOp::Delete(_) => {
                         let new_op = KeyOp::Update((old_value, new_value));
                         let err = MemTableError::InconsistentOperation {
+                            table_id: self.table_id,
                             key: e.key().clone(),
                             prev: e.get().clone(),
                             new: new_op.clone(),
@@ -432,10 +446,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_mem_table_memory_size() {
-        let mut mem_table = MemTable::new(OpConsistencyLevel::ConsistentOldValue {
-            check_old_value: CHECK_BYTES_EQUAL.clone(),
-            is_log_store: false,
-        });
+        let mut mem_table = MemTable::new(
+            233.into(),
+            OpConsistencyLevel::ConsistentOldValue {
+                check_old_value: CHECK_BYTES_EQUAL.clone(),
+                is_log_store: false,
+            },
+        );
         assert_eq!(mem_table.kv_size.size(), 0);
 
         mem_table
@@ -545,7 +562,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mem_table_memory_size_not_consistent_op() {
-        let mut mem_table = MemTable::new(OpConsistencyLevel::Inconsistent);
+        let mut mem_table = MemTable::new(233.into(), OpConsistencyLevel::Inconsistent);
         assert_eq!(mem_table.kv_size.size(), 0);
 
         mem_table
@@ -628,10 +645,13 @@ mod tests {
         let mut test_data = ordered_test_data.clone();
 
         test_data.shuffle(&mut rng);
-        let mut mem_table = MemTable::new(OpConsistencyLevel::ConsistentOldValue {
-            check_old_value: CHECK_BYTES_EQUAL.clone(),
-            is_log_store: false,
-        });
+        let mut mem_table = MemTable::new(
+            233.into(),
+            OpConsistencyLevel::ConsistentOldValue {
+                check_old_value: CHECK_BYTES_EQUAL.clone(),
+                is_log_store: false,
+            },
+        );
         for (key, op) in test_data {
             match op {
                 KeyOp::Insert(value) => {

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -991,7 +991,7 @@ impl<R: RangeKv> RangeKvLocalStateStore<R> {
     pub fn new(inner: RangeKvStateStore<R>, option: NewLocalOptions) -> Self {
         Self {
             inner,
-            mem_table: MemTable::new(option.op_consistency_level.clone()),
+            mem_table: MemTable::new(option.table_id, option.op_consistency_level.clone()),
             epoch: None,
             table_id: option.table_id,
             op_consistency_level: option.op_consistency_level,
@@ -1128,6 +1128,7 @@ impl<R: RangeKv> StateStoreWriteEpochControl for RangeKvLocalStateStore<R> {
                 KeyOp::Insert(value) => {
                     if let Some(sanity_check_read_snapshot) = &sanity_check_read_snapshot {
                         do_insert_sanity_check(
+                            self.table_id,
                             &key,
                             &value,
                             sanity_check_read_snapshot,
@@ -1141,6 +1142,7 @@ impl<R: RangeKv> StateStoreWriteEpochControl for RangeKvLocalStateStore<R> {
                 KeyOp::Delete(old_value) => {
                     if let Some(sanity_check_read_snapshot) = &sanity_check_read_snapshot {
                         do_delete_sanity_check(
+                            self.table_id,
                             &key,
                             &old_value,
                             sanity_check_read_snapshot,
@@ -1154,6 +1156,7 @@ impl<R: RangeKv> StateStoreWriteEpochControl for RangeKvLocalStateStore<R> {
                 KeyOp::Update((old_value, new_value)) => {
                     if let Some(sanity_check_read_snapshot) = &sanity_check_read_snapshot {
                         do_update_sanity_check(
+                            self.table_id,
                             &key,
                             &old_value,
                             &new_value,

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -1113,7 +1113,7 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
             _ => unreachable!("should only get memtable error"),
         };
         match *e {
-            MemTableError::InconsistentOperation { key, prev, new } => {
+            MemTableError::InconsistentOperation { key, prev, new, .. } => {
                 let (vnode, key) = deserialize_pk_with_vnode(&key, &self.pk_serde).unwrap();
                 panic!(
                     "mem-table operation inconsistent! table_id: {}, vnode: {}, key: {:?}, prev: {}, new: {}",

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -315,6 +315,10 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
         table_watermarks: Option<(WatermarkDirection, Vec<VnodeWatermark>, WatermarkSerdeType)>,
         switch_consistent_op: Option<StateTableOpConsistencyLevel>,
     ) -> StreamExecutorResult<()> {
+        // TODO: remove the temp logic and clear range when seeing watermark
+        if table_watermarks.is_some() {
+            self.all_rows = None;
+        }
         self.state_store
             .flush()
             .instrument(tracing::info_span!("state_table_flush"))

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Bound;
 use std::ops::Bound::*;
 use std::sync::Arc;
@@ -178,7 +178,9 @@ where
     /// In streaming executors, this methods must be called **after** receiving and yielding the first barrier,
     /// and otherwise, deadlock can be likely to happen.
     pub async fn init_epoch(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
-        self.row_store.init(epoch).await?;
+        self.row_store
+            .init(epoch, self.distribution.vnodes())
+            .await?;
         assert_eq!(None, self.epoch.replace(epoch), "should not init for twice");
         Ok(())
     }
@@ -248,6 +250,7 @@ macro_rules! dispatch_value_indices {
 
 struct StateTableRowStore<LS: LocalStateStore, SD: ValueRowSerde> {
     state_store: LS,
+    all_rows: Option<BTreeMap<TableKey<Bytes>, OwnedRow>>,
 
     table_id: TableId,
     table_option: TableOption,
@@ -257,15 +260,48 @@ struct StateTableRowStore<LS: LocalStateStore, SD: ValueRowSerde> {
 }
 
 impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
-    async fn init(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
-        Ok(self.state_store.init(InitOptions::new(epoch)).await?)
+    async fn may_reload_all_rows(&mut self, vnode_bitmap: &Bitmap) -> StreamExecutorResult<()> {
+        if let Some(rows) = &mut self.all_rows {
+            rows.clear();
+            for vnode in vnode_bitmap.iter_vnodes() {
+                let memcomparable_range_with_vnode = prefixed_range_with_vnode::<Bytes>(.., vnode);
+                // TODO: set read options
+                let stream = deserialize_keyed_row_stream::<Bytes>(
+                    self.state_store
+                        .iter(
+                            memcomparable_range_with_vnode,
+                            ReadOptions {
+                                prefix_hint: None,
+                                prefetch_options: Default::default(),
+                                cache_policy: Default::default(),
+                                retention_seconds: self.table_option.retention_seconds,
+                            },
+                        )
+                        .await?,
+                    &*self.row_serde,
+                );
+                pin_mut!(stream);
+                while let Some((encoded_key, row)) = stream.try_next().await? {
+                    let key = TableKey(encoded_key);
+                    rows.try_insert(key, row).expect("non-duplicated");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn init(&mut self, epoch: EpochPair, vnode_bitmap: &Bitmap) -> StreamExecutorResult<()> {
+        self.state_store.init(InitOptions::new(epoch)).await?;
+        self.may_reload_all_rows(vnode_bitmap).await
     }
 
     async fn update_vnode_bitmap(
         &mut self,
         vnodes: Arc<Bitmap>,
     ) -> StreamExecutorResult<Arc<Bitmap>> {
-        Ok(self.state_store.update_vnode_bitmap(vnodes).await?)
+        let prev_vnodes = self.state_store.update_vnode_bitmap(vnodes.clone()).await?;
+        self.may_reload_all_rows(&vnodes).await?;
+        Ok(prev_vnodes)
     }
 
     async fn try_flush(&mut self) -> StreamExecutorResult<()> {
@@ -574,9 +610,12 @@ where
         // Compute output indices
         let (_, output_indices) = find_columns_by_ids(&columns[..], &output_column_ids);
 
+        // TODO: provide options to enable or disable loading all rows
+
         Self {
             table_id,
             row_store: StateTableRowStore {
+                all_rows: Some(BTreeMap::new()),
                 table_option,
                 state_store: local_state_store,
                 row_serde,
@@ -743,6 +782,9 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
         key_bytes: TableKey<Bytes>,
         prefix_hint: Option<Bytes>,
     ) -> StreamExecutorResult<Option<OwnedRow>> {
+        if let Some(row) = &self.all_rows {
+            return Ok(row.get(&key_bytes).cloned());
+        }
         let read_options = ReadOptions {
             prefix_hint,
             retention_seconds: self.table_option.retention_seconds,
@@ -767,6 +809,9 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
         key_bytes: TableKey<Bytes>,
         prefix_hint: Option<Bytes>,
     ) -> StreamExecutorResult<bool> {
+        if let Some(row) = &self.all_rows {
+            return Ok(row.contains_key(&key_bytes));
+        }
         let read_options = ReadOptions {
             prefix_hint,
             retention_seconds: self.table_option.retention_seconds,
@@ -907,7 +952,10 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
 
     fn insert(&mut self, key: TableKey<Bytes>, value: impl Row) {
         insane_mode_discard_point!();
-        let value_bytes = self.row_serde.serialize(value).into();
+        let value_bytes = self.row_serde.serialize(&value).into();
+        if let Some(rows) = &mut self.all_rows {
+            rows.insert(key.clone(), value.into_owned_row());
+        }
         self.state_store
             .insert(key, value_bytes, None)
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
@@ -916,6 +964,9 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
     fn delete(&mut self, key: TableKey<Bytes>, value: impl Row) {
         insane_mode_discard_point!();
         let value_bytes = self.row_serde.serialize(value).into();
+        if let Some(rows) = &mut self.all_rows {
+            rows.remove(&key);
+        }
         self.state_store
             .delete(key, value_bytes)
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
@@ -923,8 +974,11 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
 
     fn update(&mut self, key_bytes: TableKey<Bytes>, old_value: impl Row, new_value: impl Row) {
         insane_mode_discard_point!();
-        let new_value_bytes = self.row_serde.serialize(new_value).into();
+        let new_value_bytes = self.row_serde.serialize(&new_value).into();
         let old_value_bytes = self.row_serde.serialize(old_value).into();
+        if let Some(rows) = &mut self.all_rows {
+            rows.insert(key_bytes.clone(), new_value.into_owned_row());
+        }
         self.state_store
             .insert(key_bytes, new_value_bytes, Some(old_value_bytes))
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
@@ -1342,10 +1396,16 @@ where
 impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
     async fn iter_kv<K: CopyFromSlice>(
         &self,
-        table_key_range: TableKeyRange,
+        (start, end): TableKeyRange,
         prefix_hint: Option<Bytes>,
         prefetch_options: PrefetchOptions,
     ) -> StreamExecutorResult<impl PkRowStream<'_, K>> {
+        if let Some(rows) = &self.all_rows {
+            return Ok(futures::future::Either::Left(futures::stream::iter(
+                rows.range((start, end))
+                    .map(|(key, value)| Ok((K::copy_from_slice(key.to_ref().0), value.clone()))),
+            )));
+        }
         let read_options = ReadOptions {
             prefix_hint,
             retention_seconds: self.table_option.retention_seconds,
@@ -1353,18 +1413,27 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
             cache_policy: CachePolicy::Fill(Hint::Normal),
         };
 
-        Ok(deserialize_keyed_row_stream(
-            self.state_store.iter(table_key_range, read_options).await?,
-            &*self.row_serde,
+        Ok(futures::future::Either::Right(
+            deserialize_keyed_row_stream(
+                self.state_store.iter((start, end), read_options).await?,
+                &*self.row_serde,
+            ),
         ))
     }
 
     async fn rev_iter_kv<K: CopyFromSlice>(
         &self,
-        table_key_range: TableKeyRange,
+        (start, end): TableKeyRange,
         prefix_hint: Option<Bytes>,
         prefetch_options: PrefetchOptions,
     ) -> StreamExecutorResult<impl PkRowStream<'_, K>> {
+        if let Some(rows) = &self.all_rows {
+            return Ok(futures::future::Either::Left(futures::stream::iter(
+                rows.range((start, end))
+                    .rev()
+                    .map(|(key, value)| Ok((K::copy_from_slice(key.to_ref().0), value.clone()))),
+            )));
+        }
         let read_options = ReadOptions {
             prefix_hint,
             retention_seconds: self.table_option.retention_seconds,
@@ -1372,11 +1441,13 @@ impl<LS: LocalStateStore, SD: ValueRowSerde> StateTableRowStore<LS, SD> {
             cache_policy: CachePolicy::Fill(Hint::Normal),
         };
 
-        Ok(deserialize_keyed_row_stream(
-            self.state_store
-                .rev_iter(table_key_range, read_options)
-                .await?,
-            &*self.row_serde,
+        Ok(futures::future::Either::Right(
+            deserialize_keyed_row_stream(
+                self.state_store
+                    .rev_iter((start, end), read_options)
+                    .await?,
+                &*self.row_serde,
+            ),
         ))
     }
 }

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -1939,8 +1939,8 @@ async fn test_replicated_state_table_replication() {
 
     // Create a replicated state table
     let output_column_ids = vec![ColumnId::from(2), ColumnId::from(0)];
-    let mut replicated_state_table =
-        TestReplicatedStateTable::from_table_catalog_with_output_column_ids(
+    let mut replicated_state_table: TestReplicatedStateTable =
+        TestReplicatedStateTable::new_replicated(
             &table,
             test_env.storage.clone(),
             None,

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -1953,7 +1953,6 @@ async fn test_replicated_state_table_replication() {
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
     state_table.init_epoch(epoch).await.unwrap();
-    replicated_state_table.init_epoch(epoch).await.unwrap();
 
     // Insert first record into base state table
     state_table.insert(OwnedRow::new(vec![
@@ -1967,8 +1966,8 @@ async fn test_replicated_state_table_replication() {
         .storage
         .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
     state_table.commit_for_test(epoch).await.unwrap();
-    replicated_state_table.commit_for_test(epoch).await.unwrap();
     test_env.commit_epoch(epoch.prev).await;
+    replicated_state_table.init_epoch(epoch).await.unwrap();
 
     {
         let range_bounds: (Bound<OwnedRow>, Bound<OwnedRow>) = (

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -119,6 +119,7 @@ mod row_merge;
 #[cfg(test)]
 mod integration_tests;
 mod sync_kv_log_store;
+#[cfg(any(test, feature = "test"))]
 pub mod test_utils;
 mod utils;
 mod vector_index;

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -24,7 +24,7 @@ use itertools::Itertools;
 use risingwave_common::array::Op;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{
-    ColumnDesc, ColumnId, ConflictBehavior, TableId, checked_conflict_behaviors,
+    ColumnDesc, ConflictBehavior, TableId, checked_conflict_behaviors,
 };
 use risingwave_common::row::{CompactedRow, OwnedRow};
 use risingwave_common::types::{DEBEZIUM_UNAVAILABLE_VALUE, DataType, ScalarImpl};
@@ -41,7 +41,6 @@ use crate::common::metrics::MetricsInfo;
 use crate::common::table::state_table::{
     StateTableBuilder, StateTableInner, StateTableOpConsistencyLevel,
 };
-use crate::common::table::test_utils::gen_pbtable;
 use crate::executor::monitor::MaterializeMetrics;
 use crate::executor::prelude::*;
 
@@ -171,6 +170,7 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
         // Note: The current implementation could potentially trigger a switch on the inconsistent_op flag. If the storage relies on this flag to perform optimizations, it would be advisable to maintain consistency with it throughout the lifecycle.
         let state_table = StateTableBuilder::new(table_catalog, store, vnodes)
             .with_op_consistency_level(op_consistency_level)
+            .enable_preload_all_rows_by_config(&actor_context.streaming_config)
             .build()
             .await;
 
@@ -402,13 +402,13 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
 
 impl<S: StateStore> MaterializeExecutor<S, BasicSerde> {
     /// Create a new `MaterializeExecutor` without distribution info for test purpose.
-    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(test, feature = "test"))]
     pub async fn for_test(
         input: Executor,
         store: S,
         table_id: TableId,
         keys: Vec<ColumnOrder>,
-        column_ids: Vec<ColumnId>,
+        column_ids: Vec<risingwave_common::catalog::ColumnId>,
         watermark_epoch: AtomicU64Ref,
         conflict_behavior: ConflictBehavior,
     ) -> Self {
@@ -426,7 +426,7 @@ impl<S: StateStore> MaterializeExecutor<S, BasicSerde> {
             Arc::from(columns.clone().into_boxed_slice()),
         );
         let state_table = StateTableInner::from_table_catalog(
-            &gen_pbtable(
+            &crate::common::table::test_utils::gen_pbtable(
                 table_id,
                 columns,
                 arrange_order_types,
@@ -2148,7 +2148,7 @@ mod tests {
         let pk_indices = vec![0];
 
         let mut table = StateTable::from_table_catalog(
-            &gen_pbtable(
+            &crate::common::table::test_utils::gen_pbtable(
                 TableId::from(1002),
                 column_descs.clone(),
                 order_types,

--- a/src/stream/src/executor/source/source_backfill_state_table.rs
+++ b/src/stream/src/executor/source/source_backfill_state_table.rs
@@ -24,7 +24,7 @@ use risingwave_pb::catalog::PbTable;
 use risingwave_storage::StateStore;
 
 use super::source_backfill_executor::{BackfillStateWithProgress, BackfillStates};
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::{StateTable, StateTableBuilder};
 use crate::executor::StreamExecutorResult;
 
 pub struct BackfillStateTableHandler<S: StateStore> {
@@ -35,7 +35,10 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
     /// See also [`super::SourceStateTableHandler::from_table_catalog`] for how the state table looks like.
     pub async fn from_table_catalog(table_catalog: &PbTable, store: S) -> Self {
         Self {
-            state_store: StateTable::from_table_catalog(table_catalog, store, None).await,
+            state_store: StateTableBuilder::new(table_catalog, store, None)
+                .preload_all_rows(false)
+                .build()
+                .await,
         }
     }
 

--- a/src/stream/src/executor/source/source_backfill_state_table.rs
+++ b/src/stream/src/executor/source/source_backfill_state_table.rs
@@ -35,8 +35,11 @@ impl<S: StateStore> BackfillStateTableHandler<S> {
     /// See also [`super::SourceStateTableHandler::from_table_catalog`] for how the state table looks like.
     pub async fn from_table_catalog(table_catalog: &PbTable, store: S) -> Self {
         Self {
+            // Note: should not enable `preload_all_rows` for `StateTable` of source backfill
+            // because it uses storage to synchronize different parallelisms, which is a special
+            // access pattern that in-mem state table has not supported yet.
             state_store: StateTableBuilder::new(table_catalog, store, None)
-                .preload_all_rows(false)
+                .forbid_preload_all_rows()
                 .build()
                 .await,
         }

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -35,7 +35,7 @@ use risingwave_connector::source::{SplitImpl, SplitMetaData};
 use risingwave_pb::catalog::PbTable;
 use risingwave_storage::StateStore;
 
-use crate::common::table::state_table::{StateTable, StateTablePostCommit};
+use crate::common::table::state_table::{StateTable, StateTableBuilder, StateTablePostCommit};
 use crate::executor::StreamExecutorResult;
 
 pub struct SourceStateTableHandler<S: StateStore> {
@@ -48,7 +48,10 @@ impl<S: StateStore> SourceStateTableHandler<S> {
     /// Refer to `infer_internal_table_catalog` in `src/frontend/src/optimizer/plan_node/generic/source.rs` for more details.
     pub async fn from_table_catalog(table_catalog: &PbTable, store: S) -> Self {
         Self {
-            state_table: StateTable::from_table_catalog(table_catalog, store, None).await,
+            state_table: StateTableBuilder::new(table_catalog, store, None)
+                .preload_all_rows(false)
+                .build()
+                .await,
         }
     }
 

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -48,8 +48,11 @@ impl<S: StateStore> SourceStateTableHandler<S> {
     /// Refer to `infer_internal_table_catalog` in `src/frontend/src/optimizer/plan_node/generic/source.rs` for more details.
     pub async fn from_table_catalog(table_catalog: &PbTable, store: S) -> Self {
         Self {
+            // Note: should not enable `preload_all_rows` for `StateTable` of source
+            // because it uses storage to synchronize different parallelisms, which is a special
+            // access pattern that in-mem state table has not supported yet.
             state_table: StateTableBuilder::new(table_catalog, store, None)
-                .preload_all_rows(false)
+                .forbid_preload_all_rows()
                 .build()
                 .await,
         }
@@ -62,7 +65,13 @@ impl<S: StateStore> SourceStateTableHandler<S> {
         vnodes: Option<Arc<Bitmap>>,
     ) -> Self {
         Self {
-            state_table: StateTable::from_table_catalog(table_catalog, store, vnodes).await,
+            // Note: should not enable `preload_all_rows` for `StateTable` of source
+            // because it uses storage to synchronize different parallelisms, which is a special
+            // access pattern that in-mem state table has not supported yet.
+            state_table: StateTableBuilder::new(table_catalog, store, vnodes)
+                .forbid_preload_all_rows()
+                .build()
+                .await,
         }
     }
 

--- a/src/stream/src/from_proto/group_top_n.rs
+++ b/src/stream/src/from_proto/group_top_n.rs
@@ -21,7 +21,7 @@ use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_pb::stream_plan::GroupTopNNode;
 
 use super::*;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::{StateTable, StateTableBuilder};
 use crate::executor::{ActorContextRef, AppendOnlyGroupTopNExecutor, GroupTopNExecutor};
 use crate::task::AtomicU64Ref;
 
@@ -42,7 +42,10 @@ impl<const APPEND_ONLY: bool> ExecutorBuilder for GroupTopNExecutorBuilder<APPEN
             .collect();
         let table = node.get_table()?;
         let vnodes = params.vnode_bitmap.map(Arc::new);
-        let state_table = StateTable::from_table_catalog(table, store, vnodes).await;
+        let state_table = StateTableBuilder::new(table, store, vnodes)
+            .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+            .build()
+            .await;
         let storage_key = table
             .get_pk()
             .iter()

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -25,7 +25,7 @@ use super::agg_common::{
     build_agg_state_storages_from_proto, build_distinct_dedup_table_from_proto,
 };
 use super::*;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::StateTableBuilder;
 use crate::executor::aggregate::{AggExecutorArgs, HashAggExecutor, HashAggExecutorExtraArgs};
 
 pub struct HashAggExecutorDispatcherArgs<S: StateStore> {
@@ -79,18 +79,25 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             node.get_agg_call_states(),
             store.clone(),
             vnodes.clone(),
+            &params.actor_context.streaming_config,
         )
         .await;
         // disable sanity check so that old value is not required when updating states
-        let intermediate_state_table = StateTable::from_table_catalog(
+        let intermediate_state_table = StateTableBuilder::new(
             node.get_intermediate_state_table().unwrap(),
             store.clone(),
             vnodes.clone(),
         )
+        .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+        .build()
         .await;
-        let distinct_dedup_tables =
-            build_distinct_dedup_table_from_proto(node.get_distinct_dedup_tables(), store, vnodes)
-                .await;
+        let distinct_dedup_tables = build_distinct_dedup_table_from_proto(
+            node.get_distinct_dedup_tables(),
+            store,
+            vnodes,
+            &params.actor_context.streaming_config,
+        )
+        .await;
 
         let exec = HashAggExecutorDispatcherArgs {
             args: AggExecutorArgs {

--- a/src/stream/src/from_proto/now.rs
+++ b/src/stream/src/from_proto/now.rs
@@ -21,7 +21,7 @@ use risingwave_pb::stream_plan::{NowNode, PbNowModeGenerateSeries};
 use risingwave_storage::StateStore;
 
 use super::ExecutorBuilder;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::StateTableBuilder;
 use crate::error::StreamResult;
 use crate::executor::{Executor, NowExecutor, NowMode};
 use crate::task::ExecutorParams;
@@ -70,8 +70,10 @@ impl ExecutorBuilder for NowExecutorBuilder {
             NowMode::UpdateCurrent
         };
 
-        let state_table =
-            StateTable::from_table_catalog(node.get_state_table()?, store, None).await;
+        let state_table = StateTableBuilder::new(node.get_state_table()?, store, None)
+            .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+            .build()
+            .await;
         let barrier_interval_ms = params
             .env
             .system_params_manager_ref()

--- a/src/stream/src/from_proto/over_window.rs
+++ b/src/stream/src/from_proto/over_window.rs
@@ -21,7 +21,7 @@ use risingwave_pb::stream_plan::PbOverWindowNode;
 use risingwave_storage::StateStore;
 
 use super::ExecutorBuilder;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::StateTableBuilder;
 use crate::error::StreamResult;
 use crate::executor::{Executor, OverWindowExecutor, OverWindowExecutorArgs};
 use crate::task::ExecutorParams;
@@ -58,8 +58,10 @@ impl ExecutorBuilder for OverWindowExecutorBuilder {
                 .vnode_bitmap
                 .expect("vnodes not set for EOWC over window"),
         ));
-        let state_table =
-            StateTable::from_table_catalog(node.get_state_table()?, store, vnodes).await;
+        let state_table = StateTableBuilder::new(node.get_state_table()?, store, vnodes)
+            .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+            .build()
+            .await;
         let exec = OverWindowExecutor::new(OverWindowExecutorArgs {
             actor_ctx: params.actor_context,
 

--- a/src/stream/src/from_proto/simple_agg.rs
+++ b/src/stream/src/from_proto/simple_agg.rs
@@ -21,7 +21,7 @@ use super::agg_common::{
     build_agg_state_storages_from_proto, build_distinct_dedup_table_from_proto,
 };
 use super::*;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::StateTableBuilder;
 use crate::executor::aggregate::{AggExecutorArgs, SimpleAggExecutor, SimpleAggExecutorExtraArgs};
 
 pub struct SimpleAggExecutorBuilder;
@@ -40,19 +40,29 @@ impl ExecutorBuilder for SimpleAggExecutorBuilder {
             .iter()
             .map(AggCall::from_protobuf)
             .try_collect()?;
-        let storages =
-            build_agg_state_storages_from_proto(node.get_agg_call_states(), store.clone(), None)
-                .await;
+        let storages = build_agg_state_storages_from_proto(
+            node.get_agg_call_states(),
+            store.clone(),
+            None,
+            &params.actor_context.streaming_config,
+        )
+        .await;
         // disable sanity check so that old value is not required when updating states
-        let intermediate_state_table = StateTable::from_table_catalog(
+        let intermediate_state_table = StateTableBuilder::new(
             node.get_intermediate_state_table().unwrap(),
             store.clone(),
             None,
         )
+        .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+        .build()
         .await;
-        let distinct_dedup_tables =
-            build_distinct_dedup_table_from_proto(node.get_distinct_dedup_tables(), store, None)
-                .await;
+        let distinct_dedup_tables = build_distinct_dedup_table_from_proto(
+            node.get_distinct_dedup_tables(),
+            store,
+            None,
+            &params.actor_context.streaming_config,
+        )
+        .await;
         let must_output_per_barrier = node.get_must_output_per_barrier();
 
         let exec = SimpleAggExecutor::new(AggExecutorArgs {

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -181,8 +181,10 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
                 );
 
                 let state_table = node.get_state_table()?;
+                // if we enable preload memory for this state table, the test in e2e_test/backfill/sink/different_pk_and_dist_key.slt
+                // will become flaky. It can occasionally fail due to consistency check in storage mem table.
                 let state_table = StateTableBuilder::new(state_table, state_store.clone(), vnodes)
-                    .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+                    .forbid_preload_all_rows()
                     .build()
                     .await;
 

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -23,7 +23,7 @@ use risingwave_pb::stream_plan::{StreamScanNode, StreamScanType};
 use risingwave_storage::table::batch_table::BatchTable;
 
 use super::*;
-use crate::common::table::state_table::{ReplicatedStateTable, StateTable};
+use crate::common::table::state_table::{ReplicatedStateTable, StateTableBuilder};
 use crate::executor::{
     ArrangementBackfillExecutor, BackfillExecutor, ChainExecutor, RearrangedChainExecutor,
     TroublemakerExecutor, UpstreamTableExecutor,
@@ -75,7 +75,11 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
 
                 let state_table = if let Ok(table) = node.get_state_table() {
                     Some(
-                        StateTable::from_table_catalog(table, state_store.clone(), vnodes.clone())
+                        StateTableBuilder::new(table, state_store.clone(), vnodes.clone())
+                            .enable_preload_all_rows_by_config(
+                                &params.actor_context.streaming_config,
+                            )
+                            .build()
                             .await,
                     )
                 } else {
@@ -109,12 +113,11 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
                 let vnodes = params.vnode_bitmap.map(Arc::new);
 
                 let state_table = node.get_state_table().unwrap();
-                let state_table = StateTable::from_table_catalog(
-                    state_table,
-                    state_store.clone(),
-                    vnodes.clone(),
-                )
-                .await;
+                let state_table =
+                    StateTableBuilder::new(state_table, state_store.clone(), vnodes.clone())
+                        .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+                        .build()
+                        .await;
 
                 let upstream_table = node.get_arrangement_table().unwrap();
                 let versioned = upstream_table.get_version().is_ok();
@@ -178,8 +181,10 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
                 );
 
                 let state_table = node.get_state_table()?;
-                let state_table =
-                    StateTable::from_table_catalog(state_table, state_store.clone(), vnodes).await;
+                let state_table = StateTableBuilder::new(state_table, state_store.clone(), vnodes)
+                    .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+                    .build()
+                    .await;
 
                 let chunk_size = params.env.config().developer.chunk_size;
                 let snapshot_epoch = node

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -181,10 +181,8 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
                 );
 
                 let state_table = node.get_state_table()?;
-                // if we enable preload memory for this state table, the test in e2e_test/backfill/sink/different_pk_and_dist_key.slt
-                // will become flaky. It can occasionally fail due to consistency check in storage mem table.
                 let state_table = StateTableBuilder::new(state_table, state_store.clone(), vnodes)
-                    .forbid_preload_all_rows()
+                    .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
                     .build()
                     .await;
 

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -121,14 +121,14 @@ impl ExecutorBuilder for StreamScanExecutorBuilder {
 
                 macro_rules! new_executor {
                     ($SD:ident) => {{
-                        let upstream_table =
-                            ReplicatedStateTable::<_, $SD>::from_table_catalog_with_output_column_ids(
-                                upstream_table,
-                                state_store.clone(),
-                                vnodes,
-                                column_ids,
-                            )
-                            .await;
+                        // TODO: can it be ConsistentOldValue?
+                        let upstream_table = ReplicatedStateTable::new_replicated(
+                            upstream_table,
+                            state_store.clone(),
+                            vnodes,
+                            column_ids,
+                        )
+                        .await;
                         ArrangementBackfillExecutor::<_, $SD>::new(
                             upstream_table,
                             upstream,

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -22,7 +22,7 @@ use risingwave_pb::plan_common::{JoinType as JoinTypeProto, StorageTableDesc};
 use risingwave_storage::table::batch_table::BatchTable;
 
 use super::*;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::{StateTable, StateTableBuilder};
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{
     ActorContextRef, JoinType, NestedLoopTemporalJoinExecutor, TemporalJoinExecutor,
@@ -135,12 +135,12 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                             .expect("vnodes not set for temporal join"),
                     );
                     Some(
-                        StateTable::from_table_catalog(
-                            memo_table,
-                            store.clone(),
-                            Some(vnodes.clone()),
-                        )
-                        .await,
+                        StateTableBuilder::new(memo_table, store.clone(), Some(vnodes.clone()))
+                            .enable_preload_all_rows_by_config(
+                                &params.actor_context.streaming_config,
+                            )
+                            .build()
+                            .await,
                     )
                 }
                 Err(_) => None,

--- a/src/stream/src/from_proto/top_n.rs
+++ b/src/stream/src/from_proto/top_n.rs
@@ -18,7 +18,7 @@ use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_pb::stream_plan::TopNNode;
 
 use super::*;
-use crate::common::table::state_table::StateTable;
+use crate::common::table::state_table::StateTableBuilder;
 use crate::executor::{AppendOnlyTopNExecutor, TopNExecutor};
 
 pub struct TopNExecutorBuilder<const APPEND_ONLY: bool>;
@@ -35,7 +35,10 @@ impl<const APPEND_ONLY: bool> ExecutorBuilder for TopNExecutorBuilder<APPEND_ONL
 
         let table = node.get_table()?;
         let vnodes = params.vnode_bitmap.map(Arc::new);
-        let state_table = StateTable::from_table_catalog(table, store, vnodes).await;
+        let state_table = StateTableBuilder::new(table, store, vnodes)
+            .enable_preload_all_rows_by_config(&params.actor_context.streaming_config)
+            .build()
+            .await;
         let storage_key = table
             .get_pk()
             .iter()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Support preloading all rows in memory for state table. The feature is a premium feature `StateTableMemoryPreload`.

Added 3 streaming developer config to configure whether to enable in memory state table for some specific table ids.
```
/// Whether by default enable preloading all rows in memory for state table.
/// If true, all capable state tables will preload its state to memory
#[serde(default = "default::streaming::default_enable_mem_preload_state_table")]
pub default_enable_mem_preload_state_table: bool,

/// The list of state table ids to *enable* preloading all rows in memory for state table.
/// Only takes effect when `default_enable_mem_preload_state_table` is false.
#[serde(default)]
pub mem_preload_state_table_ids_whilelist: Vec<u32>,

/// The list of state table ids to *disable* preloading all rows in memory for state table.
/// Only takes effect when `default_enable_mem_preload_state_table` is true.
#[serde(default)]
pub mem_preload_state_table_ids_blacklist: Vec<u32>,
```

Introduce `StateTableBuilder` to build `StateTable`. Each `StateTableBuilder` must exactly-once call either `enable_preload_all_rows_by_config` to enable in memory mode by configuration, or `forbid_preload_all_rows` to disable in memory mode.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
