### PR TITLE
fix: float comparison in vector::distance tests

### DIFF
--- a/src/storage/src/vector/distance.rs
+++ b/src/storage/src/vector/distance.rs
@@ -235,17 +235,24 @@ mod tests {
         0.22877127, 0.97690505, 0.44438475,
     ];
 
-    const FLOAT_ALLOWED_BIAS: f32 = 1e-5;
+    const FLOAT_ABS_EPS: f32 = 2e-5;
+    const FLOAT_REL_EPS: f32 = 1e-6;
 
     macro_rules! assert_eq_float {
-        ($first:expr, $second:expr) => {
+        ($first:expr, $second:expr) => {{
+            let a: f32 = $first;
+            let b: f32 = $second;
+            let diff = (a - b).abs();
+            let tol = FLOAT_ABS_EPS.max(FLOAT_REL_EPS * a.abs().max(b.abs()));
             assert!(
-                ($first - $second) < FLOAT_ALLOWED_BIAS,
-                "Expected: {}, Actual: {}",
-                $second,
-                $first
+                diff <= tol,
+                "Expected: {}, Actual: {}, |Δ|={} > tol={}",
+                b,
+                a,
+                diff,
+                tol
             );
-        };
+        }};
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

issue: resolve #22872 

## What's changed and what's your intention?

Tests under src/storage/src/vector/distance.rs used a signed difference to compare floating-point values:
`($first - $second) < FLOAT_ALLOWED_BIAS`

This is asymmetric and can let large negative differences pass. After upgrading CMake I also observed a drift (~1.2e-5) that slightly exceeds the current 1e-5 epsilon causing the test to fail locally.

Observed failure: `Expected: 31.531513, Actual: 31.531525  (|Δ| ≈ 1.2e-5)`

**This PR:**
- Fixes the logic to compare absolute difference.
- Uses a combined absolute + relative tolerance to remain strict yet robust across SIMD/FMA/BLAS/FAISS code paths.

**Changes:**
- Replace the signed comparison with abs() on the difference, this measures the magnitude of the difference, so both positive and negative deviations are caught.
- Introduce FLOAT_ABS_EPS = 2e-5 and FLOAT_REL_EPS = 1e-6 to allow for expected noise while still detecting genuine errors.
- The tolerance is computed as the larger of the absolute floor (FLOAT_ABS_EPS) and a scaled relative term (FLOAT_REL_EPS * max(|a|, |b|)). This relative component adjusts the allowed difference based on the magnitude of the values, ensuring the comparison remains fair and consistent across both small and large numbers.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
