### PR TITLE
fix(redshift): update VARCHAR to VARCHAR(MAX) for compatibility

### DIFF
--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -742,7 +742,7 @@ pub fn build_create_table_sql(
         })
         .collect::<Result<Vec<String>>>()?;
     if need_op_and_row_id {
-        columns.push(format!("{} VARCHAR", __ROW_ID));
+        columns.push(format!("{} VARCHAR(MAX)", __ROW_ID));
         columns.push(format!("{} INT", __OP));
     }
     let columns_str = columns.join(", ");
@@ -761,11 +761,11 @@ fn convert_redshift_data_type(data_type: &DataType) -> Result<String> {
         DataType::Float32 => "REAL".to_owned(),
         DataType::Float64 => "FLOAT".to_owned(),
         DataType::Boolean => "BOOLEAN".to_owned(),
-        DataType::Varchar => "VARCHAR".to_owned(),
+        DataType::Varchar => "VARCHAR(MAX)".to_owned(),
         DataType::Date => "DATE".to_owned(),
         DataType::Timestamp => "TIMESTAMP".to_owned(),
         DataType::Timestamptz => "TIMESTAMPTZ".to_owned(),
-        DataType::Jsonb => "VARCHAR".to_owned(),
+        DataType::Jsonb => "VARCHAR(MAX)".to_owned(),
         DataType::Decimal => "DECIMAL".to_owned(),
         DataType::Time => "TIME".to_owned(),
         _ => {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- updates Redshift sink to use `VARCHAR(MAX)` instead of `VARCHAR` for the following data types: `Varchar`, `Jsonb`, Internal columns like `__ROW_ID`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
