### PR TITLE
refactor(sink): Simplify sink-into-table with new dynamic operator

### DIFF
--- a/e2e_test/batch/describe_fragment.slt
+++ b/e2e_test/batch/describe_fragment.slt
@@ -28,7 +28,8 @@ StreamMaterialize { columns: [id, value], stream_key: [id], pk_columns: [id], pk
 ├── output: [ id, value ]
 ├── stream key: [ id ]
 └── StreamUnion { all: true } { output: [ id, value ], stream key: [] }
-    └── MergeExecutor { output: [ id, value ], stream key: [] }'
+    ├── MergeExecutor { output: [ id, value ], stream key: [] }
+    └── StreamUpstreamSinkUnion { output: [ id, value ], stream key: [] }'
 
 
 # Test with non-existent fragment ID

--- a/e2e_test/batch/describe_fragments.slt
+++ b/e2e_test/batch/describe_fragments.slt
@@ -83,7 +83,8 @@ StreamMaterialize { columns: [id, name, age, created_at, data], stream_key: [id]
 ├── stream key: [ id ]
 └── StreamFilter { predicate: IsNotNull(name) } { output: [ id, name, age, created_at, data ], stream key: [] }
     └── StreamUnion { all: true } { output: [ id, name, age, created_at, data ], stream key: [] }
-        └── MergeExecutor { output: [ id, name, age, created_at, data ], stream key: [] }
+        ├── MergeExecutor { output: [ id, name, age, created_at, data ], stream key: [] }
+        └── StreamUpstreamSinkUnion { output: [ id, name, age, created_at, data ], stream key: [] }
 (empty)
 Fragment % (Actor %)
 StreamDml { columns: [id, name, age, created_at, data] } { output: [ id, name, age, created_at, data ], stream key: [] }

--- a/e2e_test/ddl/drop/drop_schema_cascade.slt
+++ b/e2e_test/ddl/drop/drop_schema_cascade.slt
@@ -50,14 +50,8 @@ create sink schema1.s2 into schema2.t4 from schema1.t2;
 statement error
 drop schema schema1;
 
-statement error Found sink into table in dependency
-drop schema schema1 cascade;
-
-statement ok
-drop table schema2.t4 cascade;
-
 statement ok
 drop schema schema1 cascade;
 
 statement ok
-drop schema schema2;
+drop schema schema2 cascade;

--- a/e2e_test/sink/sink_into_table/alter_column.slt
+++ b/e2e_test/sink/sink_into_table/alter_column.slt
@@ -178,6 +178,9 @@ select * from t_append_only;
 statement ok
 create sink s21 into t_append_only as select v1+1000 as v1, v1+2000 as v2, v1+3000 as v3 from t_s2 with (type = 'append-only', force_append_only = 'true');
 
+statement ok
+recover;
+
 query III rowsort
 select * from t_append_only;
 ----
@@ -210,9 +213,12 @@ statement ok
 create sink s_alter_1 into m_alter_1 (v2, v1) as select v2 as w2, v1 + 10 as w1 from t_alter_1;
 
 statement ok
+recover;
+
+statement ok
 insert into t_alter_1 values (1, 'a'), (2, 'b'), (3, 'c');
 
-query IT rowsort
+query TI rowsort
 select * from m_alter_1;
 ----
 a 11
@@ -222,7 +228,7 @@ c 13
 statement ok
 alter table m_alter_1 add column v3 int default 1000;
 
-query ITI rowsort
+query TII rowsort
 select * from m_alter_1;
 ----
 a 11 1000
@@ -232,7 +238,7 @@ c 13 1000
 statement ok
 insert into t_alter_1 values (4, 'd'), (5, 'e');
 
-query ITI rowsort
+query TII rowsort
 select * from m_alter_1;
 ----
 a 11 1000
@@ -281,3 +287,71 @@ drop table t2;
 
 statement ok
 drop table t1;
+
+statement ok
+create table t_drop_1 (v1 int, v2 varchar);
+
+statement ok
+create table m_drop_1 (v2 varchar, v1 int primary key);
+
+statement ok
+create sink s_drop_1 into m_drop_1 (v2, v1) as select v2, v1 from t_drop_1;
+
+statement ok
+recover;
+
+statement ok
+insert into t_drop_1 values (1, 'a'), (2, 'b'), (3, 'c');
+
+statement error dropping columns in target table of sinks is not supported
+alter table m_drop_1 drop column v2;
+
+statement ok
+drop sink s_drop_1;
+
+statement ok
+alter table m_drop_1 drop column v2;
+
+query I rowsort
+select * from m_drop_1;
+----
+1
+2
+3
+
+statement ok
+alter table m_drop_1 add column v3 int default 1000;
+
+query II rowsort
+select * from m_drop_1;
+----
+1 1000
+2 1000
+3 1000
+
+statement ok
+create sink s_drop_1 into m_drop_1 (v1, v3) as select v1, v1 + 10 from t_drop_1;
+
+statement ok
+insert into t_drop_1 values (4, 'd'), (5, 'e');
+
+query II rowsort
+select * from m_drop_1;
+----
+1 11
+2 12
+3 13
+4 14
+5 15
+
+statement error dropping columns in target table of sinks is not supported
+alter table m_drop_1 drop column v2;
+
+statement ok
+drop sink s_drop_1;
+
+statement ok
+drop table m_drop_1;
+
+statement ok
+drop table t_drop_1;

--- a/e2e_test/sink/sink_into_table/cascade_drop.slt
+++ b/e2e_test/sink/sink_into_table/cascade_drop.slt
@@ -1,0 +1,82 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t1 (v1 int, v2 varchar);
+
+statement ok
+create table t2 (v1 int, v2 varchar);
+
+statement ok
+create table t3 (v1 varchar, v2 int);
+
+statement ok
+create table t4 (v1 int primary key, v2 varchar, v3 int default 10);
+
+statement ok
+create sink s1 into t4 as select v1, v2 from t1;
+
+statement ok
+create sink s2 into t4 from t2;
+
+statement ok
+create sink s3 into t4 as select v2, v1 from t3;
+
+query I
+select count(*) from rw_sinks;
+----
+3
+
+statement ok
+insert into t1 values (1, 'a');
+
+statement ok
+insert into t2 values (2, 'b');
+
+statement ok
+insert into t3 values ('c', 3);
+
+query ITI rowsort
+select * from t4;
+----
+1 a 10
+2 b 10
+3 c 10
+
+statement ok
+drop table t1 cascade;
+
+query I
+select count(*) from rw_sinks;
+----
+2
+
+statement ok
+insert into t2 values (4, 'd');
+
+query ITI rowsort
+select * from t4;
+----
+1 a 10
+2 b 10
+3 c 10
+4 d 10
+
+statement ok
+drop table t4 cascade;
+
+query I
+select count(*) from rw_sinks;
+----
+0
+
+query I
+select count(*) from rw_tables;
+----
+2
+
+statement ok
+drop table t2;
+
+statement ok
+drop table t3;

--- a/e2e_test/sink/sink_into_table/parallelism.slt
+++ b/e2e_test/sink/sink_into_table/parallelism.slt
@@ -88,3 +88,63 @@ drop table t_simple;
 statement ok
 drop table m_simple;
 
+statement ok
+SET STREAMING_PARALLELISM TO default;
+
+statement ok
+create table t_simple (v1 int, v2 int);
+
+statement ok
+create table m_simple (v1 int primary key, v2 int);
+
+statement ok
+create sink s_simple into m_simple from t_simple;
+
+statement ok
+insert into t_simple values (1, 101), (2, 102);
+
+query I
+select count(*) from m_simple;
+----
+2
+
+statement ok
+alter table t_simple set PARALLELISM = 8;
+
+query I
+select distinct(parallelism) from rw_fragment_parallelism where name = 't_simple';
+----
+8
+
+statement ok
+alter sink s_simple set PARALLELISM = 6;
+
+query I
+select parallelism from rw_fragment_parallelism where array_position(flags, 'SINK') is not null and name = 's_simple';
+----
+6
+
+statement ok
+alter table m_simple set PARALLELISM = 12;
+
+query I
+select distinct(parallelism) from rw_fragment_parallelism where name = 'm_simple';
+----
+12
+
+statement ok
+insert into t_simple values (3, 103), (4, 104);
+
+query I
+select count(*) from m_simple;
+----
+4
+
+statement ok
+drop sink s_simple;
+
+statement ok
+drop table t_simple;
+
+statement ok
+drop table m_simple;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -88,8 +88,8 @@ message AlterSourceResponse {
 message CreateSinkRequest {
   catalog.Sink sink = 1;
   stream_plan.StreamFragmentGraph fragment_graph = 2;
-  // It is used to provide a replace plan for the downstream table in `create sink into table` requests.
-  optional ReplaceJobPlan affected_table_change = 3;
+  reserved 3;
+  reserved "affected_table_change";
   // The list of object IDs that this sink depends on.
   repeated uint32 dependencies = 4;
   bool if_not_exists = 5;
@@ -103,7 +103,8 @@ message CreateSinkResponse {
 message DropSinkRequest {
   uint32 sink_id = 1;
   bool cascade = 2;
-  optional ReplaceJobPlan affected_table_change = 3;
+  reserved 3;
+  reserved "affected_table_change";
 }
 
 message DropSinkResponse {

--- a/src/frontend/planner_test/tests/testdata/output/create_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/create_source.yaml
@@ -25,9 +25,10 @@
       └─StreamUnion { all: true }
         ├─StreamExchange [no_shuffle] { dist: SomeShard }
         │ └─StreamSource { source: s0, columns: [v1, v2, _row_id] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamDml { columns: [v1, v2, _row_id] }
-            └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamDml { columns: [v1, v2, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
 - id: csv_delimiter_semicolon
   sql: |
     explain create table s0 (v1 int, v2 varchar) with (
@@ -42,9 +43,10 @@
       └─StreamUnion { all: true }
         ├─StreamExchange [no_shuffle] { dist: SomeShard }
         │ └─StreamSource { source: s0, columns: [v1, v2, _row_id] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamDml { columns: [v1, v2, _row_id] }
-            └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamDml { columns: [v1, v2, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
 - id: csv_delimiter_tab
   sql: |
     explain create table s0 (v1 int, v2 varchar) with (
@@ -59,6 +61,7 @@
       └─StreamUnion { all: true }
         ├─StreamExchange [no_shuffle] { dist: SomeShard }
         │ └─StreamSource { source: s0, columns: [v1, v2, _row_id] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamDml { columns: [v1, v2, _row_id] }
-            └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamDml { columns: [v1, v2, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion

--- a/src/frontend/planner_test/tests/testdata/output/explain.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/explain.yaml
@@ -146,9 +146,10 @@
     StreamMaterialize { columns: [v1, v2, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: Overwrite }
     └─StreamRowIdGen { row_id_index: 2 }
       └─StreamUnion { all: true }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamDml { columns: [v1, v2, _row_id] }
-            └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamDml { columns: [v1, v2, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
 - sql: |
     explain create table t (v1 int, v2 varchar) with ( connector = 'kafka', kafka.topic = 'kafka_3_partition_topic', kafka.brokers = '127.0.0.1:1234', kafka.scan.startup.mode='earliest'  ) FORMAT PLAIN ENCODE JSON;
   explain_output: |
@@ -157,9 +158,10 @@
       └─StreamUnion { all: true }
         ├─StreamExchange [no_shuffle] { dist: SomeShard }
         │ └─StreamSource { source: t, columns: [v1, v2, _row_id] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamDml { columns: [v1, v2, _row_id] }
-            └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamDml { columns: [v1, v2, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
 - sql: |
     explain create table t (v1 int, v2 varchar) append only with ( connector = 'kafka', kafka.topic = 'kafka_3_partition_topic', kafka.brokers = '127.0.0.1:1234', kafka.scan.startup.mode='earliest'  ) FORMAT PLAIN ENCODE JSON;
   explain_output: |
@@ -168,9 +170,10 @@
       └─StreamUnion { all: true }
         ├─StreamExchange [no_shuffle] { dist: SomeShard }
         │ └─StreamSource { source: t, columns: [v1, v2, _row_id] }
-        └─StreamExchange [no_shuffle] { dist: SomeShard }
-          └─StreamDml { columns: [v1, v2, _row_id] }
-            └─StreamSource
+        ├─StreamExchange [no_shuffle] { dist: SomeShard }
+        │ └─StreamDml { columns: [v1, v2, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
 - sql: |
     explain create table t (v1 int, v2 varchar primary key) with ( connector = 'kafka', kafka.topic = 'kafka_3_partition_topic', kafka.brokers = '127.0.0.1:1234', kafka.scan.startup.mode='earliest'  ) FORMAT PLAIN ENCODE JSON;
   explain_output: |
@@ -178,9 +181,10 @@
     └─StreamUnion { all: true }
       ├─StreamExchange { dist: HashShard(v2) }
       │ └─StreamSource { source: t, columns: [v1, v2] }
-      └─StreamExchange { dist: HashShard(v2) }
-        └─StreamDml { columns: [v1, v2] }
-          └─StreamSource
+      ├─StreamExchange { dist: HashShard(v2) }
+      │ └─StreamDml { columns: [v1, v2] }
+      │   └─StreamSource
+      └─StreamUpstreamSinkUnion
 - sql: |
     explain create table t (v1 int, v2 varchar primary key) append only with ( connector = 'kafka', kafka.topic = 'kafka_3_partition_topic', kafka.brokers = '127.0.0.1:1234', kafka.scan.startup.mode='earliest'  ) FORMAT PLAIN ENCODE JSON;
   explain_output: |
@@ -188,6 +192,7 @@
     └─StreamUnion { all: true }
       ├─StreamExchange { dist: HashShard(v2) }
       │ └─StreamSource { source: t, columns: [v1, v2] }
-      └─StreamExchange { dist: HashShard(v2) }
-        └─StreamDml { columns: [v1, v2] }
-          └─StreamSource
+      ├─StreamExchange { dist: HashShard(v2) }
+      │ └─StreamDml { columns: [v1, v2] }
+      │   └─StreamSource
+      └─StreamUpstreamSinkUnion

--- a/src/frontend/planner_test/tests/testdata/output/generated_columns.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/generated_columns.yaml
@@ -6,10 +6,11 @@
     StreamMaterialize { columns: [v1, v2, v3, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: Overwrite }
     └─StreamRowIdGen { row_id_index: 3 }
       └─StreamUnion { all: true }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamProject { exprs: [(v2 - 1:Int32) as $expr1, v2, (v2 + 1:Int32) as $expr2, _row_id] }
-            └─StreamDml { columns: [v2, _row_id] }
-              └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamProject { exprs: [(v2 - 1:Int32) as $expr1, v2, (v2 + 1:Int32) as $expr2, _row_id] }
+        │   └─StreamDml { columns: [v2, _row_id] }
+        │     └─StreamSource
+        └─StreamUpstreamSinkUnion
 - name: source with generated columns
   sql: |
     create source s1 (v1 int as v2-1, v2 int, v3 int as v2+1) with (connector = 'kinesis') FORMAT PLAIN ENCODE JSON;
@@ -33,10 +34,11 @@
     StreamMaterialize { columns: [proc_time, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: Overwrite, watermark_columns: [proc_time] }
     └─StreamRowIdGen { row_id_index: 1 }
       └─StreamUnion { all: true, output_watermarks: [[$expr1]] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamProject { exprs: [Proctime as $expr1, _row_id], output_watermarks: [[$expr1]] }
-            └─StreamDml { columns: [_row_id] }
-              └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamProject { exprs: [Proctime as $expr1, _row_id], output_watermarks: [[$expr1]] }
+        │   └─StreamDml { columns: [_row_id] }
+        │     └─StreamSource
+        └─StreamUpstreamSinkUnion
 - name: proctime cast to without timezone
   sql: |
     explain create table t1 (proc_time TIMESTAMP AS proctime());
@@ -44,10 +46,11 @@
     StreamMaterialize { columns: [proc_time, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: Overwrite, watermark_columns: [proc_time] }
     └─StreamRowIdGen { row_id_index: 1 }
       └─StreamUnion { all: true, output_watermarks: [[$expr1]] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamProject { exprs: [AtTimeZone(Proctime, 'UTC':Varchar) as $expr1, _row_id], output_watermarks: [[$expr1]] }
-            └─StreamDml { columns: [_row_id] }
-              └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamProject { exprs: [AtTimeZone(Proctime, 'UTC':Varchar) as $expr1, _row_id], output_watermarks: [[$expr1]] }
+        │   └─StreamDml { columns: [_row_id] }
+        │     └─StreamSource
+        └─StreamUpstreamSinkUnion
 - name: watermark on generated column
   sql: |
     explain create table t (v int, w int as v+1, watermark for w as w) append only
@@ -56,7 +59,8 @@
     └─StreamRowIdGen { row_id_index: 2 }
       └─StreamWatermarkFilter { watermark_descs: [Desc { column: $expr1, expr: $expr1 }], output_watermarks: [[$expr1]] }
         └─StreamUnion { all: true }
-          └─StreamExchange [no_shuffle] { dist: SomeShard }
-            └─StreamProject { exprs: [v, (v + 1:Int32) as $expr1, _row_id] }
-              └─StreamDml { columns: [v, _row_id] }
-                └─StreamSource
+          ├─StreamExchange [no_shuffle] { dist: SomeShard }
+          │ └─StreamProject { exprs: [v, (v + 1:Int32) as $expr1, _row_id] }
+          │   └─StreamDml { columns: [v, _row_id] }
+          │     └─StreamSource
+          └─StreamUpstreamSinkUnion

--- a/src/frontend/planner_test/tests/testdata/output/shared_source.yml
+++ b/src/frontend/planner_test/tests/testdata/output/shared_source.yml
@@ -23,9 +23,10 @@
       └─StreamUnion { all: true }
         ├─StreamExchange [no_shuffle] { dist: SomeShard }
         │ └─StreamSource { source: s, columns: [x, y, _row_id] }
-        └─StreamExchange { dist: HashShard(_row_id) }
-          └─StreamDml { columns: [x, y, _row_id] }
-            └─StreamSource
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamDml { columns: [x, y, _row_id] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
   with_config_map:
     streaming_use_shared_source: 'true'
 - before:

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -53,9 +53,10 @@
         └─StreamUnion { all: true }
           ├─StreamExchange [no_shuffle] { dist: SomeShard }
           │ └─StreamSource { source: t, columns: [v1, _row_id] }
-          └─StreamExchange [no_shuffle] { dist: SomeShard }
-            └─StreamDml { columns: [v1, _row_id] }
-              └─StreamSource
+          ├─StreamExchange [no_shuffle] { dist: SomeShard }
+          │ └─StreamDml { columns: [v1, _row_id] }
+          │   └─StreamSource
+          └─StreamUpstreamSinkUnion
 - name: watermark on append only table without source
   sql: |
     explain create table t (v1 timestamp with time zone, watermark for v1 as v1 - INTERVAL '1' SECOND) append only;
@@ -64,9 +65,10 @@
     └─StreamRowIdGen { row_id_index: 1 }
       └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: (v1 - '00:00:01':Interval) }], output_watermarks: [[v1]] }
         └─StreamUnion { all: true }
-          └─StreamExchange [no_shuffle] { dist: SomeShard }
-            └─StreamDml { columns: [v1, _row_id] }
-              └─StreamSource
+          ├─StreamExchange [no_shuffle] { dist: SomeShard }
+          │ └─StreamDml { columns: [v1, _row_id] }
+          │   └─StreamSource
+          └─StreamUpstreamSinkUnion
 - name: hash agg
   sql: |
     create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -45,30 +45,24 @@ use risingwave_connector::{
     AUTO_SCHEMA_CHANGE_KEY, SINK_CREATE_TABLE_IF_NOT_EXISTS_KEY, SINK_INTERMEDIATE_TABLE_NAME,
     SINK_TARGET_TABLE_NAME, WithPropertiesExt,
 };
-use risingwave_pb::catalog::PbSink;
 use risingwave_pb::catalog::connection_params::PbConnectionType;
-use risingwave_pb::ddl_service::{ReplaceJobPlan, TableJobType, replace_job_plan};
-use risingwave_pb::stream_plan::stream_node::{NodeBody, PbNodeBody};
-use risingwave_pb::stream_plan::{MergeNode, StreamFragmentGraph, StreamNode};
 use risingwave_pb::telemetry::TelemetryDatabaseObject;
 use risingwave_sqlparser::ast::{
     CreateSink, CreateSinkStatement, EmitMode, Encode, ExplainOptions, Format, FormatEncodeOptions,
-    ObjectName, Query, Statement,
+    ObjectName, Query,
 };
 
 use super::RwPgResponse;
 use super::create_mv::get_column_names;
-use super::create_source::{SqlColumnStrategy, UPSTREAM_SOURCE_KEY};
+use super::create_source::UPSTREAM_SOURCE_KEY;
 use super::util::gen_query_from_table_name;
 use crate::binder::{Binder, Relation};
-use crate::catalog::source_catalog::SourceCatalog;
 use crate::catalog::table_catalog::TableType;
 use crate::error::{ErrorCode, Result, RwError};
 use crate::expr::{ExprImpl, InputRef, rewrite_now_to_proctime};
 use crate::handler::HandlerArgs;
 use crate::handler::alter_table_column::fetch_table_catalog_for_alter;
 use crate::handler::create_mv::parse_column_names;
-use crate::handler::create_table::{ColumnIdGenerator, generate_stream_graph_for_replace_table};
 use crate::handler::util::{check_connector_match_connection_type, ensure_connection_type_allowed};
 use crate::optimizer::plan_node::{
     IcebergPartitionInfo, LogicalSource, PartitionComputeInfo, StreamPlanRef as PlanRef,
@@ -607,40 +601,8 @@ pub async fn handle_create_sink(
         (sink, graph, target_table_catalog, dependencies)
     };
 
-    let mut target_table_replace_plan = None;
     if let Some(table_catalog) = target_table_catalog {
-        use crate::handler::alter_table_column::hijack_merger_for_target_table;
-
-        let (mut graph, table, source, target_job_type) =
-            reparse_table_for_sink(&session, &table_catalog).await?;
-
-        sink.original_target_columns = table.columns.clone();
-
-        let incoming_sinks = fetch_incoming_sinks(&session, &table_catalog)?;
-
-        let columns_without_rw_timestamp = table_catalog.columns_without_rw_timestamp();
-        for existing_sink in incoming_sinks {
-            hijack_merger_for_target_table(
-                &mut graph,
-                &columns_without_rw_timestamp,
-                &existing_sink,
-                Some(&existing_sink.unique_identity()),
-            )?;
-        }
-
-        // for new creating sink, we don't have a unique identity because the sink id is not generated yet.
-        hijack_merger_for_target_table(&mut graph, &columns_without_rw_timestamp, &sink, None)?;
-
-        target_table_replace_plan = Some(ReplaceJobPlan {
-            replace_job: Some(replace_job_plan::ReplaceJob::ReplaceTable(
-                replace_job_plan::ReplaceTable {
-                    table: Some(table.to_prost()),
-                    source: source.map(|x| x.to_prost()),
-                    job_type: target_job_type as _,
-                },
-            )),
-            fragment_graph: Some(graph),
-        });
+        sink.original_target_columns = table_catalog.columns_without_rw_timestamp();
     }
 
     let _job_guard =
@@ -656,13 +618,7 @@ pub async fn handle_create_sink(
 
     let catalog_writer = session.catalog_writer()?;
     catalog_writer
-        .create_sink(
-            sink.to_proto(),
-            graph,
-            target_table_replace_plan,
-            dependencies,
-            if_not_exists,
-        )
+        .create_sink(sink.to_proto(), graph, dependencies, if_not_exists)
         .await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_SINK))
@@ -687,70 +643,6 @@ pub fn fetch_incoming_sinks(
         );
     }
     Ok(sinks)
-}
-
-pub(crate) async fn reparse_table_for_sink(
-    session: &Arc<SessionImpl>,
-    table_catalog: &Arc<TableCatalog>,
-) -> Result<(
-    StreamFragmentGraph,
-    TableCatalog,
-    Option<SourceCatalog>,
-    TableJobType,
-)> {
-    // Retrieve the original table definition and parse it to AST.
-    let definition = table_catalog.create_sql_ast_purified()?;
-    let Statement::CreateTable { name, .. } = &definition else {
-        panic!("unexpected statement: {:?}", definition);
-    };
-    let table_name = name.clone();
-
-    // Create handler args as if we're creating a new table with the altered definition.
-    let handler_args = HandlerArgs::new(session.clone(), &definition, Arc::from(""))?;
-    let col_id_gen = ColumnIdGenerator::new_alter(table_catalog);
-
-    let (graph, table, source, job_type) = generate_stream_graph_for_replace_table(
-        session,
-        table_name,
-        table_catalog,
-        handler_args,
-        definition,
-        col_id_gen,
-        SqlColumnStrategy::FollowUnchecked,
-    )
-    .await?;
-
-    Ok((graph, table, source, job_type))
-}
-
-pub(crate) fn insert_merger_to_union_with_project(
-    node: &mut StreamNode,
-    project_node: &PbNodeBody,
-    uniq_identity: Option<&str>,
-) {
-    if let Some(NodeBody::Union(_union_node)) = &mut node.node_body {
-        // TODO: MergeNode is used as a placeholder, see issue #17658
-        node.input.push(StreamNode {
-            input: vec![StreamNode {
-                node_body: Some(NodeBody::Merge(Box::new(MergeNode {
-                    ..Default::default()
-                }))),
-                ..Default::default()
-            }],
-            identity: uniq_identity
-                .unwrap_or(PbSink::UNIQUE_IDENTITY_FOR_CREATING_TABLE_SINK)
-                .to_owned(),
-            fields: node.fields.clone(),
-            node_body: Some(project_node.clone()),
-            ..Default::default()
-        });
-
-        return;
-    }
-
-    for input in &mut node.input {
-        insert_merger_to_union_with_project(input, project_node, uniq_identity);
-    }
 }
 
 fn derive_sink_to_table_expr(

--- a/src/frontend/src/handler/drop_mv.rs
+++ b/src/frontend/src/handler/drop_mv.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 use pgwire::pg_response::{PgResponse, StatementType};
-use risingwave_common::catalog::StreamJobStatus;
-use risingwave_pb::meta::cancel_creating_jobs_request::{CreatingJobIds, PbJobs};
 use risingwave_sqlparser::ast::ObjectName;
 
 use super::RwPgResponse;
@@ -39,7 +37,7 @@ pub async fn handle_drop_mv(
 
     let schema_path = SchemaPath::new(schema_name.as_deref(), &search_path, user_name);
 
-    let (table_id, status) = {
+    let table_id = {
         let reader = session.env().catalog_reader().read_guard();
         let (table, schema_name) =
             match reader.get_any_table_by_name(&session.database(), schema_path, &table_name) {
@@ -70,27 +68,13 @@ pub async fn handle_drop_mv(
             _ => return Err(table.bad_drop_error()),
         }
 
-        (table.id(), table.stream_job_status)
+        table.id()
     };
 
-    match status {
-        StreamJobStatus::Created => {
-            let catalog_writer = session.catalog_writer()?;
-            catalog_writer
-                .drop_materialized_view(table_id, cascade)
-                .await?;
-        }
-        StreamJobStatus::Creating => {
-            let canceled_jobs = session
-                .env()
-                .meta_client()
-                .cancel_creating_jobs(PbJobs::Ids(CreatingJobIds {
-                    job_ids: vec![table_id.table_id],
-                }))
-                .await?;
-            tracing::info!(?canceled_jobs, "cancelled creating jobs");
-        }
-    }
+    let catalog_writer = session.catalog_writer()?;
+    catalog_writer
+        .drop_materialized_view(table_id, cascade)
+        .await?;
 
     Ok(PgResponse::empty_result(
         StatementType::DROP_MATERIALIZED_VIEW,

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -83,8 +83,8 @@ use crate::handler::create_table::{CreateTableInfo, CreateTableProps};
 use crate::optimizer::plan_node::generic::{GenericPlanRef, SourceNodeKind, Union};
 use crate::optimizer::plan_node::{
     Batch, BatchExchange, BatchPlanNodeType, BatchPlanRef, ConventionMarker, PlanTreeNode, Stream,
-    StreamExchange, StreamPlanRef, StreamUnion, StreamVectorIndexWrite, ToStream,
-    VisitExprsRecursive,
+    StreamExchange, StreamPlanRef, StreamUnion, StreamUpstreamSinkUnion, StreamVectorIndexWrite,
+    ToStream, VisitExprsRecursive,
 };
 use crate::optimizer::plan_visitor::{RwTimestampValidator, TemporalJoinValidator};
 use crate::optimizer::property::Distribution;
@@ -796,7 +796,16 @@ impl LogicalPlanRoot {
         };
 
         let with_external_source = source_catalog.is_some();
-        let union_inputs = if with_external_source {
+        let (dml_source_node, external_source_node) = if with_external_source {
+            let dummy_source_node = LogicalSource::new(
+                None,
+                columns.clone(),
+                row_id_index,
+                SourceNodeKind::CreateTable,
+                context.clone(),
+                None,
+            )
+            .and_then(|s| s.to_stream(&mut ToStreamContext::new(false)))?;
             let mut external_source_node = stream_plan.plan;
             external_source_node =
                 inject_project_for_generated_column_if_needed(&columns, external_source_node)?;
@@ -810,43 +819,24 @@ impl LogicalPlanRoot {
                     StreamExchange::new_no_shuffle(external_source_node).into()
                 }
             };
-
-            let dummy_source_node = LogicalSource::new(
-                None,
-                columns.clone(),
-                row_id_index,
-                SourceNodeKind::CreateTable,
-                context.clone(),
-                None,
-            )
-            .and_then(|s| s.to_stream(&mut ToStreamContext::new(false)))?;
-
-            let dml_node = inject_dml_node(
-                &columns,
-                append_only,
-                dummy_source_node,
-                &pk_column_indices,
-                kind,
-                column_descs,
-            )?;
-
-            vec![external_source_node, dml_node]
+            (dummy_source_node, Some(external_source_node))
         } else {
-            let dml_node = inject_dml_node(
-                &columns,
-                append_only,
-                stream_plan.plan,
-                &pk_column_indices,
-                kind,
-                column_descs,
-            )?;
-
-            vec![dml_node]
+            (stream_plan.plan, None)
         };
 
-        let dists = union_inputs
+        let dml_node = inject_dml_node(
+            &columns,
+            append_only,
+            dml_source_node,
+            &pk_column_indices,
+            kind,
+            column_descs,
+        )?;
+
+        let dists = external_source_node
             .iter()
             .map(|input| input.distribution())
+            .chain([dml_node.distribution()])
             .unique()
             .collect_vec();
 
@@ -861,13 +851,30 @@ impl LogicalPlanRoot {
             }
         };
 
+        let generated_column_exprs =
+            LogicalSource::derive_output_exprs_from_generated_columns(&columns)?;
+        let upstream_sink_union = StreamUpstreamSinkUnion::new(
+            context.clone(),
+            dml_node.schema(),
+            dml_node.stream_key(),
+            dist.clone(), // should always be the same as dist of `Union`
+            append_only,
+            row_id_index.is_none(),
+            generated_column_exprs,
+        );
+
+        let union_inputs = external_source_node
+            .into_iter()
+            .chain([dml_node, upstream_sink_union.into()])
+            .collect_vec();
+
         let mut stream_plan = StreamUnion::new_with_dist(
             Union {
                 all: true,
                 inputs: union_inputs,
                 source_col: None,
             },
-            dist.clone(),
+            dist,
         )
         .into();
 

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -1083,6 +1083,7 @@ mod stream_cdc_table_scan;
 mod stream_share;
 mod stream_temporal_join;
 mod stream_union;
+mod stream_upstream_sink_union;
 mod stream_vector_index_write;
 pub mod utils;
 
@@ -1196,6 +1197,7 @@ pub use stream_table_scan::StreamTableScan;
 pub use stream_temporal_join::StreamTemporalJoin;
 pub use stream_topn::StreamTopN;
 pub use stream_union::StreamUnion;
+pub use stream_upstream_sink_union::StreamUpstreamSinkUnion;
 pub use stream_values::StreamValues;
 pub use stream_vector_index_write::StreamVectorIndexWrite;
 pub use stream_watermark_filter::StreamWatermarkFilter;
@@ -1337,6 +1339,7 @@ macro_rules! for_all_plan_nodes {
             , { Stream, SyncLogStore }
             , { Stream, MaterializedExprs }
             , { Stream, VectorIndexWrite }
+            , { Stream, UpstreamSinkUnion }
             $(,$rest)*
         }
     };

--- a/src/frontend/src/optimizer/plan_node/stream_upstream_sink_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_upstream_sink_union.rs
@@ -1,0 +1,175 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use educe::Educe;
+use pretty_xmlish::XmlNode;
+use risingwave_common::catalog::Schema;
+use risingwave_pb::stream_plan::UpstreamSinkUnionNode;
+use risingwave_pb::stream_plan::stream_node::PbNodeBody;
+
+use super::stream::prelude::*;
+use crate::OptimizerContextRef;
+use crate::expr::ExprImpl;
+use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
+use crate::optimizer::plan_node::utils::{Distill, childless_record, watermark_pretty};
+use crate::optimizer::plan_node::{ExprRewritable, PlanBase, Stream, StreamNode};
+use crate::optimizer::property::{
+    Distribution, FunctionalDependencySet, MonotonicityDerivation, MonotonicityMap,
+    WatermarkColumns, analyze_monotonicity,
+};
+use crate::stream_fragmenter::BuildFragmentGraphState;
+
+#[derive(Debug, Clone, Educe)]
+#[educe(PartialEq, Eq, Hash)]
+struct UpstreamSinkUnionInner {
+    #[educe(PartialEq(ignore), Hash(ignore))]
+    ctx: OptimizerContextRef,
+    schema: Schema,
+    stream_key: Option<Vec<usize>>,
+    dist: Distribution,
+    stream_kind: StreamKind,
+    // `generated_column` is used to generate the `watermark_columns` field and affects the derivation of subsequent
+    // operators. Since the project operator of `generated_column` is actually on the sink-fragment, not on the table,
+    // only expr can be retained here to determine the `watermark_columns`.
+    generated_column_exprs: Option<Vec<ExprImpl>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamUpstreamSinkUnion {
+    pub base: PlanBase<Stream>,
+    pub generated_column_exprs: Option<Vec<ExprImpl>>,
+}
+
+impl StreamUpstreamSinkUnion {
+    pub fn new(
+        ctx: OptimizerContextRef,
+        schema: &Schema,
+        stream_key: Option<&[usize]>,
+        dist: Distribution,
+        append_only: bool,
+        user_defined_pk: bool,
+        generated_column_exprs: Option<Vec<ExprImpl>>,
+    ) -> Self {
+        // For upstream sink creating, we require that if the table doesn't define pk or the table is `append_only`, the
+        // upstream sink must be `append_only`.
+        let stream_kind = if append_only || !user_defined_pk {
+            StreamKind::AppendOnly
+        } else {
+            StreamKind::Upsert
+        };
+        let inner = UpstreamSinkUnionInner {
+            ctx,
+            schema: schema.clone(),
+            stream_key: stream_key.map(|keys| keys.to_vec()),
+            dist,
+            stream_kind,
+            generated_column_exprs,
+        };
+
+        Self::new_inner(inner)
+    }
+
+    fn new_inner(inner: UpstreamSinkUnionInner) -> Self {
+        let mut out_watermark_columns = WatermarkColumns::new();
+        let mut out_monotonicity_map = MonotonicityMap::new();
+        // reference `StreamProject::new_inner()`
+        if let Some(ref generated_column_exprs) = inner.generated_column_exprs {
+            for (expr_idx, expr) in generated_column_exprs.iter().enumerate() {
+                if let MonotonicityDerivation::Inherent(monotonicity) = analyze_monotonicity(expr) {
+                    out_monotonicity_map.insert(expr_idx, monotonicity);
+                    if monotonicity.is_non_decreasing() && !monotonicity.is_constant() {
+                        out_watermark_columns.insert(expr_idx, inner.ctx.next_watermark_group_id());
+                    }
+                }
+            }
+        }
+
+        let field_num = inner.schema.fields().len();
+        let base = PlanBase::new_stream(
+            inner.ctx,
+            inner.schema,
+            inner.stream_key, // maybe incorrect
+            FunctionalDependencySet::new(field_num),
+            inner.dist,
+            inner.stream_kind,
+            false, // emit_on_window_close
+            out_watermark_columns,
+            out_monotonicity_map,
+        );
+
+        Self {
+            base,
+            generated_column_exprs: inner.generated_column_exprs,
+        }
+    }
+
+    fn rebuild_inner(&self) -> UpstreamSinkUnionInner {
+        UpstreamSinkUnionInner {
+            ctx: self.base.ctx(),
+            schema: self.base.schema().clone(),
+            stream_key: self.base.stream_key().map(|keys| keys.to_vec()),
+            dist: self.base.distribution().clone(),
+            stream_kind: self.base.stream_kind(),
+            generated_column_exprs: self.generated_column_exprs.clone(),
+        }
+    }
+}
+
+impl Distill for StreamUpstreamSinkUnion {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        let verbose = self.base.ctx().is_explain_verbose();
+        let mut vec = Vec::new();
+        if verbose && let Some(ow) = watermark_pretty(self.watermark_columns(), self.schema()) {
+            vec.push(("output_watermarks", ow));
+        }
+        childless_record("StreamUpstreamSinkUnion", vec)
+    }
+}
+
+impl_plan_tree_node_for_leaf! { Stream, StreamUpstreamSinkUnion }
+
+impl StreamNode for StreamUpstreamSinkUnion {
+    fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> PbNodeBody {
+        PbNodeBody::UpstreamSinkUnion(Box::new(UpstreamSinkUnionNode {
+            // When the table is created, there are no upstreams, so this is empty. When upstream sinks are created
+            // later, the actual upstreams in executor will increase, and during recovery, it will be filled with the
+            // actual upstream infos.
+            init_upstreams: vec![],
+        }))
+    }
+}
+
+impl ExprRewritable<Stream> for StreamUpstreamSinkUnion {
+    fn has_rewritable_expr(&self) -> bool {
+        self.generated_column_exprs.is_some()
+    }
+
+    fn rewrite_exprs(&self, r: &mut dyn crate::expr::ExprRewriter) -> super::PlanRef<Stream> {
+        let mut inner = self.rebuild_inner();
+        inner.generated_column_exprs = inner
+            .generated_column_exprs
+            .map(|exprs| exprs.into_iter().map(|expr| r.rewrite_expr(expr)).collect());
+        Self::new_inner(inner).into()
+    }
+}
+
+impl ExprVisitable for StreamUpstreamSinkUnion {
+    fn visit_exprs(&self, v: &mut dyn crate::expr::ExprVisitor) {
+        if let Some(exprs) = self.generated_column_exprs.as_ref() {
+            exprs.iter().for_each(|expr| {
+                v.visit_expr(expr);
+            });
+        }
+    }
+}

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -46,8 +46,8 @@ use risingwave_pb::catalog::{
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::ddl_service::alter_owner_request::Object;
 use risingwave_pb::ddl_service::{
-    DdlProgress, PbTableJobType, ReplaceJobPlan, TableJobType, alter_name_request,
-    alter_set_schema_request, alter_swap_rename_request, create_connection_request,
+    DdlProgress, PbTableJobType, TableJobType, alter_name_request, alter_set_schema_request,
+    alter_swap_rename_request, create_connection_request,
 };
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
@@ -378,7 +378,6 @@ impl CatalogWriter for MockCatalogWriter {
         &self,
         sink: PbSink,
         graph: StreamFragmentGraph,
-        _affected_table_change: Option<ReplaceJobPlan>,
         _dependencies: HashSet<ObjectId>,
         _if_not_exists: bool,
     ) -> Result<()> {
@@ -518,12 +517,7 @@ impl CatalogWriter for MockCatalogWriter {
         Ok(())
     }
 
-    async fn drop_sink(
-        &self,
-        sink_id: u32,
-        cascade: bool,
-        _target_table_change: Option<ReplaceJobPlan>,
-    ) -> Result<()> {
+    async fn drop_sink(&self, sink_id: u32, cascade: bool) -> Result<()> {
         if cascade {
             return Err(ErrorCode::NotSupported(
                 "drop cascade in MockCatalogWriter is unsupported".to_owned(),

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -274,7 +274,6 @@ impl DdlService for DdlServiceImpl {
                     .run_command(DdlCommand::CreateStreamingJob {
                         stream_job,
                         fragment_graph,
-                        affected_table_replace_info: None,
                         dependencies: HashSet::new(),
                         specific_resource_group: None,
                         if_not_exists: req.if_not_exists,
@@ -316,33 +315,17 @@ impl DdlService for DdlServiceImpl {
 
         let sink = req.get_sink()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
-        let affected_table_change = req
-            .get_affected_table_change()
-            .cloned()
-            .ok()
-            .map(Self::extract_replace_table_info);
         let dependencies = req
             .get_dependencies()
             .iter()
             .map(|id| *id as ObjectId)
             .collect();
 
-        let stream_job = match &affected_table_change {
-            None => StreamingJob::Sink(sink, None),
-            Some(change) => {
-                let (source, table, _) = change
-                    .streaming_job
-                    .clone()
-                    .try_as_table()
-                    .expect("must be replace table");
-                StreamingJob::Sink(sink, Some((table, source)))
-            }
-        };
+        let stream_job = StreamingJob::Sink(sink);
 
         let command = DdlCommand::CreateStreamingJob {
             stream_job,
             fragment_graph,
-            affected_table_replace_info: affected_table_change,
             dependencies,
             specific_resource_group: None,
             if_not_exists: req.if_not_exists,
@@ -367,9 +350,6 @@ impl DdlService for DdlServiceImpl {
         let command = DdlCommand::DropStreamingJob {
             job_id: StreamingJobId::Sink(sink_id as _),
             drop_mode,
-            target_replace_info: request
-                .affected_table_change
-                .map(Self::extract_replace_table_info),
         };
 
         let version = self.ddl_controller.run_command(command).await?;
@@ -443,7 +423,6 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::CreateStreamingJob {
                 stream_job,
                 fragment_graph,
-                affected_table_replace_info: None,
                 dependencies,
                 specific_resource_group,
                 if_not_exists: req.if_not_exists,
@@ -471,7 +450,6 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::DropStreamingJob {
                 job_id: StreamingJobId::MaterializedView(table_id as _),
                 drop_mode,
-                target_replace_info: None,
             })
             .await?;
 
@@ -498,7 +476,6 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::CreateStreamingJob {
                 stream_job,
                 fragment_graph,
-                affected_table_replace_info: None,
                 dependencies: HashSet::new(),
                 specific_resource_group: None,
                 if_not_exists: req.if_not_exists,
@@ -525,7 +502,6 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::DropStreamingJob {
                 job_id: StreamingJobId::Index(index_id as _),
                 drop_mode,
-                target_replace_info: None,
             })
             .await?;
 
@@ -594,7 +570,6 @@ impl DdlService for DdlServiceImpl {
             .run_command(DdlCommand::CreateStreamingJob {
                 stream_job,
                 fragment_graph,
-                affected_table_replace_info: None,
                 dependencies,
                 specific_resource_group: None,
                 if_not_exists: request.if_not_exists,
@@ -624,7 +599,6 @@ impl DdlService for DdlServiceImpl {
                     table_id as _,
                 ),
                 drop_mode,
-                target_replace_info: None,
             })
             .await?;
 

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -987,18 +987,18 @@ impl DatabaseCheckpointControl {
             (None, vec![])
         };
 
-        for table_to_cancel in command
+        for job_to_cancel in command
             .as_ref()
-            .map(Command::tables_to_drop)
+            .map(Command::jobs_to_drop)
             .into_iter()
             .flatten()
         {
             if self
                 .creating_streaming_job_controls
-                .contains_key(&table_to_cancel)
+                .contains_key(&job_to_cancel)
             {
                 warn!(
-                    table_id = table_to_cancel.table_id,
+                    job_id = job_to_cancel.table_id,
                     "ignore cancel command on creating streaming job"
                 );
                 for notifier in notifiers {

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -23,9 +23,12 @@ use itertools::Itertools;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::WorkerSlotId;
+use risingwave_common::util::stream_graph_visitor::visit_stream_node_body;
 use risingwave_connector::source::cdc::CdcTableSnapshotSplitAssignmentWithGeneration;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_meta_model::StreamingParallelism;
+use risingwave_pb::catalog::table::PbTableType;
+use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use thiserror_ext::AsReport;
 use tokio::time::Instant;
 use tracing::{debug, info, warn};
@@ -36,6 +39,7 @@ use crate::barrier::info::InflightStreamingJobInfo;
 use crate::barrier::{DatabaseRuntimeInfoSnapshot, InflightSubscriptionInfo};
 use crate::manager::ActiveStreamingWorkerNodes;
 use crate::model::{ActorId, StreamActor, StreamJobFragments, TableParallelism};
+use crate::rpc::ddl_controller::refill_upstream_sink_union_in_table;
 use crate::stream::cdc::assign_cdc_table_snapshot_splits_pairs;
 use crate::stream::{
     JobParallelismTarget, JobReschedulePolicy, JobRescheduleTarget, JobResourceGroupTarget,
@@ -250,6 +254,69 @@ impl GlobalBarrierWorkerContextImpl {
         Ok((table_committed_epoch, log_epochs))
     }
 
+    /// For normal DDL operations, the `UpstreamSinkUnion` operator is modified dynamically, and does not persist the
+    /// newly added or deleted upstreams in meta-store. Therefore, when restoring jobs, we need to restore the
+    /// information required by the operator based on the current state of the upstream (sink) and downstream (table) of
+    /// the operator.
+    async fn recovery_table_with_upstream_sinks(
+        &self,
+        inflight_jobs: &mut HashMap<DatabaseId, HashMap<TableId, InflightStreamingJobInfo>>,
+    ) -> MetaResult<()> {
+        let mut jobs = inflight_jobs.values_mut().try_fold(
+            HashMap::new(),
+            |mut acc, table_map| -> MetaResult<_> {
+                for (tid, job) in table_map {
+                    if acc.insert(tid.table_id, job).is_some() {
+                        return Err(anyhow::anyhow!("Duplicate table id found: {:?}", tid).into());
+                    }
+                }
+                Ok(acc)
+            },
+        )?;
+        let job_ids = jobs.keys().cloned().collect_vec();
+        // Only `Table` will be returned here, ignoring other catalog objects.
+        let tables = self
+            .metadata_manager
+            .catalog_controller
+            .get_user_created_table_by_ids(job_ids.into_iter().map(|id| id as _).collect())
+            .await?;
+        for table in tables {
+            assert_eq!(table.table_type(), PbTableType::Table);
+            let fragments = jobs.get_mut(&table.id).unwrap();
+            let mut target_fragment_id = None;
+            for fragment in fragments.fragment_infos.values_mut() {
+                let mut is_target_fragment = false;
+                visit_stream_node_body(&fragment.nodes, |body| {
+                    if let PbNodeBody::UpstreamSinkUnion(_) = body {
+                        is_target_fragment = true;
+                    }
+                });
+                if is_target_fragment {
+                    // Each table should have only one target fragment.
+                    if let Some(ref target_fragment_id) = target_fragment_id {
+                        assert_eq!(*target_fragment_id, fragment.fragment_id);
+                    } else {
+                        target_fragment_id = Some(fragment.fragment_id);
+                    }
+                }
+            }
+            let target_fragment_id =
+                target_fragment_id.expect("Table should have upstream-sink-union node");
+            let target_fragment = fragments
+                .fragment_infos
+                .get_mut(&target_fragment_id)
+                .unwrap();
+            let upstream_infos = self
+                .metadata_manager
+                .catalog_controller
+                .get_all_upstream_sink_infos(&table, target_fragment_id as _)
+                .await?;
+            refill_upstream_sink_union_in_table(&mut target_fragment.nodes, &upstream_infos);
+        }
+
+        Ok(())
+    }
+
     pub(super) async fn reload_runtime_info_impl(
         &self,
     ) -> MetaResult<BarrierWorkerRuntimeInfoSnapshot> {
@@ -367,6 +434,8 @@ impl GlobalBarrierWorkerContextImpl {
                             warn!(error = %err.as_report(), "resolve actor info failed");
                         })?
                     }
+
+                    self.recovery_table_with_upstream_sinks(&mut info).await?;
 
                     let info = info;
 
@@ -516,12 +585,15 @@ impl GlobalBarrierWorkerContextImpl {
             .scheduled_barriers
             .pre_apply_drop_cancel(Some(database_id));
 
-        let info = self
+        let mut info = self
             .resolve_graph_info(Some(database_id))
             .await
             .inspect_err(|err| {
                 warn!(error = %err.as_report(), "resolve actor info failed");
             })?;
+
+        self.recovery_table_with_upstream_sinks(&mut info).await?;
+
         assert!(info.len() <= 1);
         let Some(info) = info.into_iter().next().map(|(loaded_database_id, info)| {
             assert_eq!(loaded_database_id, database_id);

--- a/src/meta/src/barrier/edge_builder.rs
+++ b/src/meta/src/barrier/edge_builder.rs
@@ -130,7 +130,11 @@ impl FragmentEdgeBuilder {
         }
     }
 
-    fn add_edge(&mut self, fragment_id: FragmentId, downstream: &DownstreamFragmentRelation) {
+    pub(super) fn add_edge(
+        &mut self,
+        fragment_id: FragmentId,
+        downstream: &DownstreamFragmentRelation,
+    ) {
         let fragment = &self
             .fragments
             .get(&fragment_id)

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -484,7 +484,7 @@ impl CreateMviewProgressTracker {
                 .flat_map(|resp| resp.create_mview_progress.iter()),
             version_stats,
         );
-        for table_id in command.map(Command::tables_to_drop).into_iter().flatten() {
+        for table_id in command.map(Command::jobs_to_drop).into_iter().flatten() {
             // the cancelled command is possibly stashed in `finished_commands` and waiting
             // for checkpoint, we should also clear it.
             self.cancel_command(table_id);

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -127,28 +127,6 @@ impl CatalogController {
             removed_objects.extend(removed_sink_objs);
         }
 
-        // When there is a table sink in the dependency chain of drop cascade, an error message needs to be returned currently to manually drop the sink.
-        if object_type != ObjectType::Sink {
-            for obj in &removed_objects {
-                if obj.obj_type == ObjectType::Sink {
-                    let sink = Sink::find_by_id(obj.oid)
-                        .one(&txn)
-                        .await?
-                        .ok_or_else(|| MetaError::catalog_id_not_found("sink", obj.oid))?;
-
-                    // Since dropping the sink into the table requires the frontend to handle some of the logic (regenerating the plan), it’s not compatible with the current cascade dropping.
-                    if let Some(target_table) = sink.target_table
-                        && !removed_object_ids.contains(&target_table)
-                    {
-                        return Err(MetaError::permission_denied(format!(
-                            "Found sink into table in dependency: {}, please drop it manually",
-                            sink.name,
-                        )));
-                    }
-                }
-            }
-        }
-
         // 1. Detect when an Iceberg table is part of the dependencies.
         // 2. Drop database with iceberg tables in it is not supported.
         if object_type != ObjectType::Table || drop_database {
@@ -268,8 +246,25 @@ impl CatalogController {
             }
         }
 
-        let (removed_source_fragments, removed_actors, removed_fragments) =
+        let (removed_source_fragments, removed_sink_fragments, removed_actors, removed_fragments) =
             get_fragments_for_jobs(&txn, removed_streaming_job_ids.clone()).await?;
+
+        let sink_target_fragments = fetch_target_fragments(&txn, removed_sink_fragments).await?;
+        let mut removed_sink_fragment_by_targets = HashMap::new();
+        for (sink_fragment, target_fragments) in sink_target_fragments {
+            assert!(
+                target_fragments.len() <= 1,
+                "sink should have at most one downstream fragment"
+            );
+            if let Some(target_fragment) = target_fragments.first()
+                && !removed_fragments.contains(target_fragment)
+            {
+                removed_sink_fragment_by_targets
+                    .entry(*target_fragment)
+                    .or_insert_with(Vec::new)
+                    .push(sink_fragment);
+            }
+        }
 
         // Find affect users with privileges on all this objects.
         let updated_user_ids: Vec<UserId> = UserPrivilege::find()
@@ -314,6 +309,7 @@ impl CatalogController {
         inner
             .dropped_tables
             .extend(dropped_tables.map(|t| (TableId::try_from(t.id).unwrap(), t)));
+
         let version = match object_type {
             ObjectType::Database => {
                 // TODO: Notify objects in other databases when the cross-database query is supported.
@@ -360,6 +356,7 @@ impl CatalogController {
                 removed_source_fragments,
                 removed_actors,
                 removed_fragments,
+                removed_sink_fragment_by_targets,
             },
             version,
         ))

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -135,6 +135,9 @@ pub struct ReleaseContext {
 
     pub(crate) removed_actors: HashSet<ActorId>,
     pub(crate) removed_fragments: HashSet<FragmentId>,
+
+    /// Removed sink fragment by target fragment.
+    pub(crate) removed_sink_fragment_by_targets: HashMap<FragmentId, Vec<FragmentId>>,
 }
 
 impl CatalogController {

--- a/src/meta/src/controller/catalog/util.rs
+++ b/src/meta/src/controller/catalog/util.rs
@@ -337,6 +337,11 @@ impl CatalogController {
         // clean upstream fragment ids from (fragment)
         // clean stream node from (fragment)
         // clean upstream actor ids from (actor)
+
+        // The cleanup of fragment and StreamNode is to maintain compatibility with old versions of data. For the
+        // current sink-into-table implementation, there is no need to restore the contents of StreamNode, because the
+        // `UpstreamSinkUnion` operator does not persist any data, but relies on refill during recovery.
+
         let all_fragment_ids: Vec<FragmentId> = Fragment::find()
             .select_only()
             .column(fragment::Column::FragmentId)

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -23,7 +23,6 @@ use risingwave_common::bail;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
 use risingwave_common::hash::{VnodeCount, VnodeCountCompat, WorkerSlotId};
-use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common::util::stream_graph_visitor::{
     visit_stream_node_body, visit_stream_node_mut,
 };
@@ -1792,10 +1791,15 @@ impl CatalogController {
         let sink_fragment_ids = get_sink_fragment_by_ids(&txn, sink_ids).await?;
 
         let mut upstream_sink_infos = Vec::with_capacity(incoming_sinks.len());
-        for (pb_sink, sink_fragment_id) in incoming_sinks
-            .iter()
-            .zip_eq_debug(sink_fragment_ids.into_iter())
-        {
+        for pb_sink in &incoming_sinks {
+            let sink_fragment_id =
+                sink_fragment_ids
+                    .get(&(pb_sink.id as _))
+                    .cloned()
+                    .ok_or(anyhow::anyhow!(
+                        "sink fragment not found for sink id {}",
+                        pb_sink.id
+                    ))?;
             let upstream_info = build_upstream_sink_info(
                 pb_sink,
                 sink_fragment_id,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -572,14 +572,12 @@ impl CatalogController {
                 let sink_target_fragment = fetch_target_fragments(&txn, [sink_fragment_id]).await?;
                 sink_target_fragment
                     .get(&sink_fragment_id)
-                    .and_then(|target_fragments| {
-                        assert!(
-                            !target_fragments.is_empty(),
-                            "sink should have at least one downstream fragment"
-                        );
-                        target_fragments.first().cloned()
+                    .map(|target_fragments| {
+                        let target_fragment_id = *target_fragments
+                            .first()
+                            .expect("sink should have at least one downstream fragment");
+                        (sink_fragment_id, target_fragment_id)
                     })
-                    .map(|target_fragment_id| (sink_fragment_id, target_fragment_id))
             } else {
                 None
             };

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -18,7 +18,7 @@ use std::num::NonZeroUsize;
 use anyhow::anyhow;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
+use risingwave_common::catalog::{self, FragmentTypeFlag, FragmentTypeMask};
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::util::iter_util::ZipEqDebug;
@@ -67,14 +67,14 @@ use sea_orm::{
 use thiserror_ext::AsReport;
 
 use super::rename::IndexItemRewriter;
-use crate::barrier::{ReplaceStreamJobPlan, Reschedule};
+use crate::barrier::{Command, Reschedule};
 use crate::controller::ObjectModel;
 use crate::controller::catalog::{CatalogController, DropTableConnectorContext};
 use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_relation_name_duplicate,
     check_sink_into_table_cycle, ensure_job_not_canceled, ensure_object_id, ensure_user_id,
-    get_fragment_actor_ids, get_internal_tables_by_id, get_table_columns,
+    fetch_target_fragments, get_fragment_actor_ids, get_internal_tables_by_id, get_table_columns,
     grant_default_privileges_automatically, insert_fragment_relations, list_user_info_by_ids,
 };
 use crate::error::MetaErrorInner;
@@ -201,7 +201,7 @@ impl CatalogController {
                 let table_model: table::ActiveModel = table.clone().into();
                 Table::insert(table_model).exec(&txn).await?;
             }
-            StreamingJob::Sink(sink, _) => {
+            StreamingJob::Sink(sink) => {
                 if let Some(target_table_id) = sink.target_table
                     && check_sink_into_table_cycle(
                         target_table_id as ObjectId,
@@ -502,7 +502,7 @@ impl CatalogController {
         // Add streaming job objects to notification
         if need_notify {
             match creating_streaming_job.unwrap() {
-                StreamingJob::Sink(sink, _) => {
+                StreamingJob::Sink(sink) => {
                     objects_to_notify.push(PbObject {
                         object_info: Some(PbObjectInfo::Sink(sink.clone())),
                     });
@@ -555,6 +555,48 @@ impl CatalogController {
         }
 
         Ok(())
+    }
+
+    /// Builds a cancel command for the streaming job. If the sink (with target table) needs to be dropped, additional
+    /// information is required to build barrier mutation.
+    pub async fn build_cancel_command(
+        &self,
+        table_fragments: &StreamJobFragments,
+    ) -> MetaResult<Command> {
+        let inner = self.inner.read().await;
+        let txn = inner.db.begin().await?;
+
+        let dropped_sink_fragment_with_target =
+            if let Some(sink_fragment) = table_fragments.sink_fragment() {
+                let sink_fragment_id = sink_fragment.fragment_id as FragmentId;
+                let sink_target_fragment = fetch_target_fragments(&txn, [sink_fragment_id]).await?;
+                sink_target_fragment
+                    .get(&sink_fragment_id)
+                    .and_then(|target_fragments| {
+                        assert!(
+                            !target_fragments.is_empty(),
+                            "sink should have at least one downstream fragment"
+                        );
+                        target_fragments.first().cloned()
+                    })
+                    .map(|target_fragment_id| (sink_fragment_id, target_fragment_id))
+            } else {
+                None
+            };
+
+        Ok(Command::DropStreamingJobs {
+            streaming_job_ids: HashSet::from_iter([table_fragments.stream_job_id()]),
+            actors: table_fragments.actor_ids(),
+            unregistered_state_table_ids: table_fragments
+                .all_table_ids()
+                .map(catalog::TableId::new)
+                .collect(),
+            unregistered_fragment_ids: table_fragments.fragment_ids().collect(),
+            dropped_sink_fragment_by_targets: dropped_sink_fragment_with_target
+                .into_iter()
+                .map(|(sink, target)| (target as _, vec![sink as _]))
+                .collect(),
+        })
     }
 
     /// `try_abort_creating_streaming_job` is used to abort the job that is under initial status or in `FOREGROUND` mode.
@@ -742,20 +784,12 @@ impl CatalogController {
         actor_ids: Vec<crate::model::ActorId>,
         upstream_fragment_new_downstreams: &FragmentDownstreamRelation,
         split_assignment: &SplitAssignment,
-        replace_plan: Option<&ReplaceStreamJobPlan>,
+        new_sink_downstream: Option<FragmentDownstreamRelation>,
     ) -> MetaResult<()> {
         let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
-        let actor_ids = actor_ids
-            .into_iter()
-            .chain(
-                replace_plan
-                    .iter()
-                    .flat_map(|plan| plan.new_fragments.actor_ids().into_iter()),
-            )
-            .map(|id| id as ActorId)
-            .collect_vec();
+        let actor_ids = actor_ids.into_iter().map(|id| id as ActorId).collect_vec();
 
         Actor::update_many()
             .col_expr(
@@ -766,13 +800,7 @@ impl CatalogController {
             .exec(&txn)
             .await?;
 
-        for splits in split_assignment.values().chain(
-            replace_plan
-                .as_ref()
-                .map(|plan| plan.init_split_assignment.values())
-                .into_iter()
-                .flatten(),
-        ) {
+        for splits in split_assignment.values() {
             for (actor_id, splits) in splits {
                 let splits = splits.iter().map(PbConnectorSplit::from).collect_vec();
                 let connector_splits = &PbConnectorSplits { splits };
@@ -787,25 +815,10 @@ impl CatalogController {
         }
 
         insert_fragment_relations(&txn, upstream_fragment_new_downstreams).await?;
-        let objects = if let Some(plan) = &replace_plan {
-            insert_fragment_relations(&txn, &plan.upstream_fragment_downstreams).await?;
 
-            let (objects, _) = Self::finish_replace_streaming_job_inner(
-                plan.tmp_id as _,
-                plan.replace_upstream.clone(),
-                SinkIntoTableContext {
-                    updated_sink_catalogs: vec![],
-                },
-                &txn,
-                plan.streaming_job.clone(),
-                None,
-                None,
-            )
-            .await?;
-            objects
-        } else {
-            vec![]
-        };
+        if let Some(new_downstream) = new_sink_downstream {
+            insert_fragment_relations(&txn, &new_downstream).await?;
+        }
 
         // Mark job as CREATING.
         streaming_job::ActiveModel {
@@ -817,13 +830,6 @@ impl CatalogController {
         .await?;
 
         txn.commit().await?;
-        if !objects.is_empty() {
-            self.notify_frontend(
-                NotificationOperation::Update,
-                NotificationInfo::ObjectGroup(PbObjectGroup { objects }),
-            )
-            .await;
-        }
 
         Ok(())
     }

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -21,6 +21,8 @@ use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask};
 use risingwave_common::hash::{ActorMapping, VnodeBitmapExt, WorkerSlotId, WorkerSlotMapping};
+use risingwave_common::types::Datum;
+use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_common::{bail, hash};
 use risingwave_meta_model::actor::ActorStatus;
@@ -42,12 +44,17 @@ use risingwave_pb::catalog::{
     PbSubscription, PbTable, PbView,
 };
 use risingwave_pb::common::WorkerNode;
+use risingwave_pb::expr::{PbExprNode, expr_node};
 use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::Info as NotificationInfo;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, PbFragmentWorkerSlotMapping, PbObject, PbObjectGroup,
 };
-use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
+use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
+use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
+use risingwave_pb::stream_plan::{
+    PbDispatchOutputMapping, PbDispatcher, PbDispatcherType, PbStreamNode,
+};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
 use risingwave_sqlparser::ast::Statement as SqlStatement;
@@ -65,6 +72,7 @@ use thiserror_ext::AsReport;
 
 use crate::barrier::SharedFragmentInfo;
 use crate::controller::ObjectModel;
+use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::model::{FragmentActorDispatchers, FragmentDownstreamRelation};
 use crate::{MetaError, MetaResult};
 
@@ -1686,6 +1694,7 @@ where
 
 /// For the given streaming jobs, returns
 /// - All source fragments
+/// - All sink fragments
 /// - All actors
 /// - All fragments
 pub async fn get_fragments_for_jobs<C>(
@@ -1693,6 +1702,7 @@ pub async fn get_fragments_for_jobs<C>(
     streaming_jobs: Vec<ObjectId>,
 ) -> MetaResult<(
     HashMap<SourceId, BTreeSet<FragmentId>>,
+    HashSet<FragmentId>,
     HashSet<ActorId>,
     HashSet<FragmentId>,
 )>
@@ -1700,7 +1710,12 @@ where
     C: ConnectionTrait,
 {
     if streaming_jobs.is_empty() {
-        return Ok((HashMap::default(), HashSet::default(), HashSet::default()));
+        return Ok((
+            HashMap::default(),
+            HashSet::default(),
+            HashSet::default(),
+            HashSet::default(),
+        ));
     }
 
     let fragments: Vec<(FragmentId, i32, StreamNode)> = Fragment::find()
@@ -1730,20 +1745,23 @@ where
         .collect();
 
     let mut source_fragment_ids: HashMap<SourceId, BTreeSet<FragmentId>> = HashMap::new();
+    let mut sink_fragment_ids: HashSet<FragmentId> = HashSet::new();
     for (fragment_id, mask, stream_node) in fragments {
-        if !FragmentTypeMask::from(mask).contains(FragmentTypeFlag::Source) {
-            continue;
-        }
-        if let Some(source_id) = stream_node.to_protobuf().find_stream_source() {
+        if FragmentTypeMask::from(mask).contains(FragmentTypeFlag::Source)
+            && let Some(source_id) = stream_node.to_protobuf().find_stream_source()
+        {
             source_fragment_ids
                 .entry(source_id as _)
                 .or_default()
                 .insert(fragment_id);
+        } else if FragmentTypeMask::from(mask).contains(FragmentTypeFlag::Sink) {
+            sink_fragment_ids.insert(fragment_id);
         }
     }
 
     Ok((
         source_fragment_ids,
+        sink_fragment_ids,
         actors.into_iter().collect(),
         fragment_ids,
     ))
@@ -2165,6 +2183,121 @@ where
     }
 
     Ok(())
+}
+
+pub async fn fetch_target_fragments<C>(
+    txn: &C,
+    src_fragment_id: impl IntoIterator<Item = FragmentId>,
+) -> MetaResult<HashMap<FragmentId, Vec<FragmentId>>>
+where
+    C: ConnectionTrait,
+{
+    let source_target_fragments: Vec<(FragmentId, FragmentId)> = FragmentRelation::find()
+        .select_only()
+        .columns([
+            fragment_relation::Column::SourceFragmentId,
+            fragment_relation::Column::TargetFragmentId,
+        ])
+        .filter(fragment_relation::Column::SourceFragmentId.is_in(src_fragment_id))
+        .into_tuple()
+        .all(txn)
+        .await?;
+
+    let source_target_fragments = source_target_fragments.into_iter().into_group_map();
+
+    Ok(source_target_fragments)
+}
+
+pub async fn get_sink_fragment_node_by_id<C>(
+    txn: &C,
+    sink_id: SinkId,
+) -> MetaResult<(FragmentId, PbStreamNode)>
+where
+    C: ConnectionTrait,
+{
+    let sink_fragment: Vec<(FragmentId, StreamNode)> = Fragment::find()
+        .select_only()
+        .columns([fragment::Column::FragmentId, fragment::Column::StreamNode])
+        .filter(
+            fragment::Column::JobId
+                .eq(sink_id)
+                .and(FragmentTypeMask::intersects(FragmentTypeFlag::Sink)),
+        )
+        .into_tuple()
+        .all(txn)
+        .await?;
+
+    if sink_fragment.len() != 1 {
+        return Err(anyhow::anyhow!(
+            "expected exactly one sink fragment for sink {}, found {}",
+            sink_id,
+            sink_fragment.len()
+        )
+        .into());
+    }
+
+    Ok(sink_fragment
+        .into_iter()
+        .next()
+        .map(|(id, node)| (id, node.to_protobuf()))
+        .unwrap())
+}
+
+pub fn build_select_node_list(
+    from: &[ColumnCatalog],
+    to: &[ColumnCatalog],
+) -> MetaResult<Vec<PbExprNode>> {
+    let mut exprs = Vec::with_capacity(to.len());
+    let idx_by_col_id = from
+        .iter()
+        .enumerate()
+        .map(|(idx, col)| (col.column_desc.as_ref().unwrap().column_id, idx))
+        .collect::<HashMap<_, _>>();
+
+    for to_col in to {
+        let to_col = to_col.column_desc.as_ref().unwrap();
+        let to_col_type = to_col.column_type.clone();
+        if let Some(from_idx) = idx_by_col_id.get(&to_col.column_id) {
+            let from_col_type = from[*from_idx]
+                .column_desc
+                .as_ref()
+                .unwrap()
+                .column_type
+                .clone();
+            if to_col_type != from_col_type {
+                return Err(anyhow!(
+                    "Column type mismatch: {:?} != {:?}",
+                    from_col_type,
+                    to_col_type
+                )
+                .into());
+            }
+            exprs.push(PbExprNode {
+                function_type: expr_node::Type::Unspecified.into(),
+                return_type: to_col_type,
+                rex_node: Some(expr_node::RexNode::InputRef(*from_idx as _)),
+            });
+        } else {
+            let to_default_node =
+                if let Some(GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc {
+                    expr,
+                    ..
+                })) = &to_col.generated_or_default_column
+                {
+                    expr.clone().unwrap()
+                } else {
+                    let null = Datum::None.to_protobuf();
+                    PbExprNode {
+                        function_type: expr_node::Type::Unspecified.into(),
+                        return_type: to_col_type,
+                        rex_node: Some(expr_node::RexNode::Constant(null)),
+                    }
+                };
+            exprs.push(to_default_node);
+        }
+    }
+
+    Ok(exprs)
 }
 
 #[cfg(test)]

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -2210,14 +2210,14 @@ where
 pub async fn get_sink_fragment_by_ids<C>(
     txn: &C,
     sink_ids: Vec<SinkId>,
-) -> MetaResult<Vec<FragmentId>>
+) -> MetaResult<HashMap<SinkId, FragmentId>>
 where
     C: ConnectionTrait,
 {
     let sink_num = sink_ids.len();
-    let sink_fragment_ids: Vec<FragmentId> = Fragment::find()
+    let sink_fragment_ids: Vec<(SinkId, FragmentId)> = Fragment::find()
         .select_only()
-        .column(fragment::Column::FragmentId)
+        .columns([fragment::Column::JobId, fragment::Column::FragmentId])
         .filter(
             fragment::Column::JobId
                 .is_in(sink_ids)
@@ -2236,7 +2236,7 @@ where
         .into());
     }
 
-    Ok(sink_fragment_ids)
+    Ok(sink_fragment_ids.into_iter().collect())
 }
 
 pub fn build_select_node_list(

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -484,9 +484,9 @@ impl MetadataManager {
             .await
     }
 
-    pub async fn get_table_catalog_by_ids(&self, ids: Vec<u32>) -> MetaResult<Vec<PbTable>> {
+    pub async fn get_table_catalog_by_ids(&self, ids: &[u32]) -> MetaResult<Vec<PbTable>> {
         self.catalog_controller
-            .get_table_by_ids(ids.into_iter().map(|id| id as _).collect(), false)
+            .get_table_by_ids(ids.iter().map(|id| *id as _).collect(), false)
             .await
     }
 

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -37,7 +37,7 @@ use crate::{MetaError, MetaResult};
 #[derive(Debug, Clone, EnumIs, EnumTryAs)]
 pub enum StreamingJob {
     MaterializedView(Table),
-    Sink(Sink, Option<(Table, Option<PbSource>)>),
+    Sink(Sink),
     Table(Option<PbSource>, Table, TableJobType),
     Index(Index, Table),
     Source(PbSource),
@@ -49,7 +49,7 @@ impl std::fmt::Display for StreamingJob {
             StreamingJob::MaterializedView(table) => {
                 write!(f, "MaterializedView: {}({})", table.name, table.id)
             }
-            StreamingJob::Sink(sink, _) => write!(f, "Sink: {}({})", sink.name, sink.id),
+            StreamingJob::Sink(sink) => write!(f, "Sink: {}({})", sink.name, sink.id),
             StreamingJob::Table(_, table, _) => write!(f, "Table: {}({})", table.name, table.id),
             StreamingJob::Index(index, _) => write!(f, "Index: {}({})", index.name, index.id),
             StreamingJob::Source(source) => write!(f, "Source: {}({})", source.name, source.id),
@@ -70,7 +70,7 @@ impl From<&StreamingJob> for StreamingJobType {
     fn from(job: &StreamingJob) -> Self {
         match job {
             StreamingJob::MaterializedView(_) => StreamingJobType::MaterializedView,
-            StreamingJob::Sink(_, _) => StreamingJobType::Sink,
+            StreamingJob::Sink(_) => StreamingJobType::Sink,
             StreamingJob::Table(_, _, ty) => StreamingJobType::Table(*ty),
             StreamingJob::Index(_, _) => StreamingJobType::Index,
             StreamingJob::Source(_) => StreamingJobType::Source,
@@ -99,7 +99,7 @@ impl StreamingJob {
             Self::MaterializedView(table) | Self::Index(_, table) | Self::Table(_, table, ..) => {
                 table.maybe_vnode_count = Some(vnode_count as u32);
             }
-            Self::Sink(_, _) | Self::Source(_) => {}
+            Self::Sink(_) | Self::Source(_) => {}
         }
     }
 
@@ -113,14 +113,14 @@ impl StreamingJob {
             Self::MaterializedView(table) | Self::Index(_, table) => {
                 table.fragment_id = graph.table_fragment_id();
             }
-            Self::Sink(_, _) | Self::Source(_) => {}
+            Self::Sink(_) | Self::Source(_) => {}
         }
     }
 
     pub fn id(&self) -> u32 {
         match self {
             Self::MaterializedView(table) => table.id,
-            Self::Sink(sink, _) => sink.id,
+            Self::Sink(sink) => sink.id,
             Self::Table(_, table, ..) => table.id,
             Self::Index(index, _) => index.id,
             Self::Source(source) => source.id,
@@ -130,7 +130,7 @@ impl StreamingJob {
     pub fn mv_table(&self) -> Option<u32> {
         match self {
             Self::MaterializedView(table) => Some(table.id),
-            Self::Sink(_, _) => None,
+            Self::Sink(_) => None,
             Self::Table(_, table, ..) => Some(table.id),
             Self::Index(_, table) => Some(table.id),
             Self::Source(_) => None,
@@ -143,14 +143,14 @@ impl StreamingJob {
             Self::MaterializedView(table) | Self::Index(_, table) | Self::Table(_, table, ..) => {
                 Some(table)
             }
-            Self::Sink(_, _) | Self::Source(_) => None,
+            Self::Sink(_) | Self::Source(_) => None,
         }
     }
 
     pub fn schema_id(&self) -> u32 {
         match self {
             Self::MaterializedView(table) => table.schema_id,
-            Self::Sink(sink, _) => sink.schema_id,
+            Self::Sink(sink) => sink.schema_id,
             Self::Table(_, table, ..) => table.schema_id,
             Self::Index(index, _) => index.schema_id,
             Self::Source(source) => source.schema_id,
@@ -160,7 +160,7 @@ impl StreamingJob {
     pub fn database_id(&self) -> u32 {
         match self {
             Self::MaterializedView(table) => table.database_id,
-            Self::Sink(sink, _) => sink.database_id,
+            Self::Sink(sink) => sink.database_id,
             Self::Table(_, table, ..) => table.database_id,
             Self::Index(index, _) => index.database_id,
             Self::Source(source) => source.database_id,
@@ -170,7 +170,7 @@ impl StreamingJob {
     pub fn name(&self) -> String {
         match self {
             Self::MaterializedView(table) => table.name.clone(),
-            Self::Sink(sink, _) => sink.name.clone(),
+            Self::Sink(sink) => sink.name.clone(),
             Self::Table(_, table, ..) => table.name.clone(),
             Self::Index(index, _) => index.name.clone(),
             Self::Source(source) => source.name.clone(),
@@ -180,7 +180,7 @@ impl StreamingJob {
     pub fn owner(&self) -> u32 {
         match self {
             StreamingJob::MaterializedView(mv) => mv.owner,
-            StreamingJob::Sink(sink, _) => sink.owner,
+            StreamingJob::Sink(sink) => sink.owner,
             StreamingJob::Table(_, table, ..) => table.owner,
             StreamingJob::Index(index, _) => index.owner,
             StreamingJob::Source(source) => source.owner,
@@ -194,7 +194,7 @@ impl StreamingJob {
     pub fn job_type_str(&self) -> &'static str {
         match self {
             StreamingJob::MaterializedView(_) => "materialized view",
-            StreamingJob::Sink(_, _) => "sink",
+            StreamingJob::Sink(_) => "sink",
             StreamingJob::Table(_, _, _) => "table",
             StreamingJob::Index(_, _) => "index",
             StreamingJob::Source(_) => "source",
@@ -206,7 +206,7 @@ impl StreamingJob {
             Self::MaterializedView(table) => table.definition.clone(),
             Self::Table(_, table, ..) => table.definition.clone(),
             Self::Index(_, table) => table.definition.clone(),
-            Self::Sink(sink, _) => sink.definition.clone(),
+            Self::Sink(sink) => sink.definition.clone(),
             Self::Source(source) => source.definition.clone(),
         }
     }
@@ -214,7 +214,7 @@ impl StreamingJob {
     pub fn object_type(&self) -> ObjectType {
         match self {
             Self::MaterializedView(_) => ObjectType::Table, // Note MV is special.
-            Self::Sink(_, _) => ObjectType::Sink,
+            Self::Sink(_) => ObjectType::Sink,
             Self::Table(_, _, _) => ObjectType::Table,
             Self::Index(_, _) => ObjectType::Index,
             Self::Source(_) => ObjectType::Source,
@@ -240,7 +240,7 @@ impl StreamingJob {
             Self::MaterializedView(table) => {
                 table.get_create_type().unwrap_or(CreateType::Foreground)
             }
-            Self::Sink(s, _) => s.get_create_type().unwrap_or(CreateType::Foreground),
+            Self::Sink(s) => s.get_create_type().unwrap_or(CreateType::Foreground),
             Self::Index(index, _) => {
                 CreateType::try_from(index.create_type).unwrap_or(CreateType::Foreground)
             }
@@ -258,7 +258,7 @@ impl StreamingJob {
                     Ok(HashSet::new())
                 }
             }
-            StreamingJob::Sink(sink, _) => Ok(get_referred_connection_ids_from_sink(sink)),
+            StreamingJob::Sink(sink) => Ok(get_referred_connection_ids_from_sink(sink)),
             StreamingJob::MaterializedView(_) | StreamingJob::Index(_, _) => Ok(HashSet::new()),
         }
     }
@@ -266,7 +266,7 @@ impl StreamingJob {
     // Get the secret ids that are referenced by this job.
     pub fn dependent_secret_ids(&self) -> MetaResult<HashSet<u32>> {
         match self {
-            StreamingJob::Sink(sink, _) => Ok(get_referred_secret_ids_from_sink(sink)),
+            StreamingJob::Sink(sink) => Ok(get_referred_secret_ids_from_sink(sink)),
             StreamingJob::Table(source, _, _) => {
                 if let Some(source) = source {
                     get_referred_secret_ids_from_source(source)
@@ -318,7 +318,7 @@ impl StreamingJob {
                 // No version check for materialized view, since `ALTER MATERIALIZED VIEW AS QUERY`
                 // is a full rewrite.
             }
-            StreamingJob::Sink(_, _) => {
+            StreamingJob::Sink(_) => {
                 // No version check for sink, since sink fragment altering is triggered along with Table
             }
             StreamingJob::Index(_, _) => {
@@ -331,5 +331,9 @@ impl StreamingJob {
     // Check whether we should notify the FE about the `CREATING` catalog of this job.
     pub fn should_notify_creating(&self) -> bool {
         self.is_materialized_view() || matches!(self.create_type(), CreateType::Background)
+    }
+
+    pub fn is_sink_into_table(&self) -> bool {
+        matches!(self, Self::Sink(sink) if sink.target_table.is_some())
     }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -25,8 +25,9 @@ use risingwave_common::catalog::{DatabaseId, Field, TableId};
 use risingwave_connector::source::cdc::CdcTableSnapshotSplitAssignmentWithGeneration;
 use risingwave_meta_model::ObjectId;
 use risingwave_pb::catalog::{CreateType, PbSink, PbTable, Subscription};
+use risingwave_pb::expr::PbExprNode;
 use risingwave_pb::meta::table_fragments::ActorStatus;
-use risingwave_pb::plan_common::PbColumnCatalog;
+use risingwave_pb::plan_common::{PbColumnCatalog, PbField};
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{Mutex, oneshot};
@@ -47,8 +48,9 @@ use crate::manager::{
     MetaSrvEnv, MetadataManager, NotificationVersion, StreamingJob, StreamingJobType,
 };
 use crate::model::{
-    ActorId, Fragment, FragmentDownstreamRelation, FragmentId, FragmentNewNoShuffle,
-    FragmentReplaceUpstream, StreamJobFragments, StreamJobFragmentsToCreate, TableParallelism,
+    ActorId, DownstreamFragmentRelation, Fragment, FragmentDownstreamRelation, FragmentId,
+    FragmentNewNoShuffle, FragmentReplaceUpstream, StreamJobFragments, StreamJobFragmentsToCreate,
+    TableParallelism,
 };
 use crate::stream::cdc::{
     assign_cdc_table_snapshot_splits, is_parallelized_backfill_enabled_cdc_scan_fragment,
@@ -61,6 +63,17 @@ pub type GlobalStreamManagerRef = Arc<GlobalStreamManager>;
 #[derive(Default)]
 pub struct CreateStreamingJobOption {
     // leave empty as a placeholder for future option if there is any
+}
+
+#[derive(Debug, Clone)]
+pub struct UpstreamSinkInfo {
+    pub sink_id: ObjectId,
+    pub sink_fragment_id: FragmentId,
+    pub sink_output_fields: Vec<PbField>,
+    // for backwards compatibility
+    pub sink_original_target_columns: Vec<PbColumnCatalog>,
+    pub project_exprs: Vec<PbExprNode>,
+    pub new_sink_downstream: DownstreamFragmentRelation,
 }
 
 /// [`CreateStreamingJobContext`] carries one-time infos for creating a streaming job.
@@ -84,12 +97,8 @@ pub struct CreateStreamingJobContext {
 
     pub job_type: StreamingJobType,
 
-    /// Context provided for potential replace table, typically used when sinking into a table.
-    pub replace_table_job_info: Option<(
-        StreamingJob,
-        ReplaceStreamJobContext,
-        StreamJobFragmentsToCreate,
-    )>,
+    /// Used for sink-into-table.
+    pub new_upstream_sink: Option<UpstreamSinkInfo>,
 
     pub snapshot_backfill_info: Option<SnapshotBackfillInfo>,
     pub cross_db_snapshot_backfill_info: SnapshotBackfillInfo,
@@ -405,13 +414,20 @@ impl GlobalStreamManager {
                             tracing::debug!(
                                 "cancelling streaming job {table_id} by issue cancel command."
                             );
+
+                            let cancel_command = self
+                                .metadata_manager
+                                .catalog_controller
+                                .build_cancel_command(&table_fragments)
+                                .await?;
+
                             self.metadata_manager
                                 .catalog_controller
                                 .try_abort_creating_streaming_job(table_id.table_id as _, true)
                                 .await?;
 
                             self.barrier_scheduler
-                                .run_command(database_id, Command::cancel(&table_fragments))
+                                .run_command(database_id, cancel_command)
                                 .await?;
                         } else {
                             // streaming job is already completed.
@@ -448,51 +464,17 @@ impl GlobalStreamManager {
             definition,
             create_type,
             job_type,
-            replace_table_job_info,
+            new_upstream_sink,
             snapshot_backfill_info,
             cross_db_snapshot_backfill_info,
             fragment_backfill_ordering,
             ..
         }: CreateStreamingJobContext,
     ) -> MetaResult<(SourceChange, StreamingJob)> {
-        let mut replace_table_command = None;
-
         tracing::debug!(
             table_id = %stream_job_fragments.stream_job_id(),
             "built actors finished"
         );
-
-        if let Some((streaming_job, context, stream_job_fragments)) = replace_table_job_info {
-            self.metadata_manager
-                .catalog_controller
-                .prepare_stream_job_fragments(&stream_job_fragments, &streaming_job, true)
-                .await?;
-
-            let tmp_table_id = stream_job_fragments.stream_job_id();
-            let init_split_assignment = self
-                .source_manager
-                .allocate_splits(&stream_job_fragments)
-                .await?;
-            let cdc_table_snapshot_split_assignment = assign_cdc_table_snapshot_splits(
-                context.old_fragments.stream_job_id.table_id,
-                &stream_job_fragments.inner,
-                self.env.meta_store_ref(),
-            )
-            .await?;
-
-            replace_table_command = Some(ReplaceStreamJobPlan {
-                old_fragments: context.old_fragments,
-                new_fragments: stream_job_fragments,
-                replace_upstream: context.replace_upstream,
-                upstream_fragment_downstreams: context.upstream_fragment_downstreams,
-                init_split_assignment,
-                streaming_job,
-                tmp_id: tmp_table_id.table_id,
-                to_drop_state_table_ids: Vec::new(), /* the create streaming job command will not drop any state table */
-                auto_refresh_schema_sinks: None,
-                cdc_table_snapshot_split_assignment,
-            });
-        }
 
         // Here we need to consider:
         // - Shared source
@@ -571,8 +553,8 @@ impl GlobalStreamManager {
             CreateStreamingJobType::SnapshotBackfill(snapshot_backfill_info)
         } else {
             tracing::debug!("sending Command::CreateStreamingJob");
-            if let Some(replace_table_command) = replace_table_command {
-                CreateStreamingJobType::SinkIntoTable(replace_table_command)
+            if let Some(new_upstream_sink) = new_upstream_sink {
+                CreateStreamingJobType::SinkIntoTable(new_upstream_sink)
             } else {
                 CreateStreamingJobType::Normal
             }
@@ -671,6 +653,7 @@ impl GlobalStreamManager {
         streaming_job_ids: Vec<ObjectId>,
         state_table_ids: Vec<risingwave_meta_model::TableId>,
         fragment_ids: HashSet<FragmentId>,
+        dropped_sink_fragment_by_targets: HashMap<FragmentId, Vec<FragmentId>>,
     ) {
         // TODO(august): This is a workaround for canceling SITT via drop, remove it after refactoring SITT.
         for &job_id in &streaming_job_ids {
@@ -698,7 +681,7 @@ impl GlobalStreamManager {
                 .run_command(
                     database_id,
                     Command::DropStreamingJobs {
-                        table_fragments_ids: streaming_job_ids
+                        streaming_job_ids: streaming_job_ids
                             .iter()
                             .map(|job_id| TableId::new(*job_id as _))
                             .collect(),
@@ -708,6 +691,7 @@ impl GlobalStreamManager {
                             .map(|table_id| TableId::new(*table_id as _))
                             .collect(),
                         unregistered_fragment_ids: fragment_ids,
+                        dropped_sink_fragment_by_targets,
                     },
                 )
                 .await
@@ -757,6 +741,12 @@ impl GlobalStreamManager {
                     )))?;
                 }
 
+                let cancel_command = self
+                    .metadata_manager
+                    .catalog_controller
+                    .build_cancel_command(&fragment)
+                    .await?;
+
                 let (_, database_id) = self.metadata_manager
                     .catalog_controller
                     .try_abort_creating_streaming_job(id.table_id as _, true)
@@ -764,7 +754,7 @@ impl GlobalStreamManager {
 
                 if let Some(database_id) = database_id {
                     self.barrier_scheduler
-                        .run_command(DatabaseId::new(database_id as _), Command::cancel(&fragment))
+                        .run_command(DatabaseId::new(database_id as _), cancel_command)
                         .await?;
                 }
             };

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -474,14 +474,12 @@ impl MetaClient {
         &self,
         sink: PbSink,
         graph: StreamFragmentGraph,
-        affected_table_change: Option<ReplaceJobPlan>,
         dependencies: HashSet<ObjectId>,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateSinkRequest {
             sink: Some(sink),
             fragment_graph: Some(graph),
-            affected_table_change,
             dependencies: dependencies.into_iter().collect(),
             if_not_exists,
         };
@@ -824,17 +822,8 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
-    pub async fn drop_sink(
-        &self,
-        sink_id: u32,
-        cascade: bool,
-        affected_table_change: Option<ReplaceJobPlan>,
-    ) -> Result<WaitVersion> {
-        let request = DropSinkRequest {
-            sink_id,
-            cascade,
-            affected_table_change,
-        };
+    pub async fn drop_sink(&self, sink_id: u32, cascade: bool) -> Result<WaitVersion> {
+        let request = DropSinkRequest { sink_id, cascade };
         let resp = self.inner.drop_sink(request).await?;
         Ok(resp
             .version

--- a/src/stream/src/task/actor_manager.rs
+++ b/src/stream/src/task/actor_manager.rs
@@ -27,9 +27,8 @@ use risingwave_common::must_match;
 use risingwave_common::operator::{unique_executor_id, unique_operator_id};
 use risingwave_common::util::runtime::BackgroundShutdownRuntime;
 use risingwave_pb::plan_common::StorageTableDesc;
-use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::{StreamNode, StreamScanNode, StreamScanType};
+use risingwave_pb::stream_plan::{self, StreamNode, StreamScanNode, StreamScanType};
 use risingwave_pb::stream_service::inject_barrier_request::BuildActorInfo;
 use risingwave_storage::monitor::HummockTraceFutureExt;
 use risingwave_storage::table::batch_table::BatchTable;
@@ -44,8 +43,7 @@ use crate::executor::monitor::StreamingMetrics;
 use crate::executor::subtask::SubtaskHandle;
 use crate::executor::{
     Actor, ActorContext, ActorContextRef, DispatchExecutor, Execute, Executor, ExecutorInfo,
-    MergeExecutorInput, SnapshotBackfillExecutor, TroublemakerExecutor, UpstreamFragmentInfo,
-    UpstreamSinkUnionExecutor, WrapperExecutor,
+    MergeExecutorInput, SnapshotBackfillExecutor, TroublemakerExecutor, WrapperExecutor,
 };
 use crate::from_proto::{MergeExecutorBuilder, create_executor};
 use crate::task::{
@@ -68,12 +66,6 @@ pub(crate) struct StreamActorManager {
 
     /// Runtime for the streaming actors.
     pub(super) runtime: BackgroundShutdownRuntime,
-}
-
-struct SinkIntoTableUnion<'a> {
-    prefix_nodes: Vec<&'a stream_plan::StreamNode>,
-    merge_projects: Vec<(&'a stream_plan::StreamNode, &'a stream_plan::StreamNode)>,
-    union_node: &'a stream_plan::StreamNode,
 }
 
 impl StreamActorManager {
@@ -215,157 +207,6 @@ impl StreamActorManager {
         }
     }
 
-    #[expect(clippy::too_many_arguments)]
-    async fn create_sink_into_table_union(
-        &self,
-        fragment_id: FragmentId,
-        union_node: &stream_plan::StreamNode,
-        env: StreamEnvironment,
-        store: impl StateStore,
-        actor_context: &ActorContextRef,
-        vnode_bitmap: Option<Bitmap>,
-        has_stateful: bool,
-        subtasks: &mut Vec<SubtaskHandle>,
-        local_barrier_manager: &LocalBarrierManager,
-        prefix_nodes: Vec<&stream_plan::StreamNode>,
-        merge_projects: Vec<(&stream_plan::StreamNode, &stream_plan::StreamNode)>,
-    ) -> StreamResult<Executor> {
-        let mut input = Vec::with_capacity(union_node.get_input().len());
-
-        for input_stream_node in prefix_nodes {
-            input.push(
-                self.create_nodes_inner(
-                    fragment_id,
-                    input_stream_node,
-                    env.clone(),
-                    store.clone(),
-                    actor_context,
-                    vnode_bitmap.clone(),
-                    has_stateful,
-                    subtasks,
-                    local_barrier_manager,
-                )
-                .await?,
-            );
-        }
-
-        // Use the first MergeNode to fill in the info of the new node.
-        let first_merge = merge_projects.first().unwrap().0;
-        let executor_id = Self::get_executor_id(actor_context, first_merge);
-        let mut info = Self::get_executor_info(first_merge, executor_id);
-        info.identity = format!("UpstreamSinkUnion {:X}", executor_id);
-        let eval_error_report = ActorEvalErrorReport {
-            actor_context: actor_context.clone(),
-            identity: info.identity.clone().into(),
-        };
-
-        let mut initial_upstream_infos = Vec::with_capacity(merge_projects.len());
-        for (merge_node, project_node) in merge_projects {
-            let upstream_fragment_id = merge_node
-                .get_node_body()
-                .unwrap()
-                .as_merge()
-                .unwrap()
-                .upstream_fragment_id;
-            let project_exprs = project_node
-                .get_node_body()
-                .unwrap()
-                .as_project()
-                .unwrap()
-                .get_select_list();
-            let info = UpstreamFragmentInfo::new(
-                upstream_fragment_id,
-                &actor_context.initial_upstream_actors,
-                merge_node.get_fields(),
-                project_exprs,
-                eval_error_report.clone(),
-            )?;
-            initial_upstream_infos.push(info);
-        }
-
-        let upstream_sink_union_executor = UpstreamSinkUnionExecutor::new(
-            actor_context.clone(),
-            local_barrier_manager.clone(),
-            self.streaming_metrics.clone(),
-            env.config().developer.chunk_size,
-            initial_upstream_infos,
-            eval_error_report,
-        );
-        let executor = (info, upstream_sink_union_executor).into();
-        input.push(executor);
-
-        self.generate_executor_from_inputs(
-            fragment_id,
-            union_node,
-            env,
-            store,
-            actor_context,
-            vnode_bitmap,
-            has_stateful,
-            subtasks,
-            local_barrier_manager,
-            input,
-        )
-        .await
-    }
-
-    fn as_sink_into_table_union(node: &StreamNode) -> Option<SinkIntoTableUnion<'_>> {
-        let NodeBody::Union(_) = node.get_node_body().unwrap() else {
-            return None;
-        };
-
-        let mut merge_projects = Vec::new();
-        let mut remaining_nodes = Vec::new();
-
-        let mut rev_iter = node.get_input().iter().rev();
-        for union_input in rev_iter.by_ref() {
-            let mut is_sink_into = false;
-            if let NodeBody::Project(project) = union_input.get_node_body().unwrap() {
-                let project_input = union_input.get_input().first().unwrap();
-                // Check project conditions
-                let project_check = project.get_watermark_input_cols().is_empty()
-                    && project.get_watermark_output_cols().is_empty()
-                    && project.get_nondecreasing_exprs().is_empty()
-                    && !project.noop_update_hint;
-                if project_check
-                    && let NodeBody::Merge(merge) = project_input.get_node_body().unwrap()
-                {
-                    let merge_check = merge.upstream_dispatcher_type()
-                        == risingwave_pb::stream_plan::DispatcherType::Hash;
-                    if merge_check {
-                        is_sink_into = true;
-                        tracing::debug!(
-                            "replace sink into table union, merge: {:?}, project: {:?}",
-                            merge,
-                            project
-                        );
-                        merge_projects.push((project_input, union_input));
-                    }
-                }
-            }
-            if !is_sink_into {
-                remaining_nodes.push(union_input);
-                break;
-            }
-        }
-
-        if merge_projects.is_empty() {
-            return None;
-        }
-
-        remaining_nodes.extend(rev_iter);
-
-        merge_projects.reverse();
-        remaining_nodes.reverse();
-
-        // complete StreamNode structure is needed here, to provide some necessary fields.
-        Some(SinkIntoTableUnion {
-            prefix_nodes: remaining_nodes,
-            merge_projects,
-            union_node: node,
-        })
-    }
-
     /// Create a chain(tree) of nodes, with given `store`.
     #[expect(clippy::too_many_arguments)]
     #[async_recursion]
@@ -396,29 +237,6 @@ impl StreamActorManager {
                 )
                 .await
             });
-        }
-
-        if let Some(SinkIntoTableUnion {
-            prefix_nodes: remaining_nodes,
-            merge_projects,
-            union_node,
-        }) = Self::as_sink_into_table_union(node)
-        {
-            return self
-                .create_sink_into_table_union(
-                    fragment_id,
-                    union_node,
-                    env,
-                    store,
-                    actor_context,
-                    vnode_bitmap,
-                    has_stateful,
-                    subtasks,
-                    local_barrier_manager,
-                    remaining_nodes,
-                    merge_projects,
-                )
-                .await;
         }
 
         // The "stateful" here means that the executor may issue read operations to the state store


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

This is the second part of #22867

This PR refactors the sink-into-table implementation to use a new `StreamUpstreamSinkUnion` operator instead of manipulating the fragment graph directly. The new approach:

1. Adds a new `StreamUpstreamSinkUnion` operator that handles the merging of data from upstream sinks
2. Removes the complex graph manipulation logic that was previously used to inject merge nodes
3. Simplifies the creation and dropping of sinks that target tables
4. Removes the deprecated `affected_table_change` field from the `CreateSinkRequest` and `DropSinkRequest` protos
5. Updates the catalog controller to properly handle sink-into-table relationships

This change makes the sink-into-table implementation more maintainable and less error-prone by using a dedicated operator instead of manipulating the fragment graph directly.

Note: The backward compatibility logic will be placed in the next PR.

Previous PR:
- #22917

Related issue:
- #22491

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
