### PR TITLE
feat(expr): support vector_dims and subvector function

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -316,6 +316,8 @@ message ExprNode {
     VEC_CONCAT = 754;
     L2_NORM = 755;
     L2_NORMALIZE = 756;
+    VECTOR_DIMS = 757;
+    SUBVECTOR = 758;
 
     // Internal function for schema change
     COMPOSITE_CAST = 800;

--- a/src/expr/impl/src/scalar/vector.rs
+++ b/src/expr/impl/src/scalar/vector.rs
@@ -576,3 +576,107 @@ fn l2_normalize(vector: VectorRef<'_>) -> Result<VectorVal> {
         .map_err(|_| ExprError::NumericOverflow)?;
     Ok(result)
 }
+
+/// ```slt
+/// query R
+/// SELECT vector_dims('[1,2,3]'::vector(3));
+/// ----
+/// 3
+///
+/// query R
+/// SELECT vector_dims('[10,20,30,40]'::vector(4));
+/// ----
+/// 4
+///
+/// query error dimensions
+/// SELECT vector_dims('[]'::vector(0));
+/// ```
+#[function("vector_dims(vector) -> int4")]
+fn vector_dim(v: VectorRef<'_>) -> Result<i32> {
+    let vector = v.into_slice();
+    check_dim("vector_dim", vector.len() as i32)?;
+    Ok(vector.len() as i32)
+}
+
+fn check_dim(name: &'static str, dim: i32) -> Result<()> {
+    if dim < 1 {
+        return Err(ExprError::InvalidParam {
+            name,
+            reason: "vector must have at least 1 dimension".into(),
+        });
+    }
+    if dim > (DataType::VEC_MAX_SIZE as i32) {
+        return Err(ExprError::InvalidParam {
+            name,
+            reason: format!("vector cannot have more than {} dimensions", dim).into(),
+        });
+    }
+    Ok(())
+}
+
+/// ```slt
+/// query R
+/// SELECT subvector('[1,2,3,4,5]'::vector(5), 1, 3);
+/// ----
+/// [1,2,3]
+///
+/// query R
+/// SELECT subvector('[1,2,3,4,5]'::vector(5), 3, 2);
+/// ----
+/// [3, 4]
+///
+/// query R
+/// SELECT subvector('[1,2,3,4,5]'::vector(5), -1, 3);
+/// ----
+/// [1]
+///
+/// query R
+/// SELECT subvector('[1,2,3,4,5]'::vector(5), 3, 9);
+/// ----
+/// [3,4,5]
+///
+/// query R
+/// SELECT subvector('[1,2,3,4,5]'::vector, -2147483644, 2147483647);
+/// ----
+/// [1,2]
+///
+/// query R
+/// SELECT subvector('[1,2,3,4,5]'::vector, 3, 2147483647);
+/// ----
+/// [3,4,5]
+/// ```
+#[function("subvector(vector, int4, int4) -> vector", type_infer = "unreachable")]
+fn subvector(v: VectorRef<'_>, start: i32, count: i32) -> Result<VectorVal> {
+    let vector = v.into_slice();
+    let length = vector.len() as i32;
+    if count < 1 {
+        return Err(ExprError::InvalidParam {
+            name: "count",
+            reason: "vector must have at least 1 dimension".into(),
+        });
+    }
+    let mut start = start;
+    let end = if start > length - count {
+        length + 1
+    } else {
+        start + count
+    };
+
+    if start < 1 {
+        start = 1
+    } else if start > length {
+        return Err(ExprError::InvalidParam {
+            name: "start",
+            reason: "vector must have at least 1 dimension".into(),
+        });
+    }
+    check_dim("subvector", end - start)?;
+
+    let result = vector[(start - 1) as usize..(end - 1) as usize]
+        .iter()
+        .copied()
+        .map(|v| Finite32::try_from(v as f32))
+        .try_collect()
+        .map_err(|_| ExprError::NumericOverflow)?;
+    Ok(result)
+}

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -442,6 +442,8 @@ impl Binder {
                 ("inner_product", raw_call(ExprType::InnerProduct)),
                 ("vector_norm", raw_call(ExprType::L2Norm)),
                 ("l2_normalize", raw_call(ExprType::L2Normalize)),
+                ("vector_dims",raw_call(ExprType::VectorDims)),
+                ("subvector", raw_call(ExprType::Subvector)),
                 // Functions that return a constant value
                 ("pi", pi()),
                 // greatest and least

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -278,6 +278,8 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::VecConcat
             | Type::L2Norm
             | Type::L2Normalize
+            | Type::VectorDims
+            | Type::Subvector
             | Type::VnodeUser
             | Type::RwEpochToTs
             | Type::CheckNotNull

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -115,6 +115,8 @@ impl Strong {
             | ExprType::VecConcat
             | ExprType::L2Norm
             | ExprType::L2Normalize
+            | ExprType::VectorDims
+            | ExprType::Subvector
             | ExprType::Greatest
             | ExprType::Least => self.any_null(func_call),
             // ALL: This kind of expression is null if and only if all of its arguments are null.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Two more functions found in pgvector:
- `subvector(vector, integer, integer) → vector`
- `vector_dims(vector) → integer`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
