### PR TITLE
fix(compute): reduced compute_node_serve future size

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(let_chains)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(coverage_attribute)]
+#![warn(clippy::large_futures, clippy::large_stack_frames)]
 
 #[macro_use]
 extern crate tracing;

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -31,6 +31,7 @@ pub mod telemetry;
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use clap::{Parser, ValueEnum};
 use risingwave_common::config::{AsyncStackTraceOption, MetricLevel, OverrideConfig};
@@ -254,7 +255,7 @@ pub fn start(
             .unwrap();
         tracing::info!("advertise addr is {}", advertise_addr);
 
-        compute_node_serve(listen_addr, advertise_addr, opts, shutdown).await;
+        compute_node_serve(listen_addr, advertise_addr, Arc::new(opts), shutdown).await;
     })
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -93,10 +93,11 @@ pub async fn compute_node_serve(
     opts: ComputeNodeOpts,
     shutdown: CancellationToken,
 ) {
+    let opts = Arc::new(opts);
     // Load the configuration.
-    let config = load_config(&opts.config_path, &opts);
+    let config = Arc::new(load_config(&opts.config_path, &*opts));
     info!("Starting compute node",);
-    info!("> config: {:?}", config);
+    info!("> config: {:?}", &*config);
     info!(
         "> debug assertions: {}",
         if cfg!(debug_assertions) { "on" } else { "off" }
@@ -165,7 +166,7 @@ pub async fn compute_node_serve(
     );
 
     let storage_opts = Arc::new(StorageOpts::from((
-        &config,
+        &*config,
         &system_params,
         &storage_memory_config,
     )));
@@ -221,7 +222,7 @@ pub async fn compute_node_serve(
     .unwrap();
 
     LocalSecretManager::init(
-        opts.temp_secret_file_dir,
+        opts.temp_secret_file_dir.clone(),
         meta_client.cluster_id().to_owned(),
         worker_id,
     );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

Issue: #21635

## What's changed and what's your intention?

The `compute_node_serve` future in the compute crate was previously exceeding Clippy’s `large_futures` threshold (16 KB).

This was primarily due to:
- Large configuration and options structs (`ComputeNodeOpts`, `Config`) being captured across multiple .awaits.
- `StateStoreImpl::new` producing a very large intermediate future that was stored inline in the outer state machine.

**Changes**
- Wrapped the `compute_node_serve` opts argument in Arc to prevent a ~384 B struct from being embedded in every suspend variant.
- Wrapped the loaded configuration in Arc to prevent ~3 KB of config data from being copied into every suspend point.
- Boxed the large future returned by StateStoreImpl::new reducing the captured awaitee size from ~9 KB inline to a single pointer (8 B).

**Result**
Maximum variant size reduced from ~22 KB to ~14.7 KB, now below Clippy’s threshold.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
