### PR TITLE
fix(dashboard): fix fragment to relation backpressure edge mapping

### DIFF
--- a/dashboard/pages/relation_graph.tsx
+++ b/dashboard/pages/relation_graph.tsx
@@ -126,16 +126,19 @@ export default function StreamingGraph() {
       if (!fragmentToRelationMap) {
         return new Map<string, ChannelDeltaStats>()
       }
-      let inMap = fragmentToRelationMap.inMap
-      let outMap = fragmentToRelationMap.outMap
+      let mapping = fragmentToRelationMap.fragmentToRelationMap
       if (channelStats) {
         let map = new Map<string, ChannelDeltaStats>()
         for (const [key, stats] of channelStats) {
           const [outputFragment, inputFragment] = key.split("_").map(Number)
-          if (outMap[outputFragment] && inMap[inputFragment]) {
-            const outputRelation = outMap[outputFragment]
-            const inputRelation = inMap[inputFragment]
-            let key = `${outputRelation}_${inputRelation}`
+          let input_relation = mapping[inputFragment]
+          let output_relation = mapping[outputFragment]
+          if (
+            input_relation &&
+            output_relation &&
+            input_relation !== output_relation
+          ) {
+            let key = `${output_relation}_${input_relation}`
             map.set(key, stats)
           }
         }

--- a/e2e_test/dashboard/create_graph.slt.part
+++ b/e2e_test/dashboard/create_graph.slt.part
@@ -122,3 +122,9 @@ statement ok
 create materialized view mv8 as
 select mv4.v1, mv4.t4_v1, mv5.v1 as mv5_v1, mv5.mv4_v1
 from mv4 join mv5 on mv4.v1 = mv5.mv4_v1;
+
+statement ok
+create table t_dest(v1 int primary key, v2 int);
+
+statement ok
+create sink s1 into t_dest from t;

--- a/e2e_test/dashboard/drop_graph.slt.part
+++ b/e2e_test/dashboard/drop_graph.slt.part
@@ -1,4 +1,10 @@
-# Drop materialized views in reverse dependency order (dependent MVs first, then base MVs)
+# Drop relations in reverse dependency order (dependent MVs first, then base MVs)
+statement ok
+drop sink s1;
+
+statement ok
+drop table t_dest;
+
 statement ok
 drop materialized view mv8;
 

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -928,10 +928,8 @@ message RelationIdInfos {
 }
 
 message FragmentToRelationMap {
-  /// fragment_id -> relation_id of all in-bound fragments e.g. the ones with StreamScan
-  map<uint32, uint32> in_map = 1;
-  /// fragment_id -> relation_id of all out-bound fragments e.g. the ones with MaterializeExecutor
-  map<uint32, uint32> out_map = 2;
+  /// fragment_id -> relation_id mapping for all fragments
+  map<uint32, uint32> fragment_to_relation_map = 1;
 }
 
 message ActorCountPerParallelism {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously we only mapped fragment backpressure edges if they are between stream scan (input) and mv/table/index (output).

However, this fails to consider `sink into table`. This is because the input for sink into table to the destination table is not `stream scan`, it's currently a merge and project.

In this PR we directly do a `fragment -> relation` mapping, rather than maintain two separate maps for input and output.

On the frontend, we can simply filter out intra-node mappings, by checking whether after performing the `fragment->relation` mapping, the input and output are the same. If they are from the same relation, it's an intra node mapping.

Otherwise, they are from different relations, and we can preserve the backpressure edge, to use when constructing relation-relation backpressure.

This relies on a key fact, that between any two relations, there is not more than one fragment edge. Each relation only has a single output. So this must be true.

A second scenario is that the same fragment outputs twice. This is highly unlikely because of subplan sharing. However, if this really happens, our prometheus query groups the metrics by `fragment_id, downstream_fragment_id`, so all the backpressure metrics will get aggregated.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
