### PR TITLE
feat: treat empty(zero-field) struct as alterable

### DIFF
--- a/e2e_test/ddl/alter_table_column_type/empty_struct.slt
+++ b/e2e_test/ddl/alter_table_column_type/empty_struct.slt
@@ -1,0 +1,68 @@
+statement ok
+set RW_IMPLICIT_FLUSH to true;
+
+# Currently, parser does not allow the syntax for zero-field struct type (`struct<>`).
+# `CREATE TABLE AS` is a workaround.
+statement ok
+create table t as select row() as v;
+
+query T
+select v from t;
+----
+()
+
+statement ok
+alter table t alter column v type struct<a int>;
+
+query T
+select v from t;
+----
+()
+
+statement ok
+insert into t values (row(1));
+
+query T rowsort
+select v from t;
+----
+()
+(1)
+
+statement ok
+create materialized view mv as select (v).a from t;
+
+query I rowsort
+select a from mv;
+----
+1
+NULL
+
+statement ok
+alter table t alter column v type struct<a int, b varchar>;
+
+query T rowsort
+select v from t;
+----
+(,)
+(1,)
+
+statement ok
+insert into t values (row(2, 'hello'));
+
+query T rowsort
+select v from t;
+----
+(,)
+(1,)
+(2,hello)
+
+query I rowsort
+select a from mv;
+----
+1
+2
+NULL
+
+
+statement ok
+drop table t cascade;

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -334,6 +334,11 @@ impl StructValue {
         }
     }
 
+    /// Returns an empty struct.
+    pub fn empty() -> Self {
+        Self::new(vec![])
+    }
+
     pub fn fields(&self) -> &[Datum] {
         &self.fields
     }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -624,8 +624,8 @@ impl DataType {
             data_types::simple!() => None,
             DataType::Struct(struct_type) => {
                 // As long as we meet a struct type, we can check its `ids` field to determine if
-                // it can be altered. Empty struct is always considered alterable.
-                let struct_can_alter = struct_type.is_empty() || struct_type.has_ids();
+                // it can be altered.
+                let struct_can_alter = struct_type.has_ids();
                 // In debug build, we assert that once a struct type does (or does not) have ids,
                 // all its composite fields should have the same property.
                 if cfg!(debug_assertions) {

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -103,6 +103,8 @@ impl StructType {
     }
 
     /// Attaches given field ids to the struct type.
+    ///
+    /// Note that for empty struct, this method is a no-op.
     pub fn with_ids(self, ids: impl IntoIterator<Item = ColumnId>) -> Self {
         let ids: Box<[ColumnId]> = ids.into_iter().collect();
 
@@ -111,6 +113,11 @@ impl StructType {
             ids.iter().all(|id| *id != ColumnId::placeholder()),
             "ids should not contain placeholder value"
         );
+
+        // Do not set the field ids to `Some(<empty>)` to avoid confusion.
+        if self.is_empty() {
+            return self;
+        }
 
         let mut inner = Arc::unwrap_or_clone(self.0);
         inner.field_ids = Some(ids);

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -179,10 +179,10 @@ impl StructType {
     pub fn ids(&self) -> Option<impl ExactSizeIterator<Item = ColumnId> + '_> {
         if self.is_empty() {
             Some(Either::Left(empty()))
-        } else if let Some(field_ids) = &self.0.field_ids {
-            Some(Either::Right(field_ids.iter().copied()))
         } else {
-            None
+            (self.0.field_ids.as_ref())
+                .map(|field_ids| field_ids.iter().copied())
+                .map(Either::Right)
         }
     }
 

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -105,7 +105,8 @@ impl StructType {
 
     /// Attaches given field ids to the struct type.
     ///
-    /// Note that for empty struct, this method is a no-op.
+    /// Note that for empty struct, this method is a no-op, as [`StructType::ids`] will always
+    /// return `Some(<empty>)` for empty struct.
     pub fn with_ids(self, ids: impl IntoIterator<Item = ColumnId>) -> Self {
         let ids: Box<[ColumnId]> = ids.into_iter().collect();
 
@@ -115,7 +116,7 @@ impl StructType {
             "ids should not contain placeholder value"
         );
 
-        // Do not set the field ids to `Some(<empty>)` to avoid confusion.
+        // No-op for empty struct.
         if self.is_empty() {
             return self;
         }
@@ -125,11 +126,11 @@ impl StructType {
         Self(Arc::new(inner))
     }
 
-    /// Whether the struct type has field ids.
+    /// Whether the struct type has field ids. An empty struct is considered to have ids.
     ///
     /// Note that this does not recursively check whether composite fields have ids.
     pub fn has_ids(&self) -> bool {
-        self.0.field_ids.is_some()
+        self.is_empty() || self.0.field_ids.is_some()
     }
 
     /// Whether the fields are unnamed.
@@ -174,7 +175,7 @@ impl StructType {
     /// Gets an iterator over the field ids.
     ///
     /// Returns `None` if they are not present. See documentation on the field `field_ids`
-    /// for the cases.
+    /// for the cases. For empty struct, this returns `Some(<empty>)`.
     pub fn ids(&self) -> Option<impl ExactSizeIterator<Item = ColumnId> + '_> {
         if self.is_empty() {
             Some(Either::Left(empty()))

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::fmt::{Debug, Display, Formatter};
+use std::iter::empty;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -175,7 +176,13 @@ impl StructType {
     /// Returns `None` if they are not present. See documentation on the field `field_ids`
     /// for the cases.
     pub fn ids(&self) -> Option<impl ExactSizeIterator<Item = ColumnId> + '_> {
-        self.0.field_ids.as_ref().map(|ids| ids.iter().copied())
+        if self.is_empty() {
+            Some(Either::Left(empty()))
+        } else if let Some(field_ids) = &self.0.field_ids {
+            Some(Either::Right(field_ids.iter().copied()))
+        } else {
+            None
+        }
     }
 
     /// Gets the field id at the given index.
@@ -183,7 +190,7 @@ impl StructType {
     /// Returns `None` if they are not present. See documentation on the field `field_ids`
     /// for the cases.
     pub fn id_at(&self, index: usize) -> Option<ColumnId> {
-        self.0.field_ids.as_ref().map(|ids| ids[index])
+        self.ids().map(|mut ids| ids.nth(index).unwrap())
     }
 
     /// Get an iterator over the field ids, or a sequence of placeholder ids if they are not present.

--- a/src/common/src/util/value_encoding/column_aware_row_encoding.rs
+++ b/src/common/src/util/value_encoding/column_aware_row_encoding.rs
@@ -64,15 +64,6 @@ mod new_serde {
     //
     // Recursively construct a new column-aware `Serializer` for nested fields.
     fn new_serialize_struct(struct_type: &StructType, value: StructRef<'_>, buf: &mut impl BufMut) {
-        // Do not encode empty struct. This is consistent with `plain` serialization, making all empty structs alterable.
-        if struct_type.is_empty() {
-            debug_assert!(
-                value.is_empty(),
-                "empty struct type ({struct_type:?}) but non-empty value ({value:?})"
-            );
-            return;
-        }
-
         let serializer = super::Serializer::from_struct(struct_type.clone()); // cloning `StructType` is lightweight
 
         // `StructRef` is interpreted as a `Row` here.
@@ -136,11 +127,6 @@ mod new_serde {
     //
     // Recursively construct a new column-aware `Deserializer` for nested fields.
     fn new_deserialize_struct(struct_def: &StructType, data: &mut &[u8]) -> Result<ScalarImpl> {
-        // Do not encode empty struct. This is consistent with `plain` serialization, making all empty structs alterable.
-        if struct_def.is_empty() {
-            return Ok(ScalarImpl::Struct(StructValue::empty()));
-        }
-
         let deserializer = super::Deserializer::from_struct(struct_def.clone()); // cloning `StructType` is lightweight
         let encoded_len = data.get_u32_le() as usize;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

When introducing support for `ALTER TYPE` for columns with composite (`struct`) types, we introduced a new field `field_ids` for `struct` data type (https://github.com/risingwavelabs/risingwave/pull/20620), to differentiate between the old and new encoding.

However, by using `repeated` field in protobuf, we cannot distinguish between "unset" (`None`) and "set with empty list" (`Some([])`), which leads to some confusion when handling empty struct. We didn't treat this a problem, as we don't provide official support for empty struct since our parser doesn't support parsing something like `struct<>`. However, it appears that users can still declare a column with an empty struct type by mapping the schema, such as from protobuf, where this can also be very useful to be an arm of `oneof`.

----

This PR aimed to address such subtlety by trying to treat it alterable. Typically, this will cause a breaking change, as the format will be changed from old column-aware encoding (for non-alterable types) to the new recursive column-aware encoding (for alterable types). In other words, we used to encode empty struct column with value encoding, while we are going to recursively construct a column-aware encoder for the struct now.

However, we realized that there's actually a bug (#23050) that, in old column-aware encoding, we encoded empty struct into an empty slice, which is problematic and make it indistinguishable from `NULL`! Therefore, all previous empty struct values are converted to `NULL` once it's written into a table, meaning that an empty struct value never actually exists in storage! As a result, we can safely perform the encoding change, and this also fixes #23050.

Note that this bug doesn't exist in operators' state tables or MV , since those tables do not support schema change thus are still using the value encoding. Fortunately, it doesn't affect this PR, since whether empty struct is alterable only affects how it's encoded with column-aware encoding.

---

In future PRs we may add support for parsing `struct<>`, as it's necessary when purifying a column mapped from an empty protobuf message.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
