### PR TITLE
fix(meta): fix meta store compatibility issue

### DIFF
--- a/src/compute/tests/cdc_tests.rs
+++ b/src/compute/tests/cdc_tests.rs
@@ -81,7 +81,8 @@ impl MockOffsetGenExecutor {
                 snapshot: None,
                 file: Some("1.binlog".to_owned()),
                 pos: Some(start_offset as _),
-                lsn: None,
+                // pg uses it to filter out unnecessary data.
+                lsn: Some(start_offset as _),
                 txid: None,
                 tx_usec: None,
                 change_lsn: None,

--- a/src/compute/tests/cdc_tests.rs
+++ b/src/compute/tests/cdc_tests.rs
@@ -81,8 +81,7 @@ impl MockOffsetGenExecutor {
                 snapshot: None,
                 file: Some("1.binlog".to_owned()),
                 pos: Some(start_offset as _),
-                // pg uses it to filter out unnecessary data.
-                lsn: Some(start_offset as _),
+                lsn: None,
                 txid: None,
                 tx_usec: None,
                 change_lsn: None,

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -475,17 +475,17 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                         continue;
                                     }
 
-                                    let chunk_cdc_offset =
-                                        get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                    // TODO(zw): enable for other cdc table type
-                                    if *self.external_table.table_type()
-                                        == ExternalCdcTableType::Postgres
-                                        && let Some(cur) = actor_cdc_offset_low.as_ref()
-                                        && let Some(chunk_offset) = chunk_cdc_offset
-                                        && chunk_offset < *cur
-                                    {
-                                        continue;
-                                    }
+                                    // TODO(zw): re-enable
+                                    // let chunk_cdc_offset =
+                                    //     get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                    // if *self.external_table.table_type()
+                                    //     == ExternalCdcTableType::Postgres
+                                    //     && let Some(cur) = actor_cdc_offset_low.as_ref()
+                                    //     && let Some(chunk_offset) = chunk_cdc_offset
+                                    //     && chunk_offset < *cur
+                                    // {
+                                    //     continue;
+                                    // }
 
                                     let chunk = mapping_chunk(chunk, &self.output_indices);
                                     if let Some(filtered_chunk) = filter_stream_chunk(
@@ -633,14 +633,14 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let chunk_cdc_offset =
                             get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                        // TODO(zw): enable for other cdc table type
-                        if *self.external_table.table_type() == ExternalCdcTableType::Postgres
-                            && let Some(cur) = actor_cdc_offset_low.as_ref()
-                            && let Some(ref chunk_offset) = chunk_cdc_offset
-                            && *chunk_offset < *cur
-                        {
-                            continue;
-                        }
+                        // // TODO(zw): re-enable
+                        // if *self.external_table.table_type() == ExternalCdcTableType::Postgres
+                        //     && let Some(cur) = actor_cdc_offset_low.as_ref()
+                        //     && let Some(ref chunk_offset) = chunk_cdc_offset
+                        //     && *chunk_offset < *cur
+                        // {
+                        //     continue;
+                        // }
 
                         // should_report_actor_backfill_done is set to true at most once.
                         if let Some(high) = actor_cdc_offset_high.as_ref() {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -477,12 +477,12 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                                     let chunk_cdc_offset =
                                         get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                    // TODO(zw): fix Mock
-                                    if let Some(cur) = actor_cdc_offset_low.as_ref()
+                                    // TODO(zw): enable for other cdc table type
+                                    if *self.external_table.table_type()
+                                        == ExternalCdcTableType::Postgres
+                                        && let Some(cur) = actor_cdc_offset_low.as_ref()
                                         && let Some(chunk_offset) = chunk_cdc_offset
                                         && chunk_offset < *cur
-                                        && *self.external_table.table_type()
-                                            != ExternalCdcTableType::Mock
                                     {
                                         continue;
                                     }
@@ -633,11 +633,11 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let chunk_cdc_offset =
                             get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                        // TODO(zw): fix Mock
-                        if let Some(cur) = actor_cdc_offset_low.as_ref()
+                        // TODO(zw): enable for other cdc table type
+                        if *self.external_table.table_type() == ExternalCdcTableType::Postgres
+                            && let Some(cur) = actor_cdc_offset_low.as_ref()
                             && let Some(ref chunk_offset) = chunk_cdc_offset
                             && *chunk_offset < *cur
-                            && *self.external_table.table_type() != ExternalCdcTableType::Mock
                         {
                             continue;
                         }

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -475,17 +475,15 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                         continue;
                                     }
 
-                                    let chunk_cdc_offset =
-                                        get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                    // TODO(zw): fix Mock
-                                    if let Some(cur) = actor_cdc_offset_low.as_ref()
-                                        && let Some(chunk_offset) = chunk_cdc_offset
-                                        && chunk_offset < *cur
-                                        && *self.external_table.table_type()
-                                            != ExternalCdcTableType::Mock
-                                    {
-                                        continue;
-                                    }
+                                    // TODO(zw): resume after adding test.
+                                    // let chunk_cdc_offset =
+                                    //     get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                    // if let Some(cur) = actor_cdc_offset_low.as_ref()
+                                    //     && let Some(chunk_offset) = chunk_cdc_offset
+                                    //     && chunk_offset < *cur
+                                    // {
+                                    //     continue;
+                                    // }
 
                                     let chunk = mapping_chunk(chunk, &self.output_indices);
                                     if let Some(filtered_chunk) = filter_stream_chunk(
@@ -633,14 +631,13 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let chunk_cdc_offset =
                             get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                        // TODO(zw): fix Mock
-                        if let Some(cur) = actor_cdc_offset_low.as_ref()
-                            && let Some(ref chunk_offset) = chunk_cdc_offset
-                            && *chunk_offset < *cur
-                            && *self.external_table.table_type() != ExternalCdcTableType::Mock
-                        {
-                            continue;
-                        }
+                        // TODO(zw): resume after adding test.
+                        // if let Some(cur) = actor_cdc_offset_low.as_ref()
+                        //     && let Some(ref chunk_offset) = chunk_cdc_offset
+                        //     && *chunk_offset < *cur
+                        // {
+                        //     continue;
+                        // }
 
                         // should_report_actor_backfill_done is set to true at most once.
                         if let Some(high) = actor_cdc_offset_high.as_ref() {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -475,15 +475,17 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                         continue;
                                     }
 
-                                    // TODO(zw): resume after adding test.
-                                    // let chunk_cdc_offset =
-                                    //     get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                    // if let Some(cur) = actor_cdc_offset_low.as_ref()
-                                    //     && let Some(chunk_offset) = chunk_cdc_offset
-                                    //     && chunk_offset < *cur
-                                    // {
-                                    //     continue;
-                                    // }
+                                    let chunk_cdc_offset =
+                                        get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                    // TODO(zw): fix Mock
+                                    if let Some(cur) = actor_cdc_offset_low.as_ref()
+                                        && let Some(chunk_offset) = chunk_cdc_offset
+                                        && chunk_offset < *cur
+                                        && *self.external_table.table_type()
+                                            != ExternalCdcTableType::Mock
+                                    {
+                                        continue;
+                                    }
 
                                     let chunk = mapping_chunk(chunk, &self.output_indices);
                                     if let Some(filtered_chunk) = filter_stream_chunk(
@@ -631,13 +633,14 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let chunk_cdc_offset =
                             get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                        // TODO(zw): resume after adding test.
-                        // if let Some(cur) = actor_cdc_offset_low.as_ref()
-                        //     && let Some(ref chunk_offset) = chunk_cdc_offset
-                        //     && *chunk_offset < *cur
-                        // {
-                        //     continue;
-                        // }
+                        // TODO(zw): fix Mock
+                        if let Some(cur) = actor_cdc_offset_low.as_ref()
+                            && let Some(ref chunk_offset) = chunk_cdc_offset
+                            && *chunk_offset < *cur
+                            && *self.external_table.table_type() != ExternalCdcTableType::Mock
+                        {
+                            continue;
+                        }
 
                         // should_report_actor_backfill_done is set to true at most once.
                         if let Some(high) = actor_cdc_offset_high.as_ref() {

--- a/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backill_v2.rs
@@ -474,14 +474,17 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
                                     if chunk.cardinality() == 0 {
                                         continue;
                                     }
-                                    let chunk_cdc_offset =
-                                        get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                                    if let Some(cur) = actor_cdc_offset_low.as_ref()
-                                        && let Some(chunk_offset) = chunk_cdc_offset
-                                        && chunk_offset < *cur
-                                    {
-                                        continue;
-                                    }
+
+                                    // TODO(zw): resume after adding test.
+                                    // let chunk_cdc_offset =
+                                    //     get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                                    // if let Some(cur) = actor_cdc_offset_low.as_ref()
+                                    //     && let Some(chunk_offset) = chunk_cdc_offset
+                                    //     && chunk_offset < *cur
+                                    // {
+                                    //     continue;
+                                    // }
+
                                     let chunk = mapping_chunk(chunk, &self.output_indices);
                                     if let Some(filtered_chunk) = filter_stream_chunk(
                                         chunk,
@@ -628,12 +631,14 @@ impl<S: StateStore> ParallelizedCdcBackfillExecutor<S> {
 
                         let chunk_cdc_offset =
                             get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                        if let Some(cur) = actor_cdc_offset_low.as_ref()
-                            && let Some(ref chunk_offset) = chunk_cdc_offset
-                            && *chunk_offset < *cur
-                        {
-                            continue;
-                        }
+                        // TODO(zw): resume after adding test.
+                        // if let Some(cur) = actor_cdc_offset_low.as_ref()
+                        //     && let Some(ref chunk_offset) = chunk_cdc_offset
+                        //     && *chunk_offset < *cur
+                        // {
+                        //     continue;
+                        // }
+
                         // should_report_actor_backfill_done is set to true at most once.
                         if let Some(high) = actor_cdc_offset_high.as_ref() {
                             if state_impl.is_legacy_state() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes 2 issues introduced by #22943:
1. Two unit tests fail because #22943 introduces a new filtering logic by CDC offset, but 
    - The existing `MockExternalTableReader` and `MockOffsetGenExecutor` doesn't fit these 2 tests out-of-box. 
    - More importantly, the filtering logic may be [incorrect](https://github.com/risingwavelabs/risingwave/pull/22503#discussion_r2315818706).
    - So This PR **disables the new filtering logic for now**.
2. The meta node with MySQL meta store fails to start due to a SUM returning decimal and being unable to cast to i64.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
