### PR TITLE
fix(sink): Relax some alter table column conditions

### DIFF
--- a/e2e_test/sink/sink_into_table/alter_column.slt
+++ b/e2e_test/sink/sink_into_table/alter_column.slt
@@ -355,3 +355,43 @@ drop table m_drop_1;
 
 statement ok
 drop table t_drop_1;
+
+statement ok
+create table t1 (v1 int);
+
+statement ok
+create table t2 (v1 int primary key, v2 int as v1 + 10, v3 timestamptz as proctime());
+
+statement ok
+create sink s1 into t2 from t1;
+
+statement ok
+insert into t1 values (1), (2);
+
+query II rowsort
+select v1, v2 from t2;
+----
+1 11
+2 12
+
+statement ok
+alter table t2 add column v4 int default 100;
+
+statement ok
+insert into t1 values (3);
+
+query III rowsort
+select v1, v2, v4 from t2;
+----
+1 11 100
+2 12 100
+3 13 100
+
+statement ok
+drop sink s1;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -126,13 +126,6 @@ pub async fn handle_alter_table_column(
     let (original_catalog, has_incoming_sinks) =
         fetch_table_catalog_for_alter(session.as_ref(), &table_name)?;
 
-    if has_incoming_sinks && original_catalog.has_generated_column() {
-        return Err(RwError::from(ErrorCode::BindError(
-            "Alter a table with incoming sink and generated column has not been implemented."
-                .to_owned(),
-        )));
-    }
-
     if original_catalog.webhook_info.is_some() {
         return Err(RwError::from(ErrorCode::BindError(
             "Adding/dropping a column of a table with webhook has not been implemented.".to_owned(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Allows alter operations on tables that have incoming sinks and generated_columns.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
