### PR TITLE
fix(optimizer): fix watermark columns derivation of dynamic filter

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml
@@ -56,3 +56,20 @@
   expected_outputs:
     - eowc_stream_plan
     - stream_plan
+- sql: |
+    CREATE table s1 (
+    id VARCHAR,
+    timestamp TIMESTAMP,
+    WATERMARK FOR timestamp AS timestamp - INTERVAL '5' SECOND
+    ) append only;
+    SELECT
+        id,
+        window_start,
+        window_end,
+        MAX(timestamp) as ts
+    FROM HOP(s1, timestamp, INTERVAL '30 SECONDS', INTERVAL '2 MINUTES')
+    WHERE timestamp > NOW() - INTERVAL '7 hours'
+    GROUP BY id, window_start, window_end;
+  expected_outputs:
+    - eowc_stream_plan
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -242,3 +242,45 @@
             │   └─StreamTableScan { table: s1, columns: [s1.id, s1.value, s1.ts, s1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [s1._row_id], pk: [_row_id], dist: UpstreamHashShard(s1._row_id) }
             └─StreamExchange { dist: HashShard(s2.id) }
               └─StreamTableScan { table: s2, columns: [s2.id, s2.value, s2.ts, s2._row_id], stream_scan_type: ArrangementBackfill, stream_key: [s2._row_id], pk: [_row_id], dist: UpstreamHashShard(s2._row_id) }
+- sql: |
+    CREATE table s1 (
+    id VARCHAR,
+    timestamp TIMESTAMP,
+    WATERMARK FOR timestamp AS timestamp - INTERVAL '5' SECOND
+    ) append only;
+    SELECT
+        id,
+        window_start,
+        window_end,
+        MAX(timestamp) as ts
+    FROM HOP(s1, timestamp, INTERVAL '30 SECONDS', INTERVAL '2 MINUTES')
+    WHERE timestamp > NOW() - INTERVAL '7 hours'
+    GROUP BY id, window_start, window_end;
+  stream_plan: |-
+    StreamMaterialize { columns: [id, window_start, window_end, ts], stream_key: [id, window_start, window_end], pk_columns: [id, window_start, window_end], pk_conflict: NoCheck, watermark_columns: [window_start, window_end] }
+    └─StreamProject { exprs: [s1.id, window_start, window_end, max(s1.timestamp)], output_watermarks: [[window_start, window_end]] }
+      └─StreamHashAgg { group_key: [s1.id, window_start, window_end], aggs: [max(s1.timestamp), count], output_watermarks: [[window_start, window_end]] }
+        └─StreamExchange { dist: HashShard(s1.id, window_start, window_end) }
+          └─StreamHopWindow { time_col: s1.timestamp, slide: 00:00:30, size: 00:02:00, output: [s1.id, s1.timestamp, window_start, window_end, s1._row_id], output_watermarks: [[s1.timestamp, window_start, window_end]] }
+            └─StreamProject { exprs: [s1.id, s1.timestamp, s1._row_id], output_watermarks: [[s1.timestamp]] }
+              └─StreamDynamicFilter { predicate: ($expr1 > $expr2), output_watermarks: [[$expr1], [s1.timestamp]], output: [s1.id, s1.timestamp, $expr1, s1._row_id], cleaned_by_watermark: true }
+                ├─StreamProject { exprs: [s1.id, s1.timestamp, AtTimeZone(s1.timestamp, 'UTC':Varchar) as $expr1, s1._row_id], output_watermarks: [[s1.timestamp, $expr1]] }
+                │ └─StreamFilter { predicate: IsNotNull(s1.timestamp) }
+                │   └─StreamTableScan { table: s1, columns: [s1.id, s1.timestamp, s1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [s1._row_id], pk: [_row_id], dist: UpstreamHashShard(s1._row_id) }
+                └─StreamExchange { dist: Broadcast }
+                  └─StreamProject { exprs: [SubtractWithTimeZone(now, '07:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
+                    └─StreamNow { output: [now] }
+  eowc_stream_plan: |-
+    StreamMaterialize { columns: [id, window_start, window_end, ts], stream_key: [id, window_start, window_end], pk_columns: [id, window_start, window_end], pk_conflict: NoCheck, watermark_columns: [window_start] }
+    └─StreamProject { exprs: [s1.id, window_start, window_end, max(s1.timestamp)], output_watermarks: [[window_start]] }
+      └─StreamHashAgg [eowc] { group_key: [s1.id, window_start, window_end], aggs: [max(s1.timestamp), count], output_watermarks: [[window_start]] }
+        └─StreamExchange { dist: HashShard(s1.id, window_start, window_end) }
+          └─StreamHopWindow { time_col: s1.timestamp, slide: 00:00:30, size: 00:02:00, output: [s1.id, s1.timestamp, window_start, window_end, s1._row_id], output_watermarks: [[s1.timestamp, window_start, window_end]] }
+            └─StreamProject { exprs: [s1.id, s1.timestamp, s1._row_id], output_watermarks: [[s1.timestamp]] }
+              └─StreamDynamicFilter { predicate: ($expr1 > $expr2), output_watermarks: [[$expr1], [s1.timestamp]], output: [s1.id, s1.timestamp, $expr1, s1._row_id], cleaned_by_watermark: true }
+                ├─StreamProject { exprs: [s1.id, s1.timestamp, AtTimeZone(s1.timestamp, 'UTC':Varchar) as $expr1, s1._row_id], output_watermarks: [[s1.timestamp, $expr1]] }
+                │ └─StreamFilter { predicate: IsNotNull(s1.timestamp) }
+                │   └─StreamTableScan { table: s1, columns: [s1.id, s1.timestamp, s1._row_id], stream_scan_type: ArrangementBackfill, stream_key: [s1._row_id], pk: [_row_id], dist: UpstreamHashShard(s1._row_id) }
+                └─StreamExchange { dist: Broadcast }
+                  └─StreamProject { exprs: [SubtractWithTimeZone(now, '07:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
+                    └─StreamNow { output: [now] }

--- a/src/frontend/planner_test/tests/testdata/output/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/expr.yaml
@@ -498,8 +498,8 @@
     create table t (v1 timestamp with time zone, v2 timestamp with time zone);
     select * from t where v1 >= now() and v2 >= now();
   stream_plan: |-
-    StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: NoCheck, watermark_columns: [v2] }
-    └─StreamDynamicFilter { predicate: (t.v2 >= now), output_watermarks: [[t.v2]], output: [t.v1, t.v2, t._row_id], cleaned_by_watermark: true }
+    StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: NoCheck, watermark_columns: [v1, v2] }
+    └─StreamDynamicFilter { predicate: (t.v2 >= now), output_watermarks: [[t.v1], [t.v2]], output: [t.v1, t.v2, t._row_id], cleaned_by_watermark: true }
       ├─StreamDynamicFilter { predicate: (t.v1 >= now), output_watermarks: [[t.v1]], output: [t.v1, t.v2, t._row_id], cleaned_by_watermark: true }
       │ ├─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], stream_scan_type: ArrangementBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
       │ └─StreamExchange { dist: Broadcast }

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -74,21 +74,34 @@ impl StreamDynamicFilter {
 
     fn derive_watermark_columns(core: &DynamicFilter<PlanRef>) -> WatermarkColumns {
         let mut res = WatermarkColumns::new();
+        let lhs_watermark_columns = core.left().watermark_columns();
         let rhs_watermark_columns = core.right().watermark_columns();
-        if rhs_watermark_columns.contains(0) {
-            match core.comparator() {
-                // We can derive output watermark only if the output is supposed to be always >= rhs.
-                // While we have to keep in mind that, the propagation of watermark messages from
-                // the right input must be delayed until `Update`/`Delete`s are sent to downstream,
-                // otherwise, we will have watermark messages sent before the `Delete` of old rows.
-                ExprType::GreaterThan | ExprType::GreaterThanOrEqual => {
-                    // The watermark is generated for the left column according to the right side, but
-                    // not directly derived from the right side. So, let's assign a new group for it.
-                    res.insert(core.left_index(), core.ctx().next_watermark_group_id());
-                }
-                _ => {}
+
+        // Check if we can derive watermark from the right input
+        let can_derive_from_right = rhs_watermark_columns.contains(0)
+            && matches!(
+                core.comparator(),
+                ExprType::GreaterThan | ExprType::GreaterThanOrEqual
+            );
+
+        if can_derive_from_right {
+            // When right side can derive watermark, merge left side watermark columns first
+            for (col_idx, group_id) in lhs_watermark_columns.iter() {
+                res.insert(col_idx, group_id);
             }
+
+            // Then derive watermark column from the right input (existing logic)
+            // We can derive output watermark only if the output is supposed to be always >= rhs.
+            // While we have to keep in mind that, the propagation of watermark messages from
+            // the right input must be delayed until `Update`/`Delete`s are sent to downstream,
+            // otherwise, we will have watermark messages sent before the `Delete` of old rows.
+            // The watermark is generated for the left column according to the right side, but
+            // not directly derived from the right side. So, let's assign a new group for it.
+            res.insert(core.left_index(), core.ctx().next_watermark_group_id());
         }
+        // When right side cannot derive watermark, no watermark columns can be preserved
+        // because the dynamic filter's output correctness depends on both sides
+
         res
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Resolve https://github.com/risingwavelabs/risingwave/issues/22653
- We can merge the watermark columns from the left side when we can derive watermark columns from the right side in dynamic filter.

**Watermark propagation improvements:**

* Refactored the logic in `StreamDynamicFilter` to correctly merge watermark columns from the left input and derive new watermark columns based on the comparator type, ensuring more accurate propagation of watermarks through dynamic filters. (`src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs`)
* Updated the output plan for expressions involving dynamic filters to include both `v1` and `v2` as watermark columns, and adjusted the output watermarks to reflect propagation from both columns. (`src/frontend/planner_test/tests/testdata/output/expr.yaml`)

**Test coverage and correctness:**

* Added a new SQL query and expected outputs to test windowed aggregation with watermark propagation, including both standard and emit-on-window-close plans. (`src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml`)
* Added corresponding expected output plans for the new windowed query, detailing how watermark columns are handled in both the regular and emit-on-window-close scenarios. (`src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml`)

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
