### PR TITLE
feat: include more useful info in diagnose

### DIFF
--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -406,6 +406,7 @@ pub async fn start_service_as_election_leader(
         prometheus_client.clone(),
         prometheus_selector.clone(),
         opts.redact_sql_option_keywords.clone(),
+        env.system_params_manager_impl_ref().clone(),
     ));
 
     let trace_state = otlp_embedded::State::new(otlp_embedded::Config {

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -695,6 +695,7 @@ pub struct CatalogStats {
     pub function_num: u64,
     pub streaming_job_num: u64,
     pub actor_num: u64,
+    pub database_num: u64,
 }
 
 impl CatalogControllerInner {
@@ -750,6 +751,7 @@ impl CatalogControllerInner {
         let function_num = Function::find().count(&self.db).await?;
         let streaming_job_num = StreamingJob::find().count(&self.db).await?;
         let actor_num = Actor::find().count(&self.db).await?;
+        let database_num = Database::find().count(&self.db).await?;
 
         Ok(CatalogStats {
             table_num: table_num_map.remove(&TableType::Table).unwrap_or(0),
@@ -762,6 +764,7 @@ impl CatalogControllerInner {
             function_num,
             streaming_job_num,
             actor_num,
+            database_num
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This pull request enhances the diagnostic reporting capabilities in the meta node by expanding catalog statistics, adding detailed database and schema listings, and including system parameter information. It also improves the visibility of resource group assignments and refines the output format for catalog objects. These changes provide more comprehensive insights into the system state for debugging and operational monitoring.

**Diagnostic Report Improvements:**

* The `DiagnoseCommand` now reports the number of databases and outputs detailed tables listing all databases and schemas, including their properties such as resource group, barrier interval, and checkpoint frequency. [[1]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R131) [[2]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R140-R226)
* System parameters are now included in the diagnostic output, showing values like barrier interval, checkpoint frequency, state store, and more.

**Catalog Statistics Expansion:**

* The catalog statistics now track the number of databases, with corresponding updates to data collection and reporting. [[1]](diffhunk://#diff-8e2ee229dde0f2dfb4645ba6ad73e0f4b6707a8f9fd781255b67bbd506c111b3R698) [[2]](diffhunk://#diff-8e2ee229dde0f2dfb4645ba6ad73e0f4b6707a8f9fd781255b67bbd506c111b3R754) [[3]](diffhunk://#diff-8e2ee229dde0f2dfb4645ba6ad73e0f4b6707a8f9fd781255b67bbd506c111b3R767)

**Resource Group Visibility:**

* Resource group information is now displayed for both databases and worker nodes, improving visibility into resource allocation. [[1]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R248) [[2]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R277-R283)

**Catalog Object Output Refinement:**

* Output tables for tables, sources, and sinks now include the `database_id` field, providing more context for each catalog object. [[1]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863L636-R746) [[2]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863L656-R772) [[3]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863L679-R801) [[4]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R821-R827) [[5]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R839)

**Internal Plumbing and Dependency Injection:**

* The `DiagnoseCommand` and service startup now accept and propagate references to the system parameters controller, enabling access to system parameters throughout diagnostics. [[1]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R22) [[2]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R39) [[3]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R55) [[4]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R67) [[5]](diffhunk://#diff-368d1181485a10042ba14c3b489f5a50de8f973102e0cc15479332f50b824863R77) [[6]](diffhunk://#diff-1909dd31597b30e65c721d28db6c337021e7df1592ae20e5ebd51cdbc299d7f9R409)

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
