### PR TITLE
refactor(types): avoid leaking array as internal repr of list value (part 1 - `elem_type`)

### DIFF
--- a/src/common/src/array/arrow/arrow_deltalake.rs
+++ b/src/common/src/array/arrow/arrow_deltalake.rs
@@ -114,7 +114,7 @@ mod test {
             Some(Decimal::Normalized("1".parse().unwrap())),
             Some(Decimal::Normalized("123.456".parse().unwrap())),
         ])));
-        let array = Arc::new(ArrayImpl::List(ListArray::from_list_value(
+        let array = Arc::new(ArrayImpl::List(ListArray::from_single_value(
             DataType::Decimal,
             value,
         )));

--- a/src/common/src/array/arrow/arrow_deltalake.rs
+++ b/src/common/src/array/arrow/arrow_deltalake.rs
@@ -102,6 +102,7 @@ mod test {
     use crate::array::arrow::arrow_deltalake::DeltaLakeConvert;
     use crate::array::{ArrayImpl, Decimal, DecimalArray, ListArray, ListValue};
     use crate::bitmap::Bitmap;
+    use crate::types::DataType;
 
     #[test]
     fn test_decimal_list_chunk() {
@@ -113,7 +114,10 @@ mod test {
             Some(Decimal::Normalized("1".parse().unwrap())),
             Some(Decimal::Normalized("123.456".parse().unwrap())),
         ])));
-        let array = Arc::new(ArrayImpl::List(ListArray::from_iter(vec![value])));
+        let array = Arc::new(ArrayImpl::List(ListArray::from_list_value(
+            DataType::Decimal,
+            value,
+        )));
         let chunk = crate::array::DataChunk::new(vec![array], Bitmap::ones(1));
 
         let schema = arrow_schema::Schema::new(vec![Field::new(

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -317,19 +317,21 @@ where
     }
 }
 
-impl FromIterator<ListValue> for ListArray {
-    fn from_iter<I: IntoIterator<Item = ListValue>>(iter: I) -> Self {
-        let mut iter = iter.into_iter();
-        let first = iter.next().expect("empty iterator");
-        let mut builder =
-            ListArrayBuilder::with_type(iter.size_hint().0, DataType::list(first.elem_type()));
-        builder.append(Some(first.as_scalar_ref()));
-        for v in iter {
-            builder.append(Some(v.as_scalar_ref()));
-        }
-        builder.finish()
-    }
-}
+// impl FromIterator<ListValue> for ListArray {
+//     fn from_iter<I: IntoIterator<Item = ListValue>>(iter: I) -> Self {
+//         let mut iter = iter.into_iter();
+//         let first = iter.next().expect("empty iterator");
+//         let mut builder = ListArrayBuilder::with_type(
+//             iter.size_hint().0,
+//             DataType::list(first.data_type()),
+//         );
+//         builder.append(Some(first.as_scalar_ref()));
+//         for v in iter {
+//             builder.append(Some(v.as_scalar_ref()));
+//         }
+//         builder.finish()
+//     }
+// }
 
 #[derive(Clone, PartialEq, Eq, EstimateSize)]
 pub struct ListValue {
@@ -401,6 +403,7 @@ impl ListValue {
     }
 
     /// Returns the data type of the elements in the list.
+    #[deprecated]
     pub fn elem_type(&self) -> DataType {
         self.values.data_type()
     }
@@ -492,7 +495,8 @@ impl<'a> FromIterator<&'a str> for ListValue {
 
 impl FromIterator<ListValue> for ListValue {
     fn from_iter<I: IntoIterator<Item = ListValue>>(iter: I) -> Self {
-        Self::new(iter.into_iter().collect::<ListArray>().into())
+        // Self::new(iter.into_iter().collect::<ListArray>().into())
+        todo!()
     }
 }
 
@@ -522,6 +526,7 @@ impl<'a> ListRef<'a> {
     }
 
     /// Returns the data type of the elements in the list.
+    #[deprecated]
     pub fn elem_type(&self) -> DataType {
         self.array.data_type()
     }

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -386,17 +386,14 @@ impl ListValue {
         Self::new(builder.finish())
     }
 
-    /// Creates a new `ListValue` from an iterator of `ListValue` to nest them.
-    ///
-    /// Note that `nested_data_type` should be `DataType::List(..)`, i.e., the data type of the list value
-    /// in `iter`.
-    pub fn from_nested_iter(
-        nested_data_type: &DataType,
-        iter: impl IntoIterator<Item = ListValue>,
+    /// Creates a new `ListValue` from an iterator of elements with the given element type.
+    pub fn from_scalar_iter<T: Scalar>(
+        elem_type: &DataType,
+        iter: impl IntoIterator<Item = T>,
     ) -> Self {
         Self::from_datum_iter(
-            nested_data_type,
-            iter.into_iter().map(|v| Some(ScalarImpl::List(v))),
+            elem_type,
+            iter.into_iter().map(|v| Datum::Some(v.to_scalar_value())),
         )
     }
 

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -544,12 +544,6 @@ impl<'a> ListRef<'a> {
         self.start == self.end
     }
 
-    /// Returns the data type of the elements in the list.
-    #[deprecated]
-    pub fn elem_type(&self) -> DataType {
-        self.array.data_type()
-    }
-
     /// Returns the elements in the flattened list.
     pub fn flatten(self) -> ListRef<'a> {
         match self.array {

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -318,26 +318,11 @@ where
 }
 
 impl ListArray {
-    /// Creates a new `ListArray` from an iterator of `ListValue`, with the `elem_data_type`
-    /// as the type of the inner element.
-    pub fn from_list_value_iter<I: IntoIterator<Item = ListValue>>(
-        elem_data_type: DataType,
-        iter: I,
-    ) -> Self {
-        let iter = iter.into_iter();
-        let mut builder =
-            ListArrayBuilder::with_type(iter.size_hint().0, DataType::list(elem_data_type));
-        for v in iter {
-            builder.append(Some(v.as_scalar_ref()));
-        }
+    /// Creates a new `ListArray` from a `ListValue`.
+    pub fn from_single_value(elem_type: DataType, list_value: ListValue) -> Self {
+        let mut builder = ListArrayBuilder::with_type(1, DataType::list(elem_type));
+        builder.append_owned(Some(list_value));
         builder.finish()
-    }
-
-    /// Creates a new `ListArray` from a `ListValue`, with the `elem_data_type` as the type of the inner element.
-    /// Same as `from_list_value_iter` but with only one element.
-    #[inline]
-    pub fn from_list_value(elem_data_type: DataType, list_value: ListValue) -> Self {
-        Self::from_list_value_iter(elem_data_type, [list_value])
     }
 }
 

--- a/src/common/src/array/map_array.rs
+++ b/src/common/src/array/map_array.rs
@@ -235,6 +235,7 @@ mod scalar {
         /// Returns error if [map invariants](`super::MapArray`) are violated.
         pub fn try_from_entries(entries: ListValue) -> Result<Self, String> {
             // validates list type is valid
+            #[allow(deprecated)]
             let _ = MapType::try_from_entries(entries.elem_type())?;
             let mut keys = HashSet::with_capacity(entries.len());
             let struct_array = entries.into_array();
@@ -263,7 +264,9 @@ mod scalar {
             }
 
             let len = keys.len();
+            #[allow(deprecated)] // To be refactored.
             let key_type = keys.elem_type();
+            #[allow(deprecated)] // To be refactored.
             let value_type = values.elem_type();
             let struct_array = StructArray::new(
                 MapType::struct_type_for_map(key_type, value_type),

--- a/src/common/src/array/map_array.rs
+++ b/src/common/src/array/map_array.rs
@@ -289,7 +289,7 @@ mod scalar {
 
         pub fn insert(m: MapRef<'_>, key: ScalarImpl, value: Datum, map_type: MapType) -> Self {
             let l = ListValue::from_datum_iter(
-                &m.inner().elem_type(),
+                &map_type.into_struct(),
                 m.iter_struct()
                     .filter(|s| {
                         key.as_scalar_ref_impl() != s.field_at(0).expect("map key is not null")
@@ -302,9 +302,9 @@ mod scalar {
             Self::from_entries(l)
         }
 
-        pub fn delete(m: MapRef<'_>, key: ScalarRefImpl<'_>) -> Self {
+        pub fn delete(m: MapRef<'_>, key: ScalarRefImpl<'_>, map_type: MapType) -> Self {
             let l = ListValue::from_datum_iter(
-                &m.inner().elem_type(),
+                &map_type.into_struct(),
                 m.iter_struct()
                     .filter(|s| key != s.field_at(0).expect("map key is not null"))
                     .map(|s| Some(ScalarRefImpl::Struct(s))),

--- a/src/common/src/array/map_array.rs
+++ b/src/common/src/array/map_array.rs
@@ -275,11 +275,10 @@ mod scalar {
 
         /// # Panics
         /// Panics if `m1` and `m2` have different types.
-        pub fn concat(m1: MapRef<'_>, m2: MapRef<'_>) -> Self {
-            debug_assert_eq!(m1.inner().elem_type(), m2.inner().elem_type());
+        pub fn concat(m1: MapRef<'_>, m2: MapRef<'_>, map_type: MapType) -> Self {
             let m2_keys = m2.keys();
             let l = ListValue::from_datum_iter(
-                &m1.inner().elem_type(),
+                &map_type.into_struct(),
                 m1.iter_struct()
                     .filter(|s| !m2_keys.contains(&s.field_at(0).expect("map key is not null")))
                     .chain(m2.iter_struct())
@@ -288,7 +287,7 @@ mod scalar {
             Self::from_entries(l)
         }
 
-        pub fn insert(m: MapRef<'_>, key: ScalarImpl, value: Datum) -> Self {
+        pub fn insert(m: MapRef<'_>, key: ScalarImpl, value: Datum, map_type: MapType) -> Self {
             let l = ListValue::from_datum_iter(
                 &m.inner().elem_type(),
                 m.iter_struct()

--- a/src/connector/src/sink/encoder/avro.rs
+++ b/src/connector/src/sink/encoder/avro.rs
@@ -1177,10 +1177,13 @@ mod tests {
 
         test_ok(
             &DataType::Int32.list().list(),
-            Some(ScalarImpl::List(ListValue::from_iter([
-                ListValue::from_iter([26, 29]),
-                ListValue::from_iter([46, 49]),
-            ]))),
+            Some(ScalarImpl::List(ListValue::from_nested_iter(
+                &DataType::Int32.list(),
+                [
+                    ListValue::from_iter([26, 29]),
+                    ListValue::from_iter([46, 49]),
+                ],
+            ))),
             r#"{
                 "type": "array",
                 "items": {

--- a/src/connector/src/sink/encoder/avro.rs
+++ b/src/connector/src/sink/encoder/avro.rs
@@ -1177,7 +1177,7 @@ mod tests {
 
         test_ok(
             &DataType::Int32.list().list(),
-            Some(ScalarImpl::List(ListValue::from_nested_iter(
+            Some(ScalarImpl::List(ListValue::from_scalar_iter(
                 &DataType::Int32.list(),
                 [
                     ListValue::from_iter([26, 29]),

--- a/src/expr/core/src/aggregate/scalar_wrapper.rs
+++ b/src/expr/core/src/aggregate/scalar_wrapper.rs
@@ -83,7 +83,7 @@ impl AggregateFunction for ScalarWrapper {
         // XXX: can we avoid cloning here?
         let list = ListValue::new(state.clone().finish());
         let chunk = DataChunk::new(
-            vec![ListArray::from_list_value(self.arg_type.clone(), list).into_ref()],
+            vec![ListArray::from_single_value(self.arg_type.clone(), list).into_ref()],
             1,
         );
         let output = self.scalar.eval(&chunk).await?;

--- a/src/expr/core/src/aggregate/scalar_wrapper.rs
+++ b/src/expr/core/src/aggregate/scalar_wrapper.rs
@@ -82,7 +82,10 @@ impl AggregateFunction for ScalarWrapper {
         let state = &state.downcast_ref::<State>().0;
         // XXX: can we avoid cloning here?
         let list = ListValue::new(state.clone().finish());
-        let chunk = DataChunk::new(vec![ListArray::from_iter([list]).into_ref()], 1);
+        let chunk = DataChunk::new(
+            vec![ListArray::from_list_value(self.arg_type.clone(), list).into_ref()],
+            1,
+        );
         let output = self.scalar.eval(&chunk).await?;
         Ok(output.to_datum())
     }

--- a/src/expr/impl/src/scalar/array_access.rs
+++ b/src/expr/impl/src/scalar/array_access.rs
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn test_nested_array_access() {
-        let v = ListValue::from_nested_iter(
+        let v = ListValue::from_scalar_iter(
             &DataType::Varchar.list(),
             [
                 ListValue::from_iter(["foo", "bar"]),

--- a/src/expr/impl/src/scalar/array_access.rs
+++ b/src/expr/impl/src/scalar/array_access.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn test_nested_array_access() {
         let v = ListValue::from_nested_iter(
-            &DataType::List(Box::new(DataType::Varchar)),
+            &DataType::Varchar.list(),
             [
                 ListValue::from_iter(["foo", "bar"]),
                 ListValue::from_iter(["fizz", "buzz"]),

--- a/src/expr/impl/src/scalar/array_access.rs
+++ b/src/expr/impl/src/scalar/array_access.rs
@@ -30,7 +30,7 @@ fn array_access(list: ListRef<'_>, index: i32) -> Option<ScalarRefImpl<'_>> {
 mod tests {
 
     use risingwave_common::array::ListValue;
-    use risingwave_common::types::Scalar;
+    use risingwave_common::types::{DataType, Scalar};
 
     use super::*;
 
@@ -58,10 +58,13 @@ mod tests {
 
     #[test]
     fn test_nested_array_access() {
-        let v = ListValue::from_iter([
-            ListValue::from_iter(["foo", "bar"]),
-            ListValue::from_iter(["fizz", "buzz"]),
-        ]);
+        let v = ListValue::from_nested_iter(
+            &DataType::List(Box::new(DataType::Varchar)),
+            [
+                ListValue::from_iter(["foo", "bar"]),
+                ListValue::from_iter(["fizz", "buzz"]),
+            ],
+        );
         assert_eq!(
             array_access(v.as_scalar_ref(), 1),
             Some(ListValue::from_iter(["foo", "bar"]).as_scalar_ref().into())

--- a/src/expr/impl/src/scalar/array_distinct.rs
+++ b/src/expr/impl/src/scalar/array_distinct.rs
@@ -68,8 +68,8 @@ mod tests {
         let actual = array_distinct(
             array.as_scalar_ref(),
             &Context {
-                arg_types: vec![DataType::List(DataType::Int32.into())],
-                return_type: DataType::List(DataType::Int32.into()),
+                arg_types: vec![DataType::Int32.list()],
+                return_type: DataType::Int32.list(),
                 variadic: false,
             },
         );

--- a/src/expr/impl/src/scalar/array_range_access.rs
+++ b/src/expr/impl/src/scalar/array_range_access.rs
@@ -13,20 +13,28 @@
 // limitations under the License.
 
 use risingwave_common::array::{ListRef, ListValue};
+use risingwave_expr::expr::Context;
 use risingwave_expr::function;
 
 /// If the case is `array[1,2,3][:2]`, then start will be 0 set by the frontend
 /// If the case is `array[1,2,3][1:]`, then end will be `i32::MAX` set by the frontend
 #[function("array_range_access(anyarray, int4, int4) -> anyarray")]
-pub fn array_range_access(list: ListRef<'_>, start: i32, end: i32) -> Option<ListValue> {
+pub fn array_range_access(
+    list: ListRef<'_>,
+    start: i32,
+    end: i32,
+    ctx: &Context,
+) -> Option<ListValue> {
+    let elem_type = ctx.arg_types[0].as_list_elem();
+
     let list_all_values = list.iter();
     let start = std::cmp::max(start, 1) as usize;
     let end = std::cmp::min(std::cmp::max(0, end), list_all_values.len() as i32) as usize;
     if start > end {
-        return Some(ListValue::empty(&list.elem_type()));
+        return Some(ListValue::empty(elem_type));
     }
     Some(ListValue::from_datum_iter(
-        &list.elem_type(),
+        elem_type,
         list_all_values.take(end).skip(start - 1),
     ))
 }

--- a/src/expr/impl/src/scalar/array_remove.rs
+++ b/src/expr/impl/src/scalar/array_remove.rs
@@ -14,6 +14,7 @@
 
 use risingwave_common::array::{ListRef, ListValue};
 use risingwave_common::types::ScalarRefImpl;
+use risingwave_expr::expr::Context;
 use risingwave_expr::function;
 
 /// Removes all elements equal to the given value from the array.
@@ -67,6 +68,9 @@ use risingwave_expr::function;
 /// select array_remove(ARRAY[array[1],array[2],array[3],array[2],null], array[true]);
 /// ```
 #[function("array_remove(anyarray, any) -> anyarray")]
-fn array_remove(array: ListRef<'_>, elem: Option<ScalarRefImpl<'_>>) -> ListValue {
-    ListValue::from_datum_iter(&array.elem_type(), array.iter().filter(|x| x != &elem))
+fn array_remove(array: ListRef<'_>, elem: Option<ScalarRefImpl<'_>>, ctx: &Context) -> ListValue {
+    ListValue::from_datum_iter(
+        ctx.arg_types[0].as_list_elem(),
+        array.iter().filter(|x| x != &elem),
+    )
 }

--- a/src/expr/impl/src/scalar/array_replace.rs
+++ b/src/expr/impl/src/scalar/array_replace.rs
@@ -14,6 +14,7 @@
 
 use risingwave_common::array::{ListRef, ListValue};
 use risingwave_common::types::ScalarRefImpl;
+use risingwave_expr::expr::Context;
 use risingwave_expr::function;
 
 /// Replaces each array element equal to the second argument with the third argument.
@@ -59,9 +60,10 @@ fn array_replace(
     array: ListRef<'_>,
     elem_from: Option<ScalarRefImpl<'_>>,
     elem_to: Option<ScalarRefImpl<'_>>,
+    ctx: &Context,
 ) -> ListValue {
     ListValue::from_datum_iter(
-        &array.elem_type(),
+        ctx.arg_types[0].as_list_elem(),
         array.iter().map(|val| match val == elem_from {
             true => elem_to,
             false => val,

--- a/src/expr/impl/src/scalar/array_sort.rs
+++ b/src/expr/impl/src/scalar/array_sort.rs
@@ -15,12 +15,13 @@
 use itertools::Itertools;
 use risingwave_common::array::*;
 use risingwave_common::types::DefaultOrdered;
+use risingwave_expr::expr::Context;
 use risingwave_expr::function;
 
 #[function("array_sort(anyarray) -> anyarray")]
-pub fn array_sort(array: ListRef<'_>) -> ListValue {
+pub fn array_sort(array: ListRef<'_>, ctx: &Context) -> ListValue {
     ListValue::from_datum_iter(
-        &array.elem_type(),
+        ctx.arg_types[0].as_list_elem(),
         array.iter().map(DefaultOrdered).sorted().map(|v| v.0),
     )
 }

--- a/src/expr/impl/src/scalar/cast.rs
+++ b/src/expr/impl/src/scalar/cast.rs
@@ -340,7 +340,8 @@ mod tests {
         assert_eq!(str_to_list("{1, 2, 3}", &ctx).unwrap(), list123);
 
         // Nested List
-        let nested_list123 = ListValue::from_iter([list123]);
+        let nested_list123 =
+            ListValue::from_nested_iter(&DataType::List(Box::new(DataType::Int32)), [list123]);
         let ctx = Context {
             arg_types: vec![DataType::Varchar],
             return_type: DataType::from_str("int[][]").unwrap(),
@@ -348,10 +349,15 @@ mod tests {
         };
         assert_eq!(str_to_list("{{1, 2, 3}}", &ctx).unwrap(), nested_list123);
 
-        let nested_list445566 = ListValue::from_iter([ListValue::from_iter([44, 55, 66])]);
+        let nested_list445566 = ListValue::from_nested_iter(
+            &DataType::List(Box::new(DataType::Int32)),
+            [ListValue::from_iter([44, 55, 66])],
+        );
 
-        let double_nested_list123_445566 =
-            ListValue::from_iter([nested_list123.clone(), nested_list445566.clone()]);
+        let double_nested_list123_445566 = ListValue::from_nested_iter(
+            &DataType::List(Box::new(DataType::List(Box::new(DataType::Int32)))),
+            [nested_list123.clone(), nested_list445566.clone()],
+        );
 
         // Double nested List
         let ctx = Context {
@@ -370,10 +376,13 @@ mod tests {
             return_type: DataType::from_str("varchar[][]").unwrap(),
             variadic: false,
         };
-        let double_nested_varchar_list123_445566 = ListValue::from_iter([
-            list_cast(nested_list123.as_scalar_ref(), &ctx).unwrap(),
-            list_cast(nested_list445566.as_scalar_ref(), &ctx).unwrap(),
-        ]);
+        let double_nested_varchar_list123_445566 = ListValue::from_nested_iter(
+            &DataType::List(Box::new(DataType::List(Box::new(DataType::Varchar)))),
+            [
+                list_cast(nested_list123.as_scalar_ref(), &ctx).unwrap(),
+                list_cast(nested_list445566.as_scalar_ref(), &ctx).unwrap(),
+            ],
+        );
 
         // Double nested Varchar List
         let ctx = Context {

--- a/src/expr/impl/src/scalar/cast.rs
+++ b/src/expr/impl/src/scalar/cast.rs
@@ -340,7 +340,7 @@ mod tests {
         assert_eq!(str_to_list("{1, 2, 3}", &ctx).unwrap(), list123);
 
         // Nested List
-        let nested_list123 = ListValue::from_nested_iter(&DataType::Int32.list(), [list123]);
+        let nested_list123 = ListValue::from_scalar_iter(&DataType::Int32.list(), [list123]);
         let ctx = Context {
             arg_types: vec![DataType::Varchar],
             return_type: DataType::from_str("int[][]").unwrap(),
@@ -348,12 +348,12 @@ mod tests {
         };
         assert_eq!(str_to_list("{{1, 2, 3}}", &ctx).unwrap(), nested_list123);
 
-        let nested_list445566 = ListValue::from_nested_iter(
+        let nested_list445566 = ListValue::from_scalar_iter(
             &DataType::Int32.list(),
             [ListValue::from_iter([44, 55, 66])],
         );
 
-        let double_nested_list123_445566 = ListValue::from_nested_iter(
+        let double_nested_list123_445566 = ListValue::from_scalar_iter(
             &DataType::Int32.list().list(),
             [nested_list123.clone(), nested_list445566.clone()],
         );
@@ -375,7 +375,7 @@ mod tests {
             return_type: DataType::from_str("varchar[][]").unwrap(),
             variadic: false,
         };
-        let double_nested_varchar_list123_445566 = ListValue::from_nested_iter(
+        let double_nested_varchar_list123_445566 = ListValue::from_scalar_iter(
             &DataType::Varchar.list().list(),
             [
                 list_cast(nested_list123.as_scalar_ref(), &ctx).unwrap(),

--- a/src/expr/impl/src/scalar/cast.rs
+++ b/src/expr/impl/src/scalar/cast.rs
@@ -340,8 +340,7 @@ mod tests {
         assert_eq!(str_to_list("{1, 2, 3}", &ctx).unwrap(), list123);
 
         // Nested List
-        let nested_list123 =
-            ListValue::from_nested_iter(&DataType::List(Box::new(DataType::Int32)), [list123]);
+        let nested_list123 = ListValue::from_nested_iter(&DataType::Int32.list(), [list123]);
         let ctx = Context {
             arg_types: vec![DataType::Varchar],
             return_type: DataType::from_str("int[][]").unwrap(),
@@ -350,12 +349,12 @@ mod tests {
         assert_eq!(str_to_list("{{1, 2, 3}}", &ctx).unwrap(), nested_list123);
 
         let nested_list445566 = ListValue::from_nested_iter(
-            &DataType::List(Box::new(DataType::Int32)),
+            &DataType::Int32.list(),
             [ListValue::from_iter([44, 55, 66])],
         );
 
         let double_nested_list123_445566 = ListValue::from_nested_iter(
-            &DataType::List(Box::new(DataType::List(Box::new(DataType::Int32)))),
+            &DataType::Int32.list().list(),
             [nested_list123.clone(), nested_list445566.clone()],
         );
 
@@ -377,7 +376,7 @@ mod tests {
             variadic: false,
         };
         let double_nested_varchar_list123_445566 = ListValue::from_nested_iter(
-            &DataType::List(Box::new(DataType::List(Box::new(DataType::Varchar)))),
+            &DataType::Varchar.list().list(),
             [
                 list_cast(nested_list123.as_scalar_ref(), &ctx).unwrap(),
                 list_cast(nested_list445566.as_scalar_ref(), &ctx).unwrap(),

--- a/src/expr/impl/src/scalar/jsonb_record.rs
+++ b/src/expr/impl/src/scalar/jsonb_record.rs
@@ -71,7 +71,11 @@ pub fn jsonb_populate_map(
         .to_map(output_type)
         .map_err(|e| ExprError::Parse(e.into()))?;
     match base {
-        Some(base) => Ok(MapValue::concat(base, jsonb_map.as_scalar_ref())),
+        Some(base) => Ok(MapValue::concat(
+            base,
+            jsonb_map.as_scalar_ref(),
+            output_type.clone(),
+        )),
         None => Ok(jsonb_map),
     }
 }

--- a/src/expr/impl/src/scalar/trim_array.rs
+++ b/src/expr/impl/src/scalar/trim_array.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use risingwave_common::array::{ListRef, ListValue};
+use risingwave_expr::expr::Context;
 use risingwave_expr::{ExprError, Result, function};
 
 /// Trims an array by removing the last n elements. If the array is multidimensional, only the first
@@ -70,7 +71,7 @@ use risingwave_expr::{ExprError, Result, function};
 /// select trim_array(array[1,2,3,4,5,null], true);
 /// ```
 #[function("trim_array(anyarray, int4) -> anyarray")]
-fn trim_array(array: ListRef<'_>, n: i32) -> Result<ListValue> {
+fn trim_array(array: ListRef<'_>, n: i32, ctx: &Context) -> Result<ListValue> {
     let values = array.iter();
     let len_to_trim: usize = n.try_into().map_err(|_| ExprError::InvalidParam {
         name: "n",
@@ -85,7 +86,7 @@ fn trim_array(array: ListRef<'_>, n: i32) -> Result<ListValue> {
                 reason: "more than array length".into(),
             })?;
     Ok(ListValue::from_datum_iter(
-        &array.elem_type(),
+        ctx.arg_types[0].as_list_elem(),
         values.take(len_to_retain),
     ))
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

One should not assume it's always possible to obtain the data type solely from a scalar value.

However, since we started to use `Array` as the internal representation of `ListValue`, there's a leak of abstraction that we can call `ListValue::data_type` to get the data type from the internal array. This PR tried to eliminate such usages as much as possible.

This is also a potential preparation for future introduction of new row format.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
