### PR TITLE
feat: avoid populating the high part of append-only group topn cache

### DIFF
--- a/src/stream/src/executor/top_n/group_top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/group_top_n_appendonly.rs
@@ -167,7 +167,7 @@ where
                 self.metrics.group_top_n_cache_miss_count.inc();
                 let mut topn_cache = TopNCache::new(self.offset, self.limit, data_types.clone());
                 self.managed_state
-                    .init_topn_cache(Some(group_key), &mut topn_cache)
+                    .init_append_only_topn_cache(Some(group_key), &mut topn_cache)
                     .await?;
                 self.caches.put(group_cache_key.clone(), topn_cache);
             }

--- a/src/stream/src/executor/top_n/top_n_state.rs
+++ b/src/stream/src/executor/top_n/top_n_state.rs
@@ -198,10 +198,11 @@ impl<S: StateStore> ManagedTopNState<S> {
         Ok(())
     }
 
-    pub async fn init_topn_cache<const WITH_TIES: bool>(
+    pub async fn init_topn_cache_inner<const WITH_TIES: bool>(
         &self,
         group_key: Option<impl GroupKey>,
         topn_cache: &mut TopNCache<WITH_TIES>,
+        skip_high: bool,
     ) -> StreamExecutorResult<()> {
         assert!(topn_cache.low.as_ref().map(Cache::is_empty).unwrap_or(true));
         assert!(topn_cache.middle.is_empty());
@@ -263,41 +264,62 @@ impl<S: StateStore> ManagedTopNState<S> {
             }
         }
 
-        assert!(
-            topn_cache.high_cache_capacity > 0,
-            "topn cache high_capacity should always > 0"
-        );
-        while !topn_cache.high_is_full()
-            && let Some(item) = state_table_iter.next().await
-        {
-            group_row_count += 1;
-            let topn_row = self.get_topn_row(item?.into_owned_row(), group_key.len());
-            topn_cache
-                .high
-                .insert(topn_row.cache_key, (&topn_row.row).into());
-        }
-        if WITH_TIES && topn_cache.high_is_full() {
-            let high_last_sort_key = topn_cache.high.last_key_value().unwrap().0.0.clone();
-            while let Some(item) = state_table_iter.next().await {
+        if !skip_high {
+            assert!(
+                topn_cache.high_cache_capacity > 0,
+                "topn cache high_capacity should always > 0"
+            );
+            while !topn_cache.high_is_full()
+                && let Some(item) = state_table_iter.next().await
+            {
                 group_row_count += 1;
                 let topn_row = self.get_topn_row(item?.into_owned_row(), group_key.len());
-                if topn_row.cache_key.0 == high_last_sort_key {
-                    topn_cache
-                        .high
-                        .insert(topn_row.cache_key, (&topn_row.row).into());
-                } else {
-                    break;
+                topn_cache
+                    .high
+                    .insert(topn_row.cache_key, (&topn_row.row).into());
+            }
+            if WITH_TIES && topn_cache.high_is_full() {
+                let high_last_sort_key = topn_cache.high.last_key_value().unwrap().0.0.clone();
+                while let Some(item) = state_table_iter.next().await {
+                    group_row_count += 1;
+                    let topn_row = self.get_topn_row(item?.into_owned_row(), group_key.len());
+                    if topn_row.cache_key.0 == high_last_sort_key {
+                        topn_cache
+                            .high
+                            .insert(topn_row.cache_key, (&topn_row.row).into());
+                    } else {
+                        break;
+                    }
                 }
             }
-        }
-
-        if state_table_iter.next().await.is_none() {
-            // After trying to initially fill in the cache, all table entries are in the cache,
-            // we then get the precise table row count.
+            if state_table_iter.next().await.is_none() {
+                // After trying to initially fill in the cache, all table entries are in the cache,
+                // we then get the precise table row count.
+                topn_cache.update_table_row_count(group_row_count);
+            }
+        } else {
             topn_cache.update_table_row_count(group_row_count);
         }
 
         Ok(())
+    }
+
+    pub async fn init_topn_cache<const WITH_TIES: bool>(
+        &self,
+        group_key: Option<impl GroupKey>,
+        topn_cache: &mut TopNCache<WITH_TIES>,
+    ) -> StreamExecutorResult<()> {
+        self.init_topn_cache_inner(group_key, topn_cache, false)
+            .await
+    }
+
+    pub async fn init_append_only_topn_cache<const WITH_TIES: bool>(
+        &self,
+        group_key: Option<impl GroupKey>,
+        topn_cache: &mut TopNCache<WITH_TIES>,
+    ) -> StreamExecutorResult<()> {
+        self.init_topn_cache_inner(group_key, topn_cache, true)
+            .await
     }
 
     pub async fn flush(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

See https://github.com/risingwavelabs/risingwave/issues/23263#issuecomment-3311630206 for details.

The high part of the append only group top N cache should always be empty so calling storage iter next is wasteful.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
