### PR TITLE
feat: implement array_intersect

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -239,6 +239,7 @@ message ExprNode {
     ARRAY_CONTAINS = 550;
     ARRAY_CONTAINED = 551;
     ARRAY_FLATTEN = 552;
+    ARRAY_INTERSECT = 553;
 
     // Int256 functions
     HEX_TO_INT256 = 560;

--- a/src/expr/impl/src/scalar/array_intersect.rs
+++ b/src/expr/impl/src/scalar/array_intersect.rs
@@ -1,0 +1,126 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use risingwave_common::array::{ListRef, ListValue};
+use risingwave_expr::function;
+
+/// Returns the intersection of two arrays, i.e., elements that appear in both arrays.
+/// The result preserves the order of elements from the first array and removes duplicates.
+///
+/// ```sql
+/// array_intersect (array1 anyarray, array2 anyarray) → array
+/// ```
+///
+/// Examples:
+///
+/// ```slt
+/// query T
+/// select array_intersect(array[1,2,3], array[2,3,4]);
+/// ----
+/// {2,3}
+///
+/// query T
+/// select array_intersect(array[1,2,2,3], array[2,3,4]);
+/// ----
+/// {2,3}
+///
+/// query T
+/// select array_intersect(array[1,2,3], array[4,5,6]);
+/// ----
+/// {}
+///
+/// query T
+/// select array_intersect(array[1,2,NULL], array[2,NULL,4]);
+/// ----
+/// {2,NULL}
+///
+/// query T
+/// select array_intersect(null::int[], array[1,2,3]);
+/// ----
+/// NULL
+///
+/// query T
+/// select array_intersect(array[1,2,3], null::int[]);
+/// ----
+/// NULL
+/// ```
+
+#[function("array_intersect(anyarray, anyarray) -> anyarray")]
+fn array_intersect(left: ListRef<'_>, right: ListRef<'_>) -> ListValue {
+    let right_set: HashSet<_> = right.iter().collect();
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+
+    for item in left.iter() {
+        if right_set.contains(&item) && !seen.contains(&item) {
+            result.push(item);
+            seen.insert(item);
+        }
+    }
+
+    ListValue::from_datum_iter(&left.elem_type(), result.into_iter())
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::{ListValue, Scalar};
+
+    use super::*;
+
+    #[test]
+    fn test_array_intersect_basic() {
+        let left = ListValue::from_iter([1, 2, 3]);
+        let right = ListValue::from_iter([2, 3, 4]);
+        let expected = ListValue::from_iter([2, 3]);
+        assert_eq!(
+            array_intersect(left.as_scalar_ref(), right.as_scalar_ref()),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_array_intersect_with_duplicates() {
+        let left = ListValue::from_iter([1, 2, 2, 3]);
+        let right = ListValue::from_iter([2, 3, 4]);
+        let expected = ListValue::from_iter([2, 3]);
+        assert_eq!(
+            array_intersect(left.as_scalar_ref(), right.as_scalar_ref()),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_array_intersect_with_nulls() {
+        let left = ListValue::from_iter([Some(1), None, Some(2)]);
+        let right = ListValue::from_iter([None, Some(2), Some(3)]);
+        let expected = ListValue::from_iter([None, Some(2)]);
+        assert_eq!(
+            array_intersect(left.as_scalar_ref(), right.as_scalar_ref()),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_array_intersect_no_intersection() {
+        let left = ListValue::from_iter([1, 2, 3]);
+        let right = ListValue::from_iter([4, 5, 6]);
+        let expected = ListValue::from_iter(std::iter::empty::<i32>());
+        assert_eq!(
+            array_intersect(left.as_scalar_ref(), right.as_scalar_ref()),
+            expected
+        );
+    }
+}

--- a/src/expr/impl/src/scalar/mod.rs
+++ b/src/expr/impl/src/scalar/mod.rs
@@ -20,6 +20,7 @@ mod array_concat;
 mod array_contain;
 mod array_distinct;
 mod array_flatten;
+mod array_intersect;
 mod array_length;
 mod array_min_max;
 mod array_positions;

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -342,6 +342,7 @@ impl Binder {
                     }
                     Ok(FunctionCall::new_unchecked(ExprType::ArrayFlatten, vec![input], return_type).into())
                 })),
+                ("array_intersect", raw_call(ExprType::ArrayIntersect)),
                 ("trim_array", raw_call(ExprType::TrimArray)),
                 (
                     "array_ndims",

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -186,6 +186,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::ArrayContains
             | Type::ArrayContained
             | Type::ArrayFlatten
+            | Type::ArrayIntersect
             | Type::HexToInt256
             | Type::JsonbConcat
             | Type::JsonbAccess

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -274,6 +274,7 @@ impl Strong {
             | ExprType::ArrayContains
             | ExprType::ArrayContained
             | ExprType::ArrayFlatten
+            | ExprType::ArrayIntersect
             | ExprType::HexToInt256
             | ExprType::JsonbAccess
             | ExprType::JsonbAccessStr


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

**Implement array_intersect function**

This PR implements the `array_intersect` function that returns the intersection of two arrays, containing only elements that appear in both input arrays.

**How it works:**
- Takes two array inputs and returns a new array containing elements present in both
- Uses a HashSet-based approach for efficient O(n+m) time complexity
- Preserves element order from the first array
- Handles null values appropriately
- Supports all array element types that implement Hash + Eq

**Implementation details:**
- Added the function signature and registration in the scalar function registry
- Implemented the core logic using HashSet for fast lookups
- Properly handles ListArray/ListRef types and data type propagation
- Returns elements in the order they appear in the first array
- Deduplicates results (each element appears at most once in output)

**Example usage:**
```sql
SELECT array_intersect(ARRAY[1,2,3,4], ARRAY[3,4,5,6]); -- Returns [3,4]
SELECT array_intersect(ARRAY['a','b','c'], ARRAY['b','c','d']); -- Returns ['b','c']
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

**New Feature: array_intersect function**

Added support for the `array_intersect(array1, array2)` function that returns the intersection of two arrays. The function returns a new array containing only elements that appear in both input arrays, preserving the order from the first array.

This function is useful for finding common elements between arrays in SQL queries and supports all comparable data types.

</details>