### PR TITLE
fix(docker): reduce the default memory limit

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,10 +22,10 @@ services:
                     --advertise-addr 0.0.0.0:5688 \
                     --async-stack-trace verbose \
                     --parallelism 8 \
-                    --total-memory-bytes 21474836480 \
+                    --total-memory-bytes 2147483648 \
                     --role both \
                     --meta-address http://0.0.0.0:5690 \
-                    --memory-manager-target-bytes 22333829939 \" \
+                    --memory-manager-target-bytes 2147483648 \" \
                  --frontend-opts=\" \
                    --config-path /risingwave.toml \
                    --listen-addr 0.0.0.0:4566 \
@@ -33,13 +33,13 @@ services:
                    --prometheus-listener-addr 0.0.0.0:1250 \
                    --health-check-listener-addr 0.0.0.0:6786 \
                    --meta-addr http://0.0.0.0:5690 \
-                   --frontend-total-memory-bytes=4294967296\" \
+                   --frontend-total-memory-bytes=2147483648\" \
                  --compactor-opts=\" \
                    --listen-addr 0.0.0.0:6660 \
                    --prometheus-listener-addr 0.0.0.0:1250 \
                    --advertise-addr 0.0.0.0:6660 \
                    --meta-address http://0.0.0.0:5690 \
-                   --compactor-total-memory-bytes=4294967296\""
+                   --compactor-total-memory-bytes=2147483648\""
     expose:
       - "6660"
       - "4566"
@@ -78,9 +78,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 28G
+          memory: 6G
         reservations:
-          memory: 28G
+          memory: 6G
 
   postgres-0:
     image: "postgres:15-alpine"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Reduce the memory limit to prevent out of memory failures on machines with limited resources and simplify the first-time `docker-compose up` experience. For example, on a 2c4g EC2 instance:
```
thread 'rw-standalone-compute' panicked at src/compute/src/lib.rs:213:9:
total_memory_bytes 21474836480 is larger than the total memory available bytes 4023242752 that can be acquired.
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/f9e0239a7bc813b4aceffc7f069f4797cde3175c/library/std/src/panicking.rs:695:5
   1: core::panicking::panic_fmt
             at ./rustc/f9e0239a7bc813b4aceffc7f069f4797cde3175c/library/core/src/panicking.rs:75:14
2025-10-06T21:05:57.037424117Z  INFO      rw-standalone-meta sea_orm_migration::migrator: Migration 'm20230908_072257_init' has been applied
2025-10-06T21:05:57.038052345Z  INFO      rw-standalone-meta sea_orm_migration::migrator: Applying migration 'm20231008_020431_hummock'
```


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
