### PR TITLE
fix(docker): Update docker-compose-with-lakekeeper.yml

### DIFF
--- a/docker/docker-compose-with-lakekeeper.yml
+++ b/docker/docker-compose-with-lakekeeper.yml
@@ -470,7 +470,7 @@ services:
     container_name: lakekeeper-db
     networks:
       - default
- 
+
   lakekeeper-bootstrap:
     image: alpine:3.20
     restart: "no"
@@ -483,13 +483,11 @@ services:
       sh -lc '
         set -e
 
-        
         apk add --no-cache curl >/dev/null
 
         echo "Waiting for Lakekeeper to be ready..."
         sleep 5
 
-        
         echo "Bootstrapping Lakekeeper..."
         for attempt in 1 2 3 4 5; do
           http=$$(curl -s -o /tmp/bootstrap.json -w "%{http_code}" -X POST \
@@ -506,7 +504,6 @@ services:
           esac
         done
 
-        
         echo "Creating warehouse risingwave-warehouse..."
         sleep 2
         for attempt in 1 2 3 4 5; do


### PR DESCRIPTION
While following the [[Iceberg REST catalog guide](https://docs.risingwave.com/iceberg/iceberg-catalog-rest)](https://docs.risingwave.com/iceberg/iceberg-catalog-rest), I encountered an error because Lakekeeper wasn’t initialized and no warehouse existed:

`org.apache.iceberg.exceptions.RESTException: Unable to process: Warehouse risingwave-warehouse not found`

To fix this, I added a single service named `lakekeeper-bootstrap` to `docker-compose-with-lakekeeper.yml`. This service bootstraps Lakekeeper and provisions the `risingwave-warehouse` on MinIO via the management API. No other services were changed.