### PR TITLE
fix(streaming): use `Delete`/`Insert` instead of `UpdateDelete`/`UpdateInsert` for outer joins

### DIFF
--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -1286,8 +1286,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I I I
-                + 3 8 1 . . .
-                - 3 8 1 . . ."
+                + 3 8 1 . . . D
+                - 3 8 1 . . . D"
             )
         );
 

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -2395,8 +2395,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 "  I I
-                 + 3 8
-                 - 3 8",
+                 + 3 8 D
+                 - 3 8 D",
             )
         );
 
@@ -2525,8 +2525,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 "  I I
-                 + 3 8
-                 - 3 8",
+                 + 3 8 D
+                 - 3 8 D",
             )
         );
 
@@ -2826,8 +2826,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + 3 8 . .
-                - 3 8 . ."
+                + 3 8 . . D
+                - 3 8 . . D"
             )
         );
 
@@ -2837,9 +2837,9 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I
-                U- 2 5 . .
-                U+ 2 5 2 7"
+                " I I I I
+                - 2 5 . .
+                + 2 5 2 7"
             )
         );
 
@@ -2849,9 +2849,9 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I
-                U- 3 6 . .
-                U+ 3 6 3 10"
+                " I I I I
+                - 3 6 . .
+                + 3 6 3 10"
             )
         );
 
@@ -2910,8 +2910,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + . 8 . .
-                - . 8 . ."
+                + . 8 . . D
+                - . 8 . . D"
             )
         );
 
@@ -2921,9 +2921,9 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I
-                U- 2 5 . .
-                U+ 2 5 2 7"
+                " I I I I
+                - 2 5 . .
+                + 2 5 2 7"
             )
         );
 
@@ -2933,9 +2933,9 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I
-                U- . 6 . .
-                U+ . 6 . 10"
+                " I I I I
+                - . 6 . .
+                + . 6 . 10"
             )
         );
 
@@ -3002,8 +3002,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + . . 5 10
-                - . . 5 10"
+                + . . 5 10 D
+                - . . 5 10 D"
             )
         );
 
@@ -3074,11 +3074,11 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I I I
-                U- 2 5 2 . . .
-                U+ 2 5 2 2 5 1
-                U- 4 9 4 . . .
-                U+ 4 9 4 4 9 2"
+                " I I I I I I
+                - 2 5 2 . . .
+                + 2 5 2 2 5 1
+                - 4 9 4 . . .
+                + 4 9 4 4 9 2"
             )
         );
 
@@ -3088,11 +3088,11 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I I I
-                U- 1 4 1 . . .
-                U+ 1 4 1 1 4 4
-                U- 3 6 3 . . .
-                U+ 3 6 3 3 6 5"
+                " I I I I I I
+                - 1 4 1 . . .
+                + 1 4 1 1 4 4
+                - 3 6 3 . . .
+                + 3 6 3 3 6 5"
             )
         );
 
@@ -3222,8 +3222,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + 3 8 . .
-                - 3 8 . ."
+                + 3 8 . . D
+                - 3 8 . . D"
             )
         );
 
@@ -3233,11 +3233,11 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I
-                U-  2 5 . .
-                U+  2 5 2 7
-                +  . . 4 8
-                +  . . 6 9"
+                " I I I I
+                - 2 5 . .
+                + 2 5 2 7
+                + . . 4 8
+                + . . 6 9"
             )
         );
 
@@ -3248,8 +3248,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + . . 5 10
-                - . . 5 10"
+                + . . 5 10 D
+                - . . 5 10 D"
             )
         );
 
@@ -3291,8 +3291,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                U- 1 1 . .
-                U+ 1 1 1 1"
+                - 1 1 . .
+                + 1 1 1 1"
             )
         );
 
@@ -3374,8 +3374,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + 3 8 . .
-                - 3 8 . .
+                + 3 8 . . D
+                - 3 8 . . D
                 - 1 4 . ."
             )
         );
@@ -3386,13 +3386,13 @@ mod tests {
         assert_eq!(
             chunk,
             StreamChunk::from_pretty(
-                "  I I I I
-                U-  2 5 . .
-                U+  2 5 2 6
-                +  . . 4 8
-                +  . . 3 4" /* regression test (#2420): 3 4 should be forwarded only once
-                             * despite matching on eq join on 2
-                             * entries */
+                " I I I I
+                - 2 5 . .
+                + 2 5 2 6
+                + . . 4 8
+                + . . 3 4" /* regression test (#2420): 3 4 should be forwarded only once
+                            * despite matching on eq join on 2
+                            * entries */
             )
         );
 
@@ -3403,8 +3403,8 @@ mod tests {
             chunk,
             StreamChunk::from_pretty(
                 " I I I I
-                + . . 5 10
-                - . . 5 10
+                + . . 5 10 D
+                - . . 5 10 D
                 + . . 1 2" /* regression test (#2420): 1 2 forwarded even if matches on an empty
                             * join entry */
             )

--- a/src/stream/src/executor/join/builder.rs
+++ b/src/stream/src/executor/join/builder.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::array::stream_chunk::StreamChunkMut;
 use risingwave_common::array::stream_chunk_builder::StreamChunkBuilder;
 use risingwave_common::array::{Op, RowRef, StreamChunk};
 use risingwave_common::row::Row;
@@ -42,6 +41,11 @@ impl JoinStreamChunkBuilder {
         update_to_output: IndexMappings,
         matched_to_output: IndexMappings,
     ) -> Self {
+        // Enforce that the chunk size is at least 2, so that appending two rows to the chunk
+        // builder will at most yield one chunk. `with_match` depends on and gets simplified
+        // by such property.
+        let chunk_size = chunk_size.max(2);
+
         Self {
             builder: StreamChunkBuilder::new(chunk_size, data_types),
             update_to_output,
@@ -157,46 +161,10 @@ impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> JoinChunkBuilder
         }
     }
 
+    /// Remove unnecessary updates in the pattern `-(k, old), +(k, NULL), -(k, NULL), +(k, new)`
+    /// to avoid this issue: <https://github.com/risingwavelabs/risingwave/issues/17450>
     pub fn post_process(c: StreamChunk) -> StreamChunk {
-        let mut c = StreamChunkMut::from(c);
-
-        // NOTE(st1page): remove the pattern `UpdateDel(k, old), UpdateIns(k, NULL), UpdateDel(k, NULL),  UpdateIns(k, new)`
-        // to avoid this issue <https://github.com/risingwavelabs/risingwave/issues/17450>
-        let mut i = 2;
-        while i < c.capacity() {
-            if c.op(i - 1) == Op::UpdateInsert
-                && c.op(i) == Op::UpdateDelete
-                && c.row_ref(i) == c.row_ref(i - 1)
-            {
-                if c.op(i - 2) == Op::UpdateDelete && c.op(i + 1) == Op::UpdateInsert {
-                    c.set_op(i - 2, Op::Delete);
-                    c.set_vis(i - 1, false);
-                    c.set_vis(i, false);
-                    c.set_op(i + 1, Op::Insert);
-                    i += 3;
-                } else {
-                    debug_assert!(
-                        false,
-                        "unexpected Op sequences {:?}, {:?}, {:?}, {:?}",
-                        c.op(i - 2),
-                        c.op(i - 1),
-                        c.op(i),
-                        c.op(i + 1)
-                    );
-                    warn!(
-                        "unexpected Op sequences {:?}, {:?}, {:?}, {:?}",
-                        c.op(i - 2),
-                        c.op(i - 1),
-                        c.op(i),
-                        c.op(i + 1)
-                    );
-                    i += 1;
-                }
-            } else {
-                i += 1;
-            }
-        }
-        c.into()
+        c.eliminate_adjacent_noop_update()
     }
 
     /// TODO(kwannoel): We can actually reuse a lot of the logic between `with_match_on_insert`
@@ -239,18 +207,21 @@ impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> JoinChunkBuilder
         // Outer sides
         } else if matched_row.is_zero_degree() && outer_side_null(T, SIDE) {
             // if the matched_row does not have any current matches
-            // `StreamChunkBuilder` guarantees that `UpdateDelete` will never
-            // issue an output chunk.
-            if self
+
+            // The current side part of the stream key changes from NULL to non-NULL.
+            // Thus we cannot use `UpdateDelete` and `UpdateInsert`, as it requires the
+            // stream key to remain the same.
+            let chunk1 = self
                 .stream_chunk_builder
-                .append_row_matched(Op::UpdateDelete, &matched_row.row)
-                .is_some()
-            {
-                unreachable!("`Op::UpdateDelete` should not yield chunk");
-            }
-            self.stream_chunk_builder
-                .append_row(Op::UpdateInsert, row, &matched_row.row)
-                .map(Self::post_process)
+                .append_row_matched(Op::Delete, &matched_row.row);
+            let chunk2 = self
+                .stream_chunk_builder
+                .append_row(Op::Insert, row, &matched_row.row);
+
+            // We've enforced chunk size to be at least 2, so it's impossible to have 2 chunks yield.
+            // TODO: better to ensure they are in the same chunk to make `post_process` more effective.
+            assert!(chunk1.is_none() || chunk2.is_none());
+            chunk1.or(chunk2).map(Self::post_process)
         // Inner sides
         } else {
             self.stream_chunk_builder
@@ -284,26 +255,28 @@ impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> JoinChunkBuilder
             }
         // Outer sides
         } else if matched_row.is_zero_degree() && outer_side_null(T, SIDE) {
-            // if the matched_row does not have any current
-            // matches
-            if self
+            // if the matched_row does not have any current matches
+
+            // The current side part of the stream key changes from non-NULL to NULL.
+            // Thus we cannot use `UpdateDelete` and `UpdateInsert`, as it requires the
+            // stream key to remain the same.
+            let chunk1 = self
                 .stream_chunk_builder
-                .append_row(Op::UpdateDelete, row, &matched_row.row)
-                .is_some()
-            {
-                unreachable!("`Op::UpdateDelete` should not yield chunk");
-            }
-            self.stream_chunk_builder
-                .append_row_matched(Op::UpdateInsert, &matched_row.row)
-                .map(|c: StreamChunk| Self::post_process(c))
+                .append_row(Op::Delete, row, &matched_row.row);
+            let chunk2 = self
+                .stream_chunk_builder
+                .append_row_matched(Op::Insert, &matched_row.row);
+
+            // We've enforced chunk size to be at least 2, so it's impossible to have 2 chunks yield.
+            // TODO: better to ensure they are in the same chunk to make `post_process` more effective.
+            assert!(chunk1.is_none() || chunk2.is_none());
+            chunk1.or(chunk2).map(Self::post_process)
 
         // Inner sides
         } else {
-            // concat with the matched_row and append the new
-            // row
+            // concat with the matched_row and append the new row
             // FIXME: we always use `Op::Delete` here to avoid
-            // violating
-            // the assumption for U+ after U-.
+            // violating the assumption for U+ after U-, we can actually do better.
             self.stream_chunk_builder
                 .append_row(Op::Delete, row, &matched_row.row)
                 .map(Self::post_process)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

In streaming hash-join when matching a row with zero degree, we need to first retract the `NULL` row before yielding the new matched row. Previously, such changes will be associated with `UpdateDelete` and `UpdateInsert` operations.

However, since the stream key of the join output consists of the stream key of both sides, these 2 rows actually have different stream keys, which violates https://github.com/risingwavelabs/risingwave/issues/12539.

This PR fixes this by using plain `Delete` and `Insert` operations instead. Correspondingly, the no-op update elimination logic introduced in #17568 needs to be updated too. It appears that it can be simply replaced with an enhanced version of `StreamChunk::eliminate_adjacent_noop_update` introduced in #23483.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
