### PR TITLE
feat(streaming): also match `Insert` then `Delete` pairs when eliminating adjacent no-op updates

### DIFF
--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -321,7 +321,7 @@ impl StreamChunk {
         }
     }
 
-    /// Remove the adjacent delete-insert if their row value are the same.
+    /// Remove the adjacent delete-insert and insert-deletes if their row value are the same.
     pub fn eliminate_adjacent_noop_update(self) -> Self {
         let len = self.data_chunk().capacity();
         let mut c: StreamChunkMut = self.into();
@@ -330,17 +330,32 @@ impl StreamChunk {
             if !c.vis(curr) {
                 continue;
             }
-            if let Some(prev) = prev_r {
-                if matches!(c.op(prev), Op::UpdateDelete | Op::Delete)
-                    && matches!(c.op(curr), Op::UpdateInsert | Op::Insert)
-                    && c.row_ref(prev) == c.row_ref(curr)
-                {
-                    c.set_vis(prev, false);
-                    c.set_vis(curr, false);
-                    prev_r = None;
-                } else {
-                    prev_r = Some(curr)
-                }
+            if let Some(prev) = prev_r
+                && (
+                    // 1. Delete then Insert
+                    (matches!(c.op(prev), Op::UpdateDelete | Op::Delete)
+                    && matches!(c.op(curr), Op::UpdateInsert | Op::Insert))
+                    ||
+                    // 2. Insert then Delete
+                    //
+                    // Note that after eliminating `U+` and `U-` here, we will get a new
+                    // pair of `U-` and `U+` consisting of `prev.prev` and the `next` row.
+                    // `prev.prev` and `prev`, `curr` and `next` share the same stream key
+                    // because they are `U-` and `U+` pairs, while `prev` and `curr` share
+                    // the same stream key because they are equal, so `prev-prev` and `next`
+                    // must also share the same stream key. Therefore, it's okay to leave
+                    // their `Update` ops unchanged.
+                    //
+                    // Also, they can't be the same, otherwise these 4 rows are the same,
+                    // which should already be eliminated by the first branch.
+                    (matches!(c.op(prev), Op::UpdateInsert | Op::Insert)
+                    && matches!(c.op(curr), Op::UpdateDelete | Op::Delete))
+                )
+                && c.row_ref(prev) == c.row_ref(curr)
+            {
+                c.set_vis(prev, false);
+                c.set_vis(curr, false);
+                prev_r = None;
             } else {
                 prev_r = Some(curr);
             }
@@ -871,8 +886,6 @@ mod tests {
             "\
 +---+---+---+
 | - | 2 | 2 |
-| + | 2 | 3 |
-| - | 2 | 3 |
 | + | 1 | 6 |
 | + | 2 | 3 |
 +---+---+---+"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, we only match `Delete` then `Insert` pairs when eliminating adjacent no-op updates. However, it appears that `Insert` then `Delete` pairs are also eligible for elimination.

This is a preparation of https://github.com/risingwavelabs/risingwave/pull/23472.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
