### PR TITLE
feat: add migration for fragment parallelism column

### DIFF
--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -54,6 +54,7 @@ mod m20250821_081110_cdc_table_snapshot_splits_add_column;
 mod m20250905_144810_deprecate_table_incoming_sinks;
 mod m20250916_120000_add_refresh_fields;
 mod m20251005_000000_fragment_splits;
+mod m20251016_220528_fragment_parallelism;
 mod utils;
 
 pub struct Migrator;
@@ -146,6 +147,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250905_144810_deprecate_table_incoming_sinks::Migration),
             Box::new(m20250916_120000_add_refresh_fields::Migration),
             Box::new(m20251005_000000_fragment_splits::Migration),
+            Box::new(m20251016_220528_fragment_parallelism::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20251016_220528_fragment_parallelism.rs
+++ b/src/meta/model/migration/src/m20251016_220528_fragment_parallelism.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Fragment::Table)
+                    .add_column(ColumnDef::new(Fragment::Parallelism).json_binary().null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Fragment::Table)
+                    .drop_column(Fragment::Parallelism)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Fragment {
+    Table,
+    Parallelism,
+}


### PR DESCRIPTION
Introduce migration to add an optional JSON "parallelism" column to the "Fragment" table. This update prepares the schema for future features that require storing parallelism metadata.

- Add migration file for the new "parallelism" column
- Update migrator to include the new migration
- Enable flexible storage of parallelism data in fragments

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
**Summary**
This PR adds a new migration to extend the `Fragment` database table with a nullable `parallelism` column, enabling the storage of fragment-level parallelism information in JSON format. The change is backward-compatible, non-breaking, and designed to support future enhancements related to distributed or parallel processing.

**Details**
- Key change 1: Introduces a migration file that adds a nullable `parallelism` column of type `json_binary` to the `Fragment` table, supporting efficient storage of arbitrary JSON data.
- Key change 2: Updates the migration registry to include the new migration, ensuring it is part of the schema evolution pipeline and maintains proper migration order.
- Key change 3: Lays the foundation for tracking and configuring parallelism at the fragment level, facilitating future features in resource management or execution scaling.

## Checklist

- [x] I have written necessary rustdoc comments.
