### PR TITLE
fix(stream): convert U-/U+ to D-/I+ when dist key values change

### DIFF
--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -977,9 +977,6 @@ impl Dispatcher for HashDataDispatcher {
         let mut last_update_delete_row_idx = None;
         let mut new_ops: Vec<Op> = Vec::with_capacity(chunk.capacity());
 
-        // Apply output indices after calculating the vnode.
-        let chunk = self.output_mapping.apply(chunk);
-
         for (row_idx, ((vnode, &op), visible)) in vnodes
             .iter()
             .copied()
@@ -1028,6 +1025,8 @@ impl Dispatcher for HashDataDispatcher {
         assert!(last_update_delete_row_idx.is_none(), "missing U+ after U-");
 
         let ops = new_ops;
+        // Apply output mapping after calculating the vnode and new visibility maps.
+        let chunk = self.output_mapping.apply(chunk);
 
         // individually output StreamChunk integrated with vis_map
         futures::future::try_join_all(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

-   Previously, HashDataDispatcher only converted UpdateDelete/UpdateInsert to
  Delete/Insert when vnodes differed. However, this is incorrect because the
  distribution key should be part of the stream key of the downstream executor.

 - Even when vnodes are the same (e.g., when two different distribution key values
  hash to the same vnode), if the distribution key column values change between
  U- and U+, the messages should be rewritten to D-/I+.

-  This fix changes the logic to compare actual distribution key column values
  instead of vnodes, ensuring correct behavior when updates modify distribution
  key columns.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
