### PR TITLE
feat(streaming): better handling of `Update` on conflict in `Materialize`

### DIFF
--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -407,15 +407,23 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                                 self.metrics
                                     .materialize_input_row_count
                                     .inc_by(chunk.cardinality() as u64);
+
                                 // This is an optimization that handles conflicts only when a particular materialized view downstream has no MV dependencies.
                                 // This optimization is applied only when there is no specified version column and the is_consistent_op flag of the state table is false,
-                                // and the conflict behavior is overwrite.
-                                let do_not_handle_conflict = !self.state_table.is_consistent_op()
+                                // and the conflict behavior is overwrite. We can rely on the state table to overwrite the conflicting rows in the storage,
+                                // while outputting inconsistent changes to downstream which no one will subscribe to.
+                                let optimized_conflict_behavior = if let ConflictBehavior::Overwrite =
+                                    self.conflict_behavior
+                                    && !self.state_table.is_consistent_op()
                                     && self.version_column_indices.is_empty()
-                                    && self.conflict_behavior == ConflictBehavior::Overwrite;
+                                {
+                                    ConflictBehavior::NoCheck
+                                } else {
+                                    self.conflict_behavior
+                                };
 
-                                match self.conflict_behavior {
-                                    checked_conflict_behaviors!() if !do_not_handle_conflict => {
+                                match optimized_conflict_behavior {
+                                    checked_conflict_behaviors!() => {
                                         if chunk.cardinality() == 0 {
                                             // empty chunk
                                             continue;
@@ -507,10 +515,7 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                                             None => continue,
                                         }
                                     }
-                                    ConflictBehavior::IgnoreConflict => unreachable!(),
-                                    ConflictBehavior::NoCheck
-                                    | ConflictBehavior::Overwrite
-                                    | ConflictBehavior::DoUpdateIfNotNull => {
+                                    ConflictBehavior::NoCheck => {
                                         self.state_table.write_chunk(chunk.clone());
                                         self.state_table.try_flush().await?;
 
@@ -1389,22 +1394,34 @@ impl<SD: ValueRowSerde> MaterializeCache<SD> {
                     };
                 }
 
+                Op::UpdateDelete
+                    if matches!(
+                        conflict_behavior,
+                        ConflictBehavior::Overwrite | ConflictBehavior::DoUpdateIfNotNull
+                    ) =>
+                {
+                    // For `UpdateDelete`s, we skip processing them but directly handle the following `UpdateInsert`
+                    // instead. This is because...
+                    //
+                    // - For `Overwrite`, we only care about the new row.
+                    // - For `DoUpdateIfNotNull`, we don't want the whole row to be deleted, but instead perform
+                    //   column-wise replacement when handling the `UpdateInsert`.
+                    //
+                    // However, for `IgnoreConflict`, we still need to delete the old row first, otherwise the row
+                    // cannot be updated at all.
+                }
+
                 Op::Delete | Op::UpdateDelete => {
-                    match conflict_behavior {
-                        checked_conflict_behaviors!() => {
-                            if let Some(old_row) = self.get_expected(&key) {
-                                let old_row_deserialized =
-                                    row_serde.deserializer.deserialize(old_row.row.clone())?;
-                                change_buffer.delete(key.clone(), old_row_deserialized);
-                                // put a None into the cache to represent deletion
-                                self.lru_cache.put(key, None);
-                            } else {
-                                // delete a non-existent value
-                                // this is allowed in the case of mview conflict, so ignore
-                            };
-                        }
-                        _ => unreachable!(),
-                    };
+                    if let Some(old_row) = self.get_expected(&key) {
+                        let old_row_deserialized =
+                            row_serde.deserializer.deserialize(old_row.row.clone())?;
+                        change_buffer.delete(key.clone(), old_row_deserialized);
+                        // put a None into the cache to represent deletion
+                        self.lru_cache.put(key, None);
+                    } else {
+                        // delete a non-existent value
+                        // this is allowed in the case of mview conflict, so ignore
+                    }
                 }
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Skip `UpdateDelete` rows when conflict handling behavior is `Overwrite` or `DoUpdateIfNotNull`.

Note that although this can help https://github.com/risingwavelabs/risingwave/issues/22579, the issue is already fixed by sinking `Upsert` chunk in https://github.com/risingwavelabs/risingwave/pull/23581. As a result, the changes of this PR won't take effect in actual usage, because 

- We don't currently have retractable source, thus source won't emit `Update` rows.
- Sink-into-table won't emit `Update` rows either after #23581.
- `UPDATE` statements always operate on full record, thus typically won't hit conflict handling

The statements in doc

> Delete and update operations on the table cannot break the primary key constraint on the table, so the option will not take effect for those cases.

...should still hold, because it cannot be guaranteed that all updates in our system are represented with `Update` operations, so the actual behavior is still undefined.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
