### PR TITLE
fix(grafana): use percentage for hummock read metrics

### DIFF
--- a/grafana/dashboard/dev/hummock_read.py
+++ b/grafana/dashboard/dev/hummock_read.py
@@ -114,7 +114,7 @@ def _(outer_panels: Panels):
                         ),
                     ],
                 ),
-                panels.timeseries_latency(
+                panels.timeseries_percentage(
                     "Read Duration - Get",
                     "Histogram of the latency of Get operations that have been issued to the state store.",
                     [
@@ -134,7 +134,7 @@ def _(outer_panels: Panels):
                         ),
                     ],
                 ),
-                panels.timeseries_latency(
+                panels.timeseries_percentage(
                     "Read Duration - Iter",
                     "Histogram of the time spent on iterator initialization."
                     "Histogram of the time spent on iterator scanning.",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Artifacts generated in https://github.com/risingwavelabs/risingwave/pull/23676

These metrics are using _rate_ and so the unit can't be per second, it should be a percentage. They reflect the percentage of time spent per interval reading records, either via iteration or point gets.

```
sum(rate({table_metric('state_store_get_duration_bucket')
sum(rate({table_metric('state_store_iter_init_duration_bucket')
sum(rate({table_metric('state_store_iter_scan_duration_bucket')
```

Further, these metrics are all at the _second level_ granularity. [Since `rate` is](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate):
> rate(v range-vector) calculates the per-second average rate of increase of the time series in the range vector. 

Therefore we don't need to apply normalization as we would for other metrics tracked as sub-second level (e.g. `ns`, `ms`, etc...).

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
