### PR TITLE
feat: add RPC and system catalog for actor vnode mappings

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -296,6 +296,17 @@ message ListActorStatesResponse {
   repeated ActorState states = 1;
 }
 
+message ListActorVnodesRequest {}
+
+message ListActorVnodesResponse {
+  message ActorVnodes {
+    uint32 actor_id = 1;
+    uint32 fragment_id = 2;
+    common.Buffer vnode_bitmap = 3;
+  }
+  repeated ActorVnodes actor_vnodes = 1;
+}
+
 message ListActorSplitsRequest {}
 
 message ListActorSplitsResponse {
@@ -397,6 +408,7 @@ service StreamManagerService {
   rpc ListFragmentDistribution(ListFragmentDistributionRequest) returns (ListFragmentDistributionResponse);
   rpc ListCreatingFragmentDistribution(ListCreatingFragmentDistributionRequest) returns (ListCreatingFragmentDistributionResponse);
   rpc ListActorStates(ListActorStatesRequest) returns (ListActorStatesResponse);
+  rpc ListActorVnodes(ListActorVnodesRequest) returns (ListActorVnodesResponse);
   rpc ListActorSplits(ListActorSplitsRequest) returns (ListActorSplitsResponse);
   rpc ListObjectDependencies(ListObjectDependenciesRequest) returns (ListObjectDependenciesResponse);
   rpc ApplyThrottle(ApplyThrottleRequest) returns (ApplyThrottleResponse);

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
@@ -23,6 +23,7 @@ mod rw_description;
 mod rw_event_logs;
 mod rw_features;
 mod rw_fragment_parallelism;
+mod rw_fragment_vnodes;
 mod rw_fragments;
 mod rw_functions;
 mod rw_hummock_branched_objects;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_vnodes.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragment_vnodes.rs
@@ -1,0 +1,79 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use risingwave_common::bitmap::Bitmap;
+use risingwave_common::types::{Fields, JsonbVal};
+use risingwave_frontend_macro::system_catalog;
+use serde_json::json;
+
+use crate::catalog::system_catalog::SysCatalogReaderImpl;
+use crate::error::Result;
+
+#[derive(Fields)]
+struct RwFragmentVnode {
+    #[primary_key]
+    fragment_id: i32,
+    vnode_count: i32,
+    actor_vnodes: JsonbVal,
+}
+
+#[system_catalog(table, "rw_catalog.rw_fragment_vnodes")]
+async fn read_rw_fragment_vnodes(reader: &SysCatalogReaderImpl) -> Result<Vec<RwFragmentVnode>> {
+    // Get actor vnodes from meta (streaming vnode mapping)
+    let actor_vnodes_list = reader.meta_client.list_actor_vnodes().await?;
+
+    // Group by fragment_id
+    let mut fragment_map: HashMap<u32, Vec<(u32, Bitmap)>> = HashMap::new();
+
+    for actor_vnode in actor_vnodes_list {
+        let actor_id = actor_vnode.actor_id;
+        let fragment_id = actor_vnode.fragment_id;
+
+        if let Some(vnode_bitmap_pb) = actor_vnode.vnode_bitmap {
+            let bitmap = Bitmap::from(&vnode_bitmap_pb);
+            fragment_map
+                .entry(fragment_id)
+                .or_default()
+                .push((actor_id, bitmap));
+        }
+    }
+
+    // Build result
+    let mut result = Vec::new();
+
+    for (fragment_id, actors) in fragment_map {
+        let vnode_count = actors.first().map(|(_, bitmap)| bitmap.len()).unwrap_or(0);
+
+        // Build actor_id -> vnodes mapping
+        let mut actor_vnodes_map: HashMap<i32, Vec<i32>> = HashMap::new();
+
+        for (actor_id, bitmap) in actors {
+            let vnodes: Vec<i32> = bitmap
+                .iter_ones()
+                .map(|vnode_idx| vnode_idx as i32)
+                .collect();
+            actor_vnodes_map.insert(actor_id as i32, vnodes);
+        }
+
+        result.push(RwFragmentVnode {
+            fragment_id: fragment_id as i32,
+            vnode_count: vnode_count as i32,
+            actor_vnodes: json!(actor_vnodes_map).into(),
+        });
+    }
+
+    Ok(result)
+}

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -31,6 +31,7 @@ use risingwave_pb::hummock::{
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;
 use risingwave_pb::meta::list_actor_splits_response::ActorSplit;
 use risingwave_pb::meta::list_actor_states_response::ActorState;
+use risingwave_pb::meta::list_actor_vnodes_response::ActorVnodes;
 use risingwave_pb::meta::list_cdc_progress_response::PbCdcProgress;
 use risingwave_pb::meta::list_iceberg_tables_response::IcebergTable;
 use risingwave_pb::meta::list_object_dependencies_response::PbObjectDependencies;
@@ -76,6 +77,8 @@ pub trait FrontendMetaClient: Send + Sync {
     async fn list_creating_fragment_distribution(&self) -> Result<Vec<FragmentDistribution>>;
 
     async fn list_actor_states(&self) -> Result<Vec<ActorState>>;
+
+    async fn list_actor_vnodes(&self) -> Result<Vec<ActorVnodes>>;
 
     async fn list_actor_splits(&self) -> Result<Vec<ActorSplit>>;
 
@@ -236,6 +239,10 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn list_actor_states(&self) -> Result<Vec<ActorState>> {
         self.0.list_actor_states().await
+    }
+
+    async fn list_actor_vnodes(&self) -> Result<Vec<ActorVnodes>> {
+        Ok(self.0.list_actor_vnodes().await?.actor_vnodes)
     }
 
     async fn list_actor_splits(&self) -> Result<Vec<ActorSplit>> {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -58,6 +58,7 @@ use risingwave_pb::hummock::{
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;
 use risingwave_pb::meta::list_actor_splits_response::ActorSplit;
 use risingwave_pb::meta::list_actor_states_response::ActorState;
+use risingwave_pb::meta::list_actor_vnodes_response::ActorVnodes;
 use risingwave_pb::meta::list_cdc_progress_response::PbCdcProgress;
 use risingwave_pb::meta::list_iceberg_tables_response::IcebergTable;
 use risingwave_pb::meta::list_object_dependencies_response::PbObjectDependencies;
@@ -1078,6 +1079,10 @@ impl FrontendMetaClient for MockFrontendMetaClient {
     }
 
     async fn list_actor_states(&self) -> RpcResult<Vec<ActorState>> {
+        Ok(vec![])
+    }
+
+    async fn list_actor_vnodes(&self) -> RpcResult<Vec<ActorVnodes>> {
         Ok(vec![])
     }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1178,6 +1178,14 @@ impl MetaClient {
         Ok(resp.states)
     }
 
+    pub async fn list_actor_vnodes(&self) -> Result<ListActorVnodesResponse> {
+        let resp = self
+            .inner
+            .list_actor_vnodes(ListActorVnodesRequest {})
+            .await?;
+        Ok(resp)
+    }
+
     pub async fn list_actor_splits(&self) -> Result<Vec<ActorSplit>> {
         let resp = self
             .inner
@@ -2435,6 +2443,7 @@ macro_rules! for_all_meta_rpc {
             ,{ stream_client, list_fragment_distribution, ListFragmentDistributionRequest, ListFragmentDistributionResponse }
             ,{ stream_client, list_creating_fragment_distribution, ListCreatingFragmentDistributionRequest, ListCreatingFragmentDistributionResponse }
             ,{ stream_client, list_actor_states, ListActorStatesRequest, ListActorStatesResponse }
+            ,{ stream_client, list_actor_vnodes, ListActorVnodesRequest, ListActorVnodesResponse }
             ,{ stream_client, list_actor_splits, ListActorSplitsRequest, ListActorSplitsResponse }
             ,{ stream_client, list_object_dependencies, ListObjectDependenciesRequest, ListObjectDependenciesResponse }
             ,{ stream_client, recover, RecoverRequest, RecoverResponse }


### PR DESCRIPTION
Expose vnode assignment information per actor and fragment via a new RPC and system catalog table to improve visibility into streaming job internals.

- Define ListActorVnodesRequest/Response and new RPC in proto/meta.proto
- Implement RPC handler in meta service to return actor vnode mappings
- Extend FrontendMetaClient and MetaClient with list_actor_vnodes method
- Add rw_fragment_vnodes system catalog table with vnode mapping JSONB data
- Support querying vnode distribution for introspection and debugging purposes

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

``` 
fragment_id | vnode_count |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  actor_vnodes
-------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
           1 |         256 | {"0": [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 148, 152, 156, 160, 164, 168, 172, 176, 180, 184, 188, 192, 196, 200, 204, 208, 212, 216, 220, 224, 228, 232, 236, 240, 244, 248, 252], "1": [1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61, 65, 69, 73, 77, 81, 85, 89, 93, 97, 101, 105, 109, 113, 117, 121, 125, 129, 133, 137, 141, 145, 149, 153, 157, 161, 165, 169, 173, 177, 181, 185, 189, 193, 197, 201, 205, 209, 213, 217, 221, 225, 229, 233, 237, 241, 245, 249, 253], "2": [2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90, 94, 98, 102, 106, 110, 114, 118, 122, 126, 130, 134, 138, 142, 146, 150, 154, 158, 162, 166, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 214, 218, 222, 226, 230, 234, 238, 242, 246, 250, 254], "3": [3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47, 51, 55, 59, 63, 67, 71, 75, 79, 83, 87, 91, 95, 99,
103, 107, 111, 115, 119, 123, 127, 131, 135, 139, 143, 147, 151, 155, 159, 163, 167, 171, 175, 179, 183, 187, 191, 195, 199, 203,
 207, 211, 215, 219, 223, 227, 231, 235, 239, 243, 247, 251, 255]}
           2 |         256 | {"4": [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 148, 152, 156, 160, 164, 168, 172, 176, 180, 184, 188, 192, 196, 200, 204, 208, 212, 216, 220, 224, 228, 232, 236, 240, 244, 248, 252], "5": [1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61, 65, 69, 73, 77, 81, 85, 89, 93, 97, 101, 105, 109, 113, 117, 121, 125, 129, 133, 137, 141, 145, 149, 153, 157, 161, 165, 169, 173, 177, 181, 185, 189, 193, 197, 201, 205, 209, 213, 217, 221, 225, 229, 233, 237, 241, 245, 249, 253], "6": [2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90, 94, 98, 102, 106, 110, 114, 118, 122, 126, 130, 134, 138, 142, 146, 150, 154, 158, 162, 166, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 214, 218, 222, 226, 230, 234, 238, 242, 246, 250, 254], "7": [3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47, 51, 55, 59, 63, 67, 71, 75, 79, 83, 87, 91, 95, 99, 103, 107, 111, 115, 119, 123, 127, 131, 135, 139, 143, 147, 151, 155, 159, 163, 167, 171, 175, 179, 183, 187, 191, 195, 199, 203, 207, 211, 215, 219, 223, 227, 231, 235, 239, 243, 247, 251, 255]}
(2 rows)
```


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
