### PR TITLE
feat(sqlsmith): use different test suites for different release branches

### DIFF
--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -17,7 +17,8 @@ popd
 
 echo "--- Extract data for SqlSmith"
 pushd ./src/tests/sqlsmith/tests
-git clone https://"$GITHUB_TOKEN"@github.com/risingwavelabs/sqlsmith-query-snapshots.git
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)  
+git clone -b "$CURRENT_BRANCH" https://"$GITHUB_TOKEN"@github.com/risingwavelabs/sqlsmith-query-snapshots.git
 # FIXME(kwannoel): Uncomment this to stage changes. Should have a better approach.
 # pushd sqlsmith-query-snapshots
 # git checkout stage

--- a/ci/workflows/sqlsmith-snapshots.yml
+++ b/ci/workflows/sqlsmith-snapshots.yml
@@ -1,4 +1,12 @@
 # Generate Sqlsmith weekly snapshots.
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - "release-*"
 steps:
   - label: "build"
     command: "ci/scripts/build.sh -p ci-dev"

--- a/src/tests/sqlsmith/scripts/gen_queries.sh
+++ b/src/tests/sqlsmith/scripts/gen_queries.sh
@@ -350,7 +350,8 @@ validate() {
 sync_queries() {
   pushd $OUTDIR
   git stash
-  git checkout main
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)  
+  git checkout "$CURRENT_BRANCH"  
   git pull
   set +e
   git branch -D old-main
@@ -375,7 +376,8 @@ upload_queries() {
   pushd "$OUTDIR"
   git add .
   git commit -m 'update queries'
-  git push origin main
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD) 
+  git push origin "$CURRENT_BRANCH"
   popd
   set -x
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #23452

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
