### PR TITLE
fix: handle uninitialized streaming vnode mapping with explicit error variant

### DIFF
--- a/src/batch/src/error.rs
+++ b/src/batch/src/error.rs
@@ -135,6 +135,9 @@ pub enum BatchError {
     #[error("Serving vnode mapping not found for fragment {0}")]
     ServingVnodeMappingNotFound(FragmentId),
 
+    #[error("Streaming vnode mapping has not been initialized")]
+    StreamingVnodeMappingNotInitialized,
+
     #[error("Streaming vnode mapping not found for fragment {0}")]
     StreamingVnodeMappingNotFound(FragmentId),
 

--- a/src/tests/simulation/src/slt.rs
+++ b/src/tests/simulation/src/slt.rs
@@ -419,7 +419,7 @@ mod runner {
                 })
                 .await
             {
-                let err_string = err.to_string();
+                let err_string = err.to_string().to_ascii_lowercase();
                 // cluster could be still under recovering if killed before, retry if
                 // meets `no reader for dml in table with id {}`.
                 let allowed_errs = [
@@ -428,11 +428,12 @@ mod runner {
                     "failed to inject barrier",
                     "get error from control stream",
                     "cluster is under recovering",
+                    "streaming vnode mapping has not been initialized",
                 ];
                 let should_retry = i < MAX_RETRY
                     && allowed_errs
                         .iter()
-                        .any(|allowed_err| err_string.contains(allowed_err));
+                        .any(|allowed_err| err_string.contains(&allowed_err.to_ascii_lowercase()));
                 if !should_retry {
                     panic!("{}", err);
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

**Summary**
This PR introduces explicit handling for the uninitialized state of the streaming vnode mapping by changing its type to an `Option<HashMap>`, adding a dedicated error variant, and updating related code paths accordingly. These changes improve robustness and clarity in worker node management, especially during system startup and recovery.

**Details**
- Added a new `StreamingVnodeMappingNotInitialized` error variant to clearly signal when the vnode mapping is not yet initialized.
- Changed `streaming_fragment_vnode_mapping` from a plain `HashMap` to an `Option<HashMap>`, allowing explicit representation of an uninitialized state (`None`).
- Updated getter methods to return the new error when the vnode mapping is uninitialized, enabling callers to handle this condition explicitly.
- Mutation methods lazily initialize the vnode mapping on first use, ensuring safe and efficient updates.
- Adjusted simulation tests to expect and handle the new error, including making error string comparisons case-insensitive to improve test resilience.
- Added informative logging when vnode mappings are replaced, aiding debugging of scaling and background DDL operations.

## Checklist

- [x] I have written necessary rustdoc comments.
