### PR TITLE
refactor(meta): refine inflight info ownership and avoid unnecessary clone

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -340,9 +340,7 @@ pub enum Command {
         job_type: CreateStreamingJobType,
         cross_db_snapshot_backfill_info: SnapshotBackfillInfo,
     },
-    MergeSnapshotBackfillStreamingJobs(
-        HashMap<JobId, (HashSet<TableId>, HashMap<FragmentId, InflightFragmentInfo>)>,
-    ),
+    MergeSnapshotBackfillStreamingJobs(HashMap<JobId, HashSet<TableId>>),
 
     /// `Reschedule` command generates a `Update` barrier by the [`Reschedule`] of each fragment.
     /// Mainly used for scaling and migration.
@@ -483,7 +481,7 @@ impl Command {
         Self::Resume
     }
 
-    pub(crate) fn fragment_changes(
+    pub(super) fn fragment_changes(
         &self,
     ) -> Option<(Option<JobId>, HashMap<FragmentId, CommandFragmentChanges>)> {
         match self {
@@ -518,12 +516,12 @@ impl Command {
                 let mut changes: HashMap<_, _> = info
                     .stream_job_fragments
                     .new_fragment_info(&info.init_split_assignment)
-                    .map(|(fragment_id, fragment_info)| {
+                    .map(|(fragment_id, fragment_infos)| {
                         (
                             fragment_id,
                             CommandFragmentChanges::NewFragment {
                                 job_id: info.streaming_job.id(),
-                                info: fragment_info,
+                                info: fragment_infos,
                                 is_existing: false,
                             },
                         )
@@ -1024,13 +1022,13 @@ impl Command {
                 Some(Mutation::DropSubscriptions(DropSubscriptionsMutation {
                     info: jobs_to_merge
                         .iter()
-                        .flat_map(|(table_id, (backfill_upstream_tables, _))| {
-                            backfill_upstream_tables
-                                .iter()
-                                .map(move |upstream_table_id| SubscriptionUpstreamInfo {
+                        .flat_map(|(table_id, upstream_tables)| {
+                            upstream_tables.iter().map(move |upstream_table_id| {
+                                SubscriptionUpstreamInfo {
                                     subscriber_id: table_id.as_raw_id(),
                                     upstream_mv_table_id: *upstream_table_id,
-                                })
+                                }
+                            })
                         })
                         .collect(),
                 }))
@@ -1349,7 +1347,7 @@ impl Command {
 
     pub(super) fn actors_to_create(
         &self,
-        graph_info: &InflightDatabaseInfo,
+        database_info: &InflightDatabaseInfo,
         edges: &mut Option<FragmentEdgeBuildResult>,
         control_stream_manager: &ControlStreamManager,
     ) -> Option<StreamJobActorsToCreate> {
@@ -1389,7 +1387,7 @@ impl Command {
                         )
                     }),
                     Some((reschedules, fragment_actors)),
-                    graph_info,
+                    database_info,
                     control_stream_manager,
                 );
                 let mut map: HashMap<WorkerId, HashMap<_, (_, Vec<_>, _)>> = HashMap::new();
@@ -1406,9 +1404,9 @@ impl Command {
                         .or_default()
                         .entry(fragment_id)
                         .or_insert_with(|| {
-                            let node = graph_info.fragment(fragment_id).nodes.clone();
+                            let node = database_info.fragment(fragment_id).nodes.clone();
                             let subscribers =
-                                graph_info.fragment_subscribers(fragment_id).collect();
+                                database_info.fragment_subscribers(fragment_id).collect();
                             (node, vec![], subscribers)
                         })
                         .1
@@ -1425,7 +1423,7 @@ impl Command {
                                 fragment_id,
                                 node,
                                 actors,
-                                graph_info
+                                database_info
                                     .job_subscribers(replace_table.old_fragments.stream_job_id),
                             )
                         },
@@ -1446,7 +1444,7 @@ impl Command {
                                         .worker_node_id,
                                 )
                             }),
-                            graph_info.job_subscribers(sink.original_sink.id.as_job_id()),
+                            database_info.job_subscribers(sink.original_sink.id.as_job_id()),
                         )
                     }));
                     for (worker_id, fragment_actors) in sink_actors {
@@ -1534,12 +1532,12 @@ impl Command {
             &HashMap<FragmentId, Reschedule>,
             &HashMap<FragmentId, HashSet<ActorId>>,
         )>,
-        graph_info: &InflightDatabaseInfo,
+        database_info: &InflightDatabaseInfo,
         control_stream_manager: &ControlStreamManager,
     ) -> HashMap<ActorId, ActorUpstreams> {
         let mut actor_upstreams: HashMap<ActorId, ActorUpstreams> = HashMap::new();
         for (upstream_fragment_id, upstream_actors) in actor_dispatchers {
-            let upstream_fragment = graph_info.fragment(upstream_fragment_id);
+            let upstream_fragment = database_info.fragment(upstream_fragment_id);
             for (upstream_actor_id, dispatchers) in upstream_actors {
                 let upstream_actor_location =
                     upstream_fragment.actors[&upstream_actor_id].worker_id;
@@ -1566,7 +1564,7 @@ impl Command {
         if let Some((reschedules, fragment_actors)) = reschedule_dispatcher_update {
             for reschedule in reschedules.values() {
                 for (upstream_fragment_id, _) in &reschedule.upstream_fragment_dispatcher_ids {
-                    let upstream_fragment = graph_info.fragment(*upstream_fragment_id);
+                    let upstream_fragment = database_info.fragment(*upstream_fragment_id);
                     let upstream_reschedule = reschedules.get(upstream_fragment_id);
                     for upstream_actor_id in fragment_actors
                         .get(upstream_fragment_id)

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -94,7 +94,7 @@ impl GlobalBarrierWorkerContextImpl {
     /// Resolve actor information from cluster, fragment manager and `ChangedTableId`.
     /// We use `changed_table_id` to modify the actors to be sent or collected. Because these actor
     /// will create or drop before this barrier flow through them.
-    async fn resolve_graph_info(
+    async fn resolve_database_info(
         &self,
         database_id: Option<DatabaseId>,
         worker_nodes: &ActiveStreamingWorkerNodes,
@@ -267,15 +267,15 @@ impl GlobalBarrierWorkerContextImpl {
         let mut cdc_table_backfill_actors = HashMap::new();
 
         for (job_id, fragments) in jobs {
-            for fragment_info in fragments.values() {
-                if fragment_info
+            for fragment_infos in fragments.values() {
+                if fragment_infos
                     .fragment_type_mask
                     .contains(FragmentTypeFlag::StreamCdcScan)
                 {
                     cdc_table_backfill_actors
                         .entry(*job_id)
                         .or_insert_with(HashSet::new)
-                        .extend(fragment_info.actors.keys().cloned());
+                        .extend(fragment_infos.actors.keys().cloned());
                 }
             }
         }
@@ -419,7 +419,7 @@ impl GlobalBarrierWorkerContextImpl {
                     // TODO(error-handling): attach context to the errors and log them together, instead of inspecting everywhere.
                     let mut info = if unreschedulable_jobs.is_empty() {
                         info!("trigger offline scaling");
-                        self.resolve_graph_info(None, &active_streaming_nodes)
+                        self.resolve_database_info(None, &active_streaming_nodes)
                             .await
                             .inspect_err(|err| {
                                 warn!(error = %err.as_report(), "resolve actor info failed");
@@ -439,7 +439,7 @@ impl GlobalBarrierWorkerContextImpl {
                             .complete_dropped_tables(dropped_table_ids)
                             .await;
                         info = self
-                            .resolve_graph_info(None, &active_streaming_nodes)
+                            .resolve_database_info(None, &active_streaming_nodes)
                             .await
                             .inspect_err(|err| {
                                 warn!(error = %err.as_report(), "resolve actor info failed");
@@ -607,16 +607,15 @@ impl GlobalBarrierWorkerContextImpl {
         let active_streaming_nodes =
             ActiveStreamingWorkerNodes::new_snapshot(self.metadata_manager.clone()).await?;
 
-        let all_info = self
-            .resolve_graph_info(Some(database_id), &active_streaming_nodes)
+        let mut all_info = self
+            .resolve_database_info(Some(database_id), &active_streaming_nodes)
             .await
             .inspect_err(|err| {
                 warn!(error = %err.as_report(), "resolve actor info failed");
             })?;
 
         let mut database_info = all_info
-            .get(&database_id)
-            .cloned()
+            .remove(&database_id)
             .map_or_else(HashMap::new, |table_map| {
                 HashMap::from([(database_id, table_map)])
             });
@@ -742,8 +741,8 @@ impl GlobalBarrierWorkerContextImpl {
             let job_definition = extra_info.job_definition;
             let config_override = extra_info.config_override;
 
-            for (fragment_id, fragment_info) in streaming_info {
-                for (actor_id, InflightActorInfo { vnode_bitmap, .. }) in &fragment_info.actors {
+            for (fragment_id, fragment_infos) in streaming_info {
+                for (actor_id, InflightActorInfo { vnode_bitmap, .. }) in &fragment_infos.actors {
                     stream_actors.insert(
                         *actor_id,
                         StreamActor {

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -52,7 +52,7 @@ pub(super) struct PendingBackfillFragments {
 }
 
 /// Progress of all actors containing backfill executors while creating mview.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct Progress {
     job_id: JobId,
     // `states` and `done_count` decides whether the progress is done. See `is_done`.
@@ -272,7 +272,6 @@ impl Progress {
 ///    On recovery, the stream manager will stop managing the job.
 /// 2. if `is_recovered` is true, it is a "Recovered" tracking job.
 ///    On recovery, the barrier manager will recover and start managing the job.
-#[derive(Clone)]
 pub struct TrackingJob {
     job_id: JobId,
     is_recovered: bool,
@@ -372,7 +371,7 @@ pub(super) enum UpdateProgressResult {
     BackfillNodeFinished(PendingBackfillFragments),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct CreateMviewProgressTracker {
     job_id: JobId,
     definition: String,
@@ -381,7 +380,7 @@ pub(super) struct CreateMviewProgressTracker {
     status: CreateMviewStatus,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum CreateMviewStatus {
     Backfilling {
         /// Progress of the create-mview DDL.

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -59,7 +59,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use super::{BarrierKind, Command, TracedEpoch};
+use super::{BarrierKind, TracedEpoch};
 use crate::barrier::cdc_progress::CdcTableBackfillTrackerRef;
 use crate::barrier::checkpoint::{
     BarrierWorkerState, CreatingStreamingJobControl, DatabaseCheckpointControl,
@@ -67,8 +67,7 @@ use crate::barrier::checkpoint::{
 use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::{
-    BarrierInfo, CreateStreamingJobStatus, InflightDatabaseInfo, InflightStreamingJobInfo,
-    SubscriberType,
+    BarrierInfo, CreateStreamingJobStatus, InflightStreamingJobInfo, SubscriberType,
 };
 use crate::barrier::progress::CreateMviewProgressTracker;
 use crate::barrier::utils::{NodeToCollect, is_valid_after_worker_err};
@@ -836,13 +835,13 @@ impl ControlStreamManager {
         };
 
         let node_to_collect = {
-            let node_actors =
+            let new_actors =
                 edges.collect_actors_to_create(database_jobs.values().flat_map(move |job| {
-                    job.fragment_infos.values().map(move |fragment_info| {
+                    job.fragment_infos.values().map(move |fragment_infos| {
                         (
-                            fragment_info.fragment_id,
-                            &fragment_info.nodes,
-                            fragment_info.actors.iter().map(move |(actor_id, actor)| {
+                            fragment_infos.fragment_id,
+                            &fragment_infos.nodes,
+                            fragment_infos.actors.iter().map(move |(actor_id, actor)| {
                                 (
                                     stream_actors.get(actor_id).expect("should exist"),
                                     actor.worker_id,
@@ -853,14 +852,17 @@ impl ControlStreamManager {
                     })
                 }));
 
+            let nodes_actors =
+                InflightFragmentInfo::actor_ids_to_collect(database_jobs.values().flatten());
+
             let node_to_collect = self.inject_barrier(
                 database_id,
                 None,
                 Some(mutation.clone()),
                 &barrier_info,
-                database_jobs.values().flatten(),
-                database_jobs.values().flatten(),
-                Some(node_actors),
+                &nodes_actors,
+                InflightFragmentInfo::existing_table_ids(database_jobs.values().flatten()),
+                Some(new_actors),
             )?;
             debug!(
                 ?node_to_collect,
@@ -875,11 +877,11 @@ impl ControlStreamManager {
         for (job_id, (info, definition, upstream_table_ids, committed_epoch, snapshot_epoch)) in
             ongoing_snapshot_backfill_jobs
         {
-            let node_actors = edges.collect_actors_to_create(info.values().map(|fragment_info| {
+            let node_actors = edges.collect_actors_to_create(info.values().map(|fragment_infos| {
                 (
-                    fragment_info.fragment_id,
-                    &fragment_info.nodes,
-                    fragment_info.actors.iter().map(move |(actor_id, actor)| {
+                    fragment_infos.fragment_id,
+                    &fragment_infos.nodes,
+                    fragment_infos.actors.iter().map(move |(actor_id, actor)| {
                         (
                             stream_actors.get(actor_id).expect("should exist"),
                             actor.worker_id,
@@ -919,12 +921,8 @@ impl ControlStreamManager {
                 })
                 .chain(
                     creating_streaming_job_controls
-                        .iter()
-                        .flat_map(|(job_id, job)| {
-                            job.graph_info()
-                                .values()
-                                .map(|fragment| (fragment, *job_id))
-                        }),
+                        .values()
+                        .flat_map(|job| job.fragment_infos_with_job_id()),
                 ),
         );
 
@@ -948,31 +946,6 @@ impl ControlStreamManager {
         })
     }
 
-    pub(super) fn inject_command_ctx_barrier(
-        &mut self,
-        database_id: DatabaseId,
-        command: Option<&Command>,
-        barrier_info: &BarrierInfo,
-        is_paused: bool,
-        pre_applied_graph_info: &InflightDatabaseInfo,
-        applied_graph_info: &InflightDatabaseInfo,
-        edges: &mut Option<FragmentEdgeBuildResult>,
-    ) -> MetaResult<NodeToCollect> {
-        let mutation = command.and_then(|c| c.to_mutation(is_paused, edges, self));
-        self.inject_barrier(
-            database_id,
-            None,
-            mutation,
-            barrier_info,
-            pre_applied_graph_info.fragment_infos(),
-            applied_graph_info.fragment_infos(),
-            command
-                .as_ref()
-                .map(|command| command.actors_to_create(pre_applied_graph_info, edges, self))
-                .unwrap_or_default(),
-        )
-    }
-
     fn connected_workers(&self) -> impl Iterator<Item = (WorkerId, &ControlStreamNode)> + '_ {
         self.workers
             .iter()
@@ -984,14 +957,14 @@ impl ControlStreamManager {
             })
     }
 
-    pub(super) fn inject_barrier<'a>(
+    pub(super) fn inject_barrier(
         &mut self,
         database_id: DatabaseId,
         creating_job_id: Option<JobId>,
         mutation: Option<Mutation>,
         barrier_info: &BarrierInfo,
-        pre_applied_graph_info: impl IntoIterator<Item = &InflightFragmentInfo>,
-        applied_graph_info: impl IntoIterator<Item = &'a InflightFragmentInfo> + 'a,
+        node_actors: &HashMap<WorkerId, HashSet<ActorId>>,
+        table_ids_to_sync: impl Iterator<Item = TableId>,
         mut new_actors: Option<StreamJobActorsToCreate>,
     ) -> MetaResult<NodeToCollect> {
         fail_point!("inject_barrier_err", |_| risingwave_common::bail!(
@@ -999,8 +972,6 @@ impl ControlStreamManager {
         ));
 
         let partial_graph_id = to_partial_graph_id(creating_job_id);
-
-        let node_actors = InflightFragmentInfo::actor_ids_to_collect(pre_applied_graph_info);
 
         for worker_id in node_actors.keys() {
             if let Some((_, worker_state)) = self.workers.get(worker_id)
@@ -1011,10 +982,8 @@ impl ControlStreamManager {
             }
         }
 
-        let table_ids_to_sync: HashSet<_> =
-            InflightFragmentInfo::existing_table_ids(applied_graph_info).collect();
-
         let mut node_need_collect = HashMap::new();
+        let table_ids_to_sync = table_ids_to_sync.collect_vec();
 
         self.connected_workers()
             .try_for_each(|(node_id, node)| {
@@ -1049,10 +1018,7 @@ impl ControlStreamManager {
                                         barrier: Some(barrier),
                                         database_id,
                                         actor_ids_to_collect,
-                                        table_ids_to_sync: table_ids_to_sync
-                                            .iter()
-                                            .cloned()
-                                            .collect(),
+                                        table_ids_to_sync: table_ids_to_sync.clone(),
                                         partial_graph_id,
                                         actors_to_build: new_actors
                                             .as_mut()

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -86,7 +86,7 @@ use crate::stream::UpstreamSinkInfo;
 use crate::{MetaResult, model};
 
 /// Some information of running (inflight) actors.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct InflightActorInfo {
     pub worker_id: WorkerId,
     pub vnode_bitmap: Option<Bitmap>,
@@ -104,15 +104,15 @@ struct ActorInfo {
     pub config_override: Arc<str>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct InflightFragmentInfo {
-    pub fragment_id: crate::model::FragmentId,
+    pub fragment_id: FragmentId,
     pub distribution_type: DistributionType,
     pub fragment_type_mask: FragmentTypeMask,
     pub vnode_count: usize,
     pub nodes: PbStreamNode,
-    pub actors: HashMap<crate::model::ActorId, InflightActorInfo>,
-    pub state_table_ids: HashSet<risingwave_common::catalog::TableId>,
+    pub actors: HashMap<ActorId, InflightActorInfo>,
+    pub state_table_ids: HashSet<TableId>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -473,7 +473,7 @@ impl SourceManager {
     }
 }
 
-#[derive(strum::Display, Debug, Clone)]
+#[derive(strum::Display, Debug)]
 pub enum SourceChange {
     /// `CREATE SOURCE` (shared), or `CREATE MV`.
     /// This is applied after the job is successfully created (`post_collect` barrier).


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously we impl `Clone` for `InflightXxxInfo`, so that between `pre_apply` and `post_apply` a command, we can clone the `InflightDatabaseInfo` to take a snapshot of it and pass the snapshot for later handling. However, this intermediate snapshot is only used shortly later, and then gets dropped, and therefore in this PR, we can actually generate the information used in later handling between `pre_apply` and `post_apply` instead of cloning it to take a snapshot. And then we removed the derived `Clone` implementation on `InflightXxxInfo`, so that we can avoid unnecessary large clone on the snapshot, and in the meanwhile the ownership of each inflight actor and fragment get clearer. The naming `inflight_graph_info` is replaced with `database_info` to avoid confusion.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
