### PR TITLE
demo: using locality provider to solve join amplification issues

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -114,6 +114,7 @@ profile:
         user-managed: true
 
   full:
+    config-path: src/config/example.toml
     steps:
       - use: minio
       - use: postgres
@@ -1203,7 +1204,7 @@ template:
     user-managed: false
 
     # Total available memory for the compute node in bytes
-    total-memory-bytes: 8589934592
+    total-memory-bytes: 2589934592
 
     # Parallelism of tasks per compute node
     parallelism: 4

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -424,6 +424,10 @@ pub mod default {
         pub fn enable_state_table_vnode_stats_pruning() -> bool {
             false
         }
+
+        pub fn enable_locality_sort_buffer() -> bool {
+            true
+        }
     }
 }
 

--- a/src/common/src/config/streaming.rs
+++ b/src/common/src/config/streaming.rs
@@ -286,6 +286,10 @@ pub struct StreamingDeveloperConfig {
     #[serde(default = "default::developer::enable_state_table_vnode_stats_pruning")]
     pub enable_state_table_vnode_stats_pruning: bool,
 
+    /// Enable sort buffer in `LocalityProviderExecutor` after backfilling.
+    #[serde(default = "default::developer::enable_locality_sort_buffer")]
+    pub enable_locality_sort_buffer: bool,
+
     #[serde(default, flatten)]
     #[serde_prefix_all(skip)]
     #[config_doc(omitted)]

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -239,6 +239,7 @@ sync_log_store_pause_duration_ms = 64
 sync_log_store_buffer_size = 2048
 over_window_cache_policy = "full"
 enable_state_table_vnode_stats_pruning = false
+enable_locality_sort_buffer = true
 
 [streaming.developer.compute_client_config]
 connect_timeout_secs = 5

--- a/src/stream/src/common/change_buffer.rs
+++ b/src/stream/src/common/change_buffer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::collections::btree_map::Entry as BTreeEntry;
 use std::sync::LazyLock;
 
 use indexmap::IndexMap;
@@ -57,6 +59,9 @@ mod private {
 
     pub trait Row: Eq + Default {}
     impl<R> Row for R where R: Eq + Default {}
+
+    pub trait OrdKey: Ord {}
+    impl<K> OrdKey for K where K: Ord {}
 }
 
 /// A buffer that accumulates changes and produce compacted changes.
@@ -306,6 +311,190 @@ where
                 UPSERT => record.into_upsert(),
                 RETRACT => record,
             };
+            if let Some(chunk) = builder.append_record(record) {
+                res.push(chunk);
+            }
+        }
+        res.extend(builder.take());
+        res
+    }
+}
+
+/// A change buffer backed by a `BTreeMap`, which keeps entries ordered by key.
+#[derive(Debug)]
+pub struct BTreeChangeBuffer<K, R> {
+    buffer: BTreeMap<K, Record<R>>,
+    ib: InconsistencyBehavior,
+}
+
+impl<K, R> BTreeChangeBuffer<K, R>
+where
+    K: private::OrdKey,
+    R: private::Row,
+{
+    /// Apply an insertion of a row with the given key.
+    pub fn insert(&mut self, key: K, new_row: R) {
+        match self.buffer.entry(key) {
+            BTreeEntry::Vacant(e) => {
+                e.insert(Record::Insert { new_row });
+            }
+            BTreeEntry::Occupied(mut e) => match e.get_mut() {
+                Record::Delete { old_row } => {
+                    let old_row = std::mem::take(old_row);
+                    e.insert(Record::Update { old_row, new_row });
+                }
+                Record::Insert { new_row: dst } => {
+                    self.ib.report("inconsistent changes: double-inserting");
+                    *dst = new_row;
+                }
+                Record::Update { new_row: dst, .. } => {
+                    self.ib.report("inconsistent changes: double-inserting");
+                    *dst = new_row;
+                }
+            },
+        }
+    }
+
+    /// Apply a deletion of a row with the given key.
+    pub fn delete(&mut self, key: K, old_row: R) {
+        match self.buffer.entry(key) {
+            BTreeEntry::Vacant(e) => {
+                e.insert(Record::Delete { old_row });
+            }
+            BTreeEntry::Occupied(mut e) => match e.get_mut() {
+                Record::Insert { .. } => {
+                    e.remove_entry();
+                }
+                Record::Update { old_row: dst, .. } => {
+                    let old_row = std::mem::take(dst);
+                    e.insert(Record::Delete { old_row });
+                }
+                Record::Delete { old_row: dst } => {
+                    self.ib.report("inconsistent changes: double-deleting");
+                    *dst = old_row;
+                }
+            },
+        }
+    }
+
+    /// Apply an update of a row with the given key.
+    pub fn update(&mut self, key: K, old_row: R, new_row: R) {
+        match self.buffer.entry(key) {
+            BTreeEntry::Vacant(e) => {
+                e.insert(Record::Update { old_row, new_row });
+            }
+            BTreeEntry::Occupied(mut e) => match e.get_mut() {
+                Record::Insert { .. } => {
+                    e.insert(Record::Insert { new_row });
+                }
+                Record::Update { new_row: dst, .. } => {
+                    *dst = new_row;
+                }
+                Record::Delete { .. } => {
+                    self.ib.report("inconsistent changes: update after delete");
+                    e.insert(Record::Update { old_row, new_row });
+                }
+            },
+        }
+    }
+
+    /// Apply a change record, with the key extracted by the given function.
+    pub fn apply_record(&mut self, record: Record<R>, key_fn: impl Fn(&R) -> K) {
+        match record {
+            Record::Insert { new_row } => self.insert(key_fn(&new_row), new_row),
+            Record::Delete { old_row } => self.delete(key_fn(&old_row), old_row),
+            Record::Update { old_row, new_row } => {
+                let old_key = key_fn(&old_row);
+                let new_key = key_fn(&new_row);
+
+                if old_key != new_key {
+                    self.ib
+                        .report("inconsistent changes: mismatched key in update");
+                    self.delete(old_key, old_row);
+                    self.insert(new_key, new_row);
+                } else {
+                    self.update(old_key, old_row, new_row);
+                }
+            }
+        }
+    }
+
+    /// Apply an `Op` of a row with the given key.
+    pub fn apply_op_row(&mut self, op: Op, key: K, row: R) {
+        match op {
+            Op::Insert | Op::UpdateInsert => self.insert(key, row),
+            Op::Delete | Op::UpdateDelete => self.delete(key, row),
+        }
+    }
+
+    /// Consume the buffer and produce a list of change records.
+    pub fn into_records(self) -> impl Iterator<Item = Record<R>> {
+        self.buffer.into_values().filter(|record| match record {
+            Record::Insert { .. } => true,
+            Record::Delete { .. } => true,
+            Record::Update { old_row, new_row } => old_row != new_row,
+        })
+    }
+}
+
+impl<K, R> Default for BTreeChangeBuffer<K, R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, R> BTreeChangeBuffer<K, R> {
+    /// Create a new `BTreeChangeBuffer` that panics on inconsistency.
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Create a new `BTreeChangeBuffer` with the given capacity that panics on inconsistency.
+    #[allow(clippy::unused_self)]
+    pub fn with_capacity(_capacity: usize) -> Self {
+        Self {
+            buffer: BTreeMap::new(),
+            ib: InconsistencyBehavior::Panic,
+        }
+    }
+
+    /// Set the inconsistency behavior.
+    pub fn with_inconsistency_behavior(mut self, ib: InconsistencyBehavior) -> Self {
+        self.ib = ib;
+        self
+    }
+
+    /// Get the number of keys that have pending changes in the buffer.
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Check if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+}
+
+impl<K, R> BTreeChangeBuffer<K, R>
+where
+    K: private::OrdKey,
+    R: private::Row + Row,
+{
+    /// Consume the buffer and produce a single compacted chunk.
+    pub fn into_chunk(self, data_types: Vec<DataType>) -> Option<StreamChunk> {
+        let mut builder = StreamChunkBuilder::unlimited(data_types, Some(self.buffer.len()));
+        for record in self.into_records() {
+            let none = builder.append_record(record);
+            debug_assert!(none.is_none());
+        }
+        builder.take()
+    }
+
+    /// Consume the buffer and produce a list of compacted chunks with the given size at most.
+    pub fn into_chunks(self, data_types: Vec<DataType>, chunk_size: usize) -> Vec<StreamChunk> {
+        let mut res = Vec::new();
+        let mut builder = StreamChunkBuilder::new(chunk_size, data_types);
+        for record in self.into_records() {
             if let Some(chunk) = builder.append_record(record) {
                 res.push(chunk);
             }

--- a/src/stream/src/executor/locality_provider.rs
+++ b/src/stream/src/executor/locality_provider.rs
@@ -31,6 +31,7 @@ use risingwave_common_rate_limit::RateLimit;
 use risingwave_storage::StateStore;
 use risingwave_storage::store::PrefetchOptions;
 
+use crate::common::change_buffer::BTreeChangeBuffer;
 use crate::common::table::state_table::StateTable;
 use crate::executor::backfill::utils::create_builder;
 use crate::executor::prelude::*;
@@ -189,6 +190,10 @@ pub struct LocalityProviderExecutor<S: StateStore> {
 
     /// Chunk size for output
     chunk_size: usize,
+
+    pk_indices: Vec<usize>,
+
+    enable_locality_sort_buffer: bool,
 }
 
 impl<S: StateStore> LocalityProviderExecutor<S> {
@@ -203,6 +208,8 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
         metrics: Arc<StreamingMetrics>,
         chunk_size: usize,
         fragment_id: FragmentId,
+        pk_indices: Vec<usize>,
+        enable_locality_sort_buffer: bool,
     ) -> Self {
         Self {
             upstream,
@@ -215,6 +222,8 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
             metrics,
             chunk_size,
             fragment_id,
+            pk_indices,
+            enable_locality_sort_buffer,
         }
     }
 
@@ -796,35 +805,98 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                 }
             }
         }
+        if self.enable_locality_sort_buffer {
+            debug_assert_eq!(
+                self.pk_indices,
+                state_table.pk_indices(),
+                "locality sort buffer expects executor pk to align with state table pk"
+            );
 
-        // After backfill completion, forward messages directly
-        #[for_await]
-        for msg in upstream {
-            let msg = msg?;
+            let pk_indices = self.pk_indices.clone();
+            let pk_serde = state_table.pk_serde().clone();
+            let data_types = self.input_schema.data_types();
+            let chunk_size = self.chunk_size;
 
-            match msg {
-                Message::Barrier(barrier) => {
-                    // Commit state tables but don't modify them
-                    state_table
-                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
-                        .await?;
-                    progress_table
-                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
-                        .await?;
-                    if report_finished_on_first_barrier {
-                        // At completion, we report `total_snapshot_rows` as buffered rows to make progress accurate.
-                        self.progress.finish_with_buffered_rows(
-                            barrier.epoch,
-                            backfill_state.total_snapshot_rows,
-                            backfill_state.total_snapshot_rows,
-                        );
-                        report_finished_on_first_barrier = false;
+            let mut buffer: BTreeChangeBuffer<Vec<u8>, OwnedRow> = BTreeChangeBuffer::new();
+
+            #[for_await]
+            for msg in upstream {
+                let msg = msg?;
+
+                match msg {
+                    Message::Chunk(chunk) => {
+                        let chunk = chunk.compact_vis();
+                        for record in chunk.records() {
+                            let owned_record = record.map(|row| row.into_owned_row());
+                            buffer.apply_record(owned_record, |row| {
+                                let pk = row.project(&pk_indices);
+                                let mut key = Vec::new();
+                                pk_serde.serialize(pk, &mut key);
+                                key
+                            });
+                        }
                     }
-                    yield Message::Barrier(barrier);
+                    Message::Watermark(watermark) => {
+                        yield Message::Watermark(watermark);
+                    }
+                    Message::Barrier(barrier) => {
+                        if !buffer.is_empty() {
+                            let to_flush = std::mem::take(&mut buffer);
+                            for sorted_chunk in to_flush.into_chunks(data_types.clone(), chunk_size)
+                            {
+                                yield Message::Chunk(sorted_chunk);
+                            }
+                        }
+
+                        state_table
+                            .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                            .await?;
+                        progress_table
+                            .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                            .await?;
+                        if report_finished_on_first_barrier {
+                            // At completion, report buffered rows on the first downstream barrier.
+                            self.progress.finish_with_buffered_rows(
+                                barrier.epoch,
+                                backfill_state.total_snapshot_rows,
+                                backfill_state.total_snapshot_rows,
+                            );
+                            report_finished_on_first_barrier = false;
+                        }
+                        yield Message::Barrier(barrier);
+                    }
                 }
-                _ => {
-                    // Forward all other messages directly
-                    yield msg;
+            }
+        } else {
+            // Forward messages directly without sorting
+            #[for_await]
+            for msg in upstream {
+                let msg = msg?;
+
+                match msg {
+                    Message::Barrier(barrier) => {
+                        // Commit state tables but don't modify them
+                        state_table
+                            .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                            .await?;
+                        progress_table
+                            .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                            .await?;
+                        if report_finished_on_first_barrier {
+                            // At completion, report buffered rows on the first downstream barrier.
+                            self.progress.finish_with_buffered_rows(
+                                barrier.epoch,
+                                backfill_state.total_snapshot_rows,
+                                backfill_state.total_snapshot_rows,
+                            );
+                            report_finished_on_first_barrier = false;
+                        }
+                        yield Message::Barrier(barrier);
+                    }
+                    _ => {
+                        // Forward all other messages directly
+                        yield msg;
+                    }
                 }
             }
         }

--- a/src/stream/src/executor/locality_provider.rs
+++ b/src/stream/src/executor/locality_provider.rs
@@ -191,7 +191,7 @@ pub struct LocalityProviderExecutor<S: StateStore> {
     /// Chunk size for output
     chunk_size: usize,
 
-    pk_indices: Vec<usize>,
+    stream_key: StreamKey,
 
     enable_locality_sort_buffer: bool,
 }
@@ -208,7 +208,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
         metrics: Arc<StreamingMetrics>,
         chunk_size: usize,
         fragment_id: FragmentId,
-        pk_indices: Vec<usize>,
+        stream_key: StreamKey,
         enable_locality_sort_buffer: bool,
     ) -> Self {
         Self {
@@ -222,7 +222,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
             metrics,
             chunk_size,
             fragment_id,
-            pk_indices,
+            stream_key,
             enable_locality_sort_buffer,
         }
     }
@@ -807,12 +807,12 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
         }
         if self.enable_locality_sort_buffer {
             debug_assert_eq!(
-                self.pk_indices,
+                self.stream_key,
                 state_table.pk_indices(),
                 "locality sort buffer expects executor pk to align with state table pk"
             );
 
-            let pk_indices = self.pk_indices.clone();
+            let pk_indices = self.stream_key.clone();
             let pk_serde = state_table.pk_serde().clone();
             let data_types = self.input_schema.data_types();
             let chunk_size = self.chunk_size;

--- a/src/stream/src/from_proto/locality_provider.rs
+++ b/src/stream/src/from_proto/locality_provider.rs
@@ -67,7 +67,7 @@ impl ExecutorBuilder for LocalityProviderBuilder {
             .local_barrier_manager
             .register_create_mview_progress(&params.actor_context);
 
-        let pk_indices = params.info.stream_key.clone();
+        let stream_key = params.info.stream_key.clone();
 
         let exec = LocalityProviderExecutor::new(
             input,
@@ -79,7 +79,7 @@ impl ExecutorBuilder for LocalityProviderBuilder {
             params.executor_stats.clone(),
             params.config.developer.chunk_size,
             params.actor_context.fragment_id,
-            pk_indices,
+            stream_key,
             params.config.developer.enable_locality_sort_buffer,
         );
 

--- a/src/stream/src/from_proto/locality_provider.rs
+++ b/src/stream/src/from_proto/locality_provider.rs
@@ -67,6 +67,8 @@ impl ExecutorBuilder for LocalityProviderBuilder {
             .local_barrier_manager
             .register_create_mview_progress(&params.actor_context);
 
+        let pk_indices = params.info.stream_key.clone();
+
         let exec = LocalityProviderExecutor::new(
             input,
             locality_columns,
@@ -77,6 +79,8 @@ impl ExecutorBuilder for LocalityProviderBuilder {
             params.executor_stats.clone(),
             params.config.developer.chunk_size,
             params.actor_context.fragment_id,
+            pk_indices,
+            params.config.developer.enable_locality_sort_buffer,
         );
 
         Ok((params.info, exec).into())


### PR DESCRIPTION
## What's changed and what's your intention?

- This pull request introduces a new sort buffer to the `LocalityProviderExecutor` for improved locality after backfilling, and adds configuration options to enable this feature. The main changes include the implementation of a new `BTreeChangeBuffer`, integration of this buffer into the executor, and updates to configuration files and builder logic to support the new functionality.

### Locality sort buffer feature

* Added a new `BTreeChangeBuffer` type in `change_buffer.rs` for ordered change accumulation and compaction, including methods for applying inserts, deletes, updates, and producing sorted output chunks.
* Integrated the locality sort buffer into `LocalityProviderExecutor`, controlled by the new `enable_locality_sort_buffer` flag. When enabled, chunks are sorted by primary key before being forwarded downstream. [[1]](diffhunk://#diff-81600e59aa976afb7b290f09b29314bce5972e2476ef81fbf98de5298f81a0d4L806-R870) [[2]](diffhunk://#diff-81600e59aa976afb7b290f09b29314bce5972e2476ef81fbf98de5298f81a0d4R894)
* Updated the executor builder to pass the stream key and the new configuration flag to the executor. [[1]](diffhunk://#diff-f8af59f9c52d1e51261e0778fc800ff31a60f35b2e6a6c20a35683a8b817d013R70-R71) [[2]](diffhunk://#diff-f8af59f9c52d1e51261e0778fc800ff31a60f35b2e6a6c20a35683a8b817d013R82-R83)


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
