### PR TITLE
perf(expr): support writer-style #[function] for array type

### DIFF
--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -54,7 +54,7 @@ pub use decimal_array::{DecimalArray, DecimalArrayBuilder};
 pub use interval_array::{IntervalArray, IntervalArrayBuilder};
 pub use iterator::ArrayIterator;
 pub use jsonb_array::{JsonbArray, JsonbArrayBuilder};
-pub use list_array::{ListArray, ListArrayBuilder, ListRef, ListValue};
+pub use list_array::{ListArray, ListArrayBuilder, ListRef, ListValue, ListWrite, ListWriter};
 pub use map_array::{MapArray, MapArrayBuilder, MapRef, MapValue};
 use paste::paste;
 pub use primitive_array::{PrimitiveArray, PrimitiveArrayBuilder, PrimitiveArrayItemType};

--- a/src/expr/impl/src/scalar/array_flatten.rs
+++ b/src/expr/impl/src/scalar/array_flatten.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::array::{ListRef, ListValue};
+use risingwave_common::array::ListRef;
 use risingwave_expr::expr::Context;
 use risingwave_expr::{ExprError, Result, function};
 
@@ -64,7 +64,11 @@ use risingwave_expr::{ExprError, Result, function};
 /// NULL
 /// ```
 #[function("array_flatten(anyarray) -> anyarray")]
-fn array_flatten(array: ListRef<'_>, ctx: &Context) -> Result<ListValue> {
+fn array_flatten(
+    array: ListRef<'_>,
+    ctx: &Context,
+    writer: &mut impl risingwave_common::array::ListWrite,
+) -> Result<()> {
     // The elements of the array must be arrays themselves
     let outer_type = &ctx.arg_types[0];
     let inner_type = if outer_type.is_array() {
@@ -81,16 +85,14 @@ fn array_flatten(array: ListRef<'_>, ctx: &Context) -> Result<ListValue> {
             reason: Box::from("expected the argument to be an array of arrays"),
         });
     }
-    let inner_elem_type = inner_type.as_list_elem();
 
-    // Collect all inner array elements and flatten them into a single array
-    Ok(ListValue::from_datum_iter(
-        inner_elem_type,
+    writer.write_iter(
         array
             .iter()
             // Filter out NULL inner arrays
             .flatten()
             // Flatten all inner arrays
             .flat_map(|inner_array| inner_array.into_list().iter()),
-    ))
+    );
+    Ok(())
 }

--- a/src/expr/impl/src/scalar/array_remove.rs
+++ b/src/expr/impl/src/scalar/array_remove.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::array::{ListRef, ListValue};
+use risingwave_common::array::ListRef;
 use risingwave_common::types::ScalarRefImpl;
 use risingwave_expr::function;
 
@@ -67,6 +67,14 @@ use risingwave_expr::function;
 /// select array_remove(ARRAY[array[1],array[2],array[3],array[2],null], array[true]);
 /// ```
 #[function("array_remove(anyarray, any) -> anyarray")]
-fn array_remove(array: ListRef<'_>, elem: Option<ScalarRefImpl<'_>>) -> ListValue {
-    ListValue::from_datum_iter(&array.elem_type(), array.iter().filter(|x| x != &elem))
+fn array_remove(
+    array: ListRef<'_>,
+    elem: Option<ScalarRefImpl<'_>>,
+    writer: &mut impl risingwave_common::array::ListWrite,
+) {
+    for val in array.iter() {
+        if val != elem {
+            writer.write(val);
+        }
+    }
 }

--- a/src/expr/impl/src/scalar/array_replace.rs
+++ b/src/expr/impl/src/scalar/array_replace.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::array::{ListRef, ListValue};
+use risingwave_common::array::ListRef;
 use risingwave_common::types::ScalarRefImpl;
 use risingwave_expr::function;
 
@@ -59,12 +59,12 @@ fn array_replace(
     array: ListRef<'_>,
     elem_from: Option<ScalarRefImpl<'_>>,
     elem_to: Option<ScalarRefImpl<'_>>,
-) -> ListValue {
-    ListValue::from_datum_iter(
-        &array.elem_type(),
-        array.iter().map(|val| match val == elem_from {
-            true => elem_to,
-            false => val,
-        }),
-    )
+    writer: &mut impl risingwave_common::array::ListWrite,
+) {
+    for val in array.iter() {
+        match val == elem_from {
+            true => writer.write(elem_to),
+            false => writer.write(val),
+        }
+    }
 }

--- a/src/expr/impl/src/scalar/array_sort.rs
+++ b/src/expr/impl/src/scalar/array_sort.rs
@@ -18,9 +18,6 @@ use risingwave_common::types::DefaultOrdered;
 use risingwave_expr::function;
 
 #[function("array_sort(anyarray) -> anyarray")]
-pub fn array_sort(array: ListRef<'_>) -> ListValue {
-    ListValue::from_datum_iter(
-        &array.elem_type(),
-        array.iter().map(DefaultOrdered).sorted().map(|v| v.0),
-    )
+pub fn array_sort(array: ListRef<'_>, writer: &mut impl risingwave_common::array::ListWrite) {
+    writer.write_iter(array.iter().map(DefaultOrdered).sorted().map(|v| v.0));
 }

--- a/src/expr/impl/src/scalar/vector.rs
+++ b/src/expr/impl/src/scalar/vector.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use risingwave_common::array::Finite32;
-use risingwave_common::types::{
-    DataType, F32, F64, ListRef, ListValue, ScalarRefImpl, VectorRef, VectorVal,
-};
+use risingwave_common::types::{DataType, F32, F64, ListRef, ScalarRefImpl, VectorRef, VectorVal};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::vector::MeasureDistanceBuilder;
 use risingwave_common::vector::distance::{L1Distance, L2SqrDistance, inner_product_faiss};
@@ -335,8 +333,12 @@ fn vector_concat(lhs: VectorRef<'_>, rhs: VectorRef<'_>) -> Result<VectorVal> {
 /// {1,2,3}
 /// ```
 #[function("cast(vector) -> float4[]")]
-fn vector_to_float4(v: VectorRef<'_>) -> ListValue {
-    v.as_raw_slice().iter().copied().map(F32::from).collect()
+fn vector_to_float4(v: VectorRef<'_>, writer: &mut impl risingwave_common::array::ListWrite) {
+    writer.write_iter(
+        v.as_raw_slice()
+            .iter()
+            .map(|&f| Some(ScalarRefImpl::Float32(F32::from(f)))),
+    );
 }
 
 /// ```slt

--- a/src/expr/macro/src/parse.rs
+++ b/src/expr/macro/src/parse.rs
@@ -202,6 +202,8 @@ fn arg_writer_type(arg: &syn::FnArg) -> Option<WriterTypeKind> {
             note = "`function!` macro can only recognize fully-qualified type.";
             help = "Please use `jsonbb::Builder` instead."
         };
+    } else if elem == &parse_quote!(impl risingwave_common::array::ListWrite) {
+        Some(WriterTypeKind::ListWrite)
     } else {
         None
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

part of #13263

This PR introduces a "writer pattern" for functions that return `anyarray` or `type[]`, allowing them to write their results directly to a `ArrayBuilder` for total data chunk.

This approach **avoids the overhead of unnecessary memory allocation (`malloc`) and copying (`memcpy`)** when building the return value, significantly improving performance for these functions.

For example, `array_distinct` can now be implemented efficiently without creating an intermediate `ListValue`:

```rust
#[function("array_distinct(anyarray) -> anyarray")]
pub fn array_distinct(list: ListRef<'_>, writer: &mut impl risingwave_common::array::ListWrite) {
    writer.write_iter(list.iter().unique());
}
```

### Benchmark Enhancement

Expression benchmarks now include array support:
- Functions with `int32[]`, `float32[]`, `varchar[]`, `bytea[]` arguments are able to bench.
- Functions with `any`/`anyarray` argument types are benchmarked against four concrete types: `int32`, `float32`, `varchar`, `bytea`.

### Performance Comparision

<details>
<summary>detailes per function</summary>

```shell
cargo bench --bench expr -- "[some filters]" --baseline main-branch
```

```
array_append(integer[], integer) -> integer[]
                        time:   [12.286 ms 12.347 ms 12.407 ms]
                        change: [−51.000% −50.734% −50.470%] (p = 0.00 < 0.05)
                        Performance has improved.
array_append(real[], real) -> real[]
                        time:   [12.053 ms 12.124 ms 12.195 ms]
                        change: [−52.082% −51.772% −51.426%] (p = 0.00 < 0.05)
                        Performance has improved.
array_append(character varying[], character varying) -> character varying[]
                        time:   [17.843 ms 17.878 ms 17.916 ms]
                        change: [−51.836% −51.711% −51.581%] (p = 0.00 < 0.05)
                        Performance has improved.
array_append(bytea[], bytea) -> bytea[]
                        time:   [17.712 ms 17.759 ms 17.815 ms]
                        change: [−51.892% −51.653% −51.422%] (p = 0.00 < 0.05)
                        Performance has improved.
array_cat(integer[], integer[]) -> integer[]
                        time:   [23.700 ms 23.751 ms 23.804 ms]
                        change: [−50.680% −50.546% −50.424%] (p = 0.00 < 0.05)
                        Performance has improved.
array_cat(real[], real[]) -> real[]
                        time:   [23.642 ms 23.709 ms 23.777 ms]
                        change: [−50.382% −50.237% −50.084%] (p = 0.00 < 0.05)
                        Performance has improved.
array_cat(character varying[], character varying[]) -> character varying[]
                        time:   [34.757 ms 34.811 ms 34.874 ms]
                        change: [−50.749% −50.656% −50.546%] (p = 0.00 < 0.05)
                        Performance has improved.
array_cat(bytea[], bytea[]) -> bytea[]
                        time:   [34.095 ms 34.151 ms 34.212 ms]
                        change: [−51.173% −50.993% −50.836%] (p = 0.00 < 0.05)
                        Performance has improved.
array_distinct(integer[]) -> integer[]
                        time:   [16.185 ms 16.195 ms 16.207 ms]
                        change: [−0.9037% −0.7645% −0.6443%] (p = 0.00 < 0.05)
                        Change within noise threshold.
array_distinct(real[]) -> real[]
                        time:   [18.467 ms 18.487 ms 18.516 ms]
                        change: [+0.3734% +0.5131% +0.6604%] (p = 0.00 < 0.05)
                        Change within noise threshold.
array_distinct(character varying[]) -> character varying[]
                        time:   [76.205 ms 76.278 ms 76.357 ms]
                        change: [−20.556% −20.448% −20.334%] (p = 0.00 < 0.05)
                        Performance has improved.
array_distinct(bytea[]) -> bytea[]
                        time:   [79.050 ms 79.142 ms 79.256 ms]
                        change: [−19.332% −19.204% −19.068%] (p = 0.00 < 0.05)
                        Performance has improved.
array_flatten(integer[]) -> integer[]
                        time:   [51.656 ms 51.706 ms 51.761 ms]
                        change: [+0.3391% +0.4984% +0.6656%] (p = 0.00 < 0.05)
                        Change within noise threshold.
array_flatten(real[]) -> real[]
                        time:   [75.850 ms 75.900 ms 75.956 ms]
                        change: [+1.0292% +1.1377% +1.2436%] (p = 0.00 < 0.05)
                        Performance has regressed.
array_flatten(character varying[]) -> character varying[]
                        time:   [69.094 ms 69.656 ms 70.707 ms]
                        change: [+1.4421% +2.3103% +3.8528%] (p = 0.00 < 0.05)
                        Performance has regressed.
array_flatten(bytea[]) -> bytea[]
                        time:   [195.08 ms 195.24 ms 195.41 ms]
                        change: [+0.7312% +0.8759% +1.0131%] (p = 0.00 < 0.05)
                        Change within noise threshold.
array_positions(integer[], integer) -> integer[]
                        time:   [17.300 ms 17.320 ms 17.343 ms]
                        change: [−15.935% −15.763% −15.584%] (p = 0.00 < 0.05)
                        Performance has improved.
array_positions(real[], real) -> integer[]
                        time:   [5.5860 ms 5.5893 ms 5.5932 ms]
                        change: [−0.7138% −0.6063% −0.5090%] (p = 0.00 < 0.05)
                        Change within noise threshold.
array_positions(character varying[], character varying) -> integer[]
                        time:   [9.2015 ms 9.2073 ms 9.2144 ms]
                        change: [−1.4608% −1.3449% −1.2261%] (p = 0.00 < 0.05)
                        Performance has improved.
array_positions(bytea[], bytea) -> integer[]
                        time:   [8.5982 ms 8.6133 ms 8.6321 ms]
                        change: [−11.004% −10.776% −10.544%] (p = 0.00 < 0.05)
                        Performance has improved.
array_prepend(integer, integer[]) -> integer[]
                        time:   [11.952 ms 11.997 ms 12.044 ms]
                        change: [−53.212% −52.852% −52.541%] (p = 0.00 < 0.05)
                        Performance has improved.
array_prepend(real, real[]) -> real[]
                        time:   [11.887 ms 11.915 ms 11.944 ms]
                        change: [−54.392% −53.722% −53.272%] (p = 0.00 < 0.05)
                        Performance has improved.
array_prepend(character varying, character varying[]) -> character varying[]
                        time:   [18.114 ms 18.142 ms 18.174 ms]
                        change: [−51.926% −51.771% −51.619%] (p = 0.00 < 0.05)
                        Performance has improved.
array_prepend(bytea, bytea[]) -> bytea[]
                        time:   [17.713 ms 17.736 ms 17.762 ms]
                        change: [−52.284% −52.157% −52.033%] (p = 0.00 < 0.05)
                        Performance has improved.
array_range_access(integer[], integer, integer) -> integer[]
                        time:   [26.235 µs 26.264 µs 26.300 µs]
                        change: [−76.158% −76.102% −76.049%] (p = 0.00 < 0.05)
                        Performance has improved.
array_range_access(real[], integer, integer) -> real[]
                        time:   [26.245 µs 26.271 µs 26.300 µs]
                        change: [−75.924% −75.891% −75.855%] (p = 0.00 < 0.05)
                        Performance has improved.
array_range_access(character varying[], integer, integer) -> character varying[]
                        time:   [31.019 µs 31.063 µs 31.117 µs]
                        change: [−80.414% −80.327% −80.239%] (p = 0.00 < 0.05)
                        Performance has improved.
array_range_access(bytea[], integer, integer) -> bytea[]
                        time:   [30.525 µs 30.600 µs 30.676 µs]
                        change: [−80.956% −80.899% −80.841%] (p = 0.00 < 0.05)
                        Performance has improved.
array_remove(integer[], integer) -> integer[]
                        time:   [5.8832 ms 5.8901 ms 5.8986 ms]
                        change: [−0.6794% −0.5490% −0.3956%] (p = 0.00 < 0.05)
                        Change within noise threshold.
array_remove(real[], real) -> real[]
                        time:   [13.849 ms 13.870 ms 13.893 ms]
                        change: [−50.113% −49.988% −49.865%] (p = 0.00 < 0.05)
                        Performance has improved.
array_remove(character varying[], character varying) -> character varying[]
                        time:   [21.688 ms 21.731 ms 21.774 ms]
                        change: [−48.066% −47.943% −47.829%] (p = 0.00 < 0.05)
                        Performance has improved.
array_remove(bytea[], bytea) -> bytea[]
                        time:   [23.120 ms 23.156 ms 23.195 ms]
                        change: [−46.983% −46.846% −46.718%] (p = 0.00 < 0.05)
                        Performance has improved.
array_replace(integer[], integer, integer) -> integer[]
                        time:   [13.498 ms 13.524 ms 13.553 ms]
                        change: [−47.831% −47.581% −47.350%] (p = 0.00 < 0.05)
                        Performance has improved.
array_replace(real[], real, real) -> real[]
                        time:   [13.629 ms 13.682 ms 13.749 ms]
                        change: [−45.745% −45.530% −45.225%] (p = 0.00 < 0.05)
                        Performance has improved.
array_replace(character varying[], character varying, character varying) -> character varying[]
                        time:   [21.898 ms 21.953 ms 22.008 ms]
                        change: [−44.415% −44.245% −44.084%] (p = 0.00 < 0.05)
                        Performance has improved.
array_replace(bytea[], bytea, bytea) -> bytea[]
                        time:   [22.579 ms 22.604 ms 22.631 ms]
                        change: [−45.419% −45.308% −45.196%] (p = 0.00 < 0.05)
                        Performance has improved.
array_sort(integer[]) -> integer[]
                        time:   [19.683 ms 19.710 ms 19.739 ms]
                        change: [−37.757% −37.633% −37.510%] (p = 0.00 < 0.05)
                        Performance has improved.
array_sort(real[]) -> real[]
                        time:   [19.846 ms 19.869 ms 19.894 ms]
                        change: [−37.510% −37.233% −37.021%] (p = 0.00 < 0.05)
                        Performance has improved.
array_sort(character varying[]) -> character varying[]
                        time:   [70.592 ms 70.705 ms 70.848 ms]
                        change: [−20.848% −20.622% −20.417%] (p = 0.00 < 0.05)
                        Performance has improved.
array_sort(bytea[]) -> bytea[]
                        time:   [70.906 ms 70.984 ms 71.061 ms]
                        change: [−20.238% −20.103% −19.970%] (p = 0.00 < 0.05)
                        Performance has improved.
jsonb_to_array(jsonb) -> jsonb[]
                        time:   [301.76 µs 301.97 µs 302.19 µs]
                        change: [+2.7763% +3.0201% +3.2717%] (p = 0.00 < 0.05)
                        Performance has regressed.
regexp_match(character varying, character varying) -> character varying[]
                        time:   [2.0145 ms 2.0190 ms 2.0236 ms]
                        change: [−7.3885% −7.1480% −6.9016%] (p = 0.00 < 0.05)
                        Performance has improved.
regexp_match(character varying, character varying, character varying) -> character varying[]
                        time:   [293.79 ns 294.55 ns 295.45 ns]
                        change: [−98.307% −98.303% −98.299%] (p = 0.00 < 0.05)
                        Performance has improved.
regexp_split_to_array(character varying, character varying) -> character varying[]
                        time:   [2.0629 ms 2.0655 ms 2.0684 ms]
                        change: [−4.8549% −4.6566% −4.4275%] (p = 0.00 < 0.05)
                        Performance has improved.
regexp_split_to_array(character varying, character varying, character varying) -> character varying[]
                        time:   [294.73 ns 295.27 ns 295.75 ns]
                        change: [−98.319% −98.314% −98.309%] (p = 0.00 < 0.05)
                        Performance has improved.
string_to_array(character varying, character varying) -> character varying[]
                        time:   [63.402 µs 63.435 µs 63.474 µs]
                        change: [−67.710% −67.638% −67.578%] (p = 0.00 < 0.05)
                        Performance has improved.
string_to_array(character varying, character varying, character varying) -> character varying[]
                        time:   [64.618 µs 64.649 µs 64.687 µs]
                        change: [−68.047% −67.996% −67.945%] (p = 0.00 < 0.05)
                        Performance has improved.
trim_array(integer[], integer) -> integer[]
                        time:   [11.799 ms 11.827 ms 11.857 ms]
                        change: [−49.680% −49.547% −49.404%] (p = 0.00 < 0.05)
                        Performance has improved.
trim_array(real[], integer) -> real[]
                        time:   [11.677 ms 11.692 ms 11.709 ms]
                        change: [−50.305% −50.213% −50.121%] (p = 0.00 < 0.05)
                        Performance has improved.
trim_array(character varying[], integer) -> character varying[]
                        time:   [17.674 ms 17.716 ms 17.761 ms]
                        change: [−50.196% −50.066% −49.910%] (p = 0.00 < 0.05)
                        Performance has improved.
trim_array(bytea[], integer) -> bytea[]
                        time:   [17.418 ms 17.452 ms 17.488 ms]
                        change: [−50.306% −50.180% −50.052%] (p = 0.00 < 0.05)
                        Performance has improved.
```
</details>



<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
