### PR TITLE
fix(cdc): handle numeric identifiers in connector properties when alter source

### DIFF
--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -185,7 +185,10 @@ impl Ident {
     pub fn from_real_value(value: &str) -> Self {
         let needs_quotes = value
             .chars()
-            .any(|c| !matches!(c, 'a'..='z' | '0'..='9' | '_'));
+            .any(|c| !matches!(c, 'a'..='z' | '0'..='9' | '_'))
+            // Also need quotes if the identifier starts with a digit, as it would be
+            // tokenized as a number instead of an identifier (e.g., "2000000")
+            || value.chars().next().is_some_and(|c| c.is_ascii_digit());
 
         if needs_quotes {
             Self::with_quote_unchecked('"', value.replace('"', "\"\""))
@@ -3305,7 +3308,13 @@ impl TryFrom<(&String, &String)> for SqlOption {
     type Error = ParserError;
 
     fn try_from((name, value): (&String, &String)) -> Result<Self, Self::Error> {
-        let query = format!("{} = {}", name, value);
+        // Use from_real_value to properly escape the name, which handles cases like
+        // "debezium.column.truncate.to.2000000.chars" where "2000000" would be
+        // tokenized as a number instead of an identifier if not properly quoted.
+        let name_parts: Vec<&str> = name.split('.').collect();
+        let object_name = ObjectName(name_parts.into_iter().map(Ident::from_real_value).collect());
+
+        let query = format!("{} = {}", object_name, value);
         let mut tokenizer = Tokenizer::new(query.as_str());
         let tokens = tokenizer.tokenize_with_location()?;
         let mut parser = Parser(&tokens);

--- a/src/sqlparser/tests/testdata/alter.yaml
+++ b/src/sqlparser/tests/testdata/alter.yaml
@@ -23,3 +23,5 @@
   formatted_sql: ALTER TABLE t CONNECTOR WITH (properties.receive.message.max.bytes = secret s1)
 - input: ALTER SOURCE t_source CONNECTOR WITH ( properties.receive.message.max.bytes = secret s2 );
   formatted_sql: ALTER SOURCE t_source CONNECTOR WITH (properties.receive.message.max.bytes = secret s2)
+- input: ALTER SOURCE test_src CONNECTOR WITH (debezium.column.truncate.to."2000000".chars = 'value1');
+  formatted_sql: ALTER SOURCE test_src CONNECTOR WITH (debezium.column.truncate.to."2000000".chars = 'value1')


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
Fail to alter source if the definition of source is
```
CREATE SOURCE xxx WITH (
  connector='sqlserver-cdc',
  debezium.column.truncate.to."2000000".chars = 'xxx'
);
```
Will get following error:
```
 Invalid Parameter Value: Invalid parameter: sql parser error: Parsing Error: ContextError { context: [], cause: Some(StrError("expected =, found: .2000000")) }
```

### Root Cause
When ALTER SOURCE rebuilds the SQL definition from catalog:
1. [real_value() strips quotes from identifiers during storage](https://github.com/risingwavelabs/risingwave/blob/0c2e34a2879dd1a1fcc172cf20751be41653eb0f/src/sqlparser/src/ast/mod.rs#L167-L172)
2. SqlOption::try_from() reconstructs SQL by concatenating strings
3. Tokenizer misinterprets 2000000 as a Number token instead of an identifier
4. Parser fails when it expects = but sees .2000000

The issue is that Ident::from_real_value() didn't recognize that identifiers starting with digits require quotes per SQL standard. This pr enhanced Ident::from_real_value() to automatically quote identifiers that start with digits.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
