### PR TITLE
fix(ci): use larger runner with more disk space for workflows that build RW

### DIFF
--- a/.github/workflows/connector-node-integration.yml
+++ b/.github/workflows/connector-node-integration.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: risingwave-large # this runner comes with more disk space, necessary for workflows that build RW
     strategy:
       matrix:
         java: [ '17', '21' ]

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: risingwave-large # this runner comes with more disk space, necessary for workflows that build RW
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: risingwave-large # this runner comes with more disk space, necessary for workflows that build RW
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

After removing the problematic `maximize-disk-space` step in #23757, we started to encounter "disk out of space" issue occasionally, like

>   = note: failed to create or modify "/home/runner/work/risingwave/risingwave/target/doc/search.index/type/": failed to read column from disk: data consumer error: invalid type: null, expected type data at line 1 column 4

> [INFO]           collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
> [INFO]           compilation terminated.

This PR attempts to fix that by specifying [a larger runner](https://github.com/organizations/risingwavelabs/settings/actions/github-hosted-runners/3) with more disk space.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
