### PR TITLE
refactor(watermark): use clean_watermark_indices to replace clean_watermark_index_in_pk

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -537,8 +537,9 @@ message Table {
   optional Engine engine = 43;
 
   // Indicate the index of the watermark column in the primary key that should be cleaned.
-  // NOTICE: when it is "None", the watermark column should be the first column in the pk
-  optional int32 clean_watermark_index_in_pk = 44;
+  // NOTICE: when it is "None", the watermark column should be the first column in the pk.
+  // deprecated, use "clean_watermark_indices" instead. Only kept for backward compatibility.
+  optional int32 clean_watermark_index_in_pk = 44 [deprecated = true];
 
   // Whether the table supports manual refresh operation:
   // reload data from external source and emit messages based on the diff with current data.
@@ -551,6 +552,11 @@ message Table {
 
   reserved "refresh_state";
   reserved 48;
+
+  // Indices of watermark columns in all columns that should be used for state cleaning.
+  // This replaces clean_watermark_index_in_pk but is kept for backward compatibility.
+  // When set, this takes precedence over clean_watermark_index_in_pk.
+  repeated uint32 clean_watermark_indices = 49;
 
   // Per-table catalog version, used by schema change. `None` for internal
   // tables and tests. Not to be confused with the global catalog version for

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -202,6 +202,11 @@ pub struct TableCatalog {
 
     pub clean_watermark_index_in_pk: Option<usize>,
 
+    /// Indices of watermark columns in all columns that should be used for state cleaning.
+    /// This replaces `clean_watermark_index_in_pk` but is kept for backward compatibility.
+    /// When set, this takes precedence over `clean_watermark_index_in_pk`.
+    pub clean_watermark_indices: Vec<usize>,
+
     /// Whether the table supports manual refresh operations
     pub refreshable: bool,
 
@@ -616,7 +621,13 @@ impl TableCatalog {
             webhook_info: self.webhook_info.clone(),
             job_id: self.job_id,
             engine: Some(self.engine.to_protobuf().into()),
+            #[expect(deprecated)]
             clean_watermark_index_in_pk: self.clean_watermark_index_in_pk.map(|x| x as i32),
+            clean_watermark_indices: self
+                .clean_watermark_indices
+                .iter()
+                .map(|&x| x as u32)
+                .collect(),
             refreshable: self.refreshable,
             vector_index_info: self.vector_index_info,
             cdc_table_type: self
@@ -845,7 +856,13 @@ impl From<PbTable> for TableCatalog {
             webhook_info: tb.webhook_info,
             job_id: tb.job_id,
             engine,
+            #[expect(deprecated)]
             clean_watermark_index_in_pk: tb.clean_watermark_index_in_pk.map(|x| x as usize),
+            clean_watermark_indices: tb
+                .clean_watermark_indices
+                .iter()
+                .map(|&x| x as usize)
+                .collect(),
 
             refreshable: tb.refreshable,
             vector_index_info: tb.vector_index_info,
@@ -943,7 +960,9 @@ mod tests {
             webhook_info: None,
             job_id: None,
             engine: Some(PbEngine::Hummock as i32),
+            #[expect(deprecated)]
             clean_watermark_index_in_pk: None,
+            clean_watermark_indices: vec![],
 
             refreshable: false,
             vector_index_info: None,
@@ -1015,6 +1034,7 @@ mod tests {
                 job_id: None,
                 engine: Engine::Hummock,
                 clean_watermark_index_in_pk: None,
+                clean_watermark_indices: vec![],
 
                 refreshable: false,
                 vector_index_info: None,

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -394,6 +394,7 @@ impl StreamMaterialize {
                 }
             },
             clean_watermark_index_in_pk: None, // TODO: fill this field
+            clean_watermark_indices: vec![],   // TODO: fill this field
             refreshable,
             vector_index_info: None,
             cdc_table_type: None,
@@ -443,6 +444,7 @@ impl StreamMaterialize {
             job_id,
             engine,
             clean_watermark_index_in_pk,
+            clean_watermark_indices,
             refreshable,
             vector_index_info,
             cdc_table_type,
@@ -512,6 +514,7 @@ impl StreamMaterialize {
             job_id,
             engine,
             clean_watermark_index_in_pk,
+            clean_watermark_indices,
             refreshable: false,
             vector_index_info,
             cdc_table_type,

--- a/src/frontend/src/optimizer/plan_node/stream_materialized_exprs.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialized_exprs.rs
@@ -208,6 +208,12 @@ impl StreamMaterializedExprs {
             catalog.cleaned_by_watermark = true;
         }
 
+        // Also populate the new clean_watermark_indices field
+        if let Some(col_idx) = self.state_clean_col_idx {
+            catalog.clean_watermark_indices = vec![col_idx];
+            catalog.cleaned_by_watermark = true;
+        }
+
         catalog
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_vector_index_write.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_vector_index_write.rs
@@ -194,6 +194,7 @@ impl StreamVectorIndexWrite {
             job_id: None,
             engine: Engine::Hummock,
             clean_watermark_index_in_pk: None,
+            clean_watermark_indices: vec![],
             refreshable: false,
             vector_index_info: Some(vector_index_info),
             cdc_table_type: None,

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -216,6 +216,7 @@ impl TableCatalogBuilder {
             job_id: None,
             engine: Engine::Hummock,
             clean_watermark_index_in_pk: None, // TODO: fill this field
+            clean_watermark_indices: vec![],   // TODO: fill this field
             refreshable: false,                // Internal tables are not refreshable
             vector_index_info: None,
             cdc_table_type: None,

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -591,6 +591,7 @@ pub(crate) mod tests {
             job_id: None,
             engine: Engine::Hummock,
             clean_watermark_index_in_pk: None,
+            clean_watermark_indices: vec![],
             vector_index_info: None,
             cdc_table_type: None,
         };

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -60,6 +60,7 @@ mod m20251030_120000_refresh_jobs;
 mod m20251112_114514_streaming_job_config_override;
 mod m20251124_195858_pending_sink_state;
 mod m20251126_093529_add_is_iceberg_compactor;
+mod m20251208_134652_clean_watermark_indices;
 mod utils;
 
 pub struct Migrator;
@@ -158,6 +159,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20251112_114514_streaming_job_config_override::Migration),
             Box::new(m20251126_093529_add_is_iceberg_compactor::Migration),
             Box::new(m20251124_195858_pending_sink_state::Migration),
+            Box::new(m20251208_134652_clean_watermark_indices::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20251208_134652_clean_watermark_indices.rs
+++ b/src/meta/model/migration/src/m20251208_134652_clean_watermark_indices.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::{Table as MigrationTable, *};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                MigrationTable::alter()
+                    .table(Table::Table)
+                    .add_column(ColumnDef::new(Table::CleanWatermarkIndices).json())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                MigrationTable::alter()
+                    .table(Table::Table)
+                    .drop_column(Table::CleanWatermarkIndices)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Table {
+    Table,
+    CleanWatermarkIndices,
+}

--- a/src/meta/model/src/table.rs
+++ b/src/meta/model/src/table.rs
@@ -215,6 +215,7 @@ pub struct Model {
     pub webhook_info: Option<WebhookSourceInfo>,
     pub engine: Option<Engine>,
     pub clean_watermark_index_in_pk: Option<i32>,
+    pub clean_watermark_indices: Option<I32Array>,
     pub refreshable: bool,
     pub vector_index_info: Option<VectorIndexInfo>,
     pub cdc_table_type: Option<CdcTableType>,
@@ -357,7 +358,20 @@ impl From<PbTable> for ActiveModel {
             engine: Set(pb_table
                 .engine
                 .map(|engine| Engine::from(PbEngine::try_from(engine).expect("Invalid engine")))),
+            #[expect(deprecated)]
             clean_watermark_index_in_pk: Set(pb_table.clean_watermark_index_in_pk),
+            clean_watermark_indices: Set(if pb_table.clean_watermark_indices.is_empty() {
+                None
+            } else {
+                Some(
+                    pb_table
+                        .clean_watermark_indices
+                        .iter()
+                        .map(|x| *x as i32)
+                        .collect::<Vec<_>>()
+                        .into(),
+                )
+            }),
             refreshable: Set(pb_table.refreshable),
             vector_index_info: Set(pb_table
                 .vector_index_info

--- a/src/meta/src/controller/mod.rs
+++ b/src/meta/src/controller/mod.rs
@@ -269,7 +269,13 @@ impl From<ObjectModel<table::Model>> for PbTable {
             webhook_info: value.0.webhook_info.map(|info| info.to_protobuf()),
             job_id: value.0.belongs_to_job_id,
             engine: value.0.engine.map(|engine| PbEngine::from(engine) as i32),
+            #[expect(deprecated)]
             clean_watermark_index_in_pk: value.0.clean_watermark_index_in_pk,
+            clean_watermark_indices: value
+                .0
+                .clean_watermark_indices
+                .map(|indices| indices.0.iter().map(|&x| x as u32).collect())
+                .unwrap_or_default(),
             refreshable: value.0.refreshable,
             vector_index_info: value.0.vector_index_info.map(|index| index.to_protobuf()),
             cdc_table_type: value

--- a/src/storage/src/compaction_catalog_manager.rs
+++ b/src/storage/src/compaction_catalog_manager.rs
@@ -509,7 +509,10 @@ pub type CompactionCatalogAgentRef = Arc<CompactionCatalogAgent>;
 fn build_watermark_col_serde(
     table_catalog: &Table,
 ) -> Option<(OrderedRowSerde, OrderedRowSerde, usize)> {
-    match table_catalog.clean_watermark_index_in_pk {
+    // Get clean watermark PK index using the helper method
+    let clean_watermark_index_in_pk = table_catalog.get_clean_watermark_index_in_pk_compat();
+
+    match clean_watermark_index_in_pk {
         None => {
             // non watermark table or watermark column is the first column (pk_prefix_watermark)
             None
@@ -541,14 +544,8 @@ fn build_watermark_col_serde(
 
             assert_eq!(pk_data_types.len(), pk_order_types.len());
             let pk_serde = OrderedRowSerde::new(pk_data_types, pk_order_types);
-            let watermark_col_serde = pk_serde
-                .index(clean_watermark_index_in_pk as usize)
-                .into_owned();
-            Some((
-                pk_serde,
-                watermark_col_serde,
-                clean_watermark_index_in_pk as usize,
-            ))
+            let watermark_col_serde = pk_serde.index(clean_watermark_index_in_pk).into_owned();
+            Some((pk_serde, watermark_col_serde, clean_watermark_index_in_pk))
         }
     }
 }
@@ -677,7 +674,9 @@ mod tests {
             webhook_info: None,
             job_id: None,
             engine: Some(PbEngine::Hummock as i32),
+            #[expect(deprecated)]
             clean_watermark_index_in_pk: None,
+            clean_watermark_indices: vec![],
             refreshable: false,
             vector_index_info: None,
             cdc_table_type: None,

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -2121,7 +2121,9 @@ async fn test_non_pk_prefix_watermark_read() {
     // non-pk-prefix watermark
     let watermark_col_idx = 1;
     table.watermark_indices = vec![watermark_col_idx];
+    #[expect(deprecated)]
     table.clean_watermark_index_in_pk = Some(1);
+    table.clean_watermark_indices = vec![watermark_col_idx as u32]; // Column index, not PK index
     let test_env = prepare_hummock_test_env().await;
     test_env.register_table(table.clone()).await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Added support for multiple watermark columns for state cleaning by introducing a new `clean_watermark_indices` field in the `Table` protobuf message. This replaces the existing `clean_watermark_index_in_pk` field which only supports a single watermark column and is now deprecated.

The changes include:
- Added a new `clean_watermark_indices` field to the `Table` protobuf message that stores indices of watermark columns
- Deprecated the old `clean_watermark_index_in_pk` field but kept it for backward compatibility
- Added helper methods to get watermark indices with backward compatibility
- Updated the database schema with a new migration

TODO:
- Storage layer should start to use `get_clean_watermark_indices` to decide all the watermark columns can be used for cleaning.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.