### PR TITLE
fix(test): Use tokio time pausing in ut to avoid unstable clocks for periodic barriers

### DIFF
--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -15,7 +15,6 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
 use assert_matches::assert_matches;
@@ -31,6 +30,7 @@ use risingwave_pb::catalog::Database;
 use rw_futures_util::pending_on_none;
 use tokio::select;
 use tokio::sync::{oneshot, watch};
+use tokio::time::{Duration, Instant};
 use tokio_stream::wrappers::IntervalStream;
 use tokio_stream::{StreamExt, StreamMap};
 use tracing::{info, warn};
@@ -903,7 +903,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_next_barrier_with_different_intervals() {
         // Create databases with different intervals
         let databases = vec![
@@ -931,23 +931,40 @@ mod tests {
         // the first barrier should come from database 1 (50ms interval)
         let start_time = Instant::now();
         let barrier = periodic.next_barrier(&context).await;
-        let _elapsed = start_time.elapsed();
+        let mut elapsed = start_time.elapsed();
 
         // Verify the barrier properties
         assert_eq!(barrier.database_id, DatabaseId::from(1));
         assert!(barrier.command.is_none()); // Should be a periodic barrier, not a scheduled command
         assert!(barrier.checkpoint); // Second barrier should be checkpoint for database 1
-        // TODO(zyx): unstable in ci, temporarily commented out
-        // assert!(
-        //     elapsed <= Duration::from_millis(100),
-        //     "Elapsed time exceeded: {:?}",
-        //     elapsed
-        // ); // Should be around 50ms
+        // Use tokio's time pause mechanism, so it will be exactly 50ms here.
+        assert_eq!(
+            elapsed,
+            Duration::from_millis(50),
+            "Elapsed time exceeded: {:?}",
+            elapsed
+        );
 
         // Verify that the checkpoint frequency works
         let db1_id = DatabaseId::from(1);
         let db1_state = periodic.databases.get_mut(&db1_id).unwrap();
         assert_eq!(db1_state.num_uncheckpointed_barrier, 0); // Should reset after checkpoint
+
+        // Next barrier should come from database 1 and database 2 at 100ms
+        for _ in 0..2 {
+            let barrier = periodic.next_barrier(&context).await;
+            assert!(barrier.command.is_none()); // Should be a periodic barrier, not a scheduled command
+            assert!(!barrier.checkpoint); // Next two barriers shouldn't be checkpoints
+        }
+
+        elapsed = start_time.elapsed();
+
+        assert_eq!(
+            elapsed,
+            Duration::from_millis(100),
+            "Elapsed time exceeded: {:?}",
+            elapsed
+        );
     }
 
     #[tokio::test]
@@ -989,7 +1006,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_next_barrier_multiple_databases_timing() {
         let databases = vec![
             create_test_database(1, Some(30), Some(10)), // Fast interval
@@ -1024,7 +1041,8 @@ mod tests {
         let db2_count = barrier_counts.get(&DatabaseId::from(2)).unwrap_or(&0);
 
         // Due to timing, db1 should generally have more barriers, but allow for some variance
-        assert!(*db1_count >= *db2_count);
+        assert_eq!(*db1_count, 4);
+        assert_eq!(*db2_count, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Close #23899

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
