### PR TITLE
perf(streaming): remove `passed_actors` in barrier to reduce encoded size

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -213,9 +213,6 @@ message Barrier {
   map<string, string> tracing_context = 2;
   // The kind of the barrier.
   BarrierKind kind = 9;
-
-  // Record the actors that the barrier has passed. Only used for debugging.
-  repeated uint32 passed_actors = 255;
 }
 
 message Watermark {

--- a/src/meta/src/barrier/rpc.rs
+++ b/src/meta/src/barrier/rpc.rs
@@ -1005,7 +1005,6 @@ impl ControlStreamManager {
                         tracing_context: TracingContext::from_span(barrier_info.curr_epoch.span())
                             .to_protobuf(),
                         kind: barrier_info.kind.to_protobuf() as i32,
-                        passed_actors: vec![],
                     };
 
                     node.handle

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -582,9 +582,6 @@ for_all_wrapped_id_fields! (
             actor_splits: ActorId,
             actor_dispatchers: ActorId,
         }
-        Barrier {
-            passed_actors: ActorId,
-        }
         CdcFilterNode {
             upstream_source_id: SourceId,
         }

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -23,8 +23,7 @@ use risingwave_common::util::addr::{HostAddr, is_local_address};
 use super::permit::Receiver;
 use crate::executor::prelude::*;
 use crate::executor::{
-    BarrierInner, DispatcherBarrier, DispatcherMessage, DispatcherMessageBatch,
-    DispatcherMessageStreamItem,
+    BarrierInner, DispatcherMessage, DispatcherMessageBatch, DispatcherMessageStreamItem,
 };
 use crate::task::{FragmentId, LocalBarrierManager, UpDownActorIds, UpDownFragmentIds};
 
@@ -75,16 +74,6 @@ pub(crate) fn assert_equal_dispatcher_barrier<M1, M2>(
 ) {
     assert_eq!(first.epoch, second.epoch);
     assert_eq!(first.kind, second.kind);
-}
-
-pub(crate) fn apply_dispatcher_barrier(
-    recv_barrier: &mut Barrier,
-    dispatcher_barrier: DispatcherBarrier,
-) {
-    assert_equal_dispatcher_barrier(recv_barrier, &dispatcher_barrier);
-    recv_barrier
-        .passed_actors
-        .extend(dispatcher_barrier.passed_actors);
 }
 
 impl LocalInput {

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -257,15 +257,8 @@ impl MergeExecutor {
                     Message::Chunk(chunk)
                 }
                 DispatcherMessage::Barrier(barrier) => {
-                    tracing::debug!(
-                        target: "events::stream::barrier::path",
-                        actor_id = %actor_id,
-                        "receiver receives barrier from path: {:?}",
-                        barrier.passed_actors
-                    );
-                    let (mut barrier, new_inputs) =
+                    let (barrier, new_inputs) =
                         barrier_buffer.pop_barrier_with_inputs(barrier).await?;
-                    barrier.passed_actors.push(actor_id);
 
                     if let Some(Mutation::Update(UpdateMutation { dispatchers, .. })) =
                         barrier.mutation.as_deref()

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -59,8 +59,7 @@ use tokio::time::{Duration, Instant};
 
 use crate::error::StreamResult;
 use crate::executor::exchange::input::{
-    BoxedActorInput, BoxedInput, apply_dispatcher_barrier, assert_equal_dispatcher_barrier,
-    new_input,
+    BoxedActorInput, BoxedInput, assert_equal_dispatcher_barrier, new_input,
 };
 use crate::executor::monitor::ActorInputMetrics;
 use crate::executor::prelude::StreamingMetrics;
@@ -396,9 +395,6 @@ pub struct BarrierInner<M> {
 
     /// Tracing context for the **current** epoch of this barrier.
     pub tracing_context: TracingContext,
-
-    /// The actors that this barrier has passed locally. Used for debugging only.
-    pub passed_actors: Vec<ActorId>,
 }
 
 pub type BarrierMutationType = Option<Arc<Mutation>>;
@@ -413,7 +409,6 @@ impl<M: Default> BarrierInner<M> {
             kind: BarrierKind::Checkpoint,
             tracing_context: TracingContext::none(),
             mutation: Default::default(),
-            passed_actors: Default::default(),
         }
     }
 
@@ -423,7 +418,6 @@ impl<M: Default> BarrierInner<M> {
             kind: BarrierKind::Checkpoint,
             tracing_context: TracingContext::none(),
             mutation: Default::default(),
-            passed_actors: Default::default(),
         }
     }
 }
@@ -435,7 +429,6 @@ impl Barrier {
             mutation: (),
             kind: self.kind,
             tracing_context: self.tracing_context,
-            passed_actors: self.passed_actors,
         }
     }
 
@@ -1114,7 +1107,6 @@ impl<M> BarrierInner<M> {
             epoch,
             mutation,
             kind,
-            passed_actors,
             tracing_context,
             ..
         } = self;
@@ -1129,7 +1121,6 @@ impl<M> BarrierInner<M> {
             }),
             tracing_context: tracing_context.to_protobuf(),
             kind: *kind as _,
-            passed_actors: passed_actors.clone(),
         }
     }
 
@@ -1145,7 +1136,6 @@ impl<M> BarrierInner<M> {
             mutation: mutation_from_pb(
                 (prost.mutation.as_ref()).and_then(|mutation| mutation.mutation.as_ref()),
             )?,
-            passed_actors: prost.get_passed_actors().clone(),
             tracing_context: TracingContext::from_protobuf(&prost.tracing_context),
         })
     }
@@ -1156,7 +1146,6 @@ impl<M> BarrierInner<M> {
             mutation: f(self.mutation),
             kind: self.kind,
             tracing_context: self.tracing_context,
-            passed_actors: self.passed_actors,
         }
     }
 }
@@ -1773,8 +1762,8 @@ impl DispatchBarrierBuffer {
         while self.buffer.is_empty() {
             self.try_fetch_barrier_rx(false).await?;
         }
-        let (mut recv_barrier, inputs) = self.buffer.pop_front().unwrap();
-        apply_dispatcher_barrier(&mut recv_barrier, barrier);
+        let (recv_barrier, inputs) = self.buffer.pop_front().unwrap();
+        assert_equal_dispatcher_barrier(&recv_barrier, &barrier);
 
         Ok((recv_barrier, inputs))
     }

--- a/src/stream/src/executor/receiver.rs
+++ b/src/stream/src/executor/receiver.rs
@@ -127,15 +127,8 @@ impl Execute for ReceiverExecutor {
                         Message::Chunk(chunk)
                     }
                     DispatcherMessage::Barrier(barrier) => {
-                        tracing::debug!(
-                            target: "events::stream::barrier::path",
-                            actor_id = %actor_id,
-                            "receiver receives barrier from path: {:?}",
-                            barrier.passed_actors
-                        );
-                        let (mut barrier, new_inputs) =
+                        let (barrier, new_inputs) =
                             barrier_buffer.pop_barrier_with_inputs(barrier).await?;
-                        barrier.passed_actors.push(actor_id);
 
                         if let Some(update) = barrier
                             .as_update_merge(self.actor_context.id, self.upstream_fragment_id)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Removed `passed_actors` introduced long ago in #4911. It doesn't seem to be useful now. This may introduce significant overhead when encoding or decoding `Barrier` protobuf.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
