### PR TITLE
fix: notify local subscribers when streaming job backfill finishes

### DIFF
--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -325,6 +325,10 @@ impl TrackingJob {
         }
     }
 
+    pub(crate) fn job_id(&self) -> JobId {
+        self.job_id
+    }
+
     /// Notify the metadata manager that the job is finished.
     pub(crate) async fn finish(
         self,

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
+use risingwave_common::id::JobId;
 use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_meta_model::ObjectId;
 use risingwave_pb::common::{WorkerNode, WorkerType};
@@ -50,6 +51,7 @@ pub enum LocalNotification {
     FragmentMappingsUpsert(Vec<FragmentId>),
     FragmentMappingsDelete(Vec<FragmentId>),
     SourceDropped(ObjectId),
+    StreamingJobBackfillFinished(JobId),
 }
 
 #[derive(Debug)]
@@ -384,6 +386,7 @@ impl NotificationManagerCore {
 
 #[cfg(test)]
 mod tests {
+    use risingwave_common::id::JobId;
     use risingwave_pb::common::HostAddress;
 
     use super::*;
@@ -420,5 +423,22 @@ mod tests {
         assert!(rx1.try_recv().is_err());
         assert!(rx2.recv().await.is_some());
         assert!(rx3.recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_local_notification_backfill_finished() {
+        let mgr = NotificationManager::new(SqlMetaStore::for_test().await).await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        mgr.insert_local_sender(tx);
+
+        let job_id = JobId::new(42);
+        mgr.notify_local_subscribers(LocalNotification::StreamingJobBackfillFinished(job_id));
+
+        match rx.recv().await.expect("should receive notification") {
+            LocalNotification::StreamingJobBackfillFinished(received) => {
+                assert_eq!(received, job_id);
+            }
+            other => panic!("unexpected notification: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Add a new local notification variant to signal streaming job backfill completion within the meta service. This enables interested components to react to backfill completion events in a decoupled manner using existing notification infrastructure.

- Introduce `StreamingJobBackfillFinished(JobId)` in `LocalNotification` enum
- Expose `job_id()` getter on `TrackingJob` for cleaner access
- Emit local notification in `finish_creating_job` after job completion
- Add async unit test to verify notification dispatch and reception

## Checklist

- [x] I have written necessary rustdoc comments.

