### PR TITLE
feat(frontend): notify user to RECOVER when ALTER RATE LIMIT/PARALLEL take too long

### DIFF
--- a/src/frontend/src/handler/alter_parallelism.rs
+++ b/src/frontend/src/handler/alter_parallelism.rs
@@ -25,6 +25,7 @@ use super::alter_utils::resolve_streaming_job_id_for_alter;
 use super::{HandlerArgs, RwPgResponse};
 use crate::catalog::FragmentId;
 use crate::error::{ErrorCode, Result};
+use crate::handler::util::execute_with_long_running_notification;
 
 pub async fn handle_alter_parallelism(
     handler_args: HandlerArgs,
@@ -42,9 +43,12 @@ pub async fn handle_alter_parallelism(
     let mut builder = RwPgResponse::builder(stmt_type);
 
     let catalog_writer = session.catalog_writer()?;
-    catalog_writer
-        .alter_parallelism(job_id, target_parallelism, deferred)
-        .await?;
+    execute_with_long_running_notification(
+        catalog_writer.alter_parallelism(job_id, target_parallelism, deferred),
+        &session,
+        "ALTER PARALLELISM",
+    )
+    .await?;
 
     if deferred {
         builder = builder.notice("DEFERRED is used, please ensure that automatic parallelism control is enabled on the meta, otherwise, the alter will not take effect.".to_owned());

--- a/src/frontend/src/handler/alter_streaming_rate_limit.rs
+++ b/src/frontend/src/handler/alter_streaming_rate_limit.rs
@@ -22,6 +22,7 @@ use crate::Binder;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::table_catalog::TableType;
 use crate::error::{ErrorCode, Result};
+use crate::handler::util::execute_with_long_running_notification;
 use crate::session::SessionImpl;
 
 pub async fn handle_alter_streaming_rate_limit(
@@ -108,7 +109,12 @@ pub async fn handle_alter_streaming_rate_limit(
         }
         _ => bail!("Unsupported throttle target: {:?}", kind),
     };
-    handle_alter_streaming_rate_limit_by_id(&session, kind, id, rate_limit, stmt_type).await
+    execute_with_long_running_notification(
+        handle_alter_streaming_rate_limit_by_id(&session, kind, id, rate_limit, stmt_type),
+        &session,
+        "ALTER STREAMING RATE LIMIT",
+    )
+    .await
 }
 
 pub async fn handle_alter_streaming_rate_limit_by_id(


### PR DESCRIPTION
I hereby agree to the terms of the [[RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt)](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR extends the long-running DDL notification framework to include ALTER RATE LIMIT and ALTER PARALLELISM. These ALTER commands require a barrier-aligned mutation to take effect and may seem stuck when the cluster is busy. We now trigger a user notice if the change hasn't taken effect after the configured timeout. The notice explains that the ALTER will apply after the next barrier and suggests running RECOVER to make it happen immediately. This addresses issue #23808 and improves transparency for users.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline] and [Currently Supported Versions] to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

This PR introduces a timeout-based notice for ALTER RATE LIMIT and ALTER PARALLELISM operations. If these ALTER commands take longer than the configured `slow_ddl_notification_secs` due to barrier latency, the system will inform the user that the change will apply after the next barrier and suggest running `RECOVER` to apply it immediately. This improves user awareness of streaming latency and helps them take action when necessary.

</details>