### PR TITLE
fix: remove assigned_parallelism from stream job fragments

### DIFF
--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -79,7 +79,6 @@ use crate::manager::{ActiveStreamingWorkerNodes, LocalNotification, Notification
 use crate::model::{
     DownstreamFragmentRelation, Fragment, FragmentActorDispatchers, FragmentDownstreamRelation,
     StreamActor, StreamContext, StreamJobFragments, StreamingJobModelContextExt as _,
-    TableParallelism,
 };
 use crate::rpc::ddl_controller::build_upstream_sink_info;
 use crate::stream::UpstreamSinkInfo;
@@ -266,7 +265,6 @@ impl CatalogController {
         state: PbState,
         ctx: StreamContext,
         fragments: Vec<(fragment::Model, Vec<ActorInfo>)>,
-        parallelism: StreamingParallelism,
         max_parallelism: usize,
         job_definition: Option<String>,
     ) -> MetaResult<StreamJobFragments> {
@@ -287,11 +285,6 @@ impl CatalogController {
             fragments: pb_fragments,
             actor_status: pb_actor_status,
             ctx,
-            assigned_parallelism: match parallelism {
-                StreamingParallelism::Custom => TableParallelism::Custom,
-                StreamingParallelism::Adaptive => TableParallelism::Adaptive,
-                StreamingParallelism::Fixed(n) => TableParallelism::Fixed(n as _),
-            },
             max_parallelism,
         };
 
@@ -570,7 +563,6 @@ impl CatalogController {
             job_info.job_status.into(),
             job_info.stream_context(),
             fragment_actors,
-            job_info.parallelism.clone(),
             job_info.max_parallelism as _,
             job_definition,
         )
@@ -960,7 +952,6 @@ impl CatalogController {
                     job.job_status.into(),
                     job.stream_context(),
                     fragment_actors,
-                    job.parallelism.clone(),
                     job.max_parallelism as _,
                     job_definition.remove(&job.job_id),
                 )?,

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -82,7 +82,6 @@ use crate::manager::{
 use crate::model::{
     DownstreamFragmentRelation, Fragment, FragmentDownstreamRelation,
     FragmentId as CatalogFragmentId, StreamContext, StreamJobFragments, StreamJobFragmentsToCreate,
-    TableParallelism,
 };
 use crate::stream::cdc::{
     is_parallelized_backfill_enabled, try_init_parallel_cdc_table_snapshot_splits,
@@ -1796,19 +1795,11 @@ impl DdlController {
         // and the context that contains all information needed for building the
         // actors on the compute nodes.
 
-        // If the frontend does not specify the degree of parallelism and the default_parallelism is set to full, then set it to ADAPTIVE.
-        // Otherwise, it defaults to FIXED based on deduction.
-        let table_parallelism = match (specified_parallelism, &self.env.opts.default_parallelism) {
-            (None, DefaultParallelism::Full) => TableParallelism::Adaptive,
-            _ => TableParallelism::Fixed(parallelism.get()),
-        };
-
         let stream_job_fragments = StreamJobFragments::new(
             id,
             graph,
             &building_locations.actor_locations,
             stream_ctx.clone(),
-            table_parallelism,
             max_parallelism.get(),
         );
 
@@ -2068,7 +2059,6 @@ impl DdlController {
             graph,
             &building_locations.actor_locations,
             stream_ctx,
-            old_fragments.assigned_parallelism,
             old_fragments.max_parallelism,
         );
 


### PR DESCRIPTION
Remove the `assigned_parallelism` field from `StreamJobFragments` and related code to decouple parallelism state from fragment models. Parallelism is now fetched dynamically and passed during protobuf conversion or fragment construction.

- StreamJobFragments no longer store parallelism internally
- Catalog controller and fragment builder updated to exclude parallelism
- ScaleService and dashboard handlers query parallelism from catalog controller
- Default to `TableParallelism::Adaptive` if parallelism info is missing
- Simplifies fragment model and ensures up-to-date parallelism tracking

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
