### PR TITLE
docs: add missing CARGO_PROFILE build arg

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -89,7 +89,7 @@ The docker images for x86_64 are built with AVX2 SIMD extensions, while the imag
 To build the images, simply run:
 
 ```
-docker build . -f docker/Dockerfile
+docker build . -f docker/Dockerfile --build-arg CARGO_PROFILE=release
 ```
 
 from the project root.
@@ -97,7 +97,7 @@ from the project root.
 To build the images without SIMD vector extensions, run
 
 ```
-docker build . -f docker/Dockerfile --build-arg simd_disabled=true
+docker build . -f docker/Dockerfile --build-arg CARGO_PROFILE=release --build-arg simd_disabled=true
 ```
 
 from the project root and run any subsequent docker commands on the resultant image.


### PR DESCRIPTION
## What's changed and what's your intention?

In the process of building a Docker image, a profile also [needs to be set](https://github.com/risingwavelabs/risingwave/blob/855104222f00800bd8470b5ebb87109c8e3e1de2/docker/Dockerfile#L79).

```
ARG CARGO_PROFILE
ENV CARGO_PROFILE=$CARGO_PROFILE

RUN cargo fetch && \
  cargo build -p risingwave_cmd_all --profile ${CARGO_PROFILE}
```

In this PR, the image build command example has been updated to also set this argument.
