### PR TITLE
feat(storage): support state clean for watermark in either pk or value column

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -135,6 +135,13 @@ message VnodeWatermark {
   common.Buffer vnode_bitmap = 2;
 }
 
+enum WatermarkSerdeType {
+  TYPE_UNSPECIFIED = 0;
+  PK_PREFIX = 1;
+  NON_PK_PREFIX = 2;
+  VALUE = 3;
+}
+
 // Table watermark is a lighter weight range delete introduced in
 // https://github.com/risingwavelabs/risingwave/issues/13148
 // It means the lowest (or highest when `is_ascending` is false) visible
@@ -154,7 +161,10 @@ message TableWatermarks {
   bool is_ascending = 2;
 
   // The table watermark is non-pk prefix table watermark.
-  bool is_non_pk_prefix = 3;
+  // Deprecated. use WatermarkSerdeType instead;
+  bool is_non_pk_prefix = 3 [deprecated = true];
+
+  WatermarkSerdeType raw_watermark_serde_type = 4;
 }
 
 message EpochNewChangeLog {

--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -24,7 +24,7 @@ use risingwave_storage::compaction_catalog_manager::CompactionCatalogAgent;
 use risingwave_storage::hummock::iterator::{
     Forward, HummockIterator, HummockIteratorUnion, MergeIterator,
     NonPkPrefixSkipWatermarkIterator, NonPkPrefixSkipWatermarkState, PkPrefixSkipWatermarkIterator,
-    PkPrefixSkipWatermarkState,
+    PkPrefixSkipWatermarkState, ValueSkipWatermarkIterator, ValueSkipWatermarkState,
 };
 use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::{
     SharedBufferBatch, SharedBufferBatchIterator, SharedBufferValue,
@@ -130,6 +130,35 @@ fn criterion_benchmark(c: &mut Criterion) {
     let merge_iter = RefCell::new(combine_iter);
     c.bench_with_input(
         BenchmarkId::new("bench-merge-iter-skip-empty-watermark", "unordered"),
+        &merge_iter,
+        |b, iter_ref| {
+            b.iter(|| {
+                run_iter(iter_ref, 100 * 10000);
+            });
+        },
+    );
+
+    let combine_iter = {
+        let iter = PkPrefixSkipWatermarkIterator::new(
+            MergeIterator::new(gen_interleave_shared_buffer_batch_iter(10000, 100)),
+            PkPrefixSkipWatermarkState::new(BTreeMap::new()),
+        );
+
+        NonPkPrefixSkipWatermarkIterator::new(
+            iter,
+            NonPkPrefixSkipWatermarkState::new(
+                BTreeMap::new(),
+                Arc::new(CompactionCatalogAgent::dummy()),
+            ),
+        )
+    };
+    let combine_3_iter = ValueSkipWatermarkIterator::new(
+        combine_iter,
+        ValueSkipWatermarkState::new(BTreeMap::new(), Arc::new(CompactionCatalogAgent::dummy())),
+    );
+    let merge_iter = RefCell::new(combine_3_iter);
+    c.bench_with_input(
+        BenchmarkId::new("bench-merge-iter-skip-empty-watermark-3-iter", "unordered"),
         &merge_iter,
         |b, iter_ref| {
             b.iter(|| {

--- a/src/storage/hummock_sdk/src/compact_task.rs
+++ b/src/storage/hummock_sdk/src/compact_task.rs
@@ -73,6 +73,7 @@ pub struct CompactTask {
     pub pk_prefix_table_watermarks: BTreeMap<TableId, TableWatermarks>,
 
     pub non_pk_prefix_table_watermarks: BTreeMap<TableId, TableWatermarks>,
+    pub value_table_watermarks: BTreeMap<TableId, TableWatermarks>,
 
     pub table_schemas: BTreeMap<TableId, PbTableSchema>,
 
@@ -122,6 +123,11 @@ impl CompactTask {
                 .sum::<usize>()
             + self
                 .non_pk_prefix_table_watermarks
+                .values()
+                .map(|table_watermark| size_of::<u32>() + table_watermark.estimated_encode_len())
+                .sum::<usize>()
+            + self
+                .value_table_watermarks
                 .values()
                 .map(|table_watermark| size_of::<u32>() + table_watermark.estimated_encode_len())
                 .sum::<usize>()
@@ -233,6 +239,37 @@ impl CompactTask {
     }
 }
 
+fn split_watermark_serde_types(
+    pb_compact_task: &PbCompactTask,
+) -> (
+    BTreeMap<TableId, TableWatermarks>,
+    BTreeMap<TableId, TableWatermarks>,
+    BTreeMap<TableId, TableWatermarks>,
+) {
+    let mut pk_prefix_table_watermarks = BTreeMap::default();
+    let mut non_pk_prefix_table_watermarks = BTreeMap::default();
+    let mut value_table_watermarks = BTreeMap::default();
+    for (table_id, pbwatermark) in &pb_compact_task.table_watermarks {
+        let watermark = TableWatermarks::from(pbwatermark);
+        match watermark.watermark_type {
+            WatermarkSerdeType::PkPrefix => {
+                pk_prefix_table_watermarks.insert(*table_id, watermark);
+            }
+            WatermarkSerdeType::NonPkPrefix => {
+                non_pk_prefix_table_watermarks.insert(*table_id, watermark);
+            }
+            WatermarkSerdeType::Value => {
+                value_table_watermarks.insert(*table_id, watermark);
+            }
+        }
+    }
+    (
+        pk_prefix_table_watermarks,
+        non_pk_prefix_table_watermarks,
+        value_table_watermarks,
+    )
+}
+
 pub fn is_compaction_task_expired(
     compaction_group_version_id_in_task: u64,
     compaction_group_version_id_expected: u64,
@@ -242,20 +279,8 @@ pub fn is_compaction_task_expired(
 
 impl From<PbCompactTask> for CompactTask {
     fn from(pb_compact_task: PbCompactTask) -> Self {
-        let (pk_prefix_table_watermarks, non_pk_prefix_table_watermarks) = pb_compact_task
-            .table_watermarks
-            .into_iter()
-            .map(|(table_id, pb_table_watermark)| {
-                let table_watermark = TableWatermarks::from(pb_table_watermark);
-                (table_id, table_watermark)
-            })
-            .partition(|(_table_id, table_watermarke)| {
-                matches!(
-                    table_watermarke.watermark_type,
-                    WatermarkSerdeType::PkPrefix
-                )
-            });
-
+        let (pk_prefix_table_watermarks, non_pk_prefix_table_watermarks, value_table_watermarks) =
+            split_watermark_serde_types(&pb_compact_task);
         #[expect(deprecated)]
         Self {
             input_ssts: pb_compact_task
@@ -304,6 +329,7 @@ impl From<PbCompactTask> for CompactTask {
                 .collect(),
             pk_prefix_table_watermarks,
             non_pk_prefix_table_watermarks,
+            value_table_watermarks,
             table_schemas: pb_compact_task
                 .table_schemas
                 .iter()
@@ -318,20 +344,8 @@ impl From<PbCompactTask> for CompactTask {
 
 impl From<&PbCompactTask> for CompactTask {
     fn from(pb_compact_task: &PbCompactTask) -> Self {
-        let (pk_prefix_table_watermarks, non_pk_prefix_table_watermarks) = pb_compact_task
-            .table_watermarks
-            .iter()
-            .map(|(table_id, pb_table_watermark)| {
-                let table_watermark = TableWatermarks::from(pb_table_watermark);
-                (*table_id, table_watermark)
-            })
-            .partition(|(_table_id, table_watermarke)| {
-                matches!(
-                    table_watermarke.watermark_type,
-                    WatermarkSerdeType::PkPrefix
-                )
-            });
-
+        let (pk_prefix_table_watermarks, non_pk_prefix_table_watermarks, value_table_watermarks) =
+            split_watermark_serde_types(pb_compact_task);
         #[expect(deprecated)]
         Self {
             input_ssts: pb_compact_task
@@ -380,6 +394,7 @@ impl From<&PbCompactTask> for CompactTask {
                 .collect(),
             pk_prefix_table_watermarks,
             non_pk_prefix_table_watermarks,
+            value_table_watermarks,
             table_schemas: pb_compact_task
                 .table_schemas
                 .iter()
@@ -435,6 +450,7 @@ impl From<CompactTask> for PbCompactTask {
                 .pk_prefix_table_watermarks
                 .into_iter()
                 .chain(compact_task.non_pk_prefix_table_watermarks)
+                .chain(compact_task.value_table_watermarks)
                 .map(|(table_id, table_watermark)| (table_id, table_watermark.into()))
                 .collect(),
             split_by_state_table: compact_task.split_by_state_table,
@@ -489,6 +505,7 @@ impl From<&CompactTask> for PbCompactTask {
                 .pk_prefix_table_watermarks
                 .iter()
                 .chain(compact_task.non_pk_prefix_table_watermarks.iter())
+                .chain(compact_task.value_table_watermarks.iter())
                 .map(|(table_id, table_watermark)| (*table_id, table_watermark.into()))
                 .collect(),
             split_by_state_table: compact_task.split_by_state_table,

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -917,6 +917,7 @@ pub(crate) mod tests {
             FilterKeyExtractorImpl::Multi(multi_filter_key_extractor),
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            HashMap::default(),
         ));
 
         let compact_ctx = get_compactor_context(&storage);

--- a/src/storage/hummock_trace/src/opts.rs
+++ b/src/storage/hummock_trace/src/opts.rs
@@ -257,7 +257,7 @@ pub struct TracedInitOptions {
 #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode)]
 pub struct TracedSealCurrentEpochOptions {
     // The watermark is serialized into protobuf
-    pub table_watermarks: Option<(bool, Vec<Vec<u8>>, bool)>,
+    pub table_watermarks: Option<(bool, Vec<Vec<u8>>, i32)>,
     pub switch_op_consistency_level: Option<bool>,
 }
 

--- a/src/storage/src/compaction_catalog_manager.rs
+++ b/src/storage/src/compaction_catalog_manager.rs
@@ -14,14 +14,18 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
+use std::iter;
 use std::sync::Arc;
 
 use itertools::Itertools;
 use parking_lot::RwLock;
 use risingwave_common::catalog::{ColumnDesc, TableId};
 use risingwave_common::hash::{VirtualNode, VnodeCountCompat};
+use risingwave_common::util::memcmp_encoding;
 use risingwave_common::util::row_serde::OrderedRowSerde;
 use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
+use risingwave_common::util::value_encoding::{BasicSerde, EitherSerde, ValueRowDeserializer};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::key::{TABLE_PREFIX_LEN, get_table_id};
 use risingwave_pb::catalog::Table;
@@ -30,6 +34,7 @@ use risingwave_rpc_client::error::{Result as RpcResult, RpcError};
 use thiserror_ext::AsReport;
 
 use crate::hummock::{HummockError, HummockResult};
+use crate::row_serde::value_serde::ValueRowSerdeNew;
 
 /// `FilterKeyExtractor` generally used to extract key which will store in BloomFilter
 pub trait FilterKeyExtractor: Send + Sync {
@@ -316,6 +321,7 @@ impl CompactionCatalogManager {
         let mut multi_filter_key_extractor = MultiFilterKeyExtractor::default();
         let mut table_id_to_vnode = HashMap::new();
         let mut table_id_to_watermark_serde = HashMap::new();
+        let mut table_id_to_value_watermark_serde = HashMap::new();
 
         {
             let guard = self.table_id_to_catalog.read();
@@ -331,6 +337,10 @@ impl CompactionCatalogManager {
                     // watermark
                     table_id_to_watermark_serde
                         .insert(*table_id, build_watermark_col_serde(table_catalog));
+                    table_id_to_value_watermark_serde.insert(
+                        *table_id,
+                        build_value_watermark_col_serde(table_catalog).map(Arc::new),
+                    );
 
                     false
                 }
@@ -358,6 +368,7 @@ impl CompactionCatalogManager {
                     let key_extractor = FilterKeyExtractorImpl::from_table(&table);
                     let vnode = table.vnode_count();
                     let watermark_serde = build_watermark_col_serde(&table);
+                    let value_watermark_serde = build_value_watermark_col_serde(&table);
                     guard.insert(table_id, table);
                     // filter-key-extractor
                     multi_filter_key_extractor.register(table_id, key_extractor);
@@ -367,6 +378,8 @@ impl CompactionCatalogManager {
 
                     // watermark
                     table_id_to_watermark_serde.insert(table_id, watermark_serde);
+                    table_id_to_value_watermark_serde
+                        .insert(table_id, value_watermark_serde.map(Arc::new));
                 }
             }
         }
@@ -375,6 +388,7 @@ impl CompactionCatalogManager {
             FilterKeyExtractorImpl::Multi(multi_filter_key_extractor),
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            table_id_to_value_watermark_serde,
         )))
     }
 
@@ -385,6 +399,7 @@ impl CompactionCatalogManager {
         let mut multi_filter_key_extractor = MultiFilterKeyExtractor::default();
         let mut table_id_to_vnode = HashMap::new();
         let mut table_id_to_watermark_serde = HashMap::new();
+        let mut value_table_id_to_watermark_serde = HashMap::new();
         for (table_id, table_catalog) in table_catalogs {
             // filter-key-extractor
             multi_filter_key_extractor
@@ -395,12 +410,17 @@ impl CompactionCatalogManager {
 
             // watermark
             table_id_to_watermark_serde.insert(table_id, build_watermark_col_serde(&table_catalog));
+            value_table_id_to_watermark_serde.insert(
+                table_id,
+                build_value_watermark_col_serde(&table_catalog).map(Arc::new),
+            );
         }
 
         Arc::new(CompactionCatalogAgent::new(
             FilterKeyExtractorImpl::Multi(multi_filter_key_extractor),
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            value_table_id_to_watermark_serde,
         ))
     }
 }
@@ -415,6 +435,7 @@ pub struct CompactionCatalogAgent {
     // cache for reduce serde build
     table_id_to_watermark_serde:
         HashMap<StateTableId, Option<(OrderedRowSerde, OrderedRowSerde, usize)>>,
+    value_table_id_to_watermark_serde: HashMap<StateTableId, Option<ValueWatermarkColumnSerdeRef>>,
 }
 
 impl CompactionCatalogAgent {
@@ -425,11 +446,16 @@ impl CompactionCatalogAgent {
             StateTableId,
             Option<(OrderedRowSerde, OrderedRowSerde, usize)>,
         >,
+        value_table_id_to_watermark_serde: HashMap<
+            StateTableId,
+            Option<ValueWatermarkColumnSerdeRef>,
+        >,
     ) -> Self {
         Self {
             filter_key_extractor_manager,
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            value_table_id_to_watermark_serde,
         }
     }
 
@@ -438,6 +464,7 @@ impl CompactionCatalogAgent {
             filter_key_extractor_manager: FilterKeyExtractorImpl::Dummy(DummyFilterKeyExtractor),
             table_id_to_vnode: Default::default(),
             table_id_to_watermark_serde: Default::default(),
+            value_table_id_to_watermark_serde: Default::default(),
         }
     }
 
@@ -455,10 +482,16 @@ impl CompactionCatalogAgent {
             .map(|table_id| (*table_id, None))
             .collect();
 
+        let value_table_id_to_watermark_serde = table_id_to_vnode
+            .keys()
+            .map(|table_id| (*table_id, None))
+            .collect();
+
         Arc::new(CompactionCatalogAgent::new(
             full_key_filter_key_extractor,
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            value_table_id_to_watermark_serde,
         ))
     }
 }
@@ -489,6 +522,22 @@ impl CompactionCatalogAgent {
                     "table_id not found {} all_table_ids {:?}",
                     table_id,
                     self.table_id_to_watermark_serde.keys()
+                )
+            })
+            .clone()
+    }
+
+    pub fn value_watermark_serde(
+        &self,
+        table_id: StateTableId,
+    ) -> Option<ValueWatermarkColumnSerdeRef> {
+        self.value_table_id_to_watermark_serde
+            .get(&table_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "table_id not found {} all_table_ids {:?}",
+                    table_id,
+                    self.value_table_id_to_watermark_serde.keys()
                 )
             })
             .clone()
@@ -548,6 +597,120 @@ fn build_watermark_col_serde(
             let watermark_col_serde = pk_serde.index(clean_watermark_index_in_pk).into_owned();
             Some((pk_serde, watermark_col_serde, clean_watermark_index_in_pk))
         }
+    }
+}
+
+fn build_value_watermark_col_serde(table_catalog: &Table) -> Option<ValueWatermarkColumnSerde> {
+    /// Returns the column index of non-pk watermark column.
+    pub fn try_get_non_pk_clean_watermark_column_index(table: &Table) -> Option<usize> {
+        table
+            .get_clean_watermark_column_indices()
+            .iter()
+            .filter_map(|&col_idx| {
+                if table
+                    .pk
+                    .iter()
+                    .any(|col_order| col_order.column_index == col_idx)
+                {
+                    return None;
+                }
+                Some(col_idx as usize)
+            })
+            .at_most_one()
+            .unwrap()
+    }
+
+    let clean_watermark_index = try_get_non_pk_clean_watermark_column_index(table_catalog)?;
+    Some(ValueWatermarkColumnSerde::new(
+        table_catalog,
+        clean_watermark_index,
+    ))
+}
+
+pub struct ValueWatermarkColumnSerde {
+    /// For `ColumnAwareSerde`, only 1 column is deserialized.
+    row_serde: EitherSerde,
+    /// For `ColumnAwareSerde`, index have been rewritten to 0.
+    watermark_index_in_de_row: usize,
+    watermark_column_mem_encoding_order: OrderType,
+}
+
+pub type ValueWatermarkColumnSerdeRef = Arc<ValueWatermarkColumnSerde>;
+
+impl ValueWatermarkColumnSerde {
+    fn new(table_catalog: &Table, clean_watermark_index: usize) -> Self {
+        let table_columns: Vec<ColumnDesc> = table_catalog
+            .columns
+            .iter()
+            .map(|col| col.column_desc.as_ref().unwrap().into())
+            .collect();
+        let pk_order_type = table_catalog
+            .pk
+            .iter()
+            .filter_map(|col_order| {
+                if col_order.column_index as usize == clean_watermark_index {
+                    return Some(OrderType::from_protobuf(
+                        col_order.get_order_type().unwrap(),
+                    ));
+                }
+                None
+            })
+            .at_most_one()
+            .unwrap();
+        // Correctness requires the assumption that a table contains at most one watermark column.
+        let watermark_column_mem_encoding_order = match pk_order_type {
+            Some(o) => o,
+            // Correctness requires the assumption that the order is the same as the one used in StateTable when serializing watermark for value column.
+            None => OrderType::ascending(),
+        };
+        // Correctness requires the assumption that the watermark column is stored in the value. (See comment on Table::value_indices.)
+        let Some(watermark_index_in_value_indices) = table_catalog
+            .value_indices
+            .iter()
+            .position(|p| *p as usize == clean_watermark_index)
+        else {
+            panic!(
+                "Watermark index {} not found in value_indices {:?}.",
+                clean_watermark_index, table_catalog.value_indices
+            );
+        };
+        let (row_serde, watermark_index_in_de_row) = if table_catalog.version.is_none() {
+            let row_serde = BasicSerde::new(
+                Arc::from_iter(table_catalog.value_indices.iter().map(|val| *val as usize)),
+                Arc::from(table_columns.into_boxed_slice()),
+            )
+            .into();
+            (row_serde, watermark_index_in_value_indices)
+        } else {
+            let row_serde = ColumnAwareSerde::new(
+                Arc::from_iter(iter::once(clean_watermark_index)),
+                Arc::from(table_columns.into_boxed_slice()),
+            )
+            .into();
+            // Only one column.
+            (row_serde, 0)
+        };
+        Self {
+            row_serde,
+            watermark_index_in_de_row,
+            watermark_column_mem_encoding_order,
+        }
+    }
+
+    pub fn deserialize(&self, encoded_bytes: &[u8]) -> HummockResult<Option<Vec<u8>>> {
+        let mut row = self
+            .row_serde
+            .deserialize(encoded_bytes)
+            .map_err(HummockError::decode_error)?;
+        if self.watermark_index_in_de_row >= row.len() {
+            // The watermark column has been dropped in column aware row encoding.
+            return Ok(None);
+        }
+        let datum = std::mem::take(&mut row[self.watermark_index_in_de_row]);
+        // Correctness requires on the assumption that the watermark is serialized using memcmp_encoding in StateTable.
+        let bytes = memcmp_encoding::encode_value(datum, self.watermark_column_mem_encoding_order)
+            .map_err(HummockError::encode_error)?;
+        Ok(Some(bytes.into()))
     }
 }
 

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -56,7 +56,7 @@ use crate::hummock::compactor::{
 use crate::hummock::iterator::{
     Forward, HummockIterator, MergeIterator, NonPkPrefixSkipWatermarkIterator,
     NonPkPrefixSkipWatermarkState, PkPrefixSkipWatermarkIterator, PkPrefixSkipWatermarkState,
-    ValueMeta,
+    ValueMeta, ValueSkipWatermarkIterator, ValueSkipWatermarkState,
 };
 use crate::hummock::multi_builder::{CapacitySplitTableBuilder, TableBuilderFactory};
 use crate::hummock::utils::MemoryTracker;
@@ -235,6 +235,8 @@ impl CompactorRunner {
             }
         }
 
+        // // The `SkipWatermarkIterator` is used to handle the table watermark state cleaning introduced
+        // // in https://github.com/risingwavelabs/risingwave/issues/13148
         // The `Pk/NonPkPrefixSkipWatermarkIterator` is used to handle the table watermark state cleaning introduced
         // in https://github.com/risingwavelabs/risingwave/issues/13148
         let combine_iter = {
@@ -248,10 +250,18 @@ impl CompactorRunner {
                 ),
             );
 
-            NonPkPrefixSkipWatermarkIterator::new(
+            let pk_skip_watermark_iter = NonPkPrefixSkipWatermarkIterator::new(
                 skip_watermark_iter,
                 NonPkPrefixSkipWatermarkState::from_safe_epoch_watermarks(
                     self.compact_task.non_pk_prefix_table_watermarks.clone(),
+                    compaction_catalog_agent_ref.clone(),
+                ),
+            );
+
+            ValueSkipWatermarkIterator::new(
+                pk_skip_watermark_iter,
+                ValueSkipWatermarkState::from_safe_epoch_watermarks(
+                    self.compact_task.value_table_watermarks.clone(),
                     compaction_catalog_agent_ref,
                 ),
             )

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::marker::PhantomData;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, atomic};
@@ -29,6 +29,7 @@ use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_stats::TableStats;
+use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::{EpochWithGap, LocalSstableInfo, can_concat, compact_task_to_string};
 
 use crate::compaction_catalog_manager::CompactionCatalogAgentRef;
@@ -40,6 +41,7 @@ use crate::hummock::compactor::{
 };
 use crate::hummock::iterator::{
     NonPkPrefixSkipWatermarkState, PkPrefixSkipWatermarkState, SkipWatermarkState,
+    ValueSkipWatermarkState,
 };
 use crate::hummock::multi_builder::{CapacitySplitTableBuilder, TableBuilderFactory};
 use crate::hummock::sstable_store::SstableStoreRef;
@@ -433,11 +435,17 @@ impl<C: CompactionFilter> CompactorRunner<C> {
         ));
 
         // Can not consume the watermarks because the watermarks may be used by `check_compact_result`.
-        let state = PkPrefixSkipWatermarkState::from_safe_epoch_watermarks(
+        let pk_prefix_state = PkPrefixSkipWatermarkState::from_safe_epoch_watermarks(
             task.pk_prefix_table_watermarks.clone(),
         );
         let non_pk_prefix_state = NonPkPrefixSkipWatermarkState::from_safe_epoch_watermarks(
             task.non_pk_prefix_table_watermarks.clone(),
+            compaction_catalog_agent_ref.clone(),
+        );
+        // TODO: get value_table_watermarks from compaction task
+        let value_table_watermarks: BTreeMap<TableId, TableWatermarks> = BTreeMap::default();
+        let value_skip_watermark_state = ValueSkipWatermarkState::from_safe_epoch_watermarks(
+            value_table_watermarks,
             compaction_catalog_agent_ref,
         );
 
@@ -446,8 +454,9 @@ impl<C: CompactionFilter> CompactorRunner<C> {
                 sst_builder,
                 task_config,
                 task_progress,
-                state,
+                pk_prefix_state,
                 non_pk_prefix_state,
+                value_skip_watermark_state,
                 compaction_filter,
             ),
             left,
@@ -640,10 +649,11 @@ pub struct CompactTaskExecutor<F: TableBuilderFactory, C: CompactionFilter> {
     builder: CapacitySplitTableBuilder<F>,
     task_config: TaskConfig,
     task_progress: Arc<TaskProgress>,
-    skip_watermark_state: PkPrefixSkipWatermarkState,
+    pk_prefix_skip_watermark_state: PkPrefixSkipWatermarkState,
     last_key_is_delete: bool,
     progress_key_num: u32,
     non_pk_prefix_skip_watermark_state: NonPkPrefixSkipWatermarkState,
+    value_skip_watermark_state: ValueSkipWatermarkState,
     compaction_filter: C,
 }
 
@@ -652,8 +662,9 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
         builder: CapacitySplitTableBuilder<F>,
         task_config: TaskConfig,
         task_progress: Arc<TaskProgress>,
-        skip_watermark_state: PkPrefixSkipWatermarkState,
+        pk_prefix_skip_watermark_state: PkPrefixSkipWatermarkState,
         non_pk_prefix_skip_watermark_state: NonPkPrefixSkipWatermarkState,
+        value_skip_watermark_state: ValueSkipWatermarkState,
         compaction_filter: C,
     ) -> Self {
         Self {
@@ -665,9 +676,10 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
             last_table_id: None,
             last_table_stats: TableStats::default(),
             task_progress,
-            skip_watermark_state,
+            pk_prefix_skip_watermark_state,
             progress_key_num: 0,
             non_pk_prefix_skip_watermark_state,
+            value_skip_watermark_state,
             compaction_filter,
         }
     }
@@ -704,7 +716,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
         iter: &mut BlockIterator,
         target_key: FullKey<&[u8]>,
     ) -> HummockResult<()> {
-        self.skip_watermark_state.reset_watermark();
+        self.pk_prefix_skip_watermark_state.reset_watermark();
         self.non_pk_prefix_skip_watermark_state.reset_watermark();
 
         while iter.is_valid() && iter.key().le(&target_key) {
@@ -736,7 +748,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
                 drop = true;
             }
 
-            if !drop && self.watermark_should_delete(&iter.key()) {
+            if !drop && self.watermark_should_delete(&iter.key(), value) {
                 drop = true;
                 self.last_key_is_delete = true;
             }
@@ -782,7 +794,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
             return false;
         }
 
-        if self.watermark_should_delete(smallest_key) {
+        if self.watermark_may_delete(smallest_key) {
             return false;
         }
 
@@ -794,9 +806,43 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
         true
     }
 
-    fn watermark_should_delete(&mut self, key: &FullKey<&[u8]>) -> bool {
-        (self.skip_watermark_state.has_watermark() && self.skip_watermark_state.should_delete(key))
+    fn watermark_may_delete(&mut self, key: &FullKey<&[u8]>) -> bool {
+        // Correctness requires the assumption that these PkPrefixSkipWatermarkState and NonPkPrefixSkipWatermarkState never use the `unused_put`.
+        let pk_prefix_has_watermark = self.pk_prefix_skip_watermark_state.has_watermark();
+        let non_pk_prefix_has_watermark = self.non_pk_prefix_skip_watermark_state.has_watermark();
+        if pk_prefix_has_watermark || non_pk_prefix_has_watermark {
+            let unused = vec![];
+            let unused_put = HummockValue::Put(unused.as_slice());
+            if (pk_prefix_has_watermark
+                && self
+                    .pk_prefix_skip_watermark_state
+                    .should_delete(key, unused_put))
+                || (non_pk_prefix_has_watermark
+                    && self
+                        .non_pk_prefix_skip_watermark_state
+                        .should_delete(key, unused_put))
+            {
+                return true;
+            }
+        }
+        self.value_skip_watermark_state.has_watermark()
+            && self.value_skip_watermark_state.may_delete(key)
+    }
+
+    fn watermark_should_delete(
+        &mut self,
+        key: &FullKey<&[u8]>,
+        value: HummockValue<&[u8]>,
+    ) -> bool {
+        (self.pk_prefix_skip_watermark_state.has_watermark()
+            && self
+                .pk_prefix_skip_watermark_state
+                .should_delete(key, value))
             || (self.non_pk_prefix_skip_watermark_state.has_watermark()
-                && self.non_pk_prefix_skip_watermark_state.should_delete(key))
+                && self
+                    .non_pk_prefix_skip_watermark_state
+                    .should_delete(key, value))
+            || (self.value_skip_watermark_state.has_watermark()
+                && self.value_skip_watermark_state.should_delete(key, value))
     }
 }

--- a/src/storage/src/hummock/iterator/mod.rs
+++ b/src/storage/src/hummock/iterator/mod.rs
@@ -556,9 +556,9 @@ pub trait SkipWatermarkState: Send {
     fn has_watermark(&self) -> bool;
     /// Returns whether the incoming key needs to be deleted after watermark filtering.
     /// Note: Each `table_id` has multiple `watermarks`, and state defaults to forward traversal of `vnodes`, so you must use forward traversal of the incoming key for it to be filtered correctly.
-    fn should_delete(&mut self, key: &FullKey<&[u8]>) -> bool;
+    fn should_delete(&mut self, key: &FullKey<&[u8]>, value: HummockValue<&[u8]>) -> bool;
     /// Resets the watermark state.
     fn reset_watermark(&mut self);
     /// Determines if the current `watermark` is exhausted by the passed-in key, advances to the next `watermark`, and returns whether the key needs to be deleted.
-    fn advance_watermark(&mut self, key: &FullKey<&[u8]>) -> bool;
+    fn advance_watermark(&mut self, key: &FullKey<&[u8]>, value: HummockValue<&[u8]>) -> bool;
 }

--- a/src/storage/src/hummock/iterator/skip_watermark.rs
+++ b/src/storage/src/hummock/iterator/skip_watermark.rs
@@ -29,7 +29,7 @@ use risingwave_hummock_sdk::table_watermark::{
 };
 
 use super::SkipWatermarkState;
-use crate::compaction_catalog_manager::CompactionCatalogAgentRef;
+use crate::compaction_catalog_manager::{CompactionCatalogAgentRef, ValueWatermarkColumnSerdeRef};
 use crate::hummock::HummockResult;
 use crate::hummock::iterator::{Forward, HummockIterator, ValueMeta};
 use crate::hummock::value::HummockValue;
@@ -75,7 +75,10 @@ impl<I: HummockIterator<Direction = Forward>, S: SkipWatermarkState> SkipWaterma
         // advance key and watermark in an interleave manner until nothing
         // changed after the method is called.
         while self.inner.is_valid() {
-            if !self.state.should_delete(&self.inner.key()) {
+            if !self
+                .state
+                .should_delete(&self.inner.key(), self.inner.value())
+            {
                 break;
             }
 
@@ -178,7 +181,7 @@ impl SkipWatermarkState for PkPrefixSkipWatermarkState {
         !self.remain_watermarks.is_empty()
     }
 
-    fn should_delete(&mut self, key: &FullKey<&[u8]>) -> bool {
+    fn should_delete(&mut self, key: &FullKey<&[u8]>, value: HummockValue<&[u8]>) -> bool {
         if let Some((table_id, vnode, direction, watermark)) = self.remain_watermarks.front() {
             let key_table_id = key.user_key.table_id;
             let (key_vnode, inner_key) = key.user_key.table_key.split_vnode();
@@ -192,7 +195,7 @@ impl SkipWatermarkState for PkPrefixSkipWatermarkState {
                 Ordering::Greater => {
                     // The current key has advanced over the watermark.
                     // We may advance the watermark before advancing the key.
-                    return self.advance_watermark(key);
+                    return self.advance_watermark(key, value);
                 }
             }
         }
@@ -223,7 +226,7 @@ impl SkipWatermarkState for PkPrefixSkipWatermarkState {
     /// filter out the current or future key.
     ///
     /// Return a flag indicating whether the current key will be filtered by the current watermark.
-    fn advance_watermark(&mut self, key: &FullKey<&[u8]>) -> bool {
+    fn advance_watermark(&mut self, key: &FullKey<&[u8]>, _value: HummockValue<&[u8]>) -> bool {
         let key_table_id = key.user_key.table_id;
         let (key_vnode, inner_key) = key.user_key.table_key.split_vnode();
         while let Some((table_id, vnode, direction, watermark)) = self.remain_watermarks.front() {
@@ -338,7 +341,7 @@ impl SkipWatermarkState for NonPkPrefixSkipWatermarkState {
         !self.remain_watermarks.is_empty()
     }
 
-    fn should_delete(&mut self, key: &FullKey<&[u8]>) -> bool {
+    fn should_delete(&mut self, key: &FullKey<&[u8]>, value: HummockValue<&[u8]>) -> bool {
         if let Some((table_id, vnode, direction, watermark)) = self.remain_watermarks.front() {
             let key_table_id = key.user_key.table_id;
             {
@@ -374,7 +377,7 @@ impl SkipWatermarkState for NonPkPrefixSkipWatermarkState {
                 Ordering::Greater => {
                     // The current key has advanced over the watermark.
                     // We may advance the watermark before advancing the key.
-                    return self.advance_watermark(key);
+                    return self.advance_watermark(key, value);
                 }
             }
         }
@@ -411,7 +414,7 @@ impl SkipWatermarkState for NonPkPrefixSkipWatermarkState {
             .collect();
     }
 
-    fn advance_watermark(&mut self, key: &FullKey<&[u8]>) -> bool {
+    fn advance_watermark(&mut self, key: &FullKey<&[u8]>, _value: HummockValue<&[u8]>) -> bool {
         let key_table_id = key.user_key.table_id;
         let (key_vnode, inner_key) = key.user_key.table_key.split_vnode();
         while let Some((table_id, vnode, direction, watermark)) = self.remain_watermarks.front() {
@@ -450,6 +453,169 @@ pub type PkPrefixSkipWatermarkIterator<I> = SkipWatermarkIterator<I, PkPrefixSki
 
 pub type NonPkPrefixSkipWatermarkIterator<I> =
     SkipWatermarkIterator<I, NonPkPrefixSkipWatermarkState>;
+
+pub type ValueSkipWatermarkIterator<I> = SkipWatermarkIterator<I, ValueSkipWatermarkState>;
+
+pub struct ValueSkipWatermarkState {
+    pub watermarks: BTreeMap<TableId, ReadTableWatermark>,
+    remain_watermarks: VecDeque<(TableId, VirtualNode, WatermarkDirection, Bytes)>,
+    compaction_catalog_agent_ref: CompactionCatalogAgentRef,
+    last_serde: Option<ValueWatermarkColumnSerdeRef>,
+    last_table_id: Option<TableId>,
+}
+
+impl ValueSkipWatermarkState {
+    pub fn new(
+        watermarks: BTreeMap<TableId, ReadTableWatermark>,
+        compaction_catalog_agent_ref: CompactionCatalogAgentRef,
+    ) -> Self {
+        Self {
+            remain_watermarks: VecDeque::new(),
+            watermarks,
+            compaction_catalog_agent_ref,
+            last_serde: None,
+            last_table_id: None,
+        }
+    }
+
+    pub fn from_safe_epoch_watermarks(
+        safe_epoch_watermarks: BTreeMap<TableId, TableWatermarks>,
+        compaction_catalog_agent_ref: CompactionCatalogAgentRef,
+    ) -> Self {
+        let watermarks = safe_epoch_read_table_watermarks_impl(safe_epoch_watermarks);
+        Self::new(watermarks, compaction_catalog_agent_ref)
+    }
+
+    pub fn may_delete(&self, key: &FullKey<&[u8]>) -> bool {
+        let table_id = key.user_key.table_id;
+        self.watermarks.contains_key(&table_id)
+    }
+}
+
+impl SkipWatermarkState for ValueSkipWatermarkState {
+    #[inline(always)]
+    fn has_watermark(&self) -> bool {
+        !self.remain_watermarks.is_empty()
+    }
+
+    fn should_delete(&mut self, key: &FullKey<&[u8]>, value: HummockValue<&[u8]>) -> bool {
+        if let Some((table_id, vnode, direction, watermark)) = self.remain_watermarks.front() {
+            let key_table_id = key.user_key.table_id;
+            let key_vnode = key.user_key.table_key.vnode_part();
+            if self
+                .last_table_id
+                .is_none_or(|last_table_id| last_table_id != key_table_id)
+            {
+                self.last_table_id = Some(key_table_id);
+                self.last_serde = self
+                    .compaction_catalog_agent_ref
+                    .value_watermark_serde(*table_id);
+            }
+            match (&key_table_id, &key_vnode).cmp(&(table_id, vnode)) {
+                Ordering::Less => {
+                    return false;
+                }
+                Ordering::Equal => {
+                    let HummockValue::Put(value) = value else {
+                        return false;
+                    };
+                    let Some(ref last_serde) = self.last_serde else {
+                        return false;
+                    };
+                    let Ok(watermark_column_value) = last_serde.deserialize(value) else {
+                        tracing::error!(
+                            ?table_id,
+                            ?vnode,
+                            ?value,
+                            "Failed to deserialize watermark column"
+                        );
+                        return false;
+                    };
+                    let Some(watermark_column_value) = watermark_column_value else {
+                        tracing::debug!(
+                            ?table_id,
+                            ?vnode,
+                            ?value,
+                            "The specified watermark column was not found in the value, likely due to the use of a non-current catalog. Restarting the compactor should resolve this issue."
+                        );
+                        return false;
+                    };
+                    return direction.key_filter_by_watermark(&watermark_column_value, watermark);
+                }
+                Ordering::Greater => {
+                    // The current key has advanced over the watermark.
+                    // We may advance the watermark before advancing the key.
+                    return self.advance_watermark(key, value);
+                }
+            }
+        }
+        false
+    }
+
+    fn reset_watermark(&mut self) {
+        self.remain_watermarks = self
+            .watermarks
+            .iter()
+            .flat_map(|(table_id, read_watermarks)| {
+                read_watermarks
+                    .vnode_watermarks
+                    .iter()
+                    .map(|(vnode, watermarks)| {
+                        (
+                            *table_id,
+                            *vnode,
+                            read_watermarks.direction,
+                            watermarks.clone(),
+                        )
+                    })
+            })
+            .collect();
+    }
+
+    fn advance_watermark(&mut self, key: &FullKey<&[u8]>, value: HummockValue<&[u8]>) -> bool {
+        let key_table_id = key.user_key.table_id;
+        let key_vnode = key.user_key.table_key.vnode_part();
+        while let Some((table_id, vnode, direction, watermark)) = self.remain_watermarks.front() {
+            match (table_id, vnode).cmp(&(&key_table_id, &key_vnode)) {
+                Ordering::Less => {
+                    self.remain_watermarks.pop_front();
+                    continue;
+                }
+                Ordering::Equal => {
+                    let HummockValue::Put(value) = value else {
+                        return false;
+                    };
+                    let Some(ref last_serde) = self.last_serde else {
+                        return false;
+                    };
+                    let Ok(watermark_column_value) = last_serde.deserialize(value) else {
+                        tracing::error!(
+                            ?table_id,
+                            ?vnode,
+                            ?value,
+                            "Failed to deserialize watermark column."
+                        );
+                        return false;
+                    };
+                    let Some(watermark_column_value) = watermark_column_value else {
+                        tracing::warn!(
+                            ?table_id,
+                            ?vnode,
+                            ?value,
+                            "The specified watermark column was not found in the value, likely due to the use of a non-current catalog. Restarting the compactor should resolve this issue."
+                        );
+                        return false;
+                    };
+                    return direction.key_filter_by_watermark(&watermark_column_value, watermark);
+                }
+                Ordering::Greater => {
+                    return false;
+                }
+            }
+        }
+        false
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -774,6 +940,7 @@ mod tests {
                     full_key_filter_key_extractor,
                     table_id_to_vnode,
                     table_id_to_watermark_serde,
+                    HashMap::default(),
                 ));
 
                 let mut iter = NonPkPrefixSkipWatermarkIterator::new(
@@ -839,6 +1006,7 @@ mod tests {
                     full_key_filter_key_extractor,
                     table_id_to_vnode,
                     table_id_to_watermark_serde,
+                    HashMap::default(),
                 ));
 
                 let mut iter = NonPkPrefixSkipWatermarkIterator::new(
@@ -900,6 +1068,7 @@ mod tests {
                     full_key_filter_key_extractor,
                     table_id_to_vnode,
                     table_id_to_watermark_serde,
+                    HashMap::default(),
                 ));
 
                 let mut iter = NonPkPrefixSkipWatermarkIterator::new(
@@ -961,6 +1130,7 @@ mod tests {
                     full_key_filter_key_extractor,
                     table_id_to_vnode,
                     table_id_to_watermark_serde,
+                    HashMap::default(),
                 ));
 
                 let mut iter = NonPkPrefixSkipWatermarkIterator::new(
@@ -1135,6 +1305,7 @@ mod tests {
                 full_key_filter_key_extractor,
                 table_id_to_vnode,
                 table_id_to_watermark_serde,
+                HashMap::default(),
             ));
 
             let mut iter = NonPkPrefixSkipWatermarkIterator::new(
@@ -1236,6 +1407,7 @@ mod tests {
                 full_key_filter_key_extractor,
                 table_id_to_vnode,
                 table_id_to_watermark_serde,
+                HashMap::default(),
             ));
 
             let non_pk_prefix_iter = NonPkPrefixSkipWatermarkIterator::new(

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -157,6 +157,7 @@ impl<W: SstableWriter> SstableBuilder<W, Xor16FilterBuilder> {
                 .into_iter()
                 .map(|(table_id, v)| (table_id.into(), v))
                 .collect(),
+            HashMap::default(),
         ));
 
         Self::new(
@@ -924,6 +925,7 @@ pub(super) mod tests {
             FilterKeyExtractorImpl::Multi(filter),
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            HashMap::default(),
         ));
 
         let mut builder = SstableBuilder::new(

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -619,6 +619,7 @@ mod tests {
                 FilterKeyExtractorImpl::FullKey(FullKeyFilterKeyExtractor),
                 table_id_to_vnode,
                 table_id_to_watermark_serde,
+                HashMap::default(),
             ));
 
             let mut builder = CapacitySplitTableBuilder::new(

--- a/src/storage/src/hummock/sstable/xor_filter.rs
+++ b/src/storage/src/hummock/sstable/xor_filter.rs
@@ -509,6 +509,7 @@ mod tests {
             FilterKeyExtractorImpl::FullKey(FullKeyFilterKeyExtractor),
             table_id_to_vnode,
             table_id_to_watermark_serde,
+            HashMap::default(),
         ));
 
         let mut builder = SstableBuilder::new(

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -278,8 +278,8 @@ impl HummockReadVersion {
                                     .committed_epoch,
                             ))
                         }
-
                         WatermarkSerdeType::NonPkPrefix => None, /* do not fill the non-pk prefix watermark to index */
+                        WatermarkSerdeType::Value => None,
                     },
                     None => None,
                 }

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -267,6 +267,7 @@ pub async fn gen_test_sstable_impl<B: AsRef<[u8]> + Clone + Default + Eq, F: Fil
             .into_iter()
             .map(|(table_id, v)| (table_id.into(), v))
             .collect(),
+        HashMap::default(),
     ));
 
     let mut b = SstableBuilder::<_, F>::new(

--- a/src/storage/src/row_serde/row_serde_util.rs
+++ b/src/storage/src/row_serde/row_serde_util.rs
@@ -18,10 +18,14 @@ use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::util::row_serde::OrderedRowSerde;
 use risingwave_hummock_sdk::key::TableKey;
 
-pub fn serialize_pk(pk: impl Row, serializer: &OrderedRowSerde) -> Bytes {
-    let mut buf = BytesMut::with_capacity(pk.len());
-    pk.memcmp_serialize_into(serializer, &mut buf);
+pub fn serialize_row(row: impl Row, serializer: &OrderedRowSerde) -> Bytes {
+    let mut buf = BytesMut::with_capacity(row.len());
+    row.memcmp_serialize_into(serializer, &mut buf);
     buf.freeze()
+}
+
+pub fn serialize_pk(pk: impl Row, serializer: &OrderedRowSerde) -> Bytes {
+    serialize_row(pk, serializer)
 }
 
 pub fn serialize_pk_with_vnode(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR add a new ValueSkipWatermarkIter to support state cleanup based on watermark in non-pk column.
- The exisiting PkPrefixSkipWatermarkIter and NonPkPrefixSkipWatermarkIter only handle watermark specified in PK column.
- ValueSkipWatermarkIter  can handle watermark-based state clean for watermark specified in either PK or non-PK column.
- However, ValueSkipWatermarkIter will only be used to handle non-pk column watermark, supplementing existing PkPrefixSkipWatermarkIter and NonPkPrefixSkipWatermarkIter. The justification is ValueSkipWatermarkIter uses basic value encoding for internal table, which deserializes all columns. It brings larger overhead than deserializing PK columns in the other 2 iterators.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
