### PR TITLE
fix: initialize notification infra before first ticker tick

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -948,15 +948,15 @@ impl GlobalStreamManager {
         );
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        // waiting for the first tick
-        ticker.tick().await;
-
         let (local_notification_tx, mut local_notification_rx) =
             tokio::sync::mpsc::unbounded_channel();
 
         self.env
             .notification_manager()
             .insert_local_sender(local_notification_tx);
+
+        // waiting for the first tick
+        ticker.tick().await;
 
         let worker_nodes = self
             .metadata_manager


### PR DESCRIPTION


I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Move the first `ticker.tick().await` after setting up the notification channel and inserting it into the notification manager. This ensures the notification system is ready before the ticker advances.

- Prevents missed notifications during initialization
- Avoids races where channels are not set up in time
- Improves reliability of async task startup
- Addresses potential concurrency bug in stream scale manager

## Checklist

- [x] I have written necessary rustdoc comments.

