### PR TITLE
fix: improve error handling and retry logic in fragment and observer managers

### DIFF
--- a/src/batch/src/worker_manager/worker_node_manager.rs
+++ b/src/batch/src/worker_manager/worker_node_manager.rs
@@ -137,7 +137,11 @@ impl WorkerNodeManager {
             serving_mapping.keys()
         );
         write_guard.worker_nodes = nodes.into_iter().map(|w| (w.id, w)).collect();
-        write_guard.streaming_fragment_vnode_mapping = Some(streaming_mapping);
+        write_guard.streaming_fragment_vnode_mapping = if streaming_mapping.is_empty() {
+            None
+        } else {
+            Some(streaming_mapping)
+        };
         write_guard.serving_fragment_vnode_mapping = serving_mapping;
     }
 

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -182,6 +182,7 @@ where
                     match self.wait_init_notification().await {
                         Err(err) => {
                             tracing::warn!(error = %err.as_report(), "Receives meta's notification err");
+                            tokio::time::sleep(RE_SUBSCRIBE_RETRY_INTERVAL).await;
                             continue;
                         }
                         _ => {

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -75,6 +75,7 @@ use crate::controller::utils::{
     get_sink_fragment_by_ids, has_table_been_migrated, rebuild_fragment_mapping,
     resolve_no_shuffle_actor_dispatcher,
 };
+use crate::error::MetaError;
 use crate::manager::{ActiveStreamingWorkerNodes, LocalNotification, NotificationManager};
 use crate::model::{
     DownstreamFragmentRelation, Fragment, FragmentActorDispatchers, FragmentDownstreamRelation,
@@ -1038,25 +1039,27 @@ impl CatalogController {
         let actor_infos = {
             let info = self.env.shared_actor_infos().read_guard();
 
-            fragment_objects
-                .into_iter()
-                .flat_map(|(fragment_id, object_id, schema_id, object_type)| {
-                    let SharedFragmentInfo {
-                        fragment_id,
-                        actors,
-                        ..
-                    } = info.get_fragment(fragment_id as _).unwrap();
-                    actors.keys().map(move |actor_id| {
-                        (
-                            *actor_id as _,
-                            *fragment_id as _,
-                            object_id,
-                            schema_id,
-                            object_type,
-                        )
-                    })
-                })
-                .collect_vec()
+            let mut result = Vec::new();
+
+            for (fragment_id, object_id, schema_id, object_type) in fragment_objects {
+                let Some(fragment) = info.get_fragment(fragment_id as _) else {
+                    return Err(MetaError::unavailable(format!(
+                        "shared actor info missing for fragment {fragment_id} while listing actors"
+                    )));
+                };
+
+                for actor_id in fragment.actors.keys() {
+                    result.push((
+                        *actor_id as _,
+                        fragment.fragment_id as _,
+                        object_id,
+                        schema_id,
+                        object_type,
+                    ));
+                }
+            }
+
+            result
         };
 
         Ok(actor_infos)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

**Summary**

resolve https://github.com/risingwavelabs/risingwave/issues/23393

This PR improves error handling, robustness, and state clarity in fragment management, observer notification, and vnode mapping logic. The changes aim to prevent runtime panics, clarify empty state semantics, and introduce retry backoff, resulting in a more resilient and easier-to-maintain system.

**Details**

- Clarified the handling of empty streaming fragment vnode mapping in `worker_node_manager.rs` by explicitly setting the mapping to `None` when empty, reducing ambiguity for downstream consumers.
- Enhanced the observer manager in `observer_manager.rs` with a retry backoff interval after notification initialization failures, mitigating excessive logging and CPU usage during repeated error scenarios.
- Hardened fragment actor listing in `fragment.rs` by replacing panics (`unwrap()`) with explicit error returns, providing descriptive error messages and preventing system crashes due to missing actor/fragment info.
- Refactored imperative logic for actor listing, improving debuggability and maintainability.

## Checklist

- [x] I have written necessary rustdoc comments.


