### PR TITLE
feat: optimize streaming job count query and improve diagnostics

### DIFF
--- a/ci/scripts/standalone-utils.sh
+++ b/ci/scripts/standalone-utils.sh
@@ -105,6 +105,9 @@ wait_standalone() {
   else
     echo "Standalone is ready"
   fi
+
+  echo "Waiting additional 5s for stability"
+  sleep 5
 }
 
 restart_standalone() {

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -255,6 +255,15 @@ impl NotificationServiceImpl {
 
         let (streaming_worker_slot_mappings, streaming_worker_slot_mapping_version) =
             self.get_worker_slot_mapping_snapshot().await?;
+
+        let streaming_job_count = self.metadata_manager.count_streaming_job().await?;
+        if streaming_job_count > 0 && streaming_worker_slot_mappings.is_empty() {
+            tracing::warn!(
+                streaming_job_count,
+                "frontend subscribe returns empty streaming_worker_slot_mappings while streaming jobs exist; meta may still be recovering"
+            );
+        }
+
         let serving_worker_slot_mappings = self.get_serving_vnode_mappings();
 
         let (nodes, worker_node_version) = self.get_worker_node_snapshot().await?;

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -755,6 +755,12 @@ impl CatalogController {
         Ok(result)
     }
 
+    pub async fn count_streaming_jobs(&self) -> MetaResult<usize> {
+        let inner = self.inner.read().await;
+        let count = StreamingJob::find().count(&inner.db).await?;
+        Ok(usize::try_from(count).context("streaming job count overflow")?)
+    }
+
     pub async fn list_streaming_job_infos(&self) -> MetaResult<Vec<StreamingJobInfo>> {
         let inner = self.inner.read().await;
         let job_states = StreamingJob::find()

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -545,10 +545,7 @@ impl MetadataManager {
     }
 
     pub async fn count_streaming_job(&self) -> MetaResult<usize> {
-        self.catalog_controller
-            .list_streaming_job_infos()
-            .await
-            .map(|x| x.len())
+        self.catalog_controller.count_streaming_jobs().await
     }
 
     pub async fn list_stream_job_desc(&self) -> MetaResult<Vec<MetaTelemetryJobDesc>> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

**Summary**
This PR optimizes the streaming job count query for improved backend performance, adds targeted diagnostic logging to help identify meta node recovery scenarios, and introduces a CI script tweak to stabilize test runs. These changes aim to address observed inefficiencies, improve operational visibility, and reduce CI flakiness without introducing breaking API changes.

**Details**

- Optimized streaming job count queries by replacing in-memory counting with a direct COUNT query via SeaORM, significantly improving performance for large job sets.
- Enhanced observability in `NotificationServiceImpl` by logging a structured warning when streaming jobs exist but no worker slot mappings are found, surfacing potential meta node recovery situations.
- Improved CI reliability by adding a deliberate wait period after detecting standalone cluster readiness, mitigating timing races and reducing test flakiness.
- Updated related interfaces (`CatalogController`, `MetadataManager`) to use the new efficient count method, ensuring consistency and future-proofing diagnostics that depend on job counts.

## Checklist

- [x] I have written necessary rustdoc comments.

