### PR TITLE
fix(test): fix flaky time travel e2e tests

### DIFF
--- a/e2e_test/time_travel/basic.slt
+++ b/e2e_test/time_travel/basic.slt
@@ -30,8 +30,9 @@ query I
 SELECT *  FROM t FOR SYSTEM_TIME AS OF now() - '5' second;
 ----
 
+sleep 5s
 
-query I retry 6 backoff 1s
+query I
 SELECT *  FROM t FOR SYSTEM_TIME AS OF now() - '5' second;
 ----
 1

--- a/e2e_test/time_travel/index.slt
+++ b/e2e_test/time_travel/index.slt
@@ -26,8 +26,9 @@ query I
 SELECT *  FROM t FOR SYSTEM_TIME AS OF now() - '5' second WHERE k=1;
 ----
 
+sleep 5s
 
-query I retry 6 backoff 1s
+query I
 SELECT *  FROM t FOR SYSTEM_TIME AS OF now() - '5' second WHERE k=1;
 ----
 1

--- a/e2e_test/time_travel/join.slt
+++ b/e2e_test/time_travel/join.slt
@@ -10,10 +10,10 @@ CREATE TABLE t2 (k2 INT);
 sleep 5s
 
 statement ok
-INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
 
 statement ok
-INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
 
 query I
 SELECT count(*) FROM t1 join t2 on t1.k1=t2.k2;
@@ -35,8 +35,9 @@ SELECT count(*) FROM t1 FOR SYSTEM_TIME AS OF now() join t2  FOR SYSTEM_TIME AS 
 ----
 0
 
+sleep 5s
 
-query I retry 6 backoff 1s
+query I
 SELECT count(*) FROM t1 FOR SYSTEM_TIME AS OF now() - '5' second join t2  FOR SYSTEM_TIME AS OF now() on t1.k1=t2.k2;
 ----
 1

--- a/e2e_test/time_travel/lookup_join.slt
+++ b/e2e_test/time_travel/lookup_join.slt
@@ -10,10 +10,10 @@ CREATE TABLE t2 (k2 INT PRIMARY KEY);
 sleep 5s
 
 statement ok
-INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
 
 statement ok
-INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
 
 query I
 SELECT count(*) FROM t1 join t2 on t1.k1=t2.k2;
@@ -35,8 +35,9 @@ SELECT count(*) FROM t1 FOR SYSTEM_TIME AS OF now() join t2  FOR SYSTEM_TIME AS 
 ----
 0
 
+sleep 5s
 
-query I retry 6 backoff 1s
+query I
 SELECT count(*) FROM t1 FOR SYSTEM_TIME AS OF now() - '5' second join t2  FOR SYSTEM_TIME AS OF now() on t1.k1=t2.k2;
 ----
 1


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

It seems that #23855 made these tests flaky. This PR applies 2 changes to make it stable:

- Revert `retry` to `sleep`, as what we want here is exactly to delay execution for 5 seconds.
- Swap the insertion order of tables in `join` and `lookup_join` tests, so that as long as there's data found in `t1 FOR SYSTEM_TIME AS OF now() - '5' second`, there must be data in `t2 FOR SYSTEM_TIME AS OF now() - '5' second`.

Fix #24064  

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
