### PR TITLE
fix: imprecise pulsar topic mapping due to parallelism

### DIFF
--- a/e2e_test/source_inline/pulsar/basic.slt
+++ b/e2e_test/source_inline/pulsar/basic.slt
@@ -17,7 +17,7 @@ python3 e2e_test/commands/pulsar_util.py create-topic --topic 'persistent://publ
 system ok
 python3 e2e_test/commands/pulsar_util.py create-topic --topic 'non-persistent://public/default/non-persistent' --partitions 0 --non-persistent
 
-statement error
+statement error topic persistent://public/default/topic-non-exist not found on broker
 create table t_non_exist (
   f1 int,
   f2 varchar)
@@ -26,14 +26,6 @@ with (
   service.url = '${PULSAR_BROKER_URL}',
   topic = 'persistent://public/default/topic-non-exist',
 ) format plain encode json;
-----
-db error: ERROR: Failed to run the query
-
-Caused by these errors (recent errors listed first):
-  1: gRPC request to meta service (call `/ddl_service.DdlService/CreateTable`) failed: Internal error
-  2: failed to create source worker
-  3: topic persistent://public/default/topic-non-exist not found on broker, available topics: ["persistent://public/default/topic-partition-0", "persistent://public/default/topic-partition-1", "persistent://public/default/topic-partition-2", "persistent://public/default/unpartitioned"]
-
 
 # expected: skip existance check for non-persistent topic
 statement ok


### PR DESCRIPTION
… integration test

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

solution comes from https://github.com/risingwavelabs/risingwave/pull/23900/

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
