### PR TITLE
fix(meta): avoid global recovery on single database reload failure

### DIFF
--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -296,6 +296,9 @@ test_snapshot_backfill() {
 
   sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/create_nexmark_table.slt'
 
+  # sleep for a while to let table accumulate enough data
+  sleep 10
+
   psql -h localhost -p 4566 -d dev -U root -c 'ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 4;'
 
   TEST_NAME=nexmark_q3 sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/nexmark/nexmark_q3.slt' &

--- a/e2e_test/backfill/snapshot_backfill/create_nexmark_table.slt
+++ b/e2e_test/backfill/snapshot_backfill/create_nexmark_table.slt
@@ -49,6 +49,3 @@ CREATE table bid (
     nexmark.split.num = '8',
     nexmark.min.event.gap.in.ns = '100000'
 );
-
-# sleep for a while to let table accumulate enough data
-sleep 10s

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -27,7 +27,6 @@ use risingwave_pb::stream_service::streaming_control_stream_response::ResetDatab
 use thiserror_ext::AsReport;
 use tracing::{info, warn};
 
-use crate::MetaResult;
 use crate::barrier::DatabaseRuntimeInfoSnapshot;
 use crate::barrier::checkpoint::control::DatabaseCheckpointControlStatus;
 use crate::barrier::checkpoint::creating_job::CreatingStreamingJobControl;
@@ -39,6 +38,7 @@ use crate::barrier::worker::{
     RetryBackoffFuture, RetryBackoffStrategy, get_retry_backoff_strategy,
 };
 use crate::rpc::metrics::GLOBAL_META_METRICS;
+use crate::{MetaError, MetaResult};
 
 /// We can treat each database as a state machine of 3 states: `Running`, `Resetting` and `Initializing`.
 /// The state transition can be triggered when receiving 3 variants of response: `ReportDatabaseFailure`, `BarrierComplete`, `DatabaseReset`.
@@ -381,7 +381,7 @@ impl CheckpointControl {
                     None
                 }
                 DatabaseRecoveringStage::Initializing { .. } => {
-                    warn!(database_id = %database_id, "");
+                    warn!(database_id = %database_id, "failed to initialize database");
                     let (backoff_future, reset_request_id) = state.next_retry();
                     let remaining_workers =
                         control_stream_manager.reset_database(database_id, reset_request_id);
@@ -483,6 +483,38 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
                 };
             }
         }
+    }
+
+    pub(crate) fn fail_reload_runtime_info(self, e: MetaError) {
+        let database_status = self
+            .control
+            .databases
+            .get_mut(&self.database_id)
+            .expect("should exist");
+        let status = match database_status {
+            DatabaseCheckpointControlStatus::Running(_) => {
+                unreachable!("should not enter initializing when running")
+            }
+            DatabaseCheckpointControlStatus::Recovering(state) => match state.stage {
+                DatabaseRecoveringStage::Initializing { .. } => {
+                    unreachable!("can only enter initializing when resetting")
+                }
+                DatabaseRecoveringStage::Resetting { .. } => state,
+            },
+        };
+        warn!(
+            database_id = %self.database_id,
+            e = %e.as_report(),
+            "failed to reload runtime info"
+        );
+        let (backoff_future, reset_request_id) = status.next_retry();
+        status.metrics.recovery_failure_cnt.inc();
+        status.stage = DatabaseRecoveringStage::Resetting {
+            remaining_workers: Default::default(),
+            reset_resps: Default::default(),
+            reset_request_id,
+            backoff_future: Some(backoff_future),
+        };
     }
 
     pub(crate) fn remove(self) {

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -1003,9 +1003,14 @@ impl Command {
                         HashMap::new()
                     };
 
-                let actor_cdc_table_snapshot_splits = database_info
-                    .assign_cdc_backfill_splits(stream_job_fragments.stream_job_id)?
-                    .map(|splits| PbCdcTableSnapshotSplitsWithGeneration { splits });
+                let actor_cdc_table_snapshot_splits =
+                    if !matches!(job_type, CreateStreamingJobType::SnapshotBackfill(_)) {
+                        database_info
+                            .assign_cdc_backfill_splits(stream_job_fragments.stream_job_id)?
+                            .map(|splits| PbCdcTableSnapshotSplitsWithGeneration { splits })
+                    } else {
+                        None
+                    };
 
                 let add_mutation = AddMutation {
                     actor_dispatchers: edges

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -382,17 +382,28 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                 }));
                                 Self::report_collect_failure(&self.env, &error);
                                 self.context.notify_creating_job_failed(Some(database_id), format!("{}", error.as_report())).await;
-                                match self.context.reload_database_runtime_info(database_id).await? { Some(runtime_info) => {
-                                    runtime_info.validate(database_id, &self.active_streaming_nodes).inspect_err(|e| {
-                                        warn!(%database_id, err = ?e.as_report(), ?runtime_info, "reloaded database runtime info failed to validate");
-                                    })?;
-                                    entering_initializing.enter(runtime_info, &mut self.control_stream_manager);
-                                } _ => {
-                                    info!(%database_id, "database removed after reloading empty runtime info");
-                                    // mark ready to unblock subsequent request
-                                    self.context.mark_ready(MarkReadyOptions::Database(database_id));
-                                    entering_initializing.remove();
-                                }}
+                                match self.context.reload_database_runtime_info(database_id).await.and_then(|runtime_info| {
+                                    runtime_info.map(|runtime_info| {
+                                        runtime_info.validate(database_id, &self.active_streaming_nodes).inspect_err(|e| {
+                                            warn!(%database_id, err = ?e.as_report(), ?runtime_info, "reloaded database runtime info failed to validate");
+                                        })?;
+                                        Ok(runtime_info)
+                                    })
+                                    .transpose()
+                                }) {
+                                    Ok(Some(runtime_info)) => {
+                                        entering_initializing.enter(runtime_info, &mut self.control_stream_manager);
+                                    }
+                                    Ok(None) => {
+                                        info!(%database_id, "database removed after reloading empty runtime info");
+                                        // mark ready to unblock subsequent request
+                                        self.context.mark_ready(MarkReadyOptions::Database(database_id));
+                                        entering_initializing.remove();
+                                    }
+                                    Err(e) => {
+                                        entering_initializing.fail_reload_runtime_info(e);
+                                    }
+                                }
                             }
                             CheckpointControlEvent::EnteringRunning(entering_running) => {
                                 self.context.mark_ready(MarkReadyOptions::Database(entering_running.database_id()));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

As titled. On `reload_database_runtime_info` failure, instead of triggering global recovery by throwing an error, we will change to mark the status of the current database as `Resetting`.

Also fix a bug introduced in https://github.com/risingwavelabs/risingwave/pull/23795 that can be triggered in snapshot backfill.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
