### PR TITLE
chore: ignore `.cargo/` (for trailing space check and maybe more) (#24244)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ venv/
 go/bin/
 
 # Rust
+.cargo/
 src/**/target
 src/**/target_tarpaulin
 target/


### PR DESCRIPTION
Cherry picking #24244 onto branch release-2.6,

This PR resolves #24247 created by cherry-pick action from commit 62f41838fc9b02e3cb2d500b55671351a09062fe.,