### PR TITLE
test(streaming): add a test case demonstrating `scan.startup.mode = 'latest'` with shared source

### DIFF
--- a/e2e_test/source_inline/kafka/shared_source_latest.serial
+++ b/e2e_test/source_inline/kafka/shared_source_latest.serial
@@ -1,0 +1,87 @@
+# Demonstrate that multiple MVs created from a shared source with `scan.startup.mode = 'latest'`
+# will use the same start offset resolved at the time when the source is created, no matter when
+# the MV is created.
+
+control substitution on
+
+statement ok
+SET streaming_use_shared_source TO true;
+
+statement ok
+drop source if exists s_latest_shared cascade;
+
+system ok
+rpk topic delete shared_source_latest || true
+
+system ok
+rpk topic create shared_source_latest -p 1
+
+# Create shared source with latest, then produce data before MV creation.
+statement ok
+create source s_latest_shared (v1 int, v2 varchar) with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'shared_source_latest',
+  scan.startup.mode = 'latest'
+) FORMAT PLAIN ENCODE JSON;
+
+system ok
+cat << EOF | rpk topic produce shared_source_latest -f "%v\n"
+{"v1": 1, "v2": "before"}
+EOF
+
+
+sleep 3s
+
+statement ok
+flush;
+
+statement ok
+create materialized view mv_late as select * from s_latest_shared;
+
+query I
+select count(*) from mv_late;
+----
+1
+
+system ok
+cat << EOF | rpk topic produce shared_source_latest -f "%v\n"
+{"v1": 3, "v2": "after"}
+{"v1": 4, "v2": "after"}
+EOF
+
+
+sleep 3s
+
+statement ok
+flush;
+
+query IT rowsort
+select * from mv_late;
+----
+1 before
+3 after
+4 after
+
+
+# Now create a new MV from the source.
+# Even though the source is created with `scan.startup.mode` set to `latest`, we still get the same
+# view as the previous MV, because the `latest` is regarded as the high watermark at the time
+# when the **source** was initially created, not the MV.
+statement ok
+create materialized view mv_late_2 as select * from s_latest_shared;
+
+query IT rowsort
+select * from mv_late_2;
+----
+1 before
+3 after
+4 after
+
+statement ok
+drop source s_latest_shared cascade;
+
+system ok
+rpk topic delete shared_source_latest
+
+statement ok
+SET streaming_use_shared_source TO DEFAULT;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The behavior of `scan.startup.mode = 'latest'` with shared source is slightly different from non-shared source. In short:

- With non-shared source, a new job referencing the source will start ingestion from the latest offset resolved at the time **the job is created**. Different jobs referencing the same source may have different start offset, if they are created at different times.
- With shared source, a new job referencing the source will start ingestion from the latest offset resolved at the time **the source is created**. Different jobs referencing the same source have the same start offset, no matter when they are created (as long as data is not truncated or expired in upstream).

As a result, backfilling may still be required when creating a job referencing a shared source with `scan.startup.mode = 'latest'`, which might be surprising to users.

We may also update the documentation.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
