### PR TITLE
feat(meta): pause/resume cluster checkpoint on command

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -36,9 +36,8 @@ message AddMutation {
   // `Source` and `SourceBackfill` are handled together here.
   // TODO: we may allow multiple mutations in a single barrier.
   map<uint32, source.ConnectorSplits> actor_splits = 2;
-  // We may embed a pause mutation here.
-  // TODO: we may allow multiple mutations in a single barrier.
-  bool pause = 4;
+  reserved "pause";
+  reserved 4;
   repeated SubscriptionUpstreamInfo subscriptions_to_add = 5;
   // nodes which should be paused initially.
   repeated uint32 backfill_nodes_to_pause = 6;
@@ -106,10 +105,6 @@ message SourceChangeSplitMutation {
   map<uint32, source.ConnectorSplits> actor_splits = 2;
 }
 
-message PauseMutation {}
-
-message ResumeMutation {}
-
 message ThrottleMutation {
   message RateLimit {
     optional uint32 rate_limit = 1;
@@ -165,10 +160,6 @@ message BarrierMutation {
     UpdateMutation update = 5;
     // Change the split of some sources.
     SourceChangeSplitMutation splits = 6;
-    // Pause the dataflow of the whole streaming graph, only used for scaling.
-    PauseMutation pause = 7;
-    // Resume the dataflow of the whole streaming graph, only used for scaling.
-    ResumeMutation resume = 8;
     // Throttle specific source exec or backfill exec.
     ThrottleMutation throttle = 10;
     // Drop subscription on mv
@@ -188,6 +179,8 @@ message BarrierMutation {
     // List finish signal for refreshing tables
     ListFinishMutation list_finish = 17;
   }
+  reserved "pause", "resume";
+  reserved 7, 8;
 }
 
 message Barrier {

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -117,20 +117,12 @@ impl StreamManagerService for StreamServiceImpl {
     }
 
     async fn pause(&self, _: Request<PauseRequest>) -> Result<Response<PauseResponse>, Status> {
-        for database_id in self.metadata_manager.list_active_database_ids().await? {
-            self.barrier_scheduler
-                .run_command(database_id, Command::pause())
-                .await?;
-        }
+        self.barrier_manager.pause().await?;
         Ok(Response::new(PauseResponse {}))
     }
 
     async fn resume(&self, _: Request<ResumeRequest>) -> Result<Response<ResumeResponse>, Status> {
-        for database_id in self.metadata_manager.list_active_database_ids().await? {
-            self.barrier_scheduler
-                .run_command(database_id, Command::resume())
-                .await?;
-        }
+        self.barrier_manager.resume().await?;
         Ok(Response::new(ResumeResponse {}))
     }
 

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -156,8 +156,6 @@ impl CreatingStreamingJobControl {
             actor_dispatchers: Default::default(),
             added_actors,
             actor_splits,
-            // we assume that when handling snapshot backfill, the cluster must not be paused
-            pause: false,
             subscriptions_to_add: Default::default(),
             backfill_nodes_to_pause,
             actor_cdc_table_snapshot_splits: None,

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -454,7 +454,6 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
                 &mut source_splits,
                 &mut background_jobs,
                 &mut mv_depended_subscriptions,
-                false,
                 &self.control.hummock_version_stats,
                 &mut cdc_table_snapshot_splits,
             )?

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -265,10 +265,6 @@ impl CommandContext {
 
             Command::Throttle(_) => {}
 
-            Command::Pause => {}
-
-            Command::Resume => {}
-
             Command::SourceChangeSplit(SplitState {
                 split_assignment: assignment,
                 ..

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -998,8 +998,6 @@ impl InflightDatabaseInfo {
             }
             Some(command) => match command {
                 Command::Flush
-                | Command::Pause
-                | Command::Resume
                 | Command::DropStreamingJobs { .. }
                 | Command::RescheduleFragment { .. }
                 | Command::SourceChangeSplit { .. }

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -96,6 +96,24 @@ impl GlobalBarrierManager {
         Ok(())
     }
 
+    pub async fn pause(&self) -> MetaResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx
+            .send(BarrierManagerRequest::Pause(tx))
+            .context("failed to send pause request")?;
+        rx.await.context("failed to wait pause")?;
+        Ok(())
+    }
+
+    pub async fn resume(&self) -> MetaResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx
+            .send(BarrierManagerRequest::Resume(tx))
+            .context("failed to send resume request")?;
+        rx.await.context("failed to wait resume")?;
+        Ok(())
+    }
+
     pub async fn update_database_barrier(
         &self,
         database_id: DatabaseId,

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -114,6 +114,8 @@ pub(crate) enum BarrierManagerRequest {
         checkpoint_frequency: Option<u64>,
         sender: Sender<()>,
     },
+    Pause(Sender<()>),
+    Resume(Sender<()>),
 }
 
 #[derive(Debug)]

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -524,12 +524,11 @@ impl PeriodicBarriers {
                 scheduled = context.next_scheduled() => {
                     let database_id = scheduled.database_id;
                     self.reset_database_timer(database_id);
-                    let checkpoint = scheduled.command.need_checkpoint() || self.try_get_checkpoint(database_id);
                     NewBarrier {
                         database_id: scheduled.database_id,
                         command: Some((scheduled.command, scheduled.notifiers)),
                         span: scheduled.span,
-                        checkpoint,
+                        checkpoint: true, // always ckpt on command
                     }
                 },
                 // If there is no database, we won't wait for `Interval`, but only wait for command.

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -167,7 +167,7 @@ async fn test_barrier_manager_worker_crash_no_early_commit() {
     let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
     let _join_handle = tokio::spawn(async move {
-        worker.recovery(false, RecoveryReason::Bootstrap).await;
+        worker.recovery(RecoveryReason::Bootstrap).await;
         worker.run_inner(shutdown_rx).await
     });
 

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -545,13 +545,10 @@ where
                 // handle mutations
                 if let Some(mutation) = barrier.mutation.as_deref() {
                     use crate::executor::Mutation;
+                    mutation.on_new_pause_resume(|new_pause| {
+                        global_pause = new_pause;
+                    });
                     match mutation {
-                        Mutation::Pause => {
-                            global_pause = true;
-                        }
-                        Mutation::Resume => {
-                            global_pause = false;
-                        }
                         Mutation::StartFragmentBackfill { fragment_ids } if backfill_paused => {
                             if fragment_ids.contains(&self.fragment_id) {
                                 backfill_paused = false;

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -453,13 +453,10 @@ where
 
                 // Update snapshot read chunk builder.
                 if let Some(mutation) = barrier.mutation.as_deref() {
+                    mutation.on_new_pause_resume(|new_pause| {
+                        global_pause = new_pause;
+                    });
                     match mutation {
-                        Mutation::Pause => {
-                            global_pause = true;
-                        }
-                        Mutation::Resume => {
-                            global_pause = false;
-                        }
                         Mutation::StartFragmentBackfill { fragment_ids } if backfill_paused => {
                             if fragment_ids.contains(&self.fragment_id) {
                                 backfill_paused = false;

--- a/src/stream/src/executor/project/project_scalar.rs
+++ b/src/stream/src/executor/project/project_scalar.rs
@@ -199,15 +199,9 @@ impl Inner {
                     }
 
                     if let Some(mutation) = barrier.mutation.as_deref() {
-                        match mutation {
-                            Mutation::Pause => {
-                                self.is_paused = true;
-                            }
-                            Mutation::Resume => {
-                                self.is_paused = false;
-                            }
-                            _ => (),
-                        }
+                        mutation.on_new_pause_resume(|new_pause| {
+                            self.is_paused = new_pause;
+                        });
                     }
 
                     yield Message::Barrier(barrier);

--- a/src/stream/src/executor/project/project_set.rs
+++ b/src/stream/src/executor/project/project_set.rs
@@ -136,15 +136,9 @@ impl Inner {
                     }
 
                     if let Some(mutation) = barrier.mutation.as_deref() {
-                        match mutation {
-                            Mutation::Pause => {
-                                is_paused = true;
-                            }
-                            Mutation::Resume => {
-                                is_paused = false;
-                            }
-                            _ => (),
-                        }
+                        mutation.on_new_pause_resume(|new_pause| {
+                            is_paused = new_pause;
+                        });
                     }
 
                     yield Message::Barrier(barrier);

--- a/src/stream/src/executor/source/batch_source/batch_adbc_snowflake_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_adbc_snowflake_fetch.rs
@@ -116,9 +116,14 @@ impl<S: StateStore> BatchAdbcSnowflakeFetchExecutor<S> {
                         Message::Barrier(barrier) => {
                             let mut need_rebuild_reader = false;
                             if let Some(mutation) = barrier.mutation.as_deref() {
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                                 match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
                                     Mutation::RefreshStart {
                                         associated_source_id,
                                         ..

--- a/src/stream/src/executor/source/batch_source/batch_adbc_snowflake_list.rs
+++ b/src/stream/src/executor/source/batch_source/batch_adbc_snowflake_list.rs
@@ -129,9 +129,14 @@ impl<S: StateStore> BatchAdbcSnowflakeListExecutor<S> {
                     Either::Left(msg) => match msg {
                         Message::Barrier(barrier) => {
                             if let Some(mutation) = barrier.mutation.as_deref() {
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                                 match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
                                     Mutation::RefreshStart {
                                         associated_source_id,
                                         ..

--- a/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_iceberg_fetch.rs
@@ -372,15 +372,20 @@ impl<S: StateStore> BatchIcebergFetchExecutor<S> {
             return false;
         };
 
-        match mutation {
-            Mutation::Pause => {
+        let mut pause_resume = None;
+        mutation.on_new_pause_resume(|new_pause| {
+            pause_resume = Some(new_pause);
+        });
+        if let Some(new_pause) = pause_resume {
+            if new_pause {
                 stream.pause_stream();
-                false
-            }
-            Mutation::Resume => {
+            } else {
                 stream.resume_stream();
-                false
             }
+            return false;
+        }
+
+        match mutation {
             Mutation::RefreshStart {
                 associated_source_id,
                 ..

--- a/src/stream/src/executor/source/batch_source/batch_iceberg_list.rs
+++ b/src/stream/src/executor/source/batch_source/batch_iceberg_list.rs
@@ -151,9 +151,14 @@ impl<S: StateStore> BatchIcebergListExecutor<S> {
                     Either::Left(msg) => match msg {
                         Message::Barrier(barrier) => {
                             if let Some(mutation) = barrier.mutation.as_deref() {
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                                 match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
                                     Mutation::RefreshStart {
                                         associated_source_id,
                                         ..

--- a/src/stream/src/executor/source/batch_source/batch_posix_fs_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_posix_fs_fetch.rs
@@ -285,9 +285,14 @@ impl<S: StateStore> BatchPosixFsFetchExecutor<S> {
                             let need_rebuild_reader = false;
 
                             if let Some(mutation) = barrier.mutation.as_deref() {
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                                 match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
                                     Mutation::RefreshStart {
                                         associated_source_id,
                                         ..

--- a/src/stream/src/executor/source/batch_source/batch_posix_fs_list.rs
+++ b/src/stream/src/executor/source/batch_source/batch_posix_fs_list.rs
@@ -248,9 +248,14 @@ impl<S: StateStore> BatchPosixFsListExecutor<S> {
                     Either::Left(msg) => match &msg {
                         Message::Barrier(barrier) => {
                             if let Some(mutation) = barrier.mutation.as_deref() {
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                                 match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
                                     Mutation::RefreshStart {
                                         associated_source_id,
                                         ..

--- a/src/stream/src/executor/source/fs_list_executor.rs
+++ b/src/stream/src/executor/source/fs_list_executor.rs
@@ -150,11 +150,13 @@ impl<S: StateStore> FsListExecutor<S> {
                     Either::Left(msg) => match &msg {
                         Message::Barrier(barrier) => {
                             if let Some(mutation) = barrier.mutation.as_deref() {
-                                match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
-                                    _ => (),
-                                }
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                             }
 
                             // Propagate the barrier.

--- a/src/stream/src/executor/source/iceberg_fetch_executor.rs
+++ b/src/stream/src/executor/source/iceberg_fetch_executor.rs
@@ -496,24 +496,25 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                                     let mut need_rebuild_reader = false;
 
                                     if let Some(mutation) = barrier.mutation.as_deref() {
-                                        match mutation {
-                                            Mutation::Pause => stream.pause_stream(),
-                                            Mutation::Resume => stream.resume_stream(),
-                                            Mutation::Throttle(actor_to_apply) => {
-                                                if let Some(new_rate_limit) =
-                                                    actor_to_apply.get(&self.actor_ctx.id)
-                                                    && *new_rate_limit != self.rate_limit_rps
-                                                {
-                                                    tracing::debug!(
-                                                        "updating rate limit from {:?} to {:?}",
-                                                        self.rate_limit_rps,
-                                                        *new_rate_limit
-                                                    );
-                                                    self.rate_limit_rps = *new_rate_limit;
-                                                    need_rebuild_reader = true;
-                                                }
+                                        mutation.on_new_pause_resume(|new_pause| {
+                                            if new_pause {
+                                                stream.pause_stream();
+                                            } else {
+                                                stream.resume_stream();
                                             }
-                                            _ => (),
+                                        });
+                                        if let Mutation::Throttle(actor_to_apply) = mutation
+                                            && let Some(new_rate_limit) =
+                                                actor_to_apply.get(&self.actor_ctx.id)
+                                            && *new_rate_limit != self.rate_limit_rps
+                                        {
+                                            tracing::debug!(
+                                                "updating rate limit from {:?} to {:?}",
+                                                self.rate_limit_rps,
+                                                *new_rate_limit
+                                            );
+                                            self.rate_limit_rps = *new_rate_limit;
+                                            need_rebuild_reader = true;
                                         }
                                     }
 

--- a/src/stream/src/executor/source/iceberg_list_executor.rs
+++ b/src/stream/src/executor/source/iceberg_list_executor.rs
@@ -228,11 +228,13 @@ impl<S: StateStore> IcebergListExecutor<S> {
                     Either::Left(msg) => match &msg {
                         Message::Barrier(barrier) => {
                             if let Some(mutation) = barrier.mutation.as_deref() {
-                                match mutation {
-                                    Mutation::Pause => stream.pause_stream(),
-                                    Mutation::Resume => stream.resume_stream(),
-                                    _ => (),
-                                }
+                                mutation.on_new_pause_resume(|new_pause| {
+                                    if new_pause {
+                                        stream.pause_stream();
+                                    } else {
+                                        stream.resume_stream();
+                                    }
+                                });
                             }
                             if let Some(last_snapshot) = *last_snapshot.lock() {
                                 let state_row =

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -620,15 +620,15 @@ impl<S: StateStore> SourceExecutor<S> {
                     let mut split_change = None;
 
                     if let Some(mutation) = barrier.mutation.as_deref() {
+                        mutation.on_new_pause_resume(|new_pause| {
+                            command_paused = new_pause;
+                            if new_pause {
+                                stream.pause_stream();
+                            } else {
+                                stream.resume_stream();
+                            }
+                        });
                         match mutation {
-                            Mutation::Pause => {
-                                command_paused = true;
-                                stream.pause_stream()
-                            }
-                            Mutation::Resume => {
-                                command_paused = false;
-                                stream.resume_stream()
-                            }
                             Mutation::SourceChangeSplit(actor_splits) => {
                                 tracing::info!(
                                     actor_id = %self.actor_ctx.id,

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -718,15 +718,9 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                                             self.metrics.unclean_state.inc();
                                         } else {
                                             if let Some(mutation) = barrier.mutation.as_deref() {
-                                                match mutation {
-                                                    Mutation::Pause => {
-                                                        pause_stream = true;
-                                                    }
-                                                    Mutation::Resume => {
-                                                        pause_stream = false;
-                                                    }
-                                                    _ => {}
-                                                }
+                                                mutation.on_new_pause_resume(|new_pause| {
+                                                    pause_stream = new_pause;
+                                                });
                                             }
                                             let write_state_post_write_barrier =
                                                 Self::write_barrier(

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -236,15 +236,9 @@ impl<S: StateStore> WatermarkFilterExecutor<S> {
                     let post_commit = table.commit(barrier.epoch).await?;
 
                     if let Some(mutation) = barrier.mutation.as_deref() {
-                        match mutation {
-                            Mutation::Pause => {
-                                is_paused = true;
-                            }
-                            Mutation::Resume => {
-                                is_paused = false;
-                            }
-                            _ => (),
-                        }
+                        mutation.on_new_pause_resume(|new_pause| {
+                            is_paused = new_pause;
+                        });
                     }
 
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(ctx.id);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Remove the handling of pause/resume in barrier command mutation, and instead pause/resume the cluster by triggering recovery to rebuild the cluster, which simplifies the management of running job graphs to let it avoid handling the logic of pause/resume in low-level actors and barriers.

resolve https://github.com/risingwavelabs/risingwave/issues/24199 by the way.

Below is generated by AI.

This pull request removes the "Pause" and "Resume" mutation types and associated logic from the streaming cluster's barrier management system. Instead, pausing and resuming are now handled at a higher level in the barrier manager, simplifying the protocol buffers, command infrastructure, and state management. The changes also clean up related code paths and remove unnecessary checks and fields.

Protocol and mutation changes:
* Removed `PauseMutation` and `ResumeMutation` messages and fields from the `stream_plan.proto` protobuf definitions, and marked their field numbers and names as reserved to prevent reuse. [[1]](diffhunk://#diff-548bcb845b3db0225b2c6ab9d843234320a813af3a44855b764aaa284eda2dd8L39-R40) [[2]](diffhunk://#diff-548bcb845b3db0225b2c6ab9d843234320a813af3a44855b764aaa284eda2dd8L113-L116) [[3]](diffhunk://#diff-548bcb845b3db0225b2c6ab9d843234320a813af3a44855b764aaa284eda2dd8L172-L175) [[4]](diffhunk://#diff-548bcb845b3db0225b2c6ab9d843234320a813af3a44855b764aaa284eda2dd8R186-R187)
* Updated the `AddMutation` and related mutation structures to remove the `pause` field and all logic around pausing/resuming at the mutation level. [[1]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L159-L160) [[2]](diffhunk://#diff-7b07624ead7f8be9a6b4094f7944fc2148c8e913eafc9470c87030b80863e51fL457) [[3]](diffhunk://#diff-d1502364216dc3b2ed3e8a355337f1b1c91755516ee2156fcb04317672af1130L634) [[4]](diffhunk://#diff-d1502364216dc3b2ed3e8a355337f1b1c91755516ee2156fcb04317672af1130L644)

Barrier command and state management:
* Removed the `Pause` and `Resume` variants from the `Command` enum, as well as all related logic, display formatting, and helper methods. [[1]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L294-L302) [[2]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L400-L401) [[3]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L456-L463) [[4]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L473-L474) [[5]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L617-L621) [[6]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L846-L872) [[7]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L1011-L1012) [[8]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L1244) [[9]](diffhunk://#diff-de9637b343bd5dc38b424a066bc5a13cb98b1a2c26038309829e4c7447ab8607L268-L271) [[10]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2L1001-L1002)
* Removed the `is_paused` field and related methods from `BarrierWorkerState` and `DatabaseCheckpointControl`, and eliminated pause state checks throughout the codebase. [[1]](diffhunk://#diff-44229b137399d20ef70c07c7f928527ec494356b08b98ac0e68c6ccf7b3371b0L53-L86) [[2]](diffhunk://#diff-44229b137399d20ef70c07c7f928527ec494356b08b98ac0e68c6ccf7b3371b0L164) [[3]](diffhunk://#diff-44229b137399d20ef70c07c7f928527ec494356b08b98ac0e68c6ccf7b3371b0L266-L276) [[4]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L1020-L1035)

Pause/resume handling at the barrier manager level:
* Added `pause` and `resume` methods to `GlobalBarrierManager`, and new `BarrierManagerRequest` variants, so pausing and resuming are now managed at the barrier manager level rather than through mutations. Updated the service layer to use these new methods. [[1]](diffhunk://#diff-6ae613e0313025924be82ea866d0ff355c3b5c8825b61f487227225c908b2939R99-R116) [[2]](diffhunk://#diff-c7d2fe56d7d1503b969b97b4e7503738a8778d351960e87745c32bbc164b217dR117-R118) [[3]](diffhunk://#diff-66d82e7ca80b658c018a0a5f6407e235d890ba46ecc677cdf83a626f4af7dde7L120-R125)

General code cleanup:
* Removed unused imports and parameters related to the old pause/resume logic. [[1]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L48-R50) [[2]](diffhunk://#diff-d1502364216dc3b2ed3e8a355337f1b1c91755516ee2156fcb04317672af1130L29) [[3]](diffhunk://#diff-d1502364216dc3b2ed3e8a355337f1b1c91755516ee2156fcb04317672af1130L612)

These changes streamline the barrier and mutation system by removing the need for pause/resume mutations, reducing complexity, and centralizing pause/resume control.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
