### PR TITLE
feat: support order by in datafusion

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/datafusion/order.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/datafusion/order.slt
@@ -1,0 +1,205 @@
+statement ok
+set enable_datafusion_engine = true;
+
+statement ok
+create secret my_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+statement ok
+create connection my_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg_connection',
+    s3.access.key = secret my_secret,
+    s3.secret.key = secret my_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2',
+    catalog.type = 'storage',
+);
+
+statement ok
+set iceberg_engine_connection = 'public.my_conn';
+
+statement ok
+CREATE TABLE t (
+    id INT,
+    name VARCHAR,
+    score FLOAT,
+    status BOOLEAN,
+) WITH (commit_checkpoint_interval = 1) ENGINE = iceberg;
+
+statement ok
+INSERT INTO t VALUES
+    (1, 'Alice', 85.5, true),
+    (2, 'Bob', 92.0, true),
+    (3, 'Charlie', 78.5, false),
+    (4, 'Diana', 91.0, true),
+    (5, 'Eve', 88.0, false),
+    (6, 'Frank', NULL, true);
+
+statement ok
+FLUSH;
+
+sleep 5s
+
+# Test: Basic ORDER BY with single column ascending
+query ????
+SELECT id, name, score, status FROM t ORDER BY id;
+----
+1 Alice 85.5 t
+2 Bob 92 t
+3 Charlie 78.5 f
+4 Diana 91 t
+5 Eve 88 f
+6 Frank NULL t
+
+# Test: Basic ORDER BY with single column descending
+query ????
+SELECT id, name, score, status FROM t ORDER BY id DESC;
+----
+6 Frank NULL t
+5 Eve 88 f
+4 Diana 91 t
+3 Charlie 78.5 f
+2 Bob 92 t
+1 Alice 85.5 t
+
+# Test: ORDER BY string column ascending
+query ????
+SELECT id, name, score, status FROM t ORDER BY name;
+----
+1 Alice 85.5 t
+2 Bob 92 t
+3 Charlie 78.5 f
+4 Diana 91 t
+5 Eve 88 f
+6 Frank NULL t
+
+# Test: ORDER BY string column descending
+query ????
+SELECT id, name, score, status FROM t ORDER BY name DESC;
+----
+6 Frank NULL t
+5 Eve 88 f
+4 Diana 91 t
+3 Charlie 78.5 f
+2 Bob 92 t
+1 Alice 85.5 t
+
+# Test: ORDER BY float column with NULLs
+query ????
+SELECT id, name, score, status FROM t ORDER BY score;
+----
+3 Charlie 78.5 f
+1 Alice 85.5 t
+5 Eve 88 f
+4 Diana 91 t
+2 Bob 92 t
+6 Frank NULL t
+
+# Test: ORDER BY float column descending with NULLs
+query ????
+SELECT id, name, score, status FROM t ORDER BY score DESC;
+----
+6 Frank NULL t
+2 Bob 92 t
+4 Diana 91 t
+5 Eve 88 f
+1 Alice 85.5 t
+3 Charlie 78.5 f
+
+# Test: ORDER BY multiple columns with mixed ASC/DESC
+query ????
+SELECT id, name, score, status FROM t ORDER BY status DESC, score ASC;
+----
+1 Alice 85.5 t
+4 Diana 91 t
+2 Bob 92 t
+6 Frank NULL t
+3 Charlie 78.5 f
+5 Eve 88 f
+
+# Test: ORDER BY with LIMIT
+query ????
+SELECT id, name, score, status FROM t ORDER BY score DESC LIMIT 3;
+----
+6 Frank NULL t
+2 Bob 92 t
+4 Diana 91 t
+
+# Test: ORDER BY with LIMIT and OFFSET
+query ????
+SELECT id, name, score, status FROM t ORDER BY id ASC LIMIT 3 OFFSET 2;
+----
+3 Charlie 78.5 f
+4 Diana 91 t
+5 Eve 88 f
+
+# Test: ORDER BY with expression
+query ??
+SELECT id, score * 2 AS doubled_score FROM t ORDER BY score * 2 DESC LIMIT 4;
+----
+6 NULL
+2 184
+4 182
+5 176
+
+# Test: ORDER BY with WHERE clause
+query ????
+SELECT id, name, score, status FROM t WHERE score > 80 ORDER BY score DESC;
+----
+2 Bob 92 t
+4 Diana 91 t
+5 Eve 88 f
+1 Alice 85.5 t
+
+# Test: ORDER BY with NULL handling - NULLS FIRST
+query ????
+SELECT id, name, score, status FROM t ORDER BY score NULLS FIRST;
+----
+6 Frank NULL t
+3 Charlie 78.5 f
+1 Alice 85.5 t
+5 Eve 88 f
+4 Diana 91 t
+2 Bob 92 t
+
+# Test: ORDER BY with NULL handling - NULLS LAST
+query ????
+SELECT id, name, score, status FROM t ORDER BY score DESC NULLS LAST;
+----
+2 Bob 92 t
+4 Diana 91 t
+5 Eve 88 f
+1 Alice 85.5 t
+3 Charlie 78.5 f
+6 Frank NULL t
+
+# Test: ORDER BY on computed column using CASE
+query ???
+SELECT id, name, CASE WHEN score >= 90 THEN 'A' WHEN score >= 80 THEN 'B' ELSE 'C' END AS grade FROM t ORDER BY grade, name;
+----
+2 Bob A
+4 Diana A
+1 Alice B
+5 Eve B
+3 Charlie C
+6 Frank C
+
+# Test: ORDER BY without SELECT all columns
+query ?
+SELECT id FROM t ORDER BY score DESC LIMIT 3;
+----
+6
+2
+4
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP CONNECTION my_conn;
+
+statement ok
+DROP SECRET my_secret;

--- a/src/frontend/src/datafusion/execute.rs
+++ b/src/frontend/src/datafusion/execute.rs
@@ -49,7 +49,6 @@ pub async fn execute_datafusion_plan(
     let df_config = create_config(session.as_ref());
     let ctx = DFSessionContext::new_with_config(df_config);
     let state = ctx.state();
-    tracing::debug!("Datafusion state: {:?}", state);
 
     let pg_descs: Vec<PgFieldDescriptor> = plan.schema.fields().iter().map(to_pg_field).collect();
     let column_types = plan.schema.fields().iter().map(|f| f.data_type()).collect();

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -329,19 +329,14 @@ fn gen_batch_query_plan(
 
     #[cfg(feature = "datafusion")]
     {
-        use crate::optimizer::{LogicalIcebergScanExt, LogicalPlanToDataFusionExt};
+        use crate::optimizer::LogicalIcebergScanExt;
 
         if session.config().enable_datafusion_engine()
             && optimized_logical.plan.contains_iceberg_scan()
         {
-            tracing::debug!(
-                "Converting RisingWave logical plan to DataFusion plan:\nRisingWave Plan: {:?}",
-                optimized_logical
-            );
-            let df_plan = optimized_logical.plan.to_datafusion_logical_plan()?;
-            tracing::debug!("Converted DataFusion plan:\nDataFusion Plan: {:?}", df_plan);
+            let plan = optimized_logical.gen_datafusion_logical_plan()?;
             return Ok(BatchPlanChoice::Df(DfBatchQueryPlanResult {
-                plan: df_plan,
+                plan,
                 schema,
                 stmt_type,
             }));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Add `order by` support, it may add a `Sort` at the top of logical plan.
- Add conversion for `LogicalTopN` node.
- Add `inline_session_timezone` and `const_eval_exprs`
- Risingwave may have a further projection at the top of logical plan. This case has been handled in this PR.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
