### PR TITLE
feat(sqlsmith): add EXPLAIN TRACE output for failing queries

### DIFF
--- a/src/tests/sqlsmith/src/reducer.rs
+++ b/src/tests/sqlsmith/src/reducer.rs
@@ -58,7 +58,9 @@ fn shrink_statements(sql: &str) -> Result<String> {
 
     // Session variable before the failing query.
     let session_variable = sql_statements
-        .get(sql_statements.len() - 2)
+        .len()
+        .checked_sub(2)
+        .and_then(|idx| sql_statements.get(idx))
         .filter(|statement| matches!(statement, Statement::SetVariable { .. }));
 
     let failing_query = sql_statements


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
Fixes: #23746 

adds a new `get_explain_trace` method that:
1. Attempts to get `EXPLAIN (LOGICAL, TRACE)` first (most likely to succeed)
2. Falls back to `EXPLAIN (TRACE)` if logical plan succeeds
3. Appends the trace output as SQL comments to the reduced query file

- `src/tests/sqlsmith/src/sqlreduce/reducer.rs`: Added explain trace functionality
- `src/tests/sqlsmith/src/reducer.rs`: Fixed integer underflow bug

Before:
```sql
SELECT a FROM t1 WHERE a / (b - 2) > 0;
```

After:
```sql
SELECT a FROM t1 WHERE a / (b - 2) > 0;

-- EXPLAIN TRACE for the failing query:
-- -- Logical plan with trace --
-- Begin:
-- 
-- LogicalProject { exprs: [t1.a] }
-- └─LogicalFilter { predicate: ((t1.a / (t1.b - 2:Int32)) > 0:Int32) }
--   └─LogicalScan { table: t1, columns: [a, b, _row_id, _rw_timestamp] }
-- 
-- Logical Filter Expression Simplify:
-- ...
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
