### PR TITLE
feat(meta): support drop/cancel creating snapshot backfill job

### DIFF
--- a/ci/scripts/run-backfill-tests.sh
+++ b/ci/scripts/run-backfill-tests.sh
@@ -329,7 +329,7 @@ test_snapshot_backfill() {
 
   sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/drop_nexmark_table.slt'
 
-  sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/failed_tests.slt' --label snapshot-backfill
+  sqllogictest -p 4566 -d dev 'e2e_test/backfill/snapshot_backfill/failed_tests.slt'
 
   kill_cluster
 }

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -712,7 +712,7 @@ steps:
           <<: *docker-compose
           run: source-test-env
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
 
   - label: "e2e standalone binary test"
     command: "ci/scripts/e2e-test-serial.sh -p ci-dev -m standalone"

--- a/e2e_test/backfill/snapshot_backfill/failed_tests.slt
+++ b/e2e_test/backfill/snapshot_backfill/failed_tests.slt
@@ -5,3 +5,5 @@ include ../../streaming/alter_mv/alter_mv_simple.slt
 include ../../batch/explain_analyze.slt
 include ../../background_ddl/basic.slt
 include ../../batch/catalog/rw_depend.slt.part
+include ../../background_ddl/basic.slt
+

--- a/e2e_test/background_ddl/basic.slt
+++ b/e2e_test/background_ddl/basic.slt
@@ -85,18 +85,6 @@ select count(*) from rw_catalog.rw_ddl_progress;
 ----
 1
 
-onlyif snapshot-backfill
-statement ok
-alter materialized view m1 set backfill_rate_limit=10000;
-
-onlyif snapshot-backfill
-statement ok
-recover;
-
-onlyif snapshot-backfill
-statement ok
-wait;
-
 statement ok
 drop materialized view m1;
 
@@ -137,18 +125,6 @@ statement ok
 create materialized view if not exists m1 as select * from t;
 
 sleep 1s
-
-onlyif snapshot-backfill
-statement ok
-alter materialized view m1 set backfill_rate_limit=10000;
-
-onlyif snapshot-backfill
-statement ok
-recover;
-
-onlyif snapshot-backfill
-statement ok
-wait;
 
 statement ok
 drop materialized view m1;

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -404,10 +404,34 @@ impl CheckpointControl {
         worker_id: WorkerId,
         resp: ResetPartialGraphResponse,
     ) {
-        let (database_id, _) = from_partial_graph_id(resp.partial_graph_id);
+        let (database_id, creating_job) = from_partial_graph_id(resp.partial_graph_id);
         match self.databases.get_mut(&database_id).expect("should exist") {
-            DatabaseCheckpointControlStatus::Running(_) => {
-                unreachable!("should not receive reset database resp when running")
+            DatabaseCheckpointControlStatus::Running(database) => {
+                if let Some(creating_job_id) = creating_job {
+                    let Entry::Occupied(mut entry) = database
+                        .creating_streaming_job_controls
+                        .entry(creating_job_id)
+                    else {
+                        if cfg!(debug_assertions) {
+                            panic!(
+                                "receive reset partial graph resp on non-existing creating job: {resp:?}"
+                            )
+                        }
+                        warn!(
+                            %database_id,
+                            %creating_job_id,
+                            %worker_id,
+                            ?resp,
+                            "ignore reset partial graph resp on non-existing creating job on running database"
+                        );
+                        return;
+                    };
+                    if entry.get_mut().on_reset_partial_graph_resp(worker_id, resp) {
+                        entry.remove();
+                    }
+                } else {
+                    unreachable!("should not receive reset database resp when database running")
+                }
             }
             DatabaseCheckpointControlStatus::Recovering(state) => {
                 state.on_reset_partial_graph_resp(worker_id, resp)
@@ -976,24 +1000,33 @@ impl DatabaseCheckpointControl {
             (None, vec![])
         };
 
-        for job_to_cancel in command
-            .as_ref()
-            .map(Command::jobs_to_drop)
-            .into_iter()
-            .flatten()
+        if let Some(Command::DropStreamingJobs {
+            streaming_job_ids, ..
+        }) = &command
         {
-            if self
-                .creating_streaming_job_controls
-                .contains_key(&job_to_cancel)
-            {
-                warn!(
-                    job_id = %job_to_cancel,
-                    "ignore cancel command on creating streaming job"
-                );
-                for notifier in notifiers {
-                    notifier
-                        .notify_start_failed(anyhow!("cannot cancel creating streaming job, the job will continue creating until created or recovery").into());
+            if streaming_job_ids.len() > 1 {
+                for job_to_cancel in streaming_job_ids {
+                    if self
+                        .creating_streaming_job_controls
+                        .contains_key(job_to_cancel)
+                    {
+                        warn!(
+                            job_id = %job_to_cancel,
+                            "ignore multi-job cancel command on creating snapshot backfill streaming job"
+                        );
+                        for notifier in notifiers {
+                            notifier
+                                .notify_start_failed(anyhow!("cannot cancel creating snapshot backfill streaming job with other jobs, \
+                                the job will continue creating until created or recovery. Please cancel the snapshot backfilling job in a single DDL ").into());
+                        }
+                        return Ok(());
+                    }
                 }
+            } else if let Some(job_to_drop) = streaming_job_ids.iter().next()
+                && let Some(creating_job) =
+                    self.creating_streaming_job_controls.get_mut(job_to_drop)
+                && creating_job.drop(&mut notifiers, control_stream_manager)
+            {
                 return Ok(());
             }
         }

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -33,16 +33,19 @@ use risingwave_pb::stream_plan::barrier::PbBarrierKind;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_plan::{AddMutation, StopMutation};
 use risingwave_pb::stream_service::BarrierCompleteResponse;
+use risingwave_pb::stream_service::streaming_control_stream_response::ResetPartialGraphResponse;
 use status::CreatingStreamingJobStatus;
 use tracing::{debug, info};
 
 use crate::MetaResult;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
 use crate::barrier::checkpoint::creating_job::status::CreateMviewLogStoreProgressTracker;
+use crate::barrier::checkpoint::recovery::ResetPartialGraphCollector;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
+use crate::barrier::notifier::Notifier;
 use crate::barrier::progress::{CreateMviewProgressTracker, TrackingJob};
-use crate::barrier::rpc::ControlStreamManager;
+use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
 use crate::barrier::{
     BackfillOrderState, BackfillProgress, BarrierKind, CreateStreamingJobCommandInfo, TracedEpoch,
 };
@@ -532,6 +535,7 @@ impl CreatingStreamingJobControl {
                     self.barrier_control.inflight_barrier_count()
                 )
             }
+            CreatingStreamingJobStatus::Resetting(_, _) => "Resetting".to_owned(),
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -709,6 +713,9 @@ impl CreatingStreamingJobControl {
                     .map(Excluded)
                     .unwrap_or(Unbounded),
             ),
+            CreatingStreamingJobStatus::Resetting(_, _) => {
+                return None;
+            }
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -742,7 +749,8 @@ impl CreatingStreamingJobControl {
         match &self.status {
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
             | CreatingStreamingJobStatus::ConsumingLogStore { .. } => true,
-            CreatingStreamingJobStatus::Finishing(..) => false,
+            CreatingStreamingJobStatus::Finishing(..)
+            | CreatingStreamingJobStatus::Resetting(_, _) => false,
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -767,10 +775,99 @@ impl CreatingStreamingJobControl {
         match self.status {
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
             | CreatingStreamingJobStatus::ConsumingLogStore { .. }
+            | CreatingStreamingJobStatus::Resetting(_, _)
             | CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!("expect finish")
             }
             CreatingStreamingJobStatus::Finishing(_, tracking_job) => tracking_job,
+        }
+    }
+
+    pub(super) fn on_reset_partial_graph_resp(
+        &mut self,
+        worker_id: WorkerId,
+        resp: ResetPartialGraphResponse,
+    ) -> bool {
+        match &mut self.status {
+            CreatingStreamingJobStatus::Resetting(collector, notifiers) => {
+                collector.collect(worker_id, resp);
+                if collector.remaining_workers.is_empty() {
+                    for notifier in notifiers.drain(..) {
+                        notifier.notify_collected();
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. }
+            | CreatingStreamingJobStatus::Finishing(_, _) => {
+                panic!(
+                    "should be resetting when receiving reset partial graph resp, but at {:?}",
+                    self.status
+                )
+            }
+            CreatingStreamingJobStatus::PlaceHolder => {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Drop a creating snapshot backfill job by directly resetting the partial graph
+    /// Return `false` if the partial graph has been merged to upstream database, and `true` otherwise
+    /// to mean that the job has been dropped.
+    pub(super) fn drop(
+        &mut self,
+        notifiers: &mut Vec<Notifier>,
+        control_stream_manager: &mut ControlStreamManager,
+    ) -> bool {
+        match &mut self.status {
+            CreatingStreamingJobStatus::Resetting(_, existing_notifiers) => {
+                for notifier in &mut *notifiers {
+                    notifier.notify_started();
+                }
+                existing_notifiers.append(notifiers);
+                true
+            }
+            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. } => {
+                for notifier in &mut *notifiers {
+                    notifier.notify_started();
+                }
+                let remaining_workers =
+                    control_stream_manager.reset_partial_graphs(vec![to_partial_graph_id(
+                        self.database_id,
+                        Some(self.job_id),
+                    )]);
+                let collector = ResetPartialGraphCollector {
+                    remaining_workers,
+                    reset_resps: Default::default(),
+                };
+                self.status = CreatingStreamingJobStatus::Resetting(collector, take(notifiers));
+                true
+            }
+            CreatingStreamingJobStatus::Finishing(_, _) => false,
+            CreatingStreamingJobStatus::PlaceHolder => {
+                unreachable!()
+            }
+        }
+    }
+
+    pub(super) fn reset(self) -> Option<ResetPartialGraphCollector> {
+        match self.status {
+            CreatingStreamingJobStatus::Resetting(collector, notifiers) => {
+                for notifier in notifiers {
+                    notifier.notify_collected();
+                }
+                Some(collector)
+            }
+            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. }
+            | CreatingStreamingJobStatus::Finishing(_, _) => None,
+            CreatingStreamingJobStatus::PlaceHolder => {
+                unreachable!()
+            }
         }
     }
 }

--- a/src/meta/src/barrier/checkpoint/creating_job/status.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/status.rs
@@ -31,6 +31,8 @@ use risingwave_pb::stream_service::barrier_complete_response::{
 use tracing::warn;
 
 use crate::barrier::checkpoint::creating_job::CreatingJobInfo;
+use crate::barrier::checkpoint::recovery::ResetPartialGraphCollector;
+use crate::barrier::notifier::Notifier;
 use crate::barrier::progress::{CreateMviewProgressTracker, TrackingJob};
 use crate::barrier::{BarrierInfo, BarrierKind, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
@@ -129,6 +131,7 @@ pub(super) enum CreatingStreamingJobStatus {
     /// will be finished when all previously injected barriers have been collected
     /// Store the `prev_epoch` that will finish at.
     Finishing(u64, TrackingJob),
+    Resetting(ResetPartialGraphCollector, Vec<Notifier>),
     PlaceHolder,
 }
 
@@ -198,7 +201,8 @@ impl CreatingStreamingJobStatus {
             } => {
                 log_store_progress_tracker.update(create_mview_progress);
             }
-            CreatingStreamingJobStatus::Finishing(..) => {}
+            CreatingStreamingJobStatus::Finishing(..)
+            | CreatingStreamingJobStatus::Resetting(_, _) => {}
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }
@@ -228,6 +232,9 @@ impl CreatingStreamingJobStatus {
             }
             CreatingStreamingJobStatus::Finishing { .. } => {
                 unreachable!("should not start consuming upstream for a job again")
+            }
+            CreatingStreamingJobStatus::Resetting(_, _) => {
+                unreachable!("unlikely to start consume upstream when resetting")
             }
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
@@ -286,7 +293,8 @@ impl CreatingStreamingJobStatus {
                 .chain([barrier_info.clone()])
                 .map(|barrier_info| (barrier_info, None))
                 .collect(),
-            CreatingStreamingJobStatus::Finishing { .. } => {
+            CreatingStreamingJobStatus::Finishing { .. }
+            | CreatingStreamingJobStatus::Resetting(_, _) => {
                 vec![]
             }
             CreatingStreamingJobStatus::PlaceHolder => {
@@ -336,7 +344,8 @@ impl CreatingStreamingJobStatus {
             | CreatingStreamingJobStatus::ConsumingLogStore { info, .. } => {
                 Some(&info.fragment_infos)
             }
-            CreatingStreamingJobStatus::Finishing(..) => None,
+            CreatingStreamingJobStatus::Finishing(..)
+            | CreatingStreamingJobStatus::Resetting(_, _) => None,
             CreatingStreamingJobStatus::PlaceHolder => {
                 unreachable!()
             }

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -43,7 +43,7 @@ use crate::barrier::worker::{
 use crate::rpc::metrics::GLOBAL_META_METRICS;
 use crate::{MetaError, MetaResult};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(super) struct ResetPartialGraphCollector {
     pub(super) remaining_workers: HashSet<WorkerId>,
     pub(super) reset_resps: HashMap<WorkerId, ResetPartialGraphResponse>,
@@ -389,12 +389,23 @@ impl DatabaseStatusAction<'_, EnterReset> {
             .expect("should exist");
         match database_status {
             DatabaseCheckpointControlStatus::Running(database) => {
-                let (database_resp_collector, creating_job_collectors) =
+                let mut resetting_job_collectors = HashMap::new();
+                let (database_resp_collector, mut creating_job_collectors) =
                     DatabaseRecoveringState::reset_database_partial_graphs(
                         self.database_id,
-                        database.creating_streaming_job_controls.keys().copied(),
+                        database.creating_streaming_job_controls.drain().filter_map(
+                            |(job_id, job)| {
+                                if let Some(collector) = job.reset() {
+                                    resetting_job_collectors.insert(job_id, collector);
+                                    None
+                                } else {
+                                    Some(job_id)
+                                }
+                            },
+                        ),
                         control_stream_manager,
                     );
+                creating_job_collectors.extend(resetting_job_collectors);
                 let metrics = DatabaseRecoveryMetrics::new(self.database_id);
                 event_log_manager_ref.add_event_logs(vec![Event::Recovery(
                     EventRecovery::database_recovery_start(self.database_id.as_raw_id()),

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -1501,18 +1501,6 @@ impl Command {
             ..Default::default()
         }))
     }
-
-    /// For `CancelStreamingJob`, returns the table id of the target table.
-    pub fn jobs_to_drop(&self) -> impl Iterator<Item = JobId> + '_ {
-        match self {
-            Command::DropStreamingJobs {
-                streaming_job_ids, ..
-            } => Some(streaming_job_ids.iter().cloned()),
-            _ => None,
-        }
-        .into_iter()
-        .flatten()
-    }
 }
 
 impl Command {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously we don't support dropping snapshot backfilling jobs because we drop jobs by issuing a barrier in the database streaming graph. However, the snapshot backfilling jobs have their separate streaming graphs, and therefore cannot follow the same mechanism. 

In this PR, we support dropping a snapshot backfill jobs by directly resetting the partial graph of the job, following the code path of resetting partial graph during database recovery. After the partial graph is reset, we notify the completion of the command.

### AI generated
This pull request introduces improvements and fixes to the snapshot backfill streaming job cancellation logic, adds better handling of job state transitions (especially for resetting jobs), and refines related test cases and CI configurations. The main focus is to ensure that snapshot backfill jobs can only be cancelled individually, and to robustly handle the "resetting" state for creating streaming jobs.

**Key changes include:**

### Streaming job cancellation and state handling

* Updated the logic in `DatabaseCheckpointControl` and `DatabaseCheckpointControlStatus` to only allow cancelling (dropping) a snapshot backfill streaming job if it is the only job being cancelled, and to provide clear error messages if a multi-job cancel is attempted. This prevents issues with partial graph resets during concurrent job cancellations.
* Added a new `Resetting` state to `CreatingStreamingJobStatus`, with corresponding logic in `CreatingStreamingJobControl` to handle transitions, notifications, and responses during partial graph resets. This ensures correct state management when a job is being reset. [[1]](diffhunk://#diff-579e7b5833f96932674208d719b0af14438711e8be52e4d622a2caa300ebf0feR134) [[2]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R538) [[3]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L745-R753) [[4]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R778-R872) [[5]](diffhunk://#diff-579e7b5833f96932674208d719b0af14438711e8be52e4d622a2caa300ebf0feL201-R205) [[6]](diffhunk://#diff-579e7b5833f96932674208d719b0af14438711e8be52e4d622a2caa300ebf0feR236-R238) [[7]](diffhunk://#diff-579e7b5833f96932674208d719b0af14438711e8be52e4d622a2caa300ebf0feL289-R297) [[8]](diffhunk://#diff-579e7b5833f96932674208d719b0af14438711e8be52e4d622a2caa300ebf0feL339-R348)
* Improved the handling of draining and resetting job controls in the recovery path, ensuring that jobs in the `Resetting` state are properly managed and not left in an inconsistent state.
* Enhanced logging and debugging by making `ResetPartialGraphCollector` `Debug` and improving warning messages for ignored or invalid commands. [[1]](diffhunk://#diff-7b07624ead7f8be9a6b4094f7944fc2148c8e913eafc9470c87030b80863e51fL46-R46) [[2]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L407-R434)

### Test and CI improvements

* Simplified and updated snapshot backfill SLT tests to remove unnecessary `onlyif snapshot-backfill` guards and duplicated includes, ensuring the tests reflect the new cancellation logic. [[1]](diffhunk://#diff-9b378d93f5f9c4e4eac10624b20bd707478ebb2655003b361783e377bb8fe51bL88-L99) [[2]](diffhunk://#diff-9b378d93f5f9c4e4eac10624b20bd707478ebb2655003b361783e377bb8fe51bL141-L152) [[3]](diffhunk://#diff-40d75e28b104e9b2588ac48c4fbd940dcef9c98e2e245164831f7723845b8c5aR8-R9)
* Adjusted the CI workflow to increase the timeout for certain jobs from 30 to 35 minutes, addressing potential flakiness due to longer test runs.
* Removed the use of the `--label snapshot-backfill` flag in the test script, as it is no longer needed with the updated test structure.

### Internal refactoring

* Removed the now-unused `jobs_to_drop` method from the `Command` struct, as job cancellation logic has been refactored.
* Updated imports and code organization to reflect the new state handling and collector logic. [[1]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R36-R48) [[2]](diffhunk://#diff-579e7b5833f96932674208d719b0af14438711e8be52e4d622a2caa300ebf0feR34-R35)

These changes together improve the reliability and maintainability of snapshot backfill job management and recovery.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
