### PR TITLE
fix(iceberg): Remove some limit between sink-decouple and exactly-once

### DIFF
--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
@@ -45,24 +45,6 @@ CREATE SINK s6 AS select mv6.v1 as v1, mv6.v2 as v2, mv6.v3 as v3 from mv6 WITH 
     table.name='e2e_demo_table',
 );
 
-# test is_exactly_once is true with sink_decouple = false
-statement error
-CREATE SINK s6 AS select mv6.v1 as v1, mv6.v2 as v2, mv6.v3 as v3 from mv6 WITH (
-    connector = 'iceberg',
-    type = 'upsert',
-    primary_key = 'v1',
-    warehouse.path = 's3a://icebergdata',
-    s3.endpoint = 'http://127.0.0.1:9301',
-    s3.access.key = secret iceberg_s3_access_key,
-    s3.secret.key = secret iceberg_s3_secret_key,
-    s3.region = 'us-east-1',
-    catalog.name = 'demo',
-    catalog.type = 'storage',
-    database.name='demo_db',
-    table.name='e2e_demo_table',
-    is_exactly_once = true
-);
-
 statement ok
 CREATE SOURCE iceberg_demo_source WITH (
     connector = 'iceberg',


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Removed the hard limit, while retaining the derivation of the default value, for iceberg sink decouple and exactly once.

For default value: If someone manually turns off `sink-decouple`, it may be because they want better consistency (including in CI). However, if `exactly_once` is default enabled, we cannot control the commit time in coordinator, and consistency cannot be guaranteed.
But we should also support any option if the user explicitly specifies it.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
