### PR TITLE
chore: fix iceberg schema change test in main cron

### DIFF
--- a/ci/scripts/e2e-iceberg-sink-cdc-test.sh
+++ b/ci/scripts/e2e-iceberg-sink-cdc-test.sh
@@ -18,7 +18,7 @@ verify_iceberg_source() {
     local expected_file
     local actual_file
     local retry_count=0
-    local max_retries=3
+    local max_retries=4
 
     shift
     expected=$(cat)
@@ -155,6 +155,9 @@ WITH (
     table.name = 't',
 );"
 
+# Wait for data to be synced to Iceberg
+echo "Waiting for data to sync to Iceberg..."
+sleep 5
 
 echo "Verifying initial data in iceberg_s1..."
 risedev psql -c "select * from iceberg_s1 ORDER BY id;"
@@ -197,6 +200,10 @@ WITH (
     table.name = 't',
 );"
 
+
+echo "Waiting for data to sync to Iceberg..."
+sleep 5
+
 echo "Verifying data after first schema change..."
 risedev psql -c "select * from iceberg_s2 ORDER BY id;"
 verify_iceberg_source iceberg_s2 <<'EOF'
@@ -231,6 +238,10 @@ WITH (
     table.name = 't',
 );"
 sleep 5
+
+echo "Waiting for data to sync to Iceberg..."
+sleep 5
+
 
 echo "Verifying data after second schema change..."
 risedev psql -c "select * from iceberg_s3 ORDER BY id";


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
as title, close https://github.com/risingwavelabs/risingwave/issues/24268
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
