### PR TITLE
refactor(meta): include upstream partial graph id in exchange request

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -24,6 +24,7 @@ message HostAddress {
 message ActorInfo {
   uint32 actor_id = 1;
   HostAddress host = 2;
+  uint32 partial_graph_id = 3;
 }
 
 enum WorkerType {

--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -130,6 +130,7 @@ message GetStreamRequest {
     uint32 down_fragment_id = 4;
     uint32 database_id = 5;
     string term_id = 6;
+    uint32 up_partial_graph_id = 7;
   }
 
   oneof value {

--- a/src/compute/src/rpc/service/stream_exchange_service.rs
+++ b/src/compute/src/rpc/service/stream_exchange_service.rs
@@ -61,6 +61,7 @@ impl StreamExchangeService for StreamExchangeServiceImpl {
             up_fragment_id,
             down_fragment_id,
             database_id,
+            up_partial_graph_id,
             term_id,
         } = {
             let req = request_stream
@@ -75,7 +76,12 @@ impl StreamExchangeService for StreamExchangeServiceImpl {
 
         let receiver = self
             .stream_mgr
-            .take_receiver(database_id, term_id, (up_actor_id, down_actor_id))
+            .take_receiver(
+                database_id,
+                up_partial_graph_id,
+                term_id,
+                (up_actor_id, down_actor_id),
+            )
             .await?;
 
         // Map the remaining stream to add-permits.

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -638,7 +638,7 @@ impl DatabaseCheckpointControl {
         tracing::trace!(
             %worker_id,
             prev_epoch,
-            partial_graph_id = resp.partial_graph_id,
+            partial_graph_id = %resp.partial_graph_id,
             "barrier collected"
         );
         let creating_job_id = from_partial_graph_id(resp.partial_graph_id);

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -32,7 +32,6 @@ use crate::barrier::checkpoint::control::DatabaseCheckpointControlStatus;
 use crate::barrier::checkpoint::creating_job::CreatingStreamingJobControl;
 use crate::barrier::checkpoint::{BarrierWorkerState, CheckpointControl};
 use crate::barrier::complete_task::BarrierCompleteOutput;
-use crate::barrier::edge_builder::FragmentEdgeBuilder;
 use crate::barrier::rpc::{ControlStreamManager, DatabaseInitialBarrierCollector};
 use crate::barrier::worker::{
     RetryBackoffFuture, RetryBackoffStrategy, get_retry_backoff_strategy,
@@ -435,21 +434,12 @@ impl DatabaseStatusAction<'_, EnterInitializing> {
             mut cdc_table_snapshot_splits,
         } = runtime_info;
         let result: MetaResult<_> = try {
-            let mut builder = FragmentEdgeBuilder::new(
-                job_infos
-                    .values()
-                    .flat_map(|fragment_infos| fragment_infos.values()),
-                control_stream_manager,
-            );
-            builder.add_relations(&fragment_relations);
-            let mut edges = builder.build();
             control_stream_manager.inject_database_initial_barrier(
                 self.database_id,
                 job_infos,
                 &mut state_table_committed_epochs,
                 &mut state_table_log_epochs,
                 &fragment_relations,
-                &mut edges,
                 &stream_actors,
                 &mut source_splits,
                 &mut background_jobs,

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -34,7 +34,7 @@ use crate::barrier::edge_builder::FragmentEdgeBuilder;
 use crate::barrier::info::{
     BarrierInfo, CreateStreamingJobStatus, InflightStreamingJobInfo, SubscriberType,
 };
-use crate::barrier::rpc::ControlStreamManager;
+use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
 use crate::barrier::utils::NodeToCollect;
 use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
 use crate::controller::fragment::InflightFragmentInfo;
@@ -394,13 +394,16 @@ impl DatabaseCheckpointControl {
                                     )
                                 }),
                         );
+                        // new actors belong to the database partial graph
+                        let partial_graph_id = to_partial_graph_id(None);
                         let mut edge_builder = FragmentEdgeBuilder::new(
                             info.upstream_fragment_downstreams
                                 .keys()
                                 .map(|upstream_fragment_id| {
                                     self.database_info.fragment(*upstream_fragment_id)
                                 })
-                                .chain(new_fragment_info.values()),
+                                .chain(new_fragment_info.values())
+                                .map(|info| (info, partial_graph_id)),
                             control_stream_manager,
                         );
                         edge_builder.add_relations(&info.upstream_fragment_downstreams);

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -42,7 +42,7 @@ use crate::MetaResult;
 use crate::barrier::cdc_progress::{CdcProgress, CdcTableBackfillTracker};
 use crate::barrier::edge_builder::{FragmentEdgeBuildResult, FragmentEdgeBuilder};
 use crate::barrier::progress::{CreateMviewProgressTracker, StagingCommitInfo};
-use crate::barrier::rpc::ControlStreamManager;
+use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
 use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::controller::utils::rebuild_fragment_mapping;
@@ -1021,7 +1021,9 @@ impl InflightDatabaseInfo {
                     } else {
                         None
                     };
-                    (Some(info), None, new_upstream_sink)
+                    let is_snapshot_backfill =
+                        matches!(job_type, CreateStreamingJobType::SnapshotBackfill(_));
+                    (Some((info, is_snapshot_backfill)), None, new_upstream_sink)
                 }
                 Command::ReplaceStreamJob(replace_job) => (None, Some(replace_job), None),
                 Command::ResetSource { .. } => (None, None, None),
@@ -1036,13 +1038,13 @@ impl InflightDatabaseInfo {
         //  - should contain the `fragment_id` of the downstream table.
         let existing_fragment_ids = info
             .into_iter()
-            .flat_map(|info| info.upstream_fragment_downstreams.keys())
+            .flat_map(|(info, _)| info.upstream_fragment_downstreams.keys())
             .chain(replace_job.into_iter().flat_map(|replace_job| {
                 replace_job
                     .upstream_fragment_downstreams
                     .keys()
                     .filter(|fragment_id| {
-                        info.map(|info| {
+                        info.map(|(info, _)| {
                             !info
                                 .stream_job_fragments
                                 .fragments
@@ -1060,34 +1062,56 @@ impl InflightDatabaseInfo {
             .cloned();
         let new_fragment_infos = info
             .into_iter()
-            .flat_map(|info| {
+            .flat_map(|(info, is_snapshot_backfill)| {
+                let partial_graph_id =
+                    to_partial_graph_id(is_snapshot_backfill.then_some(info.streaming_job.id()));
                 info.stream_job_fragments
                     .new_fragment_info(&info.init_split_assignment)
+                    .map(move |(fragment_id, info)| (fragment_id, info, partial_graph_id))
             })
-            .chain(replace_job.into_iter().flat_map(|replace_job| {
+            .chain(
                 replace_job
-                    .new_fragments
-                    .new_fragment_info(&replace_job.init_split_assignment)
-                    .chain(
+                    .into_iter()
+                    .flat_map(|replace_job| {
                         replace_job
-                            .auto_refresh_schema_sinks
-                            .as_ref()
-                            .into_iter()
-                            .flat_map(|sinks| {
-                                sinks.iter().map(|sink| {
-                                    (sink.new_fragment.fragment_id, sink.new_fragment_info())
-                                })
-                            }),
-                    )
-            }))
+                            .new_fragments
+                            .new_fragment_info(&replace_job.init_split_assignment)
+                            .chain(
+                                replace_job
+                                    .auto_refresh_schema_sinks
+                                    .as_ref()
+                                    .into_iter()
+                                    .flat_map(|sinks| {
+                                        sinks.iter().map(|sink| {
+                                            (
+                                                sink.new_fragment.fragment_id,
+                                                sink.new_fragment_info(),
+                                            )
+                                        })
+                                    }),
+                            )
+                    })
+                    .map(|(fragment_id, fragment)| {
+                        (
+                            fragment_id,
+                            fragment,
+                            // we assume that replace job only happens in database partial graph
+                            to_partial_graph_id(None),
+                        )
+                    }),
+            )
             .collect_vec();
         let mut builder = FragmentEdgeBuilder::new(
             existing_fragment_ids
-                .map(|fragment_id| self.fragment(fragment_id))
-                .chain(new_fragment_infos.iter().map(|(_, info)| info)),
+                .map(|fragment_id| (self.fragment(fragment_id), to_partial_graph_id(None)))
+                .chain(
+                    new_fragment_infos
+                        .iter()
+                        .map(|(_, info, partial_graph_id)| (info, *partial_graph_id)),
+                ),
             control_stream_manager,
         );
-        if let Some(info) = info {
+        if let Some((info, _)) = info {
             builder.add_relations(&info.upstream_fragment_downstreams);
             builder.add_relations(&info.stream_job_fragments.downstreams);
         }

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -712,8 +712,6 @@ pub(crate) use retry_strategy::*;
 use risingwave_common::error::tonic::extra::{Score, ScoredError};
 use risingwave_pb::meta::event_log::{Event, EventRecovery};
 
-use crate::barrier::edge_builder::FragmentEdgeBuilder;
-
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
     /// Recovery the whole cluster from the latest epoch.
     ///
@@ -806,10 +804,6 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
 
 
             {
-                let mut builder = FragmentEdgeBuilder::new(database_job_infos.values().flat_map(|jobs| jobs.values().flat_map(|fragments| fragments.values())), &control_stream_manager);
-                builder.add_relations(&fragment_relations);
-                let mut edges = builder.build();
-
                 let mut collected_databases = HashMap::new();
                 let mut collecting_databases = HashMap::new();
                 let mut failed_databases = HashSet::new();
@@ -820,7 +814,6 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         &mut state_table_committed_epochs,
                         &mut state_table_log_epochs,
                         &fragment_relations,
-                        &mut edges,
                         &stream_actors,
                         &mut source_splits,
                         &mut background_jobs,

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -34,7 +34,7 @@ use risingwave_common::{bail, hash};
 use risingwave_connector::source::cdc::{CDC_BACKFILL_MAX_PARALLELISM, CdcScanOptions};
 use risingwave_meta_model::WorkerId;
 use risingwave_meta_model::fragment::DistributionType;
-use risingwave_pb::common::{ActorInfo, WorkerNode};
+use risingwave_pb::common::WorkerNode;
 use risingwave_pb::meta::table_fragments::fragment::PbFragmentDistributionType;
 use risingwave_pb::stream_plan::DispatcherType::{self, *};
 
@@ -445,28 +445,6 @@ pub struct Locations {
     pub actor_locations: BTreeMap<ActorId, ActorAlignmentId>,
     /// worker location map.
     pub worker_locations: HashMap<WorkerId, WorkerNode>,
-}
-
-impl Locations {
-    /// Returns all actors for every worker node.
-    pub fn worker_actors(&self) -> HashMap<WorkerId, Vec<ActorId>> {
-        self.actor_locations
-            .iter()
-            .map(|(actor_id, alignment_id)| (alignment_id.worker_id(), *actor_id))
-            .into_group_map()
-    }
-
-    /// Returns an iterator of `ActorInfo`.
-    pub fn actor_infos(&self) -> impl Iterator<Item = ActorInfo> + '_ {
-        self.actor_locations
-            .iter()
-            .map(|(&actor_id, alignment_id)| ActorInfo {
-                actor_id,
-                host: self.worker_locations[&(alignment_id.worker_id() as WorkerId)]
-                    .host
-                    .clone(),
-            })
-    }
 }
 
 #[cfg(test)]

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -155,6 +155,7 @@ for_all_wrapped_id_fields! (
     common {
         ActorInfo {
             actor_id: ActorId,
+            partial_graph_id: PartialGraphId,
         }
         ActorLocation {
             worker_node_id: WorkerId,
@@ -496,6 +497,7 @@ for_all_wrapped_id_fields! (
         }
         ListTableFragmentsResponse.ActorInfo {
             id: ActorId,
+            partial_graph_id: PartialGraphId,
         }
         ListTableFragmentsResponse.FragmentInfo {
             id: FragmentId,
@@ -713,6 +715,7 @@ for_all_wrapped_id_fields! (
             worker_id: WorkerId,
             list_finished_source_ids: SourceId,
             load_finished_source_ids: SourceId,
+            partial_graph_id: PartialGraphId,
         }
         BarrierCompleteResponse.CdcTableBackfillProgress {
             fragment_id: FragmentId,
@@ -739,6 +742,7 @@ for_all_wrapped_id_fields! (
             database_id: DatabaseId,
             table_ids_to_sync: TableId,
             actor_ids_to_collect: ActorId,
+            partial_graph_id: PartialGraphId,
         }
         InjectBarrierRequest.BuildActorInfo {
             fragment_upstreams: FragmentId,
@@ -750,9 +754,11 @@ for_all_wrapped_id_fields! (
         }
         StreamingControlStreamRequest.CreatePartialGraphRequest {
             database_id: DatabaseId,
+            partial_graph_id: PartialGraphId,
         }
         StreamingControlStreamRequest.RemovePartialGraphRequest {
             database_id: DatabaseId,
+            partial_graph_ids: PartialGraphId,
         }
         StreamingControlStreamRequest.ResetDatabaseRequest {
             database_id: DatabaseId,
@@ -770,6 +776,7 @@ for_all_wrapped_id_fields! (
         }
         GetStreamRequest.Get {
             database_id: DatabaseId,
+            up_partial_graph_id: PartialGraphId,
             up_fragment_id: FragmentId,
             down_fragment_id: FragmentId,
             up_actor_id: ActorId,

--- a/src/prost/src/id.rs
+++ b/src/prost/src/id.rs
@@ -312,7 +312,8 @@ declare_id_types!(
     ConnectionId,
     SecretId,
     SubscriberId,
-    LocalOperatorId
+    LocalOperatorId,
+    PartialGraphId
 );
 
 declare_id_type!(ObjectId, u32, 256);

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -28,6 +28,7 @@ use risingwave_pb::compute::config_service_client::ConfigServiceClient;
 use risingwave_pb::compute::{
     ResizeCacheRequest, ResizeCacheResponse, ShowConfigRequest, ShowConfigResponse,
 };
+use risingwave_pb::id::PartialGraphId;
 use risingwave_pb::monitor_service::monitor_service_client::MonitorServiceClient;
 use risingwave_pb::monitor_service::{
     AnalyzeHeapRequest, AnalyzeHeapResponse, GetStreamingStatsRequest, GetStreamingStatsResponse,
@@ -124,6 +125,7 @@ impl ComputeClient {
         up_fragment_id: FragmentId,
         down_fragment_id: FragmentId,
         database_id: DatabaseId,
+        up_partial_graph_id: PartialGraphId,
         term_id: String,
     ) -> Result<(
         Streaming<GetStreamResponse>,
@@ -143,6 +145,7 @@ impl ComputeClient {
                     up_fragment_id,
                     down_fragment_id,
                     database_id,
+                    up_partial_graph_id,
                     term_id,
                 })),
             },

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -481,9 +481,9 @@ mod tests {
     use crate::executor::exchange::input::{ActorInput, LocalInput, RemoteInput};
     use crate::executor::exchange::permit::channel_for_test;
     use crate::executor::{BarrierInner as Barrier, MessageInner as Message};
-    use crate::task::NewOutputRequest;
     use crate::task::barrier_test_utils::LocalBarrierTestEnv;
     use crate::task::test_utils::helper_make_local_actor;
+    use crate::task::{NewOutputRequest, TEST_PARTIAL_GRAPH_ID};
 
     fn build_test_chunk(size: u64) -> StreamChunk {
         let ops = vec![Op::Insert; size as usize];
@@ -929,6 +929,7 @@ mod tests {
             RemoteInput::new(
                 &test_env.local_barrier_manager,
                 addr.into(),
+                TEST_PARTIAL_GRAPH_ID,
                 (0.into(), 0.into()),
                 (0.into(), 0.into()),
                 Arc::new(StreamingMetrics::unused()),

--- a/src/stream/src/task/barrier_manager/mod.rs
+++ b/src/stream/src/task/barrier_manager/mod.rs
@@ -19,7 +19,7 @@ pub use progress::CreateMviewProgressReporter;
 use risingwave_common::catalog::DatabaseId;
 use risingwave_common::id::{SourceId, TableId};
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_pb::id::FragmentId;
+use risingwave_pb::id::{FragmentId, PartialGraphId};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
@@ -69,6 +69,7 @@ pub(super) enum LocalBarrierEvent {
     RegisterLocalUpstreamOutput {
         actor_id: ActorId,
         upstream_actor_id: ActorId,
+        upstream_partial_graph_id: PartialGraphId,
         tx: permit::Sender,
     },
     ReportCdcTableBackfillProgress {
@@ -160,11 +161,13 @@ impl LocalBarrierManager {
         &self,
         actor_id: ActorId,
         upstream_actor_id: ActorId,
+        upstream_partial_graph_id: PartialGraphId,
     ) -> permit::Receiver {
         let (tx, rx) = channel_from_config(self.env.global_config());
         self.send_event(LocalBarrierEvent::RegisterLocalUpstreamOutput {
             actor_id,
             upstream_actor_id,
+            upstream_partial_graph_id,
             tx,
         });
         rx

--- a/src/stream/src/task/barrier_manager/progress.rs
+++ b/src/stream/src/task/barrier_manager/progress.rs
@@ -104,8 +104,7 @@ impl DatabaseManagedBarrierState {
         state: BackfillState,
     ) {
         if let Some(actor_state) = self.actor_states.get(&actor)
-            && let Some(partial_graph_id) = actor_state.inflight_barriers.get(&epoch.prev)
-            && let Some(graph_state) = self.graph_states.get_mut(partial_graph_id)
+            && let Some(graph_state) = self.graph_states.get_mut(&actor_state.partial_graph_id)
         {
             if let Some((prev_fragment_id, _)) = graph_state
                 .create_mview_progress
@@ -127,8 +126,7 @@ impl DatabaseManagedBarrierState {
         state: CdcTableBackfillState,
     ) {
         if let Some(actor_state) = self.actor_states.get(&actor)
-            && let Some(partial_graph_id) = actor_state.inflight_barriers.get(&epoch.prev)
-            && let Some(graph_state) = self.graph_states.get_mut(partial_graph_id)
+            && let Some(graph_state) = self.graph_states.get_mut(&actor_state.partial_graph_id)
         {
             graph_state
                 .cdc_table_backfill_progress

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -95,7 +95,7 @@ pub use actor_manager::*;
 pub use barrier_manager::*;
 pub use barrier_worker::*;
 pub use env::*;
-pub use risingwave_common::id::{ActorId, FragmentId};
+pub use risingwave_common::id::{ActorId, FragmentId, PartialGraphId};
 pub use stream_manager::*;
 
 pub type ConsumableChannelPair = (Option<Sender>, Option<Receiver>);
@@ -104,24 +104,9 @@ pub type DispatcherId = FragmentId;
 pub type UpDownActorIds = (ActorId, ActorId);
 pub type UpDownFragmentIds = (FragmentId, FragmentId);
 
-#[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
-pub(crate) struct PartialGraphId(u32);
-
 #[cfg(test)]
 pub(crate) const TEST_DATABASE_ID: risingwave_common::catalog::DatabaseId =
     risingwave_common::catalog::DatabaseId::new(u32::MAX);
 
 #[cfg(test)]
-pub(crate) const TEST_PARTIAL_GRAPH_ID: PartialGraphId = PartialGraphId(u32::MAX);
-
-impl PartialGraphId {
-    fn new(id: u32) -> Self {
-        Self(id)
-    }
-}
-
-impl From<PartialGraphId> for u32 {
-    fn from(val: PartialGraphId) -> u32 {
-        val.0
-    }
-}
+pub(crate) const TEST_PARTIAL_GRAPH_ID: PartialGraphId = PartialGraphId::new(u32::MAX);

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 use futures::FutureExt;
 use futures::stream::BoxStream;
 use risingwave_common::catalog::DatabaseId;
+use risingwave_pb::id::PartialGraphId;
 use risingwave_pb::stream_service::streaming_control_stream_request::InitRequest;
 use risingwave_pb::stream_service::{
     StreamingControlStreamRequest, StreamingControlStreamResponse,
@@ -32,7 +33,7 @@ use crate::executor::ActorContextRef;
 use crate::executor::exchange::permit::Receiver;
 use crate::executor::monitor::StreamingMetrics;
 use crate::task::barrier_worker::{
-    ControlStreamHandle, EventSender, LocalActorOperation, LocalBarrierWorker,
+    ControlStreamHandle, EventSender, LocalActorOperation, LocalBarrierWorker, TakeReceiverRequest,
 };
 use crate::task::{StreamEnvironment, UpDownActorIds};
 
@@ -141,15 +142,17 @@ impl LocalStreamManager {
     pub async fn take_receiver(
         &self,
         database_id: DatabaseId,
+        partial_graph_id: PartialGraphId,
         term_id: String,
         ids: UpDownActorIds,
     ) -> StreamResult<Receiver> {
         self.actor_op_tx
             .send_and_await(|result_sender| LocalActorOperation::TakeReceiver {
                 database_id,
+                partial_graph_id,
                 term_id,
                 ids,
-                result_sender,
+                request: TakeReceiverRequest::Remote(result_sender),
             })
             .await?
     }
@@ -182,6 +185,7 @@ pub mod test_utils {
     use risingwave_pb::common::{ActorInfo, HostAddress};
 
     use super::*;
+    use crate::task::TEST_PARTIAL_GRAPH_ID;
 
     pub fn helper_make_local_actor(actor_id: ActorId) -> ActorInfo {
         ActorInfo {
@@ -190,6 +194,7 @@ pub mod test_utils {
                 host: LOCAL_TEST_ADDR.host.clone(),
                 port: LOCAL_TEST_ADDR.port as i32,
             }),
+            partial_graph_id: TEST_PARTIAL_GRAPH_ID,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

part of the downstream PR https://github.com/risingwavelabs/risingwave/pull/24239.

assume that an actor belongs to a fixed partial graph, and modify the local barrier worker state accordingly.

### copilot gen

This pull request introduces support for tracking and propagating the `partial_graph_id` throughout the system, especially in actor info and fragment edge management. This change is important for distinguishing different partial graphs within a database, which can improve scalability and correctness in distributed streaming jobs. The update touches protocol buffer definitions, actor and fragment info structures, and various places where actors and fragments are constructed and referenced.

The most important changes are:

**Protocol and Data Model Updates**
* Added `partial_graph_id` to the `ActorInfo` message in `proto/common.proto` and to relevant request messages in `proto/task_service.proto`, allowing this information to be transmitted in RPCs. [[1]](diffhunk://#diff-1747d3070a2311a07389bc9e83309513fbf9f16f7aac7a80988344c38fb98635R27) [[2]](diffhunk://#diff-16957e1cacfb175a8b2a8c6f82e420cf4fb719b4a6fb8585da19f0c86bcf8422R133)
* Updated the `FragmentInfo` struct and `FragmentEdgeBuilder` logic to include and propagate `partial_graph_id` for each fragment, ensuring that edges and actor info are correctly associated with their partial graph. [[1]](diffhunk://#diff-c1e2ae28d65d56b87cf439388c51e15ae3ec9b262da74ab1c8b1ac086b78a0eeR39) [[2]](diffhunk://#diff-c1e2ae28d65d56b87cf439388c51e15ae3ec9b262da74ab1c8b1ac086b78a0eeL109-R114) [[3]](diffhunk://#diff-c1e2ae28d65d56b87cf439388c51e15ae3ec9b262da74ab1c8b1ac086b78a0eeR131) [[4]](diffhunk://#diff-c1e2ae28d65d56b87cf439388c51e15ae3ec9b262da74ab1c8b1ac086b78a0eeR202)

**Actor and Fragment Construction**
* Modified actor info construction in several places to include the correct `partial_graph_id`, especially when scaling or rescheduling database partial graphs, and updated relevant helper functions to support this. [[1]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R974) [[2]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R1171-R1172) [[3]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R1535) [[4]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R1579)
* Changed the collection of actor upstreams to focus specifically on database partial graphs, renaming and updating the logic to use `collect_database_partial_graph_actor_upstreams`. [[1]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L1335-R1339) [[2]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19L1499-R1503)

**Fragment Edge Building and Relations**
* Updated fragment edge building to handle cases where upstream or downstream fragments may not be present, improving robustness and correctness of edge construction.

**Integration and Propagation**
* Ensured that the `partial_graph_id` is correctly propagated through checkpoint control, command, and info modules, including during snapshot backfill and replace job scenarios. [[1]](diffhunk://#diff-44229b137399d20ef70c07c7f928527ec494356b08b98ac0e68c6ccf7b3371b0R397-R406) [[2]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2L1024-R1026) [[3]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2L1038-R1046) [[4]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2L1062-R1074) [[5]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2L1077-R1113)

These changes collectively enhance the system's ability to manage and distinguish partial graphs, which is critical for supporting scalable and reliable distributed streaming jobs.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
