### PR TITLE
feat(iceberg): support explain datafusion physical plan

### DIFF
--- a/src/frontend/src/datafusion/execute.rs
+++ b/src/frontend/src/datafusion/execute.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use datafusion::config::ConfigOptions;
-use datafusion::physical_plan::execute_stream;
+use datafusion::physical_plan::{ExecutionPlan, execute_stream};
 use datafusion::prelude::{SessionConfig as DFSessionConfig, SessionContext as DFSessionContext};
 use futures_async_stream::for_await;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
@@ -35,23 +35,23 @@ use crate::handler::util::{DataChunkToRowSetAdapter, to_pg_field};
 use crate::scheduler::SchedulerError;
 use crate::session::SessionImpl;
 
+#[derive(Clone)]
 pub struct DfBatchQueryPlanResult {
     pub(crate) plan: Arc<datafusion::logical_expr::LogicalPlan>,
     pub(crate) schema: RwSchema,
     pub(crate) stmt_type: StatementType,
 }
 
-pub async fn execute_datafusion_plan(
-    session: Arc<SessionImpl>,
-    plan: DfBatchQueryPlanResult,
-    formats: Vec<Format>,
-) -> RwResult<RwPgResponse> {
-    let df_config = create_config(session.as_ref());
-    let ctx = DFSessionContext::new_with_config(df_config);
-    let state = ctx.state();
+pub fn create_datafusion_context(session: &SessionImpl) -> DFSessionContext {
+    let df_config = create_config(session);
+    DFSessionContext::new_with_config(df_config)
+}
 
-    let pg_descs: Vec<PgFieldDescriptor> = plan.schema.fields().iter().map(to_pg_field).collect();
-    let column_types = plan.schema.fields().iter().map(|f| f.data_type()).collect();
+pub async fn build_datafusion_physical_plan(
+    ctx: &DFSessionContext,
+    plan: &DfBatchQueryPlanResult,
+) -> RwResult<Arc<dyn ExecutionPlan>> {
+    let state = ctx.state();
 
     // TODO: some optimizing rules will cause inconsistency, need to investigate later
     // Currently we disable all optimizing rules to ensure correctness
@@ -65,6 +65,20 @@ pub async fn execute_datafusion_plan(
         .query_planner()
         .create_physical_plan(&df_plan, &state)
         .await?;
+    Ok(physical_plan)
+}
+
+pub async fn execute_datafusion_plan(
+    session: Arc<SessionImpl>,
+    plan: DfBatchQueryPlanResult,
+    formats: Vec<Format>,
+) -> RwResult<RwPgResponse> {
+    let ctx = create_datafusion_context(session.as_ref());
+
+    let pg_descs: Vec<PgFieldDescriptor> = plan.schema.fields().iter().map(to_pg_field).collect();
+    let column_types = plan.schema.fields().iter().map(|f| f.data_type()).collect();
+
+    let physical_plan = build_datafusion_physical_plan(&ctx, &plan).await?;
     let data_stream = execute_stream(physical_plan, ctx.task_ctx())?;
 
     let compute_runtime = session.env().compute_runtime();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Support explain datafusion physical plan instead of logical plan. 
- Resolve https://github.com/risingwavelabs/risingwave/issues/24337

### Example: 

```
dev=> explain select count(*) from lineitem;
                                        QUERY PLAN
-------------------------------------------------------------------------------------------
 AggregateExec: mode=Final, gby=[], aggr=[count(Int32(1))]
   CoalescePartitionsExec
     AggregateExec: mode=Partial, gby=[], aggr=[count(Int32(1))]
       CooperativeExec
         IcebergScan: iceberg_scan_type=ICEBERG_SCAN_TYPE_DATA_SCAN, table=public.lineitem
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
