### PR TITLE
feat: support alter compaction group config via sql

### DIFF
--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -82,6 +82,24 @@ SELECT (compaction_config::jsonb)->>'enableEmergencyPicker' FROM rw_hummock_comp
 ----
 true
 
+# Test boolean config using unquoted identifier literal
+statement ok
+ALTER COMPACTION GROUP 2 SET enable_emergency_picker = off;
+
+query T
+SELECT (compaction_config::jsonb)->>'enableEmergencyPicker' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+false
+
+# Test boolean config using numeric literal
+statement ok
+ALTER COMPACTION GROUP 2 SET enable_emergency_picker = 1;
+
+query T
+SELECT (compaction_config::jsonb)->>'enableEmergencyPicker' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+true
+
 # Reject comma-separated list RHS (comma is reserved for separating assignments)
 statement error
 ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1,2;

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -52,6 +52,67 @@ SELECT id, (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_c
 2 268435456
 3 268435456
 
+# Test ALTER COMPACTION GROUP using TO syntax (config-param style)
+statement ok
+ALTER COMPACTION GROUP 2 SET target_file_size_base TO 134217728;
+
+# Verify TO syntax updated the config
+query I
+SELECT (compaction_config::jsonb)->>'targetFileSizeBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+134217728
+
+# Test ALTER COMPACTION GROUP with mixed TO/= in multiple configs
+statement ok
+ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base TO 268435456, target_file_size_base = 33554432;
+
+# Verify both configs were updated
+query TT
+SELECT (compaction_config::jsonb)->>'maxBytesForLevelBase', (compaction_config::jsonb)->>'targetFileSizeBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+268435456 33554432
+
+# Test boolean config using quoted string literal
+statement ok
+ALTER COMPACTION GROUP 2 SET enable_emergency_picker = 'true';
+
+# Verify boolean config was updated
+query T
+SELECT (compaction_config::jsonb)->>'enableEmergencyPicker' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+true
+
+# Reject comma-separated list RHS (comma is reserved for separating assignments)
+statement error
+ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1,2;
+
+# DEFAULT resets compaction configs to built-in defaults
+statement ok
+ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = DEFAULT;
+
+query I
+SELECT (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+536870912
+
+# DEFAULT resets compression algorithm for all levels
+statement ok
+ALTER COMPACTION GROUP 2 SET compression_algorithm = DEFAULT;
+
+query T
+SELECT (compaction_config::jsonb)->'compressionAlgorithm'->>6 FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+Zstd
+
+# DEFAULT for optional configs can become NULL
+statement ok
+ALTER COMPACTION GROUP 2 SET vnode_aligned_level_size_threshold = DEFAULT;
+
+query T
+SELECT (compaction_config::jsonb)->>'vnodeAlignedLevelSizeThreshold' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+NULL
+
 # Test invalid config name
 statement error unknown compaction config parameter
 ALTER COMPACTION GROUP 2 SET invalid_config_name = 123;

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -87,7 +87,7 @@ statement ok
 ALTER COMPACTION GROUP 2 SET enable_emergency_picker = off;
 
 query T
-SELECT (compaction_config::jsonb)->>'enableEmergencyPicker' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+SELECT COALESCE(((compaction_config::jsonb)->>'enableEmergencyPicker')::boolean, false)::varchar FROM rw_hummock_compaction_group_configs WHERE id = 2;
 ----
 false
 

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -1,0 +1,69 @@
+# ALTER COMPACTION GROUP tests
+
+# Test basic ALTER COMPACTION GROUP with single config and verify it was applied
+statement ok
+ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1073741824;
+
+# Verify the config was updated
+query I
+SELECT (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+1073741824
+
+# Test ALTER COMPACTION GROUP with multiple configs
+statement ok
+ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 536870912, target_file_size_base = 67108864;
+
+# Verify both configs were updated
+query TT
+SELECT (compaction_config::jsonb)->>'maxBytesForLevelBase', (compaction_config::jsonb)->>'targetFileSizeBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+536870912 67108864
+
+# Test ALTER COMPACTION GROUP with boolean config
+statement ok
+ALTER COMPACTION GROUP 2 SET enable_emergency_picker = true;
+
+# Verify boolean config was updated
+query T
+SELECT (compaction_config::jsonb)->>'enableEmergencyPicker' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+true
+
+# Test ALTER COMPACTION GROUP with compression_algorithm (format: 'level:algorithm')
+# This sets the compression algorithm for a specific LSM-tree level (0-6)
+statement ok
+ALTER COMPACTION GROUP 2 SET compression_algorithm = '6:lz4';
+
+# Verify compression algorithm was updated for level 6
+query T
+SELECT (compaction_config::jsonb)->'compressionAlgorithm'->>6 FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+Lz4
+
+# Test ALTER COMPACTION GROUP with multiple groups
+statement ok
+ALTER COMPACTION GROUP 2, 3 SET max_bytes_for_level_base = 268435456;
+
+# Verify both groups were updated
+query II
+SELECT id, (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_compaction_group_configs WHERE id IN (2, 3) ORDER BY id;
+----
+2 268435456
+3 268435456
+
+# Test invalid config name
+statement error unknown compaction config parameter
+ALTER COMPACTION GROUP 2 SET invalid_config_name = 123;
+
+# Test empty config
+statement error
+ALTER COMPACTION GROUP 2 SET;
+
+# Test missing SET keyword
+statement error
+ALTER COMPACTION GROUP 2 max_bytes_for_level_base = 1073741824;
+
+# Test missing GROUP keyword
+statement error
+ALTER COMPACTION 2 SET max_bytes_for_level_base = 1073741824;

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -5,7 +5,7 @@ statement ok
 ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1073741824;
 
 # Verify the config was updated
-query I
+query T
 SELECT (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
 ----
 1073741824
@@ -46,7 +46,7 @@ statement ok
 ALTER COMPACTION GROUP 2, 3 SET max_bytes_for_level_base = 268435456;
 
 # Verify both groups were updated
-query II
+query IT
 SELECT id, (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_compaction_group_configs WHERE id IN (2, 3) ORDER BY id;
 ----
 2 268435456
@@ -57,7 +57,7 @@ statement ok
 ALTER COMPACTION GROUP 2 SET target_file_size_base TO 134217728;
 
 # Verify TO syntax updated the config
-query I
+query T
 SELECT (compaction_config::jsonb)->>'targetFileSizeBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
 ----
 134217728
@@ -108,7 +108,7 @@ ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1,2;
 statement ok
 ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = DEFAULT;
 
-query I
+query T
 SELECT (compaction_config::jsonb)->>'maxBytesForLevelBase' FROM rw_hummock_compaction_group_configs WHERE id = 2;
 ----
 536870912
@@ -122,14 +122,9 @@ SELECT (compaction_config::jsonb)->'compressionAlgorithm'->>6 FROM rw_hummock_co
 ----
 Zstd
 
-# DEFAULT for optional configs can become NULL
-statement ok
+# Deprecated no-op configs are rejected by SQL instead of reporting success without effect
+statement error deprecated and cannot be altered via SQL
 ALTER COMPACTION GROUP 2 SET vnode_aligned_level_size_threshold = DEFAULT;
-
-query T
-SELECT (compaction_config::jsonb)->>'vnodeAlignedLevelSizeThreshold' FROM rw_hummock_compaction_group_configs WHERE id = 2;
-----
-NULL
 
 statement ok
 ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = 1024;
@@ -147,6 +142,22 @@ SELECT (compaction_config::jsonb)->>'maxVnodeKeyRangeBytes' FROM rw_hummock_comp
 ----
 NULL
 
+statement ok
+ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = 1024;
+
+query T
+SELECT (compaction_config::jsonb)->>'maxKvCountForXor16' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+1024
+
+statement ok
+ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = DEFAULT;
+
+query T
+SELECT (compaction_config::jsonb)->>'maxKvCountForXor16' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+262144
+
 # Optional positive configs reject sentinel values instead of silently treating them as unset
 statement error must be between 1 and 18446744073709551614, or DEFAULT
 ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = 0;
@@ -159,6 +170,9 @@ ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = 18446744073709551615;
 
 statement error must be between 1 and 18446744073709551614, or DEFAULT
 ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = 18446744073709551615;
+
+statement error managed by the system and cannot be altered via SQL
+ALTER COMPACTION GROUP 2 SET split_weight_by_vnode = 1;
 
 # Test invalid config name
 statement error unknown compaction config parameter

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -131,6 +131,22 @@ SELECT (compaction_config::jsonb)->>'vnodeAlignedLevelSizeThreshold' FROM rw_hum
 ----
 NULL
 
+statement ok
+ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = 1024;
+
+query T
+SELECT (compaction_config::jsonb)->>'maxVnodeKeyRangeBytes' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+1024
+
+statement ok
+ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = DEFAULT;
+
+query T
+SELECT (compaction_config::jsonb)->>'maxVnodeKeyRangeBytes' FROM rw_hummock_compaction_group_configs WHERE id = 2;
+----
+NULL
+
 # Test invalid config name
 statement error unknown compaction config parameter
 ALTER COMPACTION GROUP 2 SET invalid_config_name = 123;

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -147,12 +147,18 @@ SELECT (compaction_config::jsonb)->>'maxVnodeKeyRangeBytes' FROM rw_hummock_comp
 ----
 NULL
 
-# Optional positive configs reject 0 instead of silently treating it as unset
-statement error must be positive or DEFAULT
+# Optional positive configs reject sentinel values instead of silently treating them as unset
+statement error must be between 1 and 18446744073709551614, or DEFAULT
 ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = 0;
 
-statement error must be positive or DEFAULT
+statement error must be between 1 and 18446744073709551614, or DEFAULT
 ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = 0;
+
+statement error must be between 1 and 18446744073709551614, or DEFAULT
+ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = 18446744073709551615;
+
+statement error must be between 1 and 18446744073709551614, or DEFAULT
+ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = 18446744073709551615;
 
 # Test invalid config name
 statement error unknown compaction config parameter

--- a/e2e_test/ddl/alter_compaction_group.slt
+++ b/e2e_test/ddl/alter_compaction_group.slt
@@ -147,6 +147,13 @@ SELECT (compaction_config::jsonb)->>'maxVnodeKeyRangeBytes' FROM rw_hummock_comp
 ----
 NULL
 
+# Optional positive configs reject 0 instead of silently treating it as unset
+statement error must be positive or DEFAULT
+ALTER COMPACTION GROUP 2 SET max_kv_count_for_xor16 = 0;
+
+statement error must be positive or DEFAULT
+ALTER COMPACTION GROUP 2 SET max_vnode_key_range_bytes = 0;
+
 # Test invalid config name
 statement error unknown compaction config parameter
 ALTER COMPACTION GROUP 2 SET invalid_config_name = 123;

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -882,6 +882,8 @@ message RiseCtlUpdateCompactionConfigRequest {
       uint64 max_kv_count_for_xor16 = 32;
       // Max bytes for vnode key-range hints recorded into each SST.
       uint64 max_vnode_key_range_bytes = 33;
+      // Reset compression algorithm for all levels to defaults according to group max_level.
+      bool reset_compression_algorithm = 34;
     }
   }
   repeated uint64 compaction_group_ids = 1;

--- a/src/common/src/config/meta.rs
+++ b/src/common/src/config/meta.rs
@@ -1069,6 +1069,27 @@ pub mod default {
             Some(DEFAULT_MAX_KV_COUNT_FOR_XOR16)
         }
 
+        /// Default compression algorithm for a given LSM-tree level.
+        ///
+        /// This is the single source of truth used by meta's default compaction config builder
+        /// and by SQL `ALTER COMPACTION GROUP ... SET compression_algorithm = DEFAULT`.
+        pub fn compression_algorithm_for_level(level: u32) -> &'static str {
+            // L0/L1 and L2 do not use compression algorithms.
+            // L3 - L4 use Lz4, else use Zstd.
+            match level {
+                0..=2 => "None",
+                3 | 4 => "Lz4",
+                _ => "Zstd",
+            }
+        }
+
+        /// Default compression algorithm vector for levels `0..=max_level`.
+        pub fn compression_algorithm_vec(max_level: u32) -> Vec<String> {
+            (0..=max_level)
+                .map(|level| compression_algorithm_for_level(level).to_owned())
+                .collect()
+        }
+
         pub fn max_vnode_key_range_bytes() -> Option<u64> {
             DEFAULT_MAX_VNODE_KEY_RANGE_BYTES
         }

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -13,12 +13,21 @@
 // limitations under the License.
 
 use pgwire::pg_response::StatementType;
+use risingwave_common::config::meta::default::compaction_config;
 use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::CompressionAlgorithm;
 use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
-use risingwave_sqlparser::ast::{AlterCompactionGroupOperation, SqlOption, SqlOptionValue, Value};
+use risingwave_sqlparser::ast::{
+    AlterCompactionGroupOperation, ConfigParam, SetVariableValue, SetVariableValueSingle, Value,
+};
 
 use super::{HandlerArgs, RwPgResponse};
 use crate::error::{ErrorCode, Result};
+
+/// Wire encoding for clearing optional `u64` compaction configs.
+///
+/// Note: meta currently treats both `u64::MIN` and `u64::MAX` as "unset" for historical reasons.
+/// We always *send* `u64::MAX` to avoid ambiguity, since `0` can be a valid user value.
+const OPTIONAL_U64_UNSET_WIRE: u64 = u64::MAX;
 
 pub async fn handle_alter_compaction_group(
     handler_args: HandlerArgs,
@@ -35,7 +44,7 @@ pub async fn handle_alter_compaction_group(
 
     let configs = match operation {
         AlterCompactionGroupOperation::Set { configs } => {
-            build_compaction_config_from_options(&configs)?
+            build_compaction_config_from_params(&configs)?
         }
     };
 
@@ -59,102 +68,211 @@ pub async fn handle_alter_compaction_group(
         .into())
 }
 
-fn build_compaction_config_from_options(options: &[SqlOption]) -> Result<Vec<MutableConfig>> {
+fn build_compaction_config_from_params(params: &[ConfigParam]) -> Result<Vec<MutableConfig>> {
     let mut configs = vec![];
 
-    for option in options {
-        let name = option.name.real_value().to_lowercase();
-        let value = &option.value;
+    for param in params {
+        // Config parameter names are ASCII identifiers. Prefer ASCII-only case folding.
+        let name = param.param.real_value().to_ascii_lowercase();
+        let value = &param.value;
 
         let config = match name.as_str() {
-            "max_bytes_for_level_base" => {
-                MutableConfig::MaxBytesForLevelBase(parse_u64_value(value, &name)?)
-            }
+            "max_bytes_for_level_base" => MutableConfig::MaxBytesForLevelBase(parse_u64_value(
+                value,
+                &name,
+                compaction_config::max_bytes_for_level_base(),
+            )?),
             "max_bytes_for_level_multiplier" => {
-                MutableConfig::MaxBytesForLevelMultiplier(parse_u64_value(value, &name)?)
+                MutableConfig::MaxBytesForLevelMultiplier(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::max_bytes_for_level_multiplier(),
+                )?)
             }
-            "max_compaction_bytes" => {
-                MutableConfig::MaxCompactionBytes(parse_u64_value(value, &name)?)
-            }
+            "max_compaction_bytes" => MutableConfig::MaxCompactionBytes(parse_u64_value(
+                value,
+                &name,
+                compaction_config::max_compaction_bytes(),
+            )?),
             "sub_level_max_compaction_bytes" => {
-                MutableConfig::SubLevelMaxCompactionBytes(parse_u64_value(value, &name)?)
+                MutableConfig::SubLevelMaxCompactionBytes(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::sub_level_max_compaction_bytes(),
+                )?)
             }
             "level0_tier_compact_file_number" => {
-                MutableConfig::Level0TierCompactFileNumber(parse_u64_value(value, &name)?)
+                MutableConfig::Level0TierCompactFileNumber(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::level0_tier_compact_file_number(),
+                )?)
             }
-            "target_file_size_base" => {
-                MutableConfig::TargetFileSizeBase(parse_u64_value(value, &name)?)
-            }
-            "compaction_filter_mask" => {
-                MutableConfig::CompactionFilterMask(parse_u32_value(value, &name)?)
-            }
-            "max_sub_compaction" => MutableConfig::MaxSubCompaction(parse_u32_value(value, &name)?),
+            "target_file_size_base" => MutableConfig::TargetFileSizeBase(parse_u64_value(
+                value,
+                &name,
+                compaction_config::target_file_size_base(),
+            )?),
+            "compaction_filter_mask" => MutableConfig::CompactionFilterMask(parse_u32_value(
+                value,
+                &name,
+                compaction_config::compaction_filter_mask(),
+            )?),
+            "max_sub_compaction" => MutableConfig::MaxSubCompaction(parse_u32_value(
+                value,
+                &name,
+                compaction_config::max_sub_compaction(),
+            )?),
             "level0_stop_write_threshold_sub_level_number" => {
                 MutableConfig::Level0StopWriteThresholdSubLevelNumber(parse_u64_value(
-                    value, &name,
+                    value,
+                    &name,
+                    compaction_config::level0_stop_write_threshold_sub_level_number(),
                 )?)
             }
             "level0_sub_level_compact_level_count" => {
-                MutableConfig::Level0SubLevelCompactLevelCount(parse_u32_value(value, &name)?)
+                MutableConfig::Level0SubLevelCompactLevelCount(parse_u32_value(
+                    value,
+                    &name,
+                    compaction_config::level0_sub_level_compact_level_count(),
+                )?)
             }
-            "max_space_reclaim_bytes" => {
-                MutableConfig::MaxSpaceReclaimBytes(parse_u64_value(value, &name)?)
-            }
+            "max_space_reclaim_bytes" => MutableConfig::MaxSpaceReclaimBytes(parse_u64_value(
+                value,
+                &name,
+                compaction_config::max_space_reclaim_bytes(),
+            )?),
             "level0_max_compact_file_number" => {
-                MutableConfig::Level0MaxCompactFileNumber(parse_u64_value(value, &name)?)
+                MutableConfig::Level0MaxCompactFileNumber(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::level0_max_compact_file_number(),
+                )?)
             }
             "level0_overlapping_sub_level_compact_level_count" => {
                 MutableConfig::Level0OverlappingSubLevelCompactLevelCount(parse_u32_value(
-                    value, &name,
+                    value,
+                    &name,
+                    compaction_config::level0_overlapping_sub_level_compact_level_count(),
                 )?)
             }
-            "enable_emergency_picker" => {
-                MutableConfig::EnableEmergencyPicker(parse_bool_value(value, &name)?)
-            }
-            "tombstone_reclaim_ratio" => {
-                MutableConfig::TombstoneReclaimRatio(parse_u32_value(value, &name)?)
-            }
+            "enable_emergency_picker" => MutableConfig::EnableEmergencyPicker(parse_bool_value(
+                value,
+                &name,
+                compaction_config::enable_emergency_picker(),
+            )?),
+            "tombstone_reclaim_ratio" => MutableConfig::TombstoneReclaimRatio(parse_u32_value(
+                value,
+                &name,
+                compaction_config::tombstone_reclaim_ratio(),
+            )?),
             "compression_algorithm" => {
                 // Format: 'level:algorithm' e.g., '3:lz4' or '6:zstd'
                 // This sets the compression algorithm for a specific LSM-tree level
-                let algorithm = parse_compression_algorithm_with_level(value, &name)?;
-                MutableConfig::CompressionAlgorithm(algorithm)
+                match value {
+                    // For DEFAULT, reset *all* levels to the built-in defaults.
+                    // (This matches meta's `CompactionConfigBuilder::new()` default behavior.)
+                    SetVariableValue::Default => {
+                        let max_level = compaction_config::max_level();
+                        for level in 0..=max_level {
+                            configs.push(MutableConfig::CompressionAlgorithm(
+                                CompressionAlgorithm {
+                                    level,
+                                    compression_algorithm:
+                                        compaction_config::compression_algorithm_for_level(level)
+                                            .to_owned(),
+                                },
+                            ));
+                        }
+                        continue;
+                    }
+                    _ => {
+                        let algorithm = parse_compression_algorithm_with_level(value, &name)?;
+                        MutableConfig::CompressionAlgorithm(algorithm)
+                    }
+                }
             }
-            "max_l0_compact_level_count" => {
-                MutableConfig::MaxL0CompactLevelCount(parse_u32_value(value, &name)?)
-            }
+            "max_l0_compact_level_count" => MutableConfig::MaxL0CompactLevelCount(parse_u32_value(
+                value,
+                &name,
+                compaction_config::max_l0_compact_level_count(),
+            )?),
             "sst_allowed_trivial_move_min_size" => {
-                MutableConfig::SstAllowedTrivialMoveMinSize(parse_u64_value(value, &name)?)
+                MutableConfig::SstAllowedTrivialMoveMinSize(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::sst_allowed_trivial_move_min_size(),
+                )?)
             }
             "disable_auto_group_scheduling" => {
-                MutableConfig::DisableAutoGroupScheduling(parse_bool_value(value, &name)?)
+                MutableConfig::DisableAutoGroupScheduling(parse_bool_value(
+                    value,
+                    &name,
+                    compaction_config::disable_auto_group_scheduling(),
+                )?)
             }
             "max_overlapping_level_size" => {
-                MutableConfig::MaxOverlappingLevelSize(parse_u64_value(value, &name)?)
+                MutableConfig::MaxOverlappingLevelSize(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::max_overlapping_level_size(),
+                )?)
             }
             "sst_allowed_trivial_move_max_count" => {
-                MutableConfig::SstAllowedTrivialMoveMaxCount(parse_u32_value(value, &name)?)
+                MutableConfig::SstAllowedTrivialMoveMaxCount(parse_u32_value(
+                    value,
+                    &name,
+                    compaction_config::sst_allowed_trivial_move_max_count(),
+                )?)
             }
             "emergency_level0_sst_file_count" => {
-                MutableConfig::EmergencyLevel0SstFileCount(parse_u32_value(value, &name)?)
+                MutableConfig::EmergencyLevel0SstFileCount(parse_u32_value(
+                    value,
+                    &name,
+                    compaction_config::emergency_level0_sst_file_count(),
+                )?)
             }
             "emergency_level0_sub_level_partition" => {
-                MutableConfig::EmergencyLevel0SubLevelPartition(parse_u32_value(value, &name)?)
+                MutableConfig::EmergencyLevel0SubLevelPartition(parse_u32_value(
+                    value,
+                    &name,
+                    compaction_config::emergency_level0_sub_level_partition(),
+                )?)
             }
             "level0_stop_write_threshold_max_sst_count" => {
-                MutableConfig::Level0StopWriteThresholdMaxSstCount(parse_u32_value(value, &name)?)
+                MutableConfig::Level0StopWriteThresholdMaxSstCount(parse_u32_value(
+                    value,
+                    &name,
+                    compaction_config::level0_stop_write_threshold_max_sst_count(),
+                )?)
             }
             "level0_stop_write_threshold_max_size" => {
-                MutableConfig::Level0StopWriteThresholdMaxSize(parse_u64_value(value, &name)?)
+                MutableConfig::Level0StopWriteThresholdMaxSize(parse_u64_value(
+                    value,
+                    &name,
+                    compaction_config::level0_stop_write_threshold_max_size(),
+                )?)
             }
             "enable_optimize_l0_interval_selection" => {
-                MutableConfig::EnableOptimizeL0IntervalSelection(parse_bool_value(value, &name)?)
+                MutableConfig::EnableOptimizeL0IntervalSelection(parse_bool_value(
+                    value,
+                    &name,
+                    compaction_config::enable_optimize_l0_interval_selection(),
+                )?)
             }
             "vnode_aligned_level_size_threshold" => {
-                MutableConfig::VnodeAlignedLevelSizeThreshold(parse_u64_value(value, &name)?)
+                MutableConfig::VnodeAlignedLevelSizeThreshold(parse_optional_u64_value(
+                    value,
+                    &name,
+                    compaction_config::vnode_aligned_level_size_threshold(),
+                )?)
             }
             "max_kv_count_for_xor16" => {
-                MutableConfig::MaxKvCountForXor16(parse_u64_value(value, &name)?)
+                MutableConfig::MaxKvCountForXor16(parse_optional_u64_value(
+                    value,
+                    &name,
+                    compaction_config::max_kv_count_for_xor16(),
+                )?)
             }
             _ => {
                 return Err(ErrorCode::InvalidInputSyntax(format!(
@@ -170,67 +288,110 @@ fn build_compaction_config_from_options(options: &[SqlOption]) -> Result<Vec<Mut
     Ok(configs)
 }
 
-fn parse_u64_value(value: &SqlOptionValue, name: &str) -> Result<u64> {
+fn expect_single_literal<'a>(value: &'a SetVariableValue, name: &str) -> Result<&'a Value> {
     match value {
-        SqlOptionValue::Value(Value::Number(n)) => n.parse::<u64>().map_err(|_| {
+        SetVariableValue::Single(SetVariableValueSingle::Literal(v)) => Ok(v),
+        _ => Err(ErrorCode::InvalidInputSyntax(format!(
+            "expected a single literal value for {}, got {}",
+            name, value
+        ))
+        .into()),
+    }
+}
+
+fn parse_u64_value(value: &SetVariableValue, name: &str, default_value: u64) -> Result<u64> {
+    if matches!(value, SetVariableValue::Default) {
+        return Ok(default_value);
+    }
+
+    let v = expect_single_literal(value, name)?;
+    match v {
+        Value::Number(n) => n.parse::<u64>().map_err(|_| {
             ErrorCode::InvalidInputSyntax(format!("invalid u64 value for {}: {}", name, n)).into()
         }),
         _ => Err(ErrorCode::InvalidInputSyntax(format!(
-            "expected numeric value for {}, got {:?}",
-            name, value
+            "expected numeric value for {}, got {}",
+            name, v
         ))
         .into()),
     }
 }
 
-fn parse_u32_value(value: &SqlOptionValue, name: &str) -> Result<u32> {
-    match value {
-        SqlOptionValue::Value(Value::Number(n)) => n.parse::<u32>().map_err(|_| {
+fn parse_u32_value(value: &SetVariableValue, name: &str, default_value: u32) -> Result<u32> {
+    if matches!(value, SetVariableValue::Default) {
+        return Ok(default_value);
+    }
+
+    let v = expect_single_literal(value, name)?;
+    match v {
+        Value::Number(n) => n.parse::<u32>().map_err(|_| {
             ErrorCode::InvalidInputSyntax(format!("invalid u32 value for {}: {}", name, n)).into()
         }),
         _ => Err(ErrorCode::InvalidInputSyntax(format!(
-            "expected numeric value for {}, got {:?}",
-            name, value
+            "expected numeric value for {}, got {}",
+            name, v
         ))
         .into()),
     }
 }
 
-fn parse_bool_value(value: &SqlOptionValue, name: &str) -> Result<bool> {
-    match value {
-        SqlOptionValue::Value(Value::Boolean(b)) => Ok(*b),
-        SqlOptionValue::Value(Value::SingleQuotedString(s))
-        | SqlOptionValue::Value(Value::DoubleQuotedString(s)) => match s.to_lowercase().as_str() {
-            "true" | "on" | "1" => Ok(true),
-            "false" | "off" | "0" => Ok(false),
-            _ => Err(ErrorCode::InvalidInputSyntax(format!(
-                "invalid boolean value for {}: {}",
-                name, s
-            ))
-            .into()),
-        },
+fn parse_bool_value(value: &SetVariableValue, name: &str, default_value: bool) -> Result<bool> {
+    if matches!(value, SetVariableValue::Default) {
+        return Ok(default_value);
+    }
+
+    let v = expect_single_literal(value, name)?;
+    match v {
+        Value::Boolean(b) => Ok(*b),
+        Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => {
+            match s.to_ascii_lowercase().as_str() {
+                "true" | "on" | "1" => Ok(true),
+                "false" | "off" | "0" => Ok(false),
+                _ => Err(ErrorCode::InvalidInputSyntax(format!(
+                    "invalid boolean value for {}: {}",
+                    name, s
+                ))
+                .into()),
+            }
+        }
         _ => Err(ErrorCode::InvalidInputSyntax(format!(
-            "expected boolean value for {}, got {:?}",
-            name, value
+            "expected boolean value for {}, got {}",
+            name, v
         ))
         .into()),
     }
+}
+
+fn parse_optional_u64_value(
+    value: &SetVariableValue,
+    name: &str,
+    default_value: Option<u64>,
+) -> Result<u64> {
+    if matches!(value, SetVariableValue::Default) {
+        return Ok(default_value.unwrap_or(OPTIONAL_U64_UNSET_WIRE));
+    }
+
+    parse_u64_value(
+        value,
+        name,
+        default_value.unwrap_or(OPTIONAL_U64_UNSET_WIRE),
+    )
 }
 
 fn parse_compression_algorithm_with_level(
-    value: &SqlOptionValue,
+    value: &SetVariableValue,
     name: &str,
 ) -> Result<CompressionAlgorithm> {
     // Format: 'level:algorithm' e.g., '3:lz4', '6:zstd', '0:none'
     // level: non-negative integer (validation is done by meta service)
     // algorithm: none, lz4, zstd
-    let input_str = match value {
-        SqlOptionValue::Value(Value::SingleQuotedString(s))
-        | SqlOptionValue::Value(Value::DoubleQuotedString(s)) => s.to_lowercase(),
+    let v = expect_single_literal(value, name)?;
+    let input_str = match v {
+        Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => s.to_ascii_lowercase(),
         _ => {
             return Err(ErrorCode::InvalidInputSyntax(format!(
-                "expected string value for {} in format 'level:algorithm' (e.g., '3:lz4'), got {:?}",
-                name, value
+                "expected string value for {} in format 'level:algorithm' (e.g., '3:lz4'), got {}",
+                name, v
             ))
             .into());
         }

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -247,18 +247,13 @@ fn parse_compression_algorithm_with_level(
 
     let level: u32 = parts[0].parse().map_err(|_| {
         ErrorCode::InvalidInputSyntax(format!(
-            "invalid level for {}: '{}', expected 0-6",
+            "invalid level for {}: '{}', expected a non-negative integer",
             name, parts[0]
         ))
     })?;
 
-    if level > 6 {
-        return Err(ErrorCode::InvalidInputSyntax(format!(
-            "level for {} must be 0-6, got {}",
-            name, level
-        ))
-        .into());
-    }
+    // Note: level validation (whether it exceeds max_level) is done by meta service
+    // since max_level is per-compaction-group configuration
 
     let algo_name = match parts[1] {
         "none" => "None",

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -1,0 +1,280 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::pg_response::StatementType;
+use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::CompressionAlgorithm;
+use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
+use risingwave_sqlparser::ast::{AlterCompactionGroupOperation, SqlOption, SqlOptionValue, Value};
+
+use super::{HandlerArgs, RwPgResponse};
+use crate::error::{ErrorCode, Result};
+
+pub async fn handle_alter_compaction_group(
+    handler_args: HandlerArgs,
+    group_ids: Vec<u64>,
+    operation: AlterCompactionGroupOperation,
+) -> Result<RwPgResponse> {
+    // Only superuser can alter compaction group config
+    if !handler_args.session.is_super_user() {
+        return Err(ErrorCode::PermissionDenied(
+            "must be superuser to execute ALTER COMPACTION GROUP command".to_owned(),
+        )
+        .into());
+    }
+
+    let configs = match operation {
+        AlterCompactionGroupOperation::Set { configs } => {
+            build_compaction_config_from_options(&configs)?
+        }
+    };
+
+    if configs.is_empty() {
+        return Err(ErrorCode::InvalidInputSyntax(
+            "no valid compaction config specified".to_owned(),
+        )
+        .into());
+    }
+
+    let meta_client = handler_args.session.env().meta_client();
+    meta_client
+        .update_compaction_config(group_ids.clone(), configs)
+        .await?;
+
+    Ok(RwPgResponse::builder(StatementType::ALTER_SYSTEM)
+        .notice(format!(
+            "Compaction group(s) {:?} config updated successfully",
+            group_ids
+        ))
+        .into())
+}
+
+fn build_compaction_config_from_options(options: &[SqlOption]) -> Result<Vec<MutableConfig>> {
+    let mut configs = vec![];
+
+    for option in options {
+        let name = option.name.real_value().to_lowercase();
+        let value = &option.value;
+
+        let config = match name.as_str() {
+            "max_bytes_for_level_base" => {
+                MutableConfig::MaxBytesForLevelBase(parse_u64_value(value, &name)?)
+            }
+            "max_bytes_for_level_multiplier" => {
+                MutableConfig::MaxBytesForLevelMultiplier(parse_u64_value(value, &name)?)
+            }
+            "max_compaction_bytes" => {
+                MutableConfig::MaxCompactionBytes(parse_u64_value(value, &name)?)
+            }
+            "sub_level_max_compaction_bytes" => {
+                MutableConfig::SubLevelMaxCompactionBytes(parse_u64_value(value, &name)?)
+            }
+            "level0_tier_compact_file_number" => {
+                MutableConfig::Level0TierCompactFileNumber(parse_u64_value(value, &name)?)
+            }
+            "target_file_size_base" => {
+                MutableConfig::TargetFileSizeBase(parse_u64_value(value, &name)?)
+            }
+            "compaction_filter_mask" => {
+                MutableConfig::CompactionFilterMask(parse_u32_value(value, &name)?)
+            }
+            "max_sub_compaction" => MutableConfig::MaxSubCompaction(parse_u32_value(value, &name)?),
+            "level0_stop_write_threshold_sub_level_number" => {
+                MutableConfig::Level0StopWriteThresholdSubLevelNumber(parse_u64_value(
+                    value, &name,
+                )?)
+            }
+            "level0_sub_level_compact_level_count" => {
+                MutableConfig::Level0SubLevelCompactLevelCount(parse_u32_value(value, &name)?)
+            }
+            "max_space_reclaim_bytes" => {
+                MutableConfig::MaxSpaceReclaimBytes(parse_u64_value(value, &name)?)
+            }
+            "level0_max_compact_file_number" => {
+                MutableConfig::Level0MaxCompactFileNumber(parse_u64_value(value, &name)?)
+            }
+            "level0_overlapping_sub_level_compact_level_count" => {
+                MutableConfig::Level0OverlappingSubLevelCompactLevelCount(parse_u32_value(
+                    value, &name,
+                )?)
+            }
+            "enable_emergency_picker" => {
+                MutableConfig::EnableEmergencyPicker(parse_bool_value(value, &name)?)
+            }
+            "tombstone_reclaim_ratio" => {
+                MutableConfig::TombstoneReclaimRatio(parse_u32_value(value, &name)?)
+            }
+            "compression_algorithm" => {
+                // Format: 'level:algorithm' e.g., '3:lz4' or '6:zstd'
+                // This sets the compression algorithm for a specific LSM-tree level
+                let algorithm = parse_compression_algorithm_with_level(value, &name)?;
+                MutableConfig::CompressionAlgorithm(algorithm)
+            }
+            "max_l0_compact_level_count" => {
+                MutableConfig::MaxL0CompactLevelCount(parse_u32_value(value, &name)?)
+            }
+            "sst_allowed_trivial_move_min_size" => {
+                MutableConfig::SstAllowedTrivialMoveMinSize(parse_u64_value(value, &name)?)
+            }
+            "disable_auto_group_scheduling" => {
+                MutableConfig::DisableAutoGroupScheduling(parse_bool_value(value, &name)?)
+            }
+            "max_overlapping_level_size" => {
+                MutableConfig::MaxOverlappingLevelSize(parse_u64_value(value, &name)?)
+            }
+            "sst_allowed_trivial_move_max_count" => {
+                MutableConfig::SstAllowedTrivialMoveMaxCount(parse_u32_value(value, &name)?)
+            }
+            "emergency_level0_sst_file_count" => {
+                MutableConfig::EmergencyLevel0SstFileCount(parse_u32_value(value, &name)?)
+            }
+            "emergency_level0_sub_level_partition" => {
+                MutableConfig::EmergencyLevel0SubLevelPartition(parse_u32_value(value, &name)?)
+            }
+            "level0_stop_write_threshold_max_sst_count" => {
+                MutableConfig::Level0StopWriteThresholdMaxSstCount(parse_u32_value(value, &name)?)
+            }
+            "level0_stop_write_threshold_max_size" => {
+                MutableConfig::Level0StopWriteThresholdMaxSize(parse_u64_value(value, &name)?)
+            }
+            "enable_optimize_l0_interval_selection" => {
+                MutableConfig::EnableOptimizeL0IntervalSelection(parse_bool_value(value, &name)?)
+            }
+            "vnode_aligned_level_size_threshold" => {
+                MutableConfig::VnodeAlignedLevelSizeThreshold(parse_u64_value(value, &name)?)
+            }
+            "max_kv_count_for_xor16" => {
+                MutableConfig::MaxKvCountForXor16(parse_u64_value(value, &name)?)
+            }
+            _ => {
+                return Err(ErrorCode::InvalidInputSyntax(format!(
+                    "unknown compaction config parameter: {}",
+                    name
+                ))
+                .into());
+            }
+        };
+        configs.push(config);
+    }
+
+    Ok(configs)
+}
+
+fn parse_u64_value(value: &SqlOptionValue, name: &str) -> Result<u64> {
+    match value {
+        SqlOptionValue::Value(Value::Number(n)) => n.parse::<u64>().map_err(|_| {
+            ErrorCode::InvalidInputSyntax(format!("invalid u64 value for {}: {}", name, n)).into()
+        }),
+        _ => Err(ErrorCode::InvalidInputSyntax(format!(
+            "expected numeric value for {}, got {:?}",
+            name, value
+        ))
+        .into()),
+    }
+}
+
+fn parse_u32_value(value: &SqlOptionValue, name: &str) -> Result<u32> {
+    match value {
+        SqlOptionValue::Value(Value::Number(n)) => n.parse::<u32>().map_err(|_| {
+            ErrorCode::InvalidInputSyntax(format!("invalid u32 value for {}: {}", name, n)).into()
+        }),
+        _ => Err(ErrorCode::InvalidInputSyntax(format!(
+            "expected numeric value for {}, got {:?}",
+            name, value
+        ))
+        .into()),
+    }
+}
+
+fn parse_bool_value(value: &SqlOptionValue, name: &str) -> Result<bool> {
+    match value {
+        SqlOptionValue::Value(Value::Boolean(b)) => Ok(*b),
+        SqlOptionValue::Value(Value::SingleQuotedString(s))
+        | SqlOptionValue::Value(Value::DoubleQuotedString(s)) => match s.to_lowercase().as_str() {
+            "true" | "on" | "1" => Ok(true),
+            "false" | "off" | "0" => Ok(false),
+            _ => Err(ErrorCode::InvalidInputSyntax(format!(
+                "invalid boolean value for {}: {}",
+                name, s
+            ))
+            .into()),
+        },
+        _ => Err(ErrorCode::InvalidInputSyntax(format!(
+            "expected boolean value for {}, got {:?}",
+            name, value
+        ))
+        .into()),
+    }
+}
+
+fn parse_compression_algorithm_with_level(
+    value: &SqlOptionValue,
+    name: &str,
+) -> Result<CompressionAlgorithm> {
+    // Format: 'level:algorithm' e.g., '3:lz4', '6:zstd', '0:none'
+    // level: 0-6 (LSM-tree levels)
+    // algorithm: none, lz4, zstd
+    let input_str = match value {
+        SqlOptionValue::Value(Value::SingleQuotedString(s))
+        | SqlOptionValue::Value(Value::DoubleQuotedString(s)) => s.to_lowercase(),
+        _ => {
+            return Err(ErrorCode::InvalidInputSyntax(format!(
+                "expected string value for {} in format 'level:algorithm' (e.g., '3:lz4'), got {:?}",
+                name, value
+            ))
+            .into());
+        }
+    };
+
+    let parts: Vec<&str> = input_str.split(':').collect();
+    if parts.len() != 2 {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "invalid format for {}: '{}', expected 'level:algorithm' (e.g., '3:lz4', '6:zstd')",
+            name, input_str
+        ))
+        .into());
+    }
+
+    let level: u32 = parts[0].parse().map_err(|_| {
+        ErrorCode::InvalidInputSyntax(format!(
+            "invalid level for {}: '{}', expected 0-6",
+            name, parts[0]
+        ))
+    })?;
+
+    if level > 6 {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "level for {} must be 0-6, got {}",
+            name, level
+        ))
+        .into());
+    }
+
+    let algo_name = match parts[1] {
+        "none" => "None",
+        "lz4" => "Lz4",
+        "zstd" => "Zstd",
+        _ => {
+            return Err(ErrorCode::InvalidInputSyntax(format!(
+                "invalid compression algorithm for {}: '{}', expected one of: none, lz4, zstd",
+                name, parts[1]
+            ))
+            .into());
+        }
+    };
+
+    Ok(CompressionAlgorithm {
+        level,
+        compression_algorithm: algo_name.to_owned(),
+    })
+}

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -60,7 +60,7 @@ pub async fn handle_alter_compaction_group(
         .update_compaction_config(group_ids.clone(), configs)
         .await?;
 
-    Ok(RwPgResponse::builder(StatementType::ALTER_SYSTEM)
+    Ok(RwPgResponse::builder(StatementType::ALTER_COMPACTION_GROUP)
         .notice(format!(
             "Compaction group(s) {:?} config updated successfully",
             group_ids

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -27,7 +27,7 @@ use crate::error::{ErrorCode, Result};
 /// Wire encoding for clearing optional `u64` compaction configs.
 ///
 /// Note: meta currently treats both `u64::MIN` and `u64::MAX` as "unset" for historical reasons.
-/// We always *send* `u64::MAX` to avoid ambiguity, since `0` can be a valid user value.
+/// SQL `DEFAULT` always sends `u64::MAX` to avoid overloading `0` at the SQL layer.
 const OPTIONAL_U64_UNSET_WIRE: u64 = u64::MAX;
 
 pub async fn handle_alter_compaction_group(
@@ -259,14 +259,14 @@ fn build_compaction_config_from_params(params: &[ConfigParam]) -> Result<Vec<Mut
                 parse_optional_u64_value(value, &name, None)?,
             ),
             "max_kv_count_for_xor16" => {
-                MutableConfig::MaxKvCountForXor16(parse_optional_u64_value(
+                MutableConfig::MaxKvCountForXor16(parse_optional_positive_u64_value(
                     value,
                     &name,
                     compaction_config::max_kv_count_for_xor16(),
                 )?)
             }
             "max_vnode_key_range_bytes" => {
-                MutableConfig::MaxVnodeKeyRangeBytes(parse_optional_u64_value(
+                MutableConfig::MaxVnodeKeyRangeBytes(parse_optional_positive_u64_value(
                     value,
                     &name,
                     compaction_config::max_vnode_key_range_bytes(),
@@ -389,6 +389,20 @@ fn parse_optional_u64_value(
         name,
         default_value.unwrap_or(OPTIONAL_U64_UNSET_WIRE),
     )
+}
+
+fn parse_optional_positive_u64_value(
+    value: &SetVariableValue,
+    name: &str,
+    default_value: Option<u64>,
+) -> Result<u64> {
+    let value = parse_optional_u64_value(value, name, default_value)?;
+    if value == 0 {
+        return Err(
+            ErrorCode::InvalidInputSyntax(format!("{} must be positive or DEFAULT", name)).into(),
+        );
+    }
+    Ok(value)
 }
 
 fn parse_compression_algorithm_with_level(

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -396,11 +396,18 @@ fn parse_optional_positive_u64_value(
     name: &str,
     default_value: Option<u64>,
 ) -> Result<u64> {
+    if matches!(value, SetVariableValue::Default) {
+        return Ok(default_value.unwrap_or(OPTIONAL_U64_UNSET_WIRE));
+    }
+
     let value = parse_optional_u64_value(value, name, default_value)?;
-    if value == 0 {
-        return Err(
-            ErrorCode::InvalidInputSyntax(format!("{} must be positive or DEFAULT", name)).into(),
-        );
+    if value == 0 || value == OPTIONAL_U64_UNSET_WIRE {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "{} must be between 1 and {}, or DEFAULT",
+            name,
+            OPTIONAL_U64_UNSET_WIRE - 1
+        ))
+        .into());
     }
     Ok(value)
 }

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -254,10 +254,13 @@ fn build_compaction_config_from_params(params: &[ConfigParam]) -> Result<Vec<Mut
                     compaction_config::enable_optimize_l0_interval_selection(),
                 )?)
             }
-            #[expect(deprecated)]
-            "vnode_aligned_level_size_threshold" => MutableConfig::VnodeAlignedLevelSizeThreshold(
-                parse_optional_u64_value(value, &name, None)?,
-            ),
+            "vnode_aligned_level_size_threshold" => {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "vnode_aligned_level_size_threshold is deprecated and cannot be altered via SQL"
+                        .to_owned(),
+                )
+                .into());
+            }
             "max_kv_count_for_xor16" => {
                 MutableConfig::MaxKvCountForXor16(parse_optional_positive_u64_value(
                     value,

--- a/src/frontend/src/handler/alter_compaction_group.rs
+++ b/src/frontend/src/handler/alter_compaction_group.rs
@@ -254,18 +254,22 @@ fn build_compaction_config_from_params(params: &[ConfigParam]) -> Result<Vec<Mut
                     compaction_config::enable_optimize_l0_interval_selection(),
                 )?)
             }
-            "vnode_aligned_level_size_threshold" => {
-                MutableConfig::VnodeAlignedLevelSizeThreshold(parse_optional_u64_value(
-                    value,
-                    &name,
-                    compaction_config::vnode_aligned_level_size_threshold(),
-                )?)
-            }
+            #[expect(deprecated)]
+            "vnode_aligned_level_size_threshold" => MutableConfig::VnodeAlignedLevelSizeThreshold(
+                parse_optional_u64_value(value, &name, None)?,
+            ),
             "max_kv_count_for_xor16" => {
                 MutableConfig::MaxKvCountForXor16(parse_optional_u64_value(
                     value,
                     &name,
                     compaction_config::max_kv_count_for_xor16(),
+                )?)
+            }
+            "max_vnode_key_range_bytes" => {
+                MutableConfig::MaxVnodeKeyRangeBytes(parse_optional_u64_value(
+                    value,
+                    &name,
+                    compaction_config::max_vnode_key_range_bytes(),
                 )?)
             }
             "split_weight_by_vnode" => {

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -42,6 +42,7 @@ use crate::scheduler::{DistributedQueryStream, LocalQueryStream};
 use crate::session::SessionImpl;
 use crate::utils::WithOptions;
 
+mod alter_compaction_group;
 mod alter_connection_props;
 mod alter_database_param;
 mod alter_mv;
@@ -1568,6 +1569,17 @@ pub async fn handle(
         },
         Statement::AlterDefaultPrivileges { .. } => {
             handle_privilege::handle_alter_default_privileges(handler_args, stmt).await
+        }
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            alter_compaction_group::handle_alter_compaction_group(
+                handler_args,
+                group_ids,
+                operation,
+            )
+            .await
         }
         Statement::StartTransaction { modes } => {
             transaction::handle_begin(handler_args, START_TRANSACTION, modes)

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -235,6 +235,12 @@ pub trait FrontendMetaClient: Send + Sync {
     fn cluster_id(&self) -> &str;
 
     async fn list_unmigrated_tables(&self) -> Result<HashMap<TableId, String>>;
+
+    async fn update_compaction_config(
+        &self,
+        compaction_group_ids: Vec<u64>,
+        configs: Vec<risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig>,
+    ) -> Result<()>;
 }
 
 pub struct FrontendMetaClientImpl(pub MetaClient);
@@ -595,5 +601,15 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn list_iceberg_compaction_status(&self) -> Result<Vec<IcebergCompactionStatus>> {
         self.0.list_iceberg_compaction_status().await
+    }
+
+    async fn update_compaction_config(
+        &self,
+        compaction_group_ids: Vec<u64>,
+        configs: Vec<risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig>,
+    ) -> Result<()> {
+        self.0
+            .risectl_update_compaction_config(&compaction_group_ids, &configs)
+            .await
     }
 }

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -26,6 +26,7 @@ use risingwave_pb::backup_service::{BackupJobStatus, MetaSnapshotMetadata};
 use risingwave_pb::catalog::Table;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::ddl_service::DdlProgress;
+use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig as PbMutableConfig;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     BranchedObject, CompactTaskAssignment, CompactTaskProgress, CompactionGroupInfo,
@@ -238,8 +239,8 @@ pub trait FrontendMetaClient: Send + Sync {
 
     async fn update_compaction_config(
         &self,
-        compaction_group_ids: Vec<u64>,
-        configs: Vec<risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig>,
+        compaction_group_ids: Vec<CompactionGroupId>,
+        configs: Vec<PbMutableConfig>,
     ) -> Result<()>;
 }
 
@@ -605,8 +606,8 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn update_compaction_config(
         &self,
-        compaction_group_ids: Vec<u64>,
-        configs: Vec<risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig>,
+        compaction_group_ids: Vec<CompactionGroupId>,
+        configs: Vec<PbMutableConfig>,
     ) -> Result<()> {
         self.0
             .risectl_update_compaction_config(&compaction_group_ids, &configs)

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1446,6 +1446,14 @@ impl FrontendMetaClient for MockFrontendMetaClient {
     ) -> RpcResult<TableChangeLogs> {
         Ok(HashMap::default())
     }
+
+    async fn update_compaction_config(
+        &self,
+        _compaction_group_ids: Vec<u64>,
+        _configs: Vec<risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig>,
+    ) -> RpcResult<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -52,6 +52,7 @@ use risingwave_pb::ddl_service::{
     DdlProgress, PbTableJobType, TableJobType, alter_name_request, alter_set_schema_request,
     alter_swap_rename_request, create_connection_request, streaming_job_resource_type,
 };
+use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig as PbMutableConfig;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
     BranchedObject, CompactTaskAssignment, CompactTaskProgress, CompactionGroupInfo,
@@ -1449,8 +1450,8 @@ impl FrontendMetaClient for MockFrontendMetaClient {
 
     async fn update_compaction_config(
         &self,
-        _compaction_group_ids: Vec<u64>,
-        _configs: Vec<risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig>,
+        _compaction_group_ids: Vec<risingwave_hummock_sdk::CompactionGroupId>,
+        _configs: Vec<PbMutableConfig>,
     ) -> RpcResult<()> {
         Ok(())
     }

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -38,15 +38,9 @@ impl CompactionConfigBuilder {
                 // support compression setting per level
                 // L0/L1 and L2 do not use compression algorithms
                 // L3 - L4 use Lz4, else use Zstd
-                compression_algorithm: vec![
-                    "None".to_owned(),
-                    "None".to_owned(),
-                    "None".to_owned(),
-                    "Lz4".to_owned(),
-                    "Lz4".to_owned(),
-                    "Zstd".to_owned(),
-                    "Zstd".to_owned(),
-                ],
+                compression_algorithm: compaction_config::compression_algorithm_vec(
+                    compaction_config::max_level(),
+                ),
                 compaction_filter_mask: compaction_config::compaction_filter_mask(),
                 max_sub_compaction: compaction_config::max_sub_compaction(),
                 max_space_reclaim_bytes: compaction_config::max_space_reclaim_bytes(),

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -648,15 +648,19 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
                 // Deprecated. Keep accepting the field for old clients but do not apply it.
             }
             MutableConfig::MaxKvCountForXor16(c) => {
-                target.max_kv_count_for_xor16 = (*c != u64::MIN && *c != u64::MAX).then_some(*c);
+                target.max_kv_count_for_xor16 = optional_u64_config(*c);
             }
             MutableConfig::MaxVnodeKeyRangeBytes(c) => {
-                target.max_vnode_key_range_bytes = (*c > 0).then_some(*c);
+                target.max_vnode_key_range_bytes = optional_u64_config(*c);
             }
         }
     }
 
     Ok(())
+}
+
+fn optional_u64_config(value: u64) -> Option<u64> {
+    (value != u64::MIN && value != u64::MAX && value > 0).then_some(value)
 }
 
 fn try_u32_max_level(max_level: u64) -> Result<u32> {

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -537,7 +537,7 @@ impl CompactionGroupManager {
     }
 }
 
-fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfig]) {
+fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfig]) -> Result<()> {
     for item in items {
         match item {
             MutableConfig::MaxBytesForLevelBase(c) => {
@@ -586,8 +586,22 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
                 target.tombstone_reclaim_ratio = *c;
             }
             MutableConfig::CompressionAlgorithm(c) => {
-                target.compression_algorithm[c.get_level() as usize]
-                    .clone_from(&c.compression_algorithm);
+                let level = c.get_level();
+                if level > target.max_level as u32 {
+                    return Err(Error::CompactionGroup(format!(
+                        "invalid compression_algorithm level {}, max_level is {}",
+                        level, target.max_level
+                    )));
+                }
+
+                let Some(algorithm) = target.compression_algorithm.get_mut(level as usize) else {
+                    return Err(Error::CompactionGroup(format!(
+                        "invalid compression_algorithm level {}, compression_algorithm len is {}",
+                        level,
+                        target.compression_algorithm.len()
+                    )));
+                };
+                algorithm.clone_from(&c.compression_algorithm);
             }
             MutableConfig::MaxL0CompactLevelCount(c) => {
                 target.max_l0_compact_level_count = Some(*c);
@@ -634,6 +648,8 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
             }
         }
     }
+
+    Ok(())
 }
 
 impl CompactionGroupTransaction<'_> {
@@ -700,7 +716,7 @@ impl CompactionGroupTransaction<'_> {
                 Error::CompactionGroup(format!("invalid group {}", *compaction_group_id))
             })?;
             let mut config = group.compaction_config.as_ref().clone();
-            update_compaction_config(&mut config, config_to_update);
+            update_compaction_config(&mut config, config_to_update)?;
             if let Err(reason) = validate_compaction_config(&config) {
                 return Err(Error::CompactionGroup(reason));
             }

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
+use risingwave_common::config::meta::default::compaction_config as default_compaction_config;
 use risingwave_common::util::epoch::INVALID_EPOCH;
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
@@ -587,7 +588,8 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
             }
             MutableConfig::CompressionAlgorithm(c) => {
                 let level = c.get_level();
-                if level > target.max_level as u32 {
+                let max_level = try_u32_max_level(target.max_level)?;
+                if level > max_level {
                     return Err(Error::CompactionGroup(format!(
                         "invalid compression_algorithm level {}, max_level is {}",
                         level, target.max_level
@@ -602,6 +604,11 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
                     )));
                 };
                 algorithm.clone_from(&c.compression_algorithm);
+            }
+            MutableConfig::ResetCompressionAlgorithm(_) => {
+                target.compression_algorithm = default_compaction_config::compression_algorithm_vec(
+                    try_u32_max_level(target.max_level)?,
+                );
             }
             MutableConfig::MaxL0CompactLevelCount(c) => {
                 target.max_l0_compact_level_count = Some(*c);
@@ -650,6 +657,16 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
     }
 
     Ok(())
+}
+
+fn try_u32_max_level(max_level: u64) -> Result<u32> {
+    u32::try_from(max_level).map_err(|_| {
+        Error::CompactionGroup(format!(
+            "invalid max_level {}, expect <= {}",
+            max_level,
+            u32::MAX
+        ))
+    })
 }
 
 impl CompactionGroupTransaction<'_> {
@@ -733,10 +750,12 @@ impl CompactionGroupTransaction<'_> {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashSet};
+    use std::sync::Arc;
 
     use itertools::Itertools;
     use risingwave_common::id::JobId;
     use risingwave_hummock_sdk::CompactionGroupId;
+    use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::CompressionAlgorithm;
     use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
 
     use crate::controller::SqlMetaStore;
@@ -779,6 +798,23 @@ mod tests {
             }
         }
 
+        async fn insert_compaction_group_config_with_max_level(
+            meta: &SqlMetaStore,
+            inner: &mut CompactionGroupManager,
+            cg_id: u64,
+            max_level: u64,
+        ) {
+            let mut config = inner.default_compaction_config().as_ref().clone();
+            config.max_level = max_level;
+            config.compression_algorithm =
+                super::default_compaction_config::compression_algorithm_vec(
+                    super::try_u32_max_level(max_level).expect("max_level should fit u32 in test"),
+                );
+            let mut compaction_groups_txn = inner.start_compaction_groups_txn();
+            compaction_groups_txn.create_compaction_groups(cg_id.into(), Arc::new(config));
+            commit_multi_var!(meta, compaction_groups_txn).unwrap();
+        }
+
         update_compaction_config(env.meta_store_ref(), &mut inner, &[100, 200], &[])
             .await
             .unwrap_err();
@@ -811,6 +847,40 @@ mod tests {
                 .compaction_config
                 .max_sub_compaction,
             123
+        );
+
+        insert_compaction_group_config_with_max_level(env.meta_store_ref(), &mut inner, 300, 4)
+            .await;
+        update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[300],
+            &[MutableConfig::ResetCompressionAlgorithm(true)],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner
+                .try_get_compaction_group_config(300)
+                .unwrap()
+                .compaction_config
+                .compression_algorithm,
+            super::default_compaction_config::compression_algorithm_vec(4)
+        );
+        let err = update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[300],
+            &[MutableConfig::CompressionAlgorithm(CompressionAlgorithm {
+                level: 6,
+                compression_algorithm: "Zstd".to_owned(),
+            })],
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invalid compression_algorithm level 6")
         );
     }
 

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -651,7 +651,7 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
                 target.max_kv_count_for_xor16 = optional_u64_config(*c);
             }
             MutableConfig::MaxVnodeKeyRangeBytes(c) => {
-                target.max_vnode_key_range_bytes = optional_u64_config(*c);
+                target.max_vnode_key_range_bytes = optional_positive_u64_config(*c);
             }
         }
     }
@@ -660,7 +660,11 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
 }
 
 fn optional_u64_config(value: u64) -> Option<u64> {
-    (value != u64::MIN && value != u64::MAX && value > 0).then_some(value)
+    (value != u64::MIN && value != u64::MAX).then_some(value)
+}
+
+fn optional_positive_u64_config(value: u64) -> Option<u64> {
+    optional_u64_config(value).filter(|value| *value > 0)
 }
 
 fn try_u32_max_level(max_level: u64) -> Result<u32> {
@@ -885,6 +889,88 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("invalid compression_algorithm level 6")
+        );
+
+        update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[100],
+            &[MutableConfig::MaxKvCountForXor16(0)],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner
+                .try_get_compaction_group_config(100)
+                .unwrap()
+                .compaction_config
+                .max_kv_count_for_xor16,
+            None
+        );
+        update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[100],
+            &[MutableConfig::MaxKvCountForXor16(1024)],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner
+                .try_get_compaction_group_config(100)
+                .unwrap()
+                .compaction_config
+                .max_kv_count_for_xor16,
+            Some(1024)
+        );
+        update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[100],
+            &[MutableConfig::MaxKvCountForXor16(u64::MAX)],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner
+                .try_get_compaction_group_config(100)
+                .unwrap()
+                .compaction_config
+                .max_kv_count_for_xor16,
+            None
+        );
+
+        update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[100],
+            &[MutableConfig::MaxVnodeKeyRangeBytes(0)],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner
+                .try_get_compaction_group_config(100)
+                .unwrap()
+                .compaction_config
+                .max_vnode_key_range_bytes,
+            None
+        );
+        update_compaction_config(
+            env.meta_store_ref(),
+            &mut inner,
+            &[100],
+            &[MutableConfig::MaxVnodeKeyRangeBytes(1024)],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner
+                .try_get_compaction_group_config(100)
+                .unwrap()
+                .compaction_config
+                .max_vnode_key_range_bytes,
+            Some(1024)
         );
     }
 

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [package.metadata.cargo-machete]
-ignored = ["enum-as-inner", "pbjson", "prost-helpers", "strum"]
+ignored = ["enum-as-inner", "pbjson", "prost-helpers", "strum", "tonic-prost"]
 
 [dependencies]
 enum-as-inner = "0.7"

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -355,7 +355,7 @@ pub enum AlterFragmentOperation {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterCompactionGroupOperation {
-    Set { configs: Vec<SqlOption> },
+    Set { configs: Vec<ConfigParam> },
 }
 
 impl fmt::Display for AlterDatabaseOperation {
@@ -889,7 +889,16 @@ impl fmt::Display for AlterCompactionGroupOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AlterCompactionGroupOperation::Set { configs } => {
-                write!(f, "SET {}", display_comma_separated(configs))
+                struct Assign<'a>(&'a ConfigParam);
+
+                impl fmt::Display for Assign<'_> {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        write!(f, "{} = {}", self.0.param, self.0.value)
+                    }
+                }
+
+                let assigns: Vec<Assign<'_>> = configs.iter().map(Assign).collect();
+                write!(f, "SET {}", display_comma_separated(&assigns))
             }
         }
     }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -353,6 +353,11 @@ pub enum AlterFragmentOperation {
     SetParallelism { parallelism: SetVariableValue },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AlterCompactionGroupOperation {
+    Set { configs: Vec<SqlOption> },
+}
+
 impl fmt::Display for AlterDatabaseOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -875,6 +880,16 @@ impl fmt::Display for AlterFragmentOperation {
             }
             AlterFragmentOperation::SetParallelism { parallelism } => {
                 write!(f, "SET PARALLELISM TO {}", parallelism)
+            }
+        }
+    }
+}
+
+impl fmt::Display for AlterCompactionGroupOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AlterCompactionGroupOperation::Set { configs } => {
+                write!(f, "SET {}", display_comma_separated(configs))
             }
         }
     }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -30,10 +30,10 @@ use winnow::ModalResult;
 
 pub use self::data_type::{DataType, StructField};
 pub use self::ddl::{
-    AlterColumnOperation, AlterConnectionOperation, AlterDatabaseOperation, AlterFragmentOperation,
-    AlterFunctionOperation, AlterSchemaOperation, AlterSecretOperation, AlterTableOperation,
-    ColumnDef, ColumnOption, ColumnOptionDef, ReferentialAction, SourceWatermark, TableConstraint,
-    WebhookSourceInfo,
+    AlterColumnOperation, AlterCompactionGroupOperation, AlterConnectionOperation,
+    AlterDatabaseOperation, AlterFragmentOperation, AlterFunctionOperation, AlterSchemaOperation,
+    AlterSecretOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef,
+    ReferentialAction, SourceWatermark, TableConstraint, WebhookSourceInfo,
 };
 pub use self::legacy_source::{CompatibleFormatEncode, get_delimiter};
 pub use self::operator::{BinaryOperator, QualifiedOperator, UnaryOperator};
@@ -1504,6 +1504,11 @@ pub enum Statement {
         fragment_ids: Vec<u32>,
         operation: AlterFragmentOperation,
     },
+    /// ALTER COMPACTION GROUP
+    AlterCompactionGroup {
+        group_ids: Vec<u64>,
+        operation: AlterCompactionGroupOperation,
+    },
     /// DESCRIBE relation
     /// ALTER DEFAULT PRIVILEGES
     AlterDefaultPrivileges {
@@ -2515,6 +2520,17 @@ impl Statement {
                     f,
                     "ALTER FRAGMENT {} {}",
                     display_comma_separated(fragment_ids),
+                    operation
+                )
+            }
+            Statement::AlterCompactionGroup {
+                group_ids,
+                operation,
+            } => {
+                write!(
+                    f,
+                    "ALTER COMPACTION GROUP {} {}",
+                    display_comma_separated(group_ids),
                     operation
                 )
             }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -138,6 +138,7 @@ define_keywords!(
     COMMENT,
     COMMIT,
     COMMITTED,
+    COMPACTION,
     CONCURRENTLY,
     CONDITION,
     CONFIG,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -99,7 +99,7 @@ pub enum IsLateral {
 
 use IsLateral::*;
 
-use crate::ast::ddl::AlterFragmentOperation;
+use crate::ast::ddl::{AlterCompactionGroupOperation, AlterFragmentOperation};
 
 pub type IncludeOption = Vec<IncludeOptionItem>;
 
@@ -3153,11 +3153,13 @@ impl Parser<'_> {
             self.parse_alter_secret()
         } else if self.parse_word("FRAGMENT") {
             self.parse_alter_fragment()
+        } else if self.parse_word("COMPACTION") {
+            self.parse_alter_compaction_group()
         } else if self.parse_keywords(&[Keyword::DEFAULT, Keyword::PRIVILEGES]) {
             self.parse_alter_default_privileges()
         } else {
             self.expected(
-                "DATABASE, FRAGMENT, SCHEMA, TABLE, INDEX, MATERIALIZED, VIEW, SINK, SUBSCRIPTION, SOURCE, FUNCTION, USER, SECRET or SYSTEM after ALTER"
+                "COMPACTION, DATABASE, FRAGMENT, SCHEMA, TABLE, INDEX, MATERIALIZED, VIEW, SINK, SUBSCRIPTION, SOURCE, FUNCTION, USER, SECRET or SYSTEM after ALTER"
             )
         }
     }
@@ -4019,6 +4021,25 @@ impl Parser<'_> {
         };
         Ok(Statement::AlterFragment {
             fragment_ids,
+            operation,
+        })
+    }
+
+    pub fn parse_alter_compaction_group(&mut self) -> ModalResult<Statement> {
+        if !self.parse_keyword(Keyword::GROUP) {
+            return self.expected("GROUP after ALTER COMPACTION");
+        }
+        let mut group_ids = vec![self.parse_literal_u64()?];
+        while self.consume_token(&Token::Comma) {
+            group_ids.push(self.parse_literal_u64()?);
+        }
+        if !self.parse_keyword(Keyword::SET) {
+            return self.expected("SET after ALTER COMPACTION GROUP <id>");
+        }
+        let configs = self.parse_comma_separated(Parser::parse_sql_option)?;
+        let operation = AlterCompactionGroupOperation::Set { configs };
+        Ok(Statement::AlterCompactionGroup {
+            group_ids,
             operation,
         })
     }

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3153,7 +3153,7 @@ impl Parser<'_> {
             self.parse_alter_secret()
         } else if self.parse_word("FRAGMENT") {
             self.parse_alter_fragment()
-        } else if self.parse_word("COMPACTION") {
+        } else if self.parse_keyword(Keyword::COMPACTION) {
             self.parse_alter_compaction_group()
         } else if self.parse_keywords(&[Keyword::DEFAULT, Keyword::PRIVILEGES]) {
             self.parse_alter_default_privileges()

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3060,12 +3060,49 @@ impl Parser<'_> {
     // <config_param> { TO | = } { <value> | DEFAULT }
     // <config_param> is not a keyword, but an identifier
     pub fn parse_config_param(&mut self) -> ModalResult<ConfigParam> {
+        self.parse_config_param_inner(Self::parse_set_variable)
+    }
+
+    fn parse_config_param_inner(
+        &mut self,
+        parse_value: fn(&mut Self) -> ModalResult<SetVariableValue>,
+    ) -> ModalResult<ConfigParam> {
         let param = self.parse_identifier()?;
         if !self.consume_token(&Token::Eq) && !self.parse_keyword(Keyword::TO) {
             return self.expected("'=' or 'TO' after config parameter");
         }
-        let value = self.parse_set_variable()?;
+        let value = parse_value(self)?;
         Ok(ConfigParam { param, value })
+    }
+
+    /// Parse a single-value config param.
+    ///
+    /// This differs from [`parse_config_param`] in that it does **not** allow a comma-separated
+    /// list on the RHS, so it can be safely used in constructs where comma separates multiple
+    /// assignments (e.g. `... SET a = 1, b = 2`).
+    fn parse_config_param_no_list(&mut self) -> ModalResult<ConfigParam> {
+        self.parse_config_param_inner(Self::parse_set_variable_no_list)
+    }
+
+    fn parse_set_variable_no_list(&mut self) -> ModalResult<SetVariableValue> {
+        alt((
+            Keyword::DEFAULT.value(SetVariableValue::Default),
+            alt((
+                Self::ensure_parse_value.map(SetVariableValueSingle::Literal),
+                |parser: &mut Self| {
+                    let checkpoint = *parser;
+                    let ident = parser.parse_identifier()?;
+                    if ident.value == "default" {
+                        *parser = checkpoint;
+                        return parser.expected("parameter list value").map_err(|e| e.cut());
+                    }
+                    Ok(SetVariableValueSingle::Ident(ident))
+                },
+                fail.expect("parameter value"),
+            ))
+            .map(|single: SetVariableValueSingle| SetVariableValue::Single(single)),
+        ))
+        .parse_next(self)
     }
 
     pub fn parse_since(&mut self) -> ModalResult<Since> {
@@ -4036,7 +4073,10 @@ impl Parser<'_> {
         if !self.parse_keyword(Keyword::SET) {
             return self.expected("SET after ALTER COMPACTION GROUP <id>");
         }
-        let configs = self.parse_comma_separated(Parser::parse_sql_option)?;
+        // NOTE: use the `no_list` variant here, because `parse_set_variable` allows comma-separated
+        // lists (e.g., `SET foo = 1,2,3`), which would conflict with our use of comma to separate
+        // multiple config assignments.
+        let configs = self.parse_comma_separated(Parser::parse_config_param_no_list)?;
         let operation = AlterCompactionGroupOperation::Set { configs };
         Ok(Statement::AlterCompactionGroup {
             group_ids,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3077,7 +3077,7 @@ impl Parser<'_> {
 
     /// Parse a single-value config param.
     ///
-    /// This differs from [`parse_config_param`] in that it does **not** allow a comma-separated
+    /// This differs from [`Self::parse_config_param`] in that it does **not** allow a comma-separated
     /// list on the RHS, so it can be safely used in constructs where comma separates multiple
     /// assignments (e.g. `... SET a = 1, b = 2`).
     fn parse_config_param_no_list(&mut self) -> ModalResult<ConfigParam> {

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -4341,4 +4341,25 @@ fn parse_alter_compaction_group() {
         }
         _ => panic!("unexpected statement kind"),
     }
+
+    // String config
+    match verified_stmt("ALTER COMPACTION GROUP 2 SET compression_algorithm = '6:lz4'") {
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            assert_eq!(group_ids, vec![2]);
+            match operation {
+                AlterCompactionGroupOperation::Set { configs } => {
+                    assert_eq!(configs.len(), 1);
+                    assert_eq!(configs[0].name.real_value(), "compression_algorithm");
+                    assert_eq!(
+                        configs[0].value,
+                        SqlOptionValue::Value(Value::SingleQuotedString("6:lz4".into()))
+                    );
+                }
+            }
+        }
+        _ => panic!("unexpected statement kind"),
+    }
 }

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -4368,4 +4368,26 @@ fn parse_alter_compaction_group() {
         }
         _ => panic!("unexpected statement kind"),
     }
+
+    // Boolean config using unquoted identifier literal
+    match verified_stmt("ALTER COMPACTION GROUP 2 SET enable_emergency_picker = on") {
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            assert_eq!(group_ids, vec![2]);
+            match operation {
+                AlterCompactionGroupOperation::Set { configs } => {
+                    assert_eq!(configs.len(), 1);
+                    assert_eq!(configs[0].param.real_value(), "enable_emergency_picker");
+                    assert!(matches!(
+                        configs[0].value,
+                        SetVariableValue::Single(SetVariableValueSingle::Ident(ref ident))
+                            if ident.real_value() == "on"
+                    ));
+                }
+            }
+        }
+        _ => panic!("unexpected statement kind"),
+    }
 }

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -4261,7 +4261,7 @@ fn parse_wait_target() {
 
 #[test]
 fn parse_alter_compaction_group() {
-    use risingwave_sqlparser::ast::{AlterCompactionGroupOperation, SqlOptionValue};
+    use risingwave_sqlparser::ast::AlterCompactionGroupOperation;
 
     // Single group with single config
     match verified_stmt("ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1073741824") {
@@ -4273,10 +4273,12 @@ fn parse_alter_compaction_group() {
             match operation {
                 AlterCompactionGroupOperation::Set { configs } => {
                     assert_eq!(configs.len(), 1);
-                    assert_eq!(configs[0].name.real_value(), "max_bytes_for_level_base");
+                    assert_eq!(configs[0].param.real_value(), "max_bytes_for_level_base");
                     assert_eq!(
                         configs[0].value,
-                        SqlOptionValue::Value(Value::Number("1073741824".into()))
+                        SetVariableValue::Single(SetVariableValueSingle::Literal(Value::Number(
+                            "1073741824".into()
+                        )))
                     );
                 }
             }
@@ -4296,8 +4298,8 @@ fn parse_alter_compaction_group() {
             match operation {
                 AlterCompactionGroupOperation::Set { configs } => {
                     assert_eq!(configs.len(), 2);
-                    assert_eq!(configs[0].name.real_value(), "max_bytes_for_level_base");
-                    assert_eq!(configs[1].name.real_value(), "target_file_size_base");
+                    assert_eq!(configs[0].param.real_value(), "max_bytes_for_level_base");
+                    assert_eq!(configs[1].param.real_value(), "target_file_size_base");
                 }
             }
         }
@@ -4331,10 +4333,12 @@ fn parse_alter_compaction_group() {
             match operation {
                 AlterCompactionGroupOperation::Set { configs } => {
                     assert_eq!(configs.len(), 1);
-                    assert_eq!(configs[0].name.real_value(), "enable_emergency_picker");
+                    assert_eq!(configs[0].param.real_value(), "enable_emergency_picker");
                     assert_eq!(
                         configs[0].value,
-                        SqlOptionValue::Value(Value::Boolean(true))
+                        SetVariableValue::Single(SetVariableValueSingle::Literal(Value::Boolean(
+                            true
+                        )))
                     );
                 }
             }
@@ -4352,10 +4356,12 @@ fn parse_alter_compaction_group() {
             match operation {
                 AlterCompactionGroupOperation::Set { configs } => {
                     assert_eq!(configs.len(), 1);
-                    assert_eq!(configs[0].name.real_value(), "compression_algorithm");
+                    assert_eq!(configs[0].param.real_value(), "compression_algorithm");
                     assert_eq!(
                         configs[0].value,
-                        SqlOptionValue::Value(Value::SingleQuotedString("6:lz4".into()))
+                        SetVariableValue::Single(SetVariableValueSingle::Literal(
+                            Value::SingleQuotedString("6:lz4".into())
+                        ))
                     );
                 }
             }

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -4258,3 +4258,87 @@ fn parse_wait_target() {
     one_statement_parses_to("WAIT SINK snk1", "WAIT SINK snk1");
     one_statement_parses_to("WAIT INDEX idx1", "WAIT INDEX idx1");
 }
+
+#[test]
+fn parse_alter_compaction_group() {
+    use risingwave_sqlparser::ast::{AlterCompactionGroupOperation, SqlOptionValue};
+
+    // Single group with single config
+    match verified_stmt("ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1073741824") {
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            assert_eq!(group_ids, vec![2]);
+            match operation {
+                AlterCompactionGroupOperation::Set { configs } => {
+                    assert_eq!(configs.len(), 1);
+                    assert_eq!(configs[0].name.real_value(), "max_bytes_for_level_base");
+                    assert_eq!(
+                        configs[0].value,
+                        SqlOptionValue::Value(Value::Number("1073741824".into()))
+                    );
+                }
+            }
+        }
+        _ => panic!("unexpected statement kind"),
+    }
+
+    // Single group with multiple configs
+    match verified_stmt(
+        "ALTER COMPACTION GROUP 2 SET max_bytes_for_level_base = 1073741824, target_file_size_base = 67108864",
+    ) {
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            assert_eq!(group_ids, vec![2]);
+            match operation {
+                AlterCompactionGroupOperation::Set { configs } => {
+                    assert_eq!(configs.len(), 2);
+                    assert_eq!(configs[0].name.real_value(), "max_bytes_for_level_base");
+                    assert_eq!(configs[1].name.real_value(), "target_file_size_base");
+                }
+            }
+        }
+        _ => panic!("unexpected statement kind"),
+    }
+
+    // Multiple groups
+    match verified_stmt("ALTER COMPACTION GROUP 1, 2, 3 SET max_bytes_for_level_base = 1073741824")
+    {
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            assert_eq!(group_ids, vec![1, 2, 3]);
+            match operation {
+                AlterCompactionGroupOperation::Set { configs } => {
+                    assert_eq!(configs.len(), 1);
+                }
+            }
+        }
+        _ => panic!("unexpected statement kind"),
+    }
+
+    // Boolean config
+    match verified_stmt("ALTER COMPACTION GROUP 2 SET enable_emergency_picker = true") {
+        Statement::AlterCompactionGroup {
+            group_ids,
+            operation,
+        } => {
+            assert_eq!(group_ids, vec![2]);
+            match operation {
+                AlterCompactionGroupOperation::Set { configs } => {
+                    assert_eq!(configs.len(), 1);
+                    assert_eq!(configs[0].name.real_value(), "enable_emergency_picker");
+                    assert_eq!(
+                        configs[0].value,
+                        SqlOptionValue::Value(Value::Boolean(true))
+                    );
+                }
+            }
+        }
+        _ => panic!("unexpected statement kind"),
+    }
+}

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -92,6 +92,7 @@ pub enum StatementType {
     ALTER_SYSTEM,
     ALTER_SECRET,
     ALTER_FRAGMENT,
+    ALTER_COMPACTION_GROUP,
     REVOKE_PRIVILEGE,
     // Introduce ORDER_BY statement type cuz Calcite unvalidated AST has SqlKind.ORDER_BY. Note
     // that Statement Type is not designed to be one to one mapping with SqlKind.
@@ -294,6 +295,7 @@ impl StatementType {
             Statement::AlterTable { .. } => Ok(StatementType::ALTER_TABLE),
             Statement::AlterSystem { .. } => Ok(StatementType::ALTER_SYSTEM),
             Statement::AlterFragment { .. } => Ok(StatementType::ALTER_FRAGMENT),
+            Statement::AlterCompactionGroup { .. } => Ok(StatementType::ALTER_COMPACTION_GROUP),
             Statement::DropFunction { .. } => Ok(StatementType::DROP_FUNCTION),
             Statement::Discard(..) => Ok(StatementType::DISCARD),
             Statement::SetVariable { .. } => Ok(StatementType::SET_VARIABLE),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds SQL support for updating Hummock compaction group configs with `ALTER COMPACTION GROUP ... SET ...`.

It introduces parser/AST support, a frontend handler that validates superuser access and converts SQL config assignments into Hummock mutable config updates, and meta-side handling for compression algorithm reset/default behavior. It also adds SLT coverage for numeric, boolean, string, multi-group, DEFAULT, and invalid-config cases.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [x] <!-- OPTIONAL --> Fuzzing tests are not needed for this targeted admin SQL handler. <!-- Recommended for new SQL features, see #7934 -->
- [x] <!-- OPTIONAL --> This PR contains no breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [x] <!-- OPTIONAL --> This PR does not change performance-critical code, so benchmarks are not needed. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> This PR needs no documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A

</details>
