### PR TITLE
fix(meta): handle post collect snapshot backfill job on collecting first job barrier

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -848,7 +848,7 @@ impl DatabaseCheckpointControl {
                 self.handle_refresh_table_info(task, &node);
 
                 self.database_info.apply_collected_command(
-                    node.command_ctx.command.as_ref(),
+                    &node.command_ctx.command,
                     &node.state.resps,
                     hummock_version_stats,
                 );
@@ -909,7 +909,7 @@ impl DatabaseCheckpointControl {
                         .state_table_ids()
                         .iter()
                         .copied(),
-                    create_info.is_some(),
+                    create_info.as_ref(),
                 );
                 let (_, creating_job_epochs) =
                     task.epoch_infos.entry(self.database_id).or_default();

--- a/src/meta/src/barrier/checkpoint/creating_job/barrier_control.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/barrier_control.rs
@@ -26,7 +26,7 @@ use risingwave_pb::stream_service::BarrierCompleteResponse;
 use tracing::debug;
 
 use crate::barrier::BarrierKind;
-use crate::barrier::context::CreateSnapshotBackfillJobInfo;
+use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::notifier::Notifier;
 use crate::barrier::utils::{NodeToCollect, is_valid_after_worker_err};
 use crate::rpc::metrics::GLOBAL_META_METRICS;
@@ -38,7 +38,7 @@ struct CreatingStreamingJobEpochState {
     resps: Vec<BarrierCompleteResponse>,
     notifiers: Vec<Notifier>,
     kind: BarrierKind,
-    first_create_info: Option<CreateSnapshotBackfillJobInfo>,
+    first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
     enqueue_time: Instant,
 }
 
@@ -122,7 +122,7 @@ impl CreatingStreamingJobBarrierControl {
         node_to_collect: NodeToCollect,
         kind: BarrierKind,
         notifiers: Vec<Notifier>,
-        first_create_info: Option<CreateSnapshotBackfillJobInfo>,
+        first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
     ) {
         debug!(
             epoch,
@@ -208,7 +208,7 @@ impl CreatingStreamingJobBarrierControl {
     ) -> Option<(
         u64,
         Vec<BarrierCompleteResponse>,
-        Option<CreateSnapshotBackfillJobInfo>,
+        Option<CreateSnapshotBackfillJobCommandInfo>,
     )> {
         assert!(self.completing_barrier.is_none());
         let epoch_range: (Bound<u64>, Bound<u64>) = (Unbounded, epoch_end_bound);

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -41,7 +41,7 @@ use crate::MetaResult;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
 use crate::barrier::checkpoint::creating_job::status::CreateMviewLogStoreProgressTracker;
 use crate::barrier::checkpoint::recovery::ResetPartialGraphCollector;
-use crate::barrier::context::CreateSnapshotBackfillJobInfo;
+use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::{BarrierInfo, InflightStreamingJobInfo};
 use crate::barrier::notifier::Notifier;
@@ -80,7 +80,7 @@ pub(crate) struct CreatingStreamingJobControl {
 
 impl CreatingStreamingJobControl {
     pub(super) fn new(
-        create_info: CreateSnapshotBackfillJobInfo,
+        create_info: CreateSnapshotBackfillJobCommandInfo,
         notifiers: Vec<Notifier>,
         snapshot_backfill_upstream_tables: HashSet<TableId>,
         snapshot_epoch: u64,
@@ -562,7 +562,7 @@ impl CreatingStreamingJobControl {
         new_actors: Option<StreamJobActorsToCreate>,
         mutation: Option<Mutation>,
         mut notifiers: Vec<Notifier>,
-        first_create_info: Option<CreateSnapshotBackfillJobInfo>,
+        first_create_info: Option<CreateSnapshotBackfillJobCommandInfo>,
     ) -> MetaResult<()> {
         let (state_table_ids, nodes_to_sync_table) = if let Some(state_table_ids) = state_table_ids
         {
@@ -698,7 +698,7 @@ impl CreatingStreamingJobControl {
 
 pub(super) enum CompleteJobType {
     /// The first barrier
-    First(CreateSnapshotBackfillJobInfo),
+    First(CreateSnapshotBackfillJobCommandInfo),
     Normal,
     /// The last barrier to complete
     Finished,

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -30,7 +30,8 @@ use tracing::warn;
 
 use crate::MetaResult;
 use crate::barrier::checkpoint::{CreatingStreamingJobControl, DatabaseCheckpointControl};
-use crate::barrier::context::CreateSnapshotBackfillJobInfo;
+use crate::barrier::command::PostCollectCommand;
+use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::barrier::edge_builder::FragmentEdgeBuilder;
 use crate::barrier::info::{
     BarrierInfo, CreateStreamingJobStatus, InflightStreamingJobInfo, SubscriberType,
@@ -128,7 +129,7 @@ pub(super) struct ApplyCommandInfo {
     pub table_ids_to_commit: HashSet<TableId>,
     pub jobs_to_wait: HashSet<JobId>,
     pub node_to_collect: NodeToCollect,
-    pub command: Option<Command>,
+    pub command: PostCollectCommand,
 }
 
 impl DatabaseCheckpointControl {
@@ -192,7 +193,7 @@ impl DatabaseCheckpointControl {
                         .collect();
 
                     let job = CreatingStreamingJobControl::new(
-                        CreateSnapshotBackfillJobInfo {
+                        CreateSnapshotBackfillJobCommandInfo {
                             info: info.clone(),
                             snapshot_backfill_info: snapshot_backfill_info.clone(),
                             cross_db_snapshot_backfill_info: cross_db_snapshot_backfill_info
@@ -578,7 +579,9 @@ impl DatabaseCheckpointControl {
             table_ids_to_commit,
             jobs_to_wait: finished_snapshot_backfill_jobs,
             node_to_collect,
-            command,
+            command: command
+                .map(Command::into_post_collect)
+                .unwrap_or(PostCollectCommand::barrier()),
         })
     }
 }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -14,7 +14,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
@@ -24,13 +24,11 @@ use risingwave_common::id::{JobId, SourceId};
 use risingwave_common::must_match;
 use risingwave_common::types::Timestamptz;
 use risingwave_common::util::epoch::Epoch;
-use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
 use risingwave_connector::source::{CdcTableSnapshotSplitRaw, SplitImpl};
 use risingwave_hummock_sdk::change_log::build_table_change_log_delta;
 use risingwave_hummock_sdk::vector_index::VectorIndexDelta;
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::catalog::CreateType;
-use risingwave_pb::catalog::table::PbTableType;
 use risingwave_pb::common::PbActorInfo;
 use risingwave_pb::hummock::vector_index_delta::PbVectorIndexInit;
 use risingwave_pb::plan_common::PbField;
@@ -42,7 +40,6 @@ use risingwave_pb::stream_plan::barrier::BarrierKind as PbBarrierKind;
 use risingwave_pb::stream_plan::barrier_mutation::Mutation;
 use risingwave_pb::stream_plan::connector_props_change_mutation::ConnectorPropsInfo;
 use risingwave_pb::stream_plan::sink_schema_change::Op as PbSinkSchemaChangeOp;
-use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::throttle_mutation::ThrottleConfig;
 use risingwave_pb::stream_plan::update_mutation::*;
 use risingwave_pb::stream_plan::{
@@ -61,7 +58,7 @@ use crate::barrier::cdc_progress::CdcTableBackfillTracker;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::BarrierInfo;
 use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
-use crate::barrier::utils::collect_resp_info;
+use crate::barrier::utils::{collect_new_vector_index_info, collect_resp_info};
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
 use crate::manager::{StreamingJob, StreamingJobType};
@@ -286,7 +283,7 @@ pub enum CreateStreamingJobType {
 
 /// [`Command`] is the input of [`crate::barrier::worker::GlobalBarrierWorker`]. For different commands,
 /// it will [build different barriers to send](Self::to_mutation),
-/// and may [do different stuffs after the barrier is collected](CommandContext::post_collect).
+/// and may [do different stuffs after the barrier is collected](PostCollectCommand::post_collect).
 // FIXME: this enum is significantly large on stack, box it
 #[derive(Debug)]
 pub enum Command {
@@ -635,6 +632,107 @@ impl Command {
     }
 }
 
+#[derive(Debug)]
+pub enum PostCollectCommand {
+    Command(String),
+    DropStreamingJobs {
+        streaming_job_ids: HashSet<JobId>,
+        unregistered_state_table_ids: HashSet<TableId>,
+    },
+    CreateStreamingJob {
+        info: CreateStreamingJobCommandInfo,
+        job_type: CreateStreamingJobType,
+        cross_db_snapshot_backfill_info: SnapshotBackfillInfo,
+    },
+    RescheduleFragment {
+        reschedules: HashMap<FragmentId, Reschedule>,
+    },
+    ReplaceStreamJob(ReplaceStreamJobPlan),
+    SourceChangeSplit {
+        split_assignment: SplitAssignment,
+    },
+    CreateSubscription {
+        subscription_id: SubscriptionId,
+    },
+    ConnectorPropsChange(ConnectorPropsChange),
+}
+
+impl PostCollectCommand {
+    pub fn barrier() -> Self {
+        PostCollectCommand::Command("barrier".to_owned())
+    }
+
+    pub fn command_name(&self) -> &str {
+        match self {
+            PostCollectCommand::Command(name) => name.as_str(),
+            PostCollectCommand::DropStreamingJobs { .. } => "DropStreamingJobs",
+            PostCollectCommand::CreateStreamingJob { .. } => "CreateStreamingJob",
+            PostCollectCommand::RescheduleFragment { .. } => "RescheduleFragment",
+            PostCollectCommand::ReplaceStreamJob(_) => "ReplaceStreamJob",
+            PostCollectCommand::SourceChangeSplit { .. } => "SourceChangeSplit",
+            PostCollectCommand::CreateSubscription { .. } => "CreateSubscription",
+            PostCollectCommand::ConnectorPropsChange(_) => "ConnectorPropsChange",
+        }
+    }
+}
+
+impl Display for PostCollectCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.command_name())
+    }
+}
+
+impl Command {
+    pub(super) fn into_post_collect(self) -> PostCollectCommand {
+        match self {
+            Command::DropStreamingJobs {
+                streaming_job_ids,
+                unregistered_state_table_ids,
+                ..
+            } => PostCollectCommand::DropStreamingJobs {
+                streaming_job_ids,
+                unregistered_state_table_ids,
+            },
+            Command::CreateStreamingJob {
+                info,
+                job_type,
+                cross_db_snapshot_backfill_info,
+            } => match job_type {
+                CreateStreamingJobType::SnapshotBackfill(_) => PostCollectCommand::barrier(),
+                job_type => PostCollectCommand::CreateStreamingJob {
+                    info,
+                    job_type,
+                    cross_db_snapshot_backfill_info,
+                },
+            },
+            Command::RescheduleFragment { reschedules, .. } => {
+                PostCollectCommand::RescheduleFragment { reschedules }
+            }
+            Command::ReplaceStreamJob(plan) => PostCollectCommand::ReplaceStreamJob(plan),
+            Command::SourceChangeSplit(SplitState { split_assignment }) => {
+                PostCollectCommand::SourceChangeSplit { split_assignment }
+            }
+            Command::CreateSubscription {
+                subscription_id, ..
+            } => PostCollectCommand::CreateSubscription { subscription_id },
+            Command::ConnectorPropsChange(connector_props_change) => {
+                PostCollectCommand::ConnectorPropsChange(connector_props_change)
+            }
+            Command::Flush => PostCollectCommand::Command("Flush".to_owned()),
+            Command::Pause => PostCollectCommand::Command("Pause".to_owned()),
+            Command::Resume => PostCollectCommand::Command("Resume".to_owned()),
+            Command::Throttle { .. } => PostCollectCommand::Command("Throttle".to_owned()),
+            Command::DropSubscription { .. } => {
+                PostCollectCommand::Command("DropSubscription".to_owned())
+            }
+            Command::Refresh { .. } => PostCollectCommand::Command("Refresh".to_owned()),
+            Command::ListFinish { .. } => PostCollectCommand::Command("ListFinish".to_owned()),
+            Command::LoadFinish { .. } => PostCollectCommand::Command("LoadFinish".to_owned()),
+            Command::ResetSource { .. } => PostCollectCommand::Command("ResetSource".to_owned()),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum BarrierKind {
     Initial,
@@ -678,7 +776,7 @@ pub(super) struct CommandContext {
 
     pub(super) table_ids_to_commit: HashSet<TableId>,
 
-    pub(super) command: Option<Command>,
+    pub(super) command: PostCollectCommand,
 
     /// The tracing span of this command.
     ///
@@ -692,24 +790,8 @@ impl std::fmt::Debug for CommandContext {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CommandContext")
             .field("barrier_info", &self.barrier_info)
-            .field("command", &self.command)
+            .field("command", &self.command.command_name())
             .finish()
-    }
-}
-
-impl std::fmt::Display for CommandContext {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "prev_epoch={}, curr_epoch={}, kind={}",
-            self.barrier_info.prev_epoch(),
-            self.barrier_info.curr_epoch(),
-            self.barrier_info.kind.as_str_name()
-        )?;
-        if let Some(command) = &self.command {
-            write!(f, ", command={}", command)?;
-        }
-        Ok(())
     }
 }
 
@@ -718,7 +800,7 @@ impl CommandContext {
         barrier_info: BarrierInfo,
         mv_subscription_max_retention: HashMap<TableId, u64>,
         table_ids_to_commit: HashSet<TableId>,
-        command: Option<Command>,
+        command: PostCollectCommand,
         span: tracing::Span,
     ) -> Self {
         Self {
@@ -761,9 +843,11 @@ impl CommandContext {
         ) = collect_resp_info(resps);
 
         let new_table_fragment_infos =
-            if let Some(Command::CreateStreamingJob { info, job_type, .. }) = &self.command
-                && !matches!(job_type, CreateStreamingJobType::SnapshotBackfill(_))
-            {
+            if let PostCollectCommand::CreateStreamingJob { info, job_type, .. } = &self.command {
+                assert!(!matches!(
+                    job_type,
+                    CreateStreamingJobType::SnapshotBackfill(_)
+                ));
                 let table_fragments = &info.stream_job_fragments;
                 let mut table_ids: HashSet<_> =
                     table_fragments.internal_table_ids().into_iter().collect();
@@ -825,27 +909,17 @@ impl CommandContext {
                 .try_insert(table_id, VectorIndexDelta::Adds(vector_index_adds))
                 .expect("non-duplicate");
         }
-        if let Some(Command::CreateStreamingJob { info: job_info, .. }) = &self.command {
-            for fragment in job_info.stream_job_fragments.fragments.values() {
-                visit_stream_node_cont(&fragment.nodes, |node| {
-                    match node.node_body.as_ref().unwrap() {
-                        NodeBody::VectorIndexWrite(vector_index_write) => {
-                            let index_table = vector_index_write.table.as_ref().unwrap();
-                            assert_eq!(index_table.table_type, PbTableType::VectorIndex as i32);
-                            info.vector_index_delta
-                                .try_insert(
-                                    index_table.id,
-                                    VectorIndexDelta::Init(PbVectorIndexInit {
-                                        info: Some(index_table.vector_index_info.unwrap()),
-                                    }),
-                                )
-                                .expect("non-duplicate");
-                            false
-                        }
-                        _ => true,
-                    }
-                })
-            }
+        if let PostCollectCommand::CreateStreamingJob { info: job_info, .. } = &self.command
+            && let Some(index_table) = collect_new_vector_index_info(job_info)
+        {
+            info.vector_index_delta
+                .try_insert(
+                    index_table.id,
+                    VectorIndexDelta::Init(PbVectorIndexInit {
+                        info: Some(index_table.vector_index_info.unwrap()),
+                    }),
+                )
+                .expect("non-duplicate");
         }
         info.truncate_tables.extend(truncate_tables);
     }

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -30,13 +30,13 @@ use risingwave_pb::stream_service::streaming_control_stream_request::PbInitReque
 use risingwave_rpc_client::StreamingControlHandle;
 
 use crate::MetaResult;
-use crate::barrier::command::CommandContext;
+use crate::barrier::command::PostCollectCommand;
 use crate::barrier::progress::TrackingJob;
 use crate::barrier::schedule::{MarkReadyOptions, ScheduledBarriers};
 use crate::barrier::{
     BarrierManagerStatus, BarrierScheduler, BarrierWorkerRuntimeInfoSnapshot,
-    CreateStreamingJobCommandInfo, DatabaseRuntimeInfoSnapshot, RecoveryReason, Scheduled,
-    SnapshotBackfillInfo,
+    CreateStreamingJobCommandInfo, CreateStreamingJobType, DatabaseRuntimeInfoSnapshot,
+    RecoveryReason, Scheduled, SnapshotBackfillInfo,
 };
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
 use crate::manager::sink_coordination::SinkCoordinatorManager;
@@ -44,10 +44,20 @@ use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::stream::{GlobalRefreshManagerRef, ScaleControllerRef, SourceManagerRef};
 
 #[derive(Debug)]
-pub(super) struct CreateSnapshotBackfillJobInfo {
+pub(super) struct CreateSnapshotBackfillJobCommandInfo {
     pub info: CreateStreamingJobCommandInfo,
     pub snapshot_backfill_info: SnapshotBackfillInfo,
     pub cross_db_snapshot_backfill_info: SnapshotBackfillInfo,
+}
+
+impl CreateSnapshotBackfillJobCommandInfo {
+    pub(super) fn into_post_collect(self) -> PostCollectCommand {
+        PostCollectCommand::CreateStreamingJob {
+            info: self.info,
+            job_type: CreateStreamingJobType::SnapshotBackfill(self.snapshot_backfill_info),
+            cross_db_snapshot_backfill_info: self.cross_db_snapshot_backfill_info,
+        }
+    }
 }
 
 pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
@@ -64,15 +74,10 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
     );
     fn mark_ready(&self, options: MarkReadyOptions);
 
-    fn post_collect_command<'a>(
-        &'a self,
-        command: &'a CommandContext,
-    ) -> impl Future<Output = MetaResult<()>> + Send + 'a;
-
-    fn post_collect_create_snapshot_backfill<'a>(
-        &'a self,
-        info: &'a CreateSnapshotBackfillJobInfo,
-    ) -> impl Future<Output = MetaResult<()>> + Send + 'a;
+    fn post_collect_command(
+        &self,
+        command: PostCollectCommand,
+    ) -> impl Future<Output = MetaResult<()>> + Send + '_;
 
     async fn notify_creating_job_failed(&self, database_id: Option<DatabaseId>, err: String);
 

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -40,6 +40,7 @@ use tracing::{info, warn};
 
 use crate::MetaResult;
 use crate::barrier::cdc_progress::{CdcProgress, CdcTableBackfillTracker};
+use crate::barrier::command::PostCollectCommand;
 use crate::barrier::edge_builder::{FragmentEdgeBuildResult, FragmentEdgeBuilder};
 use crate::barrier::progress::{CreateMviewProgressTracker, StagingCommitInfo};
 use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
@@ -555,11 +556,11 @@ impl InflightDatabaseInfo {
 
     pub(super) fn apply_collected_command(
         &mut self,
-        command: Option<&Command>,
+        command: &PostCollectCommand,
         resps: &[BarrierCompleteResponse],
         version_stats: &HummockVersionStats,
     ) {
-        if let Some(Command::CreateStreamingJob { info, job_type, .. }) = command {
+        if let PostCollectCommand::CreateStreamingJob { info, job_type, .. } = command {
             match job_type {
                 CreateStreamingJobType::Normal | CreateStreamingJobType::SinkIntoTable(_) => {
                     let job_id = info.streaming_job.id();
@@ -581,7 +582,7 @@ impl InflightDatabaseInfo {
                 }
             }
         }
-        if let Some(Command::RescheduleFragment { reschedules, .. }) = command {
+        if let PostCollectCommand::RescheduleFragment { reschedules, .. } = command {
             // During reschedule we expect fragments to be rebuilt with new actors and no vnode bitmap update.
             debug_assert!(
                 reschedules

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -798,7 +798,6 @@ mod tests {
     use futures::FutureExt;
 
     use super::*;
-    use crate::barrier::context::CreateSnapshotBackfillJobInfo;
 
     fn create_test_database(
         id: u32,
@@ -855,16 +854,9 @@ mod tests {
             unimplemented!()
         }
 
-        async fn post_collect_command<'a>(
-            &'a self,
-            _command: &'a crate::barrier::command::CommandContext,
-        ) -> MetaResult<()> {
-            unimplemented!()
-        }
-
-        async fn post_collect_create_snapshot_backfill<'a>(
-            &'a self,
-            _info: &'a CreateSnapshotBackfillJobInfo,
+        async fn post_collect_command(
+            &self,
+            _command: crate::barrier::command::PostCollectCommand,
         ) -> MetaResult<()> {
             unimplemented!()
         }

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -38,8 +38,8 @@ use tokio::task::yield_now;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::MetaResult;
-use crate::barrier::command::CommandContext;
-use crate::barrier::context::{CreateSnapshotBackfillJobInfo, GlobalBarrierWorkerContext};
+use crate::barrier::command::PostCollectCommand;
+use crate::barrier::context::GlobalBarrierWorkerContext;
 use crate::barrier::progress::TrackingJob;
 use crate::barrier::rpc::from_partial_graph_id;
 use crate::barrier::schedule::MarkReadyOptions;
@@ -88,15 +88,8 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
         self.0.send(ContextRequest::MarkReady).unwrap();
     }
 
-    async fn post_collect_command<'a>(&'a self, _command: &'a CommandContext) -> MetaResult<()> {
+    async fn post_collect_command(&self, _command: PostCollectCommand) -> MetaResult<()> {
         unreachable!()
-    }
-
-    async fn post_collect_create_snapshot_backfill<'a>(
-        &'a self,
-        _info: &'a CreateSnapshotBackfillJobInfo,
-    ) -> MetaResult<()> {
-        unimplemented!()
     }
 
     async fn notify_creating_job_failed(&self, database_id: Option<DatabaseId>, _err: String) {

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -16,6 +16,7 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
+use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_stats::from_prost_table_stats_map;
 use risingwave_hummock_sdk::table_watermark::{
@@ -24,8 +25,14 @@ use risingwave_hummock_sdk::table_watermark::{
 use risingwave_hummock_sdk::vector_index::{VectorIndexAdd, VectorIndexDelta};
 use risingwave_hummock_sdk::{HummockSstableObjectId, LocalSstableInfo};
 use risingwave_meta_model::WorkerId;
+use risingwave_pb::catalog::PbTable;
+use risingwave_pb::catalog::table::PbTableType;
+use risingwave_pb::hummock::vector_index_delta::PbVectorIndexInit;
+use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 
+use crate::barrier::CreateStreamingJobCommandInfo;
+use crate::barrier::context::CreateSnapshotBackfillJobCommandInfo;
 use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
 
 #[expect(clippy::type_complexity)]
@@ -96,12 +103,34 @@ pub(super) fn collect_resp_info(
     )
 }
 
+pub(super) fn collect_new_vector_index_info(
+    info: &CreateStreamingJobCommandInfo,
+) -> Option<&PbTable> {
+    let mut vector_index_table = None;
+    {
+        for fragment in info.stream_job_fragments.fragments.values() {
+            visit_stream_node_cont(&fragment.nodes, |node| {
+                match node.node_body.as_ref().unwrap() {
+                    NodeBody::VectorIndexWrite(vector_index_write) => {
+                        let index_table = vector_index_write.table.as_ref().unwrap();
+                        assert_eq!(index_table.table_type, PbTableType::VectorIndex as i32);
+                        vector_index_table = Some(index_table);
+                        false
+                    }
+                    _ => true,
+                }
+            })
+        }
+        vector_index_table
+    }
+}
+
 pub(super) fn collect_creating_job_commit_epoch_info(
     commit_info: &mut CommitEpochInfo,
     epoch: u64,
     resps: Vec<BarrierCompleteResponse>,
     tables_to_commit: impl Iterator<Item = TableId>,
-    is_first_time: bool,
+    create_info: Option<&CreateSnapshotBackfillJobCommandInfo>,
 ) {
     let (
         sst_to_context,
@@ -131,12 +160,23 @@ pub(super) fn collect_creating_job_commit_epoch_info(
             .try_insert(*table_id, epoch)
             .expect("non duplicate");
     });
-    if is_first_time {
+    if let Some(info) = create_info {
         commit_info
             .new_table_fragment_infos
             .push(NewTableFragmentInfo {
                 table_ids: tables_to_commit,
             });
+        if let Some(index_table) = collect_new_vector_index_info(&info.info) {
+            commit_info
+                .vector_index_delta
+                .try_insert(
+                    index_table.id,
+                    VectorIndexDelta::Init(PbVectorIndexInit {
+                        info: Some(index_table.vector_index_info.unwrap()),
+                    }),
+                )
+                .expect("non-duplicate");
+        }
     };
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Previously, in snapshot backfill, the work of post_collect for a create streaming job command is handled when the barrier of upstream database partial graph has been collected. In this post_collect, we mark the snapshot backfill job as creating, and in background ddl the snapshot backfill job will be recovered and continue backfill.

However, this post_collect may happen before the first barrier of the snapshot backfill partial graph is collected, which registers the table_id to hummock. If recovery happens before it, in recovery when we recover snapshot backfill job, we will not be able to see the table_id of the job, and then keep recovery looping.

In this PR, instead of doing post_collect in the upstream database partial graph, we change to do it after the first barrier of the snapshot backfill partial graph is collected.

### generate by AI
This pull request refactors the logic for handling the creation and completion of streaming jobs during database checkpointing. The main focus is on improving how the system tracks and manages the first commit of a snapshot backfill job, replacing simple boolean flags with richer information, and ensuring correct ordering and safety when committing jobs. The changes also clarify and streamline data structures and function signatures for better maintainability.

**Key changes include:**

### Improved Tracking of First Commit Information

* Replaced the `is_first_commit` boolean flag with an `Option<CreateSnapshotBackfillJobCommandInfo>`, allowing the system to carry richer context about the first commit of a snapshot backfill job throughout the checkpointing process. [[1]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4L40-R41) [[2]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4R125-R133) [[3]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4L168-R161) [[4]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4L215-R212) [[5]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4L226-R232) [[6]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L697-R701) [[7]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L794-R804) [[8]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L903-R903) [[9]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L912-R916)

* Updated the `CompleteJobType::First` variant to hold `CreateSnapshotBackfillJobCommandInfo` instead of being a unit variant, enabling propagation of creation info where needed. [[1]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L697-R701) [[2]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L794-R804)

### Refactoring and API Simplification

* Refactored constructors and methods in `CreatingStreamingJobBarrierControl` and `CreatingStreamingJobControl` to remove the `is_first_committed` parameter and instead use the richer creation info where necessary. [[1]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4L50) [[2]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4L66-L77) [[3]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L84-R91) [[4]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L133-R134) [[5]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L394-R397)

* Updated function signatures and internal logic to pass `CreateSnapshotBackfillJobCommandInfo` and related context explicitly, improving clarity and reducing reliance on implicit state. [[1]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L184-R186) [[2]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R475) [[3]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R565) [[4]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R589) [[5]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R624) [[6]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R668)

### Safety and Correctness Improvements

* Added a guard in `start_completing` to ensure that snapshot backfill jobs are not committed until the upstream has committed the snapshot epoch, preventing premature commits.

* Improved assertions and checks to ensure that the correct barrier types and commit information are used throughout the job lifecycle. [[1]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4L736-R756) [[2]](diffhunk://#diff-cb1843c1f7ff32fb09e02765ba39002c78b7e2e46fa65ddd87c9128271a5ebb4R125-R133)

### Data Structure and Typing Updates

* Changed the `ApplyCommandInfo` struct to use a `PostCollectCommand` instead of an `Option<Command>`, clarifying intent and usage.

* Adjusted how commit information and epochs are tracked and stored, now including creation info where relevant for downstream processing. [[1]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L912-R916) [[2]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9L903-R903)

### Minor Cleanups and Dependency Updates

* Updated imports and removed unused parameters and fields to reflect the new logic and data flow. [[1]](diffhunk://#diff-36d1b059149fc82438a9db6a5cfac2fd4c436264fbceb947544d9ae598b5bcb4R44-R50) [[2]](diffhunk://#diff-44229b137399d20ef70c07c7f928527ec494356b08b98ac0e68c6ccf7b3371b0R33-R34)

* Added an `#[expect(clippy::too_many_arguments)]` attribute to suppress lint warnings for a function with many parameters, acknowledging complexity while keeping the interface explicit.

These changes collectively make the checkpointing and streaming job creation logic more robust, maintainable, and expressive, reducing the risk of subtle bugs and making future enhancements easier.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
