### PR TITLE
fix(cdc): excluded generated column from postgres publication validation

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
@@ -507,6 +507,28 @@ public class PostgresValidator extends DatabaseValidator implements AutoCloseabl
             }
         }
 
+        // Query generated columns - they should be excluded from publication validation
+        // because PostgreSQL does not replicate generated columns in logical replication
+        List<String> generatedColumns = new ArrayList<>();
+        try (var stmt =
+                jdbcConnection.prepareStatement(
+                        ValidatorUtils.getSql("postgres.generated_columns"))) {
+            stmt.setString(1, schemaName);
+            stmt.setString(2, tableName);
+            var res = stmt.executeQuery();
+            while (res.next()) {
+                generatedColumns.add(res.getString("attname"));
+            }
+            if (!generatedColumns.isEmpty()) {
+                LOG.info(
+                        "Found generated columns in table '{}': {}",
+                        schemaName + "." + tableName,
+                        String.join(", ", generatedColumns));
+            }
+        } catch (SQLException e) {
+            // For PostgreSQL < 12 that doesn't support generated columns, ignore the error
+            LOG.debug("Failed to query generated columns (likely PG < 12): {}", e.getMessage());
+        }
         // PG 15 and up supports partial publication of table
         // check whether publication covers all columns of the table schema
         if (isPartialPublicationEnabled) {
@@ -522,22 +544,25 @@ public class PostgresValidator extends DatabaseValidator implements AutoCloseabl
                     List<String> attNames = Arrays.asList(columnsPub);
                     for (int i = 0; i < tableSchema.getNumColumns(); i++) {
                         String columnName = tableSchema.getColumnNames()[i];
+                        // Skip generated columns - they are not included in publication
+                        if (generatedColumns.contains(columnName)) {
+                            LOG.info(
+                                    "Skipping generated column '{}' in publication validation",
+                                    columnName);
+                            continue;
+                        }
                         if (!attNames.contains(columnName)) {
                             throw ValidatorUtils.invalidArgument(
                                     String.format(
                                             "The publication '%s' does not cover all columns of the table '%s'",
                                             pubName, schemaName + "." + tableName));
                         }
-                        if (i == tableSchema.getNumColumns() - 1) {
-                            isPublicationCoversTable = true;
-                        }
                     }
-                    if (isPublicationCoversTable) {
-                        LOG.info(
-                                "The publication covers the table '{}'.",
-                                schemaName + "." + tableName);
-                        break;
-                    }
+                    // If we reach here, all non-generated columns are covered
+                    isPublicationCoversTable = true;
+                    LOG.info(
+                            "The publication covers the table '{}'.", schemaName + "." + tableName);
+                    break;
                 }
             }
         } else {

--- a/java/connector-node/risingwave-connector-service/src/main/resources/validate_sql.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/validate_sql.properties
@@ -19,6 +19,7 @@ postgres.table_read_privilege.check=SELECT has_table_privilege(?, ?, 'SELECT')
 postgres.table_owner=SELECT tableowner FROM pg_tables WHERE schemaname = ? and tablename = ?
 postgres.publication_att_exists=SELECT count(*) > 0 FROM information_schema.columns WHERE table_name = 'pg_publication_tables' AND column_name = 'attnames'
 postgres.publication_attnames=SELECT attnames FROM pg_publication_tables WHERE schemaname = ? AND tablename = ? AND pubname = ?
+postgres.generated_columns=SELECT a.attname FROM pg_attribute a JOIN pg_class c ON a.attrelid = c.oid JOIN pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = ? AND c.relname = ? AND a.attnum > 0 AND NOT a.attisdropped AND a.attgenerated != ''
 postgres.publication_exist=SELECT count(*) > 0 from pg_publication WHERE pubname = ?
 postgres.publication_pubviaroot=SELECT pubviaroot from pg_publication WHERE pubname = ?
 postgres.publication_has_table=SELECT COUNT(*) > 0 AS count FROM pg_publication_tables WHERE schemaname = ? AND tablename = ? AND pubname = ?


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?


When creating a PostgreSQL CDC source, if the publication already exists, the validation logic checks whether all columns in the table schema are covered by the publication. However, generated columns are automatically excluded from PostgreSQL logical replication publications, causing false validation errors like:
```
INVALID_ARGUMENT: The publication 'rw_publication' does not cover all columns of the table
```


This issue occurs when:
1. A source is created with a table containing generated columns
2. The source is dropped, leaving the publication behind
3. The source is recreated with the same table, triggering validation against the existing publication

## Solution

Exclude generated columns from publication validation by:
1. Querying generated columns from the upstream PostgreSQL table
2. Skipping validation for these columns when checking publication coverage

This aligns with PostgreSQL's behavior where generated columns are not included in logical replication publications.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
