### PR TITLE
fix(test): only check SST subset in meta backup sst test

### DIFF
--- a/src/storage/backup/integration_tests/common.sh
+++ b/src/storage/backup/integration_tests/common.sh
@@ -197,9 +197,13 @@ function execute_sql_and_expect() {
   [ -n "${result}" ]
 }
 
-function get_total_sst_count() {
+function get_all_sst_paths() {
   ${BACKUP_TEST_MCLI} -C "${BACKUP_TEST_MCLI_CONFIG}" \
-  find "hummock-minio/hummock001" -name "*.data" |wc -l
+  find "hummock-minio/hummock001" -name "*.data" | sort
+}
+
+function get_total_sst_count() {
+  get_all_sst_paths | wc -l
 }
 
 function get_table_committed_epoch_in_meta_snapshot() {

--- a/src/storage/backup/integration_tests/run_all.sh
+++ b/src/storage/backup/integration_tests/run_all.sh
@@ -11,6 +11,7 @@ tests=( \
 )
 for t in "${tests[@]}"
 do
+  echo "--- running ${t}"
   bash "${DIR}/${t}"
 done
 

--- a/src/storage/backup/integration_tests/test_pin_sst.sh
+++ b/src/storage/backup/integration_tests/test_pin_sst.sh
@@ -10,31 +10,54 @@ start_cluster
 echo "try to backup meta for empty cluster"
 job_id_1=$(backup)
 echo "create snapshot ${job_id_1} succeeded"
+get_all_sst_paths
 
 create_mvs
 query_mvs
 
 echo "try to backup meta after creating mvs"
+ssts_snapshot_2_file=$(mktemp)
+get_all_sst_paths > "${ssts_snapshot_2_file}"
 job_id_2=$(backup)
 echo "create snapshot ${job_id_2} succeeded"
+cat "${ssts_snapshot_2_file}"
 
 sleep 5
 
 restore "${job_id_1}"
 start_cluster
+get_all_sst_paths
 sst_count_before_gc=$(get_total_sst_count)
 # SSTs are pinned by snapshot 2
 full_gc_sst
 sst_count_after_gc=$(get_total_sst_count)
-[ "${sst_count_before_gc}" -eq "${sst_count_after_gc}" ]
+ssts_after_gc_file=$(mktemp)
+get_all_sst_paths > "${ssts_after_gc_file}"
+echo "after gc"
+cat "${ssts_after_gc_file}"
+echo "sst count before gc: ${sst_count_before_gc}, after gc: ${sst_count_after_gc}"
+missing_ssts=$(comm -23 "${ssts_snapshot_2_file}" "${ssts_after_gc_file}")
+rm -f "${ssts_after_gc_file}"
+if [ -n "${missing_ssts}" ]; then
+  echo "Missing pinned SSTs after GC:"
+  echo "${missing_ssts}"
+  exit 1
+fi
 [ "${sst_count_before_gc}" -gt 0 ]
-echo "sst count: ${sst_count_after_gc} ${sst_count_after_gc}"
 
 delete_snapshot "${job_id_2}"
 restore "${job_id_1}"
 start_cluster
 sst_count_before_gc=$(get_total_sst_count)
-[ "${sst_count_before_gc}" -gt 0 ]
+ssts_before_final_gc_file=$(mktemp)
+get_all_sst_paths > "${ssts_before_final_gc_file}"
+missing_ssts=$(comm -23 "${ssts_snapshot_2_file}" "${ssts_before_final_gc_file}")
+rm -f "${ssts_before_final_gc_file}" "${ssts_snapshot_2_file}"
+if [ -n "${missing_ssts}" ]; then
+  echo "Missing SSTs after deleting snapshot 2:"
+  echo "${missing_ssts}"
+  exit 1
+fi
 # SSTs are no longer pinned
 full_gc_sst
 sst_count_after_gc=$(get_total_sst_count)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

As titled. In meta backup test, we assume that when there are running job, if no data is written, no new SST file will be written. This will be false when we enable snapshot backfill by default, because it keeps persisting the latest progress and write new data to state store.

In this PR, get the list of sst files before we do the snapshot as the list of SSTs of the snapshot. And then in later check, we ensure that the list of SSTs in the snapshot won't be deleted in GC, rather than checking the SST count before and after GC.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
