### PR TITLE
test: resolve massive log when prepare sql server data

### DIFF
--- a/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
+++ b/e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql
@@ -1,3 +1,5 @@
+SET NOCOUNT ON;
+
 EXEC sys.sp_cdc_enable_db;
 
 CREATE TABLE orders (


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

often see massive log like

```log
2026-01-09T12:51:29.575469Z  INFO sqllogictest::system_command: system command executed command="sqlcmd -C -i e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql -b" status=ExitStatus(unix_wait_status(0)) stdout="Update mask evaluation will be disabled in net_changes_function because the CLR configuration option is disabled.\nJob 'cdc.mydb_capture' started successfully.\nJob 'cdc.mydb_cleanup' started successfully.\n\n(3 rows affected)\nUpdate mask evaluation will be disabled in net_changes_function because the CLR configuration option is disabled.\n\n(1 rows affected)\nUpdate mask evaluation will be disabled in net_changes_function because the CLR configuration option is disabled.\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\nUpdate mask evaluation will be disabled in net_changes_function because the CLR configuration option is disabled.\nUpdate mask evaluation will be disabled in net_changes_function because the CLR configuration option is disabled.\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows affected)\n\n(1 rows
```

due to `e2e_test/source_inline/cdc/sql_server/sql_server_cdc_prepare.sql`, iter to insert data 4k times

use `SET NOCOUNT ON` to disable `(1 rows affected)` logs, ref https://learn.microsoft.com/en-us/sql/t-sql/statements/set-nocount-transact-sql

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
