### PR TITLE
ci: trigger homebrew bump on release

### DIFF
--- a/.github/workflows/trigger-homebrew-bump.yml
+++ b/.github/workflows/trigger-homebrew-bump.yml
@@ -52,7 +52,6 @@ jobs:
 
             const ref = workflow.default_branch || "main";
             const inputs = version ? { version } : {};
-            const dispatchTime = new Date();
             await github.rest.actions.createWorkflowDispatch({
               owner,
               repo,
@@ -63,30 +62,3 @@ jobs:
 
             const detail = version ? `version ${version}` : "latest stable release (no override)";
             core.info(`Dispatched "${targetName}" with ${detail}`);
-
-            const earliestTime = new Date(dispatchTime.getTime() - 60000);
-            const maxAttempts = 6;
-            const delayMs = 5000;
-            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: workflow.id,
-                event: "workflow_dispatch",
-                branch: ref,
-                per_page: 5,
-              });
-              const run = runs.data.workflow_runs.find(
-                (candidate) => new Date(candidate.created_at) >= earliestTime,
-              );
-              if (run?.html_url) {
-                core.info(`Workflow run URL: ${run.html_url}`);
-                break;
-              }
-              if (attempt === maxAttempts) {
-                core.warning("Workflow run not found yet. Check Actions page later.");
-              } else {
-                core.info(`Waiting for workflow run... (${attempt}/${maxAttempts})`);
-              }
-            }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?


Add a release-triggered workflow that dispatches the homebrew-risingwave "bump risingwave" workflow, skipping prereleases and allowing a manual version override for testing.

Tested:
- https://github.com/BugenZhao/risingwave/actions/runs/20911433598
- https://github.com/risingwavelabs/homebrew-risingwave/actions/runs/20911436073
- https://github.com/risingwavelabs/homebrew-risingwave/pull/54

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
