### PR TITLE
feat(iceberg): support iceberg v3 delete vector (read and write) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5819,6 +5819,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcp_auth"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b3d0b409a042a380111af38136310839af8ac1a0917fb6e84515ed1e4bf3ee"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
 name = "genawaiter2"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6533,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a#da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4d5f635572a8e90c77a3c56c12aa40d5362f0d68#4d5f635572a8e90c77a3c56c12aa40d5362f0d68"
 dependencies = [
  "anyhow",
  "apache-avro 0.20.0",
@@ -6554,6 +6580,7 @@ dependencies = [
  "bimap",
  "bytes",
  "chrono",
+ "crc32fast",
  "derive_builder",
  "expect-test",
  "flate2",
@@ -6591,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a#da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4d5f635572a8e90c77a3c56c12aa40d5362f0d68#4d5f635572a8e90c77a3c56c12aa40d5362f0d68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6606,10 +6633,12 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a#da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4d5f635572a8e90c77a3c56c12aa40d5362f0d68#4d5f635572a8e90c77a3c56c12aa40d5362f0d68"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
+ "gcp_auth",
  "http 1.4.0",
  "iceberg",
  "itertools 0.13.0",
@@ -6626,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=084c897cda8f259640a331a5896c4c9b561bf7c9#084c897cda8f259640a331a5896c4c9b561bf7c9"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=e5b75408cef82ce25d70ab1b05e42d46aaabd22b#e5b75408cef82ce25d70ab1b05e42d46aaabd22b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6656,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a#da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4d5f635572a8e90c77a3c56c12aa40d5362f0d68#4d5f635572a8e90c77a3c56c12aa40d5362f0d68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11059,6 +11088,7 @@ dependencies = [
  "futures-async-stream",
  "futures-util",
  "hashbrown 0.16.0",
+ "iceberg",
  "itertools 0.14.0",
  "linkme",
  "madsim-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,14 +169,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20251111
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4d5f635572a8e90c77a3c56c12aa40d5362f0d68", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "da0a554ac6de294e2a04d96fdf6dd4c535aa8d2a" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4d5f635572a8e90c77a3c56c12aa40d5362f0d68" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4d5f635572a8e90c77a3c56c12aa40d5362f0d68" }
 
 adbc_core = { version = "0.22" }
 adbc_snowflake = { version = "0.22", default-features = false }

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3.slt
@@ -1,0 +1,165 @@
+control substitution on
+
+statement ok
+create secret hosted_catalog_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+# Test hosted catalog connection using the warehouse created by risedev
+statement ok
+create connection hosted_catalog_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg_v3_puffin',
+    s3.access.key = secret hosted_catalog_secret,
+    s3.secret.key = secret hosted_catalog_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2',
+    hosted_catalog = true
+);
+
+statement ok
+set iceberg_engine_connection = 'public.hosted_catalog_conn';
+
+statement ok
+create table t_v3(id int primary key, name varchar, v1 int)
+with(
+    commit_checkpoint_interval = 3,
+    format_version = 3
+) engine = iceberg;
+
+statement ok
+insert into t_v3 values(1, 'alice', 100), (2, 'bob', 200), (3, 'charlie', 300);
+
+statement ok
+flush;
+
+statement ok
+update t_v3 set v1 = 150 where id = 1;
+
+statement ok
+delete from t_v3 where id = 2;
+
+statement ok
+FLUSH;
+
+query ?? retry 6 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and file_format = 'puffin';
+----
+t
+
+query ?? retry 6 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and content = 'EqualityDeletes';
+----
+t
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v3;
+----
+1 alice 150
+3 charlie 300
+
+# generate eq deletes to test the reader of mixed delete files in v3
+statement ok
+delete from t_v3 where id = 1;
+
+statement ok
+FLUSH;
+
+query ?? retry 6 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and content = 'EqualityDeletes';
+----
+t
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v3;
+----
+3 charlie 300
+
+# This compaction won't clean up puffin files, but only generate new data files.
+statement ok
+VACUUM FULL t_v3;
+
+# Run again to clean up the puffin files.
+statement ok
+VACUUM FULL t_v3;
+
+query ? retry 3 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and file_format = 'puffin';
+----
+t
+
+query ?? retry 3 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and content in ('EqualityDeletes', 'PositionDeletes');
+----
+t
+
+query ??? rowsort
+select * from t_v3;
+----
+3 charlie 300
+
+statement ok
+DROP TABLE t_v3;
+
+statement ok
+DROP CONNECTION hosted_catalog_conn;
+
+# Test storage catalog connection with format version 3
+statement ok
+create connection storage_catalog_conn
+with (
+    type = 'iceberg',
+    catalog.type = 'storage',
+    warehouse.path = 's3://hummock001/iceberg_v3_puffin',
+    s3.access.key = secret hosted_catalog_secret,
+    s3.secret.key = secret hosted_catalog_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2'
+);
+
+statement ok
+set iceberg_engine_connection = 'public.storage_catalog_conn';
+
+statement ok
+create table t_v3_storage(id int primary key, name varchar)
+with(
+    commit_checkpoint_interval = 2,
+    format_version = 3
+) engine = iceberg;
+
+statement ok
+insert into t_v3_storage values(1, 'alice'), (2, 'bob');
+
+statement ok
+flush;
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v3_storage;
+----
+1 alice
+2 bob
+
+statement ok
+DROP TABLE t_v3_storage;
+
+statement ok
+DROP CONNECTION storage_catalog_conn;
+
+statement ok
+DROP SECRET hosted_catalog_secret;

--- a/src/batch/executors/Cargo.toml
+++ b/src/batch/executors/Cargo.toml
@@ -18,6 +18,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 futures-util = "0.3"
 hashbrown = { workspace = true }
+iceberg = { workspace = true }
 itertools = { workspace = true }
 linkme = { workspace = true }
 mysql_async = { workspace = true }

--- a/src/batch/executors/src/executor/iceberg_scan.rs
+++ b/src/batch/executors/src/executor/iceberg_scan.rs
@@ -108,7 +108,8 @@ impl IcebergScanExecutor {
                     chunk_size: self.chunk_size,
                     need_seq_num: self.need_seq_num,
                     need_file_path_and_pos: self.need_file_path_and_pos,
-                    handle_delete_files: false,
+                    handle_delete_files: table.metadata().format_version()
+                        >= iceberg::spec::FormatVersion::V3,
                 },
                 self.metrics.as_ref().map(|m| m.iceberg_scan_metrics()),
             ) {

--- a/src/connector/src/connector_common/iceberg/storage_catalog.rs
+++ b/src/connector/src/connector_common/iceberg/storage_catalog.rs
@@ -27,7 +27,7 @@ use iceberg::io::{
     GCS_DISABLE_CONFIG_LOAD, S3_ACCESS_KEY_ID, S3_DISABLE_CONFIG_LOAD, S3_ENDPOINT,
     S3_PATH_STYLE_ACCESS, S3_REGION, S3_SECRET_ACCESS_KEY,
 };
-use iceberg::spec::{TableMetadata, TableMetadataBuilder};
+use iceberg::spec::{TableMetadata, TableMetadataBuilder, TableProperties};
 use iceberg::table::Table;
 use iceberg::{
     Catalog, Error, ErrorKind, Namespace, NamespaceIdent, Result, TableCommit, TableCreation,
@@ -275,10 +275,16 @@ impl Catalog for StorageCatalog {
     async fn create_table(
         &self,
         namespace: &NamespaceIdent,
-        creation: TableCreation,
+        mut creation: TableCreation,
     ) -> iceberg::Result<Table> {
         let table_ident = TableIdent::new(namespace.clone(), creation.name.clone());
         let table_path = self.table_path(&table_ident);
+
+        // Remove format-version from properties if exists, because TableMetadataBuilder doesn't allow this field in properties.
+        // But we still allow users to set this field in TableCreation properties for other catalog like jdbc.
+        creation
+            .properties
+            .remove(TableProperties::PROPERTY_FORMAT_VERSION);
 
         // Create the metadata directory
         let metadata_path = format!("{table_path}/metadata");

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -27,17 +27,22 @@ use iceberg::arrow::{
     RecordBatchPartitionSplitter, arrow_schema_to_schema, schema_to_arrow_schema,
 };
 use iceberg::spec::{
-    DataFile, MAIN_BRANCH, Operation, PartitionSpecRef, SchemaRef as IcebergSchemaRef,
-    SerializedDataFile, Transform, UnboundPartitionField, UnboundPartitionSpec,
+    DataFile, FormatVersion, MAIN_BRANCH, Operation, PartitionSpecRef,
+    SchemaRef as IcebergSchemaRef, SerializedDataFile, TableProperties, Transform,
+    UnboundPartitionField, UnboundPartitionSpec,
 };
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use iceberg::writer::base_writer::deletion_vector_writer::{
+    DeletionVectorWriter, DeletionVectorWriterBuilder,
+};
 use iceberg::writer::base_writer::equality_delete_writer::{
     EqualityDeleteFileWriterBuilder, EqualityDeleteWriterConfig,
 };
 use iceberg::writer::base_writer::position_delete_file_writer::{
-    POSITION_DELETE_SCHEMA, PositionDeleteFileWriterBuilder,
+    POSITION_DELETE_SCHEMA, PositionDeleteFileWriter, PositionDeleteFileWriterBuilder,
+    PositionDeleteInput,
 };
 use iceberg::writer::delta_writer::{DELETE_OP, DeltaWriterBuilder, INSERT_OP};
 use iceberg::writer::file_writer::ParquetWriterBuilder;
@@ -69,6 +74,7 @@ use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::connector_service::sink_metadata::Metadata::Serialized;
 use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
 use risingwave_pb::stream_plan::PbSinkSchemaChange;
+use serde::de::{self, Deserializer, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json::from_value;
 use serde_with::{DisplayFromStr, serde_as};
@@ -167,6 +173,7 @@ pub const ENABLE_COMPACTION: &str = "enable_compaction";
 pub const COMPACTION_INTERVAL_SEC: &str = "compaction_interval_sec";
 pub const ENABLE_SNAPSHOT_EXPIRATION: &str = "enable_snapshot_expiration";
 pub const WRITE_MODE: &str = "write_mode";
+pub const FORMAT_VERSION: &str = "format_version";
 pub const SNAPSHOT_EXPIRATION_RETAIN_LAST: &str = "snapshot_expiration_retain_last";
 pub const SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS: &str = "snapshot_expiration_max_age_millis";
 pub const SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES: &str = "snapshot_expiration_clear_expired_files";
@@ -192,12 +199,80 @@ fn default_iceberg_write_mode() -> IcebergWriteMode {
     IcebergWriteMode::MergeOnRead
 }
 
+fn default_iceberg_format_version() -> FormatVersion {
+    FormatVersion::V2
+}
+
 fn default_true() -> bool {
     true
 }
 
 fn default_some_true() -> Option<bool> {
     Some(true)
+}
+
+fn parse_format_version_str(value: &str) -> std::result::Result<FormatVersion, String> {
+    let parsed = value
+        .trim()
+        .parse::<u8>()
+        .map_err(|_| "`format-version` must be one of 1, 2, or 3".to_owned())?;
+    match parsed {
+        1 => Ok(FormatVersion::V1),
+        2 => Ok(FormatVersion::V2),
+        3 => Ok(FormatVersion::V3),
+        _ => Err("`format-version` must be one of 1, 2, or 3".to_owned()),
+    }
+}
+
+fn deserialize_format_version<'de, D>(
+    deserializer: D,
+) -> std::result::Result<FormatVersion, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct FormatVersionVisitor;
+
+    impl<'de> Visitor<'de> for FormatVersionVisitor {
+        type Value = FormatVersion;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("format-version as 1, 2, or 3")
+        }
+
+        fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let value = u8::try_from(value)
+                .map_err(|_| E::custom("`format-version` must be one of 1, 2, or 3"))?;
+            parse_format_version_str(&value.to_string()).map_err(E::custom)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let value = u8::try_from(value)
+                .map_err(|_| E::custom("`format-version` must be one of 1, 2, or 3"))?;
+            parse_format_version_str(&value.to_string()).map_err(E::custom)
+        }
+
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            parse_format_version_str(value).map_err(E::custom)
+        }
+
+        fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_str(&value)
+        }
+    }
+
+    deserializer.deserialize_any(FormatVersionVisitor)
 }
 
 /// Compaction type for Iceberg sink
@@ -339,6 +414,14 @@ pub struct IcebergConfig {
     /// The iceberg write mode, can be `merge-on-read` or `copy-on-write`.
     #[serde(rename = "write_mode", default = "default_iceberg_write_mode")]
     pub write_mode: IcebergWriteMode,
+
+    /// Iceberg format version for table creation.
+    #[serde(
+        rename = "format_version",
+        default = "default_iceberg_format_version",
+        deserialize_with = "deserialize_format_version"
+    )]
+    pub format_version: FormatVersion,
 
     /// The maximum age (in milliseconds) for snapshots before they expire
     /// For example, if set to 3600000, snapshots older than 1 hour will be expired
@@ -513,6 +596,10 @@ impl IcebergConfig {
 
     pub fn catalog_name(&self) -> String {
         self.common.catalog_name()
+    }
+
+    pub fn table_format_version(&self) -> FormatVersion {
+        self.format_version
     }
 
     pub fn compaction_interval_sec(&self) -> u64 {
@@ -719,9 +806,17 @@ async fn create_table_if_not_exists_impl(config: &IcebergConfig, param: &SinkPar
             None => None,
         };
 
+        // Put format-version into table properties, because catalog like jdbc extract format-version from table properties.
+        let properties = HashMap::from([(
+            TableProperties::PROPERTY_FORMAT_VERSION.to_owned(),
+            (config.format_version as u8).to_string(),
+        )]);
+
         let table_creation_builder = TableCreation::builder()
             .name(config.table.table_name().to_owned())
-            .schema(iceberg_schema);
+            .schema(iceberg_schema)
+            .format_version(config.table_format_version())
+            .properties(properties);
 
         let table_creation = match (location, partition_spec) {
             (Some(location), Some(partition_spec)) => table_creation_builder
@@ -980,11 +1075,67 @@ type PositionDeleteFileWriterBuilderType = PositionDeleteFileWriterBuilder<
     DefaultLocationGenerator,
     DefaultFileNameGenerator,
 >;
+type PositionDeleteFileWriterType = PositionDeleteFileWriter<
+    ParquetWriterBuilder,
+    DefaultLocationGenerator,
+    DefaultFileNameGenerator,
+>;
+type DeletionVectorWriterBuilderType =
+    DeletionVectorWriterBuilder<DefaultLocationGenerator, DefaultFileNameGenerator>;
+type DeletionVectorWriterType =
+    DeletionVectorWriter<DefaultLocationGenerator, DefaultFileNameGenerator>;
 type EqualityDeleteFileWriterBuilderType = EqualityDeleteFileWriterBuilder<
     ParquetWriterBuilder,
     DefaultLocationGenerator,
     DefaultFileNameGenerator,
 >;
+
+#[derive(Clone)]
+enum PositionDeleteWriterBuilderType {
+    PositionDelete(PositionDeleteFileWriterBuilderType),
+    DeletionVector(DeletionVectorWriterBuilderType),
+}
+
+enum PositionDeleteWriterType {
+    PositionDelete(PositionDeleteFileWriterType),
+    DeletionVector(DeletionVectorWriterType),
+}
+
+#[async_trait]
+impl IcebergWriterBuilder<Vec<PositionDeleteInput>> for PositionDeleteWriterBuilderType {
+    type R = PositionDeleteWriterType;
+
+    async fn build(
+        self,
+        partition_key: Option<iceberg::spec::PartitionKey>,
+    ) -> iceberg::Result<Self::R> {
+        match self {
+            PositionDeleteWriterBuilderType::PositionDelete(builder) => Ok(
+                PositionDeleteWriterType::PositionDelete(builder.build(partition_key).await?),
+            ),
+            PositionDeleteWriterBuilderType::DeletionVector(builder) => Ok(
+                PositionDeleteWriterType::DeletionVector(builder.build(partition_key).await?),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl IcebergWriter<Vec<PositionDeleteInput>> for PositionDeleteWriterType {
+    async fn write(&mut self, input: Vec<PositionDeleteInput>) -> iceberg::Result<()> {
+        match self {
+            PositionDeleteWriterType::PositionDelete(writer) => writer.write(input).await,
+            PositionDeleteWriterType::DeletionVector(writer) => writer.write(input).await,
+        }
+    }
+
+    async fn close(&mut self) -> iceberg::Result<Vec<DataFile>> {
+        match self {
+            PositionDeleteWriterType::PositionDelete(writer) => writer.close().await,
+            PositionDeleteWriterType::DeletionVector(writer) => writer.close().await,
+        }
+    }
+}
 
 #[derive(Clone)]
 struct TaskWriterBuilderWrapper<B: IcebergWriterBuilder> {
@@ -1075,7 +1226,7 @@ enum IcebergWriterDispatch {
             MonitoredGeneralWriterBuilder<
                 DeltaWriterBuilder<
                     DataFileWriterBuilderType,
-                    PositionDeleteFileWriterBuilderType,
+                    PositionDeleteWriterBuilderType,
                     EqualityDeleteFileWriterBuilderType,
                 >,
             >,
@@ -1153,7 +1304,6 @@ impl IcebergSinkWriterInner {
         let schema = table.metadata().current_schema();
         let partition_spec = table.metadata().default_partition_spec();
         let fanout_enabled = !partition_spec.fields().is_empty();
-
         // To avoid duplicate file name, each time the sink created will generate a unique uuid as file name suffix.
         let unique_uuid_suffix = Uuid::now_v7();
 
@@ -1262,6 +1412,7 @@ impl IcebergSinkWriterInner {
         let schema = table.metadata().current_schema();
         let partition_spec = table.metadata().default_partition_spec();
         let fanout_enabled = !partition_spec.fields().is_empty();
+        let use_deletion_vectors = table.metadata().format_version() >= FormatVersion::V3;
 
         // To avoid duplicate file name, each time the sink created will generate a unique uuid as file name suffix.
         let unique_uuid_suffix = Uuid::now_v7();
@@ -1291,7 +1442,19 @@ impl IcebergSinkWriterInner {
             );
             DataFileWriterBuilder::new(rolling_writer_builder)
         };
-        let position_delete_builder = {
+        let position_delete_builder = if use_deletion_vectors {
+            let location_generator = DefaultLocationGenerator::new(table.metadata().clone())
+                .map_err(|err| SinkError::Iceberg(anyhow!(err)))?;
+            PositionDeleteWriterBuilderType::DeletionVector(DeletionVectorWriterBuilder::new(
+                table.file_io().clone(),
+                location_generator,
+                DefaultFileNameGenerator::new(
+                    writer_param.actor_id.to_string(),
+                    Some(format!("delvec-{}", unique_uuid_suffix)),
+                    iceberg::spec::DataFileFormat::Puffin,
+                ),
+            ))
+        } else {
             let parquet_writer_builder = ParquetWriterBuilder::new(
                 parquet_writer_properties.clone(),
                 POSITION_DELETE_SCHEMA.clone().into(),
@@ -1307,7 +1470,9 @@ impl IcebergSinkWriterInner {
                     iceberg::spec::DataFileFormat::Parquet,
                 ),
             );
-            PositionDeleteFileWriterBuilder::new(rolling_writer_builder)
+            PositionDeleteWriterBuilderType::PositionDelete(PositionDeleteFileWriterBuilder::new(
+                rolling_writer_builder,
+            ))
         };
         let equality_delete_builder = {
             let config = EqualityDeleteWriterConfig::new(
@@ -2702,6 +2867,8 @@ pub fn should_enable_iceberg_cow(sink_type: &str, write_mode: IcebergWriteMode) 
 
 impl crate::with_options::WithOptions for IcebergWriteMode {}
 
+impl crate::with_options::WithOptions for FormatVersion {}
+
 impl crate::with_options::WithOptions for CompactionType {}
 
 #[cfg(test)]
@@ -2715,7 +2882,7 @@ mod test {
     use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
     use crate::sink::iceberg::{
         COMPACTION_INTERVAL_SEC, COMPACTION_MAX_SNAPSHOTS_NUM, CompactionType, ENABLE_COMPACTION,
-        ENABLE_SNAPSHOT_EXPIRATION, IcebergConfig, IcebergWriteMode,
+        ENABLE_SNAPSHOT_EXPIRATION, FormatVersion, IcebergConfig, IcebergWriteMode,
         SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA,
         SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS, SNAPSHOT_EXPIRATION_RETAIN_LAST, WRITE_MODE,
     };
@@ -2978,6 +3145,7 @@ mod test {
             compaction_interval_sec: Some(DEFAULT_ICEBERG_COMPACTION_INTERVAL / 2),
             enable_snapshot_expiration: true,
             write_mode: IcebergWriteMode::MergeOnRead,
+            format_version: FormatVersion::V2,
             snapshot_expiration_max_age_millis: None,
             snapshot_expiration_retain_last: None,
             snapshot_expiration_clear_expired_files: true,

--- a/src/connector/src/source/iceberg/mod.rs
+++ b/src/connector/src/source/iceberg/mod.rs
@@ -25,6 +25,7 @@ use futures_async_stream::{for_await, try_stream};
 use iceberg::Catalog;
 use iceberg::expr::{BoundPredicate, Predicate as IcebergPredicate};
 use iceberg::scan::FileScanTask;
+use iceberg::spec::FormatVersion;
 use iceberg::table::Table;
 pub use parquet_file_handler::*;
 use phf::{Set, phf_set};
@@ -257,6 +258,7 @@ pub struct IcebergListResult {
     pub equality_delete_files: Vec<FileScanTask>,
     pub position_delete_files: Vec<FileScanTask>,
     pub equality_delete_columns: Vec<String>,
+    pub format_version: FormatVersion,
 }
 
 impl IcebergSplitEnumerator {
@@ -324,6 +326,7 @@ impl IcebergSplitEnumerator {
         snapshot_id: i64,
         predicate: IcebergPredicate,
     ) -> ConnectorResult<IcebergListResult> {
+        let format_version = table.metadata().format_version();
         let table_schema = table.metadata().current_schema();
         tracing::debug!("iceberg_table_schema: {:?}", table_schema);
 
@@ -402,6 +405,7 @@ impl IcebergSplitEnumerator {
             equality_delete_files,
             position_delete_files,
             equality_delete_columns,
+            format_version,
         })
     }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -664,6 +664,11 @@ IcebergConfig:
     comments: The iceberg write mode, can be `merge-on-read` or `copy-on-write`.
     required: false
     default: 'IcebergWriteMode :: MergeOnRead'
+  - name: format_version
+    field_type: FormatVersion
+    comments: Iceberg format version for table creation.
+    required: false
+    default: 'FormatVersion :: V2'
   - name: snapshot_expiration_max_age_millis
     field_type: i64
     comments: |-

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -98,10 +98,11 @@ use risingwave_connector::sink::iceberg::{
     COMPACTION_DELETE_FILES_COUNT_THRESHOLD, COMPACTION_INTERVAL_SEC, COMPACTION_MAX_SNAPSHOTS_NUM,
     COMPACTION_SMALL_FILES_THRESHOLD_MB, COMPACTION_TARGET_FILE_SIZE_MB,
     COMPACTION_TRIGGER_SNAPSHOT_COUNT, COMPACTION_TYPE, CompactionType, ENABLE_COMPACTION,
-    ENABLE_SNAPSHOT_EXPIRATION, ICEBERG_WRITE_MODE_COPY_ON_WRITE, ICEBERG_WRITE_MODE_MERGE_ON_READ,
-    IcebergSink, IcebergWriteMode, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES,
-    SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA, SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS,
-    SNAPSHOT_EXPIRATION_RETAIN_LAST, WRITE_MODE, parse_partition_by_exprs,
+    ENABLE_SNAPSHOT_EXPIRATION, FORMAT_VERSION, ICEBERG_WRITE_MODE_COPY_ON_WRITE,
+    ICEBERG_WRITE_MODE_MERGE_ON_READ, IcebergSink, IcebergWriteMode,
+    SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA,
+    SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS, SNAPSHOT_EXPIRATION_RETAIN_LAST, WRITE_MODE,
+    parse_partition_by_exprs,
 };
 use risingwave_pb::ddl_service::create_iceberg_table_request::{PbSinkJobInfo, PbTableJobInfo};
 
@@ -1950,6 +1951,24 @@ pub async fn create_iceberg_engine_table(
                     .remove(SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA)
             });
         }
+    }
+
+    if let Some(format_version) = handler_args.with_options.get(FORMAT_VERSION) {
+        let format_version = format_version.parse::<u8>().map_err(|_| {
+            ErrorCode::InvalidInputSyntax(format!(
+                "format_version must be 1, 2 or 3: {}",
+                format_version
+            ))
+        })?;
+        if format_version != 1 && format_version != 2 && format_version != 3 {
+            bail!("format_version must be 1, 2 or 3");
+        }
+        sink_with.insert(FORMAT_VERSION.to_owned(), format_version.to_string());
+
+        // remove format_version from source options, otherwise it will be considered as an unknown field.
+        source
+            .as_mut()
+            .map(|x| x.with_properties.remove(FORMAT_VERSION));
     }
 
     if let Some(write_mode) = handler_args.with_options.get(WRITE_MODE) {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "084c897cda8f259640a331a5896c4c9b561bf7c9" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "e5b75408cef82ce25d70ab1b05e42d46aaabd22b" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/stream/src/executor/source/iceberg_fetch_executor.rs
+++ b/src/stream/src/executor/source/iceberg_fetch_executor.rs
@@ -369,7 +369,8 @@ impl<S: StateStore> IcebergFetchExecutor<S> {
                     chunk_size: streaming_config.developer.chunk_size,
                     need_seq_num: true, /* Although this column is unnecessary, we still keep it for potential usage in the future */
                     need_file_path_and_pos: true,
-                    handle_delete_files: false,
+                    handle_delete_files: table.metadata().format_version()
+                        >= iceberg::spec::FormatVersion::V3,
                 },
                 None,
             ) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- This is an experimental feature.
- Minimal support iceberg v3 delete vector. Replace the parquet format position delete with puffin format.
- Support delete vector write(via iceberg sink)
- Support delete vector read (via iceberg-rust) instead of constructing anti join (for position) in RisingWave query plan, so the file scan tasks containing (position) delete files to pass to iceberg-rust directly in v3, while equality deletes still use anti join to process.
- Support iceberg compaction for the iceberg v3 format. The main change is supporting read iceberg v3 table with delete vector, we also delegate the read to the iceberg-rust.
- The v3 table test example could be found in `e2e_test/iceberg/test_case/pure_slt/iceberg_v3.slt`
- Related iceberg-compaction PR https://github.com/nimtable/iceberg-compaction/pull/121
- Related iceberg-rust PR https://github.com/risingwavelabs/iceberg-rust/pull/113

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
