### PR TITLE
fix(stream): fix inconsistent global approx percentile initial state

### DIFF
--- a/src/stream/src/executor/approx_percentile/global.rs
+++ b/src/stream/src/executor/approx_percentile/global.rs
@@ -65,9 +65,8 @@ impl<S: StateStore> GlobalApproxPercentileExecutor<S> {
                     state.apply_chunk(chunk)?;
                 }
                 Message::Barrier(barrier) => {
-                    if let Some(output) = state.get_output() {
-                        yield Message::Chunk(output);
-                    }
+                    let output = state.get_output();
+                    yield Message::Chunk(output);
                     state.commit(barrier.epoch).await?;
                     yield Message::Barrier(barrier);
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

In initialization, `approx_percentile` send `None` as its initial output, in the meantime, it initializes its row_count state as `Some(0)`. However, when there is no data before a recovery, after recovery, in the init of `approx_percentile`, when it sees row_count state as `Some(0)`, it treat its last output as `Some(0.0)`, and then when update happens, the old value in the row sent to downstream will be inconsistent.

See error like
```
sanity check fail first=[None, None, None, None] second=[Some(Float64(0.0)), None, Some(Float64(0.0)), Some(Float64(0.0))]
```

To reproduce
```
create table t(p_col double, grp_col int);

create materialized view m1 as
 select
     approx_percentile(0.01, 0.01) within group (order by p_col) as p01,
     approx_percentile(0.1, 0.01) within group (order by p_col) as p10,
     approx_percentile(0.5, 0.01) within group (order by p_col) as p50,
     approx_percentile(0.9, 0.01) within group (order by p_col) as p90,
     approx_percentile(0.99, 0.01) within group (order by p_col) as p99
 from t;

recover;

insert into t values (1.0, 1); FLUSH; // see error
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
