### PR TITLE
ci: upload redis cluster logs on failure & add sleep before running slt

### DIFF
--- a/ci/scripts/e2e-redis-sink-test.sh
+++ b/ci/scripts/e2e-redis-sink-test.sh
@@ -70,6 +70,7 @@ redis-server ./ci/redis-conf/redis-7001.conf --daemonize yes --logfile "$REDIS_C
 redis-server ./ci/redis-conf/redis-7002.conf --daemonize yes --logfile "$REDIS_CLUSTER_LOG_DIR/redis-7002.log"
 
 echo "yes" | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002
+# Wait a bit for cluster_state to become ok before running SLT.
 sleep 2
 
 sqllogictest -p 4566 -d dev './e2e_test/sink/redis_cluster_sink.slt'


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
- Add Redis cluster logfile output for the 7000/7001/7002 nodes in the e2e redis sink test so Buildkite can capture them on failure.
- The logs are written into `.risingwave/log`, which is already collected by the upload-failure-logs hook.
- Add a short sleep after Redis cluster creation to avoid a cluster readiness race in SLT.

Investigation note: compute log shows `ClusterDown: The cluster is down` at 08:55:03.412, while redis-7000 log shows `Cluster state changed: ok` at 08:55:03.547, indicating a readiness race. Buildkite log: https://buildkite.com/risingwavelabs/pull-request/builds/89670#019bc5f2-caf2-4156-ad1c-eb47be18c5c5/L388

This is for debugging https://github.com/risingwavelabs/risingwave/issues/24281#issuecomment-3758770618

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
