### PR TITLE
fix(stream): fix inconsistent global approx percentile initial state again

### DIFF
--- a/src/stream/src/executor/approx_percentile/global_state.rs
+++ b/src/stream/src/executor/approx_percentile/global_state.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, Bound};
+use std::mem;
 
 use risingwave_common::array::Op;
 use risingwave_common::bail;
@@ -29,7 +30,7 @@ use crate::executor::prelude::*;
 pub struct GlobalApproxPercentileState<S: StateStore> {
     quantile: f64,
     base: f64,
-    row_count: Option<i64>,
+    row_count: i64,
     bucket_state_table: StateTable<S>,
     count_state_table: StateTable<S>,
     cache: BucketTableCache,
@@ -48,7 +49,7 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
         Self {
             quantile,
             base,
-            row_count: None,
+            row_count: 0,
             bucket_state_table,
             count_state_table,
             cache: BucketTableCache::new(),
@@ -64,7 +65,7 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
 
         // Refill row_count
         let row_count_state = self.get_row_count_state().await?;
-        let row_count = Self::decode_row_count(&row_count_state);
+        let row_count = Self::decode_row_count(&row_count_state)?;
         self.row_count = row_count;
         tracing::debug!(?row_count, "recovered row_count");
 
@@ -72,10 +73,10 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
         self.refill_cache().await?;
 
         // Update the last output downstream
-        let last_output = if let Some(row_count) = row_count {
-            Some(self.cache.get_output(row_count, self.quantile, self.base))
-        } else {
+        let last_output = if row_count_state.is_none() {
             None
+        } else {
+            Some(self.cache.get_output(row_count, self.quantile, self.base))
         };
         tracing::debug!(?last_output, "recovered last_output");
         self.last_output = last_output;
@@ -116,10 +117,15 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
         self.count_state_table.get_row(&[Datum::None; 0]).await
     }
 
-    fn decode_row_count(row_count_state: &Option<OwnedRow>) -> Option<i64> {
-        row_count_state
-            .as_ref()
-            .and_then(|row| row.datum_at(0).map(|datum| datum.into_int64()))
+    fn decode_row_count(row_count_state: &Option<OwnedRow>) -> StreamExecutorResult<i64> {
+        if let Some(row) = row_count_state.as_ref() {
+            let Some(datum) = row.datum_at(0) else {
+                bail!("Invalid row count state: {:?}", row)
+            };
+            Ok(datum.into_int64())
+        } else {
+            Ok(0)
+        }
     }
 }
 
@@ -154,13 +160,8 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
         self.output_changed = true;
 
         // Updates
-        self.row_count = Some(
-            self.row_count
-                .unwrap_or(0)
-                .checked_add(delta as i64)
-                .unwrap(),
-        );
-        tracing::debug!("updated row_count: {}", self.row_count.unwrap());
+        self.row_count = self.row_count.checked_add(delta as i64).unwrap();
+        tracing::debug!("updated row_count: {}", self.row_count);
 
         let (is_new_entry, old_count, new_count) = match sign {
             -1 => {
@@ -226,7 +227,7 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
 
     pub async fn commit(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
         // Commit row count state.
-        let row_count_datum = self.row_count.map(ScalarImpl::Int64);
+        let row_count_datum = Datum::from(ScalarImpl::Int64(self.row_count));
         let row_count_row = &[row_count_datum];
         let last_row_count_state = self.count_state_table.get_row(&[Datum::None; 0]).await?;
         match last_row_count_state {
@@ -248,34 +249,21 @@ impl<S: StateStore> GlobalApproxPercentileState<S> {
 // Read
 impl<S: StateStore> GlobalApproxPercentileState<S> {
     pub fn get_output(&mut self) -> StreamChunk {
-        let new_output = if !self.output_changed {
-            if cfg!(debug_assertions) {
-                let new_output = if let Some(row_count) = self.row_count {
-                    Some(self.cache.get_output(row_count, self.quantile, self.base))
-                } else {
-                    None
-                };
-                assert_eq!(new_output, self.last_output);
-            }
-            static EMPTY_DATUM: Datum = None;
-            let last_datum = self.last_output.as_ref().unwrap_or(&EMPTY_DATUM);
-            // we emit a trivial chunk to ensure that RowMerge has data in every epoch
-            return StreamChunk::from_rows(
-                &[
-                    (Op::UpdateDelete, std::slice::from_ref(&last_datum)),
-                    (Op::UpdateInsert, std::slice::from_ref(&last_datum)),
-                ],
-                &[DataType::Float64],
+        let last_output = mem::take(&mut self.last_output);
+        let new_output = if let Some(last_output) = &last_output
+            && !self.output_changed
+        {
+            debug_assert_eq!(
+                *last_output,
+                self.cache
+                    .get_output(self.row_count, self.quantile, self.base)
             );
+            last_output.clone()
         } else {
-            self.cache.get_output(
-                self.row_count
-                    .expect("should have row count when output changed"),
-                self.quantile,
-                self.base,
-            )
+            self.cache
+                .get_output(self.row_count, self.quantile, self.base)
         };
-        let last_output = self.last_output.replace(new_output.clone());
+        self.last_output = Some(new_output.clone());
         let output_chunk = match last_output {
             None => StreamChunk::from_rows(&[(Op::Insert, &[new_output])], &[DataType::Float64]),
             Some(last_output) => StreamChunk::from_rows(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The root cause of the issue fixed by https://github.com/risingwavelabs/risingwave/pull/24480 is that we send `None` as the initial output, while in recovery we treat the initial output as `Some(0.0)`. The original solution of https://github.com/risingwavelabs/risingwave/pull/24480 break some assumption of the following `StreamRowMerge`, and the later patch to align with the assumption is problematic.

In this PR, we revert the fix in https://github.com/risingwavelabs/risingwave/pull/24480 and fix it in another way. Instead of sending `None` as the initial output, we send `Some(0.0)` if there is no row in the first barrier. There was error in https://buildkite.com/risingwavelabs/main-cron/builds/8479, and with the fix logic, there is no error anymore in https://buildkite.com/risingwavelabs/main-cron/builds/8484.

See diff between the fix in the main branch. 
https://github.com/risingwavelabs/risingwave/compare/54a308f..18e562f268

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
