### PR TITLE
Persist backfill ordering for recovery

### DIFF
--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -61,6 +61,7 @@ mod m20251112_114514_streaming_job_config_override;
 mod m20251124_195858_pending_sink_state;
 mod m20251126_093529_add_is_iceberg_compactor;
 mod m20251130_120000_streaming_job_backfill_parallelism;
+mod m20260106_120000_streaming_job_backfill_orders;
 mod m20251208_134652_clean_watermark_indices;
 mod m20251224_142321_sink_schema_change;
 mod m20251231_000000_sink_ignore_delete;
@@ -166,6 +167,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20251208_134652_clean_watermark_indices::Migration),
             Box::new(m20251224_142321_sink_schema_change::Migration),
             Box::new(m20251231_000000_sink_ignore_delete::Migration),
+            Box::new(m20260106_120000_streaming_job_backfill_orders::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260106_120000_streaming_job_backfill_orders.rs
+++ b/src/meta/model/migration/src/m20260106_120000_streaming_job_backfill_orders.rs
@@ -1,0 +1,39 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(StreamingJob::Table)
+                    .add_column(
+                        ColumnDef::new(StreamingJob::BackfillOrders)
+                            .json_binary()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(StreamingJob::Table)
+                    .drop_column(StreamingJob::BackfillOrders)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum StreamingJob {
+    Table,
+    BackfillOrders,
+}

--- a/src/meta/model/src/streaming_job.rs
+++ b/src/meta/model/src/streaming_job.rs
@@ -33,6 +33,8 @@ pub struct Model {
     pub config_override: Option<String>,
     pub parallelism: StreamingParallelism,
     pub backfill_parallelism: Option<StreamingParallelism>,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub backfill_orders: Option<BackfillOrders>,
     pub max_parallelism: i32,
     pub specific_resource_group: Option<String>,
 }


### PR DESCRIPTION
### Motivation
- Backfill ordering (fragment-level backfill dependency graph) is currently lost after meta-node recovery causing all upstreams to backfill in parallel.
- The system needs to persist the static backfill ordering so recovered meta can reconstruct scheduling state and resume background backfilling correctly.

### Description
- Persist backfill ordering in the streaming job catalog by adding an optional `backfill_orders` JSON column and a migration `m20260106_120000_streaming_job_backfill_orders`.
- Wire storage of the planned fragment backfill ordering during job creation by converting `FragmentBackfillOrder` to `BackfillOrders` in the DDL flow and persisting it in `prepare_stream_job_fragments` / `create_streaming_job_obj`.
- Add recovery support: load persisted `BackfillOrders` for jobs during meta recovery (`inject_database_initial_barrier`), build a locality-provider state-table mapping, and reconstruct `BackfillOrderState` via a new `recover_from_fragment_infos` constructor so background creating jobs resume with correct scheduling state.
- Misc: small API plumbing to thread `BackfillOrders` through `prepare_stream_job_fragments` and helper functions to load and translate persisted orders.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c730f634833386db7697d61c7c9b)