### PR TITLE
chore: release binary without debug info to reduce size (#24565)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,6 +379,10 @@ inherits = "release"
 incremental = false
 lto = "thin"
 
+[profile.thin-production]
+inherits = "production"
+debug = 0 # no debug info, only symbols
+
 [profile.ci-release]
 inherits = "release"
 incremental = false

--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -7,6 +7,10 @@ SKIP_RELEASE=${SKIP_RELEASE:-0}
 REPO_ROOT=${PWD}
 ARCH="$(uname -m)"
 
+# By default, we use `thin-production` for binary release.
+# This includes only symbol tables but no debug info, aiming for a small binary size.
+CARGO_PROFILE=${CARGO_PROFILE:-thin-production}
+
 echo "--- Check env"
 if [ "${BUILDKITE_SOURCE}" != "schedule" ] && [ "${BUILDKITE_SOURCE}" != "webhook" ] && [[ -z "${BINARY_NAME+x}" ]]; then
   exit 0
@@ -36,9 +40,10 @@ echo "--- Install rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --default-toolchain none -y
 source "$HOME/.cargo/env"
 rustup show
-source ci/scripts/common.sh
-unset RUSTC_WRAPPER # disable sccache
-unset RUSTC_WORKSPACE_WRAPPER
+
+echo "--- Install sccache"
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+cargo binstall -y --locked sccache@0.10.0
 
 echo "--- Install protoc3"
 PROTOC_ARCH=${ARCH}
@@ -69,6 +74,9 @@ if [[ -n "${BUILDKITE_TAG}" ]]; then
 fi
 
 echo "--- Build risingwave release binary"
+source ci/scripts/common.sh
+unset RUSTC_WORKSPACE_WRAPPER # disable rustc-workspace-wrapper, for coverage instrumentation
+
 export ENABLE_BUILD_DASHBOARD=1
 if [ "${ARCH}" == "aarch64" ]; then
   # enable large page size support for jemalloc
@@ -76,13 +84,19 @@ if [ "${ARCH}" == "aarch64" ]; then
   export JEMALLOC_SYS_WITH_LG_PAGE=16
 fi
 
-cargo build -p risingwave_cmd_all --features "rw-static-link" --features udf --features openssl-vendored --profile production
-cargo build -p risingwave_cmd --bin risectl --features "rw-static-link" --features openssl-vendored --profile production
+cargo build -p risingwave_cmd_all --features "rw-static-link" --features udf --features openssl-vendored --profile "${CARGO_PROFILE}"
+cargo build -p risingwave_cmd --bin risectl --features "rw-static-link" --features openssl-vendored --profile "${CARGO_PROFILE}"
 
-echo "--- check link info"
-check_link_info production
+echo "--- Check link info"
+check_link_info "${CARGO_PROFILE}"
 
-cd target/production && chmod +x risingwave risectl
+echo "--- Show sccache stats"
+sccache --show-stats
+sccache --zero-stats
+
+echo "--- Check binary size"
+cd target/"${CARGO_PROFILE}" && chmod +x risingwave risectl
+du -sh risingwave* risectl
 
 if [ "${SKIP_RELEASE}" -ne 1 ]; then
   echo "--- Upload nightly binary to s3"
@@ -103,7 +117,7 @@ cd "${REPO_ROOT}"/java && mvn -B package -Dmaven.test.skip=true -Dno-build-rust
 if [[ -n "${BUILDKITE_TAG}" ]]; then
   echo "--- Collect all release assets"
   cd "${REPO_ROOT}" && mkdir release-assets && cd release-assets
-  cp -r "${REPO_ROOT}"/target/production/* .
+  cp -r "${REPO_ROOT}"/target/"${CARGO_PROFILE}"/* .
   mv "${REPO_ROOT}"/java/connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz risingwave-connector-"${BUILDKITE_TAG}".tar.gz
   tar -zxvf risingwave-connector-"${BUILDKITE_TAG}".tar.gz libs
   ls -l
@@ -130,8 +144,13 @@ if [[ -n "${BUILDKITE_TAG}" ]]; then
     gh release upload --clobber "${BUILDKITE_TAG}" risingwave-"${BUILDKITE_TAG}"-"${ARCH}"-unknown-linux.tar.gz
 
     echo "--- Release upload risingwave debug info"
-    tar -czvf risingwave-"${BUILDKITE_TAG}"-"${ARCH}"-unknown-linux.dwp.tar.gz risingwave.dwp
-    gh release upload --clobber "${BUILDKITE_TAG}" risingwave-"${BUILDKITE_TAG}"-"${ARCH}"-unknown-linux.dwp.tar.gz
+    # Some cargo profiles may not generate split debug info (e.g. no `risingwave.dwp`).
+    if [[ -f risingwave.dwp ]]; then
+      tar -czvf risingwave-"${BUILDKITE_TAG}"-"${ARCH}"-unknown-linux.dwp.tar.gz risingwave.dwp
+      gh release upload --clobber "${BUILDKITE_TAG}" risingwave-"${BUILDKITE_TAG}"-"${ARCH}"-unknown-linux.dwp.tar.gz
+    else
+      echo "No risingwave.dwp found; skipping debug info upload."
+    fi
 
     echo "--- Release upload risectl asset"
     tar -czvf risectl-"${BUILDKITE_TAG}"-"${ARCH}"-unknown-linux.tar.gz risectl


### PR DESCRIPTION
Cherry-picks 91a69b6a99d8af344dc17a80d5388884bc781272 (from #24565) onto `release-2.7`.

Notes:
- Resolved a conflict in `ci/scripts/release.sh` by keeping the `release-2.7` feature set (no `--features datafusion`) while switching the cargo profile to `${CARGO_PROFILE}` as intended.

Fixes #24574.