### PR TITLE
perf(frontend): improve has_repeated_element from O(n²) to O(n)

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic/join.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/join.rs
@@ -122,7 +122,8 @@ pub struct Join<PlanRef> {
 }
 
 pub(crate) fn has_repeated_element(slice: &[usize]) -> bool {
-    (1..slice.len()).any(|i| slice[i..].contains(&slice[i - 1]))
+    let mut seen = std::collections::HashSet::with_capacity(slice.len());
+    slice.iter().any(|x| !seen.insert(x))
 }
 
 impl<PlanRef: GenericPlanRef> Join<PlanRef> {

--- a/src/frontend/src/optimizer/rule/project_join_merge_rule.rs
+++ b/src/frontend/src/optimizer/rule/project_join_merge_rule.rs
@@ -43,5 +43,6 @@ impl Rule<Logical> for ProjectJoinMergeRule {
 }
 
 fn has_repeated_element(slice: &[usize]) -> bool {
-    (1..slice.len()).any(|i| slice[i..].contains(&slice[i - 1]))
+    let mut seen = std::collections::HashSet::with_capacity(slice.len());
+    slice.iter().any(|x| !seen.insert(x))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR improves the time complexity of the `has_repeated_element` function from O(n²) to O(n) by using a HashSet instead of nested iteration.

**Previous implementation:**
```rust
(1..slice.len()).any(|i| slice[i..].contains(&slice[i - 1]))
```
For each element, this calls `contains()` on the remaining slice, resulting in O(n²) complexity.

**New implementation:**
```rust
let mut seen = std::collections::HashSet::with_capacity(slice.len());
slice.iter().any(|x| !seen.insert(x))
```
Uses a HashSet to track seen elements with O(1) lookup, resulting in O(n) overall complexity.

This function is used in the optimizer path for join operations (checking for repeated output indices), so the improvement could benefit query planning performance for queries with many output columns.

**Note for reviewers:** The same function exists in two files (`join.rs` and `project_join_merge_rule.rs`). This PR updates both, but consolidating them into a shared utility could be considered as a follow-up.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

N/A - Internal optimization with no user-facing changes.

</details>

---

Link to Devin run: https://app.devin.ai/sessions/4131f15e3af44cc8a2c003e3656721b8
Requested by: Yingjun Wu (@yingjunwu)