### PR TITLE
ci(license): reduce hawkeye false positive due to implicit merge

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        # For pull_request, `GITHUB_SHA` contains a implicit merge commit we want to avoid
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - uses: taiki-e/install-action@v2
       with:
         tool: hawkeye@6.3


### PR DESCRIPTION
This PR contains a single empty commit b91c763bb3c017a347de8a7239bd35f8e1c0d801 whose parent is 0114267d6aba4eee335e8f7a4e4dbb88e35df434 from `main` branch.

Hawkeye does not work well with merge commit (https://github.com/korandoru/hawkeye/issues/203) and prefer a linear history. What makes it worse is that `GITHUB_SHA` defaults to an implicit merge commit for `pull_request`. We alleviate the false positives by avoiding this merge commit. (Developers are also encouraged to avoid update-by-merge-commit and use rebase when running into issues.)