### PR TITLE
refactor: refactor iceberg compaction trigger condition and fix snapshot count

### DIFF
--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -510,7 +510,7 @@ impl IcebergConfig {
     }
 
     pub fn trigger_snapshot_count(&self) -> usize {
-        self.trigger_snapshot_count.unwrap_or(16)
+        self.trigger_snapshot_count.unwrap_or(usize::MAX)
     }
 
     pub fn small_files_threshold_mb(&self) -> u64 {

--- a/src/meta/src/manager/iceberg_compaction.rs
+++ b/src/meta/src/manager/iceberg_compaction.rs
@@ -75,7 +75,7 @@ struct CompactionTrack {
     task_type: TaskType,
     trigger_interval_sec: u64,
     /// Minimum snapshot count threshold to trigger compaction (early trigger).
-    /// Compaction triggers when snapshot_count >= this threshold, even before interval expires.
+    /// Compaction triggers when `pending_snapshot_count` >= this threshold, even before interval expires.
     trigger_snapshot_count: usize,
     state: CompactionTrackState,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

## Summary

This PR improves the Iceberg compaction trigger condition to ensure `compaction_interval_sec` works as expected as a maximum wait time.

## Problem

Previously, the compaction trigger used AND logic:

    time_ready && snapshot_ready

This caused an issue where if user set `compaction_interval_sec=100s`, `commit_checkpoint_interval=10s`, and `trigger_snapshot_count=100`, the actual compaction trigger time would be:
- `100 snapshots * 10s = 1000s` (much longer than the expected 100s)

The `compaction_interval_sec` was effectively ignored because compaction only triggered when BOTH conditions were met.

## Solution

Changed the trigger condition to OR logic with safeguards:

    snapshot_ready || (time_ready && has_snapshots)

- `snapshot_ready`: Early trigger when snapshot count reaches threshold
- `time_ready && has_snapshots`: Guarantees compaction within `compaction_interval_sec` as long as there are pending snapshots

### Changes

1. **Trigger logic**: Changed from AND to OR, ensuring `compaction_interval_sec` acts as maximum wait time
2. **Default `trigger_snapshot_count`**: Changed from `16` to `usize::MAX` for backward compatibility (disables early trigger by default)
3. **Fixed COW/MOR branch handling**: 
   - COW mode: Uses `current_snapshot()` timestamp comparison to count pending snapshots on ingestion branch
   - MOR mode: Uses `rposition` to find last Replace operation on main branch
4. **Renamed function**: `get_snapshot_count` → `get_pending_snapshot_count` for clarity

## Backward Compatibility

- Existing sinks without explicit `trigger_snapshot_count` setting will use `usize::MAX`, meaning early trigger is disabled and only time-based trigger applies
- Users who want early trigger can explicitly set `compaction.trigger_snapshot_count` to their desired value

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
