### PR TITLE
fix(compute): avoid panic in GetStreamingStats

### DIFF
--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -232,13 +232,7 @@ impl MonitorService for MonitorServiceImpl {
         let metrics = global_streaming_metrics(MetricLevel::Info);
 
         fn collect<T: Collector>(m: &T) -> Vec<Metric> {
-            // `Collector::collect` is not guaranteed to return a non-empty list.
-            // Stats RPC should never panic even if metrics are momentarily inconsistent.
-            m.collect()
-                .into_iter()
-                .next()
-                .map(|mut mf| mf.take_metric())
-                .unwrap_or_default()
+            m.collect().into_iter().next().unwrap().take_metric()
         }
 
         let actor_output_buffer_blocking_duration_ns =


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix compute `GetStreamingStats` to avoid panicking on temporarily inconsistent/empty Prometheus metric collections (e.g. missing `stream_actor_count` for a fragment). When `actor_id` is masked and actor count is unavailable, we log a warning and skip that channel entry instead. Fixes #24598.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out Notion. -->
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

<!-- N/A -->

</details>
