### PR TITLE
feat(meta): render after reload runtime info and isolate database render failure

### DIFF
--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -122,7 +122,7 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
     async fn reload_database_runtime_info(
         &self,
         database_id: DatabaseId,
-    ) -> MetaResult<Option<DatabaseRuntimeInfoSnapshot>> {
+    ) -> MetaResult<DatabaseRuntimeInfoSnapshot> {
         self.reload_database_runtime_info_impl(database_id).await
     }
 

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod context_impl;
-mod recovery;
+pub(crate) mod recovery;
 
 use std::future::Future;
 use std::sync::Arc;
@@ -102,7 +102,7 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
     async fn reload_database_runtime_info(
         &self,
         database_id: DatabaseId,
-    ) -> MetaResult<Option<DatabaseRuntimeInfoSnapshot>>;
+    ) -> MetaResult<DatabaseRuntimeInfoSnapshot>;
 
     fn handle_list_finished_source_ids(
         &self,

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -14,8 +14,8 @@
 
 use std::cmp::{Ordering, max, min};
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::num::NonZeroUsize;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::AtomicU32;
 
 use anyhow::{Context, anyhow};
 use itertools::Itertools;
@@ -23,8 +23,8 @@ use risingwave_common::bail;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::system_param::AdaptiveParallelismStrategy;
-use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_cont;
+use risingwave_connector::source::SplitImpl;
 use risingwave_hummock_sdk::version::HummockVersion;
 use risingwave_meta_model::SinkId;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
@@ -38,7 +38,8 @@ use crate::barrier::DatabaseRuntimeInfoSnapshot;
 use crate::barrier::context::GlobalBarrierWorkerContextImpl;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::controller::scale::{
-    FragmentRenderMap, LoadedFragmentContext, RenderedGraph, WorkerInfo, render_actor_assignments,
+    FragmentRenderMap, LoadedFragment, LoadedFragmentContext, RenderedGraph,
+    render_actor_assignments,
 };
 use crate::controller::utils::StreamingJobExtraInfo;
 use crate::manager::ActiveStreamingWorkerNodes;
@@ -47,16 +48,18 @@ use crate::rpc::ddl_controller::refill_upstream_sink_union_in_table;
 use crate::stream::cdc::reload_cdc_table_snapshot_splits;
 use crate::stream::{SourceChange, StreamFragmentGraph, UpstreamSinkInfo};
 
-struct UpstreamSinkRecoveryInfo {
+#[derive(Debug)]
+pub(crate) struct UpstreamSinkRecoveryInfo {
     target_fragment_id: FragmentId,
     upstream_infos: Vec<UpstreamSinkInfo>,
 }
 
-struct LoadedRecoveryContext {
-    fragment_context: LoadedFragmentContext,
-    job_extra_info: HashMap<JobId, StreamingJobExtraInfo>,
-    upstream_sink_recovery: HashMap<JobId, UpstreamSinkRecoveryInfo>,
-    fragment_relations: FragmentDownstreamRelation,
+#[derive(Debug)]
+pub struct LoadedRecoveryContext {
+    pub fragment_context: LoadedFragmentContext,
+    pub job_extra_info: HashMap<JobId, StreamingJobExtraInfo>,
+    pub upstream_sink_recovery: HashMap<JobId, UpstreamSinkRecoveryInfo>,
+    pub fragment_relations: FragmentDownstreamRelation,
 }
 
 impl LoadedRecoveryContext {
@@ -68,18 +71,65 @@ impl LoadedRecoveryContext {
             fragment_relations: FragmentDownstreamRelation::default(),
         }
     }
+}
 
-    fn backfill_orders(&self) -> HashMap<JobId, HashMap<FragmentId, Vec<FragmentId>>> {
-        self.job_extra_info
-            .iter()
-            .map(|(job_id, extra_info)| {
-                (
-                    *job_id,
-                    extra_info.backfill_orders.clone().unwrap_or_default().0,
-                )
-            })
-            .collect()
+pub struct RenderedDatabaseRuntimeInfo {
+    pub job_infos: HashMap<JobId, HashMap<FragmentId, InflightFragmentInfo>>,
+    pub stream_actors: HashMap<ActorId, StreamActor>,
+    pub source_splits: HashMap<ActorId, Vec<SplitImpl>>,
+}
+
+pub fn render_runtime_info(
+    actor_id_generator: &AtomicU32,
+    worker_nodes: &ActiveStreamingWorkerNodes,
+    adaptive_parallelism_strategy: AdaptiveParallelismStrategy,
+    recovery_context: &LoadedRecoveryContext,
+    database_id: DatabaseId,
+) -> MetaResult<Option<RenderedDatabaseRuntimeInfo>> {
+    let Some(per_database_context) = recovery_context.fragment_context.for_database(database_id)
+    else {
+        return Ok(None);
+    };
+
+    assert!(!per_database_context.is_empty());
+
+    let RenderedGraph { mut fragments, .. } = render_actor_assignments(
+        actor_id_generator,
+        worker_nodes.current(),
+        adaptive_parallelism_strategy,
+        &per_database_context,
+    )?;
+
+    let single_database = match fragments.remove(&database_id) {
+        Some(info) => info,
+        None => return Ok(None),
+    };
+
+    let mut database_map = HashMap::from([(database_id, single_database)]);
+    recovery_table_with_upstream_sinks(
+        &mut database_map,
+        &recovery_context.upstream_sink_recovery,
+    )?;
+    let stream_actors = build_stream_actors(&database_map, &recovery_context.job_extra_info)?;
+
+    let job_infos = database_map
+        .remove(&database_id)
+        .expect("database entry must exist");
+
+    let mut source_splits = HashMap::new();
+    for fragment_infos in job_infos.values() {
+        for fragment in fragment_infos.values() {
+            for (actor_id, info) in &fragment.actors {
+                source_splits.insert(*actor_id, info.splits.clone());
+            }
+        }
     }
+
+    Ok(Some(RenderedDatabaseRuntimeInfo {
+        job_infos,
+        stream_actors,
+        source_splits,
+    }))
 }
 
 /// For normal DDL operations, the `UpstreamSinkUnion` operator is modified dynamically, and does not persist the
@@ -271,52 +321,6 @@ impl GlobalBarrierWorkerContextImpl {
             .await
     }
 
-    /// Sync render stage: uses loaded context and current workers to produce actor assignments.
-    fn render_actor_assignments(
-        &self,
-        database_id: Option<DatabaseId>,
-        loaded: &LoadedFragmentContext,
-        worker_nodes: &ActiveStreamingWorkerNodes,
-        adaptive_parallelism_strategy: AdaptiveParallelismStrategy,
-    ) -> MetaResult<FragmentRenderMap> {
-        if loaded.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let available_workers: BTreeMap<_, _> = worker_nodes
-            .current()
-            .values()
-            .filter(|worker| worker.is_streaming_schedulable())
-            .map(|worker| {
-                (
-                    worker.id,
-                    WorkerInfo {
-                        parallelism: NonZeroUsize::new(worker.compute_node_parallelism()).unwrap(),
-                        resource_group: worker.resource_group(),
-                    },
-                )
-            })
-            .collect();
-
-        let RenderedGraph { fragments, .. } = render_actor_assignments(
-            self.metadata_manager
-                .catalog_controller
-                .env
-                .actor_id_generator(),
-            &available_workers,
-            adaptive_parallelism_strategy,
-            loaded,
-        )?;
-
-        if let Some(database_id) = database_id {
-            for loaded_database_id in fragments.keys() {
-                assert_eq!(*loaded_database_id, database_id);
-            }
-        }
-
-        Ok(fragments)
-    }
-
     async fn load_recovery_context(
         &self,
         database_id: Option<DatabaseId>,
@@ -349,9 +353,13 @@ impl GlobalBarrierWorkerContextImpl {
             .await?;
 
         let mut upstream_targets = HashMap::new();
-        for fragment in fragment_context.fragment_map.values() {
+        for fragment in fragment_context
+            .job_fragments
+            .values()
+            .flat_map(|fragments| fragments.values())
+        {
             let mut has_upstream_union = false;
-            visit_stream_node_cont(&fragment.stream_node.to_protobuf(), |node| {
+            visit_stream_node_cont(&fragment.nodes, |node| {
                 if let Some(PbNodeBody::UpstreamSinkUnion(_)) = node.node_body {
                     has_upstream_union = true;
                     false
@@ -413,7 +421,11 @@ impl GlobalBarrierWorkerContextImpl {
             .catalog_controller
             .get_fragment_downstream_relations_in_txn(
                 &txn,
-                fragment_context.fragment_map.keys().copied().collect_vec(),
+                fragment_context
+                    .job_fragments
+                    .values()
+                    .flat_map(|fragments| fragments.keys().copied())
+                    .collect_vec(),
             )
             .await?;
 
@@ -427,7 +439,7 @@ impl GlobalBarrierWorkerContextImpl {
 
     #[expect(clippy::type_complexity)]
     fn resolve_hummock_version_epochs(
-        background_jobs: impl Iterator<Item = (JobId, &HashMap<FragmentId, InflightFragmentInfo>)>,
+        background_jobs: impl Iterator<Item = (JobId, &HashMap<FragmentId, LoadedFragment>)>,
         version: &HummockVersion,
     ) -> MetaResult<(
         HashMap<TableId, u64>,
@@ -447,8 +459,9 @@ impl GlobalBarrierWorkerContextImpl {
         let mut min_downstream_committed_epochs = HashMap::new();
         for (job_id, fragments) in background_jobs {
             let job_committed_epoch = {
-                let mut table_id_iter =
-                    InflightFragmentInfo::existing_table_ids(fragments.values());
+                let mut table_id_iter = fragments
+                    .values()
+                    .flat_map(|fragment| fragment.state_table_ids.iter().copied());
                 let Some(first_table_id) = table_id_iter.next() else {
                     bail!("job {} has no state table", job_id);
                 };
@@ -587,16 +600,6 @@ impl GlobalBarrierWorkerContextImpl {
                         .cleanup_dropped_tables()
                         .await;
 
-                    let adaptive_parallelism_strategy = {
-                        let system_params_reader = self
-                            .metadata_manager
-                            .catalog_controller
-                            .env
-                            .system_params_reader()
-                            .await;
-                        system_params_reader.adaptive_parallelism_strategy()
-                    };
-
                     let active_streaming_nodes =
                         ActiveStreamingWorkerNodes::new_snapshot(self.metadata_manager.clone())
                             .await?;
@@ -648,22 +651,7 @@ impl GlobalBarrierWorkerContextImpl {
                         );
                     }
 
-                    info!("trigger offline re-rendering");
                     let mut recovery_context = self.load_recovery_context(None).await?;
-
-                    let mut info = self
-                        .render_actor_assignments(
-                            None,
-                            &recovery_context.fragment_context,
-                            &active_streaming_nodes,
-                            adaptive_parallelism_strategy,
-                        )
-                        .inspect_err(|err| {
-                            warn!(error = %err.as_report(), "render actor assignments failed");
-                        })?;
-
-                    info!("offline re-rendering completed");
-
                     let dropped_table_ids = self.scheduled_barriers.pre_apply_drop_cancel(None);
                     if !dropped_table_ids.is_empty() {
                         self.metadata_manager
@@ -671,32 +659,15 @@ impl GlobalBarrierWorkerContextImpl {
                             .complete_dropped_tables(dropped_table_ids)
                             .await;
                         recovery_context = self.load_recovery_context(None).await?;
-                        info = self
-                            .render_actor_assignments(
-                                None,
-                                &recovery_context.fragment_context,
-                                &active_streaming_nodes,
-                                adaptive_parallelism_strategy,
-                            )
-                            .inspect_err(|err| {
-                                warn!(error = %err.as_report(), "render actor assignments failed");
-                            })?
                     }
 
-                    recovery_table_with_upstream_sinks(
-                        &mut info,
-                        &recovery_context.upstream_sink_recovery,
-                    )?;
-
-                    let info = info;
-
                     self.purge_state_table_from_hummock(
-                        &info
+                        &recovery_context
+                            .fragment_context
+                            .job_fragments
                             .values()
-                            .flatten()
-                            .flat_map(|(_, fragments)| {
-                                InflightFragmentInfo::existing_table_ids(fragments.values())
-                            })
+                            .flat_map(|fragments| fragments.values())
+                            .flat_map(|fragment| fragment.state_table_ids.iter().copied())
                             .collect(),
                     )
                     .await
@@ -706,13 +677,15 @@ impl GlobalBarrierWorkerContextImpl {
                         .hummock_manager
                         .on_current_version(|version| {
                             Self::resolve_hummock_version_epochs(
-                                info.values().flat_map(|jobs| {
-                                    jobs.iter().filter_map(|(job_id, job)| {
+                                recovery_context
+                                    .fragment_context
+                                    .job_fragments
+                                    .iter()
+                                    .filter_map(|(job_id, job)| {
                                         initial_background_jobs
                                             .contains(job_id)
                                             .then_some((*job_id, job))
-                                    })
-                                }),
+                                    }),
                                 version,
                             )
                         })
@@ -723,21 +696,17 @@ impl GlobalBarrierWorkerContextImpl {
                         .get_mv_depended_subscriptions(None)
                         .await?;
 
-                    let stream_actors =
-                        build_stream_actors(&info, &recovery_context.job_extra_info)?;
-
-                    let backfill_orders = recovery_context.backfill_orders();
-                    let fragment_relations = recovery_context.fragment_relations;
-
                     // Refresh background job progress for the final snapshot to reflect any catalog changes.
                     let background_jobs = {
                         let mut refreshed_background_jobs = self
                             .list_background_job_progress(None)
                             .await
                             .context("recover background job progress should not fail")?;
-                        info.values()
-                            .flatten()
-                            .filter_map(|(job_id, _)| {
+                        recovery_context
+                            .fragment_context
+                            .job_map
+                            .keys()
+                            .filter_map(|job_id| {
                                 refreshed_background_jobs.remove(job_id).then_some(*job_id)
                             })
                             .collect()
@@ -749,30 +718,16 @@ impl GlobalBarrierWorkerContextImpl {
                         .list_databases()
                         .await?;
 
-                    // get split assignments for all actors
-                    let mut source_splits = HashMap::new();
-                    for (_, fragment_infos) in info.values().flatten() {
-                        for fragment in fragment_infos.values() {
-                            for (actor_id, info) in &fragment.actors {
-                                source_splits.insert(*actor_id, info.splits.clone());
-                            }
-                        }
-                    }
-
                     let cdc_table_snapshot_splits =
                         reload_cdc_table_snapshot_splits(&self.env.meta_store_ref().conn, None)
                             .await?;
 
                     Ok(BarrierWorkerRuntimeInfoSnapshot {
                         active_streaming_nodes,
-                        database_job_infos: info,
-                        backfill_orders,
+                        recovery_context,
                         state_table_committed_epochs,
                         state_table_log_epochs,
                         mv_depended_subscriptions,
-                        stream_actors,
-                        fragment_relations,
-                        source_splits,
                         background_jobs,
                         hummock_version_stats: self.hummock_manager.get_version_stats().await,
                         database_infos,
@@ -786,7 +741,7 @@ impl GlobalBarrierWorkerContextImpl {
     pub(super) async fn reload_database_runtime_info_impl(
         &self,
         database_id: DatabaseId,
-    ) -> MetaResult<Option<DatabaseRuntimeInfoSnapshot>> {
+    ) -> MetaResult<DatabaseRuntimeInfoSnapshot> {
         self.clean_dirty_streaming_jobs(Some(database_id))
             .await
             .context("clean dirty streaming jobs")?;
@@ -819,61 +774,16 @@ impl GlobalBarrierWorkerContextImpl {
             .complete_dropped_tables(dropped_table_ids)
             .await;
 
-        let adaptive_parallelism_strategy = {
-            let system_params_reader = self
-                .metadata_manager
-                .catalog_controller
-                .env
-                .system_params_reader()
-                .await;
-            system_params_reader.adaptive_parallelism_strategy()
-        };
-
-        let active_streaming_nodes =
-            ActiveStreamingWorkerNodes::new_snapshot(self.metadata_manager.clone()).await?;
-
         let recovery_context = self.load_recovery_context(Some(database_id)).await?;
-
-        let mut all_info = self
-            .render_actor_assignments(
-                Some(database_id),
-                &recovery_context.fragment_context,
-                &active_streaming_nodes,
-                adaptive_parallelism_strategy,
-            )
-            .inspect_err(|err| {
-                warn!(error = %err.as_report(), "render actor assignments failed");
-            })?;
-
-        let mut database_info = all_info
-            .remove(&database_id)
-            .map_or_else(HashMap::new, |table_map| {
-                HashMap::from([(database_id, table_map)])
-            });
-
-        recovery_table_with_upstream_sinks(
-            &mut database_info,
-            &recovery_context.upstream_sink_recovery,
-        )?;
-
-        assert!(database_info.len() <= 1);
-
-        let stream_actors = build_stream_actors(&database_info, &recovery_context.job_extra_info)?;
-
-        let Some(info) = database_info
-            .into_iter()
-            .next()
-            .map(|(loaded_database_id, info)| {
-                assert_eq!(loaded_database_id, database_id);
-                info
-            })
-        else {
-            return Ok(None);
-        };
 
         let missing_background_jobs = background_jobs
             .iter()
-            .filter(|job_id| !info.contains_key(job_id))
+            .filter(|job_id| {
+                !recovery_context
+                    .fragment_context
+                    .job_map
+                    .contains_key(job_id)
+            })
             .copied()
             .collect_vec();
         if !missing_background_jobs.is_empty() {
@@ -888,9 +798,13 @@ impl GlobalBarrierWorkerContextImpl {
             .hummock_manager
             .on_current_version(|version| {
                 Self::resolve_hummock_version_epochs(
-                    background_jobs
-                        .iter()
-                        .filter_map(|job_id| info.get(job_id).map(|job| (*job_id, job))),
+                    background_jobs.iter().filter_map(|job_id| {
+                        recovery_context
+                            .fragment_context
+                            .job_fragments
+                            .get(job_id)
+                            .map(|job| (*job_id, job))
+                    }),
                     version,
                 )
             })
@@ -901,17 +815,6 @@ impl GlobalBarrierWorkerContextImpl {
             .get_mv_depended_subscriptions(Some(database_id))
             .await?;
 
-        let backfill_orders = recovery_context.backfill_orders();
-        let fragment_relations = recovery_context.fragment_relations;
-
-        // get split assignments for all actors
-        let mut source_splits = HashMap::new();
-        for (_, fragment) in info.values().flatten() {
-            for (actor_id, info) in &fragment.actors {
-                source_splits.insert(*actor_id, info.splits.clone());
-            }
-        }
-
         let cdc_table_snapshot_splits =
             reload_cdc_table_snapshot_splits(&self.env.meta_store_ref().conn, Some(database_id))
                 .await?;
@@ -919,18 +822,14 @@ impl GlobalBarrierWorkerContextImpl {
         self.refresh_manager
             .remove_trackers_by_database(database_id);
 
-        Ok(Some(DatabaseRuntimeInfoSnapshot {
-            job_infos: info,
-            backfill_orders,
+        Ok(DatabaseRuntimeInfoSnapshot {
+            recovery_context,
             state_table_committed_epochs,
             state_table_log_epochs,
             mv_depended_subscriptions,
-            stream_actors,
-            fragment_relations,
-            source_splits,
             background_jobs,
             cdc_table_snapshot_splits,
-        }))
+        })
     }
 }
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -16,7 +16,6 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::anyhow;
 use risingwave_common::catalog::{DatabaseId, TableId};
-use risingwave_connector::source::SplitImpl;
 use risingwave_pb::catalog::Database;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::meta::PbRecoveryStatus;
@@ -25,7 +24,7 @@ use tokio::sync::oneshot::Sender;
 use self::notifier::Notifier;
 use crate::barrier::info::BarrierInfo;
 use crate::manager::ActiveStreamingWorkerNodes;
-use crate::model::{ActorId, FragmentDownstreamRelation, FragmentId, StreamActor, SubscriptionId};
+use crate::model::{ActorId, FragmentId, StreamActor, SubscriptionId};
 use crate::{MetaError, MetaResult};
 
 mod backfill_order_control;
@@ -33,7 +32,7 @@ pub mod cdc_progress;
 mod checkpoint;
 mod command;
 mod complete_task;
-mod context;
+pub(super) mod context;
 mod edge_builder;
 mod info;
 mod manager;
@@ -60,6 +59,7 @@ pub use self::manager::{BarrierManagerRef, GlobalBarrierManager};
 pub use self::schedule::BarrierScheduler;
 pub use self::trace::TracedEpoch;
 use crate::barrier::cdc_progress::CdcProgress;
+use crate::barrier::context::recovery::LoadedRecoveryContext;
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::stream::cdc::CdcTableSnapshotSplits;
 
@@ -127,16 +127,11 @@ pub(crate) enum BarrierManagerRequest {
 #[derive(Debug)]
 struct BarrierWorkerRuntimeInfoSnapshot {
     active_streaming_nodes: ActiveStreamingWorkerNodes,
-    database_job_infos:
-        HashMap<DatabaseId, HashMap<JobId, HashMap<FragmentId, InflightFragmentInfo>>>,
-    backfill_orders: HashMap<JobId, HashMap<FragmentId, Vec<FragmentId>>>,
+    recovery_context: LoadedRecoveryContext,
     state_table_committed_epochs: HashMap<TableId, u64>,
     /// `table_id` -> (`Vec<non-checkpoint epoch>`, checkpoint epoch)
     state_table_log_epochs: HashMap<TableId, Vec<(Vec<u64>, u64)>>,
     mv_depended_subscriptions: HashMap<TableId, HashMap<SubscriptionId, u64>>,
-    stream_actors: HashMap<ActorId, StreamActor>,
-    fragment_relations: FragmentDownstreamRelation,
-    source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashSet<JobId>,
     hummock_version_stats: HummockVersionStats,
     database_infos: Vec<Database>,
@@ -214,48 +209,15 @@ impl BarrierWorkerRuntimeInfoSnapshot {
         }
         Ok(())
     }
-
-    fn validate(&self) -> MetaResult<()> {
-        for (database_id, job_infos) in &self.database_job_infos {
-            Self::validate_database_info(
-                *database_id,
-                job_infos,
-                &self.active_streaming_nodes,
-                &self.stream_actors,
-                &self.state_table_committed_epochs,
-            )?
-        }
-        Ok(())
-    }
 }
 
 #[derive(Debug)]
 struct DatabaseRuntimeInfoSnapshot {
-    job_infos: HashMap<JobId, HashMap<FragmentId, InflightFragmentInfo>>,
-    backfill_orders: HashMap<JobId, HashMap<FragmentId, Vec<FragmentId>>>,
+    recovery_context: LoadedRecoveryContext,
     state_table_committed_epochs: HashMap<TableId, u64>,
     /// `table_id` -> (`Vec<non-checkpoint epoch>`, checkpoint epoch)
     state_table_log_epochs: HashMap<TableId, Vec<(Vec<u64>, u64)>>,
     mv_depended_subscriptions: HashMap<TableId, HashMap<SubscriptionId, u64>>,
-    stream_actors: HashMap<ActorId, StreamActor>,
-    fragment_relations: FragmentDownstreamRelation,
-    source_splits: HashMap<ActorId, Vec<SplitImpl>>,
     background_jobs: HashSet<JobId>,
     cdc_table_snapshot_splits: HashMap<JobId, CdcTableSnapshotSplits>,
-}
-
-impl DatabaseRuntimeInfoSnapshot {
-    fn validate(
-        &self,
-        database_id: DatabaseId,
-        active_streaming_nodes: &ActiveStreamingWorkerNodes,
-    ) -> MetaResult<()> {
-        BarrierWorkerRuntimeInfoSnapshot::validate_database_info(
-            database_id,
-            &self.job_infos,
-            active_streaming_nodes,
-            &self.stream_actors,
-            &self.state_table_committed_epochs,
-        )
-    }
 }

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -889,7 +889,7 @@ mod tests {
         async fn reload_database_runtime_info(
             &self,
             _database_id: DatabaseId,
-        ) -> MetaResult<Option<crate::barrier::DatabaseRuntimeInfoSnapshot>> {
+        ) -> MetaResult<crate::barrier::DatabaseRuntimeInfoSnapshot> {
             unimplemented!()
         }
 

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -23,9 +23,14 @@ use risingwave_common::hash::VirtualNode;
 use risingwave_common::id::JobId;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_meta_model::fragment::DistributionType;
+use risingwave_meta_model::{
+    CreateType, I32Array, JobStatus, StreamNode, StreamingParallelism, TableIdArray, database,
+    fragment, streaming_job,
+};
 use risingwave_pb::catalog::Database;
 use risingwave_pb::common::{HostAddress, PbWorkerType, WorkerNode, worker_node};
 use risingwave_pb::hummock::HummockVersionStats;
+use risingwave_pb::stream_plan::PbStreamNode;
 use risingwave_pb::stream_service::streaming_control_stream_request::{PbInitRequest, Request};
 use risingwave_pb::stream_service::streaming_control_stream_response::Response;
 use risingwave_pb::stream_service::{
@@ -40,6 +45,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::MetaResult;
 use crate::barrier::command::PostCollectCommand;
 use crate::barrier::context::GlobalBarrierWorkerContext;
+use crate::barrier::context::recovery::LoadedRecoveryContext;
 use crate::barrier::progress::TrackingJob;
 use crate::barrier::rpc::from_partial_graph_id;
 use crate::barrier::schedule::MarkReadyOptions;
@@ -47,10 +53,11 @@ use crate::barrier::worker::GlobalBarrierWorker;
 use crate::barrier::{
     BarrierWorkerRuntimeInfoSnapshot, DatabaseRuntimeInfoSnapshot, RecoveryReason, Scheduled,
 };
-use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
+use crate::controller::scale::{LoadedFragment, LoadedFragmentContext, NoShuffleEnsemble};
+use crate::controller::utils::StreamingJobExtraInfo;
 use crate::hummock::CommitEpochInfo;
 use crate::manager::{ActiveStreamingWorkerNodes, MetaOpts, MetaSrvEnv};
-use crate::model::StreamActor;
+use crate::model::{FragmentDownstreamRelation, FragmentId};
 
 enum ContextRequest {
     AbortAndMarkBlocked(RecoveryReason),
@@ -121,7 +128,7 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
     async fn reload_database_runtime_info(
         &self,
         _database_id: DatabaseId,
-    ) -> MetaResult<Option<DatabaseRuntimeInfoSnapshot>> {
+    ) -> MetaResult<DatabaseRuntimeInfoSnapshot> {
         unreachable!()
     }
 
@@ -181,8 +188,9 @@ async fn test_barrier_manager_worker_crash_no_early_commit() {
         unreachable!()
     };
     let database_id = DatabaseId::new(233);
-    let job_id = JobId::new(234);
-    let worker_node = |id: u32| WorkerNode {
+    let job_id1 = JobId::new(234);
+    let job_id2 = JobId::new(235);
+    let worker_node = |id: u32, resource_group: &str| WorkerNode {
         id: id.into(),
         r#type: PbWorkerType::ComputeNode as i32,
         host: Some(HostAddress {
@@ -190,94 +198,129 @@ async fn test_barrier_manager_worker_crash_no_early_commit() {
             port: 0,
         }),
         state: worker_node::State::Running as i32,
-        property: None,
+        property: Some(worker_node::Property {
+            is_streaming: true,
+            is_serving: true,
+            is_unschedulable: false,
+            internal_rpc_host_addr: "".to_owned(),
+            parallelism: 1,
+            resource_group: Some(resource_group.to_owned()),
+            is_iceberg_compactor: false,
+        }),
         transactional_id: None,
         resource: None,
         started_at: None,
     };
-    let worker1 = worker_node(1);
-    let worker2 = worker_node(2);
-    // two actors on two singleton fragments
-    let new_actor = |actor_id| StreamActor {
-        actor_id,
-        fragment_id: actor_id.as_raw_id().into(),
-        vnode_bitmap: None,
-        mview_definition: "".to_owned(),
-        expr_context: None,
-        config_override: "".into(),
-    };
+    let worker1_group = "rg-a";
+    let worker2_group = "rg-b";
+    let worker1 = worker_node(1, worker1_group);
+    let worker2 = worker_node(2, worker2_group);
     let table1 = TableId::new(1);
     let table2 = TableId::new(2);
-    let actor1 = new_actor(1.into());
-    let actor2 = new_actor(2.into());
+    let fragment1 = FragmentId::new(101);
+    let fragment2 = FragmentId::new(102);
     let initial_epoch = test_epoch(100);
+
+    let fragment_model = |fragment_id: FragmentId, job_id: JobId, table_id: TableId| {
+        #[allow(deprecated)]
+        LoadedFragment::from(fragment::Model {
+            fragment_id,
+            job_id,
+            fragment_type_mask: 0,
+            distribution_type: DistributionType::Single,
+            stream_node: StreamNode::from(&PbStreamNode::default()),
+            state_table_ids: TableIdArray(vec![table_id]),
+            upstream_fragment_id: I32Array::default(),
+            vnode_count: VirtualNode::COUNT_FOR_TEST as i32,
+            parallelism: Some(StreamingParallelism::Fixed(1)),
+        })
+    };
+
+    let fragment_map_job1 =
+        HashMap::from([(fragment1, fragment_model(fragment1, job_id1, table1))]);
+    let fragment_map_job2 =
+        HashMap::from([(fragment2, fragment_model(fragment2, job_id2, table2))]);
+
+    let build_job_model = |job_id: JobId, resource_group: &str| streaming_job::Model {
+        job_id,
+        job_status: JobStatus::Creating,
+        create_type: CreateType::Foreground,
+        timezone: None,
+        config_override: None,
+        adaptive_parallelism_strategy: None,
+        parallelism: StreamingParallelism::Fixed(1),
+        backfill_parallelism: None,
+        backfill_orders: None,
+        max_parallelism: 1,
+        specific_resource_group: Some(resource_group.to_owned()),
+        is_serverless_backfill: false,
+    };
+    let job_model1 = build_job_model(job_id1, worker1_group);
+    let job_model2 = build_job_model(job_id2, worker2_group);
+
+    let database_model = database::Model {
+        database_id,
+        name: "db".to_owned(),
+        resource_group: "test".to_owned(),
+        barrier_interval_ms: None,
+        checkpoint_frequency: None,
+    };
+
+    let fragment_context = LoadedFragmentContext {
+        ensembles: vec![
+            NoShuffleEnsemble::for_test([fragment1], [fragment1]),
+            NoShuffleEnsemble::for_test([fragment2], [fragment2]),
+        ],
+        job_fragments: HashMap::from([(job_id1, fragment_map_job1), (job_id2, fragment_map_job2)]),
+        job_map: HashMap::from([(job_id1, job_model1), (job_id2, job_model2)]),
+        streaming_job_databases: HashMap::from([(job_id1, database_id), (job_id2, database_id)]),
+        database_map: HashMap::from([(database_id, database_model)]),
+        fragment_source_ids: HashMap::new(),
+        fragment_splits: HashMap::new(),
+    };
+
+    let recovery_context = LoadedRecoveryContext {
+        fragment_context,
+        job_extra_info: HashMap::from([
+            (
+                job_id1,
+                StreamingJobExtraInfo {
+                    timezone: None,
+                    config_override: Arc::<str>::from(""),
+                    adaptive_parallelism_strategy: None,
+                    job_definition: "".to_owned(),
+                    backfill_orders: None,
+                },
+            ),
+            (
+                job_id2,
+                StreamingJobExtraInfo {
+                    timezone: None,
+                    config_override: Arc::<str>::from(""),
+                    adaptive_parallelism_strategy: None,
+                    job_definition: "".to_owned(),
+                    backfill_orders: None,
+                },
+            ),
+        ]),
+        upstream_sink_recovery: HashMap::new(),
+        fragment_relations: FragmentDownstreamRelation::default(),
+    };
 
     tx.send(BarrierWorkerRuntimeInfoSnapshot {
         active_streaming_nodes: ActiveStreamingWorkerNodes::for_test(HashMap::from_iter([
             (worker1.id, worker1.clone()),
             (worker2.id, worker2.clone()),
         ])),
-        database_job_infos: HashMap::from_iter([(
-            database_id,
-            HashMap::from_iter([(
-                job_id,
-                HashMap::from_iter([
-                    (
-                        actor1.fragment_id,
-                        InflightFragmentInfo {
-                            fragment_id: actor1.fragment_id,
-                            distribution_type: DistributionType::Single,
-                            fragment_type_mask: Default::default(),
-                            vnode_count: VirtualNode::COUNT_FOR_TEST,
-                            nodes: Default::default(),
-                            actors: HashMap::from_iter([(
-                                actor1.actor_id as _,
-                                InflightActorInfo {
-                                    worker_id: worker1.id,
-                                    vnode_bitmap: None,
-                                    splits: vec![],
-                                },
-                            )]),
-                            state_table_ids: HashSet::from_iter([table1]),
-                        },
-                    ),
-                    (
-                        actor2.fragment_id,
-                        InflightFragmentInfo {
-                            fragment_id: actor2.fragment_id,
-                            distribution_type: DistributionType::Single,
-                            fragment_type_mask: Default::default(),
-                            vnode_count: VirtualNode::COUNT_FOR_TEST,
-                            nodes: Default::default(),
-                            actors: HashMap::from_iter([(
-                                actor2.actor_id as _,
-                                InflightActorInfo {
-                                    worker_id: worker2.id,
-                                    vnode_bitmap: None,
-                                    splits: vec![],
-                                },
-                            )]),
-                            state_table_ids: HashSet::from_iter([table2]),
-                        },
-                    ),
-                ]),
-            )]),
-        )]),
-        backfill_orders: Default::default(),
-        state_table_committed_epochs: HashMap::from_iter([
+        recovery_context,
+        state_table_committed_epochs: HashMap::from([
             (table1, initial_epoch),
             (table2, initial_epoch),
         ]),
-        state_table_log_epochs: Default::default(),
-        mv_depended_subscriptions: Default::default(),
-        stream_actors: HashMap::from_iter([
-            (actor1.actor_id as _, actor1.clone()),
-            (actor2.actor_id as _, actor2.clone()),
-        ]),
-        fragment_relations: Default::default(),
-        source_splits: Default::default(),
-        background_jobs: Default::default(),
-        hummock_version_stats: Default::default(),
+        state_table_log_epochs: HashMap::new(),
+        mv_depended_subscriptions: HashMap::new(),
+        background_jobs: HashSet::new(),
+        hummock_version_stats: HummockVersionStats::default(),
         database_infos: vec![Database {
             id: database_id,
             name: "".to_owned(),
@@ -286,7 +329,7 @@ async fn test_barrier_manager_worker_crash_no_early_commit() {
             barrier_interval_ms: None,
             checkpoint_frequency: None,
         }],
-        cdc_table_snapshot_splits: Default::default(),
+        cdc_table_snapshot_splits: HashMap::new(),
     })
     .unwrap();
     let make_control_stream_handle = || {

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -23,8 +23,8 @@ use anyhow::anyhow;
 use arc_swap::ArcSwap;
 use futures::{TryFutureExt, pin_mut};
 use itertools::Itertools;
-use risingwave_common::system_param::PAUSE_ON_NEXT_BOOTSTRAP_KEY;
 use risingwave_common::system_param::reader::SystemParamsRead;
+use risingwave_common::system_param::{AdaptiveParallelismStrategy, PAUSE_ON_NEXT_BOOTSTRAP_KEY};
 use risingwave_pb::meta::Recovery;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::stream_service::streaming_control_stream_response::Response;
@@ -39,6 +39,7 @@ use uuid::Uuid;
 
 use crate::barrier::checkpoint::{CheckpointControl, CheckpointControlEvent};
 use crate::barrier::complete_task::{BarrierCompleteOutput, CompletingTask};
+use crate::barrier::context::recovery::{RenderedDatabaseRuntimeInfo, render_runtime_info};
 use crate::barrier::context::{GlobalBarrierWorkerContext, GlobalBarrierWorkerContextImpl};
 use crate::barrier::rpc::{
     ControlStreamManager, WorkerNodeEvent, from_partial_graph_id, merge_node_rpc_errors,
@@ -78,6 +79,8 @@ pub(super) struct GlobalBarrierWorker<C> {
     /// Whether per database failure isolation is enabled in system parameters.
     system_enable_per_database_isolation: bool,
 
+    adaptive_parallelism_strategy: AdaptiveParallelismStrategy,
+
     pub(super) context: Arc<C>,
 
     env: MetaSrvEnv,
@@ -113,12 +116,14 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
         let system_enable_per_database_isolation = reader.per_database_isolation();
         // Load config will be performed in bootstrap phase.
         let periodic_barriers = PeriodicBarriers::default();
+        let adaptive_parallelism_strategy = reader.adaptive_parallelism_strategy();
 
         let checkpoint_control = CheckpointControl::new(env.clone());
         Self {
             enable_recovery,
             periodic_barriers,
             system_enable_per_database_isolation,
+            adaptive_parallelism_strategy,
             context,
             env,
             checkpoint_control,
@@ -355,6 +360,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             self.periodic_barriers
                                 .set_sys_checkpoint_frequency(p.checkpoint_frequency());
                             self.system_enable_per_database_isolation = p.per_database_isolation();
+                            self.adaptive_parallelism_strategy = p.adaptive_parallelism_strategy();
                         }
                     }
                 }
@@ -391,17 +397,43 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                 }));
                                 Self::report_collect_failure(&self.env, &error);
                                 self.context.notify_creating_job_failed(Some(database_id), format!("{}", error.as_report())).await;
-                                match self.context.reload_database_runtime_info(database_id).await.and_then(|runtime_info| {
-                                    runtime_info.map(|runtime_info| {
-                                        runtime_info.validate(database_id, &self.active_streaming_nodes).inspect_err(|e| {
-                                            warn!(%database_id, err = ?e.as_report(), ?runtime_info, "reloaded database runtime info failed to validate");
+                                let result: MetaResult<_> = try {
+                                    let runtime_info = self.context.reload_database_runtime_info(database_id).await.inspect_err(|err| {
+                                        warn!(%database_id, err = %err.as_report(), "reload runtime info failed");
+                                    })?;
+                                    let rendered_info = render_runtime_info(
+                                        self.env.actor_id_generator(),
+                                        &self.active_streaming_nodes,
+                                        self.adaptive_parallelism_strategy,
+                                        &runtime_info.recovery_context,
+                                        database_id,
+                                    )
+                                    .inspect_err(|err: &MetaError| {
+                                        warn!(%database_id, err = %err.as_report(), "render runtime info failed");
+                                    })?;
+                                    if let Some(rendered_info) = rendered_info {
+                                        BarrierWorkerRuntimeInfoSnapshot::validate_database_info(
+                                            database_id,
+                                            &rendered_info.job_infos,
+                                            &self.active_streaming_nodes,
+                                            &rendered_info.stream_actors,
+                                            &runtime_info.state_table_committed_epochs,
+                                        )
+                                        .inspect_err(|err| {
+                                            warn!(%database_id, err = ?err.as_report(), "database runtime info failed validation");
                                         })?;
-                                        Ok(runtime_info)
-                                    })
-                                    .transpose()
-                                }) {
-                                    Ok(Some(runtime_info)) => {
-                                        entering_initializing.enter(runtime_info, &mut self.control_stream_manager);
+                                        Some((runtime_info, rendered_info))
+                                    } else {
+                                        None
+                                    }
+                                };
+                                match result {
+                                    Ok(Some((runtime_info, rendered_info))) => {
+                                        entering_initializing.enter(
+                                            runtime_info,
+                                            rendered_info,
+                                            &mut self.control_stream_manager,
+                                        );
                                     }
                                     Ok(None) => {
                                         info!(%database_id, "database removed after reloading empty runtime info");
@@ -782,19 +814,12 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 .context
                 .reload_runtime_info()
                 .await?;
-            runtime_info_snapshot.validate().inspect_err(|e| {
-                warn!(err = ?e.as_report(), ?runtime_info_snapshot, "reloaded runtime info failed to validate");
-            })?;
             let BarrierWorkerRuntimeInfoSnapshot {
                 active_streaming_nodes,
-                database_job_infos,
-                mut backfill_orders,
+                recovery_context,
                 mut state_table_committed_epochs,
                 mut state_table_log_epochs,
                 mut mv_depended_subscriptions,
-                stream_actors,
-                fragment_relations,
-                mut source_splits,
                 mut background_jobs,
                 hummock_version_stats,
                 database_infos,
@@ -811,31 +836,59 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     self.context.clone(),
                 )
                 .await;
-
-
             {
+                let mut empty_databases = HashSet::new();
                 let mut collected_databases = HashMap::new();
                 let mut collecting_databases = HashMap::new();
                 let mut failed_databases = HashMap::new();
-                for (database_id, jobs) in database_job_infos {
+                for &database_id in recovery_context.fragment_context.database_map.keys() {
                     let mut injected_creating_jobs = HashSet::new();
-                    let database_backfill_orders = jobs.keys().map(|job_id| (*job_id, backfill_orders.remove(job_id).unwrap_or_default())).collect();
-                    let result = control_stream_manager.inject_database_initial_barrier(
-                        database_id,
-                        jobs,
-                        database_backfill_orders,
-                        &mut state_table_committed_epochs,
-                        &mut state_table_log_epochs,
-                        &fragment_relations,
-                        &stream_actors,
-                        &mut source_splits,
-                        &mut background_jobs,
-                        &mut mv_depended_subscriptions,
-                        is_paused,
-                        &hummock_version_stats,
-                        &mut cdc_table_snapshot_splits,
-                        &mut injected_creating_jobs,
-                    );
+                    let result: MetaResult<_> = try {
+                        let Some(rendered_info) = render_runtime_info(
+                            self.env.actor_id_generator(),
+                            &active_streaming_nodes,
+                            self.adaptive_parallelism_strategy,
+                            &recovery_context,
+                            database_id,
+                        )
+                            .inspect_err(|err: &MetaError| {
+                                warn!(%database_id, err = %err.as_report(), "render runtime info failed");
+                            })? else {
+                            empty_databases.insert(database_id);
+                            continue;
+                        };
+                        BarrierWorkerRuntimeInfoSnapshot::validate_database_info(
+                            database_id,
+                            &rendered_info.job_infos,
+                            &active_streaming_nodes,
+                            &rendered_info.stream_actors,
+                            &state_table_committed_epochs,
+                        )
+                        .inspect_err(|err| {
+                            warn!(%database_id, err = %err.as_report(), "rendered runtime info failed validation");
+                        })?;
+                        let RenderedDatabaseRuntimeInfo {
+                            job_infos,
+                            stream_actors,
+                            mut source_splits,
+                        } = rendered_info;
+                        control_stream_manager.inject_database_initial_barrier(
+                            database_id,
+                            job_infos,
+                            &recovery_context.job_extra_info,
+                            &mut state_table_committed_epochs,
+                            &mut state_table_log_epochs,
+                            &recovery_context.fragment_relations,
+                            &stream_actors,
+                            &mut source_splits,
+                            &mut background_jobs,
+                            &mut mv_depended_subscriptions,
+                            is_paused,
+                            &hummock_version_stats,
+                            &mut cdc_table_snapshot_splits,
+                            &mut injected_creating_jobs,
+                        )?
+                    };
                     let node_to_collect = match result {
                         Ok(info) => {
                             info
@@ -852,6 +905,9 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         warn!(%database_id, "database has no node to inject initial barrier");
                         assert!(collected_databases.insert(database_id, node_to_collect.finish()).is_none());
                     }
+                }
+                if !empty_databases.is_empty() {
+                    info!(?empty_databases, "empty database in global recovery");
                 }
                 while !collecting_databases.is_empty() {
                     let (worker_id, result) =
@@ -909,12 +965,6 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                     }
                 }
                 debug!("collected initial barrier");
-                if !stream_actors.is_empty() {
-                    warn!(actor_ids = ?stream_actors.keys().collect_vec(), "unused stream actors in recovery");
-                }
-                if !source_splits.is_empty() {
-                    warn!(actor_ids = ?source_splits.keys().collect_vec(), "unused actor source splits in recovery");
-                }
                 if !background_jobs.is_empty() {
                     warn!(job_ids = ?background_jobs.iter().collect_vec(), "unused recovered background mview in recovery");
                 }

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -14,7 +14,6 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
@@ -68,7 +67,7 @@ use serde::{Deserialize, Serialize};
 use crate::barrier::{SharedActorInfos, SharedFragmentInfo, SnapshotBackfillInfo};
 use crate::controller::catalog::CatalogController;
 use crate::controller::scale::{
-    FragmentRenderMap, LoadedFragmentContext, NoShuffleEnsemble, RenderedGraph, WorkerInfo,
+    FragmentRenderMap, LoadedFragmentContext, NoShuffleEnsemble, RenderedGraph,
     find_fragment_no_shuffle_dags_detailed, load_fragment_context_for_jobs,
     render_actor_assignments, resolve_streaming_job_definition,
 };
@@ -1353,24 +1352,9 @@ impl CatalogController {
             system_params_reader.adaptive_parallelism_strategy()
         };
 
-        let available_workers: BTreeMap<_, _> = worker_nodes
-            .current()
-            .values()
-            .filter(|worker| worker.is_streaming_schedulable())
-            .map(|worker| {
-                (
-                    worker.id,
-                    WorkerInfo {
-                        parallelism: NonZeroUsize::new(worker.compute_node_parallelism()).unwrap(),
-                        resource_group: worker.resource_group(),
-                    },
-                )
-            })
-            .collect();
-
         let RenderedGraph { fragments, .. } = render_actor_assignments(
             self.env.actor_id_generator(),
-            &available_workers,
+            worker_nodes.current(),
             adaptive_parallelism_strategy,
             &loaded,
         )?;

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -98,7 +98,10 @@ impl ActiveStreamingWorkerNodes {
             .subscribe_active_streaming_compute_nodes()
             .await?;
         Ok(Self {
-            worker_nodes: nodes.into_iter().map(|node| (node.id, node)).collect(),
+            worker_nodes: nodes
+                .into_iter()
+                .filter_map(|node| node.is_streaming_schedulable().then_some((node.id, node)))
+                .collect(),
             rx,
             meta_manager: Some(meta_manager),
         })
@@ -115,12 +118,16 @@ impl ActiveStreamingWorkerNodes {
                 .recv()
                 .await
                 .expect("notification stopped or uninitialized");
+            fn is_target_worker_node(worker: &WorkerNode) -> bool {
+                worker.r#type == WorkerType::ComputeNode as i32
+                    && worker.property.as_ref().unwrap().is_streaming
+                    && worker.is_streaming_schedulable()
+            }
             match notification {
                 LocalNotification::WorkerNodeDeleted(worker) => {
-                    let is_streaming_compute_node = worker.r#type == WorkerType::ComputeNode as i32
-                        && worker.property.as_ref().unwrap().is_streaming;
+                    let is_target_worker_node = is_target_worker_node(&worker);
                     let Some(prev_worker) = self.worker_nodes.remove(&worker.id) else {
-                        if is_streaming_compute_node {
+                        if is_target_worker_node {
                             warn!(
                                 ?worker,
                                 "notify to delete an non-existing streaming compute worker"
@@ -128,7 +135,7 @@ impl ActiveStreamingWorkerNodes {
                         }
                         continue;
                     };
-                    if !is_streaming_compute_node {
+                    if !is_target_worker_node {
                         warn!(
                             ?worker,
                             ?prev_worker,
@@ -146,9 +153,7 @@ impl ActiveStreamingWorkerNodes {
                     break ActiveStreamingWorkerChange::Remove(prev_worker);
                 }
                 LocalNotification::WorkerNodeActivated(worker) => {
-                    if worker.r#type != WorkerType::ComputeNode as i32
-                        || !worker.property.as_ref().unwrap().is_streaming
-                    {
+                    if !is_target_worker_node(&worker) {
                         if let Some(prev_worker) = self.worker_nodes.remove(&worker.id) {
                             warn!(
                                 ?worker,

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -14,7 +14,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,11 +35,11 @@ use tokio::time::{Instant, MissedTickBehavior};
 
 use crate::barrier::{Command, Reschedule, SharedFragmentInfo};
 use crate::controller::scale::{
-    FragmentRenderMap, NoShuffleEnsemble, RenderedGraph, WorkerInfo,
-    find_fragment_no_shuffle_dags_detailed, render_fragments, render_jobs,
+    FragmentRenderMap, NoShuffleEnsemble, RenderedGraph, find_fragment_no_shuffle_dags_detailed,
+    render_fragments, render_jobs,
 };
 use crate::error::bail_invalid_parameter;
-use crate::manager::{LocalNotification, MetaSrvEnv, MetadataManager};
+use crate::manager::{ActiveStreamingWorkerNodes, LocalNotification, MetaSrvEnv, MetadataManager};
 use crate::model::{ActorId, FragmentId, StreamActor, StreamActorWithDispatchers};
 use crate::stream::{GlobalStreamManager, SourceManagerRef};
 use crate::{MetaError, MetaResult};
@@ -263,7 +262,7 @@ impl ScaleController {
     pub async fn reschedule_inplace(
         &self,
         policy: HashMap<JobId, ReschedulePolicy>,
-        workers: HashMap<WorkerId, PbWorkerNode>,
+        workers: &HashMap<WorkerId, WorkerNode>,
     ) -> MetaResult<HashMap<DatabaseId, Command>> {
         let inner = self.metadata_manager.catalog_controller.inner.read().await;
         let txn = inner.db.begin().await?;
@@ -305,19 +304,6 @@ impl ScaleController {
 
         let jobs = policy.keys().copied().collect();
 
-        let workers = workers
-            .into_iter()
-            .map(|(id, worker)| {
-                (
-                    id,
-                    WorkerInfo {
-                        parallelism: NonZeroUsize::new(worker.compute_node_parallelism()).unwrap(),
-                        resource_group: worker.resource_group(),
-                    },
-                )
-            })
-            .collect();
-
         let command = self.rerender_inner(&txn, jobs, workers).await?;
 
         txn.commit().await?;
@@ -328,7 +314,7 @@ impl ScaleController {
     pub async fn reschedule_fragment_inplace(
         &self,
         policy: HashMap<risingwave_meta_model::FragmentId, Option<StreamingParallelism>>,
-        workers: HashMap<WorkerId, PbWorkerNode>,
+        workers: &HashMap<WorkerId, PbWorkerNode>,
     ) -> MetaResult<HashMap<DatabaseId, Command>> {
         if policy.is_empty() {
             return Ok(HashMap::new());
@@ -417,19 +403,6 @@ impl ScaleController {
             target_ensembles.push(ensemble);
         }
 
-        let workers = workers
-            .into_iter()
-            .map(|(id, worker)| {
-                (
-                    id,
-                    WorkerInfo {
-                        parallelism: NonZeroUsize::new(worker.compute_node_parallelism()).unwrap(),
-                        resource_group: worker.resource_group(),
-                    },
-                )
-            })
-            .collect();
-
         let command = self
             .rerender_fragment_inner(&txn, target_ensembles, workers)
             .await?;
@@ -442,7 +415,7 @@ impl ScaleController {
     async fn rerender(
         &self,
         jobs: HashSet<JobId>,
-        workers: BTreeMap<WorkerId, WorkerInfo>,
+        workers: &HashMap<WorkerId, WorkerNode>,
     ) -> MetaResult<HashMap<DatabaseId, Command>> {
         let inner = self.metadata_manager.catalog_controller.inner.read().await;
         self.rerender_inner(&inner.db, jobs, workers).await
@@ -452,7 +425,7 @@ impl ScaleController {
         &self,
         txn: &impl ConnectionTrait,
         ensembles: Vec<NoShuffleEnsemble>,
-        workers: BTreeMap<WorkerId, WorkerInfo>,
+        workers: &HashMap<WorkerId, WorkerNode>,
     ) -> MetaResult<HashMap<DatabaseId, Command>> {
         if ensembles.is_empty() {
             return Ok(HashMap::new());
@@ -479,7 +452,7 @@ impl ScaleController {
         &self,
         txn: &impl ConnectionTrait,
         jobs: HashSet<JobId>,
-        workers: BTreeMap<WorkerId, WorkerInfo>,
+        workers: &HashMap<WorkerId, WorkerNode>,
     ) -> MetaResult<HashMap<DatabaseId, Command>> {
         let adaptive_parallelism_strategy = {
             let system_params_reader = self.env.system_params_reader().await;
@@ -852,31 +825,8 @@ impl GlobalStreamManager {
             return Ok(false);
         }
 
-        let workers = self
-            .metadata_manager
-            .cluster_controller
-            .list_active_streaming_workers()
-            .await?;
-
-        let schedulable_workers: BTreeMap<_, _> = workers
-            .iter()
-            .filter(|worker| {
-                !worker
-                    .property
-                    .as_ref()
-                    .map(|p| p.is_unschedulable)
-                    .unwrap_or(false)
-            })
-            .map(|worker| {
-                (
-                    worker.id,
-                    WorkerInfo {
-                        parallelism: NonZeroUsize::new(worker.compute_node_parallelism()).unwrap(),
-                        resource_group: worker.resource_group(),
-                    },
-                )
-            })
-            .collect();
+        let active_workers =
+            ActiveStreamingWorkerNodes::new_snapshot(self.metadata_manager.clone()).await?;
 
         if job_ids.is_empty() {
             tracing::info!("no streaming jobs for scaling, maybe an empty cluster");
@@ -886,7 +836,7 @@ impl GlobalStreamManager {
         tracing::info!(
             "trigger parallelism control for jobs: {:#?}, workers {:#?}",
             job_ids,
-            schedulable_workers
+            active_workers.current()
         );
 
         let batch_size = match self.env.opts.parallelism_control_batch_size {
@@ -898,7 +848,7 @@ impl GlobalStreamManager {
             "total {} streaming jobs, batch size {}, schedulable worker ids: {:?}",
             job_ids.len(),
             batch_size,
-            schedulable_workers
+            active_workers.current()
         );
 
         let batches: Vec<_> = job_ids
@@ -913,7 +863,7 @@ impl GlobalStreamManager {
 
             let commands = self
                 .scale_controller
-                .rerender(jobs, schedulable_workers.clone())
+                .rerender(jobs, active_workers.current())
                 .await?;
 
             let futures = commands.into_iter().map(|(database_id, command)| {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

render actor info after reload runtime info, and render database actor one by one, so that in global recovery, the render error in different database can be isolated.

### by AI
This pull request refactors and improves the recovery and checkpoint logic for streaming jobs in the barrier subsystem. The main changes include introducing a new `RenderedDatabaseRuntimeInfo` structure to encapsulate rendered runtime information, updating the recovery and checkpoint flow to use this structure, and cleaning up related code and interfaces for clarity and maintainability.

**Recovery and checkpoint flow improvements:**

* Introduced the `RenderedDatabaseRuntimeInfo` struct and the `render_runtime_info` function in `recovery.rs` to encapsulate job info, stream actors, and source splits for a database, replacing ad hoc data structures and improving clarity.
* Updated the `DatabaseStatusAction::enter` method to accept and use the new `RenderedDatabaseRuntimeInfo`, streamlining how runtime info is passed and used during checkpoint recovery. [[1]](diffhunk://#diff-7b07624ead7f8be9a6b4094f7944fc2148c8e913eafc9470c87030b80863e51fR502) [[2]](diffhunk://#diff-7b07624ead7f8be9a6b4094f7944fc2148c8e913eafc9470c87030b80863e51fL520-R543)

**Interface and visibility changes:**

* Changed the return type of `reload_database_runtime_info` in the `GlobalBarrierWorkerContext` trait and its implementation to always return a `DatabaseRuntimeInfoSnapshot` instead of an `Option`, simplifying downstream logic. [[1]](diffhunk://#diff-f00eaafd63c1dade601f2d6ce216951813957b5a1586ffe61d35957eb795f453L105-R105) [[2]](diffhunk://#diff-de9637b343bd5dc38b424a066bc5a13cb98b1a2c26038309829e4c7447ab8607L125-R125)
* Made the `recovery` module public within the crate to allow broader access to recovery-related types and functions.

**Code cleanup and refactoring:**

* Removed the old `render_actor_assignments` method and related logic from `GlobalBarrierWorkerContextImpl`, consolidating rendering logic into the new flow and relying on the new data structures.
* Refactored how fragment relations and job info are accessed throughout the recovery process, updating usages to work with the new structure and improving code readability. [[1]](diffhunk://#diff-4723364d6d7b53bd1b186448d68f965d5e46d53358726ce3420d9535a909ce6bL352-R362) [[2]](diffhunk://#diff-4723364d6d7b53bd1b186448d68f965d5e46d53358726ce3420d9535a909ce6bL416-R428) [[3]](diffhunk://#diff-4723364d6d7b53bd1b186448d68f965d5e46d53358726ce3420d9535a909ce6bL430-R442) [[4]](diffhunk://#diff-4723364d6d7b53bd1b186448d68f965d5e46d53358726ce3420d9535a909ce6bL651-R670) [[5]](diffhunk://#diff-4723364d6d7b53bd1b186448d68f965d5e46d53358726ce3420d9535a909ce6bL709-L714) [[6]](diffhunk://#diff-4723364d6d7b53bd1b186448d68f965d5e46d53358726ce3420d9535a909ce6bL726-R709)

These changes collectively modernize the recovery and checkpoint handling, making it easier to maintain and extend in the future.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
