### PR TITLE
fix(stream): always comapct chunk if eliminate_adjacent_noop_update successfully

### DIFF
--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -331,6 +331,7 @@ impl StreamChunk {
     pub fn eliminate_adjacent_noop_update(self) -> Self {
         let len = self.data_chunk().capacity();
         let mut c: StreamChunkMut = self.into();
+        let mut eliminated = false;
         let mut prev_r = None;
         for curr in 0..len {
             if !c.vis(curr) {
@@ -361,12 +362,18 @@ impl StreamChunk {
             {
                 c.set_vis(prev, false);
                 c.set_vis(curr, false);
+                eliminated = true;
                 prev_r = None;
             } else {
                 prev_r = Some(curr);
             }
         }
-        c.into()
+        let chunk: StreamChunk = c.into();
+        if eliminated {
+            chunk.compact_vis()
+        } else {
+            chunk
+        }
     }
 
     /// Reorder columns and set visibility.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Always compact chunk if eliminate_adjacent_noop_update eliminates successfully. Because we found that this optimization would convert [-U1, +U2, -U3, +U4] to [-U1, invis, invis, +U4] potentially which would cause panic in dispatcher https://github.com/risingwavelabs/risingwave/blob/0ca295b3159a9332cb6172fcf910b5b37af575c1/src/stream/src/executor/dispatch.rs#L989 Compact the chunk while preserving the $-U$ and $+U$ invariant.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
