### PR TITLE
fix(metrics): label sync log store for sink into table

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1036,9 +1036,7 @@ message SyncLogStoreNode {
   // Deprecated. Use the one from `StreamingDeveloperConfig` instead.
   optional uint32 buffer_size = 3 [deprecated = true];
   bool aligned = 4;
-  // Metric label for this sync log store target, e.g. unaligned join or sink into table.
-  string metrics_target = 5;
-  SyncLogStoreTarget target = 6;
+  SyncLogStoreTarget target = 5;
 }
 
 message MaterializedExprsNode {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1023,6 +1023,12 @@ message RowMergeNode {
   catalog.ColIndexMapping rhs_mapping = 2;
 }
 
+enum SyncLogStoreTarget {
+  SYNC_LOG_STORE_TARGET_UNSPECIFIED = 0;
+  SYNC_LOG_STORE_TARGET_UNALIGNED_HASH_JOIN = 1;
+  SYNC_LOG_STORE_TARGET_SINK_INTO_TABLE = 2;
+}
+
 message SyncLogStoreNode {
   catalog.Table log_store_table = 1;
   // Deprecated. Use the one from `StreamingDeveloperConfig` instead.
@@ -1030,8 +1036,9 @@ message SyncLogStoreNode {
   // Deprecated. Use the one from `StreamingDeveloperConfig` instead.
   optional uint32 buffer_size = 3 [deprecated = true];
   bool aligned = 4;
-  // Metric label for this sync log store target, e.g. unaligned join or sink into table.
-  string metrics_target = 5;
+  // Deprecated. Use `target` instead.
+  string metrics_target = 5 [deprecated = true];
+  SyncLogStoreTarget target = 6;
 }
 
 message MaterializedExprsNode {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1030,6 +1030,8 @@ message SyncLogStoreNode {
   // Deprecated. Use the one from `StreamingDeveloperConfig` instead.
   optional uint32 buffer_size = 3 [deprecated = true];
   bool aligned = 4;
+  // Metric label for this sync log store target, e.g. unaligned join or sink into table.
+  string metrics_target = 5;
 }
 
 message MaterializedExprsNode {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1036,8 +1036,8 @@ message SyncLogStoreNode {
   // Deprecated. Use the one from `StreamingDeveloperConfig` instead.
   optional uint32 buffer_size = 3 [deprecated = true];
   bool aligned = 4;
-  // Deprecated. Use `target` instead.
-  string metrics_target = 5 [deprecated = true];
+  // Metric label for this sync log store target, e.g. unaligned join or sink into table.
+  string metrics_target = 5;
   SyncLogStoreTarget target = 6;
 }
 

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -1250,7 +1250,7 @@ pub use stream_sort::StreamEowcSort;
 pub use stream_source::StreamSource;
 pub use stream_source_scan::StreamSourceScan;
 pub use stream_stateless_simple_agg::StreamStatelessSimpleAgg;
-pub use stream_sync_log_store::{StreamSyncLogStore, SyncLogStoreTarget};
+pub use stream_sync_log_store::StreamSyncLogStore;
 pub use stream_table_scan::StreamTableScan;
 pub use stream_temporal_join::StreamTemporalJoin;
 pub use stream_topn::StreamTopN;

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -1250,7 +1250,7 @@ pub use stream_sort::StreamEowcSort;
 pub use stream_source::StreamSource;
 pub use stream_source_scan::StreamSourceScan;
 pub use stream_stateless_simple_agg::StreamStatelessSimpleAgg;
-pub use stream_sync_log_store::StreamSyncLogStore;
+pub use stream_sync_log_store::{StreamSyncLogStore, SyncLogStoreTarget};
 pub use stream_table_scan::StreamTableScan;
 pub use stream_temporal_join::StreamTemporalJoin;
 pub use stream_topn::StreamTopN;

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -33,8 +33,8 @@ use risingwave_connector::sink::{
 };
 use risingwave_connector::{WithPropertiesExt, match_sink_name_str};
 use risingwave_pb::expr::expr_node::Type;
-use risingwave_pb::stream_plan::{SinkLogStoreType, SyncLogStoreTarget};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
+use risingwave_pb::stream_plan::{SinkLogStoreType, SyncLogStoreTarget};
 
 use super::derive::{derive_columns, derive_pk};
 use super::stream::prelude::*;

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -562,11 +562,8 @@ impl StreamSink {
 
         // sink into table should have logstore for sink_decouple
         let input = if sink_decouple && target_table.is_some() {
-            StreamSyncLogStore::new_with_target(
-                input,
-                StreamSyncLogStore::TARGET_SINK_INTO_TABLE,
-            )
-            .into()
+            StreamSyncLogStore::new_with_target(input, StreamSyncLogStore::TARGET_SINK_INTO_TABLE)
+                .into()
         } else {
             input
         };

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -43,7 +43,7 @@ use super::utils::{
 };
 use super::{
     ExprRewritable, PlanBase, StreamExchange, StreamNode, StreamPlanRef as PlanRef, StreamProject,
-    StreamSyncLogStore, generic,
+    StreamPlanNodeType, StreamSyncLogStore, SyncLogStoreTarget, generic,
 };
 use crate::TableCatalog;
 use crate::error::{ErrorCode, Result, RwError, bail_bind_error, bail_invalid_input_syntax};
@@ -562,8 +562,11 @@ impl StreamSink {
 
         // sink into table should have logstore for sink_decouple
         let input = if sink_decouple && target_table.is_some() {
-            StreamSyncLogStore::new_with_target(input, StreamSyncLogStore::TARGET_SINK_INTO_TABLE)
-                .into()
+            StreamSyncLogStore::new_with_target(
+                input,
+                SyncLogStoreTarget::sink_into_table(StreamPlanNodeType::StreamSink),
+            )
+            .into()
         } else {
             input
         };

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -33,7 +33,7 @@ use risingwave_connector::sink::{
 };
 use risingwave_connector::{WithPropertiesExt, match_sink_name_str};
 use risingwave_pb::expr::expr_node::Type;
-use risingwave_pb::stream_plan::SinkLogStoreType;
+use risingwave_pb::stream_plan::{SinkLogStoreType, SyncLogStoreTarget};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::derive::{derive_columns, derive_pk};
@@ -42,8 +42,8 @@ use super::utils::{
     Distill, IndicesDisplay, childless_record, infer_kv_log_store_table_catalog_inner,
 };
 use super::{
-    ExprRewritable, PlanBase, StreamExchange, StreamNode, StreamPlanNodeType,
-    StreamPlanRef as PlanRef, StreamProject, StreamSyncLogStore, SyncLogStoreTarget, generic,
+    ExprRewritable, PlanBase, StreamExchange, StreamNode, StreamPlanRef as PlanRef, StreamProject,
+    StreamSyncLogStore, generic,
 };
 use crate::TableCatalog;
 use crate::error::{ErrorCode, Result, RwError, bail_bind_error, bail_invalid_input_syntax};
@@ -562,12 +562,7 @@ impl StreamSink {
 
         // sink into table should have logstore for sink_decouple
         let input = if sink_decouple && target_table.is_some() {
-            StreamSyncLogStore::new_with_target(
-                input,
-                StreamPlanNodeType::StreamSink,
-                SyncLogStoreTarget::SinkIntoTable,
-            )
-            .into()
+            StreamSyncLogStore::new_with_target(input, SyncLogStoreTarget::SinkIntoTable).into()
         } else {
             input
         };

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -562,7 +562,11 @@ impl StreamSink {
 
         // sink into table should have logstore for sink_decouple
         let input = if sink_decouple && target_table.is_some() {
-            StreamSyncLogStore::new(input).into()
+            StreamSyncLogStore::new_with_target(
+                input,
+                StreamSyncLogStore::TARGET_SINK_INTO_TABLE,
+            )
+            .into()
         } else {
             input
         };

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -564,7 +564,8 @@ impl StreamSink {
         let input = if sink_decouple && target_table.is_some() {
             StreamSyncLogStore::new_with_target(
                 input,
-                SyncLogStoreTarget::sink_into_table(StreamPlanNodeType::StreamSink),
+                StreamPlanNodeType::StreamSink,
+                SyncLogStoreTarget::SinkIntoTable,
             )
             .into()
         } else {

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -42,8 +42,8 @@ use super::utils::{
     Distill, IndicesDisplay, childless_record, infer_kv_log_store_table_catalog_inner,
 };
 use super::{
-    ExprRewritable, PlanBase, StreamExchange, StreamNode, StreamPlanRef as PlanRef, StreamProject,
-    StreamPlanNodeType, StreamSyncLogStore, SyncLogStoreTarget, generic,
+    ExprRewritable, PlanBase, StreamExchange, StreamNode, StreamPlanNodeType,
+    StreamPlanRef as PlanRef, StreamProject, StreamSyncLogStore, SyncLogStoreTarget, generic,
 };
 use crate::TableCatalog;
 use crate::error::{ErrorCode, Result, RwError, bail_bind_error, bail_invalid_input_syntax};

--- a/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
@@ -35,8 +35,8 @@ pub struct StreamSyncLogStore {
 }
 
 impl StreamSyncLogStore {
-    pub const TARGET_UNALIGNED_HASH_JOIN: &'static str = "unaligned_hash_join";
     pub const TARGET_SINK_INTO_TABLE: &'static str = "sink-into-table";
+    pub const TARGET_UNALIGNED_HASH_JOIN: &'static str = "unaligned_hash_join";
 
     pub fn new(input: PlanRef) -> Self {
         Self::new_with_target(input, Self::TARGET_UNALIGNED_HASH_JOIN)

--- a/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
@@ -84,7 +84,6 @@ impl StreamNode for StreamSyncLogStore {
         NodeBody::SyncLogStore(Box::new(SyncLogStoreNode {
             log_store_table,
             aligned: false,
-            metrics_target: String::new(),
             target: self.metrics_target as i32,
 
             // The following fields should now be read from per-job config override.
@@ -92,6 +91,7 @@ impl StreamNode for StreamSyncLogStore {
             pause_duration_ms: None,
             #[allow(deprecated)]
             buffer_size: None,
+            ..Default::default()
         }))
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
@@ -81,18 +81,19 @@ impl StreamNode for StreamSyncLogStore {
             .with_id(state.gen_table_id_wrapped())
             .to_internal_table_prost()
             .into();
-        NodeBody::SyncLogStore(Box::new(SyncLogStoreNode {
+        let mut node = SyncLogStoreNode {
             log_store_table,
             aligned: false,
             target: self.metrics_target as i32,
-
-            // The following fields should now be read from per-job config override.
-            #[allow(deprecated)]
-            pause_duration_ms: None,
-            #[allow(deprecated)]
-            buffer_size: None,
             ..Default::default()
-        }))
+        };
+        // The following fields should now be read from per-job config override.
+        #[allow(deprecated)]
+        {
+            node.pause_duration_ms = None;
+            node.buffer_size = None;
+        }
+        NodeBody::SyncLogStore(Box::new(node))
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sync_log_store.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use pretty_xmlish::XmlNode;
-use risingwave_pb::stream_plan::{SyncLogStoreNode, SyncLogStoreTarget};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::{SyncLogStoreNode, SyncLogStoreTarget};
 
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
 use crate::optimizer::plan_node::generic::PhysicalPlanRef;

--- a/src/frontend/src/optimizer/rule/add_logstore_rule.rs
+++ b/src/frontend/src/optimizer/rule/add_logstore_rule.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::optimizer::plan_node::{Stream, StreamPlanRef as PlanRef, StreamSyncLogStore};
+use crate::optimizer::plan_node::{
+    Stream, StreamPlanNodeType, StreamPlanRef as PlanRef, StreamSyncLogStore, SyncLogStoreTarget,
+};
 use crate::optimizer::rule::{BoxedRule, Rule};
 
 pub struct AddLogstoreRule {}
@@ -20,7 +22,10 @@ pub struct AddLogstoreRule {}
 impl Rule<Stream> for AddLogstoreRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         plan.as_stream_hash_join()?;
-        let log_store_plan = StreamSyncLogStore::new(plan);
+        let log_store_plan = StreamSyncLogStore::new_with_target(
+            plan,
+            SyncLogStoreTarget::unaligned_hash_join(StreamPlanNodeType::StreamHashJoin),
+        );
         Some(log_store_plan.into())
     }
 }

--- a/src/frontend/src/optimizer/rule/add_logstore_rule.rs
+++ b/src/frontend/src/optimizer/rule/add_logstore_rule.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::optimizer::plan_node::{
-    Stream, StreamPlanNodeType, StreamPlanRef as PlanRef, StreamSyncLogStore, SyncLogStoreTarget,
-};
+use risingwave_pb::stream_plan::SyncLogStoreTarget;
+
+use crate::optimizer::plan_node::{Stream, StreamPlanRef as PlanRef, StreamSyncLogStore};
 use crate::optimizer::rule::{BoxedRule, Rule};
 
 pub struct AddLogstoreRule {}
@@ -22,11 +22,8 @@ pub struct AddLogstoreRule {}
 impl Rule<Stream> for AddLogstoreRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         plan.as_stream_hash_join()?;
-        let log_store_plan = StreamSyncLogStore::new_with_target(
-            plan,
-            StreamPlanNodeType::StreamHashJoin,
-            SyncLogStoreTarget::UnalignedHashJoin,
-        );
+        let log_store_plan =
+            StreamSyncLogStore::new_with_target(plan, SyncLogStoreTarget::UnalignedHashJoin);
         Some(log_store_plan.into())
     }
 }

--- a/src/frontend/src/optimizer/rule/add_logstore_rule.rs
+++ b/src/frontend/src/optimizer/rule/add_logstore_rule.rs
@@ -24,7 +24,8 @@ impl Rule<Stream> for AddLogstoreRule {
         plan.as_stream_hash_join()?;
         let log_store_plan = StreamSyncLogStore::new_with_target(
             plan,
-            SyncLogStoreTarget::unaligned_hash_join(StreamPlanNodeType::StreamHashJoin),
+            StreamPlanNodeType::StreamHashJoin,
+            SyncLogStoreTarget::UnalignedHashJoin,
         );
         Some(log_store_plan.into())
     }

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -148,7 +148,7 @@ pub mod metrics {
             actor_id: ActorId,
             fragment_id: FragmentId,
             name: &str,
-            target: &'static str,
+            target: &str,
         ) -> Self {
             let actor_id_str = actor_id.to_string();
             let fragment_id_str = fragment_id.to_string();

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -42,12 +42,13 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             let actor_id = actor_context.id;
             let fragment_id = params.fragment_id;
             let name = "sync_log_store";
-            let target = if node.metrics_target.is_empty() {
-                "unaligned_hash_join"
-            } else {
-                node.metrics_target.as_str()
-            };
-            SyncedKvLogStoreMetrics::new(streaming_metrics, actor_id, fragment_id, name, target)
+            SyncedKvLogStoreMetrics::new(
+                streaming_metrics,
+                actor_id,
+                fragment_id,
+                name,
+                node.metrics_target.as_str(),
+            )
         };
 
         let serde = LogStoreRowSerde::new(

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -47,7 +47,7 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             let metrics_target = match target {
                 SyncLogStoreTarget::Unspecified => "",
                 SyncLogStoreTarget::UnalignedHashJoin => "unaligned_hash_join",
-                SyncLogStoreTarget::SinkIntoTable => "sink-into-table",
+                SyncLogStoreTarget::SinkIntoTable => "sink_into_table",
             };
             let legacy_metrics_target = node.metrics_target.as_str();
             let metrics_target = if metrics_target.is_empty() {

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -42,15 +42,17 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             let actor_id = actor_context.id;
             let fragment_id = params.fragment_id;
             let name = "sync_log_store";
-            let target = SyncLogStoreTarget::from_i32(node.target)
-                .unwrap_or(SyncLogStoreTarget::Unspecified);
+            let target =
+                SyncLogStoreTarget::try_from(node.target).unwrap_or(SyncLogStoreTarget::Unspecified);
             let metrics_target = match target {
                 SyncLogStoreTarget::Unspecified => "",
                 SyncLogStoreTarget::UnalignedHashJoin => "unaligned_hash_join",
                 SyncLogStoreTarget::SinkIntoTable => "sink-into-table",
             };
+            #[allow(deprecated)]
+            let legacy_metrics_target = node.metrics_target.as_str();
             let metrics_target = if metrics_target.is_empty() {
-                node.metrics_target.as_str()
+                legacy_metrics_target
             } else {
                 metrics_target
             };

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -49,12 +49,6 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
                 SyncLogStoreTarget::UnalignedHashJoin => "unaligned_hash_join",
                 SyncLogStoreTarget::SinkIntoTable => "sink_into_table",
             };
-            let legacy_metrics_target = node.metrics_target.as_str();
-            let metrics_target = if metrics_target.is_empty() {
-                legacy_metrics_target
-            } else {
-                metrics_target
-            };
             SyncedKvLogStoreMetrics::new(
                 streaming_metrics,
                 actor_id,

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_pb::stream_plan::SyncLogStoreNode;
+use risingwave_pb::stream_plan::{SyncLogStoreNode, SyncLogStoreTarget};
 use risingwave_storage::StateStore;
 use tokio::time::Duration;
 
@@ -42,12 +42,24 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             let actor_id = actor_context.id;
             let fragment_id = params.fragment_id;
             let name = "sync_log_store";
+            let target = SyncLogStoreTarget::from_i32(node.target)
+                .unwrap_or(SyncLogStoreTarget::Unspecified);
+            let metrics_target = match target {
+                SyncLogStoreTarget::Unspecified => "",
+                SyncLogStoreTarget::UnalignedHashJoin => "unaligned_hash_join",
+                SyncLogStoreTarget::SinkIntoTable => "sink-into-table",
+            };
+            let metrics_target = if metrics_target.is_empty() {
+                node.metrics_target.as_str()
+            } else {
+                metrics_target
+            };
             SyncedKvLogStoreMetrics::new(
                 streaming_metrics,
                 actor_id,
                 fragment_id,
                 name,
-                node.metrics_target.as_str(),
+                metrics_target,
             )
         };
 

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -42,8 +42,8 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             let actor_id = actor_context.id;
             let fragment_id = params.fragment_id;
             let name = "sync_log_store";
-            let target =
-                SyncLogStoreTarget::try_from(node.target).unwrap_or(SyncLogStoreTarget::Unspecified);
+            let target = SyncLogStoreTarget::try_from(node.target)
+                .unwrap_or(SyncLogStoreTarget::Unspecified);
             let metrics_target = match target {
                 SyncLogStoreTarget::Unspecified => "",
                 SyncLogStoreTarget::UnalignedHashJoin => "unaligned_hash_join",

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -49,7 +49,6 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
                 SyncLogStoreTarget::UnalignedHashJoin => "unaligned_hash_join",
                 SyncLogStoreTarget::SinkIntoTable => "sink-into-table",
             };
-            #[allow(deprecated)]
             let legacy_metrics_target = node.metrics_target.as_str();
             let metrics_target = if metrics_target.is_empty() {
                 legacy_metrics_target

--- a/src/stream/src/from_proto/sync_log_store.rs
+++ b/src/stream/src/from_proto/sync_log_store.rs
@@ -42,7 +42,11 @@ impl ExecutorBuilder for SyncLogStoreExecutorBuilder {
             let actor_id = actor_context.id;
             let fragment_id = params.fragment_id;
             let name = "sync_log_store";
-            let target = "unaligned_hash_join";
+            let target = if node.metrics_target.is_empty() {
+                "unaligned_hash_join"
+            } else {
+                node.metrics_target.as_str()
+            };
             SyncedKvLogStoreMetrics::new(streaming_metrics, actor_id, fragment_id, name, target)
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

This adds a metrics target field to SyncLogStore plans and plumbs it through to the executor so sync-log-store metrics can be labeled by caller. For sink-into-table with sink_decouple enabled, the target is set to `sink_into_table`, while the default for joins remains `unaligned_hash_join`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
