### PR TITLE
feat(frontend): support equivalent batch orders for eq-prefix scans

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -595,3 +595,27 @@
     select b from t where a = 1 order by b, c limit 1;
   expected_outputs:
     - batch_plan
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by c;
+  expected_outputs:
+    - batch_plan
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by c limit 5;
+  expected_outputs:
+    - batch_plan
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by a, b, c;
+  expected_outputs:
+    - batch_plan
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by a, b, c limit 5;
+  expected_outputs:
+    - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -1016,3 +1016,37 @@
           └─BatchExchange { order: [], dist: Single }
             └─BatchLimit { limit: 1, offset: 0 }
               └─BatchScan { table: t, columns: [t.c, t.b, t.a], scan_ranges: [t.a = Int32(1)], limit: 1, distribution: UpstreamHashShard(t.a, t.b, t.c) }
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by c;
+  batch_plan: |-
+    BatchExchange { order: [t.c ASC], dist: Single }
+    └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by c limit 5;
+  batch_plan: |-
+    BatchSort { order: [t.c ASC] }
+    └─BatchTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 5, offset: 0 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchLimit { limit: 5, offset: 0 }
+          └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], limit: 5, distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by a, b, c;
+  batch_plan: |-
+    BatchExchange { order: [t.a ASC, t.b ASC, t.c ASC], dist: Single }
+    └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }
+- name: batch sort elimination with eq-prefix-derived orders
+  sql: |
+    create table t (a int, b int, c int, d int, primary key (a, b, c, d));
+    select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by a, b, c limit 5;
+  batch_plan: |-
+    BatchSort { order: [t.c ASC] }
+    └─BatchTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 5, offset: 0 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchLimit { limit: 5, offset: 0 }
+          └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], limit: 5, distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }

--- a/src/frontend/src/optimizer/plan_node/batch.rs
+++ b/src/frontend/src/optimizer/plan_node/batch.rs
@@ -26,6 +26,9 @@ use crate::optimizer::property::Order;
 #[auto_impl::auto_impl(&)]
 pub trait BatchPlanNodeMetadata: PhysicalPlanRef {
     fn order(&self) -> &Order;
+    fn orders(&self) -> Vec<Order> {
+        vec![self.order().clone()]
+    }
 }
 
 /// Prelude for batch plan nodes.

--- a/src/frontend/src/optimizer/plan_node/batch_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_filter.rs
@@ -37,10 +37,10 @@ pub struct BatchFilter {
 impl BatchFilter {
     pub fn new(core: generic::Filter<PlanRef>) -> Self {
         // TODO: derive from input
-        let base = PlanBase::new_batch_with_core(
+        let base = PlanBase::new_batch_with_core_and_orders(
             &core,
             core.input.distribution().clone(),
-            core.input.order().clone(),
+            core.input.orders(),
         );
         BatchFilter { base, core }
     }

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -42,11 +42,13 @@ impl BatchProject {
         let distribution = core
             .i2o_col_mapping()
             .rewrite_provided_distribution(core.input.distribution());
-        let order = core
-            .i2o_col_mapping()
-            .rewrite_provided_order(core.input.order());
-
-        let base = PlanBase::new_batch_with_core(&core, distribution, order);
+        let orders = core
+            .input
+            .orders()
+            .into_iter()
+            .map(|order| core.i2o_col_mapping().rewrite_provided_order(&order))
+            .collect();
+        let base = PlanBase::new_batch_with_core_and_orders(&core, distribution, orders);
         BatchProject { base, core }
     }
 

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -46,12 +46,29 @@ impl BatchSeqScan {
         scan_ranges: Vec<ScanRange>,
         limit: Option<u64>,
     ) -> Self {
-        let order = if scan_ranges.len() > 1 {
-            Order::any()
+        let orders = if scan_ranges.len() > 1 {
+            vec![Order::any()]
         } else {
-            core.get_out_column_index_order()
+            let base_order = core.get_out_column_index_order();
+            if scan_ranges.len() == 1 && !base_order.is_any() {
+                let eq_prefix_len = scan_ranges[0].eq_conds.len();
+                if eq_prefix_len > 0 {
+                    let mut orders = vec![base_order.clone()];
+                    let max_trim = eq_prefix_len.min(base_order.column_orders.len());
+                    for trim in 1..=max_trim {
+                        orders.push(Order {
+                            column_orders: base_order.column_orders[trim..].to_vec(),
+                        });
+                    }
+                    orders
+                } else {
+                    vec![base_order]
+                }
+            } else {
+                vec![base_order]
+            }
         };
-        let base = PlanBase::new_batch_with_core(&core, dist, order);
+        let base = PlanBase::new_batch_with_core_and_orders(&core, dist, orders);
 
         {
             // validate scan_range

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -728,6 +728,10 @@ impl BatchPlanNodeMetadata for BatchPlanRef {
     fn order(&self) -> &Order {
         self.plan_base().order()
     }
+
+    fn orders(&self) -> Vec<Order> {
+        self.plan_base().orders()
+    }
 }
 
 /// In order to let expression display id started from 1 for explaining, hidden column names and

--- a/src/frontend/src/optimizer/plan_node/plan_base.rs
+++ b/src/frontend/src/optimizer/plan_node/plan_base.rs
@@ -79,9 +79,20 @@ pub struct BatchExtra {
     /// Common fields for physical plan nodes.
     physical: PhysicalCommonExtra,
 
-    /// The order property of the `PlanNode`'s output, store an `&Order::any()` here will not affect
-    /// correctness, but insert unnecessary sort in plan
-    order: Order,
+    /// Equivalent order properties of the `PlanNode`'s output.
+    ///
+    /// The first item is canonical and returned by `order()`. Additional items represent
+    /// equivalent orders that can also satisfy required order checks.
+    ///
+    /// Example (`BatchSeqScan`):
+    /// - Base table order: `(a, b, c, d)`.
+    /// - Scan range fixes `a = const` and `b = const` (`eq_prefix_len = 2`).
+    /// - The scan can provide these equivalent orders:
+    ///   `(a, b, c, d)`, `(b, c, d)`, `(c, d)`.
+    ///
+    /// This lets optimization rules avoid unnecessary `BatchSort` when required order is a suffix
+    /// after fixed equality prefixes.
+    orders: Vec<Order>,
 }
 
 impl GetPhysicalCommon for BatchExtra {
@@ -178,7 +189,14 @@ impl stream::StreamPlanNodeMetadata for PlanBase<Stream> {
 
 impl batch::BatchPlanNodeMetadata for PlanBase<Batch> {
     fn order(&self) -> &Order {
-        &self.extra.order
+        self.extra
+            .orders
+            .first()
+            .expect("batch plan node should always have at least one order")
+    }
+
+    fn orders(&self) -> Vec<Order> {
+        self.extra.orders.clone()
     }
 }
 
@@ -276,6 +294,19 @@ impl PlanBase<Batch> {
         dist: Distribution,
         order: Order,
     ) -> Self {
+        Self::new_batch_with_orders(ctx, schema, dist, vec![order])
+    }
+
+    pub fn new_batch_with_orders(
+        ctx: OptimizerContextRef,
+        schema: Schema,
+        dist: Distribution,
+        orders: Vec<Order>,
+    ) -> Self {
+        assert!(
+            !orders.is_empty(),
+            "batch plan node should always have at least one order"
+        );
         let id = ctx.next_plan_node_id();
         let functional_dependency = FunctionalDependencySet::new(schema.len());
         Self {
@@ -286,7 +317,7 @@ impl PlanBase<Batch> {
             functional_dependency,
             extra: BatchExtra {
                 physical: PhysicalCommonExtra { dist },
-                order,
+                orders,
             },
         }
     }
@@ -297,6 +328,14 @@ impl PlanBase<Batch> {
         order: Order,
     ) -> Self {
         Self::new_batch(core.ctx(), core.schema(), dist, order)
+    }
+
+    pub fn new_batch_with_core_and_orders(
+        core: &impl GenericPlanNode,
+        dist: Distribution,
+        orders: Vec<Order>,
+    ) -> Self {
+        Self::new_batch_with_orders(core.ctx(), core.schema(), dist, orders)
     }
 }
 

--- a/src/frontend/src/optimizer/property/order.rs
+++ b/src/frontend/src/optimizer/property/order.rs
@@ -96,7 +96,7 @@ impl Order {
     pub fn enforce_if_not_satisfies(&self, plan: BatchPlanRef) -> Result<BatchPlanRef> {
         use crate::optimizer::plan_node::batch::prelude::*;
 
-        if !plan.order().satisfies(self) {
+        if !plan.orders().iter().any(|order| order.satisfies(self)) {
             Ok(self.enforce(plan))
         } else {
             Ok(plan)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

-  This PR improves batch order property modeling by allowing a plan node to expose multiple equivalent orders, instead of a single canonical order only. The key motivation is eq-prefix scans (e.g. PK/index prefix fixed by = predicates). In these cases, suffix orders are also valid and should be recognized to avoid unnecessary BatchSort.
 - BatchExtra now stores orders: Vec<Order> instead of a single order.
 - Kept backward-compatible behavior: order() still exists and returns the first (canonical) order. Added orders() for full equivalent-order set.



## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
