### PR TITLE
cherry-pick fix: clean up timed-out sqlsmith mviews

### DIFF
--- a/e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial
@@ -1,5 +1,11 @@
 control substitution on
 
+system ok
+rpk topic delete test_rate_limit_shared || true
+
+system ok
+rpk topic create test_rate_limit_shared -p 1
+
 ############## Create kafka seed data
 
 statement ok
@@ -162,3 +168,6 @@ drop source kafka_source cascade;
 
 statement ok
 drop table kafka_seed_data cascade;
+
+system ok
+rpk topic delete test_rate_limit_shared || true


### PR DESCRIPTION
## Summary

- cancel timed-out sqlsmith queries and drop any timed-out materialized view
- track all attempted mviews so cleanup always drops them


## Testing
- not run (fuzzing job)