### PR TITLE
feat(sink): support alter sink connector force with

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -405,6 +405,7 @@ message AlterConnectorPropsRequest {
   oneof extra_options {
     AlterIcebergTableIds alter_iceberg_table_ids = 6;
   }
+  bool force = 7;
 }
 
 message AlterConnectorPropsResponse {}

--- a/src/frontend/src/handler/alter_sink_props.rs
+++ b/src/frontend/src/handler/alter_sink_props.rs
@@ -26,6 +26,7 @@ pub async fn handle_alter_sink_props(
     handler_args: HandlerArgs,
     sink_name: ObjectName,
     changed_props: Vec<SqlOption>,
+    force: bool,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session;
     let user_name = &session.user_name();
@@ -78,6 +79,7 @@ pub async fn handle_alter_sink_props(
             changed_props,
             changed_secret_refs,
             connector_conn_ref, // always None, keep the interface for future extension
+            force,
         )
         .await?;
 

--- a/src/frontend/src/handler/alter_table_props.rs
+++ b/src/frontend/src/handler/alter_table_props.rs
@@ -28,6 +28,7 @@ pub async fn handle_alter_table_props(
     handler_args: HandlerArgs,
     table_name: ObjectName,
     changed_props: Vec<SqlOption>,
+    force: bool,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
     let (original_table, _) = fetch_table_catalog_for_alter(session.as_ref(), &table_name)?;
@@ -36,7 +37,7 @@ pub async fn handle_alter_table_props(
             handle_alter_table_connector_props(handler_args, table_name, changed_props).await
         }
         risingwave_common::catalog::Engine::Iceberg => {
-            handle_alter_iceberg_table_props(handler_args, table_name, changed_props).await
+            handle_alter_iceberg_table_props(handler_args, table_name, changed_props, force).await
         }
     }
 }
@@ -45,6 +46,7 @@ pub async fn handle_alter_iceberg_table_props(
     handler_args: HandlerArgs,
     table_name: ObjectName,
     changed_props: Vec<SqlOption>,
+    force: bool,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
     let db_name = &session.database();
@@ -104,6 +106,7 @@ pub async fn handle_alter_iceberg_table_props(
             changed_props,
             changed_secret_refs,
             connector_conn_ref,
+            force,
         )
         .await?;
 

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -912,8 +912,8 @@ pub async fn handle(
                 )
                 .await
             }
-            AlterTableOperation::AlterConnectorProps { alter_props } => {
-                alter_table_props::handle_alter_table_props(handler_args, name, alter_props).await
+            AlterTableOperation::AlterConnectorProps { alter_props, force } => {
+                alter_table_props::handle_alter_table_props(handler_args, name, alter_props, force).await
             }
             AlterTableOperation::AddConstraint { .. }
             | AlterTableOperation::DropConstraint { .. }
@@ -1108,7 +1108,8 @@ pub async fn handle(
         Statement::AlterSink { name, operation } => match operation {
             AlterSinkOperation::AlterConnectorProps {
                 alter_props: changed_props,
-            } => alter_sink_props::handle_alter_sink_props(handler_args, name, changed_props).await,
+                force,
+            } => alter_sink_props::handle_alter_sink_props(handler_args, name, changed_props, force).await,
             AlterSinkOperation::RenameSink { sink_name } => {
                 alter_rename::handle_rename_sink(handler_args, name, sink_name).await
             }

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -167,6 +167,7 @@ pub trait FrontendMetaClient: Send + Sync {
         changed_props: BTreeMap<String, String>,
         changed_secret_refs: BTreeMap<String, PbSecretRef>,
         connector_conn_ref: Option<ConnectionId>,
+        force: bool,
     ) -> Result<()>;
 
     async fn alter_iceberg_table_props(
@@ -177,6 +178,7 @@ pub trait FrontendMetaClient: Send + Sync {
         changed_props: BTreeMap<String, String>,
         changed_secret_refs: BTreeMap<String, PbSecretRef>,
         connector_conn_ref: Option<ConnectionId>,
+        force: bool,
     ) -> Result<()>;
 
     async fn alter_source_connector_props(
@@ -439,6 +441,7 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
         changed_props: BTreeMap<String, String>,
         changed_secret_refs: BTreeMap<String, PbSecretRef>,
         connector_conn_ref: Option<ConnectionId>,
+        force: bool,
     ) -> Result<()> {
         self.0
             .alter_sink_props(
@@ -446,6 +449,7 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
                 changed_props,
                 changed_secret_refs,
                 connector_conn_ref,
+                force,
             )
             .await
     }
@@ -458,6 +462,7 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
         changed_props: BTreeMap<String, String>,
         changed_secret_refs: BTreeMap<String, PbSecretRef>,
         connector_conn_ref: Option<ConnectionId>,
+        force: bool,
     ) -> Result<()> {
         self.0
             .alter_iceberg_table_props(
@@ -467,6 +472,7 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
                 changed_props,
                 changed_secret_refs,
                 connector_conn_ref,
+                force,
             )
             .await
     }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1248,6 +1248,7 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         _changed_props: BTreeMap<String, String>,
         _changed_secret_refs: BTreeMap<String, PbSecretRef>,
         _connector_conn_ref: Option<ConnectionId>,
+        _force: bool,
     ) -> RpcResult<()> {
         unimplemented!()
     }
@@ -1260,6 +1261,7 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         _changed_props: BTreeMap<String, String>,
         _changed_secret_refs: BTreeMap<String, PbSecretRef>,
         _connector_conn_ref: Option<ConnectionId>,
+        _force: bool,
     ) -> RpcResult<()> {
         unimplemented!()
     }

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -697,6 +697,7 @@ impl StreamManagerService for StreamServiceImpl {
                     .update_sink_props_by_sink_id(
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),
+                        request.force,
                     )
                     .await?,
                 request.object_id.into(),
@@ -708,6 +709,7 @@ impl StreamManagerService for StreamServiceImpl {
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),
                         request.extra_options,
+                        request.force,
                     )
                     .await?;
                 (prop, sink_id.as_object_id())

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2288,6 +2288,7 @@ impl CatalogController {
         &self,
         sink_id: SinkId,
         props: BTreeMap<String, String>,
+        force: bool,
     ) -> MetaResult<HashMap<String, String>> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
@@ -2297,7 +2298,9 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &props)?;
+        if !force {
+            validate_sink_props(&sink, &props)?;
+        }
         let definition = sink.definition.clone();
         let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
             .map_err(|e| SinkError::Config(anyhow!(e)))?
@@ -2355,6 +2358,7 @@ impl CatalogController {
         alter_iceberg_table_props: Option<
             risingwave_pb::meta::alter_connector_props_request::PbExtraOptions,
         >,
+        force: bool,
     ) -> MetaResult<(HashMap<String, String>, SinkId)> {
         let risingwave_pb::meta::alter_connector_props_request::PbExtraOptions::AlterIcebergTableIds(AlterIcebergTableIds { sink_id, source_id }) = alter_iceberg_table_props.
             ok_or_else(|| MetaError::invalid_parameter("alter_iceberg_table_props is required"))?;
@@ -2366,7 +2370,9 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &props)?;
+        if !force {
+            validate_sink_props(&sink, &props)?;
+        }
 
         let definition = sink.definition.clone();
         let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -592,10 +592,11 @@ impl MetadataManager {
         &self,
         sink_id: SinkId,
         props: BTreeMap<String, String>,
+        force: bool,
     ) -> MetaResult<HashMap<String, String>> {
         let new_props = self
             .catalog_controller
-            .update_sink_props_by_sink_id(sink_id, props)
+            .update_sink_props_by_sink_id(sink_id, props, force)
             .await?;
         Ok(new_props)
     }
@@ -607,10 +608,11 @@ impl MetadataManager {
         alter_iceberg_table_props: Option<
             risingwave_pb::meta::alter_connector_props_request::PbExtraOptions,
         >,
+        force: bool,
     ) -> MetaResult<(HashMap<String, String>, SinkId)> {
         let (new_props, sink_id) = self
             .catalog_controller
-            .update_iceberg_table_props_by_table_id(table_id, props, alter_iceberg_table_props)
+            .update_iceberg_table_props_by_table_id(table_id, props, alter_iceberg_table_props, force)
             .await?;
         Ok((new_props, sink_id))
     }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1482,6 +1482,7 @@ impl MetaClient {
         changed_props: BTreeMap<String, String>,
         changed_secret_refs: BTreeMap<String, PbSecretRef>,
         connector_conn_ref: Option<ConnectionId>,
+        force: bool,
     ) -> Result<()> {
         let req = AlterConnectorPropsRequest {
             object_id: sink_id.as_raw_id(),
@@ -1490,6 +1491,7 @@ impl MetaClient {
             connector_conn_ref,
             object_type: AlterConnectorPropsObject::Sink as i32,
             extra_options: None,
+            force,
         };
         let _resp = self.inner.alter_connector_props(req).await?;
         Ok(())
@@ -1503,6 +1505,7 @@ impl MetaClient {
         changed_props: BTreeMap<String, String>,
         changed_secret_refs: BTreeMap<String, PbSecretRef>,
         connector_conn_ref: Option<ConnectionId>,
+        force: bool,
     ) -> Result<()> {
         let req = AlterConnectorPropsRequest {
             object_id: table_id.as_raw_id(),
@@ -1514,6 +1517,7 @@ impl MetaClient {
                 sink_id,
                 source_id,
             })),
+            force,
         };
         let _resp = self.inner.alter_connector_props(req).await?;
         Ok(())
@@ -1533,6 +1537,7 @@ impl MetaClient {
             connector_conn_ref,
             object_type: AlterConnectorPropsObject::Source as i32,
             extra_options: None,
+            force: false,
         };
         let _resp = self.inner.alter_connector_props(req).await?;
         Ok(())
@@ -1551,6 +1556,7 @@ impl MetaClient {
             connector_conn_ref: None, // Connections don't reference other connections
             object_type: AlterConnectorPropsObject::Connection as i32,
             extra_options: None,
+            force: false,
         };
         let _resp = self.inner.alter_connector_props(req).await?;
         Ok(())

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -124,9 +124,10 @@ pub enum AlterTableOperation {
     /// `DROP CONNECTOR`
     DropConnector,
 
-    /// `ALTER CONNECTOR WITH (<connector_props>)`
+    /// `ALTER CONNECTOR [FORCE] WITH (<connector_props>)`
     AlterConnectorProps {
         alter_props: Vec<SqlOption>,
+        force: bool,
     },
 }
 
@@ -233,6 +234,7 @@ pub enum AlterSinkOperation {
     },
     AlterConnectorProps {
         alter_props: Vec<SqlOption>,
+        force: bool,
     },
     SetStreamingEnableUnalignedJoin {
         enable: bool,
@@ -443,10 +445,11 @@ impl fmt::Display for AlterTableOperation {
             AlterTableOperation::DropConnector => {
                 write!(f, "DROP CONNECTOR")
             }
-            AlterTableOperation::AlterConnectorProps { alter_props } => {
+            AlterTableOperation::AlterConnectorProps { alter_props, force } => {
                 write!(
                     f,
-                    "CONNECTOR WITH ({})",
+                    "CONNECTOR {}WITH ({})",
+                    if *force { "FORCE " } else { "" },
                     display_comma_separated(alter_props)
                 )
             }
@@ -578,10 +581,12 @@ impl fmt::Display for AlterSinkOperation {
             }
             AlterSinkOperation::AlterConnectorProps {
                 alter_props: changed_props,
+                force,
             } => {
                 write!(
                     f,
-                    "CONNECTOR WITH ({})",
+                    "CONNECTOR {}WITH ({})",
+                    if *force { "FORCE " } else { "" },
                     display_comma_separated(changed_props)
                 )
             }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -237,6 +237,7 @@ define_keywords!(
     FLUSH,
     FOLLOWING,
     FOR,
+    FORCE,
     FOREIGN,
     FORMAT,
     FRAGMENT,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3342,9 +3342,11 @@ impl Parser<'_> {
             let target_table = self.parse_object_name()?;
             AlterTableOperation::SwapRenameTable { target_table }
         } else if self.parse_keyword(Keyword::CONNECTOR) {
+            let force = self.parse_keyword(Keyword::FORCE);
             let with_options = self.parse_with_properties()?;
             AlterTableOperation::AlterConnectorProps {
                 alter_props: with_options,
+                force,
             }
         } else {
             return self.expected(
@@ -3657,13 +3659,15 @@ impl Parser<'_> {
             let target_sink = self.parse_object_name()?;
             AlterSinkOperation::SwapRenameSink { target_sink }
         } else if self.parse_keyword(Keyword::CONNECTOR) {
+            let force = self.parse_keyword(Keyword::FORCE);
             let changed_props = self.parse_with_properties()?;
             AlterSinkOperation::AlterConnectorProps {
                 alter_props: changed_props,
+                force,
             }
         } else {
             return self
-                .expected("RENAME or OWNER TO or SET or RESET or CONNECTOR WITH after ALTER SINK");
+                .expected("RENAME or OWNER TO or SET or RESET or CONNECTOR [FORCE] WITH after ALTER SINK");
         };
 
         Ok(Statement::AlterSink {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

This pull request adds support for a `FORCE` option to the `ALTER CONNECTOR ... WITH (...)` statement for both tables and sinks. The main goal is to allow users to bypass property validation checks during connector property alterations when the `FORCE` flag is specified. The change is implemented end-to-end, including SQL parsing, frontend handling, protobuf definitions, RPC, and backend validation logic.

Key changes include:

These changes collectively enable users to forcibly alter connector properties by specifying the `FORCE` keyword, providing greater flexibility for advanced operations while maintaining safe defaults.

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

alter sink s1 connector force with 
Can bypass the whitelist check
