### PR TITLE
refactor(cdc): add configurable total timeout for CDC schema history `putObject`

### DIFF
--- a/src/jni_core/src/opendal_schema_history.rs
+++ b/src/jni_core/src/opendal_schema_history.rs
@@ -22,6 +22,7 @@ use risingwave_common::config::ObjectStoreConfig;
 use risingwave_common::{DATA_DIRECTORY, STATE_STORE_URL};
 use risingwave_object_store::object::object_metrics::GLOBAL_OBJECT_STORE_METRICS;
 use risingwave_object_store::object::{ObjectError, ObjectStoreImpl, build_remote_object_store};
+use thiserror_ext::AsReport;
 use tokio::sync::OnceCell;
 
 use crate::{EnvParam, JAVA_BINDING_ASYNC_RUNTIME, execute_and_catch, to_guarded_slice};
@@ -43,11 +44,11 @@ fn put_object_total_timeout() -> Option<Duration> {
                 Ok(ms) => ms,
                 Err(e) => {
                     tracing::warn!(
-                        "Invalid {}={:?} ({}), falling back to default {}ms",
+                        error = %e.as_report(),
+                        value = %v,
+                        "Invalid {}, falling back to default {}ms",
                         PUT_OBJECT_TOTAL_TIMEOUT_ENV,
-                        v,
-                        e,
-                        DEFAULT_PUT_OBJECT_TOTAL_TIMEOUT_MS
+                        DEFAULT_PUT_OBJECT_TOTAL_TIMEOUT_MS,
                     );
                     DEFAULT_PUT_OBJECT_TOTAL_TIMEOUT_MS
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

### Summary

Debezium expects poll() to return control regularly; when schema history putObject hangs, it can block the connector thread and break that assumption. This PR adds a configurable total timeout around JNI Binding_putObject uploads (default 3s) to fail fast instead of hanging indefinitely.

### Background 
- Debezium [defines](https://github.com/risingwavelabs/debezium/blob/fe174548e9247a5bd878c00d51683aa2fde7cf1b/debezium-core/src/main/java/io/debezium/config/ConfigurationDefaults.java#L15) `ConfigurationDefaults.RETURN_CONTROL_INTERVAL = 5s`, i.e. the max time poll() should block when no events are available. see debezium [source code](https://github.com/risingwavelabs/debezium/blob/fe174548e9247a5bd878c00d51683aa2fde7cf1b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java#L256-L293) 
- In `ChangeEventQueue.poll()`, Debezium explicitly enforces this by creating a timer:
`timeout=min(pollInterval,RETURN_CONTROL_INTERVAL)`

and waiting in a loop:
- isFull.await(remainingTimeoutMillis) until timeout.expired()
- then return records (possibly empty)

This is the mechanism behind the observed “returns empty list every ~5 seconds when idle”.

We saw a customer case where schema history putObject hung (no error). That can stall Debezium’s execution path beyond its intended control-return cadence and trigger internal timeouts/liveness issues.

### What changed
- Wrap object_store.upload(...) in Java_com_risingwave_java_binding_Binding_putObject with a total timeout (tokio::time::timeout).
- Add env var RW_CDC_SCHEMA_HISTORY_PUT_OBJECT_TIMEOUT_MS (ms):
- default: 3000
- 0 disables the total timeout.
### Why not OpenDAL TimeoutLayer
- The JNI path may use different object store backends depending on configuration (OpenDAL vs AWS SDK vs others). A timeout at the JNI boundary is backend-agnostic and provides a hard upper bound for the whole putObject call as observed by Debezium.
- OpenDAL TimeoutLayer would only cover the OpenDAL backend and wouldn’t uniformly protect non-OpenDAL paths or guarantee an end-to-end bound across retries.
### Notes

This PR targets putObject only (hot path that can block Debezium). getObject is unchanged for now.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
