### PR TITLE
fix(optimizer): filter_out_all_null_keys precidate with no stream keys

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1805,13 +1805,15 @@ mod tests {
 
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::{DataType, Datum};
+    use risingwave_expr::aggregate::PbAggKind;
     use risingwave_pb::expr::expr_node::Type;
 
     use super::*;
-    use crate::expr::{FunctionCall, Literal, assert_eq_input_ref};
+    use crate::expr::{AggCall, FunctionCall, Literal, OrderBy, assert_eq_input_ref};
     use crate::optimizer::optimizer_context::OptimizerContext;
-    use crate::optimizer::plan_node::LogicalValues;
+    use crate::optimizer::plan_node::{LogicalAgg, LogicalValues, RewriteStreamContext};
     use crate::optimizer::property::FunctionalDependency;
+    use crate::utils::GroupBy;
 
     /// Pruning
     /// ```text
@@ -2117,6 +2119,80 @@ mod tests {
                 .unwrap(),
             non_eq_cond
         );
+    }
+
+    #[tokio::test]
+    async fn test_full_outer_join_rewrite_with_global_agg_inputs() {
+        let ctx = OptimizerContext::mock().await;
+
+        let schema = Schema {
+            fields: vec![
+                Field::with_name(DataType::Varchar, "key"),
+                Field::with_name(DataType::Int32, "amount"),
+            ],
+        };
+
+        let left_input: PlanRef = LogicalValues::new(vec![], schema.clone(), ctx.clone()).into();
+        let right_input: PlanRef = LogicalValues::new(vec![], schema, ctx).into();
+
+        let max_key = AggCall::new(
+            PbAggKind::Max.into(),
+            vec![InputRef::new(0, DataType::Varchar).into()],
+            false,
+            OrderBy::any(),
+            Condition::true_cond(),
+            vec![],
+        )
+        .unwrap();
+        let sum_amount = AggCall::new(
+            PbAggKind::Sum.into(),
+            vec![InputRef::new(1, DataType::Int32).into()],
+            false,
+            OrderBy::any(),
+            Condition::true_cond(),
+            vec![],
+        )
+        .unwrap();
+
+        let (left_agg, _, _) = LogicalAgg::create(
+            vec![max_key.clone().into(), sum_amount.clone().into()],
+            GroupBy::GroupKey(vec![]),
+            None,
+            left_input,
+        )
+        .unwrap();
+        let (right_agg, _, _) = LogicalAgg::create(
+            vec![max_key.into(), sum_amount.into()],
+            GroupBy::GroupKey(vec![]),
+            None,
+            right_input,
+        )
+        .unwrap();
+
+        assert!(left_agg.expect_stream_key().is_empty());
+        assert!(right_agg.expect_stream_key().is_empty());
+
+        let on = FunctionCall::new(
+            Type::Equal,
+            vec![
+                InputRef::new(0, DataType::Varchar).into(),
+                InputRef::new(2, DataType::Varchar).into(),
+            ],
+        )
+        .unwrap()
+        .into();
+        let join: PlanRef = LogicalJoin::new(
+            left_agg,
+            right_agg,
+            JoinType::FullOuter,
+            Condition::with_expr(on),
+        )
+        .into();
+
+        let (rewritten, _) = join
+            .logical_rewrite_for_stream(&mut RewriteStreamContext::default())
+            .unwrap();
+        assert!(rewritten.as_logical_join().is_some());
     }
 
     /// Convert


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

closes https://github.com/risingwavelabs/risingwave/issues/24790


## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
