### PR TITLE
(ignoreme) test: add hash-join-watermark backward compat test on main (isolation)

### DIFF
--- a/e2e_test/backwards-compat-tests/README.md
+++ b/e2e_test/backwards-compat-tests/README.md
@@ -13,6 +13,7 @@ The backwards compatibility tests run in the following manner:
 
 We currently cover the following:
 1. Basic mv
-2. Nexmark (on rw table not nexmark source)
-3. TPC-H
-4. Kafka Source
+2. Hash join with watermark / EOWC
+3. Nexmark (on rw table not nexmark source)
+4. TPC-H
+5. Kafka Source

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -215,6 +215,12 @@ seed_old_cluster() {
   echo "--- BASIC TEST: Validating old cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/basic/validate_original.slt"
 
+  echo "--- HASH JOIN WATERMARK TEST: Seeding old cluster with data"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hash-join-watermark/seed.slt"
+
+  echo "--- HASH JOIN WATERMARK TEST: Validating old cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hash-join-watermark/validate_original.slt"
+
   echo "--- NEXMARK TEST: Seeding old cluster with data"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/nexmark-backwards-compat/seed.slt"
 
@@ -297,6 +303,9 @@ validate_new_cluster() {
 
   echo "--- BASIC TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/basic/validate_restart.slt"
+
+  echo "--- HASH JOIN WATERMARK TEST: Validating new cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hash-join-watermark/validate_restart.slt"
 
   echo "--- NEXMARK TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/nexmark-backwards-compat/validate_restart.slt"

--- a/e2e_test/backwards-compat-tests/slt/hash-join-watermark/seed.slt
+++ b/e2e_test/backwards-compat-tests/slt/hash-join-watermark/seed.slt
@@ -1,0 +1,79 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+CREATE TABLE hjw_left (
+    id INT,
+    ts TIMESTAMPTZ,
+    v INT,
+    WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+) APPEND ONLY;
+
+statement ok
+CREATE TABLE hjw_right (
+    id INT,
+    ts TIMESTAMPTZ,
+    v INT,
+    WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+) APPEND ONLY;
+
+statement ok
+CREATE MATERIALIZED VIEW hjw_join_mv AS
+SELECT l.id, l.ts, r.v AS rv
+FROM hjw_left l
+JOIN hjw_right r
+ON l.id = r.id AND l.ts = r.ts;
+
+statement ok
+CREATE MATERIALIZED VIEW hjw_eowc_mv AS
+SELECT * FROM hjw_join_mv
+EMIT ON WINDOW CLOSE;
+
+statement ok
+INSERT INTO hjw_right VALUES (1, '2024-01-01 00:00:01+00', 11);
+
+statement ok
+INSERT INTO hjw_left VALUES (1, '2024-01-01 00:00:01+00', 101);
+
+statement ok
+INSERT INTO hjw_right VALUES (1, '2024-01-01 00:00:05+00', 22);
+
+statement ok
+INSERT INTO hjw_left VALUES (1, '2024-01-01 00:00:05+00', 202);
+
+statement ok
+CREATE TABLE bj_left (
+    id INT,
+    ts TIMESTAMPTZ,
+    v INT,
+    WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+) APPEND ONLY;
+
+statement ok
+CREATE TABLE bj_right (
+    id INT,
+    ts TIMESTAMPTZ,
+    v INT,
+    WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+) APPEND ONLY;
+
+statement ok
+CREATE MATERIALIZED VIEW bj_mv AS
+SELECT l.id, l.ts, r.ts AS rts, l.v, r.v AS rv
+FROM bj_left l
+JOIN bj_right r
+ON l.id = r.id
+AND l.ts >= r.ts
+AND l.ts <= r.ts + INTERVAL '2' SECOND;
+
+statement ok
+INSERT INTO bj_right VALUES (1, '2024-01-01 00:00:01+00', 10);
+
+statement ok
+INSERT INTO bj_left VALUES (1, '2024-01-01 00:00:02+00', 100);
+
+statement ok
+INSERT INTO bj_left VALUES (1, '2024-01-01 00:00:05+00', 200);
+
+statement ok
+INSERT INTO bj_right VALUES (1, '2024-01-01 00:00:04+00', 20);

--- a/e2e_test/backwards-compat-tests/slt/hash-join-watermark/validate_original.slt
+++ b/e2e_test/backwards-compat-tests/slt/hash-join-watermark/validate_original.slt
@@ -1,0 +1,16 @@
+query IIT rowsort
+SELECT * FROM hjw_join_mv;
+----
+1 2024-01-01 00:00:01+00:00 11
+1 2024-01-01 00:00:05+00:00 22
+
+query IIT rowsort retry 11 backoff 1s
+SELECT * FROM hjw_eowc_mv;
+----
+1 2024-01-01 00:00:01+00:00 11
+
+query IITII rowsort
+SELECT * FROM bj_mv;
+----
+1 2024-01-01 00:00:02+00:00 2024-01-01 00:00:01+00:00 100 10
+1 2024-01-01 00:00:05+00:00 2024-01-01 00:00:04+00:00 200 20

--- a/e2e_test/backwards-compat-tests/slt/hash-join-watermark/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/hash-join-watermark/validate_restart.slt
@@ -1,0 +1,48 @@
+query IIT rowsort
+SELECT * FROM hjw_join_mv;
+----
+1 2024-01-01 00:00:01+00:00 11
+1 2024-01-01 00:00:05+00:00 22
+
+query IIT rowsort retry 11 backoff 1s
+SELECT * FROM hjw_eowc_mv;
+----
+1 2024-01-01 00:00:01+00:00 11
+
+query IITII rowsort
+SELECT * FROM bj_mv;
+----
+1 2024-01-01 00:00:02+00:00 2024-01-01 00:00:01+00:00 100 10
+1 2024-01-01 00:00:05+00:00 2024-01-01 00:00:04+00:00 200 20
+
+statement ok
+INSERT INTO hjw_right VALUES (1, '2024-01-01 00:00:09+00', 33);
+
+statement ok
+INSERT INTO hjw_left VALUES (1, '2024-01-01 00:00:09+00', 303);
+
+query IIT rowsort
+SELECT * FROM hjw_join_mv;
+----
+1 2024-01-01 00:00:01+00:00 11
+1 2024-01-01 00:00:05+00:00 22
+1 2024-01-01 00:00:09+00:00 33
+
+query IIT rowsort retry 11 backoff 1s
+SELECT * FROM hjw_eowc_mv;
+----
+1 2024-01-01 00:00:01+00:00 11
+1 2024-01-01 00:00:05+00:00 22
+
+statement ok
+INSERT INTO bj_right VALUES (1, '2024-01-01 00:00:07+00', 30);
+
+statement ok
+INSERT INTO bj_left VALUES (1, '2024-01-01 00:00:08+00', 300);
+
+query IITII rowsort
+SELECT * FROM bj_mv;
+----
+1 2024-01-01 00:00:02+00:00 2024-01-01 00:00:01+00:00 100 10
+1 2024-01-01 00:00:05+00:00 2024-01-01 00:00:04+00:00 200 20
+1 2024-01-01 00:00:08+00:00 2024-01-01 00:00:07+00:00 300 30


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Cherry-picked only the backward compatibility test for hash join with watermark / EOWC from branch `12-12-derive_watermark_handle_for_stream_join`, with no Rust code changes.

The purpose is to isolate whether the backward compat test failure (if any) is caused by:
- The test itself having incorrect SQL expectations for unmodified `main` behavior, or
- The feature branch's Rust code changes causing a regression.

If CI passes here, the failure is in the feature branch code. If CI fails here, the test is wrong.

Files added:
- `e2e_test/backwards-compat-tests/slt/hash-join-watermark/seed.slt`
- `e2e_test/backwards-compat-tests/slt/hash-join-watermark/validate_original.slt`
- `e2e_test/backwards-compat-tests/slt/hash-join-watermark/validate_restart.slt`
- Updated `scripts/utils.sh` to invoke the new SLTs
- Updated `README.md` to list the new test

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

N/A — test-only change.

</details>