### PR TITLE
test: fix kafka rate limit flaky test

### DIFF
--- a/e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial
@@ -68,9 +68,9 @@ SET BACKGROUND_DDL=true;
 statement ok
 SET BACKFILL_RATE_LIMIT=0;
 
-statement ok
 # Shared Kafka source can replay records during recovery/reconfiguration.
 # Use DISTINCT here so this test validates rate-limit behavior instead of replay multiplicity.
+statement ok
 create materialized view rl_mv2 as select count(distinct v1) from kafka_source;
 
 sleep 1s


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Whats changed and whats your intention?

This PR is now scoped to the flaky SQLLogicTest only:

- `e2e_test/source_inline/kafka/alter/rate_limit_source_kafka_shared.slt.serial`

The flaky behavior came from timing-sensitive checks (`sleep` + immediate assert) and replay-sensitive counting (`count(*)`) on a shared Kafka source.

Changes:

- Replace fixed waits with `retry ... backoff ...` assertions for eventual consistency.
- Use `count(distinct v1)` instead of `count(*)` so replayed records do not cause false negatives.
- Insert a non-overlapping second batch (`1001..2000`) to ensure post-alter assertions reflect new data only.
- Add an explicit check for resetting `source_rate_limit` to `default`.

Stable invariants checked by this test:

- With `source_rate_limit = 0`, `rl_mv1` stays at `1000` after inserting the second batch.
- After setting `source_rate_limit = 1000`, `rl_mv1` reaches `2000`.
- `rw_rate_limit` reflects the expected SOURCE/SOURCE_BACKFILL limits during each alter step.
- After `set source_rate_limit to default`, the SOURCE rate-limit entry disappears while `rl_mv2` backfill limit remains.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A

</details>
