### PR TITLE
feat(subscription): support altering retention of subscription

### DIFF
--- a/e2e_test/ddl/alter_subscription_retention.slt
+++ b/e2e_test/ddl/alter_subscription_retention.slt
@@ -1,0 +1,53 @@
+statement ok
+create table retention_t (v1 int);
+
+statement ok
+create materialized view retention_mv as select v1 from retention_t;
+
+statement ok
+create subscription retention_sub from retention_mv with (retention = '1D');
+
+# Verify initial retention via rw_subscriptions
+query TI
+select definition, retention_seconds from rw_catalog.rw_subscriptions where name = 'retention_sub';
+----
+CREATE SUBSCRIPTION retention_sub FROM retention_mv WITH (retention = '1D') 86400
+
+# Alter retention using SET RETENTION TO syntax
+statement ok
+alter subscription retention_sub set retention to '2D';
+
+# Verify updated retention via rw_subscriptions
+query TI
+select definition, retention_seconds from rw_catalog.rw_subscriptions where name = 'retention_sub';
+----
+CREATE SUBSCRIPTION retention_sub FROM retention_mv WITH (retention = '2D') 172800
+
+query TT
+show create subscription retention_sub;
+----
+public.retention_sub CREATE SUBSCRIPTION retention_sub FROM retention_mv WITH (retention = '2D')
+
+# Alter retention using SET RETENTION = syntax
+statement ok
+alter subscription retention_sub set retention = '3H';
+
+# Verify updated retention via rw_subscriptions
+query TI
+select definition, retention_seconds from rw_catalog.rw_subscriptions where name = 'retention_sub';
+----
+CREATE SUBSCRIPTION retention_sub FROM retention_mv WITH (retention = '3H') 10800
+
+query TT
+show create subscription retention_sub;
+----
+public.retention_sub CREATE SUBSCRIPTION retention_sub FROM retention_mv WITH (retention = '3H')
+
+statement ok
+drop subscription retention_sub;
+
+statement ok
+drop materialized view retention_mv;
+
+statement ok
+drop table retention_t;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -354,6 +354,17 @@ message AlterOwnerResponse {
   WaitVersion version = 2;
 }
 
+message AlterSubscriptionRetentionRequest {
+  uint32 subscription_id = 1;
+  uint64 retention_seconds = 2;
+  string definition = 3;
+}
+
+message AlterSubscriptionRetentionResponse {
+  common.Status status = 1;
+  WaitVersion version = 2;
+}
+
 message AlterSwapRenameRequest {
   message ObjectNameSwapPair {
     uint32 src_object_id = 1;
@@ -698,6 +709,7 @@ service DdlService {
   rpc AlterSource(AlterSourceRequest) returns (AlterSourceResponse);
   rpc ResetSource(ResetSourceRequest) returns (ResetSourceResponse);
   rpc AlterOwner(AlterOwnerRequest) returns (AlterOwnerResponse);
+  rpc AlterSubscriptionRetention(AlterSubscriptionRetentionRequest) returns (AlterSubscriptionRetentionResponse);
   rpc AlterSetSchema(AlterSetSchemaRequest) returns (AlterSetSchemaResponse);
   rpc AlterParallelism(AlterParallelismRequest) returns (AlterParallelismResponse);
   rpc AlterFragmentParallelism(AlterFragmentParallelismRequest) returns (AlterFragmentParallelismResponse);

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -212,6 +212,13 @@ pub trait CatalogWriter: Send + Sync {
         payload: Vec<u8>,
     ) -> Result<()>;
 
+    async fn alter_subscription_retention(
+        &self,
+        subscription_id: SubscriptionId,
+        retention_seconds: u64,
+        definition: String,
+    ) -> Result<()>;
+
     async fn alter_name(
         &self,
         object_id: alter_name_request::Object,
@@ -678,6 +685,19 @@ impl CatalogWriter for CatalogWriterImpl {
                 owner_id,
                 payload,
             )
+            .await?;
+        self.wait_version(version).await
+    }
+
+    async fn alter_subscription_retention(
+        &self,
+        subscription_id: SubscriptionId,
+        retention_seconds: u64,
+        definition: String,
+    ) -> Result<()> {
+        let version = self
+            .meta_client
+            .alter_subscription_retention(subscription_id, retention_seconds, definition)
             .await?;
         self.wait_version(version).await
     }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_subscriptions.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_subscriptions.rs
@@ -27,6 +27,7 @@ struct RwSubscription {
     schema_id: SchemaId,
     owner: UserId,
     definition: String,
+    retention_seconds: i64,
     acl: Vec<String>,
     initialized_at: Option<Timestamptz>,
     created_at: Option<Timestamptz>,
@@ -55,6 +56,7 @@ fn read_rw_subscriptions_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSub
                     schema_id: schema.id(),
                     owner: subscription.owner,
                     definition: subscription.definition.clone(),
+                    retention_seconds: subscription.retention_seconds as i64,
                     acl: get_acl_items(subscription.id, false, &users, username_map),
                     initialized_at: subscription
                         .initialized_at_epoch

--- a/src/frontend/src/handler/alter_subscription_retention.rs
+++ b/src/frontend/src/handler/alter_subscription_retention.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_sqlparser::ast::{
+    Ident, ObjectName, SqlOption, SqlOptionValue, Statement, Value, WithProperties,
+};
+use risingwave_sqlparser::parser::Parser;
+
+use super::{HandlerArgs, RwPgResponse};
+use crate::Binder;
+use crate::catalog::root_catalog::SchemaPath;
+use crate::error::{ErrorCode, Result};
+use crate::handler::util::convert_interval_to_u64_seconds;
+
+fn retention_value_to_string(retention: &Value) -> Result<String> {
+    match retention {
+        Value::SingleQuotedString(value) => Ok(value.clone()),
+        Value::CstyleEscapedString(value) => Ok(value.value.clone()),
+        Value::Number(value) => Ok(value.clone()),
+        _ => Err(ErrorCode::InvalidParameterValue(
+            "ALTER SUBSCRIPTION SET RETENTION only supports string or numeric literals".to_owned(),
+        )
+        .into()),
+    }
+}
+
+fn update_retention_in_with_properties(with_properties: &mut WithProperties, retention: Value) {
+    if let Some(option) = with_properties
+        .0
+        .iter_mut()
+        .find(|option| option.name.real_value().eq_ignore_ascii_case("retention"))
+    {
+        option.value = SqlOptionValue::Value(retention);
+        return;
+    }
+
+    with_properties.0.push(SqlOption {
+        name: ObjectName(vec![Ident::new_unchecked("retention")]),
+        value: SqlOptionValue::Value(retention),
+    });
+}
+
+fn update_subscription_definition(definition: &str, retention: Value) -> Result<String> {
+    let mut statements = Parser::parse_sql(definition)?;
+    let statement = match statements.as_mut_slice() {
+        [statement] => statement,
+        _ => {
+            return Err(ErrorCode::InternalError(
+                "Subscription definition should contain a single statement.".to_owned(),
+            )
+            .into());
+        }
+    };
+
+    match statement {
+        Statement::CreateSubscription { stmt } => {
+            update_retention_in_with_properties(&mut stmt.with_properties, retention);
+        }
+        _ => {
+            return Err(ErrorCode::InternalError(
+                "Unexpected statement in subscription definition.".to_owned(),
+            )
+            .into());
+        }
+    }
+
+    Ok(statement.to_string())
+}
+
+pub async fn handle_alter_subscription_retention(
+    handler_args: HandlerArgs,
+    subscription_name: ObjectName,
+    retention: Value,
+) -> Result<RwPgResponse> {
+    let session = handler_args.session;
+    let db_name = &session.database();
+    let (schema_name, real_subscription_name) =
+        Binder::resolve_schema_qualified_name(db_name, &subscription_name)?;
+    let search_path = session.config().search_path();
+    let user_name = &session.user_name();
+    let schema_path = SchemaPath::new(schema_name.as_deref(), &search_path, user_name);
+
+    let subscription = {
+        let reader = session.env().catalog_reader().read_guard();
+        let (subscription, schema_name) =
+            reader.get_subscription_by_name(db_name, schema_path, &real_subscription_name)?;
+        session.check_privilege_for_drop_alter(schema_name, &**subscription)?;
+        subscription.clone()
+    };
+
+    let retention_value = retention_value_to_string(&retention)?;
+    let retention_seconds = convert_interval_to_u64_seconds(&retention_value)?;
+    let new_definition = update_subscription_definition(&subscription.definition, retention)?;
+
+    let catalog_writer = session.catalog_writer()?;
+    catalog_writer
+        .alter_subscription_retention(subscription.id, retention_seconds, new_definition)
+        .await?;
+
+    Ok(PgResponse::empty_result(StatementType::ALTER_SUBSCRIPTION))
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_sqlparser::ast::Value;
+
+    use super::update_subscription_definition;
+
+    #[test]
+    fn test_update_subscription_definition() {
+        let definition = "CREATE SUBSCRIPTION sub FROM mv WITH (retention = '1D')";
+        let updated =
+            update_subscription_definition(definition, Value::SingleQuotedString("2H".to_owned()))
+                .unwrap();
+        assert_eq!(
+            updated,
+            "CREATE SUBSCRIPTION sub FROM mv WITH (retention = '2H')"
+        );
+    }
+}

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -58,6 +58,7 @@ mod alter_source_with_sr;
 mod alter_streaming_config;
 mod alter_streaming_enable_unaligned_join;
 mod alter_streaming_rate_limit;
+mod alter_subscription_retention;
 mod alter_swap_rename;
 mod alter_system;
 mod alter_table_column;
@@ -1225,6 +1226,14 @@ pub async fn handle(
                     new_schema_name,
                     StatementType::ALTER_SUBSCRIPTION,
                     None,
+                )
+                .await
+            }
+            AlterSubscriptionOperation::SetRetention { retention } => {
+                alter_subscription_retention::handle_alter_subscription_retention(
+                    handler_args,
+                    name,
+                    retention,
                 )
                 .await
             }

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -909,6 +909,29 @@ impl DdlService for DdlServiceImpl {
         }))
     }
 
+    async fn alter_subscription_retention(
+        &self,
+        request: Request<AlterSubscriptionRetentionRequest>,
+    ) -> Result<Response<AlterSubscriptionRetentionResponse>, Status> {
+        let AlterSubscriptionRetentionRequest {
+            subscription_id,
+            retention_seconds,
+            definition,
+        } = request.into_inner();
+        let version = self
+            .ddl_controller
+            .run_command(DdlCommand::AlterSubscriptionRetention {
+                subscription_id,
+                retention_seconds,
+                definition,
+            })
+            .await?;
+        Ok(Response::new(AlterSubscriptionRetentionResponse {
+            status: None,
+            version,
+        }))
+    }
+
     async fn alter_set_schema(
         &self,
         request: Request<AlterSetSchemaRequest>,

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -270,6 +270,7 @@ impl CheckpointControl {
                     | Command::SourceChangeSplit(_)
                     | Command::Throttle { .. }
                     | Command::CreateSubscription { .. }
+                    | Command::AlterSubscriptionRetention { .. }
                     | Command::ConnectorPropsChange(_)
                     | Command::Refresh { .. }
                     | Command::ListFinish { .. }

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -243,6 +243,17 @@ impl DatabaseCheckpointControl {
                     SubscriberType::Subscription(*retention_second),
                 );
             }
+            Some(Command::AlterSubscriptionRetention {
+                subscription_id,
+                upstream_mv_table_id,
+                retention_second,
+            }) => {
+                self.database_info.update_subscription_retention(
+                    upstream_mv_table_id.as_job_id(),
+                    subscription_id.as_subscriber_id(),
+                    *retention_second,
+                );
+            }
             Some(Command::CreateStreamingJob {
                 info,
                 job_type: CreateStreamingJobType::SnapshotBackfill(snapshot_backfill_info),

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -377,6 +377,13 @@ pub enum Command {
         upstream_mv_table_id: TableId,
     },
 
+    /// `AlterSubscriptionRetention` command updates the subscription retention time.
+    AlterSubscriptionRetention {
+        subscription_id: SubscriptionId,
+        upstream_mv_table_id: TableId,
+        retention_second: u64,
+    },
+
     ConnectorPropsChange(ConnectorPropsChange),
 
     /// `Refresh` command generates a barrier to refresh a table by truncating state
@@ -453,6 +460,14 @@ impl std::fmt::Display for Command {
             Command::DropSubscription {
                 subscription_id, ..
             } => write!(f, "DropSubscription: {subscription_id}"),
+            Command::AlterSubscriptionRetention {
+                subscription_id,
+                retention_second,
+                ..
+            } => write!(
+                f,
+                "AlterSubscriptionRetention: {subscription_id} -> {retention_second}"
+            ),
             Command::ConnectorPropsChange(_) => write!(f, "ConnectorPropsChange"),
             Command::Refresh {
                 table_id,
@@ -656,6 +671,7 @@ impl Command {
             Command::Throttle { .. } => None,
             Command::CreateSubscription { .. } => None,
             Command::DropSubscription { .. } => None,
+            Command::AlterSubscriptionRetention { .. } => None,
             Command::ConnectorPropsChange(_) => None,
             Command::Refresh { .. } => None, // Refresh doesn't change fragment structure
             Command::ListFinish { .. } => None, // ListFinish doesn't change fragment structure
@@ -759,6 +775,9 @@ impl Command {
             Command::CreateSubscription {
                 subscription_id, ..
             } => PostCollectCommand::CreateSubscription { subscription_id },
+            Command::AlterSubscriptionRetention { .. } => {
+                PostCollectCommand::Command("AlterSubscriptionRetention".to_owned())
+            }
             Command::ConnectorPropsChange(connector_props_change) => {
                 PostCollectCommand::ConnectorPropsChange(connector_props_change)
             }
@@ -1394,6 +1413,7 @@ impl Command {
                     upstream_mv_table_id: *upstream_mv_table_id,
                 }],
             })),
+            Command::AlterSubscriptionRetention { .. } => None,
             Command::ConnectorPropsChange(config) => {
                 let mut connector_props_infos = HashMap::default();
                 for (k, v) in config {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -840,6 +840,30 @@ impl InflightDatabaseInfo {
             .remove(&subscriber_id)
     }
 
+    pub fn update_subscription_retention(
+        &mut self,
+        job_id: JobId,
+        subscriber_id: SubscriberId,
+        retention_second: u64,
+    ) {
+        let job = self.jobs.get_mut(&job_id).expect("should exist");
+        match job.subscribers.get_mut(&subscriber_id) {
+            Some(SubscriberType::Subscription(current_retention)) => {
+                *current_retention = retention_second;
+            }
+            Some(SubscriberType::SnapshotBackfill) => {
+                warn!(
+                    %job_id,
+                    %subscriber_id,
+                    "cannot update retention for snapshot backfill subscriber"
+                );
+            }
+            None => {
+                warn!(%job_id, %subscriber_id, "subscription subscriber not found");
+            }
+        }
+    }
+
     fn fragment_mut(&mut self, fragment_id: FragmentId) -> (&mut InflightFragmentInfo, JobId) {
         let job_id = self.fragment_location[&fragment_id];
         let fragment = self
@@ -1118,6 +1142,7 @@ impl InflightDatabaseInfo {
                 | Command::Throttle { .. }
                 | Command::CreateSubscription { .. }
                 | Command::DropSubscription { .. }
+                | Command::AlterSubscriptionRetention { .. }
                 | Command::ConnectorPropsChange(_)
                 | Command::Refresh { .. }
                 | Command::ListFinish { .. }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -187,6 +187,11 @@ pub enum DdlCommand {
     CommentOn(Comment),
     CreateSubscription(Subscription),
     DropSubscription(SubscriptionId, DropMode),
+    AlterSubscriptionRetention {
+        subscription_id: SubscriptionId,
+        retention_seconds: u64,
+        definition: String,
+    },
     AlterDatabaseParam(DatabaseId, AlterDatabaseParam),
     AlterStreamingJobConfig(JobId, HashMap<String, String>, Vec<String>),
 }
@@ -223,6 +228,9 @@ impl DdlCommand {
             DdlCommand::CommentOn(comment) => Right(comment.table_id.into()),
             DdlCommand::CreateSubscription(subscription) => Left(subscription.name.clone()),
             DdlCommand::DropSubscription(id, _) => Right(id.as_object_id()),
+            DdlCommand::AlterSubscriptionRetention {
+                subscription_id, ..
+            } => Right(subscription_id.as_object_id()),
             DdlCommand::AlterDatabaseParam(id, _) => Right(id.as_object_id()),
             DdlCommand::AlterStreamingJobConfig(job_id, _, _) => Right(job_id.as_object_id()),
         }
@@ -252,7 +260,8 @@ impl DdlCommand {
             | DdlCommand::AlterSecret(_)
             | DdlCommand::AlterSwapRename(_)
             | DdlCommand::AlterDatabaseParam(_, _)
-            | DdlCommand::AlterStreamingJobConfig(_, _, _) => true,
+            | DdlCommand::AlterStreamingJobConfig(_, _, _)
+            | DdlCommand::AlterSubscriptionRetention { .. } => true,
             DdlCommand::CreateStreamingJob { .. }
             | DdlCommand::CreateNonSharedSource(_)
             | DdlCommand::ReplaceStreamJob(_)
@@ -463,6 +472,18 @@ impl DdlController {
                 }
                 DdlCommand::DropSubscription(subscription_id, drop_mode) => {
                     ctrl.drop_subscription(subscription_id, drop_mode).await
+                }
+                DdlCommand::AlterSubscriptionRetention {
+                    subscription_id,
+                    retention_seconds,
+                    definition,
+                } => {
+                    ctrl.alter_subscription_retention(
+                        subscription_id,
+                        retention_seconds,
+                        definition,
+                    )
+                    .await
                 }
                 DdlCommand::AlterSwapRename(objects) => ctrl.alter_swap_rename(objects).await,
                 DdlCommand::AlterDatabaseParam(database_id, param) => {
@@ -827,6 +848,31 @@ impl DdlController {
             .drop_subscription(database_id, subscription_id, table_id)
             .await;
         tracing::debug!("finish drop subscription");
+        Ok(version)
+    }
+
+    async fn alter_subscription_retention(
+        &self,
+        subscription_id: SubscriptionId,
+        retention_seconds: u64,
+        definition: String,
+    ) -> MetaResult<NotificationVersion> {
+        tracing::debug!("alter subscription retention");
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock_read_guard().await;
+        let (version, subscription) = self
+            .metadata_manager
+            .catalog_controller
+            .alter_subscription_retention(subscription_id, retention_seconds, definition)
+            .await?;
+        self.stream_manager
+            .alter_subscription_retention(
+                subscription.database_id,
+                subscription.id,
+                subscription.dependent_table_id,
+                subscription.retention_seconds,
+            )
+            .await?;
+        tracing::debug!("finish alter subscription retention");
         Ok(version)
     }
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -922,4 +922,24 @@ impl GlobalStreamManager {
                 tracing::error!(error = ?err.as_report(), "failed to run drop command");
             });
     }
+
+    pub async fn alter_subscription_retention(
+        self: &Arc<Self>,
+        database_id: DatabaseId,
+        subscription_id: SubscriptionId,
+        table_id: TableId,
+        retention_second: u64,
+    ) -> MetaResult<()> {
+        let command = Command::AlterSubscriptionRetention {
+            subscription_id,
+            upstream_mv_table_id: table_id,
+            retention_second,
+        };
+
+        tracing::debug!("sending Command::AlterSubscriptionRetention");
+        self.barrier_scheduler
+            .run_command(database_id, command)
+            .await?;
+        Ok(())
+    }
 }

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -244,6 +244,9 @@ for_all_wrapped_id_fields! (
         AlterStreamingJobConfigRequest {
             job_id: JobId,
         }
+        AlterSubscriptionRetentionRequest {
+            subscription_id: SubscriptionId,
+        }
         AlterSwapRenameRequest.ObjectNameSwapPair {
             src_object_id: ObjectId,
             dst_object_id: ObjectId,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -577,6 +577,23 @@ impl MetaClient {
             .ok_or_else(|| anyhow!("wait version not set"))?)
     }
 
+    pub async fn alter_subscription_retention(
+        &self,
+        subscription_id: SubscriptionId,
+        retention_seconds: u64,
+        definition: String,
+    ) -> Result<WaitVersion> {
+        let request = AlterSubscriptionRetentionRequest {
+            subscription_id,
+            retention_seconds,
+            definition,
+        };
+        let resp = self.inner.alter_subscription_retention(request).await?;
+        Ok(resp
+            .version
+            .ok_or_else(|| anyhow!("wait version not set"))?)
+    }
+
     pub async fn alter_database_param(
         &self,
         database_id: DatabaseId,
@@ -2591,6 +2608,7 @@ macro_rules! for_all_meta_rpc {
             ,{ ddl_client, create_table, CreateTableRequest, CreateTableResponse }
             ,{ ddl_client, alter_name, AlterNameRequest, AlterNameResponse }
             ,{ ddl_client, alter_owner, AlterOwnerRequest, AlterOwnerResponse }
+            ,{ ddl_client, alter_subscription_retention, AlterSubscriptionRetentionRequest, AlterSubscriptionRetentionResponse }
             ,{ ddl_client, alter_set_schema, AlterSetSchemaRequest, AlterSetSchemaResponse }
             ,{ ddl_client, alter_parallelism, AlterParallelismRequest, AlterParallelismResponse }
             ,{ ddl_client, alter_streaming_job_config, AlterStreamingJobConfigRequest, AlterStreamingJobConfigResponse }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -244,6 +244,7 @@ pub enum AlterSubscriptionOperation {
     RenameSubscription { subscription_name: ObjectName },
     ChangeOwner { new_owner_name: Ident },
     SetSchema { new_schema_name: ObjectName },
+    SetRetention { retention: Value },
     SwapRenameSubscription { target_subscription: ObjectName },
 }
 
@@ -603,6 +604,9 @@ impl fmt::Display for AlterSubscriptionOperation {
             }
             AlterSubscriptionOperation::SetSchema { new_schema_name } => {
                 write!(f, "SET SCHEMA {}", new_schema_name)
+            }
+            AlterSubscriptionOperation::SetRetention { retention } => {
+                write!(f, "SET RETENTION TO {}", retention)
             }
             AlterSubscriptionOperation::SwapRenameSubscription {
                 target_subscription,

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -425,6 +425,7 @@ define_keywords!(
     RESOURCE_GROUP,
     RESTRICT,
     RESULT,
+    RETENTION,
     RETURN,
     RETURNING,
     RETURNS,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3692,8 +3692,16 @@ impl Parser<'_> {
                 AlterSubscriptionOperation::SetSchema {
                     new_schema_name: schema_name,
                 }
+            } else if self.parse_keyword(Keyword::RETENTION) {
+                if self.expect_keyword(Keyword::TO).is_err()
+                    && self.expect_token(&Token::Eq).is_err()
+                {
+                    return self.expected("TO or = after ALTER SUBSCRIPTION SET RETENTION");
+                }
+                let retention = self.ensure_parse_value()?;
+                AlterSubscriptionOperation::SetRetention { retention }
             } else {
-                return self.expected("SCHEMA after SET");
+                return self.expected("SCHEMA or RETENTION after SET");
             }
         } else if self.parse_keywords(&[Keyword::SWAP, Keyword::WITH]) {
             let target_subscription = self.parse_object_name()?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

resolve https://github.com/risingwavelabs/risingwave/issues/24806

This pull request introduces support for altering the retention period of subscriptions, allowing users to modify how long data is retained for a subscription after its creation. The changes span frontend, meta, and protocol layers, and include updates to system catalog, handler logic, and barrier processing to ensure the new retention value is properly propagated and reflected in system state.

**Subscription Retention Alteration Feature**

* Added a new handler `handle_alter_subscription_retention` to process `ALTER SUBSCRIPTION ... SET RETENTION` statements, updating the subscription definition and retention value. [[1]](diffhunk://#diff-3a138e2f24d9337c82a7ace46aba1ce43369befe95c68da4fa87609abbe3bcfcR1-R132) [[2]](diffhunk://#diff-70a2725b113a59baf55f0026f752219116db73cdef1b03ce3899b39fc2604ab4R61) [[3]](diffhunk://#diff-70a2725b113a59baf55f0026f752219116db73cdef1b03ce3899b39fc2604ab4R1232-R1239)
* Updated `CatalogWriter` trait and its implementations (`CatalogWriterImpl`, `MockCatalogWriter`) to support altering subscription retention, including updating the system catalog and propagating changes. [[1]](diffhunk://#diff-d212ff90b6f07b0c132b3c011e0fb4339cd2dc85c84742c594fa69e5d2cb6736R215-R221) [[2]](diffhunk://#diff-d212ff90b6f07b0c132b3c011e0fb4339cd2dc85c84742c594fa69e5d2cb6736R692-R704) [[3]](diffhunk://#diff-a9cecbeb9812b30397f23c96ac8bff466f80161c37bba0139fed0370492f4038R666-R689)
* Extended the protocol buffer definition (`proto/ddl_service.proto`) and `DdlService` to add `AlterSubscriptionRetentionRequest`/`Response` and the corresponding RPC method, enabling communication between frontend and meta services. [[1]](diffhunk://#diff-3b7ae501e30bb5af3963f86bd1df04ff1c5b7fb81d44c381a8266259a233e70cR357-R367) [[2]](diffhunk://#diff-3b7ae501e30bb5af3963f86bd1df04ff1c5b7fb81d44c381a8266259a233e70cR712) [[3]](diffhunk://#diff-6d6a3906f0c7c782273f1310c8497646663a548615d2f2afaf9fe7449cb63187R912-R934)

**System Catalog and Testing**

* Updated the `RwSubscription` struct and its catalog reading logic to include `retention_seconds`, ensuring the retention value is stored and retrievable from system catalog tables. [[1]](diffhunk://#diff-71e4b085fe29149fb1dc8e8a1ca479d18b43a8009fbb132ef50c696d3ba0b7c6R30) [[2]](diffhunk://#diff-71e4b085fe29149fb1dc8e8a1ca479d18b43a8009fbb132ef50c696d3ba0b7c6R59)
* Added an end-to-end test (`alter_subscription_retention.slt`) to verify creating, altering, and dropping subscriptions with various retention values.

**Barrier and State Propagation**

* Introduced a new `AlterSubscriptionRetention` command to the barrier processing system, ensuring retention changes are correctly applied to inflight database info and checkpoint control. [[1]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R380-R386) [[2]](diffhunk://#diff-5f6b313dd47a23ea5663db1b68de3ed3938e8e5829e484c4b76c79afbfdfcec9R273) [[3]](diffhunk://#diff-44229b137399d20ef70c07c7f928527ec494356b08b98ac0e68c6ccf7b3371b0R246-R256) [[4]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2R843-R866) [[5]](diffhunk://#diff-e11afa43355e6c4dd8488b3c725ffd7db527882de703c2ca2c53acc79b9054d2R1145)
* Updated display, fragment change, and post-collect logic for the new command to ensure proper tracking and logging. [[1]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R463-R470) [[2]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R674) [[3]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R778-R780) [[4]](diffhunk://#diff-30b031080778ca36f6e37c4769dd8941f9555643e0bab4f357c417a5093efc19R1416)

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
