### PR TITLE
chore: clarify generated alter-on-fly update path

### DIFF
--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -14,6 +14,13 @@
 
 // THIS FILE IS AUTO_GENERATED. DO NOT EDIT
 // UPDATE WITH: ./risedev generate-with-options
+// This file is rewritten by `tests::test_allow_alter_on_fly_fields_rust_up_to_date` with
+// `UPDATE_EXPECT=1`.
+// To update content, change source/sink/connection WITH options definitions (for example,
+// `#[with_option(allow_alter_on_fly)]` on struct fields), then run `./risedev generate-with-options`.
+// `./risedev generate-with-options` runs two UPDATE_EXPECT tests:
+// 1) refresh `with_options_{source,sink,connection}.yaml`;
+// 2) regenerate this file from those YAML files.
 
 #![rustfmt::skip]
 

--- a/src/connector/src/with_options_test.rs
+++ b/src/connector/src/with_options_test.rs
@@ -532,6 +532,13 @@ fn generate_rust_allow_alter_on_fly_fields_code_separate(
 
 // THIS FILE IS AUTO_GENERATED. DO NOT EDIT
 // UPDATE WITH: ./risedev generate-with-options
+// This file is rewritten by `tests::test_allow_alter_on_fly_fields_rust_up_to_date` with
+// `UPDATE_EXPECT=1`.
+// To update content, change source/sink/connection WITH options definitions (for example,
+// `#[with_option(allow_alter_on_fly)]` on struct fields), then run `./risedev generate-with-options`.
+// `./risedev generate-with-options` runs two UPDATE_EXPECT tests:
+// 1) refresh `with_options_{{source,sink,connection}}.yaml`;
+// 2) regenerate this file from those YAML files.
 
 #![rustfmt::skip]
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What is changed and what is your intention?

Added explicit header notes to the generated `allow_alter_on_fly_fields.rs` file and to its generator template in `with_options_test.rs`. The notes explain that `allow_alter_on_fly_fields.rs` must not be edited directly, that `test_allow_alter_on_fly_fields_rust_up_to_date` rewrites it with `UPDATE_EXPECT=1`, and that updates should come from source/sink/connection WITH options definitions (such as `#[with_option(allow_alter_on_fly)]`). They also document that `./risedev generate-with-options` first refreshes `with_options_{source,sink,connection}.yaml` and then regenerates the Rust file.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>


</details>
