### PR TITLE
feat: resolve create job intent in barrier worker

### DIFF
--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -147,21 +147,25 @@ impl DatabaseCheckpointControl {
         debug_assert!(
             !matches!(
                 command,
-                Some(Command::RescheduleIntent {
-                    reschedule_plan: None,
-                    ..
-                })
+                Some(
+                    Command::RescheduleIntent {
+                        reschedule_plan: None,
+                        ..
+                    } | Command::CreateStreamingJobIntent { .. }
+                )
             ),
-            "reschedule intent must be resolved before apply"
+            "intent command must be resolved before apply"
         );
         if matches!(
             command,
-            Some(Command::RescheduleIntent {
-                reschedule_plan: None,
-                ..
-            })
+            Some(
+                Command::RescheduleIntent {
+                    reschedule_plan: None,
+                    ..
+                } | Command::CreateStreamingJobIntent { .. }
+            )
         ) {
-            bail!("reschedule intent must be resolved before apply");
+            bail!("intent command must be resolved before apply");
         }
         let mut edges = self
             .database_info

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -1114,6 +1114,7 @@ impl InflightDatabaseInfo {
                 | Command::Resume
                 | Command::DropStreamingJobs { .. }
                 | Command::RescheduleIntent { .. }
+                | Command::CreateStreamingJobIntent { .. }
                 | Command::SourceChangeSplit { .. }
                 | Command::Throttle { .. }
                 | Command::CreateSubscription { .. }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -52,8 +52,9 @@ use risingwave_common::id::JobId;
 use risingwave_pb::ddl_service::PbBackfillType;
 
 pub use self::command::{
-    BarrierKind, Command, CreateStreamingJobCommandInfo, CreateStreamingJobType,
-    ReplaceStreamJobPlan, Reschedule, ReschedulePlan, ResumeBackfillTarget, SnapshotBackfillInfo,
+    BarrierKind, Command, CreateStreamingJobCommandInfo, CreateStreamingJobIntentContext,
+    CreateStreamingJobType, ReplaceStreamJobPlan, Reschedule, ReschedulePlan, ResumeBackfillTarget,
+    SnapshotBackfillInfo,
 };
 pub(crate) use self::info::{SharedActorInfos, SharedFragmentInfo};
 pub use self::manager::{BarrierManagerRef, GlobalBarrierManager};

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -225,15 +225,20 @@ impl BarrierScheduler {
             return false;
         };
 
-        if let Some(idx) = queue.queue.inner.iter().position(|scheduled| {
-            if let Command::CreateStreamingJob { info, .. } = &scheduled.command
-                && info.stream_job_fragments.stream_job_id() == job_id
-            {
-                true
-            } else {
-                false
-            }
-        }) {
+        if let Some(idx) = queue
+            .queue
+            .inner
+            .iter()
+            .position(|scheduled| match &scheduled.command {
+                Command::CreateStreamingJob { info, .. } => {
+                    info.stream_job_fragments.stream_job_id() == job_id
+                }
+                Command::CreateStreamingJobIntent { context, .. } => {
+                    context.stream_job_fragments.stream_job_id() == job_id
+                }
+                _ => false,
+            })
+        {
             queue.queue.inner.remove(idx).unwrap();
             true
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR migrates create streaming job barrier flow from eager command payloads to an intent-based rendering path aligned with `RescheduleIntent`.
`GlobalStreamManager` now emits `CreateStreamingJobIntent` with metadata loaded from meta store, and `GlobalBarrierWorker` resolves it to `CreateStreamingJob` immediately before injection.
It also adds intent-safety guards in checkpoint/apply paths, updates queued-create cancellation to support intent commands, and wires the new intent variant through command matching, display, and exports.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>


</details>
