### PR TITLE
fix(mysql-cdc): fix MySQL CDC auto schema change for UNSIGNED integer types

### DIFF
--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
@@ -9,12 +9,13 @@ mysql -e "
     DROP TABLE IF EXISTS customers;
     CREATE TABLE customers(
          id BIGINT PRIMARY KEY,
+         ubig BIGINT UNSIGNED,
          modified DATETIME,
          name VARCHAR(32),
          custinfo JSON
     );
-    INSERT INTO customers VALUES(1, NOW(), 'John', NULL);
-    INSERT INTO customers VALUES(2, NOW(), 'Doe', NULL);
+    INSERT INTO customers VALUES(1, 18446744073709551615, NOW(), 'John', NULL);
+    INSERT INTO customers VALUES(2, 0, NOW(), 'Doe', NULL);
     ALTER TABLE customers ADD INDEX zipsa( (CAST(custinfo->'zipcode' AS UNSIGNED ARRAY)) );
     "
 
@@ -31,13 +32,14 @@ create source mysql_source with (
 );
 
 statement ok
-create table rw_customers (id bigint, modified timestamp, name varchar, custinfo jsonb, primary key (id)) from mysql_source table 'mytest.customers';
+create table rw_customers (id bigint, ubig numeric, modified timestamp, name varchar, custinfo jsonb, primary key (id)) from mysql_source table 'mytest.customers';
 
 # Name, Type, Is Hidden, Description
 query TTTT
 describe rw_customers;
 ----
 id bigint false NULL
+ubig numeric false NULL
 modified timestamp without time zone false NULL
 name character varying false NULL
 custinfo jsonb false NULL
@@ -47,10 +49,10 @@ distribution key id NULL NULL
 table description rw_customers NULL NULL
 
 query IT retry 4 backoff 1s
-select id,name from rw_customers order by id;
+select id,ubig,name from rw_customers order by id;
 ----
-1 John
-2 Doe
+1 18446744073709551615 John
+2 0 Doe
 
 # add column
 system ok
@@ -66,6 +68,7 @@ query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
 id bigint false NULL
+ubig numeric false NULL
 modified timestamp without time zone false NULL
 name character varying false NULL
 custinfo jsonb false NULL
@@ -77,10 +80,10 @@ distribution key id NULL NULL
 table description rw_customers NULL NULL
 
 query TTTT
-select id,v1,v2,name from rw_customers order by id;
+select id,ubig,v1,v2,name from rw_customers order by id;
 ----
-1 hello 88.9 John
-2 hello 88.9 Doe
+1 18446744073709551615 hello 88.9 John
+2 0 hello 88.9 Doe
 
 # rename column on upstream will not be replicated, since we do not support rename column
 system ok
@@ -96,6 +99,7 @@ query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
 id bigint false NULL
+ubig numeric false NULL
 modified timestamp without time zone false NULL
 name character varying false NULL
 custinfo jsonb false NULL
@@ -129,6 +133,7 @@ query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
 id bigint false NULL
+ubig numeric false NULL
 name character varying false NULL
 custinfo jsonb false NULL
 _rw_timestamp timestamp with time zone true NULL


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
- Fix MySQL CDC auto schema change failing on Debezium typeName like BIGINT UNSIGNED / INT UNSIGNED by normalizing qualified type names and mapping UNSIGNED integer family to safe RisingWave types.
- Map BIGINT UNSIGNED to DECIMAL to avoid overflow beyond i64, and promote other UNSIGNED ints to wider signed types when needed.


Related:
* #23278 (cherry-pick [#23616](https://github.com/risingwavelabs/risingwave/pull/23616))
* #23244

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
