### PR TITLE
fix(cdc): prevent concurrent schema history writes for the same source

### DIFF
--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/internal/OpendalSchemaHistory.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/internal/OpendalSchemaHistory.java
@@ -38,7 +38,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -46,6 +48,18 @@ import org.slf4j.LoggerFactory;
 
 public class OpendalSchemaHistory extends AbstractFileBasedSchemaHistory {
     private static final Logger LOGGER = LoggerFactory.getLogger(OpendalSchemaHistory.class);
+
+    /**
+     * Process-wide lock map to serialize schema history object-store operations per source id.
+     *
+     * <p>Goal: for the same {@code sourceId}, at any point in time, only one {@link
+     * OpendalSchemaHistory} instance is allowed to write schema history to the object store (and we
+     * also serialize start-time initialization reads to avoid observing/deriving state concurrently
+     * with writes).
+     */
+    private static final ConcurrentHashMap<String, ReentrantLock> SOURCE_LOCKS =
+            new ConcurrentHashMap<>();
+
     private String sourceId = "";
     public static final String SOURCE_ID = "schema.history.internal.source.id";
     public static final String MAX_RECORDS_PER_FILE_CONFIG =
@@ -63,6 +77,12 @@ public class OpendalSchemaHistory extends AbstractFileBasedSchemaHistory {
 
     // Atomic sequence number for thread-safe increment
     private AtomicLong sequenceNumber = new AtomicLong(0);
+
+    private ReentrantLock sourceLock() {
+        // configure() validates sourceId is present, and Debezium calls start/store after
+        // configure.
+        return SOURCE_LOCKS.computeIfAbsent(sourceId, ignored -> new ReentrantLock());
+    }
 
     // Override ALL_FIELDS to include our custom configuration fields
     // This ensures that our custom fields are properly validated by Debezium
@@ -124,23 +144,32 @@ public class OpendalSchemaHistory extends AbstractFileBasedSchemaHistory {
 
     @Override
     protected void doStart() {
+        final ReentrantLock lock = sourceLock();
         try {
-            // 1. List and sort history files by sequence number
-            List<String> historyFiles = listAndSortHistoryFiles();
+            lock.lockInterruptibly();
+            try {
+                // 1. List and sort history files by sequence number
+                List<String> historyFiles = listAndSortHistoryFiles();
 
-            // 2. Initialize sequence number from existing files
-            initializeSequenceNumber(historyFiles);
+                // 2. Initialize sequence number from existing files
+                initializeSequenceNumber(historyFiles);
 
-            // 3. Load all records and initialize cache
-            // loadAllHistoryRecords will also initialize the cache for the latest file
-            this.records = loadAllHistoryRecords(historyFiles);
+                // 3. Load all records and initialize cache
+                // loadAllHistoryRecords will also initialize the cache for the latest file
+                this.records = loadAllHistoryRecords(historyFiles);
 
-            LOGGER.info(
-                    "Loaded schema history with {} total records from {} files. Current sequence number: {}",
-                    this.records.size(),
-                    historyFiles.size(),
-                    sequenceNumber.get());
-
+                LOGGER.info(
+                        "Loaded schema history with {} total records from {} files. Current sequence number: {}",
+                        this.records.size(),
+                        historyFiles.size(),
+                        sequenceNumber.get());
+            } finally {
+                lock.unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SchemaHistoryException(
+                    "Interrupted while initializing schema history for source id " + sourceId, e);
         } catch (Exception e) {
             throw new SchemaHistoryException("Failed to initialize schema history", e);
         }
@@ -155,35 +184,47 @@ public class OpendalSchemaHistory extends AbstractFileBasedSchemaHistory {
     @Override
     protected void doStoreRecord(HistoryRecord record) {
         LOGGER.info("Storing new schema history record.");
+        final ReentrantLock lock = sourceLock();
         try {
-            // Use cached information to avoid expensive list operations and getObject() calls
-            if (cachedLatestFile != null && cachedLatestFileRecords.size() < maxRecordsPerFile) {
-                // 1. Append to existing file using cached records (no getObject() needed!)
-                cachedLatestFileRecords.add(record);
-                putObject(cachedLatestFile, fromHistoryRecords(cachedLatestFileRecords));
+            lock.lockInterruptibly();
+            try {
+                // Use cached information to avoid expensive list operations and getObject() calls
+                if (cachedLatestFile != null
+                        && cachedLatestFileRecords.size() < maxRecordsPerFile) {
+                    // 1. Append to existing file using cached records (no getObject() needed!)
+                    cachedLatestFileRecords.add(record);
+                    putObject(cachedLatestFile, fromHistoryRecords(cachedLatestFileRecords));
 
-                LOGGER.info(
-                        "Appended record to existing file: {} (now {} records)",
-                        cachedLatestFile,
-                        cachedLatestFileRecords.size());
-            } else {
-                // 2. Create new file with next sequence number when current file is full or doesn't
-                // exist
-                long nextSequence = sequenceNumber.incrementAndGet();
-                String newFile = String.format("%s/schema_history_%d.dat", objectDir, nextSequence);
-                List<HistoryRecord> newRecords = new ArrayList<>();
-                newRecords.add(record);
-                putObject(newFile, fromHistoryRecords(newRecords));
+                    LOGGER.info(
+                            "Appended record to existing file: {} (now {} records)",
+                            cachedLatestFile,
+                            cachedLatestFileRecords.size());
+                } else {
+                    // 2. Create new file with next sequence number when current file is full or
+                    // doesn't exist
+                    long nextSequence = sequenceNumber.incrementAndGet();
+                    String newFile =
+                            String.format("%s/schema_history_%d.dat", objectDir, nextSequence);
+                    List<HistoryRecord> newRecords = new ArrayList<>();
+                    newRecords.add(record);
+                    putObject(newFile, fromHistoryRecords(newRecords));
 
-                // Update cache to point to new file
-                cachedLatestFile = newFile;
-                cachedLatestFileRecords = newRecords;
+                    // Update cache to point to new file
+                    cachedLatestFile = newFile;
+                    cachedLatestFileRecords = newRecords;
 
-                LOGGER.info(
-                        "Created new schema history file: {} (sequence: {})",
-                        newFile,
-                        nextSequence);
+                    LOGGER.info(
+                            "Created new schema history file: {} (sequence: {})",
+                            newFile,
+                            nextSequence);
+                }
+            } finally {
+                lock.unlock();
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SchemaHistoryException(
+                    "Interrupted while storing schema history record for source id " + sourceId, e);
         } catch (Exception e) {
             throw new SchemaHistoryException("Failed to store schema history record", e);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
Serialize `OpendalSchemaHistory` object-store operations per `sourceId` within a single connector-node JVM to prevent concurrent schema history updates from multiple instances.

### Motivation
MySQL CDC schema history persistence is a read-modify-write pattern (`list/get` → append → `putObject`). If multiple `OpendalSchemaHistory` instances for the same `sourceId` exist concurrently (e.g., fast restarts or overlapping engine lifecycles), they can:
- overwrite each other’s updates (lost schema history records)
- collide on sequence/file creation (`schema_history_N.dat`)
- derive cache/sequence state while another instance is writing

This change introduces a process-wide, per-`sourceId` lock so only one instance at a time can perform schema history initialization (`doStart`) and persistence (`doStoreRecord`) against object storage.

### Behavior change
For the same `sourceId`, `doStart()` and `doStoreRecord()` are serialized across instances in the same JVM. Different `sourceId`s remain independent.

### Performance / Overhead
Low. The added cost is a per-call lock/unlock; object-store I/O remains the dominant cost. Contention only occurs when multiple instances for the same `sourceId` overlap, in which case serialization is intended.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
