### PR TITLE
feat: enable clippy lints for stack overflow detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,6 +330,10 @@ inconsistent_struct_constructor = "warn"
 unused_async = "warn"
 map_flatten = "warn"
 await_holding_lock = "warn"
+large_futures = "warn"
+large_stack_arrays = "warn"
+large_stack_frames = "warn"
+large_types_passed_by_value = "warn"
 # For private code, this is a little pedantic and not worth fixing.
 # &Vec or &String is acceptable
 ptr_arg = "allow"


### PR DESCRIPTION
Enable four clippy lints to detect potential stack overflow issues:
- large_futures: warn about large futures
- large_stack_arrays: warn about large arrays
- large_stack_frames: warn about large stack frames
- large_types_passed_by_value: warn about large types passed by value

Fixes #21635