### PR TITLE
feat(tracing): support RW_TRACING_EXTRA_ATTRIBUTES env var

### DIFF
--- a/src/utils/runtime/src/logger.rs
+++ b/src/utils/runtime/src/logger.rs
@@ -478,11 +478,7 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
         );
 
         let extra_attributes = &settings.extra_tracing_attributes;
-        if extra_attributes.is_empty() {
-            println!(
-                "no extra tracing resource attributes configured (set RW_TRACING_EXTRA_ATTRIBUTES to add custom attributes)"
-            );
-        } else {
+        if !extra_attributes.is_empty() {
             println!(
                 "extra tracing resource attributes: {:?}",
                 extra_attributes


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add support for a new environment variable `RW_TRACING_EXTRA_ATTRIBUTES` that allows injecting custom key/value attributes into OpenTelemetry trace resources.

**Motivation:** In multi-tenant or multi-cluster deployments, it is useful to tag all traces from a RisingWave instance with extra metadata (e.g., `cluster=prod`, `region=us-east-1`, `namespace=terry-dev`) for filtering and correlation in observability backends.

**Changes (single file: `src/utils/runtime/src/logger.rs`):**

- Added `parse_extra_tracing_attributes()` helper that parses a comma-separated `key=value` string. Invalid pairs are skipped with a warning printed to stderr.
- Added `extra_tracing_attributes` field to `LoggerSettings`, loaded from the `RW_TRACING_EXTRA_ATTRIBUTES` env var at startup (same pattern as `tracing_endpoint` / `RW_TRACING_ENDPOINT`).
- Extra attributes are appended to the OTel `Resource` for both the `tracing-opentelemetry` TracerProvider and the `fastrace` reporter.
- Parsed once at startup — zero per-span overhead.
- Startup logs print the parsed attributes (or a hint if none are configured) for easy verification during deployment.
- 8 unit tests covering normal parsing, whitespace, empty input, invalid pairs, empty keys, values with `=`, trailing commas, and empty values.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Added support for `RW_TRACING_EXTRA_ATTRIBUTES` environment variable. When set (e.g., `RW_TRACING_EXTRA_ATTRIBUTES=cluster=prod,region=us-east-1`), the specified key/value pairs are attached as OpenTelemetry resource attributes to all exported traces. This is useful for tagging traces with deployment metadata in multi-cluster environments.

</details>
