### PR TITLE
fix(sink): fix redshift sink intermediate_schema name set

### DIFF
--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -515,14 +515,20 @@ impl RedshiftSinkCommitter {
     ) -> Result<()> {
         let all_path = format!("s3://{}/{}", s3_inner.bucket_name, manifest);
 
-        let (table,schema_name) = if is_append_only {
+        let (table, schema_name) = if is_append_only {
             (&config.table, config.schema.as_deref())
         } else {
-            (config.cdc_table.as_ref().ok_or_else(|| {
-                SinkError::Config(anyhow!(
-                    "intermediate.table.name is required for non-append-only sink"
-                ))
-            })?, config.intermediate_schema.as_deref().or(config.schema.as_deref()))
+            (
+                config.cdc_table.as_ref().ok_or_else(|| {
+                    SinkError::Config(anyhow!(
+                        "intermediate.table.name is required for non-append-only sink"
+                    ))
+                })?,
+                config
+                    .intermediate_schema
+                    .as_deref()
+                    .or(config.schema.as_deref()),
+            )
         };
         let copy_into_sql = build_copy_into_sql(
             schema_name,


### PR DESCRIPTION
This pull request refactors how schema names are selected and passed to the `build_copy_into_sql` function in the Redshift sink committer. The main change is to consistently determine the schema name based on whether the sink is append-only or not, improving clarity and correctness in schema selection logic.

Improvements to schema selection logic:

* Refactored the assignment of `table` and `schema_name` to use tuples, ensuring that the correct schema is chosen for append-only and non-append-only sinks. For non-append-only sinks, it now prefers `intermediate_schema` but falls back to `schema` if not present. (`src/connector/src/sink/snowflake_redshift/redshift.rs`, [src/connector/src/sink/snowflake_redshift/redshift.rsL518-R528](diffhunk://#diff-c0ffa2ae6edb0851d243a1165a43cec29d2d6668879f5fd01231903d593fd717L518-R528))
* Updated the call to `build_copy_into_sql` to use the newly determined `schema_name` instead of always using `config.schema`. (`src/connector/src/sink/snowflake_redshift/redshift.rs`, [src/connector/src/sink/snowflake_redshift/redshift.rsL518-R528](diffhunk://#diff-c0ffa2ae6edb0851d243a1165a43cec29d2d6668879f5fd01231903d593fd717L518-R528))I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
