### PR TITLE
fix(source): try fix flaky e2e source test

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/mysql_partition.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_partition.slt
@@ -2,9 +2,6 @@
 
 control substitution on
 
-statement ok
-ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 1;
-
 system ok
 mysql -e "
     SET GLOBAL time_zone = '+01:00';

--- a/e2e_test/source_inline/cdc/mysql/mysql_timestamptz_as_pk.slt
+++ b/e2e_test/source_inline/cdc/mysql/mysql_timestamptz_as_pk.slt
@@ -3,9 +3,6 @@
 
 control substitution on
 
-statement ok
-ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 1;
-
 system ok
 mysql -e "
     CREATE DATABASE IF NOT EXISTS risedev;

--- a/e2e_test/source_inline/cdc/mysql/test_unsigned_int.slt
+++ b/e2e_test/source_inline/cdc/mysql/test_unsigned_int.slt
@@ -4,9 +4,6 @@
 
 control substitution on
 
-statement ok
-ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 1;
-
 system ok
 mysql -e "
     CREATE DATABASE IF NOT EXISTS risedev;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Remove `ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 1` from 3 parallel MySQL CDC test files to fix flaky "end-to-end source test" failures in main-cron CI.

### Motivation

Since PR #24515 (`1a381a72b8`, merged Jan 21 2026), CDC source creation enters a new `CdcSourceInit` state that holds the `max_concurrent_creating_streaming_jobs` semaphore permit until the source executor receives its first non-empty binlog offset. Previously, CDC sources were marked `Finished` immediately (no actors to track), so the permit was released instantly.

Three parallel MySQL CDC tests (`test_unsigned_int.slt`, `mysql_partition.slt`, `mysql_timestamptz_as_pk.slt`) set `ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 1` — a **global** system parameter. When these tests run in parallel with `-j8` alongside ~59 other tests, this creates a global bottleneck:

1. One CDC source acquires the single permit and holds it while waiting for the debezium connector to start, complete initial snapshot, switch to binlog streaming, and emit the first heartbeat (up to 60s, configured by `heartbeat.interval.ms=60000`).
2. **All** streaming job DDLs across **all** concurrent tests serialize behind this single permit.
3. Other CDC tests' incremental data (debezium binlog changes) cannot arrive within their retry windows (4–6s), causing count mismatches like `expected 53, got 50`.

### Evidence from CI

| Build | Date | Commit | Source Test |
|-------|------|--------|-------------|
| #8523 | Jan 21 | b1ae3ca85d | Passed (pre-CdcSourceInit) |
| #8545 | Jan 22 | d4b03e7ae6 | Passed with retries (flakiness begins, first build with CdcSourceInit) |
| #8590 | Jan 28 | 91991f5f23 | **Failed** (mysql backend, first hard failure) |
| #8596–#8664 | Jan 29–Feb 7 | various | Passed (auto-retries mask intermittent failures) |
| #8671 | Feb 8 | 397ed9a175 | **Failed** (consistent failure streak begins) |
| #8928 | Mar 4 | b7cd636c5a | **Failed** (the build in question) |

### Fix

Remove the `ALTER SYSTEM SET max_concurrent_creating_streaming_jobs TO 1` from the 3 parallel test files. The CI config (`src/config/ci-recovery.toml`) already sets `max_concurrent_creating_streaming_jobs = 0` (unlimited). Sequential SQL ordering within each test file ensures correct source→table creation order without needing this global override. The `.serial` test file (`mysql_create_drop.slt.serial`) retains its setting since it runs without parallelism.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
