### PR TITLE
fix(frontend): resolve schema-qualified column references correctly across scopes

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/subquery_expr_correlated.yaml
@@ -700,3 +700,13 @@
   expected_outputs:
     - batch_plan
     - stream_plan
+- name: schema-qualified column references with same-name tables in different schemas (issue 24667)
+  sql: |
+    create schema s1;
+    create schema s2;
+    create table s1.users(id int, name varchar, is_active boolean);
+    create table s2.users(id int, name varchar, is_active boolean);
+    select * from s1.users where exists (select 1 from s2.users where s2.users.id = s1.users.id and s2.users.is_active = false);
+  expected_outputs:
+    - logical_plan
+    - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -2531,3 +2531,26 @@
     StreamMaterialize { columns: [c, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: NoCheck }
     └─StreamProject { exprs: [(t.a + t.b) as $expr1, t._row_id] }
       └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: schema-qualified column references with same-name tables in different schemas (issue 24667)
+  sql: |
+    create schema s1;
+    create schema s2;
+    create table s1.users(id int, name varchar, is_active boolean);
+    create table s2.users(id int, name varchar, is_active boolean);
+    select * from s1.users where exists (select 1 from s2.users where s2.users.id = s1.users.id and s2.users.is_active = false);
+  logical_plan: |-
+    LogicalProject { exprs: [users.id, users.name, users.is_active] }
+    └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+      ├─LogicalScan { table: users, columns: [users.id, users.name, users.is_active, users._row_id, users._rw_timestamp] }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalFilter { predicate: (users.id = CorrelatedInputRef { index: 0, correlated_id: 1 }) AND (users.is_active = false:Boolean) }
+          └─LogicalScan { table: users, columns: [users.id, users.name, users.is_active, users._row_id, users._rw_timestamp] }
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchHashJoin { type: LeftSemi, predicate: users.id = users.id, output: all }
+      ├─BatchExchange { order: [], dist: HashShard(users.id) }
+      │ └─BatchScan { table: users, columns: [users.id, users.name, users.is_active], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(users.id) }
+        └─BatchProject { exprs: [users.id] }
+          └─BatchFilter { predicate: (users.is_active = false:Boolean) }
+            └─BatchScan { table: users, columns: [users.id, users.is_active], distribution: SomeShard }

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -33,15 +33,23 @@ use crate::binder::{BoundQuery, COLUMN_GROUP_PREFIX, ShareId};
 #[derive(Debug, Clone)]
 pub struct ColumnBinding {
     pub table_name: String,
+    pub schema_name: Option<String>,
     pub index: usize,
     pub is_hidden: bool,
     pub field: Field,
 }
 
 impl ColumnBinding {
-    pub fn new(table_name: String, index: usize, is_hidden: bool, field: Field) -> Self {
+    pub fn new(
+        table_name: String,
+        schema_name: Option<String>,
+        index: usize,
+        is_hidden: bool,
+        field: Field,
+    ) -> Self {
         ColumnBinding {
             table_name,
+            schema_name,
             index,
             is_hidden,
             field,
@@ -147,7 +155,17 @@ impl BindContext {
         table_name: &Option<String>,
         column_name: &String,
     ) -> LiteResult<usize> {
-        match &self.get_column_binding_indices(table_name, column_name)?[..] {
+        self.get_column_binding_index_with_schema(&None, table_name, column_name)
+    }
+
+    pub fn get_column_binding_index_with_schema(
+        &self,
+        schema_name: &Option<String>,
+        table_name: &Option<String>,
+        column_name: &String,
+    ) -> LiteResult<usize> {
+        match &self.get_column_binding_indices_with_schema(schema_name, table_name, column_name)?[..]
+        {
             [] => unreachable!(),
             [idx] => Ok(*idx),
             _ => Err(ErrorCode::InternalError(format!(
@@ -160,8 +178,9 @@ impl BindContext {
     /// If return Vec has len > 1, it means we have an unqualified reference to a column which has
     /// been naturally joined upon, wherein none of the columns are min-nullable. This will be
     /// handled in downstream as a `COALESCE` expression
-    pub fn get_column_binding_indices(
+    pub fn get_column_binding_indices_with_schema(
         &self,
+        schema_name: &Option<String>,
         table_name: &Option<String>,
         column_name: &String,
     ) -> LiteResult<Vec<usize>> {
@@ -172,9 +191,11 @@ impl BindContext {
                         format!("Could not parse {:?} as virtual table name `{COLUMN_GROUP_PREFIX}[group_id]`", table_name)))?;
                     self.get_indices_with_group_id(group_id, column_name)
                 } else {
-                    Ok(vec![
-                        self.get_index_with_table_name(column_name, table_name)?,
-                    ])
+                    Ok(vec![self.get_index_with_table_name(
+                        column_name,
+                        table_name,
+                        schema_name,
+                    )?])
                 }
             }
             None => self.get_unqualified_indices(column_name),
@@ -304,19 +325,26 @@ impl BindContext {
         &self,
         column_name: &String,
         table_name: &String,
+        schema_name: &Option<String>,
     ) -> LiteResult<usize> {
         let column_indexes = self
             .indices_of
             .get(column_name)
             .ok_or_else(|| ErrorCode::ItemNotFound(format!("Invalid column: {}", column_name)))?;
-        match column_indexes
-            .iter()
-            .find(|column_index| self.columns[**column_index].table_name == *table_name)
-        {
+        match column_indexes.iter().find(|column_index| {
+            let col = &self.columns[**column_index];
+            col.table_name == *table_name
+                && schema_name
+                    .as_ref()
+                    .is_none_or(|s| col.schema_name.as_ref().is_none_or(|cs| cs == s))
+        }) {
             Some(column_index) => Ok(*column_index),
             None => Err(ErrorCode::ItemNotFound(format!(
                 "missing FROM-clause entry for table \"{}\"",
-                table_name
+                match schema_name {
+                    Some(s) => format!("{}.{}", s, table_name),
+                    None => table_name.clone(),
+                }
             ))),
         }
     }

--- a/src/frontend/src/binder/expr/column.rs
+++ b/src/frontend/src/binder/expr/column.rs
@@ -22,7 +22,7 @@ use crate::expr::{CorrelatedInputRef, ExprImpl, ExprType, FunctionCall, InputRef
 impl Binder {
     pub fn bind_column(&mut self, idents: &[Ident]) -> Result<ExprImpl> {
         // TODO: check quote style of `ident`.
-        let (_schema_name, table_name, column_name) = match idents {
+        let (schema_name, table_name, column_name) = match idents {
             [column] => (None, None, column.real_value()),
             [table, column] => (None, Some(table.real_value()), column.real_value()),
             [schema, table, column] => (
@@ -44,10 +44,11 @@ impl Binder {
             return self.bind_sql_udf_parameter(&column_name);
         }
 
-        match self
-            .context
-            .get_column_binding_indices(&table_name, &column_name)
-        {
+        match self.context.get_column_binding_indices_with_schema(
+            &schema_name,
+            &table_name,
+            &column_name,
+        ) {
             Ok(mut indices) => {
                 match indices.len() {
                     0 => unreachable!(),
@@ -91,7 +92,11 @@ impl Binder {
                 }
                 // input ref from lateral context `depth` starts from 1.
                 let depth = i + 1;
-                match context.get_column_binding_index(&table_name, &column_name) {
+                match context.get_column_binding_index_with_schema(
+                    &schema_name,
+                    &table_name,
+                    &column_name,
+                ) {
                     Ok(index) => {
                         let column = &context.columns[index];
                         return Ok(CorrelatedInputRef::new(
@@ -116,7 +121,11 @@ impl Binder {
             }
             // `depth` starts from 1.
             let depth = i + 1;
-            match context.get_column_binding_index(&table_name, &column_name) {
+            match context.get_column_binding_index_with_schema(
+                &schema_name,
+                &table_name,
+                &column_name,
+            ) {
                 Ok(index) => {
                     let column = &context.columns[index];
                     return Ok(CorrelatedInputRef::new(
@@ -139,7 +148,11 @@ impl Binder {
                     }
                     // correlated input ref from lateral context `depth` starts from 1.
                     let depth = i + j + 1;
-                    match context.get_column_binding_index(&table_name, &column_name) {
+                    match context.get_column_binding_index_with_schema(
+                        &schema_name,
+                        &table_name,
+                        &column_name,
+                    ) {
                         Ok(index) => {
                             let column = &context.columns[index];
                             return Ok(CorrelatedInputRef::new(

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -342,10 +342,22 @@ impl Binder {
         table_name: String,
         alias: Option<&TableAlias>,
     ) -> Result<()> {
+        self.bind_table_to_context_with_schema(columns, table_name, None, alias)
+    }
+
+    /// Fill the [`BindContext`](super::BindContext) for table, with optional schema name.
+    pub(super) fn bind_table_to_context_with_schema(
+        &mut self,
+        columns: impl IntoIterator<Item = (bool, Field)>, // bool indicates if the field is hidden
+        table_name: String,
+        schema_name: Option<String>,
+        alias: Option<&TableAlias>,
+    ) -> Result<()> {
         const EMPTY: [Ident; 0] = [];
-        let (table_name, column_aliases) = match alias {
-            None => (table_name, &EMPTY[..]),
-            Some(TableAlias { name, columns }) => (name.real_value(), columns.as_slice()),
+        let (table_name, schema_name, column_aliases) = match alias {
+            None => (table_name, schema_name, &EMPTY[..]),
+            // When an alias is used, schema qualification is no longer relevant
+            Some(TableAlias { name, columns }) => (name.real_value(), None, columns.as_slice()),
         };
 
         let num_col_aliases = column_aliases.len();
@@ -366,6 +378,7 @@ impl Binder {
             field.name.clone_from(&name);
             self.context.columns.push(ColumnBinding::new(
                 table_name.clone(),
+                schema_name.clone(),
                 begin + index,
                 is_hidden,
                 field,

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -266,7 +266,12 @@ impl Binder {
             }
         };
 
-        self.bind_table_to_context(columns, table_name.to_owned(), alias)?;
+        self.bind_table_to_context_with_schema(
+            columns,
+            table_name.to_owned(),
+            schema_name.map(|s| s.to_owned()),
+            alias,
+        )?;
         Ok(ret)
     }
 
@@ -489,11 +494,12 @@ impl Binder {
 
         let columns = table_catalog.columns.clone();
 
-        self.bind_table_to_context(
+        self.bind_table_to_context_with_schema(
             columns
                 .iter()
                 .map(|c| (c.is_hidden, (&c.column_desc).into())),
             table_name.to_owned(),
+            Some(schema_name.to_owned()),
             None,
         )?;
 


### PR DESCRIPTION
## Summary

Fixes #24667.

Schema-qualified column references like `public_staging.users.id` were incorrectly resolved when same-named tables exist in different schemas across query scopes (e.g., outer query vs EXISTS subquery). The schema name was parsed but discarded (`_schema_name` in `column.rs:25`), so `public.users.id` in a subquery would match the inner `public_staging.users` instead of correctly falling through to the outer `public.users`.

### Changes

- **`ColumnBinding`**: Added `schema_name: Option<String>` field to store schema information when binding tables
- **`bind_table_to_context_with_schema`**: New method that accepts and stores schema name alongside table name
- **`get_column_binding_indices_with_schema`**: New lookup method that filters by schema when provided
- **`get_index_with_table_name`**: Enhanced to verify schema match when both the query reference and the column binding have schema info
- **`bind_column`**: Now passes schema name through to context lookup instead of discarding it

### How it works

When looking up a column with `schema.table.column`:
- If both the column reference and the ColumnBinding have schema info → must match
- If either side has no schema info → skip schema filter (backwards compatible)
- If schema doesn't match → `ItemNotFound`, allowing resolution to fall through to outer scopes (correlated references)

## Test plan

- [x] Added planner test: schema-qualified column references with same-name tables in different schemas (issue 24667)
- [x] `cargo check -p risingwave_frontend` passes with no warnings
- [x] `cargo fmt --all -- --check` passes
- [x] Planner test generates correct plan with `CorrelatedInputRef` for outer-scope references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*— Yingjun_Wu (agent)*