### PR TITLE
fix(test): reset adaptive parallelism strategy in log store simulation tests

### DIFF
--- a/src/tests/simulation/tests/integration_tests/log_store/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/log_store/utils.rs
@@ -39,6 +39,12 @@ pub(crate) async fn start_sync_log_store_cluster() -> Result<Cluster> {
         meta_nodes: 1,
         compactor_nodes: 1,
         compute_node_cores: 2,
+        per_session_queries: vec![
+            "set streaming_parallelism_strategy_for_table = 'DEFAULT'".into(),
+            "set streaming_parallelism_strategy_for_source = 'DEFAULT'".into(),
+            "alter system set adaptive_parallelism_strategy to AUTO".into(),
+        ]
+        .into(),
         ..Default::default()
     })
     .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix the deterministic simulation test `test_scale_in_synced_log_store` which fails consistently across all seeds in the `main-cron` pipeline (e.g., [build #8907](https://buildkite.com/risingwavelabs/main-cron/builds/8907#019cae9b-3192-49f9-a067-76dba7617c7b)).

**Root cause:** PR #24678 ("Bound default adaptive parallelism to 64") introduced `BOUNDED(4)` as the default `streaming_parallelism_strategy_for_table`. It correctly updated the `for_scale()`, `for_scale_no_shuffle()`, `for_scale_shared_source()`, and `for_auto_parallelism()` cluster configurations to override this with `DEFAULT`, but missed `start_sync_log_store_cluster()` used by the log store simulation tests.

As a result, `CREATE TABLE` in the log store test only gets 4 actors per fragment instead of the expected 10 (5 compute nodes × 2 cores), causing the `assert_parallelism_eq(&mut session, 10)` assertion to panic.

**Fix:** Add the same per-session queries (`streaming_parallelism_strategy_for_table = 'DEFAULT'`, `streaming_parallelism_strategy_for_source = 'DEFAULT'`, `adaptive_parallelism_strategy = AUTO`) to `start_sync_log_store_cluster()` in the log store test utilities. This brings it in line with all other simulation test cluster configurations.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
