### PR TITLE
feat(expr): implement casefold(text) function (PG18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12042,6 +12042,7 @@ dependencies = [
  "thiserror-ext",
  "tonic 0.12.3",
  "tracing",
+ "unicode-casefold",
  "workspace-hack",
  "zstd 0.13.3",
 ]
@@ -16178,6 +16179,12 @@ name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-casefold"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
 
 [[package]]
 name = "unicode-ident"

--- a/e2e_test/batch/functions/casefold.slt.part
+++ b/e2e_test/batch/functions/casefold.slt.part
@@ -1,0 +1,57 @@
+query T
+SELECT casefold('Hello World');
+----
+hello world
+
+query T
+SELECT casefold('HELLO RUST');
+----
+hello rust
+
+# ß folds to ss (full case folding)
+query T
+SELECT casefold('Straße');
+----
+strasse
+
+# Empty string
+query T
+SELECT casefold('');
+----
+(empty)
+
+# NULL input
+query T
+SELECT casefold(NULL::varchar);
+----
+NULL
+
+# ASCII-only input
+query T
+SELECT casefold('ABC123xyz');
+----
+abc123xyz
+
+# Already lowercase
+query T
+SELECT casefold('already lowercase');
+----
+already lowercase
+
+# Mixed with numbers and symbols
+query T
+SELECT casefold('Test@123#ABC');
+----
+test@123#abc
+
+# Latin ligatures: ﬁ folds to fi
+query T
+SELECT casefold('ﬁnd');
+----
+find
+
+# Capital sharp S also folds to ss
+query T
+SELECT casefold('GROẞE');
+----
+grosse

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -169,6 +169,7 @@ message ExprNode {
     TRIM_SCALE = 278;
     GAMMA = 288;
     LGAMMA = 289;
+    CASEFOLD = 291;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/expr/impl/Cargo.toml
+++ b/src/expr/impl/Cargo.toml
@@ -66,6 +66,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = ["time"] }
 # For arrow-udf-runtime/remote
 tonic = { version = "0.12.3", optional = true }
 tracing = "0.1"
+unicode-casefold = "0.2"
 zstd = { version = "0.13", default-features = false, optional = true }
 
 [target.'cfg(not(madsim))'.dependencies]

--- a/src/expr/impl/src/scalar/casefold.rs
+++ b/src/expr/impl/src/scalar/casefold.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_expr::function;
+use unicode_casefold::UnicodeCaseFold;
+
+/// Unicode case folding for case-insensitive comparison.
+///
+/// Unlike `lower()`, `casefold()` handles multi-character expansions
+/// (e.g., 'ß' → "ss") and normalizes all case variants to a single form
+/// (e.g., 'Σ', 'σ', 'ς' all fold to 'σ').
+///
+/// ```slt
+/// query T
+/// SELECT casefold('Hello World');
+/// ----
+/// hello world
+///
+/// query T
+/// SELECT casefold('Straße');
+/// ----
+/// strasse
+///
+/// query T
+/// SELECT casefold(NULL::varchar);
+/// ----
+/// NULL
+/// ```
+#[function("casefold(varchar) -> varchar")]
+fn casefold(s: &str, writer: &mut impl std::fmt::Write) {
+    for c in s.case_fold() {
+        writer.write_char(c).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_casefold() {
+        let cases = [
+            ("Hello World", "hello world"),
+            ("HELLO RUST", "hello rust"),
+            // ß folds to ss
+            ("Straße", "strasse"),
+            // Final sigma (ς) and capital sigma (Σ) both fold to σ
+            ("ΣΊΣΥΦΟΣ", "σίσυφοσ"),
+            ("", ""),
+        ];
+
+        for (input, expected) in cases {
+            let mut writer = String::new();
+            casefold(input, &mut writer);
+            assert_eq!(writer, expected, "casefold({:?})", input);
+        }
+    }
+}

--- a/src/expr/impl/src/scalar/mod.rs
+++ b/src/expr/impl/src/scalar/mod.rs
@@ -36,6 +36,7 @@ mod bitwise_op;
 mod bytea_bits;
 mod cardinality;
 mod case;
+mod casefold;
 mod cast;
 mod cmp;
 mod coalesce;

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -232,6 +232,7 @@ impl Binder {
                 ("length", raw_call(ExprType::Length)),
                 ("upper", raw_call(ExprType::Upper)),
                 ("lower", raw_call(ExprType::Lower)),
+                ("casefold", raw_call(ExprType::Casefold)),
                 ("trim", raw_call(ExprType::Trim)),
                 ("replace", raw_call(ExprType::Replace)),
                 ("overlay", raw_call(ExprType::Overlay)),

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -144,6 +144,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::SimilarToEscape
             | Type::Upper
             | Type::Lower
+            | Type::Casefold
             | Type::Trim
             | Type::Replace
             | Type::Position

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -152,6 +152,7 @@ impl Strong {
             | ExprType::SimilarToEscape
             | ExprType::Upper
             | ExprType::Lower
+            | ExprType::Casefold
             | ExprType::Replace
             | ExprType::Position
             | ExprType::Case


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Implement the `casefold(text) → text` function from PostgreSQL 18 ([release notes](https://www.postgresql.org/docs/18/release-18.html#RELEASE-18-DATATYPES)).

Unlike `lower()`, `casefold()` performs full Unicode case folding per the Unicode CaseFolding.txt specification:
- `ß` → `ss` (multi-character expansion)
- `ﬁ` → `fi` (ligature expansion)
- `ẞ` (capital sharp S) → `ss`

Uses the `unicode-casefold` crate (v0.2) with `Variant::Full` and `Locale::NonTurkic` for correctness.

Part of #23368.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions.

## Test plan

- Unit tests in `casefold.rs`: basic strings, ß→ss, Greek sigma normalization, empty string
- E2E tests in `e2e_test/batch/functions/casefold.slt.part`: hello world, ß→ss, NULL, ASCII, ligatures, capital sharp S

## Documentation

- [ ] My PR needs documentation updates.

— Kodomo

---
*— Kodomo (agent)*