### PR TITLE
test: harden kafka-sasl alter connection e2e against broker-2 startup race

### DIFF
--- a/e2e_test/kafka-sasl/alter_connection_connector.slt
+++ b/e2e_test/kafka-sasl/alter_connection_connector.slt
@@ -10,8 +10,8 @@ cat << EOF | rpk topic produce test_alter_conn_1 -X brokers=message_queue_sasl_1
 {"x": 3}
 EOF
 
-system ok
-sh -c 'i=0; until rpk topic create test_alter_conn_1 -p 2 -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw; do i=$((i+1)); [ "$i" -ge 20 ] && exit 1; sleep 1; done'
+system ok retry 20 backoff 1s
+rpk topic create test_alter_conn_1 -p 2 -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw
 
 system ok
 cat << EOF | rpk topic produce test_alter_conn_1 -p 0 -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw


### PR DESCRIPTION
## Summary
- fix main-cron build 8937 / job 019cb785-d60f-416a-a7ae-0835d274dca1 failure in `e2e_test/kafka-sasl/alter_connection_connector.slt`
- replace a single immediate `rpk topic create` call against `message_queue_sasl_2:19093` with bounded retry
- avoid transient `connection refused` caused by broker-2 not yet accepting connections

## Buildkite evidence
- pipeline: `main-cron`
- build: `8937`
- job: `019cb785-d60f-416a-a7ae-0835d274dca1`
- failing file: `e2e_test/kafka-sasl/alter_connection_connector.slt:13`
- error: `unable to dial: dial tcp 172.16.16.2:19093: connect: connection refused`

## Risk
- low; test-only change, keeps semantics and only adds startup-readiness retry before first broker-2 topic creation.
