### PR TITLE
feat(frontend): add binder support for recursive CTE (WITH RECURSIVE)

### DIFF
--- a/e2e_test/batch/basic/recursive_cte.slt.part
+++ b/e2e_test/batch/basic/recursive_cte.slt.part
@@ -1,0 +1,60 @@
+# Recursive CTE tests
+# Phase 1: binder support only — planning returns "not yet implemented"
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+# Basic recursive CTE — should bind successfully but fail at planning stage
+statement error not yet implemented
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t WHERE n < 10
+)
+SELECT * FROM t;
+
+# Recursive CTE must use UNION ALL, not plain UNION
+statement error must use UNION ALL
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION
+    SELECT n + 1 FROM t WHERE n < 10
+)
+SELECT * FROM t;
+
+# Recursive CTE with ORDER BY in definition is not allowed
+statement error ORDER BY, LIMIT, OFFSET, and FETCH are not allowed in recursive CTE
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t WHERE n < 10
+    ORDER BY 1
+)
+SELECT * FROM t;
+
+# Recursive CTE with LIMIT in definition is not allowed
+statement error ORDER BY, LIMIT, OFFSET, and FETCH are not allowed in recursive CTE
+WITH RECURSIVE t(n) AS (
+    (SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM t WHERE n < 10)
+    LIMIT 5
+)
+SELECT * FROM t;
+
+# Column count mismatch between anchor and recursive
+statement error anchor has 1 columns but recursive term has 2 columns
+WITH RECURSIVE t(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1, n + 2 FROM t WHERE n < 10
+)
+SELECT * FROM t;
+
+# Non-recursive CTE in WITH RECURSIVE is fine (binds and plans normally)
+# WITH RECURSIVE allows non-recursive CTEs too — only CTEs that self-reference are actually recursive
+statement ok
+WITH RECURSIVE t AS (
+    SELECT 1 AS n
+)
+SELECT * FROM t;

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 
 use parse_display::Display;
-use risingwave_common::catalog::Field;
+use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{TableAlias, WindowSpec};
 
@@ -79,6 +79,18 @@ pub enum BindingCteState {
 
     ChangeLog {
         table: Relation,
+    },
+
+    /// Placeholder state for a recursive CTE whose anchor has been bound but whose recursive
+    /// branch is still being bound. The schema comes from the anchor query.
+    Init {
+        schema: Schema,
+    },
+
+    /// A fully-bound recursive CTE with both anchor and recursive parts.
+    RecursiveUnion {
+        anchor: BoundQuery,
+        recursive: BoundQuery,
     },
 }
 

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -19,7 +19,9 @@ use std::rc::Rc;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
-use risingwave_sqlparser::ast::{Cte, CteInner, Expr, Fetch, OrderByExpr, Query, Value, With};
+use risingwave_sqlparser::ast::{
+    Cte, CteInner, Expr, Fetch, OrderByExpr, Query, SetExpr, SetOperator, TableAlias, Value, With,
+};
 use thiserror_ext::AsReport;
 
 use super::BoundValues;
@@ -364,10 +366,6 @@ impl Binder {
     }
 
     fn bind_with(&mut self, with: &With) -> Result<()> {
-        if with.recursive {
-            return Err(ErrorCode::BindError("RECURSIVE CTE is not supported".to_owned()).into());
-        }
-
         let mut cte_names: HashSet<String> = HashSet::new();
 
         for cte_table in &with.cte_tables {
@@ -388,17 +386,50 @@ impl Binder {
 
             match cte_inner {
                 CteInner::Query(query) => {
-                    let bound_query = self.bind_query(query)?;
-                    self.context.cte_to_relation.insert(
-                        table_name,
-                        Rc::new(RefCell::new(BindingCte {
-                            share_id,
-                            state: BindingCteState::Bound { query: bound_query },
-                            alias: alias.clone(),
-                        })),
-                    );
+                    if with.recursive
+                        && matches!(
+                            &query.body,
+                            SetExpr::SetOperation {
+                                op: SetOperator::Union,
+                                all: true,
+                                ..
+                            }
+                        )
+                    {
+                        self.bind_recursive_cte(share_id, alias, &table_name, query)?;
+                    } else if with.recursive
+                        && matches!(
+                            &query.body,
+                            SetExpr::SetOperation {
+                                op: SetOperator::Union,
+                                all: false,
+                                ..
+                            }
+                        )
+                    {
+                        return Err(ErrorCode::BindError(
+                            "recursive CTE must use UNION ALL, not UNION".to_owned(),
+                        )
+                        .into());
+                    } else {
+                        let bound_query = self.bind_query(query)?;
+                        self.context.cte_to_relation.insert(
+                            table_name,
+                            Rc::new(RefCell::new(BindingCte {
+                                share_id,
+                                state: BindingCteState::Bound { query: bound_query },
+                                alias: alias.clone(),
+                            })),
+                        );
+                    }
                 }
                 CteInner::ChangeLog(from_table_name) => {
+                    if with.recursive {
+                        return Err(ErrorCode::BindError(
+                            "RECURSIVE CTE with changelog is not supported".to_owned(),
+                        )
+                        .into());
+                    }
                     self.push_context();
                     let from_table_relation =
                         self.bind_relation_by_name(from_table_name, None, None, true)?;
@@ -416,6 +447,113 @@ impl Binder {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Bind a recursive CTE.
+    ///
+    /// The body of a recursive CTE must be a `UNION ALL` of an anchor query (non-recursive)
+    /// and a recursive query that references the CTE itself.
+    ///
+    /// We use a two-pass approach:
+    /// 1. Bind the anchor (left side of UNION ALL) to determine the output schema.
+    /// 2. Register the CTE with `Init` state so the recursive branch can resolve self-references.
+    /// 3. Bind the recursive query (right side of UNION ALL).
+    /// 4. Update the CTE state to `RecursiveUnion`.
+    fn bind_recursive_cte(
+        &mut self,
+        share_id: super::ShareId,
+        alias: &TableAlias,
+        table_name: &str,
+        query: &Query,
+    ) -> Result<()> {
+        // Validate: no ORDER BY, LIMIT, OFFSET, FETCH in the recursive CTE definition.
+        if !query.order_by.is_empty()
+            || query.limit.is_some()
+            || query.offset.is_some()
+            || query.fetch.is_some()
+        {
+            return Err(ErrorCode::BindError(
+                "ORDER BY, LIMIT, OFFSET, and FETCH are not allowed in recursive CTE".to_owned(),
+            )
+            .into());
+        }
+
+        // The body must be a UNION ALL of anchor and recursive parts.
+        let (anchor_set_expr, recursive_set_expr) = match &query.body {
+            SetExpr::SetOperation {
+                op: SetOperator::Union,
+                all: true,
+                left,
+                right,
+                ..
+            } => (left.as_ref(), right.as_ref()),
+            _ => {
+                return Err(ErrorCode::BindError(
+                    "the body of a recursive CTE must be a UNION ALL of anchor and recursive terms"
+                        .to_owned(),
+                )
+                .into());
+            }
+        };
+
+        // Step 1: Bind the anchor query in a fresh context.
+        self.push_context();
+        let bound_anchor = self.bind_set_expr(anchor_set_expr)?;
+        let anchor_schema = bound_anchor.schema().into_owned();
+        self.pop_context()?;
+
+        // Step 2: Register the CTE with Init state so the recursive branch can reference it.
+        let cte_ref = Rc::new(RefCell::new(BindingCte {
+            share_id,
+            state: BindingCteState::Init {
+                schema: anchor_schema.clone(),
+            },
+            alias: alias.clone(),
+        }));
+        self.context
+            .cte_to_relation
+            .insert(table_name.to_owned(), cte_ref.clone());
+
+        // Step 3: Bind the recursive query in a fresh context.
+        // push_context clones cte_to_relation, so the CTE registration is visible.
+        self.push_context();
+        let bound_recursive = self.bind_set_expr(recursive_set_expr)?;
+        self.pop_context()?;
+
+        // Validate that anchor and recursive schemas have the same number of columns.
+        let recursive_schema = bound_recursive.schema();
+        if anchor_schema.len() != recursive_schema.len() {
+            return Err(ErrorCode::BindError(format!(
+                "recursive CTE anchor has {} columns but recursive term has {} columns",
+                anchor_schema.len(),
+                recursive_schema.len()
+            ))
+            .into());
+        }
+
+        // Step 4: Update the CTE state to RecursiveUnion.
+        let anchor_query = BoundQuery {
+            body: bound_anchor,
+            order: vec![],
+            limit: None,
+            offset: None,
+            with_ties: false,
+            extra_order_exprs: vec![],
+        };
+        let recursive_query = BoundQuery {
+            body: bound_recursive,
+            order: vec![],
+            limit: None,
+            offset: None,
+            with_ties: false,
+            extra_order_exprs: vec![],
+        };
+        cte_ref.borrow_mut().state = BindingCteState::RecursiveUnion {
+            anchor: anchor_query,
+            recursive: recursive_query,
+        };
+
         Ok(())
     }
 }

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -43,7 +43,7 @@ mod window_table_function;
 
 pub use gap_fill::BoundGapFill;
 pub use join::BoundJoin;
-pub use share::{BoundShare, BoundShareInput};
+pub use share::{BoundBackCteRef, BoundShare, BoundShareInput};
 pub use subquery::BoundSubquery;
 pub use table_or_source::{BoundBaseTable, BoundSource, BoundSystemTable};
 pub use watermark::BoundWatermark;
@@ -70,6 +70,9 @@ pub enum Relation {
     Watermark(Box<BoundWatermark>),
     Share(Box<BoundShare>),
     GapFill(Box<BoundGapFill>),
+    /// A back-reference to a recursive CTE currently being defined.
+    /// Used inside the recursive branch of a `WITH RECURSIVE` CTE.
+    BackCteRef(Box<BoundBackCteRef>),
 }
 
 impl RewriteExprsRecursive for Relation {
@@ -153,6 +156,17 @@ impl Relation {
                 }
                 BoundShareInput::ChangeLog(change_log) => change_log
                     .collect_correlated_indices_by_depth_and_assign_id(depth, correlated_id),
+                BoundShareInput::RecursiveCte { anchor, recursive } => {
+                    let mut indices = anchor
+                        .collect_correlated_indices_by_depth_and_assign_id(depth, correlated_id);
+                    indices.extend(
+                        recursive.collect_correlated_indices_by_depth_and_assign_id(
+                            depth,
+                            correlated_id,
+                        ),
+                    );
+                    indices
+                }
             },
             _ => vec![],
         }
@@ -462,6 +476,27 @@ impl Binder {
                 }
                 BindingCteState::ChangeLog { table } => {
                     let input = BoundShareInput::ChangeLog(table);
+                    self.bind_table_to_context(input.fields()?, table_name, Some(&original_alias))?;
+                    Ok(Relation::Share(Box::new(BoundShare { share_id, input })))
+                }
+                BindingCteState::Init { schema } => {
+                    // This is a self-reference inside the recursive branch of a CTE.
+                    // Return a BackCteRef that the planner will convert to a CteRef node.
+                    let fields: Vec<(bool, Field)> = schema
+                        .fields()
+                        .iter()
+                        .cloned()
+                        .map(|f| (false, f))
+                        .collect();
+                    self.bind_table_to_context(fields, table_name, Some(&original_alias))?;
+                    Ok(Relation::BackCteRef(Box::new(BoundBackCteRef {
+                        share_id,
+                        schema,
+                    })))
+                }
+                BindingCteState::RecursiveUnion { anchor, recursive } => {
+                    // External reference to a fully-bound recursive CTE.
+                    let input = BoundShareInput::RecursiveCte { anchor, recursive };
                     self.bind_table_to_context(input.fields()?, table_name, Some(&original_alias))?;
                     Ok(Relation::Share(Box::new(BoundShare { share_id, input })))
                 }

--- a/src/frontend/src/binder/relation/share.rs
+++ b/src/frontend/src/binder/relation/share.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use risingwave_common::catalog::Field;
+use risingwave_common::catalog::{Field, Schema};
 
 use crate::binder::statement::RewriteExprsRecursive;
 use crate::binder::{BoundQuery, Relation, ShareId};
@@ -27,11 +27,23 @@ use crate::optimizer::plan_node::generic::{_CHANGELOG_ROW_ID, CHANGELOG_OP};
 pub enum BoundShareInput {
     Query(BoundQuery),
     ChangeLog(Relation),
+    /// A recursive CTE with anchor and recursive parts.
+    RecursiveCte {
+        anchor: BoundQuery,
+        recursive: BoundQuery,
+    },
 }
 impl BoundShareInput {
     pub fn fields(&self) -> Result<Vec<(bool, Field)>> {
         match self {
             BoundShareInput::Query(q) => Ok(q
+                .schema()
+                .fields()
+                .iter()
+                .cloned()
+                .map(|f| (false, f))
+                .collect_vec()),
+            BoundShareInput::RecursiveCte { anchor, .. } => Ok(anchor
                 .schema()
                 .fields()
                 .iter()
@@ -96,6 +108,21 @@ impl RewriteExprsRecursive for BoundShare {
         match &mut self.input {
             BoundShareInput::Query(q) => q.rewrite_exprs_recursive(rewriter),
             BoundShareInput::ChangeLog(r) => r.rewrite_exprs_recursive(rewriter),
+            BoundShareInput::RecursiveCte { anchor, recursive } => {
+                anchor.rewrite_exprs_recursive(rewriter);
+                recursive.rewrite_exprs_recursive(rewriter);
+            }
         };
     }
+}
+
+/// A reference back to a recursive CTE that is currently being defined.
+/// This is used inside the recursive branch of the CTE to refer to the CTE's working table.
+#[derive(Debug, Clone)]
+pub struct BoundBackCteRef {
+    #[allow(dead_code)]
+    pub(crate) share_id: ShareId,
+    /// Schema of the CTE (from the anchor query).
+    #[allow(dead_code)]
+    pub(crate) schema: Schema,
 }

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -61,6 +61,9 @@ impl Planner {
             Relation::Watermark(tf) => self.plan_watermark(*tf),
             Relation::Share(share) => self.plan_share(*share),
             Relation::GapFill(bound_gap_fill) => self.plan_gap_fill(*bound_gap_fill),
+            Relation::BackCteRef(_) => {
+                bail_not_implemented!("recursive CTE is not fully supported yet")
+            }
         }
     }
 
@@ -383,6 +386,9 @@ source: {:?}",
                 let logical_share = LogicalShare::create(result);
                 self.share_cache.insert(id, logical_share.clone());
                 Ok(logical_share)
+            }
+            BoundShareInput::RecursiveCte { .. } => {
+                bail_not_implemented!("planning recursive CTE is not supported yet")
             }
         }
     }


### PR DESCRIPTION
## Summary

Phase 1 of recursive CTE support (tracking issue #15135).

This PR implements binder-level support for `WITH RECURSIVE`, enabling the frontend to correctly parse, validate, and bind recursive CTEs. Planning and execution will be added in subsequent phases.

### What's changed:
- **Removed** the `RECURSIVE CTE is not supported` rejection in `bind_with()`
- **Added** `BindingCteState::Init` (placeholder during recursive binding) and `BindingCteState::RecursiveUnion` (fully-bound recursive CTE)
- **Implemented two-pass binding**: bind anchor query first to determine schema, register CTE with `Init` state, then bind recursive branch where self-references resolve via `BackCteRef`
- **Added** `BoundBackCteRef` for recursive self-references inside the CTE body
- **Added** `BoundShareInput::RecursiveCte` for external references to fully-bound recursive CTEs
- **Added** `Relation::BackCteRef` variant with `bail_not_implemented!` planner stub
- **Validation**: must be `UNION ALL`, no `ORDER BY`/`LIMIT`/`OFFSET`/`FETCH` in CTE definition, column count must match between anchor and recursive terms

### Design decisions:
- A CTE in `WITH RECURSIVE` is only treated as recursive if its body is `UNION ALL` — non-recursive CTEs work normally even with the `RECURSIVE` keyword (matching PostgreSQL behavior)
- `UNION` (without `ALL`) gives a clear error message rather than a confusing "table not found"
- The planner returns `bail_not_implemented!` for recursive CTE nodes — Phase 2 will add `LogicalRecursiveUnion` and `LogicalCteRef` plan nodes

### Related:
- Tracking issue: #15135
- RFC comment: https://github.com/risingwavelabs/risingwave/issues/15135#issuecomment-4004301747

## Test plan
- Added `e2e_test/batch/basic/recursive_cte.slt.part` with tests for:
  - Basic recursive CTE binding (expects `not yet implemented` at planning stage)
  - `UNION` without `ALL` error
  - `ORDER BY` / `LIMIT` in CTE definition error
  - Column count mismatch between anchor and recursive term error
  - Non-recursive CTE in `WITH RECURSIVE` works normally

Signed-off-by: Yingjun_Wu (agent, powered by Claude Opus 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)