### PR TITLE
chore(deps): bump thiserror-ext to 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15148,18 +15148,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext"
-version = "0.3.1-alpha.2"
+version = "0.4.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db57cc0699dee90f7265d771d766cab32001b9d93b10203086c3636d7fc023e"
+checksum = "46f4577cf807cb6d5c1722347911c7d236eff6c28bf30800a658f9396aee2cb2"
 dependencies = [
  "thiserror-ext-derive",
 ]
 
 [[package]]
 name = "thiserror-ext-derive"
-version = "0.3.1-alpha.2"
+version = "0.4.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f684f89c0e42786f5c2762626f39fbdd8bd07b54dc3ffc647a034762f5d924af"
+checksum = "4373b5910ad44361f264e07f0be9f1a19e151a99ef564623e6cb7c252cef84d7"
 dependencies = [
  "either",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ sqlx = { version = "=0.8.2", default-features = false, features = [
     "uuid",
 ] }
 thiserror = "2"
-thiserror-ext = { version = "0.3.1-alpha.2", features = ["provide"] }
+thiserror-ext = { version = "0.4.0-alpha", features = ["nightly"] }
 tikv-jemalloc-ctl = { git = "https://github.com/risingwavelabs/jemallocator.git", rev = "64a2d988d687a94cd859855e19241cd8b0705466" }
 tikv-jemallocator = { git = "https://github.com/risingwavelabs/jemallocator.git", features = [
     "profiling",

--- a/lints/Cargo.lock
+++ b/lints/Cargo.lock
@@ -1027,19 +1027,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext"
-version = "0.2.1"
+version = "0.4.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4323942237f7cc071061f2c5f0db919e6053c2cdf58c6bc974883073429737"
+checksum = "46f4577cf807cb6d5c1722347911c7d236eff6c28bf30800a658f9396aee2cb2"
 dependencies = [
- "thiserror 1.0.65",
  "thiserror-ext-derive",
 ]
 
 [[package]]
 name = "thiserror-ext-derive"
-version = "0.2.1"
+version = "0.4.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96541747c50e6c73e094737938f4f5dfaf50c48a31adff4197a3e2a481371674"
+checksum = "4373b5910ad44361f264e07f0be9f1a19e151a99ef564623e6cb7c252cef84d7"
 dependencies = [
  "either",
  "proc-macro2",

--- a/lints/Cargo.toml
+++ b/lints/Cargo.toml
@@ -24,7 +24,7 @@ dylint_testing = "=4.1.0"
 # UI test dependencies
 anyhow = "1"
 thiserror = "2"
-thiserror-ext = "0.2"
+thiserror-ext = { version = "0.4.0-alpha", features = ["nightly"] }
 tracing = "0.1"
 
 [package.metadata.rust-analyzer]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This bumps the workspace `thiserror-ext` dependency to `0.4.0-alpha` and refreshes both lockfiles. Because `0.4.0-alpha` no longer exposes the old `provide` feature, the workspace and `lints` manifests now enable `nightly` instead, which matches the repo's existing nightly error member access usage.

Validated with `cargo check -p risingwave_error --locked` and `cargo check -p risingwave_frontend --locked`. `cd lints && cargo check --locked` currently does not complete locally because `dylint-link` is not available in this environment.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>