### PR TITLE
ci: increase e2e-test-parallel timeout from 38 to 45 minutes

### DIFF
--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -198,7 +198,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 38
+    timeout_in_minutes: 45
     parallelism: 4
     retry: *auto-retry
 


### PR DESCRIPTION
## Summary
- Increase the "end-to-end test (parallel)" step timeout from 38 to 45 minutes
- This step timed out in the merge queue for PR #24988 (Buildkite Build #93133, job `end-to-end test (parallel)`)

## Test plan
- [ ] CI passes with the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)