### PR TITLE
test: stabilize non-shared source connector props flaky assertion

### DIFF
--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -89,13 +89,13 @@ alter source non_shared_source_1 connector WITH (properties.receive.message.max.
 statement ok
 alter source non_shared_source_2 connector WITH (properties.receive.message.max.bytes = secret s2);
 
-query I retry 10 backoff 1s
+query I retry 5 backoff 1s
 select count(*)  from rw_sources where definition ILIKE '%secret s2%' and name = 'non_shared_source_1';
 ----
 1
 
 
-query I retry 10 backoff 1s
+query I retry 5 backoff 1s
 select count(*)  from rw_sources where definition ILIKE '%secret s2%' and name = 'non_shared_source_2';
 ----
 1


### PR DESCRIPTION
## Summary
- fix flaky assertion in `alter_connector_props_non_shared_source.slt`
- make `rw_sources.definition` checks use retry/backoff for eventual catalog visibility
- keep retry budget small (`retry 5 backoff 1s`) to limit CI duration impact

## Scope
- test-only change
- no source/connector implementation changes

## Validation
- verified diff is limited to the target slt file

resolve https://github.com/risingwavelabs/risingwave/issues/24995
