### PR TITLE
ci: scope over-window branch to e2e-parallel repro

### DIFF
--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -69,6 +69,7 @@ other-sql-backend: &other-sql-backend
 
 steps:
   - label: "check ci image rebuild"
+    if: build.branch != "shanicky/over-window-pr-only"
     plugins:
       - monorepo-diff#v1.2.0:
           diff: "git diff --name-only origin/main"
@@ -111,6 +112,7 @@ steps:
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
     key: "build-simulation"
+    if: build.branch != "shanicky/over-window-pr-only"
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
@@ -128,9 +130,11 @@ steps:
   - label: "end-to-end test"
     command: "ci/scripts/e2e-test-serial.sh -p ci-dev -m ci-3streaming-2serving-3fe"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+      )
     depends_on:
       - "build"
     plugins:
@@ -142,9 +146,11 @@ steps:
   - label: "e2e preload-memory test"
     command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true ci/scripts/e2e-test-serial.sh -p ci-dev -m ci-3streaming-2serving-3fe"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-preload-memory-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-preload-memory-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-tests?(,|$$)/
+      )
     depends_on:
       - "build"
     plugins:
@@ -158,9 +164,11 @@ steps:
     key: "slow-e2e-test"
     command: "ci/scripts/slow-e2e-test.sh -p ci-dev -m ci-3streaming-2serving-3fe"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-slow-e2e-tests"
-      || build.env("CI_STEPS") =~ /(^|,)slow-e2e-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-slow-e2e-tests"
+        || build.env("CI_STEPS") =~ /(^|,)slow-e2e-tests?(,|$$)/
+      )
     depends_on:
       - "build"
       - "build-other"
@@ -188,9 +196,11 @@ steps:
   - label: "end-to-end test (parallel)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?(,|$$)/
+      )
     depends_on:
       - "build"
       - "build-other"
@@ -199,6 +209,20 @@ steps:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 38
+    parallelism: 4
+    retry: *auto-retry
+
+  - label: "end-to-end test (parallel, ci-dev, repro)"
+    command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
+    if: build.branch == "shanicky/over-window-pr-only"
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 45
     parallelism: 4
     retry: *auto-retry
 
@@ -216,9 +240,11 @@ steps:
   - label: "end-to-end source test"
     command: "ci/scripts/e2e-source-test.sh -p ci-dev"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-source-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-source-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-source-tests?(,|$$)/
+      )
     depends_on:
       - "build"
       - "build-other"
@@ -234,9 +260,11 @@ steps:
   - label: "end-to-end sink test"
     command: "ci/scripts/e2e-sink-test.sh -p ci-dev"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-sink-tests"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-sink-tests"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-sink-tests?(,|$$)/
+      )
     depends_on:
       - "build"
       - "build-other"
@@ -450,9 +478,11 @@ steps:
   - label: "regress test"
     command: "ci/scripts/regress-test.sh -p ci-dev"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-regress-test"
-      || build.env("CI_STEPS") =~ /(^|,)regress-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-regress-test"
+        || build.env("CI_STEPS") =~ /(^|,)regress-tests?(,|$$)/
+      )
     depends_on: "build"
     plugins:
       - docker-compose#v5.5.0:
@@ -468,9 +498,11 @@ steps:
   - label: "unit test"
     command: "ci/scripts/run-unit-test.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-unit-test"
-      || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-unit-test"
+        || build.env("CI_STEPS") =~ /(^|,)unit-tests?(,|$$)/
+      )
     plugins:
       - *cargo-cache
       - ./ci/plugins/swapfile
@@ -482,9 +514,11 @@ steps:
   - label: "check"
     command: "ci/scripts/check.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-check"
-      || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-check"
+        || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
+      )
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
@@ -494,9 +528,11 @@ steps:
   - label: "check dylint"
     command: "ci/scripts/check-dylint.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-check"
-      || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-check"
+        || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
+      )
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
@@ -506,9 +542,11 @@ steps:
   - label: "documentation"
     command: "ci/scripts/doc.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-check"
-      || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-check"
+        || build.env("CI_STEPS") =~ /(^|,)check(,|$$)/
+      )
     plugins:
       - *cargo-cache
       - docker-compose#v5.5.0: *docker-compose
@@ -518,9 +556,11 @@ steps:
   - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-unit-test.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation"
-      || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-unit-test-deterministic-simulation"
+        || build.env("CI_STEPS") =~ /(^|,)unit-tests?-deterministic-simulation(,|$$)/
+      )
     plugins:
       - docker-compose#v5.5.0: *docker-compose
     timeout_in_minutes: 12
@@ -529,9 +569,11 @@ steps:
   - label: "integration test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh pull-request"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation"
-      || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-integration-test-deterministic-simulation"
+        || build.env("CI_STEPS") =~ /(^|,)integration-tests?-deterministic-simulation(,|$$)/
+      )
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v5.5.0: *docker-compose
@@ -544,9 +586,11 @@ steps:
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=4 ci/scripts/deterministic-e2e-test.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation"
-      || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-e2e-test-deterministic-simulation"
+        || build.env("CI_STEPS") =~ /(^|,)e2e-tests?-deterministic-simulation(,|$$)/
+      )
     depends_on: "build-simulation"
     plugins:
       - seek-oss/aws-sm#v2.3.2:
@@ -564,9 +608,11 @@ steps:
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=4 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 ci/scripts/deterministic-recovery-test.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
-      || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-recovery-test-deterministic-simulation"
+        || build.env("CI_STEPS") =~ /(^|,)recovery-tests?-deterministic-simulation(,|$$)/
+      )
     depends_on: "build-simulation"
     plugins:
       # - seek-oss/aws-sm#v2.3.2:
@@ -584,8 +630,10 @@ steps:
   - label: "preload memory recovery test (deterministic simulation)"
     command: "DEFAULT_ENABLE_MEM_PRELOAD_STATE_TABLE=true TEST_NUM=4 KILL_RATE=1.0 BACKGROUND_DDL_RATE=0.0 ci/scripts/deterministic-recovery-test.sh"
     if: |
-      !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
-      || build.pull_request.labels includes "ci/run-preload-memory-tests"
+      build.branch != "shanicky/over-window-pr-only" && (
+        !(build.pull_request.labels includes "ci/pr/run-selected") && build.env("CI_STEPS") == null
+        || build.pull_request.labels includes "ci/run-preload-memory-tests"
+      )
     depends_on: "build-simulation"
     plugins:
       - docker-compose#v5.5.0: *docker-compose
@@ -815,6 +863,7 @@ steps:
 
   # Only if all steps are successful, we upload coverage reports.
   - label: "upload coverage reports"
+    if: build.branch != "shanicky/over-window-pr-only"
     command: "ci/scripts/upload-coverage.sh"
     plugins:
       - seek-oss/aws-sm#v2.3.2:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -212,7 +212,49 @@ steps:
     parallelism: 4
     retry: *auto-retry
 
-  - label: "end-to-end test (parallel, ci-dev, repro)"
+  - label: "end-to-end test (parallel, ci-dev, repro group 1)"
+    command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
+    if: build.branch == "shanicky/over-window-pr-only"
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 45
+    parallelism: 4
+    retry: *auto-retry
+
+  - label: "end-to-end test (parallel, ci-dev, repro group 2)"
+    command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
+    if: build.branch == "shanicky/over-window-pr-only"
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 45
+    parallelism: 4
+    retry: *auto-retry
+
+  - label: "end-to-end test (parallel, ci-dev, repro group 3)"
+    command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
+    if: build.branch == "shanicky/over-window-pr-only"
+    depends_on:
+      - "build"
+      - "build-other"
+      - "docslt"
+    plugins:
+      - docker-compose#v5.5.0: *docker-compose
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 45
+    parallelism: 4
+    retry: *auto-retry
+
+  - label: "end-to-end test (parallel, ci-dev, repro group 4)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
     if: build.branch == "shanicky/over-window-pr-only"
     depends_on:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR special-cases `pull-request.yml` for branch `shanicky/over-window-pr-only` so default PR jobs are gated off for this branch.
It adds four dedicated `end-to-end test (parallel, ci-dev, repro group N)` steps, each running `ci/scripts/e2e-test-parallel.sh -p ci-dev` with `parallelism: 4`, and keeps dependencies on `build`, `build-other`, and `docslt`.
It keeps regular behavior for other branches by wrapping existing default-trigger expressions with `build.branch != "shanicky/over-window-pr-only"`.
It also skips `check ci image rebuild`, deterministic simulation build jobs, and coverage upload on this branch to focus the run on reproducing the parallel e2e issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>



</details>
