### PR TITLE
docs(ago): add kickoff-ready package skeleton (no implementation)

### DIFF
--- a/docs/ago/00-goal-and-principles.md
+++ b/docs/ago/00-goal-and-principles.md
@@ -1,0 +1,28 @@
+# AGO Kickoff: Goal And Principles
+
+Status: Implementation frozen until Gates 0-4 all passed.
+
+## Problem
+We are building a RisingWave-centered self-organizing agent operating system, not a single demo pipeline.
+
+Target loop:
+`facts -> signals -> intents -> claim/execution -> writeback -> new state`
+
+## Goals
+1. Complete observe -> decide -> act within action windows.
+2. Make decisions auditable, replayable, and explainable.
+3. Support multi-agent collaboration on a shared world model.
+4. Keep the core scenario-agnostic (smart-cafe is only the first integration).
+
+## Principles
+- RW-centered, data-first: all trigger/decision/outcome paths must be visible in structured data.
+- Self-organization via shared world model: no hidden per-agent private truth.
+- RW = intelligence plane, control plane = execution plane.
+- At-least-once + idempotent by default.
+- Minimal reusable core before scenario-specific adapters.
+
+## Non-goals
+- No full workflow engine in RW.
+- No millisecond hard-real-time scheduler.
+- No demo-only architecture shortcuts.
+- No direct external side-effect commit from RW.

--- a/docs/ago/10-rw-schema-and-contracts.md
+++ b/docs/ago/10-rw-schema-and-contracts.md
@@ -1,0 +1,31 @@
+# AGO Kickoff: RW Schema And Contracts
+
+## Boundary
+- RW owns ingestion, state derivation, trigger rules, intent production, and observability projections.
+- Control plane owns claim/lease, execution orchestration, retries/compensation, policy, and side-effect commits.
+
+## Minimal Schema v0
+- `signals_raw`
+- `world_state`
+- `task_intents`
+- `task_claims`
+- `task_results`
+- `task_state` (derived, read-only)
+- `agent_events`
+- `control_commands`
+
+## Contract Fields (must-have)
+- Causality: `trace_id`, `cause_event_id`, `intent_id`, `side_effect_id`
+- Delivery semantics: `dedupe_key`, `policy_version`, `payload_version`
+- Timing: `event_time`, `ingest_time`, `deadline_at`, terminal timestamps
+
+## Ownership
+- RW writes intents and derived views.
+- Control plane writes claims/results.
+- Human/manual flow writes control commands only.
+
+## SLO v0
+- Detect p95 (`event_time -> intent emit`) <= 30s.
+- Execute p95 (`intent emit -> terminal result`) <= 5m.
+- Silent loss = 0 under failure injection suite.
+- Replay intent-set consistency >= 99% for fixed-seed input.

--- a/docs/ago/20-harness-blueprint.md
+++ b/docs/ago/20-harness-blueprint.md
@@ -1,0 +1,24 @@
+# AGO Kickoff: Harness Blueprint
+
+## Objective
+Provide a pre-implementation harness that validates boundaries, correctness, replayability, and failure behavior.
+
+## Required Components
+- Contract freeze checks (schema + ownership + semantics)
+- Replay contract (`trace_id` and `intent_id` explain path)
+- Mock harness:
+  - mock_event_producer
+  - mock_executor
+  - mock_tool_adapter
+  - mock_human_gate
+- Failure injection matrix:
+  - duplicate/reorder/late/burst
+  - worker crash/timeout
+  - side-effect success but writeback failure
+  - RW recovery/watermark stall
+  - schema drift/dead-letter growth
+- Observability baseline:
+  - lag/backlog/retry/dlq/duplicate_suppressed/orphan/stuck/state_divergence
+
+## Acceptance
+Harness is considered ready only when replay, injection, and observability checks are all executable and documented.

--- a/docs/ago/30-gates-and-collaboration.md
+++ b/docs/ago/30-gates-and-collaboration.md
@@ -1,0 +1,23 @@
+# AGO Kickoff: Gates And Collaboration
+
+Blueprint entrypoint: `notes/agent-system-on-rw.md`
+
+## Gate Policy
+No implementation starts until Gates 0-4 all pass.
+
+## Gates (DoR)
+- Gate-0: Problem/goals/non-goals frozen.
+- Gate-1: Schema/contracts/ownership frozen.
+- Gate-2: Replay and mock harness ready.
+- Gate-3: Failure injection and observability baseline ready.
+- Gate-4: Safety/policy/rollback boundaries frozen.
+
+## Collaboration Model
+- Keep architecture decisions in docs first, then implementation.
+- Every gate status update must include evidence links.
+- No hidden glue logic outside contracts.
+
+## Forbidden Patterns
+- Bypassing intents/results contracts for direct imperative agent calls.
+- Writing production feature code before gate completion.
+- Scenario-specific core schema that cannot generalize.

--- a/docs/ago/appendix-failure-matrix.md
+++ b/docs/ago/appendix-failure-matrix.md
@@ -1,0 +1,25 @@
+# AGO Kickoff: Failure Matrix (Appendix)
+
+## Input Path
+- duplicate events
+- reordered events
+- late events
+- burst traffic
+
+## RW Path
+- watermark stall
+- recovery during active intent generation
+- projection lag
+
+## Control Plane Path
+- crash after claim
+- timeout during execution
+- side-effect committed but result writeback failed
+
+## Contract Evolution
+- payload/schema drift
+- policy version mismatch
+- DLQ accumulation
+
+## Required Outcome
+For each scenario: expected behavior, detection signal, owner, and rollback action must be documented.

--- a/docs/ago/appendix-ops-playbook.md
+++ b/docs/ago/appendix-ops-playbook.md
@@ -1,0 +1,21 @@
+# AGO Kickoff: Ops Playbook (Appendix)
+
+## Triage Order
+1. Dashboard signals (lag/backlog/error classes)
+2. Log evidence in matching time window
+3. Responsibility split (RW vs control plane vs external dependency)
+
+## Required IDs
+All diagnosis paths must preserve and query by:
+- `trace_id`
+- `intent_id`
+- `task_id`
+- `worker_id`/`executor_id`
+- `policy_version`
+
+## Incident Output Template
+- Symptom
+- Evidence (with timestamps)
+- Root cause classification
+- Immediate mitigation
+- Follow-up action and owner


### PR DESCRIPTION
## Summary
- add kickoff-ready AGO doc package under docs/ago/
- capture goal/principles, RW schema/contracts, harness blueprint, gates/collaboration, and failure/ops appendices
- explicitly mark project as implementation-frozen until Gates 0-4 pass

## Files
- docs/ago/00-goal-and-principles.md
- docs/ago/10-rw-schema-and-contracts.md
- docs/ago/20-harness-blueprint.md
- docs/ago/30-gates-and-collaboration.md
- docs/ago/appendix-failure-matrix.md
- docs/ago/appendix-ops-playbook.md

## Scope
- docs-only
- no runtime/feature implementation changes
