### PR TITLE
test: decouple inject skip coverage from mysql cdc reset test

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -198,8 +198,10 @@ services:
   source-cron-only-test-env:
     image: public.ecr.aws/w1p7b4n3/rw-build-env:${BUILD_ENV_VERSION:?}
     depends_on:
-      - db
-      - message_queue
+      db:
+        condition: service_healthy
+      message_queue:
+        condition: service_healthy
     volumes:
       - ..:/risingwave
     stop_grace_period: 30s

--- a/ci/scripts/e2e-source-cron-only-test.sh
+++ b/ci/scripts/e2e-source-cron-only-test.sh
@@ -8,6 +8,25 @@ source ci/scripts/common.sh
 # prepare environment
 export CONNECTOR_LIBS_PATH="./connector-node/libs"
 
+wait_for_service() {
+    local name="$1"
+    local cmd="$2"
+    local retries="${3:-60}"
+    local interval="${4:-2}"
+
+    for ((i = 1; i <= retries; i++)); do
+        if eval "$cmd" >/dev/null 2>&1; then
+            echo "--- ${name} is ready"
+            return 0
+        fi
+        echo "--- waiting for ${name} (${i}/${retries})"
+        sleep "$interval"
+    done
+
+    echo "--- ${name} is not ready after ${retries} retries"
+    return 1
+}
+
 while getopts 'p:' opt; do
     case ${opt} in
         p )
@@ -33,6 +52,10 @@ tar xf ./risingwave-connector.tar.gz -C ./connector-node
 
 echo "--- Install dependencies"
 python3 -m pip install --break-system-packages -r ./e2e_test/requirements.txt
+
+echo "--- Wait for docker compose dependencies"
+wait_for_service "Postgres(db)" "pg_isready -h db -p 5432 -U postgres"
+wait_for_service "Kafka(message_queue)" "rpk cluster info -X brokers=message_queue:29092"
 
 echo "--- e2e, cron_only inline source tests"
 RUST_LOG="debug,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_meta=info" \

--- a/ci/scripts/e2e-source-mysql-cdc-reset.sh
+++ b/ci/scripts/e2e-source-mysql-cdc-reset.sh
@@ -1,254 +1,129 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Test: MySQL CDC binlog offset expiration and ALTER SOURCE RESET recovery
+# Test MySQL CDC binlog expiration and ALTER SOURCE RESET recovery.
 #
-# This test verifies the behavior when MySQL binlog containing the CDC offset expires,
-# and validates the ALTER SOURCE RESET command for recovery.
+# This script intentionally focuses on RESET behavior only.
+# inject-source-offsets skip/rewind behavior is covered by:
+# e2e_test/source_inline/kafka/alter/cron_only/alter_source_properties_safe.slt.serial
 #
-# Expected behavior:
-# 1. ALTER SOURCE RESET sets the expired offset in state table to NULL
-# 2. Requires one recovery (restart) to reset Debezium and update offset from NULL to latest available offset
-# 3. After recovery, new data after the latest offset is consumed normally
-# 4. Data between expired offset and latest offset is lost (expected data loss)
-#
-# Test scenario:
-# - Batch 1 (id=1-5): Consumed before binlog expiration -> SHOULD BE PRESENT
-# - Batch 2 (id=6-10): Written while source paused, binlog purged -> LOST (binlog expired)
-# - Batch 3 (id=16-20): Written after RESET but before restart -> LOST (offset not persisted)
-# - Batch 4 (id=101-120): Written after restart cluster -> SHOULD BE PRESENT
-# - Expected final count: 25 rows (5 + 20)
+# Scenario:
+# 1. Consume batch1 (id=1..5).
+# 2. Pause source and write batch2 (id=6..10), then purge old binlog.
+# 3. Resume source; expired binlog data should not be consumed.
+# 4. Execute ALTER SOURCE RESET.
+# 5. Write batch3 (id=16..20), restart RW, then write batch4 (id=101..120).
+# 6. Verify RESET recovery and expected data loss boundaries.
 
 set -euo pipefail
 
 export MYSQL_HOST=mysql MYSQL_TCP_PORT=3306 MYSQL_PWD=123456
 
-echo "\n\n\n-------------Run MySQL CDC binlog expire and RESET test------------\n\n\n"
+query_i_retry() {
+    local sql="$1"
+    local expected="$2"
+    local retry="$3"
+    local backoff="$4"
+    local tmp
+    tmp=$(mktemp)
+    cat >"$tmp" <<SLT
+query I retry ${retry} backoff ${backoff}
+${sql}
+----
+${expected}
+SLT
+    risedev slt "$tmp"
+    rm -f "$tmp"
+}
 
-# Cleanup
-risedev kill && risedev clean-data
+mysql_exec() {
+    local sql="$1"
+    mysql -e "$sql"
+}
 
-# Setup CDC table with initial schema
+echo "------------- reset-only mysql cdc test ------------"
+echo "inject-source-offsets skip behavior is validated in cron_only tests"
+
+echo "------------- setup ------------"
+risedev kill || true
+risedev clean-data
 risedev ci-resume mysql-offline-schema-change-test
-echo "\n\n\n-------------RW started------------\n\n\n"
 
-# Create database and test table
-echo "Creating test database and table..."
-mysql -e "
-    DROP DATABASE IF EXISTS binlog_test;
-    CREATE DATABASE binlog_test;
-    USE binlog_test;
-    CREATE TABLE test_table (
-        id INT PRIMARY KEY,
-        value VARCHAR(100),
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    );
-"
-
-# Create CDC source
-echo "Creating CDC source..."
-risedev psql -c "CREATE SOURCE s WITH (
-    username = '${MYSQL_USER:-root}',
-    connector = 'mysql-cdc',
-    hostname = '${MYSQL_HOST}',
-    port = '${MYSQL_TCP_PORT}',
-    password = '${MYSQL_PWD}',
-    database.name = 'binlog_test'
+mysql_exec "
+DROP DATABASE IF EXISTS binlog_test;
+CREATE DATABASE binlog_test;
+USE binlog_test;
+CREATE TABLE test_table (
+  id INT PRIMARY KEY,
+  value VARCHAR(100),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );"
 
-sleep 3
+risedev psql -c "CREATE SOURCE s WITH (
+  username = '${MYSQL_USER:-root}',
+  connector = 'mysql-cdc',
+  hostname = '${MYSQL_HOST}',
+  port = '${MYSQL_TCP_PORT}',
+  password = '${MYSQL_PWD}',
+  database.name = 'binlog_test'
+);"
 
-# Create CDC table
-echo "Creating CDC table..."
 risedev psql -c "CREATE TABLE test_table (
-    id INT PRIMARY KEY,
-    value VARCHAR,
-    created_at TIMESTAMPTZ
+  id INT PRIMARY KEY,
+  value VARCHAR,
+  created_at TIMESTAMPTZ
 ) FROM s TABLE 'binlog_test.test_table';"
 
-sleep 5
-
-echo "\n\n\n-------------Phase 1: Insert first batch and let RW consume------------\n\n\n"
-echo "Inserting first batch (id=1-5)..."
+echo "------------- phase1: baseline consume ------------"
 for i in {1..5}; do
-    mysql -e "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch1_$i');"
+    mysql_exec "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch1_$i');"
 done
+query_i_retry "SELECT COUNT(*) FROM test_table;" "5" 30 "1s"
 
-sleep 5
-
-echo "--- Verify first batch (should be 5 rows)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 5 THEN 'OK' ELSE 'FAIL' END FROM test_table;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: First batch has 5 rows"
-else
-    echo "✗ FAIL: First batch does not have 5 rows"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table;"
-    exit 1
-fi
-
-echo "\n\n\n-------------Phase 2: Pause source------------\n\n\n"
-echo "Pausing source with rate_limit=0..."
+echo "------------- phase2: pause and write batch2 ------------"
 risedev psql -c "ALTER SOURCE s SET source_rate_limit = 0;"
-
-sleep 2
-
-echo "\n\n\n-------------Phase 3: Insert second batch (will not be consumed)------------\n\n\n"
-echo "Inserting second batch (id=6-10) while source is paused..."
 for i in {6..10}; do
-    mysql -e "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch2_$i');"
+    mysql_exec "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch2_$i');"
 done
+query_i_retry "SELECT COUNT(*) FROM test_table;" "5" 10 "1s"
 
-sleep 3
+echo "------------- phase3: expire binlog and resume ------------"
+mysql_exec "FLUSH LOGS;"
+mysql_exec "USE binlog_test; INSERT INTO test_table (id, value) VALUES (50, 'dummy_data');"
+CURRENT_BINLOG=$(
+    mysql -s -N -e "SHOW BINARY LOG STATUS;" 2>/dev/null | awk '{print $1}' ||
+        mysql -s -N -e "SHOW MASTER STATUS;" 2>/dev/null | awk '{print $1}'
+)
+mysql_exec "PURGE BINARY LOGS TO '$CURRENT_BINLOG';"
 
-echo "--- Verify second batch not consumed (should still be 5 rows)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 5 THEN 'OK' ELSE 'FAIL' END FROM test_table;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Second batch not consumed, still 5 rows"
-else
-    echo "✗ FAIL: Count is not 5"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table;"
-    exit 1
-fi
-
-echo "\n\n\n-------------Phase 4: Force binlog rotation and PURGE------------\n\n\n"
-echo "Flushing logs to rotate binlog..."
-mysql -e "FLUSH LOGS;"
-
-sleep 2
-
-echo "Inserting dummy data to new binlog..."
-mysql -e "USE binlog_test; INSERT INTO test_table (id, value) VALUES (50, 'dummy_data');"
-
-sleep 1
-
-echo "Purging old binlog files..."
-CURRENT_BINLOG=$(mysql -s -N -e "SHOW BINARY LOG STATUS;" 2>/dev/null | awk '{print $1}' || mysql -s -N -e "SHOW MASTER STATUS;" 2>/dev/null | awk '{print $1}')
-mysql -e "PURGE BINARY LOGS TO '$CURRENT_BINLOG';"
-
-sleep 2
-
-echo "\n\n\n-------------Phase 5: Resume source (should fail to consume expired binlog)------------\n\n\n"
-echo "Resuming source..."
 risedev psql -c "ALTER SOURCE s SET source_rate_limit = default;"
+query_i_retry "SELECT COUNT(*) FROM test_table;" "5" 10 "1s"
 
-sleep 5
-
-echo "--- Verify source cannot consume expired binlog (should still be 5 rows)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 5 THEN 'OK' ELSE 'FAIL' END FROM test_table;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Source cannot consume expired binlog, still 5 rows"
-else
-    echo "✗ FAIL: Count is not 5, binlog may not be expired"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table;"
-    exit 1
-fi
-
-sleep 2
-
-echo "\n\n\n-------------Phase 6: Execute ALTER SOURCE RESET------------\n\n\n"
-echo "Executing ALTER SOURCE RESET..."
+echo "------------- phase4: reset and restart ------------"
 risedev psql -c "ALTER SOURCE s RESET;"
 
-sleep 2
-
-echo "\n\n\n-------------Phase 7: Insert data after RESET------------\n\n\n"
-echo "Inserting third batch (id=16-20) after RESET..."
 for i in {16..20}; do
-    mysql -e "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch3_after_reset_$i');"
+    mysql_exec "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch3_after_reset_$i');"
 done
 
-sleep 5
-
-echo "Restarting RW to ensure offset persistence..."
 risedev kill
-sleep 2
 risedev ci-resume mysql-offline-schema-change-test
-sleep 5
 
-echo "Inserting fourth batch (id=101-120) after restart..."
 for i in {101..120}; do
-    mysql -e "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch4_after_restart_$i');"
+    mysql_exec "USE binlog_test; INSERT INTO test_table (id, value) VALUES ($i, 'batch4_after_restart_$i');"
 done
 
-sleep 10
+echo "------------- verify reset behavior ------------"
+query_i_retry "SELECT COUNT(*) FROM test_table;" "25" 60 "1s"
+query_i_retry "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 1 AND 5;" "5" 10 "1s"
+query_i_retry "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 6 AND 10;" "0" 10 "1s"
+query_i_retry "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 16 AND 20;" "0" 10 "1s"
+query_i_retry "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 101 AND 120;" "20" 10 "1s"
 
-echo "\n\n\n-------------Final Verification------------\n\n\n"
-
-# Verify batch 1 (id=1-5): should have 5 rows
-echo "--- Verify batch 1 (id=1-5, should be 5 rows)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 5 THEN 'OK' ELSE 'FAIL' END FROM test_table WHERE id BETWEEN 1 AND 5;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Batch 1 has 5 rows"
-else
-    echo "✗ FAIL: Batch 1 does not have 5 rows"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 1 AND 5;"
-    exit 1
-fi
-
-# Verify batch 2 (id=6-10): should have 0 rows (binlog expired)
-echo "--- Verify batch 2 (id=6-10, should be 0 rows - binlog expired)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 0 THEN 'OK' ELSE 'FAIL' END FROM test_table WHERE id BETWEEN 6 AND 10;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Batch 2 has 0 rows (binlog expired as expected)"
-else
-    echo "✗ FAIL: Batch 2 should have 0 rows"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 6 AND 10;"
-    exit 1
-fi
-
-# Verify batch 3 (id=16-20): should have 0 rows (not persisted before restart)
-echo "--- Verify batch 3 (id=16-20, should be 0 rows - not persisted before restart)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 0 THEN 'OK' ELSE 'FAIL' END FROM test_table WHERE id BETWEEN 16 AND 20;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Batch 3 has 0 rows (not persisted as expected)"
-else
-    echo "✗ FAIL: Batch 3 should have 0 rows"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 16 AND 20;"
-    exit 1
-fi
-
-# Verify batch 4 (id=101-120): should have 20 rows
-echo "--- Verify batch 4 (id=101-120, should be 20 rows)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 20 THEN 'OK' ELSE 'FAIL' END FROM test_table WHERE id BETWEEN 101 AND 120;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Batch 4 has 20 rows"
-else
-    echo "✗ FAIL: Batch 4 does not have 20 rows"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table WHERE id BETWEEN 101 AND 120;"
-    exit 1
-fi
-
-# Verify total count (should be 25: batch1(5) + batch4(20))
-echo "--- Verify total count (should be 25 rows)"
-OUTPUT=$(risedev psql -t -c "SELECT CASE WHEN COUNT(*) = 25 THEN 'OK' ELSE 'FAIL' END FROM test_table;" 2>&1)
-if echo "$OUTPUT" | grep -q "OK"; then
-    echo "✓ PASS: Total count is 25 rows (batch1 + batch4)"
-    echo "  - Lost data as expected: batch2(5, binlog expired) + batch3(5, not persisted) + dummy(1)"
-else
-    echo "✗ FAIL: Total count is not 25"
-    echo "Debug output: $OUTPUT"
-    risedev psql -c "SELECT COUNT(*) FROM test_table;"
-    exit 1
-fi
-
-echo "\n\n\n-------------All verifications passed------------\n\n\n"
-
-echo "\n\n\n-------------Cleanup test environment------------\n\n\n"
-
-# Drop table and source
+echo "------------- cleanup ------------"
 risedev psql -c "DROP TABLE test_table;"
 risedev psql -c "DROP SOURCE s;"
+mysql_exec "DROP DATABASE IF EXISTS binlog_test;"
+risedev kill || true
+risedev clean-data
 
-# Drop database
-mysql -e "DROP DATABASE IF EXISTS binlog_test;"
-
-echo "\n\n\n-------------Cleanup completed------------\n\n\n"
-
-# Cleanup
-risedev kill && risedev clean-data
+echo "All verifications passed."

--- a/e2e_test/source_inline/kafka/alter/cron_only/alter_source_properties_safe.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/cron_only/alter_source_properties_safe.slt.serial
@@ -2,13 +2,14 @@
 # This test covers:
 # 1. Update broker address - most critical ops scenario (broker migration)
 # 2. Split reset (reset-source-splits) - force split re-discovery
-# 3. Offset injection (inject-source-offsets) - UNSAFE offset manipulation
+# 3. Offset injection rewind (inject-source-offsets) - UNSAFE offset manipulation
+# 4. Offset injection forward skip (inject-source-offsets) - UNSAFE offset manipulation
 
 control substitution on
 
 # Setup: Create topic and produce initial data
 system ok
-rpk topic create test_safe_update
+rpk topic create test_safe_update -p 1
 
 system ok
 cat <<EOF | rpk topic produce 'test_safe_update' -f "%v\n"
@@ -167,6 +168,48 @@ query I
 SELECT COUNT(*) FROM mv_test WHERE data = 'after_inject';
 ----
 2
+
+# Test 4: Inject forward offsets (UNSAFE skip behavior)
+# This test verifies offset injection by injecting a forward offset,
+# which should skip the next 2 messages.
+system ok
+python3 e2e_test/source_inline/kafka/alter/get_kafka_offsets.py \
+    --topic test_safe_update \
+    --skip-next 2 \
+    --output /tmp/offsets_skip_forward.json
+
+system ok
+SOURCE_ID=$(psql -h ${RISEDEV_RW_FRONTEND_LISTEN_ADDRESS} \
+    -p ${RISEDEV_RW_FRONTEND_PORT} \
+    -d $__DATABASE__ \
+    -U root \
+    -t -A \
+    -c "SELECT id FROM rw_sources WHERE name = 'kafka_test_source'") && \
+OFFSETS=$(cat /tmp/offsets_skip_forward.json) && \
+echo "Injecting forward offsets for Source ID: $SOURCE_ID" && \
+echo "Offsets: $OFFSETS" && \
+./risedev ctl meta inject-source-offsets \
+    --source-id $SOURCE_ID \
+    --offsets "$OFFSETS"
+
+system ok
+cat <<EOF | rpk topic produce 'test_safe_update' -f "%v\n"
+{"id": 12, "data": "after_forward_skip"}
+{"id": 13, "data": "after_forward_skip"}
+{"id": 14, "data": "after_forward_skip"}
+EOF
+
+# The first 2 newly produced records should be skipped.
+# Previous count: 15. Only one new record should be consumed.
+query I retry 10 backoff 1s
+SELECT COUNT(*) FROM mv_test;
+----
+16
+
+query I retry 10 backoff 1s
+SELECT COUNT(*) FROM mv_test WHERE data = 'after_forward_skip';
+----
+1
 
 # Cleanup
 statement ok

--- a/e2e_test/source_inline/kafka/alter/get_kafka_offsets.py
+++ b/e2e_test/source_inline/kafka/alter/get_kafka_offsets.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Get current Kafka topic offsets for all partitions.
-This is used to inject forward offsets, skipping some messages.
+Get Kafka offsets for all partitions for inject-source-offsets tests.
 """
 import argparse
 import json
@@ -9,12 +8,18 @@ import os
 from confluent_kafka import Consumer, TopicPartition
 
 
-def get_kafka_offsets(broker, topic, skip_last_n=2):
+def get_kafka_offsets(broker, topic, skip_last_n=None, skip_next_n=None):
     """
     Get offsets for all partitions.
     Args:
-        skip_last_n: Skip this many messages from the end by setting offset to high-watermark - skip_last_n
+        skip_last_n: Re-consume the last N messages by setting offset to high-watermark - N - 1.
+        skip_next_n: Skip the next N messages by setting offset to high-watermark + N - 1.
     """
+    if skip_last_n is not None and skip_next_n is not None:
+        raise ValueError("Only one of skip_last_n or skip_next_n can be set")
+    if skip_last_n is None and skip_next_n is None:
+        skip_last_n = 2
+
     consumer = Consumer({
         'bootstrap.servers': broker,
         'group.id': 'test_offset_reader',
@@ -30,10 +35,17 @@ def get_kafka_offsets(broker, topic, skip_last_n=2):
         for partition_id in partitions.keys():
             tp = TopicPartition(topic, partition_id)
             low, high = consumer.get_watermark_offsets(tp)
-            # Set offset to skip last N messages
-            # inject_source_offsets expects "last_seen_offset", so start_offset = offset + 1.
-            # We subtract 1 to ensure we start reading from (high - skip_last_n).
-            new_offset = high - skip_last_n - 1
+
+            if skip_last_n is not None:
+                # inject-source-offsets accepts "last consumed offset".
+                # To re-consume the last N messages, the next consumed offset must be (high - N).
+                # Therefore we inject (high - N - 1).
+                new_offset = high - skip_last_n - 1
+            else:
+                # To skip the next N messages, the next consumed offset must be (high + N).
+                # Therefore we inject (high + N - 1).
+                new_offset = high + skip_next_n - 1
+
             offsets[str(partition_id)] = str(new_offset)
 
         return offsets
@@ -45,15 +57,24 @@ def main():
     parser = argparse.ArgumentParser(description='Get Kafka topic offsets')
     parser.add_argument('--topic', required=True, help='Kafka topic name')
     parser.add_argument('--output', help='Output file path (default: stdout)')
-    parser.add_argument('--skip-last', type=int, default=2,
-                       help='Skip last N messages per partition')
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        '--skip-last',
+        type=int,
+        help='Re-consume the last N messages per partition',
+    )
+    mode.add_argument(
+        '--skip-next',
+        type=int,
+        help='Skip the next N messages per partition',
+    )
     args = parser.parse_args()
 
     # Get broker from environment
     broker = os.environ.get('RISEDEV_KAFKA_BOOTSTRAP_SERVERS', 'message_queue:29092')
 
     # Get offsets
-    offsets = get_kafka_offsets(broker, args.topic, args.skip_last)
+    offsets = get_kafka_offsets(broker, args.topic, args.skip_last, args.skip_next)
 
     # Output as JSON
     offsets_json = json.dumps(offsets)


### PR DESCRIPTION
## Summary
- move `inject-source-offsets` skip-forward behavior coverage to the cron-only Kafka alter test path
- keep `ci/scripts/e2e-source-mysql-cdc-reset.sh` focused on reset/binlog-expiry recovery only
- harden cron-only CI stability by waiting for service readiness in script and using compose health conditions

## What changed
- `e2e_test/source_inline/kafka/alter/cron_only/alter_source_properties_safe.slt.serial`
  - add forward-skip verification for `inject-source-offsets`
  - keep rewind/re-consume verification
  - use a single-partition topic for deterministic count assertions
- `e2e_test/source_inline/kafka/alter/get_kafka_offsets.py`
  - add `--skip-next` mode for forward-skip injection
  - keep `--skip-last` for rewind behavior
- `ci/scripts/e2e-source-cron-only-test.sh`
  - add explicit readiness waits for Postgres and Kafka before starting risedev
- `ci/docker-compose.yml`
  - use `service_healthy` conditions for `source-cron-only-test-env` dependencies
- `ci/scripts/e2e-source-mysql-cdc-reset.sh`
  - remove inject/offset-internal coupling
  - keep only reset-recovery scenario and boundary assertions

## Why
This separates two test responsibilities clearly:
1. unsafe offset injection semantics (rewind/skip) in cron-only Kafka tests
2. MySQL CDC reset recovery semantics in the reset script

This improves signal quality and reduces flaky coupling between unrelated behavior checks.
