### PR TITLE
feat(meta): reject registeration of workers in different RW_VERSION

### DIFF
--- a/src/meta/service/src/cluster_service.rs
+++ b/src/meta/service/src/cluster_service.rs
@@ -61,10 +61,11 @@ impl ClusterService for ClusterServiceImpl {
             PbWorkerType::Frontend | PbWorkerType::ComputeNode | PbWorkerType::Compactor
         ) && resource.rw_version != RW_VERSION
         {
-            return Err(Status::invalid_argument(format!(
+            return Err(MetaError::invalid_parameter(format!(
                 "worker node version {} does not match meta node version {}",
                 resource.rw_version, RW_VERSION,
-            )));
+            ))
+            .into());
         }
         let worker_id = self
             .metadata_manager


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds a version consistency check when worker nodes (compute, frontend, compactor) register with the meta node via the `AddWorkerNode` RPC.

**Summary:**
- When a worker node calls `AddWorkerNode` to register itself, the meta node now compares the `rw_version` in the request's `Resource` field against its own `RW_VERSION`.
- If the versions differ, the registration is rejected with an `INVALID_ARGUMENT` gRPC error containing both version strings for easy diagnosis.

**How it works:**
- Worker nodes already send `RW_VERSION` in the `Resource.rw_version` field of `AddWorkerNodeRequest` — no client-side changes needed.
- In `ClusterServiceImpl::add_worker_node`, after extracting the `resource`, we compare `resource.rw_version` against the meta node's `RW_VERSION` constant. On mismatch, we return `Status::invalid_argument` with a descriptive message (e.g., *"worker node version 2.2.0 does not match meta node version 2.3.0"*).

**Motivation:**
Running a cluster with mixed RisingWave versions can lead to subtle incompatibilities and hard-to-debug issues. This check enforces version consistency at registration time, providing a clear and early error rather than letting mismatched nodes join the cluster.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
