### PR TITLE
chore(deps): bump arrow used by adbc from 56 to 57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8dbe031527c9856a1e2df5e82aa8e568ffaab3be897f70d874477fb42a783bb"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
 ]
 
 [[package]]
@@ -20,8 +20,8 @@ checksum = "5beaa87308b040adcf482fb760f64ced1cbcd9469fe86ddd5be221dabbbc544e"
 dependencies = [
  "adbc_core",
  "adbc_ffi",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
  "libloading 0.8.9",
  "toml 0.9.12+spec-1.1.0",
  "windows-registry 0.6.1",
@@ -35,8 +35,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3600ae9aec2907516d088189e3b863029280f1953dd0eab903c7f4c862a0ce81"
 dependencies = [
  "adbc_core",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
 ]
 
 [[package]]
@@ -48,8 +48,8 @@ dependencies = [
  "adbc_core",
  "adbc_driver_manager",
  "adbc_ffi",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
  "url",
 ]
 
@@ -758,9 +758,6 @@ name = "arrow-schema"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
-dependencies = [
- "bitflags 2.10.0",
-]
 
 [[package]]
 name = "arrow-schema"

--- a/src/connector/src/source/adbc_snowflake/mod.rs
+++ b/src/connector/src/source/adbc_snowflake/mod.rs
@@ -26,7 +26,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::array::arrow::{
-    Arrow56FromArrow, arrow_array_56 as arrow, arrow_schema_56 as arrow_schema,
+    Arrow57FromArrow, arrow_array_57 as arrow, arrow_schema_57 as arrow_schema,
 };
 use risingwave_common::types::JsonbVal;
 use serde::{Deserialize, Serialize};
@@ -45,21 +45,21 @@ mod schema;
 #[derive(Default)]
 pub struct AdbcSnowflakeArrowConvert;
 
-impl Arrow56FromArrow for AdbcSnowflakeArrowConvert {}
+impl Arrow57FromArrow for AdbcSnowflakeArrowConvert {}
 
 impl AdbcSnowflakeArrowConvert {
     pub fn chunk_from_record_batch(
         &self,
         batch: &arrow::RecordBatch,
     ) -> Result<risingwave_common::array::DataChunk, risingwave_common::array::ArrayError> {
-        Arrow56FromArrow::from_record_batch(self, batch)
+        Arrow57FromArrow::from_record_batch(self, batch)
     }
 
     pub fn type_from_field(
         &self,
         field: &arrow_schema::Field,
     ) -> Result<risingwave_common::types::DataType, risingwave_common::array::ArrayError> {
-        Arrow56FromArrow::from_field(self, field)
+        Arrow57FromArrow::from_field(self, field)
     }
 }
 

--- a/src/connector/src/source/adbc_snowflake/schema.rs
+++ b/src/connector/src/source/adbc_snowflake/schema.rs
@@ -14,8 +14,8 @@
 
 use adbc_core::Statement as _;
 use anyhow::Context;
-use risingwave_common::array::arrow::arrow_array_56::RecordBatchReader;
-use risingwave_common::array::arrow::arrow_schema_56 as arrow_schema;
+use risingwave_common::array::arrow::arrow_array_57::RecordBatchReader;
+use risingwave_common::array::arrow::arrow_schema_57 as arrow_schema;
 
 use super::AdbcSnowflakeProperties;
 use crate::error::ConnectorResult;

--- a/src/stream/src/executor/source/batch_source/batch_adbc_snowflake_fetch.rs
+++ b/src/stream/src/executor/source/batch_source/batch_adbc_snowflake_fetch.rs
@@ -20,7 +20,7 @@ use futures::stream;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use risingwave_common::array::Op;
-use risingwave_common::array::arrow::arrow_array_56 as arrow;
+use risingwave_common::array::arrow::arrow_array_57 as arrow;
 use risingwave_common::id::TableId;
 use risingwave_common::types::{JsonbVal, Scalar, ScalarRef};
 use risingwave_connector::source::ConnectorProperties;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

This is neither a bump of adbc nor a bump of arrow.

RisingWave already depends on multiple major versions of arrow, and adbc 0.22 works with arrow `>=53.1.0, <58`.

When this happens, the arrow 56 in `Cargo.lock` is used by adbc. However, when `cargo` is asked to update the `Cargo.lock` file - including **when bumping other dependencies** by dependabot, it tends to select the latest major version `57`, and it would **require either code change in this PR or manually revert** back to 56.

As a result, this PR updates adbc to use the latest arrow major version in RisingWave, so that updating other dependencies require no manual intervention.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
