### PR TITLE
fix(stream): skip empty chunks in synced kv log store to prevent seq_id progress assertion failure

### DIFF
--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -71,7 +71,7 @@ impl LogStoreVnodeProgress {
         match prev_progress {
             None => {
                 assert!(
-                    prev_epoch < epoch,
+                    prev_epoch <= epoch,
                     "barrier epoch {} decrease to {}",
                     prev_epoch,
                     epoch
@@ -80,7 +80,24 @@ impl LogStoreVnodeProgress {
             Some(prev_progress) => {
                 assert_eq!(prev_epoch, epoch);
                 if let Some(progress) = progress {
-                    assert!(progress > prev_progress);
+                    assert!(
+                        progress >= prev_progress,
+                        "seq_id decreased: prev_epoch={}, epoch={}, prev_progress={}, progress={}",
+                        prev_epoch,
+                        epoch,
+                        prev_progress,
+                        progress
+                    );
+                    if progress == prev_progress {
+                        tracing::warn!(
+                            prev_epoch,
+                            epoch,
+                            prev_progress,
+                            progress,
+                            "progress did not strictly increase: this may indicate \
+                             empty chunks (cardinality=0) were not filtered out"
+                        );
+                    }
                 }
             }
         }

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -778,39 +778,55 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                                         }
                                     }
                                     Message::Chunk(chunk) => {
-                                        let start_seq_id = seq_id;
-                                        let new_seq_id = seq_id + chunk.cardinality() as SeqId;
-                                        let end_seq_id = new_seq_id - 1;
-                                        let epoch = write_state.epoch().curr;
-                                        tracing::trace!(
-                                            start_seq_id,
-                                            end_seq_id,
-                                            new_seq_id,
-                                            epoch,
-                                            cardinality = chunk.cardinality(),
-                                            "received chunk"
-                                        );
-                                        if let Some(chunk_to_flush) = buffer.add_or_flush_chunk(
-                                            start_seq_id,
-                                            end_seq_id,
-                                            chunk,
-                                            epoch,
-                                        ) {
-                                            seq_id = new_seq_id;
-                                            write_future_state = WriteFuture::flush_chunk(
-                                                stream,
-                                                write_state,
-                                                chunk_to_flush,
-                                                epoch,
-                                                start_seq_id,
-                                                end_seq_id,
+                                        // Skip empty chunks to avoid non-advancing seq_id
+                                        // (end_seq_id = start_seq_id - 1), which would violate the
+                                        // strict progress increase invariant in apply_aligned when
+                                        // consecutive empty chunks produce identical end_seq_id.
+                                        if chunk.cardinality() == 0 {
+                                            tracing::warn!(
+                                                epoch = write_state.epoch().curr,
+                                                "received empty chunk (cardinality=0), skipping"
                                             );
-                                        } else {
-                                            seq_id = new_seq_id;
                                             write_future_state = WriteFuture::receive_from_upstream(
                                                 stream,
                                                 write_state,
                                             );
+                                        } else {
+                                            let start_seq_id = seq_id;
+                                            let new_seq_id = seq_id + chunk.cardinality() as SeqId;
+                                            let end_seq_id = new_seq_id - 1;
+                                            let epoch = write_state.epoch().curr;
+                                            tracing::trace!(
+                                                start_seq_id,
+                                                end_seq_id,
+                                                new_seq_id,
+                                                epoch,
+                                                cardinality = chunk.cardinality(),
+                                                "received chunk"
+                                            );
+                                            if let Some(chunk_to_flush) = buffer.add_or_flush_chunk(
+                                                start_seq_id,
+                                                end_seq_id,
+                                                chunk,
+                                                epoch,
+                                            ) {
+                                                seq_id = new_seq_id;
+                                                write_future_state = WriteFuture::flush_chunk(
+                                                    stream,
+                                                    write_state,
+                                                    chunk_to_flush,
+                                                    epoch,
+                                                    start_seq_id,
+                                                    end_seq_id,
+                                                );
+                                            } else {
+                                                seq_id = new_seq_id;
+                                                write_future_state =
+                                                    WriteFuture::receive_from_upstream(
+                                                        stream,
+                                                        write_state,
+                                                    );
+                                            }
                                         }
                                     }
                                     // FIXME(kwannoel): This should truncate the logstore,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

**Fix panic `assert!(progress > prev_progress)` in `LogStoreVnodeProgress::apply_aligned`**

### Summary

Fix a panic in the synced kv log store caused by empty upstream chunks
(cardinality=0) producing non-advancing `seq_id` values. The fix skips
empty chunks on the write side so they never enter the buffer.

### Root cause

When the synced log store receives an upstream `Message::Chunk` with
`cardinality() == 0` (all rows invisible after a filter), the seq_id
arithmetic produces `end_seq_id = start_seq_id - 1` and `seq_id` does
not advance. If two consecutive empty chunks arrive at the same epoch,
they produce two buffer items with **identical** `end_seq_id`, which
violates the strict progress increase invariant.

`cardinality()` is `visibility.count_ones()` (`data_chunk.rs` L146),
so this can happen whenever an upstream operator (e.g. `FilterExecutor`)
emits a chunk where all rows are filtered out.

### Concrete call path that triggers the panic

1. **Write side receives empty chunk** (`sync_kv_log_store.rs` L748–L750):
   ```rust
   let start_seq_id = seq_id;                    // 0
   let new_seq_id = seq_id + chunk.cardinality(); // 0 + 0 = 0
   let end_seq_id = new_seq_id - 1;              // -1
   ```
   `seq_id` stays at 0. The chunk is buffered as
   `StreamChunk { start_seq_id: 0, end_seq_id: -1, epoch: E }`.

2. **Write side receives second empty chunk** at the same epoch.
   Same arithmetic: `start_seq_id = 0, end_seq_id = -1`. Buffered again.

   Buffer now contains:
   ```
   [StreamChunk(start=0, end=-1, E), StreamChunk(start=0, end=-1, E)]
   ```

3. **Read side pops first chunk** (`sync_kv_log_store.rs` L914–L918):
   ```rust
   progress.apply_aligned(vnodes, E, Some(-1));
   ```
   Progress state becomes `Aligned(vnodes, E, Some(-1))`.

4. **Read side pops second chunk**:
   ```rust
   progress.apply_aligned(vnodes, E, Some(-1));
   ```
   Enters `Aligned → Aligned` branch in `apply_aligned` (`mod.rs` L155–L158):
   ```rust
   Self::assert_progress_increase(*prev_epoch, *prev_progress, epoch, progress);
   // assert_progress_increase(E, Some(-1), E, Some(-1))
   ```

5. **`assert_progress_increase`** (`mod.rs` L81–L83):
   ```rust
   Some(prev_progress) => {
       assert_eq!(prev_epoch, epoch);       // E == E ✓
       assert!(progress > prev_progress);   // assert!(-1 > -1) → PANIC
   }
   ```

### Fix

Skip empty chunks (`cardinality == 0`) on the write side in
`sync_kv_log_store.rs`. Empty chunks carry no data and produce
degenerate `end_seq_id < start_seq_id`, so they should not enter the
buffer or affect seq_id accounting. The `assert_progress_increase`
invariant in `mod.rs` is preserved as-is — it is a correct invariant
once empty chunks are excluded.

### Why the strict assertion holds for non-empty chunks

The write side assigns each chunk a seq_id range from a running counter
(`sync_kv_log_store.rs` L748–L776):

```rust
let start_seq_id = seq_id;
let new_seq_id = seq_id + chunk.cardinality() as SeqId;
let end_seq_id = new_seq_id - 1;
seq_id = new_seq_id;
```

For chunk N with `cardinality_N > 0`:
- `end_seq_id_N = seq_id_N + cardinality_N - 1`
- `seq_id_{N+1} = end_seq_id_N + 1`

For chunk N+1 with `cardinality_{N+1} > 0`:
- `end_seq_id_{N+1} = end_seq_id_N + cardinality_{N+1} ≥ end_seq_id_N + 1`

So `end_seq_id` **strictly increases** across consecutive non-empty chunks
within the same epoch. At each barrier, `seq_id` resets to `FIRST_SEQ_ID`
and epoch advances.

The buffer is a `VecDeque` (FIFO), so the read side sees items in the
same order they were appended — preserving the seq_id ordering.

The full state-machine transition table:

| Transition                      | Prev state             | New args          | Check                                 |
|---------------------------------|------------------------|-------------------|---------------------------------------|
| Chunk → Chunk (same epoch)      | `Aligned(E, Some(s1))` | `(E, Some(s2))`  | `s2 > s1` ✓ (strictly increasing)     |
| Chunk → Barrier (same epoch)    | `Aligned(E, Some(s))`  | `(E, None)`      | strict check skipped (`progress=None`)|
| Barrier → Chunk (next epoch)    | `Aligned(E, None)`     | `(E', Some(s))`  | `E < E'` ✓                            |
| Barrier → Barrier (next epoch)  | `Aligned(E, None)`     | `(E', None)`     | `E < E'` ✓                            |

Every transition holds — **unless** `cardinality == 0`, which breaks the
`s2 > s1` invariant because `end_seq_id = start_seq_id - 1` and `seq_id`
doesn't advance.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
