### PR TITLE
feat(optimizer): support mv selection for inner join

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/mv_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/mv_selection.yaml
@@ -247,3 +247,44 @@
     group by a;
   expected_outputs:
     - batch_plan
+- id: inner_join_selection
+  sql: |
+    create table depts (deptno int, deptname varchar);
+    create table emps (empid int, deptno int, empname varchar);
+    create materialized view mv_join as
+      select empid
+      from emps
+      join depts using (deptno);
+    set enable_mv_selection = true;
+    select empid
+    from depts
+    join (
+      select empid, deptno
+      from emps
+      where empid = 1
+    ) as subq
+    on depts.deptno = subq.deptno;
+  expected_outputs:
+  - batch_plan
+- id: multi_inner_join_selection
+  sql: |
+    create table t1_multi (a int, b int);
+    create table t2_multi (b int, c int);
+    create table t3_multi (c int, d int);
+    create materialized view mv_multi_join as
+      select a
+      from t1_multi
+      join t2_multi using (b)
+      join t3_multi using (c);
+    set enable_mv_selection = true;
+    select a
+    from t3_multi
+    join t2_multi using (c)
+    join (
+      select a, b
+      from t1_multi
+      where a = 1
+    ) as subq
+    using (b);
+  expected_outputs:
+  - batch_plan

--- a/src/frontend/planner_test/tests/testdata/input/mv_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/mv_selection.yaml
@@ -288,3 +288,22 @@
     using (b);
   expected_outputs:
   - batch_plan
+- id: inner_join_self_join_selection
+  sql: |
+    create table t_self (a int, b int);
+    create materialized view mv_self_join as
+      select l.a
+      from t_self as l
+      join t_self as r
+      on l.b = r.b;
+    set enable_mv_selection = true;
+    select l.a
+    from t_self as r
+    join (
+      select a, b
+      from t_self
+      where a = 1
+    ) as l
+    on r.b = l.b;
+  expected_outputs:
+  - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/mv_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/mv_selection.yaml
@@ -275,3 +275,48 @@
     └─BatchSortAgg { group_key: [mv_rollup_dup.a], aggs: [sum0(mv_rollup_dup.s1)] }
       └─BatchExchange { order: [mv_rollup_dup.a ASC], dist: HashShard(mv_rollup_dup.a) }
         └─BatchScan { table: mv_rollup_dup, columns: [mv_rollup_dup.a, mv_rollup_dup.s1], distribution: SomeShard }
+- id: inner_join_selection
+  sql: |
+    create table depts (deptno int, deptname varchar);
+    create table emps (empid int, deptno int, empname varchar);
+    create materialized view mv_join as
+      select empid
+      from emps
+      join depts using (deptno);
+    set enable_mv_selection = true;
+    select empid
+    from depts
+    join (
+      select empid, deptno
+      from emps
+      where empid = 1
+    ) as subq
+    on depts.deptno = subq.deptno;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: (mv_join.empid = 1:Int32) }
+      └─BatchScan { table: mv_join, columns: [mv_join.empid], distribution: SomeShard }
+- id: multi_inner_join_selection
+  sql: |
+    create table t1_multi (a int, b int);
+    create table t2_multi (b int, c int);
+    create table t3_multi (c int, d int);
+    create materialized view mv_multi_join as
+      select a
+      from t1_multi
+      join t2_multi using (b)
+      join t3_multi using (c);
+    set enable_mv_selection = true;
+    select a
+    from t3_multi
+    join t2_multi using (c)
+    join (
+      select a, b
+      from t1_multi
+      where a = 1
+    ) as subq
+    using (b);
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: (mv_multi_join.a = 1:Int32) }
+      └─BatchScan { table: mv_multi_join, columns: [mv_multi_join.a], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/output/mv_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/mv_selection.yaml
@@ -320,3 +320,24 @@
     BatchExchange { order: [], dist: Single }
     └─BatchFilter { predicate: (mv_multi_join.a = 1:Int32) }
       └─BatchScan { table: mv_multi_join, columns: [mv_multi_join.a], distribution: SomeShard }
+- id: inner_join_self_join_selection
+  sql: |
+    create table t_self (a int, b int);
+    create materialized view mv_self_join as
+      select l.a
+      from t_self as l
+      join t_self as r
+      on l.b = r.b;
+    set enable_mv_selection = true;
+    select l.a
+    from t_self as r
+    join (
+      select a, b
+      from t_self
+      where a = 1
+    ) as l
+    on r.b = l.b;
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: (mv_self_join.a = 1:Int32) }
+      └─BatchScan { table: mv_self_join, columns: [mv_self_join.a], distribution: SomeShard }

--- a/src/frontend/src/optimizer/rule/mv_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/mv_selection_rule.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use super::prelude::{PlanRef, *};
-use crate::expr::{Expr, ExprType, FunctionCall};
+use crate::expr::{Expr, ExprImpl, ExprType, FunctionCall};
 use crate::optimizer::optimizer_context::MaterializedViewCandidate;
 use crate::optimizer::plan_node::generic::{Agg, GenericPlanRef, PlanAggCall};
 use crate::optimizer::plan_node::{
@@ -268,7 +268,6 @@ impl MvSelectionRule {
             return None;
         }
 
-        let mv_input_to_query = Self::match_join_inputs(&query_join.inputs, &mv_join.inputs)?;
         let query_input_to_query = (0..query_join.inputs.len()).collect::<Vec<_>>();
         let query_base_offsets = Self::input_base_offsets(&query_join.inputs);
         let total_base_len = query_join.total_base_len();
@@ -279,34 +278,57 @@ impl MvSelectionRule {
             &query_base_offsets,
             total_base_len,
         )?;
-        let mv_conditions = Self::normalize_join_conditions(
-            &mv_join,
-            &mv_input_to_query,
-            &query_base_offsets,
-            total_base_len,
-        )?;
-        let rewritten_predicate = Self::subtract_conditions(query_conditions, mv_conditions)?;
 
         let query_output_to_base =
             Self::normalize_join_outputs(&query_join, &query_input_to_query, &query_base_offsets)?;
-        let mv_output_to_base =
-            Self::normalize_join_outputs(&mv_join, &mv_input_to_query, &query_base_offsets)?;
-        let base_to_mv_output =
-            Self::invert_mapping(&mv_output_to_base, query_join.total_base_len())?;
-        let rewritten_predicate =
-            Self::rewrite_condition_to_mv(rewritten_predicate, &base_to_mv_output)?;
-        let output_col_idx = query_output_to_base
-            .iter()
-            .map(|base_idx| base_to_mv_output.get(*base_idx).copied().flatten())
-            .collect::<Option<Vec<_>>>()?;
 
-        let mv_scan: LogicalPlanRef = Self::candidate_scan(candidate, plan.ctx())?.into();
-        let rewritten = LogicalFilter::create(mv_scan, rewritten_predicate);
-        if output_col_idx.iter().copied().eq(0..output_col_idx.len()) {
-            Some(rewritten)
-        } else {
-            Some(LogicalProject::with_out_col_idx(rewritten, output_col_idx.into_iter()).into())
+        for mv_input_to_query in Self::match_join_inputs(&query_join.inputs, &mv_join.inputs) {
+            let Some(mv_conditions) = Self::normalize_join_conditions(
+                &mv_join,
+                &mv_input_to_query,
+                &query_base_offsets,
+                total_base_len,
+            ) else {
+                continue;
+            };
+            let Some(rewritten_predicate) =
+                Self::subtract_conditions(query_conditions.clone(), mv_conditions)
+            else {
+                continue;
+            };
+            let Some(mv_output_to_base) =
+                Self::normalize_join_outputs(&mv_join, &mv_input_to_query, &query_base_offsets)
+            else {
+                continue;
+            };
+            let Some(base_to_mv_output) =
+                Self::invert_mapping(&mv_output_to_base, query_join.total_base_len())
+            else {
+                continue;
+            };
+            let Some(rewritten_predicate) =
+                Self::rewrite_condition_to_mv(rewritten_predicate, &base_to_mv_output)
+            else {
+                continue;
+            };
+            let Some(output_col_idx) = query_output_to_base
+                .iter()
+                .map(|base_idx| base_to_mv_output.get(*base_idx).copied().flatten())
+                .collect::<Option<Vec<_>>>()
+            else {
+                continue;
+            };
+
+            let mv_scan: LogicalPlanRef = Self::candidate_scan(candidate, plan.ctx())?.into();
+            let rewritten = LogicalFilter::create(mv_scan, rewritten_predicate);
+            return if output_col_idx.iter().copied().eq(0..output_col_idx.len()) {
+                Some(rewritten)
+            } else {
+                Some(LogicalProject::with_out_col_idx(rewritten, output_col_idx.into_iter()).into())
+            };
         }
+
+        None
     }
 
     fn extract_inner_join_rewrite(plan: &PlanRef) -> Option<InnerJoinRewrite> {
@@ -383,16 +405,18 @@ impl MvSelectionRule {
     fn match_join_inputs(
         query_inputs: &[JoinLeafRewrite],
         mv_inputs: &[JoinLeafRewrite],
-    ) -> Option<Vec<usize>> {
+    ) -> Vec<Vec<usize>> {
         fn dfs(
             mv_idx: usize,
             query_inputs: &[JoinLeafRewrite],
             mv_inputs: &[JoinLeafRewrite],
             used_query: &mut [bool],
             mapping: &mut [usize],
-        ) -> bool {
+            results: &mut Vec<Vec<usize>>,
+        ) {
             if mv_idx == mv_inputs.len() {
-                return true;
+                results.push(mapping.to_vec());
+                return;
             }
             for query_idx in 0..query_inputs.len() {
                 if used_query[query_idx]
@@ -403,17 +427,30 @@ impl MvSelectionRule {
                 }
                 used_query[query_idx] = true;
                 mapping[mv_idx] = query_idx;
-                if dfs(mv_idx + 1, query_inputs, mv_inputs, used_query, mapping) {
-                    return true;
-                }
+                dfs(
+                    mv_idx + 1,
+                    query_inputs,
+                    mv_inputs,
+                    used_query,
+                    mapping,
+                    results,
+                );
                 used_query[query_idx] = false;
             }
-            false
         }
 
         let mut used_query = vec![false; query_inputs.len()];
         let mut mapping = vec![usize::MAX; mv_inputs.len()];
-        dfs(0, query_inputs, mv_inputs, &mut used_query, &mut mapping).then_some(mapping)
+        let mut results = vec![];
+        dfs(
+            0,
+            query_inputs,
+            mv_inputs,
+            &mut used_query,
+            &mut mapping,
+            &mut results,
+        );
+        results
     }
 
     fn normalize_join_conditions(
@@ -561,6 +598,14 @@ impl MvSelectionRule {
     }
 
     fn canonicalize_expr(expr: crate::expr::ExprImpl) -> crate::expr::ExprImpl {
+        if let Some((input_ref, const_expr)) = expr.as_eq_const() {
+            return FunctionCall::new_unchecked(
+                ExprType::Equal,
+                vec![input_ref.into(), const_expr],
+                expr.return_type(),
+            )
+            .into();
+        }
         if let Some((lhs, rhs)) = expr.as_eq_cond() {
             return FunctionCall::new_unchecked(
                 ExprType::Equal,
@@ -568,6 +613,30 @@ impl MvSelectionRule {
                 expr.return_type(),
             )
             .into();
+        }
+        if let ExprImpl::FunctionCall(function_call) = &expr
+            && function_call.func_type() == ExprType::IsNotDistinctFrom
+        {
+            let (_, lhs, rhs) = function_call.clone().decompose_as_binary();
+            match (lhs, rhs) {
+                (ExprImpl::InputRef(input_ref), const_expr) if const_expr.is_const() => {
+                    return FunctionCall::new_unchecked(
+                        ExprType::IsNotDistinctFrom,
+                        vec![(*input_ref).into(), const_expr],
+                        expr.return_type(),
+                    )
+                    .into();
+                }
+                (const_expr, ExprImpl::InputRef(input_ref)) if const_expr.is_const() => {
+                    return FunctionCall::new_unchecked(
+                        ExprType::IsNotDistinctFrom,
+                        vec![(*input_ref).into(), const_expr],
+                        expr.return_type(),
+                    )
+                    .into();
+                }
+                _ => {}
+            }
         }
         if let Some((lhs, rhs)) = expr.as_is_not_distinct_from_cond() {
             return FunctionCall::new_unchecked(

--- a/src/frontend/src/optimizer/rule/mv_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/mv_selection_rule.rs
@@ -15,13 +15,15 @@
 use std::collections::HashMap;
 
 use super::prelude::{PlanRef, *};
+use crate::expr::{Expr, ExprType, FunctionCall};
 use crate::optimizer::optimizer_context::MaterializedViewCandidate;
 use crate::optimizer::plan_node::generic::{Agg, GenericPlanRef, PlanAggCall};
 use crate::optimizer::plan_node::{
-    LogicalAgg, LogicalPlanRef, LogicalProject, LogicalScan, PlanTreeNodeUnary,
+    LogicalAgg, LogicalFilter, LogicalMultiJoinBuilder, LogicalPlanRef, LogicalProject,
+    LogicalScan, PlanTreeNodeUnary,
 };
 use crate::optimizer::rule::{BoxedRule, Rule};
-use crate::utils::{ColIndexMapping, IndexSet};
+use crate::utils::{ColIndexMapping, Condition, IndexSet};
 
 pub struct MvSelectionRule;
 
@@ -51,7 +53,8 @@ impl MvSelectionRule {
         if plan == &candidate.plan {
             return Some(Self::candidate_scan(candidate, plan.ctx())?.into());
         }
-        Self::agg_rollup_rewrite(plan, candidate)
+        Self::inner_join_rewrite(plan, candidate)
+            .or_else(|| Self::agg_rollup_rewrite(plan, candidate))
     }
 
     fn candidate_scan(
@@ -253,5 +256,357 @@ impl MvSelectionRule {
             .into_iter()
             .collect::<Option<Vec<usize>>>()?;
         Some((mv_agg.clone(), mv_agg_to_mv_output))
+    }
+
+    fn inner_join_rewrite(
+        plan: &PlanRef,
+        candidate: &MaterializedViewCandidate,
+    ) -> Option<PlanRef> {
+        let query_join = Self::extract_inner_join_rewrite(plan)?;
+        let mv_join = Self::extract_inner_join_rewrite(&candidate.plan)?;
+        if query_join.inputs.len() != mv_join.inputs.len() {
+            return None;
+        }
+
+        let mv_input_to_query = Self::match_join_inputs(&query_join.inputs, &mv_join.inputs)?;
+        let query_input_to_query = (0..query_join.inputs.len()).collect::<Vec<_>>();
+        let query_base_offsets = Self::input_base_offsets(&query_join.inputs);
+        let total_base_len = query_join.total_base_len();
+
+        let query_conditions = Self::normalize_join_conditions(
+            &query_join,
+            &query_input_to_query,
+            &query_base_offsets,
+            total_base_len,
+        )?;
+        let mv_conditions = Self::normalize_join_conditions(
+            &mv_join,
+            &mv_input_to_query,
+            &query_base_offsets,
+            total_base_len,
+        )?;
+        let rewritten_predicate = Self::subtract_conditions(query_conditions, mv_conditions)?;
+
+        let query_output_to_base =
+            Self::normalize_join_outputs(&query_join, &query_input_to_query, &query_base_offsets)?;
+        let mv_output_to_base =
+            Self::normalize_join_outputs(&mv_join, &mv_input_to_query, &query_base_offsets)?;
+        let Some(base_to_mv_output) =
+            Self::invert_mapping(&mv_output_to_base, query_join.total_base_len())
+        else {
+            return None;
+        };
+        let rewritten_predicate =
+            Self::rewrite_condition_to_mv(rewritten_predicate, &base_to_mv_output)?;
+        let output_col_idx = query_output_to_base
+            .iter()
+            .map(|base_idx| base_to_mv_output.get(*base_idx).copied().flatten())
+            .collect::<Option<Vec<_>>>()?;
+
+        let mv_scan: LogicalPlanRef = Self::candidate_scan(candidate, plan.ctx())?.into();
+        let rewritten = LogicalFilter::create(mv_scan, rewritten_predicate);
+        if output_col_idx.iter().copied().eq(0..output_col_idx.len()) {
+            Some(rewritten)
+        } else {
+            Some(LogicalProject::with_out_col_idx(rewritten, output_col_idx.into_iter()).into())
+        }
+    }
+
+    fn extract_inner_join_rewrite(plan: &PlanRef) -> Option<InnerJoinRewrite> {
+        let multijoin = LogicalMultiJoinBuilder::new(plan.clone());
+        let (output_indices, conjunctions, inputs, _) = multijoin.into_parts();
+        if inputs.len() < 2 {
+            return None;
+        }
+
+        let inputs = inputs
+            .iter()
+            .map(Self::extract_join_leaf)
+            .collect::<Option<Vec<_>>>()?;
+
+        Some(InnerJoinRewrite {
+            inputs,
+            conditions: Condition { conjunctions },
+            output_indices,
+        })
+    }
+
+    fn extract_join_leaf(plan: &PlanRef) -> Option<JoinLeafRewrite> {
+        if let Some(scan) = plan.as_logical_scan() {
+            let output_to_base = scan.output_col_idx().clone();
+            let base_scan =
+                scan.clone_with_output_indices((0..scan.table().columns().len()).collect());
+            let predicate = Self::rewrite_condition(
+                scan.predicate().clone(),
+                output_to_base.clone(),
+                base_scan.schema().len(),
+            )?;
+            return Some(JoinLeafRewrite {
+                base_scan: base_scan.into(),
+                output_to_base,
+                predicate,
+            });
+        }
+        if let Some(filter) = plan.as_logical_filter() {
+            let mut child = Self::extract_join_leaf(&filter.input())?;
+            let predicate = Self::rewrite_condition(
+                filter.predicate().clone(),
+                child.output_to_base.clone(),
+                child.base_len(),
+            )?;
+            child.predicate = child.predicate.and(predicate);
+            return Some(child);
+        }
+        if let Some(project) = plan.as_logical_project() {
+            let child = Self::extract_join_leaf(&project.input())?;
+            let output_to_base = project
+                .try_as_projection()?
+                .into_iter()
+                .map(|idx| child.output_to_base.get(idx).copied())
+                .collect::<Option<Vec<_>>>()?;
+            return Some(JoinLeafRewrite {
+                base_scan: child.base_scan,
+                output_to_base,
+                predicate: child.predicate,
+            });
+        }
+        None
+    }
+
+    fn input_base_offsets(inputs: &[JoinLeafRewrite]) -> Vec<usize> {
+        let mut offsets = Vec::with_capacity(inputs.len());
+        let mut offset = 0;
+        for input in inputs {
+            offsets.push(offset);
+            offset += input.base_len();
+        }
+        offsets
+    }
+
+    fn match_join_inputs(
+        query_inputs: &[JoinLeafRewrite],
+        mv_inputs: &[JoinLeafRewrite],
+    ) -> Option<Vec<usize>> {
+        fn dfs(
+            mv_idx: usize,
+            query_inputs: &[JoinLeafRewrite],
+            mv_inputs: &[JoinLeafRewrite],
+            used_query: &mut [bool],
+            mapping: &mut [usize],
+        ) -> bool {
+            if mv_idx == mv_inputs.len() {
+                return true;
+            }
+            for query_idx in 0..query_inputs.len() {
+                if used_query[query_idx]
+                    || mv_inputs[mv_idx].base_scan != query_inputs[query_idx].base_scan
+                    || mv_inputs[mv_idx].base_len() != query_inputs[query_idx].base_len()
+                {
+                    continue;
+                }
+                used_query[query_idx] = true;
+                mapping[mv_idx] = query_idx;
+                if dfs(mv_idx + 1, query_inputs, mv_inputs, used_query, mapping) {
+                    return true;
+                }
+                used_query[query_idx] = false;
+            }
+            false
+        }
+
+        let mut used_query = vec![false; query_inputs.len()];
+        let mut mapping = vec![usize::MAX; mv_inputs.len()];
+        dfs(0, query_inputs, mv_inputs, &mut used_query, &mut mapping).then_some(mapping)
+    }
+
+    fn normalize_join_conditions(
+        join: &InnerJoinRewrite,
+        input_to_query: &[usize],
+        query_base_offsets: &[usize],
+        total_base_len: usize,
+    ) -> Option<Condition> {
+        let join_output_to_base =
+            Self::join_output_to_base_mapping(join, input_to_query, query_base_offsets);
+        let mut conditions =
+            Self::rewrite_condition(join.conditions.clone(), join_output_to_base, total_base_len)?;
+        for (input_idx, input) in join.inputs.iter().enumerate() {
+            conditions = conditions.and(Self::shift_condition_to_join_base(
+                input.predicate.clone(),
+                *query_base_offsets.get(*input_to_query.get(input_idx)?)?,
+                input.base_len(),
+                total_base_len,
+            )?);
+        }
+        Some(conditions)
+    }
+
+    fn normalize_join_outputs(
+        join: &InnerJoinRewrite,
+        input_to_query: &[usize],
+        query_base_offsets: &[usize],
+    ) -> Option<Vec<usize>> {
+        let join_output_to_base =
+            Self::join_output_to_base_mapping(join, input_to_query, query_base_offsets);
+        join.output_indices
+            .iter()
+            .map(|idx| join_output_to_base.get(*idx).copied())
+            .collect()
+    }
+
+    fn join_output_to_base_mapping(
+        join: &InnerJoinRewrite,
+        input_to_query: &[usize],
+        query_base_offsets: &[usize],
+    ) -> Vec<usize> {
+        join.inputs
+            .iter()
+            .enumerate()
+            .flat_map(|(input_idx, input)| {
+                let offset = query_base_offsets[input_to_query[input_idx]];
+                input
+                    .output_to_base
+                    .iter()
+                    .copied()
+                    .map(move |base_idx| base_idx + offset)
+            })
+            .collect()
+    }
+
+    fn subtract_conditions(query: Condition, mv: Condition) -> Option<Condition> {
+        let mut counts: HashMap<crate::expr::ExprImpl, usize> = HashMap::new();
+        for expr in query.conjunctions {
+            *counts.entry(expr).or_default() += 1;
+        }
+        for expr in mv.conjunctions {
+            let count = counts.get_mut(&expr)?;
+            *count -= 1;
+            if *count == 0 {
+                counts.remove(&expr);
+            }
+        }
+        let residual = counts
+            .into_iter()
+            .flat_map(|(expr, count)| std::iter::repeat_n(expr, count))
+            .collect();
+        Some(Self::canonicalize_condition(Condition {
+            conjunctions: residual,
+        }))
+    }
+
+    fn rewrite_condition(
+        condition: Condition,
+        output_to_base: Vec<usize>,
+        target_size: usize,
+    ) -> Option<Condition> {
+        let mut mapping =
+            ColIndexMapping::new(output_to_base.into_iter().map(Some).collect(), target_size);
+        Some(Self::canonicalize_condition(
+            condition.rewrite_expr(&mut mapping),
+        ))
+    }
+
+    fn shift_condition_to_join_base(
+        condition: Condition,
+        offset: usize,
+        source_size: usize,
+        target_size: usize,
+    ) -> Option<Condition> {
+        let mut mapping = ColIndexMapping::new(
+            (0..source_size).map(|idx| Some(idx + offset)).collect(),
+            target_size,
+        );
+        Some(Self::canonicalize_condition(
+            condition.rewrite_expr(&mut mapping),
+        ))
+    }
+
+    fn invert_mapping(mapping: &[usize], source_size: usize) -> Option<Vec<Option<usize>>> {
+        let mut inverse = vec![None; source_size];
+        for (target_idx, source_idx) in mapping.iter().copied().enumerate() {
+            match inverse.get_mut(source_idx)? {
+                slot @ None => *slot = Some(target_idx),
+                Some(_) => {}
+            }
+        }
+        Some(inverse)
+    }
+
+    fn rewrite_condition_to_mv(
+        condition: Condition,
+        base_to_mv_output: &[Option<usize>],
+    ) -> Option<Condition> {
+        let input_refs = condition.collect_input_refs(base_to_mv_output.len());
+        if input_refs
+            .ones()
+            .any(|idx| base_to_mv_output[idx].is_none())
+        {
+            return None;
+        }
+        let target_size = base_to_mv_output
+            .iter()
+            .flatten()
+            .max()
+            .copied()
+            .map_or(0, |idx| idx + 1);
+        let mut mapping = ColIndexMapping::new(base_to_mv_output.to_vec(), target_size);
+        Some(Self::canonicalize_condition(
+            condition.rewrite_expr(&mut mapping),
+        ))
+    }
+
+    fn canonicalize_condition(condition: Condition) -> Condition {
+        let mut conjunctions = condition
+            .conjunctions
+            .into_iter()
+            .map(Self::canonicalize_expr)
+            .collect::<Vec<_>>();
+        conjunctions.sort_by_cached_key(|expr| format!("{expr:?}"));
+        Condition { conjunctions }
+    }
+
+    fn canonicalize_expr(expr: crate::expr::ExprImpl) -> crate::expr::ExprImpl {
+        if let Some((lhs, rhs)) = expr.as_eq_cond() {
+            return FunctionCall::new_unchecked(
+                ExprType::Equal,
+                vec![lhs.into(), rhs.into()],
+                expr.return_type(),
+            )
+            .into();
+        }
+        if let Some((lhs, rhs)) = expr.as_is_not_distinct_from_cond() {
+            return FunctionCall::new_unchecked(
+                ExprType::IsNotDistinctFrom,
+                vec![lhs.into(), rhs.into()],
+                expr.return_type(),
+            )
+            .into();
+        }
+        expr
+    }
+}
+
+#[derive(Clone)]
+struct JoinLeafRewrite {
+    base_scan: LogicalPlanRef,
+    output_to_base: Vec<usize>,
+    predicate: Condition,
+}
+
+impl JoinLeafRewrite {
+    fn base_len(&self) -> usize {
+        self.base_scan.schema().len()
+    }
+}
+
+#[derive(Clone)]
+struct InnerJoinRewrite {
+    inputs: Vec<JoinLeafRewrite>,
+    conditions: Condition,
+    output_indices: Vec<usize>,
+}
+
+impl InnerJoinRewrite {
+    fn total_base_len(&self) -> usize {
+        self.inputs.iter().map(JoinLeafRewrite::base_len).sum()
     }
 }

--- a/src/frontend/src/optimizer/rule/mv_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/mv_selection_rule.rs
@@ -291,11 +291,8 @@ impl MvSelectionRule {
             Self::normalize_join_outputs(&query_join, &query_input_to_query, &query_base_offsets)?;
         let mv_output_to_base =
             Self::normalize_join_outputs(&mv_join, &mv_input_to_query, &query_base_offsets)?;
-        let Some(base_to_mv_output) =
-            Self::invert_mapping(&mv_output_to_base, query_join.total_base_len())
-        else {
-            return None;
-        };
+        let base_to_mv_output =
+            Self::invert_mapping(&mv_output_to_base, query_join.total_base_len())?;
         let rewritten_predicate =
             Self::rewrite_condition_to_mv(rewritten_predicate, &base_to_mv_output)?;
         let output_col_idx = query_output_to_base
@@ -523,9 +520,8 @@ impl MvSelectionRule {
     fn invert_mapping(mapping: &[usize], source_size: usize) -> Option<Vec<Option<usize>>> {
         let mut inverse = vec![None; source_size];
         for (target_idx, source_idx) in mapping.iter().copied().enumerate() {
-            match inverse.get_mut(source_idx)? {
-                slot @ None => *slot = Some(target_idx),
-                Some(_) => {}
+            if let slot @ None = inverse.get_mut(source_idx)? {
+                *slot = Some(target_idx);
             }
         }
         Some(inverse)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Tracking issue https://github.com/risingwavelabs/risingwave/issues/25045

This PR extends `MvSelectionRule` to support inner-join-based MV rewriting, including multi-way inner joins where the join order in the query differs from the join order in the materialized view.

- Reworked join matching to be order-independent for inner joins.
- Flattened query and MV join trees with LogicalMultiJoinBuilder so matching no longer depends on the original binary join tree shape.
- Normalized join conditions, scan predicates, and projected outputs into a shared base-column lineage space before comparison.

Previously, `MvSelectionRule` only handled:
1. exact-match MV scan replacement
2. aggregate rollup rewriting



## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
