### PR TITLE
feat: support ordered streaming UDAFs with materialized input state

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -461,8 +461,8 @@ impl Agg<StreamPlanRef> {
                 agg_types::single_value_state_iff_in_append_only!() if in_append_only => {
                     AggCallState::Value
                 }
-                agg_types::single_value_state!() => AggCallState::Value,
-                agg_types::materialized_input_state!() => {
+                AggType::UserDefined(_) if agg_call.order_by.is_empty() => AggCallState::Value,
+                agg_types::materialized_input_state!() | AggType::UserDefined(_) => {
                     // columns with order requirement in state table
                     let sort_keys = {
                         match agg_call.agg_type {
@@ -512,6 +512,11 @@ impl Agg<StreamPlanRef> {
                                 .iter()
                                 .map(|o| (o.order_type, o.column_index))
                                 .collect(),
+                            AggType::UserDefined(_) => agg_call
+                                .order_by
+                                .iter()
+                                .map(|o| (o.order_type, o.column_index))
+                                .collect(),
                             _ => unreachable!(),
                         }
                     };
@@ -540,7 +545,8 @@ impl Agg<StreamPlanRef> {
                             | PbAggKind::PercentileDisc
                             | PbAggKind::Mode,
                         )
-                        | AggType::WrapScalar(_) => {
+                        | AggType::WrapScalar(_)
+                        | AggType::UserDefined(_) => {
                             agg_call.inputs.iter().map(|i| i.index).collect()
                         }
                         _ => vec![],
@@ -549,6 +555,7 @@ impl Agg<StreamPlanRef> {
                     let state = gen_materialized_input_state(sort_keys, extra_keys, include_keys);
                     AggCallState::MaterializedInput(Box::new(state))
                 }
+                agg_types::single_value_state!() => AggCallState::Value,
                 agg_types::rewritten!() => {
                     unreachable!("should have been rewritten")
                 }

--- a/src/stream/src/executor/aggregate/minput.rs
+++ b/src/stream/src/executor/aggregate/minput.rs
@@ -140,7 +140,8 @@ impl MaterializedInputState {
                 | PbAggKind::PercentileDisc
                 | PbAggKind::Mode,
             )
-            | AggType::WrapScalar(_) => Box::new(GenericAggStateCache::new(
+            | AggType::WrapScalar(_)
+            | AggType::UserDefined(_) => Box::new(GenericAggStateCache::new(
                 OrderedStateCache::new(),
                 agg_call.args.arg_types(),
             )),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Adds streaming support for ordered user-defined aggregate functions.
  -   UDAFs with ORDER BY now use AggCallState::MaterializedInput.
  -   UDAFs without ORDER BY keep existing AggCallState::Value behavior.

Example usage:
```sql
create materialized view mv as
select
  k,
  udaf_agg(v order by ts) as agg_v
from t
group by k;
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
