### PR TITLE
fix(cdc): fix compatibility issues with SQL Server CDC table name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12668,7 +12668,7 @@ dependencies = [
  "twox-hash 2.1.0",
  "uuid",
  "workspace-hack",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]

--- a/src/stream/src/from_proto/cdc_filter.rs
+++ b/src/stream/src/from_proto/cdc_filter.rs
@@ -52,6 +52,7 @@ impl ExecutorBuilder for CdcFilterExecutorBuilder {
 fn build_search_condition_with_compat(node: &CdcFilterNode) -> StreamResult<ExprNode> {
     Ok(with_legacy_sqlserver_table_name_compat(
         node.get_search_condition()?,
+        node.upstream_source_id.as_raw_id(),
     ))
 }
 
@@ -63,7 +64,10 @@ fn build_search_condition_with_compat(node: &CdcFilterNode) -> StreamResult<Expr
 /// NOTE: This only rewrites a top-level equality predicate.
 /// `CdcFilter` search condition is expected to be a single equality on `_rw_table_name`.
 /// If that assumption changes in planner/proto, this function should be updated accordingly.
-fn with_legacy_sqlserver_table_name_compat(search_condition: &ExprNode) -> ExprNode {
+fn with_legacy_sqlserver_table_name_compat(
+    search_condition: &ExprNode,
+    upstream_source_id: u32,
+) -> ExprNode {
     let Some((table_name_ref_expr, table_name_literal_expr, table_name_literal)) =
         extract_cdc_filter_eq_condition(search_condition)
     else {
@@ -79,6 +83,13 @@ fn with_legacy_sqlserver_table_name_compat(search_condition: &ExprNode) -> ExprN
     if normalized_table_name == table_name_literal {
         return search_condition.clone();
     }
+
+    tracing::info!(
+        source_id = upstream_source_id,
+        original = table_name_literal,
+        normalized = %normalized_table_name,
+        "rewriting legacy SQL Server CdcFilter expression for compatibility"
+    );
 
     let mut normalized_literal_expr = table_name_literal_expr.clone();
     if let Some(RexNode::Constant(constant)) = normalized_literal_expr.rex_node.as_mut() {
@@ -219,7 +230,7 @@ mod tests {
     fn test_legacy_sqlserver_filter_rewrite() {
         let search_condition =
             equal_expr(rw_table_name_ref_expr(), literal_expr("prod.dbo.Answer"));
-        let rewritten = with_legacy_sqlserver_table_name_compat(&search_condition);
+        let rewritten = with_legacy_sqlserver_table_name_compat(&search_condition, 1);
 
         assert_eq!(rewritten.function_type(), ExprType::Or);
         let RexNode::FuncCall(or_func) = rewritten.rex_node.unwrap() else {
@@ -231,7 +242,7 @@ mod tests {
     #[test]
     fn test_normalized_filter_no_rewrite() {
         let search_condition = equal_expr(rw_table_name_ref_expr(), literal_expr("dbo.Answer"));
-        let rewritten = with_legacy_sqlserver_table_name_compat(&search_condition);
+        let rewritten = with_legacy_sqlserver_table_name_compat(&search_condition, 1);
         assert_eq!(rewritten, search_condition);
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
## Summary
This PR fixes a SQL Server CDC backward-compatibility issue for tables created before table-name normalization.

For legacy CDC tables, the persisted `CdcFilter` literal may be `db.schema.table` (for example, `prod.dbo.Answer`), while newer runtime metadata emits `_rw_table_name` as `schema.table` (for example, `dbo.Answer`).  
As a result, the filter condition never matches and all rows are dropped (`in_record_cnt > 0`, `out_record_cnt = 0`).

## Root Cause
`CdcFilter` uses an equality predicate on `_rw_table_name`:
- Left side: runtime table name from CDC metadata
- Right side: persisted table literal from historical table definition

After SQL Server table-name normalization changes, legacy persisted literals and runtime values can differ only by the database prefix:
- Legacy literal: `db.schema.table`
- Runtime value: `schema.table`

This causes a silent mismatch and zero output for affected legacy tables.

## Fix
Add compatibility rewrite for `CdcFilter` search condition during executor build:
- Detect legacy CDC equality pattern (`_rw_table_name = <literal>`)
- If literal is in `db.schema.table` form, derive normalized `schema.table`
- Rewrite predicate as:
  - `original_condition OR (_rw_table_name = normalized_literal)`

So legacy and normalized forms both match, without requiring table recreation.

## Scope
- Targeted to CDC filter condition handling
- No catalog migration required
- No behavior change for already-normalized table names

## Validation
- Added unit tests for:
  - legacy name normalization (`db.schema.table -> schema.table`)
  - predicate rewrite for legacy literals
  - no rewrite for already-normalized literals
- Local test command:
  - `cargo test -p risingwave_stream cdc_filter -- --nocapture`

## User Impact
- Existing legacy SQL Server CDC tables can continue working after upgrade
- No need to drop/recreate CDC tables solely for this table-name format mismatch

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
