### PR TITLE
fix(connector): improve Google Pub/Sub source error visibility and retry

### DIFF
--- a/src/connector/src/source/google_pubsub/source/reader.rs
+++ b/src/connector/src/source/google_pubsub/source/reader.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use futures_async_stream::try_stream;
 use google_cloud_gax::grpc::Code;
+use google_cloud_pubsub::apiv1::default_retry_setting;
 use google_cloud_pubsub::subscription::Subscription;
 use risingwave_common::{bail, ensure};
 
@@ -43,7 +44,10 @@ impl PubsubSplitReader {
         loop {
             let pull_result = self
                 .subscription
-                .pull(PUBSUB_MAX_FETCH_MESSAGES as i32, None)
+                .pull(
+                    PUBSUB_MAX_FETCH_MESSAGES as i32,
+                    Some(default_retry_setting()),
+                )
                 .await;
 
             let raw_chunk = match pull_result {
@@ -51,14 +55,17 @@ impl PubsubSplitReader {
                 Err(e) => match e.code() {
                     Code::NotFound => bail!("subscription not found"),
                     Code::PermissionDenied => bail!("not authorized to access subscription"),
-                    _ => continue,
+                    _ => {
+                        tracing::warn!(
+                            error = %e,
+                            code = ?e.code(),
+                            "failed to pull from pubsub, retrying"
+                        );
+                        continue;
+                    }
                 },
             };
 
-            // Sleep if we get an empty batch -- this should generally not happen
-            // since subscription.pull claims to block until at least a single message is available.
-            // But pull seems to time out at some point a return with no messages, so we need to see
-            // ? if that's somehow adjustable or we can skip sleeping and hand it off to pull again
             if raw_chunk.is_empty() {
                 continue;
             }


### PR DESCRIPTION
## Summary

- Add warn-level logging for transient Pub/Sub `pull()` errors that were previously silently swallowed by `_ => continue`, causing stream stalling with zero diagnostic visibility.
- Pass `default_retry_setting()` (which covers `DeadlineExceeded` / `Internal` / `ResourceExhausted`) instead of `None` to `pull()`, so the SDK properly retries these common transient failures before surfacing the error.

## Motivation

Users reported Pub/Sub source tables with parallelism=2 where one actor silently stopped consuming messages — no warn/error logs at all. Root cause: the pull loop caught all non-`NotFound`/`PermissionDenied` errors with `_ => continue` (no logging), and `pull(retry: None)` used the gax-layer default that excluded `DeadlineExceeded` from retryable codes.

## Known remaining issues

These are out of scope for this minimal fix but worth tracking:

1. **`pull()` can hang indefinitely** — `return_immediately: false` with no gRPC deadline means a half-open connection will block forever, which is likely the primary cause of the "one actor stuck" symptom. A `tokio::time::timeout()` wrapper or migration to Streaming Pull (`subscribe()`) would address this.
2. **No backoff after SDK retry exhaustion** — after the warn log, the loop immediately retries. Adding a short sleep or propagating the error to the outer `into_retry_stream` (which has 1s sleep + reader rebuild) would prevent tight-looping.

## Test plan

- [x] `cargo check -p risingwave_connector` passes
- [ ] Verify warn logs appear when Pub/Sub pull encounters transient errors
- [ ] Validate with parallelism=2 that both actors remain active under normal conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)