### PR TITLE
feat(frontend): support consuming snapshot of batch refreshable job (frontend part)

### DIFF
--- a/e2e_test/streaming/batch_refresh_snapshot.slt
+++ b/e2e_test/streaming/batch_refresh_snapshot.slt
@@ -10,6 +10,65 @@ DROP TABLE IF EXISTS t_batch;
 statement ok
 CREATE TABLE t_batch (v1 int);
 
+# ── Tests: SQL operations forbidden for batch refresh MVs ────────────────────
+
+statement ok
+CREATE MATERIALIZED VIEW mv_up AS SELECT * FROM t_batch;
+
+statement ok
+CREATE MATERIALIZED VIEW mv_batch WITH (refresh.interval.sec = 5) AS
+SELECT * FROM mv_up;
+
+statement error ALTER MATERIALIZED VIEW is not supported for batch refresh materialized views
+ALTER MATERIALIZED VIEW mv_batch AS SELECT v1 + 1 AS v1 FROM mv_up;
+
+statement ok
+DROP MATERIALIZED VIEW mv_batch;
+
+statement ok
+DROP MATERIALIZED VIEW mv_up;
+
+# ── Tests: streaming/batch-refresh jobs cannot depend on a batch-refresh MV ──
+
+statement ok
+CREATE MATERIALIZED VIEW mv_up AS SELECT * FROM t_batch;
+
+statement ok
+CREATE MATERIALIZED VIEW mv_batch WITH (refresh.interval.sec = 5) AS
+SELECT * FROM mv_up;
+
+statement error creating streaming jobs on batch refresh materialized views is not supported
+CREATE MATERIALIZED VIEW mv_on_batch AS SELECT * FROM mv_batch;
+
+statement error creating streaming jobs on batch refresh materialized views is not supported
+CREATE MATERIALIZED VIEW mv_batch_on_batch WITH (refresh.interval.sec = 5) AS
+SELECT * FROM mv_batch;
+
+statement ok
+DROP MATERIALIZED VIEW mv_batch;
+
+statement ok
+DROP MATERIALIZED VIEW mv_up;
+
+# ── Tests: batch refresh MV cannot read directly from a source ────────────────
+
+statement ok
+CREATE SOURCE src_test (v1 int) WITH (
+    connector = 'datagen',
+    fields.v1.kind = 'sequence',
+    fields.v1.start = '1',
+    datagen.rows.per.second = '1'
+);
+
+statement error batch refresh materialized views must not depend on sources
+CREATE MATERIALIZED VIEW mv_batch_source_bad WITH (refresh.interval.sec = 5) AS
+SELECT * FROM src_test;
+
+statement ok
+DROP SOURCE src_test;
+
+# ── Tests: batch refresh periodic refresh behavior ───────────────────────────
+
 statement ok
 INSERT INTO t_batch VALUES (1), (2);
 

--- a/e2e_test/streaming/batch_refresh_snapshot.slt
+++ b/e2e_test/streaming/batch_refresh_snapshot.slt
@@ -1,0 +1,57 @@
+statement ok
+DROP MATERIALIZED VIEW IF EXISTS mv_batch;
+
+statement ok
+DROP MATERIALIZED VIEW IF EXISTS mv_up;
+
+statement ok
+DROP TABLE IF EXISTS t_batch;
+
+statement ok
+CREATE TABLE t_batch (v1 int);
+
+statement ok
+INSERT INTO t_batch VALUES (1), (2);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_up AS SELECT * FROM t_batch;
+
+statement ok
+CREATE MATERIALIZED VIEW mv_batch WITH (refresh.interval.sec = 5) AS
+SELECT * FROM mv_up;
+
+query I rowsort
+SELECT * FROM mv_batch;
+----
+1
+2
+
+statement ok
+INSERT INTO t_batch VALUES (3);
+
+statement ok
+FLUSH;
+
+query I rowsort retry 5 backoff 1s
+SELECT * FROM mv_up;
+----
+1
+2
+3
+
+sleep 7s
+
+query I rowsort
+SELECT * FROM mv_batch;
+----
+1
+2
+
+statement ok
+DROP MATERIALIZED VIEW mv_batch;
+
+statement ok
+DROP MATERIALIZED VIEW mv_up;
+
+statement ok
+DROP TABLE t_batch;

--- a/e2e_test/streaming/batch_refresh_snapshot.slt
+++ b/e2e_test/streaming/batch_refresh_snapshot.slt
@@ -62,7 +62,9 @@ CREATE SOURCE src_test (v1 int) WITH (
 
 statement error batch refresh materialized views must not depend on sources
 CREATE MATERIALIZED VIEW mv_batch_source_bad WITH (refresh.interval.sec = 5) AS
-SELECT * FROM src_test;
+SELECT v1 FROM src_test
+UNION ALL
+SELECT v1 FROM t_batch;
 
 statement ok
 DROP SOURCE src_test;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -163,6 +163,7 @@ message CreateMaterializedViewRequest {
   repeated uint32 dependencies = 4;
 
   bool if_not_exists = 6;
+  optional uint64 refresh_interval_sec = 7;
 }
 
 message CreateMaterializedViewResponse {

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -820,7 +820,7 @@ impl TestCase {
                     return Err(anyhow!("expect a query"));
                 };
 
-                let (stream_plan, table) = match create_mv::gen_create_mv_plan(
+                let (stream_plan, table) = match create_mv::explain_create_mv_plan(
                     &session,
                     context.clone(),
                     q,

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -96,6 +96,7 @@ pub trait CatalogWriter: Send + Sync {
         dependencies: HashSet<ObjectId>,
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
+        refresh_interval_sec: Option<u64>,
     ) -> Result<()>;
 
     async fn replace_materialized_view(
@@ -347,11 +348,19 @@ impl CatalogWriter for CatalogWriterImpl {
         dependencies: HashSet<ObjectId>,
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
+        refresh_interval_sec: Option<u64>,
     ) -> Result<()> {
         let create_type = table.get_create_type().unwrap_or(PbCreateType::Foreground);
         let version = self
             .meta_client
-            .create_materialized_view(table, graph, dependencies, resource_type, if_not_exists)
+            .create_materialized_view(
+                table,
+                graph,
+                dependencies,
+                resource_type,
+                if_not_exists,
+                refresh_interval_sec,
+            )
             .await?;
         if matches!(create_type, PbCreateType::Foreground) {
             self.wait_version(version).await?

--- a/src/frontend/src/handler/alter_mv.rs
+++ b/src/frontend/src/handler/alter_mv.rs
@@ -146,7 +146,7 @@ async fn handle_alter_mv_bound(
 
     // TODO(alter-mv): use `ColumnIdGenerator` to generate IDs for MV columns, in order to
     // support schema changes.
-    let (mut table, graph, _dependencies, _resource_group, _refresh_interval_sec) = {
+    let (mut table, graph, _dependencies, _resource_group, refresh_interval_sec) = {
         create_mv::gen_create_mv_graph(
             handler_args,
             name,
@@ -159,6 +159,14 @@ async fn handle_alter_mv_bound(
         )
         .await?
     };
+
+    if refresh_interval_sec.is_some() {
+        return Err(ErrorCode::InvalidInputSyntax(
+            "ALTER MATERIALIZED VIEW is not supported for batch refresh materialized views"
+                .to_owned(),
+        )
+        .into());
+    }
 
     // After alter, the data of the MV is not guaranteed to be consistent.
     // Always set the conflict handler to avoid producing inconsistent changes to downstream.

--- a/src/frontend/src/handler/alter_mv.rs
+++ b/src/frontend/src/handler/alter_mv.rs
@@ -146,7 +146,7 @@ async fn handle_alter_mv_bound(
 
     // TODO(alter-mv): use `ColumnIdGenerator` to generate IDs for MV columns, in order to
     // support schema changes.
-    let (mut table, graph, _dependencies, _resource_group) = {
+    let (mut table, graph, _dependencies, _resource_group, _refresh_interval_sec) = {
         create_mv::gen_create_mv_graph(
             handler_args,
             name,

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -39,14 +39,14 @@ use crate::handler::util::{
 use crate::optimizer::backfill_order_strategy::plan_backfill_order;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
-    Explain, StreamPlanRef as PlanRef, ensure_sync_log_store_fragment_root,
+    BackfillType, Explain, StreamPlanRef as PlanRef, ensure_sync_log_store_fragment_root,
 };
 use crate::optimizer::{OptimizerContext, OptimizerContextRef, RelationCollectorVisitor};
 use crate::planner::Planner;
 use crate::scheduler::streaming_manager::CreatingStreamingJobInfo;
 use crate::session::{SESSION_MANAGER, SessionImpl};
 use crate::stream_fragmenter::{GraphJobType, build_graph_with_strategy};
-use crate::utils::ordinal;
+use crate::utils::{MV_REFRESH_INTERVAL_SEC_KEY, ordinal};
 use crate::{TableCatalog, WithOptions};
 
 pub const RESOURCE_GROUP_KEY: &str = "resource_group";
@@ -90,7 +90,7 @@ pub(super) fn get_column_names(
 }
 
 /// Bind and generate create MV plan, return plan and mv table info.
-pub fn gen_create_mv_plan(
+pub fn explain_create_mv_plan(
     session: &SessionImpl,
     context: OptimizerContextRef,
     query: Query,
@@ -100,7 +100,7 @@ pub fn gen_create_mv_plan(
 ) -> Result<(PlanRef, TableCatalog)> {
     let mut binder = Binder::new_for_stream(session);
     let bound = binder.bind_query(&query)?;
-    gen_create_mv_plan_bound(session, context, bound, name, columns, emit_mode)
+    gen_create_mv_plan_bound(session, context, bound, name, columns, emit_mode, None)
 }
 
 /// Generate create MV plan from a bound query
@@ -111,6 +111,7 @@ pub fn gen_create_mv_plan_bound(
     name: ObjectName,
     columns: Vec<Ident>,
     emit_mode: Option<EmitMode>,
+    refresh_interval_sec: Option<u64>,
 ) -> Result<(PlanRef, TableCatalog)> {
     if session.config().create_compaction_group_for_mv() {
         context.warn_to_user("The session variable CREATE_COMPACTION_GROUP_FOR_MV has been deprecated. It will not take effect.");
@@ -137,12 +138,21 @@ pub fn gen_create_mv_plan_bound(
         }
         plan_root.set_out_names(col_names)?;
     }
+
+    let backfill_type = if refresh_interval_sec.is_some() {
+        plan_root.require_snapshot_backfill_for_batch_refresh()?;
+        BackfillType::SnapshotBackfill
+    } else {
+        plan_root.derive_backfill_type(true)
+    };
+
     let materialize = plan_root.gen_materialize_plan(
         database_id,
         schema_id,
         table_name,
         definition,
         emit_on_window_close,
+        backfill_type,
     )?;
 
     let mut table = materialize.table().clone();
@@ -252,7 +262,7 @@ pub async fn handle_create_mv_bound(
         "CREATE MATERIALIZED VIEW",
     )?;
 
-    let (table, graph, dependencies, resource_type) = {
+    let (table, graph, dependencies, resource_type, refresh_interval_sec) = {
         gen_create_mv_graph(
             handler_args,
             name,
@@ -286,6 +296,7 @@ pub async fn handle_create_mv_bound(
             dependencies,
             resource_type,
             if_not_exists,
+            refresh_interval_sec,
         ),
         &session,
         "CREATE MATERIALIZED VIEW",
@@ -312,8 +323,11 @@ pub(crate) async fn gen_create_mv_graph(
     PbStreamFragmentGraph,
     HashSet<ObjectId>,
     streaming_job_resource_type::ResourceType,
+    Option<u64>,
 )> {
     let mut with_options = get_with_options(handler_args.clone());
+    let refresh_interval_sec = with_options.refresh_interval_sec()?;
+    with_options.remove(MV_REFRESH_INTERVAL_SEC_KEY);
     let resource_group = with_options.remove(&RESOURCE_GROUP_KEY.to_owned());
 
     if resource_group.is_some() {
@@ -402,8 +416,15 @@ It only indicates the physical clustering of the data, which may improve the per
     let context: OptimizerContextRef = context.into();
     let session = context.session_ctx().as_ref();
 
-    let (plan, table) =
-        gen_create_mv_plan_bound(session, context.clone(), query, name, columns, emit_mode)?;
+    let (plan, table) = gen_create_mv_plan_bound(
+        session,
+        context.clone(),
+        query,
+        name,
+        columns,
+        emit_mode,
+        refresh_interval_sec,
+    )?;
 
     let backfill_order = plan_backfill_order(
         session,
@@ -430,7 +451,13 @@ It only indicates the physical clustering of the data, which may improve the per
         Some(backfill_order),
     )?;
 
-    Ok((table, graph, dependencies, resource_type))
+    Ok((
+        table,
+        graph,
+        dependencies,
+        resource_type,
+        refresh_interval_sec,
+    ))
 }
 
 #[cfg(test)]

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -25,7 +25,7 @@ use risingwave_sqlparser::ast::{
 use thiserror_ext::AsReport;
 
 use super::create_index::{gen_create_index_plan, resolve_index_schema};
-use super::create_mv::gen_create_mv_plan;
+use super::create_mv::explain_create_mv_plan;
 use super::create_sink::gen_sink_plan;
 use super::query::{BatchPlanChoice, gen_batch_plan_by_statement};
 use super::util::SourceSchemaCompatExt;
@@ -179,16 +179,18 @@ pub async fn do_handle_explain(
                         columns,
                         emit_mode,
                         ..
-                    } => gen_create_mv_plan(&session, context, *query, name, columns, emit_mode)
-                        .map(|(plan, table)| {
-                            (
-                                PlanToExplain::Rw(PhysicalPlanRef::Stream(
-                                    plan,
-                                    Some(GraphJobType::MaterializedView),
-                                )),
-                                Some(table),
-                            )
-                        }),
+                    } => {
+                        explain_create_mv_plan(&session, context, *query, name, columns, emit_mode)
+                            .map(|(plan, table)| {
+                                (
+                                    PlanToExplain::Rw(PhysicalPlanRef::Stream(
+                                        plan,
+                                        Some(GraphJobType::MaterializedView),
+                                    )),
+                                    Some(table),
+                                )
+                            })
+                    }
                     Statement::CreateView {
                         materialized: false,
                         ..

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -92,7 +92,9 @@ use crate::optimizer::plan_visitor::{
     LocalityProviderCounter, RwTimestampValidator, TemporalJoinValidator,
 };
 use crate::optimizer::property::Distribution;
-use crate::utils::{ColIndexMappingRewriteExt, WithOptionsSecResolved};
+use crate::utils::{
+    ColIndexMappingRewriteExt, MV_REFRESH_INTERVAL_SEC_KEY, WithOptionsSecResolved,
+};
 
 /// `PlanRoot` is used to describe a plan. planner will construct a `PlanRoot` with `LogicalNode`.
 /// and required distribution and order. And `PlanRoot` can generate corresponding streaming or
@@ -524,22 +526,17 @@ impl BatchPlanRoot {
 
 impl LogicalPlanRoot {
     /// Generate optimized stream plan
-    fn gen_optimized_stream_plan(
-        self,
-        emit_on_window_close: bool,
-        allow_snapshot_backfill: bool,
-    ) -> Result<StreamOptimizedLogicalPlanRoot> {
-        let backfill_type = if allow_snapshot_backfill && self.should_use_snapshot_backfill() {
+    pub(crate) fn derive_backfill_type(&self, allow_snapshot_backfill: bool) -> BackfillType {
+        if allow_snapshot_backfill && self.should_use_snapshot_backfill() {
             BackfillType::SnapshotBackfill
         } else if self.should_use_arrangement_backfill() {
             BackfillType::ArrangementBackfill
         } else {
             BackfillType::Backfill
-        };
-        self.gen_optimized_stream_plan_inner(emit_on_window_close, backfill_type)
+        }
     }
 
-    fn gen_optimized_stream_plan_inner(
+    fn gen_optimized_stream_plan(
         self,
         emit_on_window_close: bool,
         backfill_type: BackfillType,
@@ -647,6 +644,36 @@ impl LogicalPlanRoot {
         }
 
         Ok(optimized_plan.into_phase(plan))
+    }
+
+    pub(crate) fn require_snapshot_backfill_for_batch_refresh(&self) -> Result<()> {
+        let ctx = self.plan.ctx();
+        let session_ctx = ctx.session_ctx();
+        let snapshot_backfill_enabled = session_ctx
+            .env()
+            .streaming_config()
+            .developer
+            .enable_snapshot_backfill
+            && session_ctx.config().streaming_use_snapshot_backfill();
+        if !snapshot_backfill_enabled {
+            return Err(ErrorCode::NotSupported(
+                "Batch refresh materialized view requires snapshot backfill".to_owned(),
+                format!(
+                    "Please enable snapshot backfill or remove `{}` from the WITH clause.",
+                    MV_REFRESH_INTERVAL_SEC_KEY
+                ),
+            )
+            .into());
+        }
+        if let Some(reason) = self.plan.forbid_snapshot_backfill() {
+            return Err(ErrorCode::NotSupported(
+                format!("Batch refresh materialized view requires snapshot backfill, but {reason}"),
+                "Please rewrite the query to avoid operators that forbid snapshot backfill."
+                    .to_owned(),
+            )
+            .into());
+        }
+        Ok(())
     }
 
     /// Generate create index or create materialize view plan.
@@ -767,8 +794,9 @@ impl LogicalPlanRoot {
             engine,
         }: CreateTableProps,
     ) -> Result<StreamMaterialize> {
+        let backfill_type = self.derive_backfill_type(false);
         // Snapshot backfill is not allowed for create table
-        let stream_plan = self.gen_optimized_stream_plan(false, false)?;
+        let stream_plan = self.gen_optimized_stream_plan(false, backfill_type)?;
 
         assert!(!pk_column_ids.is_empty() || row_id_index.is_some());
 
@@ -1055,9 +1083,10 @@ impl LogicalPlanRoot {
         mv_name: String,
         definition: String,
         emit_on_window_close: bool,
+        backfill_type: BackfillType,
     ) -> Result<StreamMaterialize> {
         let cardinality = self.compute_cardinality();
-        let stream_plan = self.gen_optimized_stream_plan(emit_on_window_close, true)?;
+        let stream_plan = self.gen_optimized_stream_plan(emit_on_window_close, backfill_type)?;
         StreamMaterialize::create(
             stream_plan,
             mv_name,
@@ -1080,7 +1109,8 @@ impl LogicalPlanRoot {
         retention_seconds: Option<NonZeroU32>,
     ) -> Result<StreamMaterialize> {
         let cardinality = self.compute_cardinality();
-        let stream_plan = self.gen_optimized_stream_plan(false, false)?;
+        let backfill_type = self.derive_backfill_type(false);
+        let stream_plan = self.gen_optimized_stream_plan(false, backfill_type)?;
 
         StreamMaterialize::create(
             stream_plan,
@@ -1104,7 +1134,8 @@ impl LogicalPlanRoot {
         vector_index_info: PbVectorIndexInfo,
     ) -> Result<StreamVectorIndexWrite> {
         let cardinality = self.compute_cardinality();
-        let stream_plan = self.gen_optimized_stream_plan(false, false)?;
+        let backfill_type = self.derive_backfill_type(false);
+        let stream_plan = self.gen_optimized_stream_plan(false, backfill_type)?;
 
         StreamVectorIndexWrite::create(
             stream_plan,
@@ -1169,8 +1200,7 @@ impl LogicalPlanRoot {
             ))
             .into());
         }
-        let stream_plan =
-            self.gen_optimized_stream_plan_inner(emit_on_window_close, backfill_type)?;
+        let stream_plan = self.gen_optimized_stream_plan(emit_on_window_close, backfill_type)?;
         let target_columns_to_plan_mapping = target_table.as_ref().map(|t| {
             let columns = t.columns_without_rw_timestamp();
             stream_plan.target_columns_to_plan_mapping(&columns, user_specified_columns)

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -308,6 +308,7 @@ impl CatalogWriter for MockCatalogWriter {
         dependencies: HashSet<ObjectId>,
         _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
+        _refresh_interval_sec: Option<u64>,
     ) -> Result<()> {
         table.id = self.gen_id();
         table.stream_job_status = PbStreamJobStatus::Created as _;
@@ -357,6 +358,7 @@ impl CatalogWriter for MockCatalogWriter {
             dependencies,
             streaming_job_resource_type::ResourceType::Regular(true),
             if_not_exists,
+            None,
         )
         .await?;
         Ok(())

--- a/src/frontend/src/utils/with_options.rs
+++ b/src/frontend/src/utils/with_options.rs
@@ -51,6 +51,7 @@ pub mod options {
     pub const RETENTION_SECONDS: &str = "retention_seconds";
 }
 
+pub const MV_REFRESH_INTERVAL_SEC_KEY: &str = "refresh.interval.sec";
 pub const SOURCE_REFRESH_MODE_KEY: &str = "refresh_mode";
 pub const SOURCE_REFRESH_INTERVAL_SEC_KEY: &str = "refresh_interval_sec";
 
@@ -152,6 +153,29 @@ impl WithOptions {
         self.inner
             .get(options::RETENTION_SECONDS)
             .and_then(|s| s.parse().ok())
+    }
+
+    pub fn refresh_interval_sec(&self) -> RwResult<Option<u64>> {
+        self.inner
+            .get(MV_REFRESH_INTERVAL_SEC_KEY)
+            .map(|seconds| {
+                let seconds = seconds.parse::<u64>().map_err(|e| {
+                    RwError::from(ErrorCode::InvalidParameterValue(format!(
+                        "`{}` must be a positive integer, but got: {} (error: {})",
+                        MV_REFRESH_INTERVAL_SEC_KEY,
+                        seconds,
+                        e.as_report()
+                    )))
+                })?;
+                if seconds == 0 {
+                    return Err(RwError::from(ErrorCode::InvalidParameterValue(format!(
+                        "`{}` must be larger than 0, but got: {}",
+                        MV_REFRESH_INTERVAL_SEC_KEY, seconds
+                    ))));
+                }
+                Ok(seconds)
+            })
+            .transpose()
     }
 
     /// Get a subset of the options from the given keys.

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -553,7 +553,7 @@ impl DdlService for DdlServiceImpl {
                 dependencies,
                 resource_type,
                 if_not_exists: req.if_not_exists,
-                refresh_interval_sec: None,
+                refresh_interval_sec: req.refresh_interval_sec,
             })
             .await?;
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -428,6 +428,7 @@ impl MetaClient {
         dependencies: HashSet<ObjectId>,
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
+        refresh_interval_sec: Option<u64>,
     ) -> Result<WaitVersion> {
         let request = CreateMaterializedViewRequest {
             materialized_view: Some(table),
@@ -437,6 +438,7 @@ impl MetaClient {
             }),
             dependencies: dependencies.into_iter().collect(),
             if_not_exists,
+            refresh_interval_sec,
         };
         let resp = self.inner.create_materialized_view(request).await?;
         // TODO: handle error in `resp.status` here

--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -244,3 +244,5 @@
   formatted_sql: CREATE MATERIALIZED VIEW mv WITH (backfill_order = FIXED(t1 -> t2, t2 -> t3)) AS SELECT * FROM t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t2.id = t3.id
 - input: CREATE MATERIALIZED VIEW mv WITH (backfill_order = FIXED(schema1.t1 -> schema2.t2)) AS SELECT * FROM schema1.t1 JOIN schema2.t2 ON t1.id = t2.id
   formatted_sql: CREATE MATERIALIZED VIEW mv WITH (backfill_order = FIXED(schema1.t1 -> schema2.t2)) AS SELECT * FROM schema1.t1 JOIN schema2.t2 ON t1.id = t2.id
+- input: CREATE MATERIALIZED VIEW mv WITH (refresh.interval.sec = 60) AS SELECT * FROM t
+  formatted_sql: CREATE MATERIALIZED VIEW mv WITH (refresh.interval.sec = 60) AS SELECT * FROM t

--- a/src/tests/simulation/tests/integration_tests/recovery/batch_refresh.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/batch_refresh.rs
@@ -1,0 +1,157 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use risingwave_simulation::cluster::{Cluster, Configuration};
+use tokio::time::sleep;
+
+use crate::utils::kill_cn_and_wait_recover;
+
+/// Test batch refresh MV recovery:
+///
+/// 1. Create a table and insert 10,000 rows.
+/// 2. Create a batch refresh MV (`refresh.interval.sec`) with background DDL and rate limit = 1.
+/// 3. Verify DDL progress is reported.
+/// 4. Trigger recovery and verify progress survives.
+/// 5. Alter rate limit to default (unlimited) and wait for completion.
+/// 6. Verify the MV row count matches the source table.
+#[tokio::test]
+async fn test_batch_refresh_recovery() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = cluster.start_session();
+
+    // Step 1: Create table and insert 10,000 rows.
+    session.run("CREATE TABLE t(v1 int);").await?;
+    session
+        .run("INSERT INTO t SELECT * FROM generate_series(1, 10000);")
+        .await?;
+    session.flush().await?;
+
+    // Verify table has 10,000 rows.
+    let count = session.run("SELECT COUNT(*) FROM t;").await?;
+    assert_eq!(count, "10000");
+
+    // Step 2: Create a batch refresh MV with background DDL and backfill rate limit = 1.
+    session.run("SET BACKGROUND_DDL = true;").await?;
+    session.run("SET BACKFILL_RATE_LIMIT = 1;").await?;
+
+    // Create the upstream MV first (batch refresh needs an MV as upstream).
+    session
+        .run("CREATE MATERIALIZED VIEW mv_up AS SELECT * FROM t;")
+        .await?;
+
+    // Wait for upstream MV to finish.
+    session.run("WAIT;").await?;
+
+    // Now create the batch refresh MV on top of the upstream MV.
+    session
+        .run(
+            "CREATE MATERIALIZED VIEW mv_batch WITH (refresh.interval.sec = 600) AS SELECT * FROM mv_up;",
+        )
+        .await?;
+
+    // Step 3: Wait a bit for backfill to make some progress, then check DDL progress.
+    sleep(Duration::from_secs(10)).await;
+
+    let progress = session
+        .run("SELECT progress FROM rw_catalog.rw_ddl_progress;")
+        .await?;
+    eprintln!("=== DDL progress before recovery: {}", progress);
+    assert!(
+        !progress.is_empty(),
+        "DDL progress should be reported during batch refresh backfill"
+    );
+
+    // Step 4: Trigger recovery and verify progress survives.
+    eprintln!("=== Step 4: triggering recovery during backfill...");
+    kill_cn_and_wait_recover(&cluster).await;
+    eprintln!("=== Step 4: recovery done");
+
+    let progress_after = session
+        .run("SELECT progress FROM rw_catalog.rw_ddl_progress;")
+        .await?;
+    eprintln!("=== DDL progress after recovery: {}", progress_after);
+    assert!(
+        !progress_after.is_empty(),
+        "DDL progress should still be reported after recovery"
+    );
+
+    // Step 5: Alter rate limit to default (unlimited).
+    eprintln!("=== Step 5: alter rate limit...");
+    session
+        .run("ALTER MATERIALIZED VIEW mv_batch SET BACKFILL_RATE_LIMIT = DEFAULT;")
+        .await?;
+
+    // Step 6: Wait for the batch refresh to complete.
+    eprintln!("=== Step 6: WAIT for completion...");
+    session.run("WAIT;").await?;
+    eprintln!("=== Step 6: done");
+
+    // Step 7: Verify the MV row count matches the source table.
+    eprintln!("=== Step 7: verifying row counts...");
+    let t_count = session.run("SELECT COUNT(*) FROM t;").await?;
+    let mv_count = session.run("SELECT COUNT(*) FROM mv_batch;").await?;
+    assert_eq!(
+        t_count, mv_count,
+        "MV row count should match source table: t={}, mv={}",
+        t_count, mv_count
+    );
+    assert_eq!(mv_count, "10000");
+    eprintln!("=== Step 7: PASSED");
+
+    // Step 8: Now the batch refresh job is idle (snapshot done, waiting for next refresh).
+    // Verify no DDL progress is reported.
+    eprintln!("=== Step 8: checking DDL progress is empty...");
+    let progress_idle = session
+        .run("SELECT count(*) FROM rw_catalog.rw_ddl_progress;")
+        .await?;
+    assert_eq!(
+        progress_idle, "0",
+        "No DDL progress should be reported when batch refresh is idle"
+    );
+    eprintln!("=== Step 8: PASSED");
+
+    // Step 9: Trigger another recovery while the batch refresh job is idle.
+    eprintln!("=== Step 9: triggering recovery while idle...");
+    kill_cn_and_wait_recover(&cluster).await;
+    eprintln!("=== Step 9: recovery done");
+
+    // Step 10: Verify that the MV is still queryable after idle recovery.
+    eprintln!("=== Step 10: querying mv_batch after idle recovery...");
+    let mv_count_after_idle = session.run("SELECT COUNT(*) FROM mv_batch;").await?;
+    assert_eq!(
+        mv_count_after_idle, "10000",
+        "MV should still be queryable after idle recovery"
+    );
+    eprintln!(
+        "=== Step 10: PASSED - query returned {}",
+        mv_count_after_idle
+    );
+
+    // Step 11: DROP the MV.
+    eprintln!("=== Step 11: dropping mv_batch...");
+    session.run("DROP MATERIALIZED VIEW mv_batch;").await?;
+    eprintln!("=== Step 11: mv_batch dropped");
+
+    // Cleanup
+    eprintln!("=== Cleanup: dropping mv_up...");
+    session.run("DROP MATERIALIZED VIEW mv_up;").await?;
+    eprintln!("=== Cleanup: mv_up dropped. dropping t...");
+    session.run("DROP TABLE t;").await?;
+    eprintln!("=== Cleanup: all done");
+
+    Ok(())
+}

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -14,6 +14,7 @@
 
 mod backfill;
 mod background_ddl;
+mod batch_refresh;
 mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds frontend support for consuming snapshot backfill in batch refresh materialized views.

- Parse and validate `refresh.interval.sec` from materialized view `WITH` options and pass it through the frontend catalog writer and meta RPC request.
- Force batch refresh materialized views to use snapshot backfill and reject plans that cannot use snapshot backfill.
- Reject unsupported SQL operations around batch refresh materialized views, including `ALTER MATERIALIZED VIEW` and creating downstream streaming jobs on batch refresh MVs.
- Add parser, e2e SLT, and deterministic recovery simulation coverage for batch refresh snapshot creation, validation, periodic refresh behavior, and recovery.

This is the frontend part for batch refresh MV snapshot consumption, built on top of the meta-side support merged in #25251.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Batch refresh materialized views can be created with `WITH (refresh.interval.sec = <seconds>)` to consume a snapshot-backfill upstream and refresh periodically.

Batch refresh materialized views currently require snapshot backfill, do not support `ALTER MATERIALIZED VIEW`, cannot depend directly on sources, and cannot be used as upstreams for streaming jobs.

</details>
