### PR TITLE
fix(binder): resolve columns only within visible relation context

### DIFF
--- a/src/frontend/planner_test/tests/testdata/output/struct_field_access.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/struct_field_access.yaml
@@ -2,12 +2,11 @@
 - sql: |
     create table t(c STRUCT<x INTEGER, y INTEGER>);
     select t.c.x from t
-  binder_error: |+
+  binder_error: |
     Failed to bind expression: t.c.x
 
     Caused by:
-      Invalid reference: missing FROM-clause entry for table "c"
-
+      Item not found: Invalid column: x
 - sql: |
     create table t(c STRUCT<x INTEGER, y INTEGER>);
     select (t.c).x from t

--- a/src/frontend/src/binder/expr/column.rs
+++ b/src/frontend/src/binder/expr/column.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::catalog::is_system_schema;
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::Ident;
 
@@ -26,34 +25,11 @@ impl Binder {
         let (schema_name, table_name, column_name) = match idents {
             [column] => (None, None, column.real_value()),
             [table, column] => (None, Some(table.real_value()), column.real_value()),
-            [schema, table, column] => {
-                let schema_name = schema.real_value();
-                let relation_name = table.real_value();
-                if !is_system_schema(&schema_name) {
-                    let schema = self
-                        .catalog
-                        .get_schema_by_name(&self.db_name, &schema_name)
-                        .map_err(|_| {
-                            ErrorCode::InvalidReference(format!(
-                                "missing FROM-clause entry for table \"{}\"\n",
-                                relation_name
-                            ))
-                        })?;
-                    let relation_exists = schema.get_any_table_by_name(&relation_name).is_some()
-                        || schema.get_any_index_by_name(&relation_name).is_some()
-                        || schema.get_any_sink_by_name(&relation_name).is_some()
-                        || schema.get_source_by_name(&relation_name).is_some()
-                        || schema.get_view_by_name(&relation_name).is_some();
-                    if !relation_exists {
-                        return Err(ErrorCode::InvalidReference(format!(
-                            "missing FROM-clause entry for table \"{}\"\n",
-                            relation_name
-                        ))
-                        .into());
-                    }
-                }
-                (Some(schema_name), Some(relation_name), column.real_value())
-            }
+            [schema, table, column] => (
+                Some(schema.real_value()),
+                Some(table.real_value()),
+                column.real_value(),
+            ),
             _ => {
                 return Err(
                     ErrorCode::InternalError(format!("Too many idents: {:?}", idents)).into(),

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -344,11 +344,14 @@ impl Binder {
         alias: Option<&TableAlias>,
     ) -> Result<()> {
         const EMPTY: [Ident; 0] = [];
-        let (table_name, column_aliases, table_alias) = match alias {
-            None => (table_name, &EMPTY[..], None),
-            Some(TableAlias { name, columns }) => {
-                (name.real_value(), columns.as_slice(), Some(table_name))
-            }
+        let (resolved_schema_name, table_name, column_aliases, table_alias) = match alias {
+            None => (schema_name.clone(), table_name, &EMPTY[..], None),
+            Some(TableAlias { name, columns }) => (
+                None,
+                name.real_value(),
+                columns.as_slice(),
+                Some(table_name),
+            ),
         };
 
         let num_col_aliases = column_aliases.len();
@@ -394,7 +397,7 @@ impl Binder {
         match self
             .context
             .range_of
-            .entry((schema_name, table_name.clone()))
+            .entry((resolved_schema_name, table_name.clone()))
         {
             Entry::Occupied(_) => Err(ErrorCode::InternalError(format!(
                 "Duplicated table name while binding table to context: {}",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Previously, existence checks for `schema_name` and `table_name` were performed in the Catalog. This is not correct, as name resolution should respect the visible context defined by the query.

This PR removes those checks from the Catalog layer and instead validates column references within the visible context during binding. Specifically, it ensures that columns in the SELECT list are resolved against the relations available in the current scope.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
