### PR TITLE
test: add streaming parallelism e2e and compatibility coverage

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -74,6 +74,7 @@ echo "--- Run kafka sasl test done"
 # cron_only tests are run separately in main-cron via dedicated job
 risedev slt './e2e_test/source_inline/**/*.slt' --skip 'cron_only' -j8
 risedev slt './e2e_test/source_inline/**/*.slt.serial' --skip 'cron_only'
+risedev slt './e2e_test/ddl/streaming_parallelism/source.slt' --label 'streaming_parallelism_source_kafka'
 
 echo "--- Run Vault secret tests"
 risedev slt './e2e_test/ddl/vault_secret.slt'

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -259,6 +259,15 @@ seed_old_cluster() {
     sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/version-columns/validate_original.slt"
   fi
 
+  # Test legacy streaming parallelism session parameter migration for versions in [2.8.0, 2.9.0).
+  if version_le "2.8.0" "$OLD_VERSION" && version_lt "$OLD_VERSION" "2.9.0"; then
+    echo "--- STREAMING PARALLELISM TEST: Seeding old cluster"
+    sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/streaming-parallelism/seed.slt"
+
+    echo "--- STREAMING PARALLELISM TEST: Validating old cluster"
+    sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/streaming-parallelism/validate_original.slt"
+  fi
+
   # Test invalid WITH options, if OLD_VERSION <= 1.5.0
   if version_le "$OLD_VERSION" "1.5.0"; then
     echo "--- KAFKA TEST (invalid options): Seeding old cluster with data"
@@ -323,6 +332,12 @@ validate_new_cluster() {
   if version_le "$OLD_VERSION" "2.6.0"; then
     echo "--- VERSION COLUMNS TEST: Validating new cluster"
     sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/version-columns/validate_restart.slt"
+  fi
+
+  # Test legacy streaming parallelism session parameter migration for versions in [2.8.0, 2.9.0).
+  if version_le "2.8.0" "$OLD_VERSION" && version_lt "$OLD_VERSION" "2.9.0"; then
+    echo "--- STREAMING PARALLELISM TEST: Validating new cluster"
+    sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/streaming-parallelism/validate_restart.slt"
   fi
 
   # Test invalid WITH options, if OLD_VERSION <= 1.5.0

--- a/e2e_test/backwards-compat-tests/slt/streaming-parallelism/seed.slt
+++ b/e2e_test/backwards-compat-tests/slt/streaming-parallelism/seed.slt
@@ -1,0 +1,464 @@
+# Seed 64 tables covering the 2x2x4x4 matrix of legacy streaming parallelism parameters.
+#
+# Naming convention: t_{parallelism}{parallelism_for_table}{strategy}{strategy_for_table}
+#   parallelism (streaming_parallelism):                          d=default,      f=fixed(8)
+#   parallelism_for_table (streaming_parallelism_for_table):      d=default,      f=fixed(6)
+#   strategy (streaming_parallelism_strategy):                    d=default,      b=bounded(32),  r=ratio(0.5),  a=auto
+#   strategy_for_table (streaming_parallelism_strategy_for_table): d=default,     b=bounded(16),  r=ratio(0.5),  a=auto
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+# Fix the legacy system strategy to a single value so migration can materialize it deterministically.
+statement ok
+ALTER SYSTEM SET adaptive_parallelism_strategy TO 'BOUNDED(64)';
+
+statement ok
+SET streaming_parallelism TO default;
+
+statement ok
+SET streaming_parallelism_for_table TO default;
+
+statement ok
+SET streaming_parallelism_strategy TO default;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_dddd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_dddb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_dddr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ddda (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'bounded(32)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ddbd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ddbb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ddbr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ddba (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'ratio(0.5)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ddrd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ddrb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ddrr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ddra (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO AUTO;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ddad (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ddab (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ddar (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ddaa (v int);
+
+statement ok
+SET streaming_parallelism_for_table TO 6;
+
+statement ok
+SET streaming_parallelism_strategy TO default;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_dfdd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_dfdb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_dfdr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_dfda (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'bounded(32)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_dfbd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_dfbb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_dfbr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_dfba (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'ratio(0.5)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_dfrd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_dfrb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_dfrr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_dfra (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO AUTO;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_dfad (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_dfab (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_dfar (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_dfaa (v int);
+
+statement ok
+SET streaming_parallelism TO 8;
+
+statement ok
+SET streaming_parallelism_for_table TO default;
+
+statement ok
+SET streaming_parallelism_strategy TO default;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_fddd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_fddb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_fddr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_fdda (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'bounded(32)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_fdbd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_fdbb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_fdbr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_fdba (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'ratio(0.5)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_fdrd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_fdrb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_fdrr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_fdra (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO AUTO;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_fdad (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_fdab (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_fdar (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_fdaa (v int);
+
+statement ok
+SET streaming_parallelism_for_table TO 6;
+
+statement ok
+SET streaming_parallelism_strategy TO default;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ffdd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ffdb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ffdr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ffda (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'bounded(32)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ffbd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ffbb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ffbr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ffba (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO 'ratio(0.5)';
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ffrd (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ffrb (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ffrr (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ffra (v int);
+
+statement ok
+SET streaming_parallelism_strategy TO AUTO;
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO default;
+
+statement ok
+CREATE TABLE t_ffad (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'bounded(16)';
+
+statement ok
+CREATE TABLE t_ffab (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO 'ratio(0.5)';
+
+statement ok
+CREATE TABLE t_ffar (v int);
+
+statement ok
+SET streaming_parallelism_strategy_for_table TO AUTO;
+
+statement ok
+CREATE TABLE t_ffaa (v int);

--- a/e2e_test/backwards-compat-tests/slt/streaming-parallelism/validate_original.slt
+++ b/e2e_test/backwards-compat-tests/slt/streaming-parallelism/validate_original.slt
@@ -1,0 +1,83 @@
+# Verify the legacy display on the old cluster before restart.
+#
+# Naming convention: t_{parallelism}{parallelism_for_table}{strategy}{strategy_for_table}
+#   parallelism (streaming_parallelism):                          d=default,      f=fixed(8)
+#   parallelism_for_table (streaming_parallelism_for_table):      d=default,      f=fixed(6)
+#   strategy (streaming_parallelism_strategy):                    d=default,      b=bounded(32),  r=ratio(0.5),  a=auto
+#   strategy_for_table (streaming_parallelism_strategy_for_table): d=default,     b=bounded(16),  r=ratio(0.5),  a=auto
+#
+# System strategy: ALTER SYSTEM SET adaptive_parallelism_strategy = 'BOUNDED(64)'
+#
+# In v2.8.0 the parallelism column shows "adaptive" for all adaptive jobs
+# and "fixed(N)" for fixed jobs, regardless of the strategy stored.
+
+query TT
+SELECT name, lower(parallelism)
+FROM rw_streaming_parallelism
+WHERE name ~ '^t_[df][df][dbra][dbra]$'
+ORDER BY name;
+----
+t_ddaa adaptive
+t_ddab adaptive
+t_ddad adaptive
+t_ddar adaptive
+t_ddba adaptive
+t_ddbb adaptive
+t_ddbd adaptive
+t_ddbr adaptive
+t_ddda adaptive
+t_dddb adaptive
+t_dddd adaptive
+t_dddr adaptive
+t_ddra adaptive
+t_ddrb adaptive
+t_ddrd adaptive
+t_ddrr adaptive
+t_dfaa fixed(6)
+t_dfab fixed(6)
+t_dfad fixed(6)
+t_dfar fixed(6)
+t_dfba fixed(6)
+t_dfbb fixed(6)
+t_dfbd fixed(6)
+t_dfbr fixed(6)
+t_dfda fixed(6)
+t_dfdb fixed(6)
+t_dfdd fixed(6)
+t_dfdr fixed(6)
+t_dfra fixed(6)
+t_dfrb fixed(6)
+t_dfrd fixed(6)
+t_dfrr fixed(6)
+t_fdaa fixed(8)
+t_fdab fixed(8)
+t_fdad fixed(8)
+t_fdar fixed(8)
+t_fdba fixed(8)
+t_fdbb fixed(8)
+t_fdbd fixed(8)
+t_fdbr fixed(8)
+t_fdda fixed(8)
+t_fddb fixed(8)
+t_fddd fixed(8)
+t_fddr fixed(8)
+t_fdra fixed(8)
+t_fdrb fixed(8)
+t_fdrd fixed(8)
+t_fdrr fixed(8)
+t_ffaa fixed(6)
+t_ffab fixed(6)
+t_ffad fixed(6)
+t_ffar fixed(6)
+t_ffba fixed(6)
+t_ffbb fixed(6)
+t_ffbd fixed(6)
+t_ffbr fixed(6)
+t_ffda fixed(6)
+t_ffdb fixed(6)
+t_ffdd fixed(6)
+t_ffdr fixed(6)
+t_ffra fixed(6)
+t_ffrb fixed(6)
+t_ffrd fixed(6)
+t_ffrr fixed(6)

--- a/e2e_test/backwards-compat-tests/slt/streaming-parallelism/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/streaming-parallelism/validate_restart.slt
@@ -1,0 +1,85 @@
+# Verify migrated parallelism after upgrading to the new cluster.
+#
+# Naming convention: t_{parallelism}{parallelism_for_table}{strategy}{strategy_for_table}
+#   parallelism (streaming_parallelism):                          d=default,      f=fixed(8)
+#   parallelism_for_table (streaming_parallelism_for_table):      d=default,      f=fixed(6)
+#   strategy (streaming_parallelism_strategy):                    d=default,      b=bounded(32),  r=ratio(0.5),  a=auto
+#   strategy_for_table (streaming_parallelism_strategy_for_table): d=default,     b=bounded(16),  r=ratio(0.5),  a=auto
+#
+# System strategy: ALTER SYSTEM SET adaptive_parallelism_strategy = 'BOUNDED(64)'
+#
+# After migration the new version shows the resolved strategy:
+#   - Fixed jobs display as bare numbers (e.g. "6" instead of "fixed(6)")
+#   - Adaptive jobs display the materialized strategy (e.g. "bounded(64)", "ratio(0.5)")
+#   - Auto/Full strategy resolves to "adaptive"
+
+query TT
+SELECT name, lower(parallelism)
+FROM rw_streaming_parallelism
+WHERE name ~ '^t_[df][df][dbra][dbra]$'
+ORDER BY name;
+----
+t_ddaa adaptive
+t_ddab bounded(16)
+t_ddad adaptive
+t_ddar ratio(0.5)
+t_ddba adaptive
+t_ddbb bounded(16)
+t_ddbd bounded(32)
+t_ddbr ratio(0.5)
+t_ddda adaptive
+t_dddb bounded(16)
+t_dddd bounded(64)
+t_dddr ratio(0.5)
+t_ddra adaptive
+t_ddrb bounded(16)
+t_ddrd ratio(0.5)
+t_ddrr ratio(0.5)
+t_dfaa 6
+t_dfab 6
+t_dfad 6
+t_dfar 6
+t_dfba 6
+t_dfbb 6
+t_dfbd 6
+t_dfbr 6
+t_dfda 6
+t_dfdb 6
+t_dfdd 6
+t_dfdr 6
+t_dfra 6
+t_dfrb 6
+t_dfrd 6
+t_dfrr 6
+t_fdaa 8
+t_fdab 8
+t_fdad 8
+t_fdar 8
+t_fdba 8
+t_fdbb 8
+t_fdbd 8
+t_fdbr 8
+t_fdda 8
+t_fddb 8
+t_fddd 8
+t_fddr 8
+t_fdra 8
+t_fdrb 8
+t_fdrd 8
+t_fdrr 8
+t_ffaa 6
+t_ffab 6
+t_ffad 6
+t_ffar 6
+t_ffba 6
+t_ffbb 6
+t_ffbd 6
+t_ffbr 6
+t_ffda 6
+t_ffdb 6
+t_ffdd 6
+t_ffdr 6
+t_ffra 6
+t_ffrb 6
+t_ffrd 6
+t_ffrr 6

--- a/e2e_test/ddl/alter_parallelism.slt
+++ b/e2e_test/ddl/alter_parallelism.slt
@@ -22,7 +22,7 @@ create table t (v int);
 query T
 select parallelism from table_parallelism where name = 't';
 ----
-ADAPTIVE
+bounded(4)
 
 statement ok
 alter table t set parallelism = 2;
@@ -30,7 +30,7 @@ alter table t set parallelism = 2;
 query T
 select parallelism from table_parallelism where name = 't';
 ----
-FIXED(2)
+2
 
 query I
 select parallelism from fragment_parallelism where table_name = 't';
@@ -44,7 +44,7 @@ alter table t set parallelism = adaptive;
 query T
 select parallelism from table_parallelism where name = 't';
 ----
-ADAPTIVE
+adaptive
 
 statement ok
 create materialized view m_simple as select * from t;
@@ -52,7 +52,7 @@ create materialized view m_simple as select * from t;
 query T
 select parallelism from mview_parallelism where name = 'm_simple';
 ----
-ADAPTIVE
+bounded(64)
 
 statement ok
 alter materialized view m_simple set parallelism = 3;
@@ -60,7 +60,7 @@ alter materialized view m_simple set parallelism = 3;
 query T
 select parallelism from mview_parallelism where name = 'm_simple';
 ----
-FIXED(3)
+3
 
 statement ok
 create materialized view m_join as select t1.v as t1v, t2.v as t2v from t t1, t t2 where t1.v = t2.v;
@@ -68,7 +68,7 @@ create materialized view m_join as select t1.v as t1v, t2.v as t2v from t t1, t 
 query T
 select parallelism from mview_parallelism where name = 'm_join';
 ----
-ADAPTIVE
+bounded(64)
 
 statement ok
 alter materialized view m_join set parallelism = 3;
@@ -76,7 +76,7 @@ alter materialized view m_join set parallelism = 3;
 query T
 select parallelism from mview_parallelism where name = 'm_join';
 ----
-FIXED(3)
+3
 
 statement ok
 create sink s as select t1.v as t1v, t2.v as t2v from t t1, t t2 where t1.v = t2.v with ( connector = 'blackhole', type = 'append-only', force_append_only = 'true');
@@ -84,7 +84,7 @@ create sink s as select t1.v as t1v, t2.v as t2v from t t1, t t2 where t1.v = t2
 query T
 select parallelism from sink_parallelism where name = 's';
 ----
-ADAPTIVE
+bounded(64)
 
 statement ok
 alter sink s set parallelism = 4;
@@ -92,7 +92,7 @@ alter sink s set parallelism = 4;
 query T
 select parallelism from sink_parallelism where name = 's';
 ----
-FIXED(4)
+4
 
 statement ok
 drop sink s;
@@ -115,7 +115,7 @@ create table t (v1 int);
 query T
 select parallelism from table_parallelism where name = 't';
 ----
-FIXED(2)
+2
 
 statement ok
 drop table t;
@@ -129,7 +129,7 @@ create table t (v1 int);
 query T
 select parallelism from table_parallelism where name = 't';
 ----
-ADAPTIVE
+adaptive
 
 statement ok
 drop table t;
@@ -143,7 +143,7 @@ create table t (v1 int);
 query T
 select parallelism from table_parallelism where name = 't';
 ----
-ADAPTIVE
+adaptive
 
 statement ok
 drop table t;

--- a/e2e_test/ddl/max_parallelism.slt
+++ b/e2e_test/ddl/max_parallelism.slt
@@ -17,7 +17,7 @@ create table t;
 query TT
 select parallelism, max_parallelism from table_parallelism where name = 't';
 ----
-ADAPTIVE 256
+bounded(4) 256
 
 statement ok
 drop table t;
@@ -45,7 +45,7 @@ create table t;
 query TT
 select parallelism, max_parallelism from table_parallelism where name = 't';
 ----
-FIXED(4) 4
+4 4
 
 statement ok
 drop table t;
@@ -61,7 +61,7 @@ create table t;
 query TT
 select parallelism, max_parallelism from table_parallelism where name = 't';
 ----
-ADAPTIVE 4
+bounded(4) 4
 
 # Alter parallelism to a valid value, ok.
 statement ok
@@ -70,7 +70,7 @@ alter table t set parallelism to 4;
 query TT
 select parallelism, max_parallelism from table_parallelism where name = 't';
 ----
-FIXED(4) 4
+4 4
 
 # Alter parallelism to an invalid value, return an error.
 statement error specified parallelism 8 should not exceed max parallelism 4

--- a/e2e_test/ddl/streaming_parallelism/index.slt
+++ b/e2e_test/ddl/streaming_parallelism/index.slt
@@ -1,0 +1,464 @@
+statement ok
+set rw_implicit_flush to true;
+
+statement ok
+set streaming_parallelism to 1;
+
+statement ok
+set streaming_parallelism_for_table to 1;
+
+statement ok
+create table idx_base_t (v int);
+
+# Case: global=default, streaming_parallelism_for_index=default
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_index to default;
+
+statement ok
+create index idx_dd on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_dd';
+----
+bounded(64)
+
+statement ok
+drop index idx_dd;
+
+# Case: global=default, streaming_parallelism_for_index=6
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_index to 6;
+
+statement ok
+create index idx_df on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_df';
+----
+6
+
+statement ok
+drop index idx_df;
+
+# Case: global=default, streaming_parallelism_for_index='ratio(0.5)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_index to 'ratio(0.5)';
+
+statement ok
+create index idx_dr on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_dr';
+----
+ratio(0.5)
+
+statement ok
+drop index idx_dr;
+
+# Case: global=default, streaming_parallelism_for_index='bounded(16)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_index to 'bounded(16)';
+
+statement ok
+create index idx_db on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_db';
+----
+bounded(16)
+
+statement ok
+drop index idx_db;
+
+# Case: global=default, streaming_parallelism_for_index=adaptive
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_index to adaptive;
+
+statement ok
+create index idx_da on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_da';
+----
+adaptive
+
+statement ok
+drop index idx_da;
+
+# Case: global=8, streaming_parallelism_for_index=default
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_index to default;
+
+statement ok
+create index idx_fd on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_fd';
+----
+8
+
+statement ok
+drop index idx_fd;
+
+# Case: global=8, streaming_parallelism_for_index=6
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_index to 6;
+
+statement ok
+create index idx_ff on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_ff';
+----
+6
+
+statement ok
+drop index idx_ff;
+
+# Case: global=8, streaming_parallelism_for_index='ratio(0.5)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_index to 'ratio(0.5)';
+
+statement ok
+create index idx_fr on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_fr';
+----
+ratio(0.5)
+
+statement ok
+drop index idx_fr;
+
+# Case: global=8, streaming_parallelism_for_index='bounded(16)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_index to 'bounded(16)';
+
+statement ok
+create index idx_fb on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_fb';
+----
+bounded(16)
+
+statement ok
+drop index idx_fb;
+
+# Case: global=8, streaming_parallelism_for_index=adaptive
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_index to adaptive;
+
+statement ok
+create index idx_fa on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_fa';
+----
+adaptive
+
+statement ok
+drop index idx_fa;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_index=default
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_index to default;
+
+statement ok
+create index idx_rd on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_rd';
+----
+ratio(0.5)
+
+statement ok
+drop index idx_rd;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_index=6
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_index to 6;
+
+statement ok
+create index idx_rf on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_rf';
+----
+6
+
+statement ok
+drop index idx_rf;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_index='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_index to 'ratio(0.5)';
+
+statement ok
+create index idx_rr on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_rr';
+----
+ratio(0.5)
+
+statement ok
+drop index idx_rr;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_index='bounded(16)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_index to 'bounded(16)';
+
+statement ok
+create index idx_rb on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_rb';
+----
+bounded(16)
+
+statement ok
+drop index idx_rb;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_index=adaptive
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_index to adaptive;
+
+statement ok
+create index idx_ra on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_ra';
+----
+adaptive
+
+statement ok
+drop index idx_ra;
+
+# Case: global='bounded(32)', streaming_parallelism_for_index=default
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_index to default;
+
+statement ok
+create index idx_bd on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_bd';
+----
+bounded(32)
+
+statement ok
+drop index idx_bd;
+
+# Case: global='bounded(32)', streaming_parallelism_for_index=6
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_index to 6;
+
+statement ok
+create index idx_bf on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_bf';
+----
+6
+
+statement ok
+drop index idx_bf;
+
+# Case: global='bounded(32)', streaming_parallelism_for_index='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_index to 'ratio(0.5)';
+
+statement ok
+create index idx_br on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_br';
+----
+ratio(0.5)
+
+statement ok
+drop index idx_br;
+
+# Case: global='bounded(32)', streaming_parallelism_for_index='bounded(16)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_index to 'bounded(16)';
+
+statement ok
+create index idx_bb on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_bb';
+----
+bounded(16)
+
+statement ok
+drop index idx_bb;
+
+# Case: global='bounded(32)', streaming_parallelism_for_index=adaptive
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_index to adaptive;
+
+statement ok
+create index idx_ba on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_ba';
+----
+adaptive
+
+statement ok
+drop index idx_ba;
+
+# Case: global=adaptive, streaming_parallelism_for_index=default
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_index to default;
+
+statement ok
+create index idx_ad on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_ad';
+----
+adaptive
+
+statement ok
+drop index idx_ad;
+
+# Case: global=adaptive, streaming_parallelism_for_index=6
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_index to 6;
+
+statement ok
+create index idx_af on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_af';
+----
+6
+
+statement ok
+drop index idx_af;
+
+# Case: global=adaptive, streaming_parallelism_for_index='ratio(0.5)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_index to 'ratio(0.5)';
+
+statement ok
+create index idx_ar on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_ar';
+----
+ratio(0.5)
+
+statement ok
+drop index idx_ar;
+
+# Case: global=adaptive, streaming_parallelism_for_index='bounded(16)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_index to 'bounded(16)';
+
+statement ok
+create index idx_ab on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_ab';
+----
+bounded(16)
+
+statement ok
+drop index idx_ab;
+
+# Case: global=adaptive, streaming_parallelism_for_index=adaptive
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_index to adaptive;
+
+statement ok
+create index idx_aa on idx_base_t(v);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'idx_aa';
+----
+adaptive
+
+statement ok
+drop index idx_aa;
+
+statement ok
+drop table idx_base_t;

--- a/e2e_test/ddl/streaming_parallelism/materialized_view.slt
+++ b/e2e_test/ddl/streaming_parallelism/materialized_view.slt
@@ -1,0 +1,464 @@
+statement ok
+set rw_implicit_flush to true;
+
+statement ok
+set streaming_parallelism to 1;
+
+statement ok
+set streaming_parallelism_for_table to 1;
+
+statement ok
+create table mv_base_t (v int);
+
+# Case: global=default, streaming_parallelism_for_materialized_view=default
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_materialized_view to default;
+
+statement ok
+create materialized view mv_dd as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_dd';
+----
+bounded(64)
+
+statement ok
+drop materialized view mv_dd;
+
+# Case: global=default, streaming_parallelism_for_materialized_view=6
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 6;
+
+statement ok
+create materialized view mv_df as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_df';
+----
+6
+
+statement ok
+drop materialized view mv_df;
+
+# Case: global=default, streaming_parallelism_for_materialized_view='ratio(0.5)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'ratio(0.5)';
+
+statement ok
+create materialized view mv_dr as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_dr';
+----
+ratio(0.5)
+
+statement ok
+drop materialized view mv_dr;
+
+# Case: global=default, streaming_parallelism_for_materialized_view='bounded(16)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'bounded(16)';
+
+statement ok
+create materialized view mv_db as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_db';
+----
+bounded(16)
+
+statement ok
+drop materialized view mv_db;
+
+# Case: global=default, streaming_parallelism_for_materialized_view=adaptive
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_materialized_view to adaptive;
+
+statement ok
+create materialized view mv_da as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_da';
+----
+adaptive
+
+statement ok
+drop materialized view mv_da;
+
+# Case: global=8, streaming_parallelism_for_materialized_view=default
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_materialized_view to default;
+
+statement ok
+create materialized view mv_fd as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_fd';
+----
+8
+
+statement ok
+drop materialized view mv_fd;
+
+# Case: global=8, streaming_parallelism_for_materialized_view=6
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 6;
+
+statement ok
+create materialized view mv_ff as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_ff';
+----
+6
+
+statement ok
+drop materialized view mv_ff;
+
+# Case: global=8, streaming_parallelism_for_materialized_view='ratio(0.5)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'ratio(0.5)';
+
+statement ok
+create materialized view mv_fr as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_fr';
+----
+ratio(0.5)
+
+statement ok
+drop materialized view mv_fr;
+
+# Case: global=8, streaming_parallelism_for_materialized_view='bounded(16)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'bounded(16)';
+
+statement ok
+create materialized view mv_fb as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_fb';
+----
+bounded(16)
+
+statement ok
+drop materialized view mv_fb;
+
+# Case: global=8, streaming_parallelism_for_materialized_view=adaptive
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_materialized_view to adaptive;
+
+statement ok
+create materialized view mv_fa as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_fa';
+----
+adaptive
+
+statement ok
+drop materialized view mv_fa;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_materialized_view=default
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to default;
+
+statement ok
+create materialized view mv_rd as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_rd';
+----
+ratio(0.5)
+
+statement ok
+drop materialized view mv_rd;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_materialized_view=6
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to 6;
+
+statement ok
+create materialized view mv_rf as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_rf';
+----
+6
+
+statement ok
+drop materialized view mv_rf;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_materialized_view='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'ratio(0.5)';
+
+statement ok
+create materialized view mv_rr as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_rr';
+----
+ratio(0.5)
+
+statement ok
+drop materialized view mv_rr;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_materialized_view='bounded(16)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'bounded(16)';
+
+statement ok
+create materialized view mv_rb as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_rb';
+----
+bounded(16)
+
+statement ok
+drop materialized view mv_rb;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_materialized_view=adaptive
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to adaptive;
+
+statement ok
+create materialized view mv_ra as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_ra';
+----
+adaptive
+
+statement ok
+drop materialized view mv_ra;
+
+# Case: global='bounded(32)', streaming_parallelism_for_materialized_view=default
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to default;
+
+statement ok
+create materialized view mv_bd as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_bd';
+----
+bounded(32)
+
+statement ok
+drop materialized view mv_bd;
+
+# Case: global='bounded(32)', streaming_parallelism_for_materialized_view=6
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to 6;
+
+statement ok
+create materialized view mv_bf as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_bf';
+----
+6
+
+statement ok
+drop materialized view mv_bf;
+
+# Case: global='bounded(32)', streaming_parallelism_for_materialized_view='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'ratio(0.5)';
+
+statement ok
+create materialized view mv_br as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_br';
+----
+ratio(0.5)
+
+statement ok
+drop materialized view mv_br;
+
+# Case: global='bounded(32)', streaming_parallelism_for_materialized_view='bounded(16)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'bounded(16)';
+
+statement ok
+create materialized view mv_bb as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_bb';
+----
+bounded(16)
+
+statement ok
+drop materialized view mv_bb;
+
+# Case: global='bounded(32)', streaming_parallelism_for_materialized_view=adaptive
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_materialized_view to adaptive;
+
+statement ok
+create materialized view mv_ba as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_ba';
+----
+adaptive
+
+statement ok
+drop materialized view mv_ba;
+
+# Case: global=adaptive, streaming_parallelism_for_materialized_view=default
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_materialized_view to default;
+
+statement ok
+create materialized view mv_ad as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_ad';
+----
+adaptive
+
+statement ok
+drop materialized view mv_ad;
+
+# Case: global=adaptive, streaming_parallelism_for_materialized_view=6
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 6;
+
+statement ok
+create materialized view mv_af as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_af';
+----
+6
+
+statement ok
+drop materialized view mv_af;
+
+# Case: global=adaptive, streaming_parallelism_for_materialized_view='ratio(0.5)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'ratio(0.5)';
+
+statement ok
+create materialized view mv_ar as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_ar';
+----
+ratio(0.5)
+
+statement ok
+drop materialized view mv_ar;
+
+# Case: global=adaptive, streaming_parallelism_for_materialized_view='bounded(16)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_materialized_view to 'bounded(16)';
+
+statement ok
+create materialized view mv_ab as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_ab';
+----
+bounded(16)
+
+statement ok
+drop materialized view mv_ab;
+
+# Case: global=adaptive, streaming_parallelism_for_materialized_view=adaptive
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_materialized_view to adaptive;
+
+statement ok
+create materialized view mv_aa as select * from mv_base_t;
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'mv_aa';
+----
+adaptive
+
+statement ok
+drop materialized view mv_aa;
+
+statement ok
+drop table mv_base_t;

--- a/e2e_test/ddl/streaming_parallelism/sink.slt
+++ b/e2e_test/ddl/streaming_parallelism/sink.slt
@@ -1,0 +1,614 @@
+statement ok
+set rw_implicit_flush to true;
+
+statement ok
+set streaming_parallelism to 1;
+
+statement ok
+set streaming_parallelism_for_table to 1;
+
+statement ok
+create table sk_base_t (v int);
+
+# Case: global=default, streaming_parallelism_for_sink=default
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_sink to default;
+
+statement ok
+create sink sk_dd as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_dd';
+----
+bounded(64)
+
+statement ok
+drop sink sk_dd;
+
+# Case: global=default, streaming_parallelism_for_sink=6
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_sink to 6;
+
+statement ok
+create sink sk_df as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_df';
+----
+6
+
+statement ok
+drop sink sk_df;
+
+# Case: global=default, streaming_parallelism_for_sink='ratio(0.5)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_sink to 'ratio(0.5)';
+
+statement ok
+create sink sk_dr as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_dr';
+----
+ratio(0.5)
+
+statement ok
+drop sink sk_dr;
+
+# Case: global=default, streaming_parallelism_for_sink='bounded(16)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_sink to 'bounded(16)';
+
+statement ok
+create sink sk_db as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_db';
+----
+bounded(16)
+
+statement ok
+drop sink sk_db;
+
+# Case: global=default, streaming_parallelism_for_sink=adaptive
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_sink to adaptive;
+
+statement ok
+create sink sk_da as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_da';
+----
+adaptive
+
+statement ok
+drop sink sk_da;
+
+# Case: global=8, streaming_parallelism_for_sink=default
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_sink to default;
+
+statement ok
+create sink sk_fd as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_fd';
+----
+8
+
+statement ok
+drop sink sk_fd;
+
+# Case: global=8, streaming_parallelism_for_sink=6
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_sink to 6;
+
+statement ok
+create sink sk_ff as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_ff';
+----
+6
+
+statement ok
+drop sink sk_ff;
+
+# Case: global=8, streaming_parallelism_for_sink='ratio(0.5)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_sink to 'ratio(0.5)';
+
+statement ok
+create sink sk_fr as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_fr';
+----
+ratio(0.5)
+
+statement ok
+drop sink sk_fr;
+
+# Case: global=8, streaming_parallelism_for_sink='bounded(16)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_sink to 'bounded(16)';
+
+statement ok
+create sink sk_fb as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_fb';
+----
+bounded(16)
+
+statement ok
+drop sink sk_fb;
+
+# Case: global=8, streaming_parallelism_for_sink=adaptive
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_sink to adaptive;
+
+statement ok
+create sink sk_fa as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_fa';
+----
+adaptive
+
+statement ok
+drop sink sk_fa;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_sink=default
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_sink to default;
+
+statement ok
+create sink sk_rd as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_rd';
+----
+ratio(0.5)
+
+statement ok
+drop sink sk_rd;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_sink=6
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_sink to 6;
+
+statement ok
+create sink sk_rf as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_rf';
+----
+6
+
+statement ok
+drop sink sk_rf;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_sink='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_sink to 'ratio(0.5)';
+
+statement ok
+create sink sk_rr as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_rr';
+----
+ratio(0.5)
+
+statement ok
+drop sink sk_rr;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_sink='bounded(16)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_sink to 'bounded(16)';
+
+statement ok
+create sink sk_rb as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_rb';
+----
+bounded(16)
+
+statement ok
+drop sink sk_rb;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_sink=adaptive
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_sink to adaptive;
+
+statement ok
+create sink sk_ra as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_ra';
+----
+adaptive
+
+statement ok
+drop sink sk_ra;
+
+# Case: global='bounded(32)', streaming_parallelism_for_sink=default
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_sink to default;
+
+statement ok
+create sink sk_bd as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_bd';
+----
+bounded(32)
+
+statement ok
+drop sink sk_bd;
+
+# Case: global='bounded(32)', streaming_parallelism_for_sink=6
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_sink to 6;
+
+statement ok
+create sink sk_bf as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_bf';
+----
+6
+
+statement ok
+drop sink sk_bf;
+
+# Case: global='bounded(32)', streaming_parallelism_for_sink='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_sink to 'ratio(0.5)';
+
+statement ok
+create sink sk_br as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_br';
+----
+ratio(0.5)
+
+statement ok
+drop sink sk_br;
+
+# Case: global='bounded(32)', streaming_parallelism_for_sink='bounded(16)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_sink to 'bounded(16)';
+
+statement ok
+create sink sk_bb as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_bb';
+----
+bounded(16)
+
+statement ok
+drop sink sk_bb;
+
+# Case: global='bounded(32)', streaming_parallelism_for_sink=adaptive
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_sink to adaptive;
+
+statement ok
+create sink sk_ba as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_ba';
+----
+adaptive
+
+statement ok
+drop sink sk_ba;
+
+# Case: global=adaptive, streaming_parallelism_for_sink=default
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_sink to default;
+
+statement ok
+create sink sk_ad as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_ad';
+----
+adaptive
+
+statement ok
+drop sink sk_ad;
+
+# Case: global=adaptive, streaming_parallelism_for_sink=6
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_sink to 6;
+
+statement ok
+create sink sk_af as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_af';
+----
+6
+
+statement ok
+drop sink sk_af;
+
+# Case: global=adaptive, streaming_parallelism_for_sink='ratio(0.5)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_sink to 'ratio(0.5)';
+
+statement ok
+create sink sk_ar as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_ar';
+----
+ratio(0.5)
+
+statement ok
+drop sink sk_ar;
+
+# Case: global=adaptive, streaming_parallelism_for_sink='bounded(16)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_sink to 'bounded(16)';
+
+statement ok
+create sink sk_ab as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_ab';
+----
+bounded(16)
+
+statement ok
+drop sink sk_ab;
+
+# Case: global=adaptive, streaming_parallelism_for_sink=adaptive
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_sink to adaptive;
+
+statement ok
+create sink sk_aa as
+select * from sk_base_t
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 'sk_aa';
+----
+adaptive
+
+statement ok
+drop sink sk_aa;
+
+statement ok
+drop table sk_base_t;

--- a/e2e_test/ddl/streaming_parallelism/source.slt
+++ b/e2e_test/ddl/streaming_parallelism/source.slt
@@ -1,0 +1,874 @@
+control substitution on
+
+# `onlyif` is sqllogictest conditional syntax.
+# This file is executed by `ci/scripts/e2e-source-test.sh` with
+# `--label streaming_parallelism_source_kafka`.
+onlyif streaming_parallelism_source_kafka
+statement ok
+set rw_implicit_flush to true;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_use_shared_source to true;
+
+onlyif streaming_parallelism_source_kafka
+system ok
+rpk topic delete streaming_parallelism_source -X brokers=message_queue:29092 || true
+
+onlyif streaming_parallelism_source_kafka
+system ok
+rpk topic create streaming_parallelism_source -p 32 -X brokers=message_queue:29092
+
+# Case: global=default, streaming_parallelism_for_source=default
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_dd (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_dd';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_dd';
+----
+bounded(4)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_dd;
+
+# Case: global=default, streaming_parallelism_for_source=6
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 6;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_df (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_df';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_df';
+----
+6
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_df;
+
+# Case: global=default, streaming_parallelism_for_source='ratio(0.5)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_dr (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_dr';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_dr';
+----
+ratio(0.5)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_dr;
+
+# Case: global=default, streaming_parallelism_for_source='bounded(16)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'bounded(16)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_db (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_db';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_db';
+----
+bounded(16)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_db;
+
+# Case: global=default, streaming_parallelism_for_source=adaptive
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_da (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_da';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_da';
+----
+adaptive
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_da;
+
+# Case: global=8, streaming_parallelism_for_source=default
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 8;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_fd (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_fd';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_fd';
+----
+8
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_fd;
+
+# Case: global=8, streaming_parallelism_for_source=6
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 8;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 6;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_ff (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_ff';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_ff';
+----
+6
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_ff;
+
+# Case: global=8, streaming_parallelism_for_source='ratio(0.5)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 8;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_fr (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_fr';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_fr';
+----
+ratio(0.5)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_fr;
+
+# Case: global=8, streaming_parallelism_for_source='bounded(16)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 8;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'bounded(16)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_fb (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_fb';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_fb';
+----
+bounded(16)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_fb;
+
+# Case: global=8, streaming_parallelism_for_source=adaptive
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 8;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_fa (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_fa';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_fa';
+----
+adaptive
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_fa;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_source=default
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_rd (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_rd';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_rd';
+----
+ratio(0.5)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_rd;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_source=6
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 6;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_rf (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_rf';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_rf';
+----
+6
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_rf;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_source='ratio(0.5)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_rr (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_rr';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_rr';
+----
+ratio(0.5)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_rr;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_source='bounded(16)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'bounded(16)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_rb (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_rb';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_rb';
+----
+bounded(16)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_rb;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_source=adaptive
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_ra (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_ra';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_ra';
+----
+adaptive
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_ra;
+
+# Case: global='bounded(32)', streaming_parallelism_for_source=default
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_bd (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_bd';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_bd';
+----
+bounded(32)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_bd;
+
+# Case: global='bounded(32)', streaming_parallelism_for_source=6
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 6;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_bf (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_bf';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_bf';
+----
+6
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_bf;
+
+# Case: global='bounded(32)', streaming_parallelism_for_source='ratio(0.5)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_br (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_br';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_br';
+----
+ratio(0.5)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_br;
+
+# Case: global='bounded(32)', streaming_parallelism_for_source='bounded(16)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'bounded(16)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_bb (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_bb';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_bb';
+----
+bounded(16)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_bb;
+
+# Case: global='bounded(32)', streaming_parallelism_for_source=adaptive
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_ba (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_ba';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_ba';
+----
+adaptive
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_ba;
+
+# Case: global=adaptive, streaming_parallelism_for_source=default
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to default;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_ad (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_ad';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_ad';
+----
+adaptive
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_ad;
+
+# Case: global=adaptive, streaming_parallelism_for_source=6
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 6;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_af (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_af';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_af';
+----
+6
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_af;
+
+# Case: global=adaptive, streaming_parallelism_for_source='ratio(0.5)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'ratio(0.5)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_ar (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_ar';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_ar';
+----
+ratio(0.5)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_ar;
+
+# Case: global=adaptive, streaming_parallelism_for_source='bounded(16)'
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to 'bounded(16)';
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_ab (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_ab';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_ab';
+----
+bounded(16)
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_ab;
+
+# Case: global=adaptive, streaming_parallelism_for_source=adaptive
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+set streaming_parallelism_for_source to adaptive;
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+create source s_aa (v int) with (
+    connector = 'kafka',
+    properties.bootstrap.server = 'message_queue:29092',
+    topic = 'streaming_parallelism_source',
+    scan.startup.mode = 'earliest'
+) format plain encode json;
+
+onlyif streaming_parallelism_source_kafka
+query TT
+select connector, is_shared from rw_sources where name = 's_aa';
+----
+KAFKA	t
+
+onlyif streaming_parallelism_source_kafka
+query T
+select parallelism from rw_streaming_parallelism where name = 's_aa';
+----
+adaptive
+
+onlyif streaming_parallelism_source_kafka
+statement ok
+drop source s_aa;
+
+onlyif streaming_parallelism_source_kafka
+system ok
+rpk topic delete streaming_parallelism_source -X brokers=message_queue:29092;

--- a/e2e_test/ddl/streaming_parallelism/table.slt
+++ b/e2e_test/ddl/streaming_parallelism/table.slt
@@ -1,0 +1,452 @@
+statement ok
+set rw_implicit_flush to true;
+
+# Case: global=default, streaming_parallelism_for_table=default
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_table to default;
+
+statement ok
+create table t_dd (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_dd';
+----
+bounded(4)
+
+statement ok
+drop table t_dd;
+
+# Case: global=default, streaming_parallelism_for_table=6
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_table to 6;
+
+statement ok
+create table t_df (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_df';
+----
+6
+
+statement ok
+drop table t_df;
+
+# Case: global=default, streaming_parallelism_for_table='ratio(0.5)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_table to 'ratio(0.5)';
+
+statement ok
+create table t_dr (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_dr';
+----
+ratio(0.5)
+
+statement ok
+drop table t_dr;
+
+# Case: global=default, streaming_parallelism_for_table='bounded(16)'
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_table to 'bounded(16)';
+
+statement ok
+create table t_db (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_db';
+----
+bounded(16)
+
+statement ok
+drop table t_db;
+
+# Case: global=default, streaming_parallelism_for_table=adaptive
+statement ok
+set streaming_parallelism to default;
+
+statement ok
+set streaming_parallelism_for_table to adaptive;
+
+statement ok
+create table t_da (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_da';
+----
+adaptive
+
+statement ok
+drop table t_da;
+
+# Case: global=8, streaming_parallelism_for_table=default
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_table to default;
+
+statement ok
+create table t_fd (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_fd';
+----
+8
+
+statement ok
+drop table t_fd;
+
+# Case: global=8, streaming_parallelism_for_table=6
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_table to 6;
+
+statement ok
+create table t_ff (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_ff';
+----
+6
+
+statement ok
+drop table t_ff;
+
+# Case: global=8, streaming_parallelism_for_table='ratio(0.5)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_table to 'ratio(0.5)';
+
+statement ok
+create table t_fr (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_fr';
+----
+ratio(0.5)
+
+statement ok
+drop table t_fr;
+
+# Case: global=8, streaming_parallelism_for_table='bounded(16)'
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_table to 'bounded(16)';
+
+statement ok
+create table t_fb (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_fb';
+----
+bounded(16)
+
+statement ok
+drop table t_fb;
+
+# Case: global=8, streaming_parallelism_for_table=adaptive
+statement ok
+set streaming_parallelism to 8;
+
+statement ok
+set streaming_parallelism_for_table to adaptive;
+
+statement ok
+create table t_fa (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_fa';
+----
+adaptive
+
+statement ok
+drop table t_fa;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_table=default
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_table to default;
+
+statement ok
+create table t_rd (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_rd';
+----
+ratio(0.5)
+
+statement ok
+drop table t_rd;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_table=6
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_table to 6;
+
+statement ok
+create table t_rf (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_rf';
+----
+6
+
+statement ok
+drop table t_rf;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_table='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_table to 'ratio(0.5)';
+
+statement ok
+create table t_rr (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_rr';
+----
+ratio(0.5)
+
+statement ok
+drop table t_rr;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_table='bounded(16)'
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_table to 'bounded(16)';
+
+statement ok
+create table t_rb (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_rb';
+----
+bounded(16)
+
+statement ok
+drop table t_rb;
+
+# Case: global='ratio(0.5)', streaming_parallelism_for_table=adaptive
+statement ok
+set streaming_parallelism to 'ratio(0.5)';
+
+statement ok
+set streaming_parallelism_for_table to adaptive;
+
+statement ok
+create table t_ra (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_ra';
+----
+adaptive
+
+statement ok
+drop table t_ra;
+
+# Case: global='bounded(32)', streaming_parallelism_for_table=default
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_table to default;
+
+statement ok
+create table t_bd (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_bd';
+----
+bounded(32)
+
+statement ok
+drop table t_bd;
+
+# Case: global='bounded(32)', streaming_parallelism_for_table=6
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_table to 6;
+
+statement ok
+create table t_bf (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_bf';
+----
+6
+
+statement ok
+drop table t_bf;
+
+# Case: global='bounded(32)', streaming_parallelism_for_table='ratio(0.5)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_table to 'ratio(0.5)';
+
+statement ok
+create table t_br (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_br';
+----
+ratio(0.5)
+
+statement ok
+drop table t_br;
+
+# Case: global='bounded(32)', streaming_parallelism_for_table='bounded(16)'
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_table to 'bounded(16)';
+
+statement ok
+create table t_bb (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_bb';
+----
+bounded(16)
+
+statement ok
+drop table t_bb;
+
+# Case: global='bounded(32)', streaming_parallelism_for_table=adaptive
+statement ok
+set streaming_parallelism to 'bounded(32)';
+
+statement ok
+set streaming_parallelism_for_table to adaptive;
+
+statement ok
+create table t_ba (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_ba';
+----
+adaptive
+
+statement ok
+drop table t_ba;
+
+# Case: global=adaptive, streaming_parallelism_for_table=default
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_table to default;
+
+statement ok
+create table t_ad (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_ad';
+----
+adaptive
+
+statement ok
+drop table t_ad;
+
+# Case: global=adaptive, streaming_parallelism_for_table=6
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_table to 6;
+
+statement ok
+create table t_af (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_af';
+----
+6
+
+statement ok
+drop table t_af;
+
+# Case: global=adaptive, streaming_parallelism_for_table='ratio(0.5)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_table to 'ratio(0.5)';
+
+statement ok
+create table t_ar (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_ar';
+----
+ratio(0.5)
+
+statement ok
+drop table t_ar;
+
+# Case: global=adaptive, streaming_parallelism_for_table='bounded(16)'
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_table to 'bounded(16)';
+
+statement ok
+create table t_ab (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_ab';
+----
+bounded(16)
+
+statement ok
+drop table t_ab;
+
+# Case: global=adaptive, streaming_parallelism_for_table=adaptive
+statement ok
+set streaming_parallelism to adaptive;
+
+statement ok
+set streaming_parallelism_for_table to adaptive;
+
+statement ok
+create table t_aa (v int);
+
+query T
+select parallelism from rw_streaming_parallelism where name = 't_aa';
+----
+adaptive
+
+statement ok
+drop table t_aa;

--- a/src/tests/simulation/tests/integration_tests/default_parallelism.rs
+++ b/src/tests/simulation/tests/integration_tests/default_parallelism.rs
@@ -26,7 +26,7 @@ async fn test_no_default_parallelism() -> Result<()> {
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't';")
         .await?
-        .assert_result_eq("ADAPTIVE");
+        .assert_result_eq("bounded(4)");
 
     Ok(())
 }
@@ -41,7 +41,7 @@ async fn test_default_parallelism() -> Result<()> {
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't';")
         .await?
-        .assert_result_eq("FIXED(2)");
+        .assert_result_eq("2");
 
     session
         .run("alter table t set parallelism = adaptive;")
@@ -50,7 +50,7 @@ async fn test_default_parallelism() -> Result<()> {
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't';")
         .await?
-        .assert_result_eq("ADAPTIVE");
+        .assert_result_eq("adaptive");
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/scale/adaptive_strategy.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/adaptive_strategy.rs
@@ -13,50 +13,41 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 use anyhow::Result;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_simulation::cluster::{Cluster, Configuration};
 use risingwave_simulation::utils::AssertResult;
-use tokio::time::sleep;
 
 #[tokio::test]
-async fn test_adaptive_strategy_create() -> Result<()> {
-    // 3cn * 2core
+async fn test_streaming_parallelism_adaptive_variants() -> Result<()> {
     let config = Configuration::for_auto_parallelism(10, true);
-
     let total_cores = config.total_streaming_cores();
     assert_eq!(total_cores, 6u32);
 
     let mut cluster = Cluster::start(config).await?;
     let mut session = cluster.start_session();
+
     session
-        .run("alter system set adaptive_parallelism_strategy to AUTO")
+        .run("set streaming_parallelism_for_table = adaptive")
         .await?;
     session.run("create table t_auto(v int)").await?;
     session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_auto' and distribution_type = 'HASH';").await?.assert_result_eq("6");
 
     session
-        .run("alter system set adaptive_parallelism_strategy to FULL")
+        .run("set streaming_parallelism_for_table = 'bounded(2)'")
         .await?;
-    session.run("create table t_full(v int)").await?;
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_full' and distribution_type = 'HASH';").await?.assert_result_eq("6");
+    session.run("create table t_bounded(v int)").await?;
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_bounded' and distribution_type = 'HASH';").await?.assert_result_eq("2");
 
     session
-        .run("alter system set adaptive_parallelism_strategy to 'BOUNDED(2)'")
+        .run("set streaming_parallelism_for_table = 'ratio(0.5)'")
         .await?;
-    session.run("create table t_bounded_2(v int)").await?;
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_bounded_2' and distribution_type = 'HASH';").await?.assert_result_eq("2");
+    session.run("create table t_ratio(v int)").await?;
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_ratio' and distribution_type = 'HASH';").await?.assert_result_eq("3");
 
     session
-        .run("alter system set adaptive_parallelism_strategy to 'RATIO(0.5)'")
-        .await?;
-    session.run("create table t_ratio_half(v int)").await?;
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_ratio_half' and distribution_type = 'HASH';").await?.assert_result_eq("3");
-
-    session
-        .run("alter system set adaptive_parallelism_strategy to 'RATIO(0.00001)'")
+        .run("set streaming_parallelism_for_table = 'ratio(0.00001)'")
         .await?;
     session.run("create table t_ratio_min(v int)").await?;
     session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_ratio_min' and distribution_type = 'HASH';").await?.assert_result_eq("1");
@@ -65,51 +56,150 @@ async fn test_adaptive_strategy_create() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_adaptive_strategy_alter() -> Result<()> {
-    // 3cn * 2core
+async fn test_streaming_parallelism_type_override() -> Result<()> {
     let config = Configuration::for_auto_parallelism(10, true);
-
-    let total_cores = config.total_streaming_cores();
-    assert_eq!(total_cores, 6u32);
 
     let mut cluster = Cluster::start(config).await?;
     let mut session = cluster.start_session();
 
     session
-        .run("alter system set adaptive_parallelism_strategy to AUTO")
+        .run("set streaming_parallelism_for_table = 'ratio(0.5)'")
         .await?;
-    session.run("create table t(v int)").await?;
-
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't' and distribution_type = 'HASH';").await?.assert_result_eq("6");
+    session.run("create table t_base(v int)").await?;
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_base' and distribution_type = 'HASH';").await?.assert_result_eq("3");
 
     session
-        .run("alter system set adaptive_parallelism_strategy to FULL")
+        .run("set streaming_parallelism_for_materialized_view = 'bounded(2)'")
         .await?;
-
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't' and distribution_type = 'HASH';").await?.assert_result_eq("6");
-
     session
-        .run("alter system set adaptive_parallelism_strategy to 'BOUNDED(2)'")
+        .run("create materialized view m_override as select * from t_base")
         .await?;
-
-    sleep(Duration::from_secs(100)).await;
-
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't' and distribution_type = 'HASH';").await?.assert_result_eq("2");
-
-    session
-        .run("alter system set adaptive_parallelism_strategy to 'RATIO(0.5)'")
-        .await?;
-
-    sleep(Duration::from_secs(100)).await;
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't' and distribution_type = 'HASH';").await?.assert_result_eq("3");
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 'm_override' and distribution_type = 'HASH';").await?.assert_result_eq("2");
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_adaptive_strategy_alter_resource_group() -> Result<()> {
-    let mut config = Configuration::for_arrangement_backfill();
+async fn test_rw_streaming_parallelism_display_uses_unified_dsl() -> Result<()> {
+    let config = Configuration::for_auto_parallelism(10, true);
 
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run("set streaming_parallelism = 'ratio(0.5)'")
+        .await?;
+    session.run("create table t_display(v int)").await?;
+    session
+        .run("create materialized view m_display as select * from t_display")
+        .await?;
+
+    session
+        .run("select parallelism from rw_streaming_parallelism where name = 't_display'")
+        .await?
+        .assert_result_eq("ratio(0.5)");
+    session
+        .run("select parallelism from rw_streaming_parallelism where name = 'm_display'")
+        .await?
+        .assert_result_eq("ratio(0.5)");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_alter_parallelism_accepts_unified_dsl() -> Result<()> {
+    let config = Configuration::for_auto_parallelism(10, true);
+
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session.run("create table t_alter(v int)").await?;
+
+    session
+        .run("alter table t_alter set parallelism = bounded(2)")
+        .await?;
+    session
+        .run("select parallelism from rw_streaming_parallelism where name = 't_alter'")
+        .await?
+        .assert_result_eq("bounded(2)");
+    session
+        .run(
+            "select distinct parallelism from rw_fragment_parallelism where name = 't_alter' and distribution_type = 'HASH'",
+        )
+        .await?
+        .assert_result_eq("2");
+
+    session
+        .run("alter table t_alter set parallelism = ratio(0.5)")
+        .await?;
+    session
+        .run("select parallelism from rw_streaming_parallelism where name = 't_alter'")
+        .await?
+        .assert_result_eq("ratio(0.5)");
+    session
+        .run(
+            "select distinct parallelism from rw_fragment_parallelism where name = 't_alter' and distribution_type = 'HASH'",
+        )
+        .await?
+        .assert_result_eq("3");
+
+    session
+        .run("alter table t_alter set parallelism = adaptive")
+        .await?;
+    session
+        .run("select parallelism from rw_streaming_parallelism where name = 't_alter'")
+        .await?
+        .assert_result_eq("adaptive");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_parallelism_default_fallback() -> Result<()> {
+    let config = Configuration::for_auto_parallelism(10, true);
+
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run("set streaming_parallelism = 'ratio(0.5)'")
+        .await?;
+    session
+        .run("set streaming_parallelism_for_materialized_view = default")
+        .await?;
+    session.run("create table t_base(v int)").await?;
+    session
+        .run("create materialized view m_fallback as select * from t_base")
+        .await?;
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 'm_fallback' and distribution_type = 'HASH';").await?.assert_result_eq("3");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_parallelism_persistence() -> Result<()> {
+    let config = Configuration::for_auto_parallelism(10, true);
+
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run("set streaming_parallelism_for_table = 'ratio(0.5)'")
+        .await?;
+    session.run("create table t_persist(v int)").await?;
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_persist' and distribution_type = 'HASH';").await?.assert_result_eq("3");
+
+    session
+        .run("set streaming_parallelism_for_table = 'bounded(2)'")
+        .await?;
+    session.run("select distinct parallelism from rw_fragment_parallelism where name = 't_persist' and distribution_type = 'HASH';").await?.assert_result_eq("3");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_parallelism_adaptive_resource_group_scale() -> Result<()> {
+    let mut config = Configuration::for_arrangement_backfill();
     config.compute_nodes = 3;
     config.compute_node_cores = 2;
     config.compute_resource_groups = HashMap::from([
@@ -121,21 +211,16 @@ async fn test_adaptive_strategy_alter_resource_group() -> Result<()> {
     let mut cluster = Cluster::start(config).await?;
     let mut session = cluster.start_session();
 
+    session.run("set streaming_parallelism = adaptive").await?;
     session
-        .run("SET STREAMING_USE_ARRANGEMENT_BACKFILL = true;")
+        .run("set streaming_use_arrangement_backfill = true")
         .await?;
-
-    session
-        .run("alter system set adaptive_parallelism_strategy to AUTO")
-        .await?;
-
     session.run("create table t(v int)").await?;
     session
         .run("create materialized view m as select * from t")
         .await?;
 
     session.run("select distinct parallelism from rw_fragment_parallelism where name = 't' and distribution_type = 'HASH';").await?.assert_result_eq("2");
-
     session.run("select distinct parallelism from rw_fragment_parallelism where name = 'm' and distribution_type = 'HASH';").await?.assert_result_eq("2");
 
     session
@@ -143,14 +228,6 @@ async fn test_adaptive_strategy_alter_resource_group() -> Result<()> {
         .await?;
 
     session.run("select distinct parallelism from rw_fragment_parallelism where name = 'm' and distribution_type = 'HASH';").await?.assert_result_eq("4");
-
-    session
-        .run("alter system set adaptive_parallelism_strategy to 'BOUNDED(2)'")
-        .await?;
-
-    sleep(Duration::from_secs(100)).await;
-
-    session.run("select distinct parallelism from rw_fragment_parallelism where name = 'm' and distribution_type = 'HASH';").await?.assert_result_eq("2");
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/scale/alter_fragment.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/alter_fragment.rs
@@ -77,7 +77,6 @@ async fn test_alter_fragment_no_shuffle() -> Result<()> {
 #[tokio::test]
 async fn test_alter_fragment() -> Result<()> {
     let mut cluster = Cluster::start(Configuration::for_scale()).await?;
-    let default_parallelism = cluster.config().compute_nodes * cluster.config().compute_node_cores;
     cluster.run("create table t1 (c1 int, c2 int);").await?;
     let materialize_fragment = cluster
         .locate_one_fragment([identity_contains("materialize")])
@@ -89,9 +88,9 @@ async fn test_alter_fragment() -> Result<()> {
             "select parallelism from rw_fragment_parallelism where fragment_id = {fragment_id};"
         ))
         .await?
-        .assert_result_eq(format!("{default_parallelism}"));
+        .assert_result_eq("4");
 
-    let new_parallelism = default_parallelism + 1;
+    let new_parallelism = 5;
 
     cluster
         .run(&format!(

--- a/src/tests/simulation/tests/integration_tests/scale/auto_parallelism.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/auto_parallelism.rs
@@ -87,14 +87,14 @@ async fn test_passive_online_and_offline() -> Result<()> {
 
     let all_worker_slots = table_mat_fragment.all_worker_count();
     let used_worker_slots = table_mat_fragment.used_worker_count();
-    assert_eq!(all_worker_slots, used_worker_slots);
+    assert_eq!(
+        all_worker_slots.keys().copied().sorted().collect_vec(),
+        used_worker_slots.keys().copied().sorted().collect_vec()
+    );
 
     let initialized_parallelism = table_mat_fragment.parallelism();
 
-    assert_eq!(
-        initialized_parallelism,
-        config.compute_nodes * config.compute_node_cores
-    );
+    assert_eq!(initialized_parallelism, 4);
 
     cluster.simple_kill_nodes(vec![host_name.clone()]).await;
     // wait for a while
@@ -109,19 +109,13 @@ async fn test_passive_online_and_offline() -> Result<()> {
         ])
         .await?;
 
-    assert_eq!(
-        initialized_parallelism - config.compute_node_cores,
-        table_mat_fragment.parallelism()
-    );
+    assert_eq!(initialized_parallelism, table_mat_fragment.parallelism());
 
     let stream_scan_fragment = cluster
         .locate_one_fragment(vec![identity_contains("streamTableScan")])
         .await?;
 
-    assert_eq!(
-        initialized_parallelism - config.compute_node_cores,
-        stream_scan_fragment.parallelism()
-    );
+    assert_eq!(initialized_parallelism, stream_scan_fragment.parallelism());
 
     let single_agg_fragment = cluster
         .locate_one_fragment(vec![
@@ -176,13 +170,13 @@ async fn test_passive_online_and_offline() -> Result<()> {
         ])
         .await?;
 
-    assert_eq!(initialized_parallelism, table_mat_fragment.parallelism());
-
     let stream_scan_fragment = cluster
         .locate_one_fragment(vec![identity_contains("streamTableScan")])
         .await?;
 
-    assert_eq!(initialized_parallelism, stream_scan_fragment.parallelism());
+    let restored_parallelism = config.compute_nodes * config.compute_node_cores;
+    assert_eq!(initialized_parallelism, table_mat_fragment.parallelism());
+    assert_eq!(restored_parallelism, stream_scan_fragment.parallelism());
 
     session
         .run("select count(*) from t")
@@ -264,7 +258,10 @@ async fn test_active_online() -> Result<()> {
 
     let used_worker_slots = table_mat_fragment.used_worker_count();
 
-    assert_eq!(all_worker_slots, used_worker_slots);
+    assert_eq!(
+        all_worker_slots.keys().copied().sorted().collect_vec(),
+        used_worker_slots.keys().copied().sorted().collect_vec()
+    );
     assert_eq!(all_worker_slots.len(), config.compute_nodes);
 
     Ok(())
@@ -307,7 +304,7 @@ async fn test_auto_parallelism_control_with_fixed_and_auto_helper(
     session
         .run("select parallelism from rw_table_fragments")
         .await?
-        .assert_result_eq("ADAPTIVE");
+        .assert_result_eq("bounded(4)");
 
     async fn locate_table_fragment(cluster: &mut Cluster) -> Result<Fragment> {
         cluster
@@ -331,7 +328,7 @@ async fn test_auto_parallelism_control_with_fixed_and_auto_helper(
     session
         .run("select parallelism from rw_table_fragments")
         .await?
-        .assert_result_eq("FIXED(3)");
+        .assert_result_eq("3");
 
     let table_mat_fragment = locate_table_fragment(&mut cluster).await?;
 
@@ -399,7 +396,7 @@ async fn test_auto_parallelism_control_with_fixed_and_auto_helper(
     session
         .run("select parallelism from rw_table_fragments")
         .await?
-        .assert_result_eq("ADAPTIVE");
+        .assert_result_eq("adaptive");
 
     let table_mat_fragment = locate_table_fragment(&mut cluster).await?;
 

--- a/src/tests/simulation/tests/integration_tests/scale/backfill_parallelism.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/backfill_parallelism.rs
@@ -28,22 +28,62 @@ async fn wait_parallelism(
     name: &str,
     expected: &str,
 ) -> Result<()> {
+    wait_query_result(
+        session,
+        &format!(
+            "select distinct parallelism from rw_fragment_parallelism where name = '{}' order by parallelism;",
+            name
+        ),
+        expected,
+    )
+    .await
+}
+
+async fn wait_streaming_parallelism(
+    session: &mut risingwave_simulation::cluster::Session,
+    name: &str,
+    expected: &str,
+) -> Result<()> {
+    wait_query_result(
+        session,
+        &format!(
+            "select parallelism from rw_streaming_parallelism where name = '{}';",
+            name
+        ),
+        expected,
+    )
+    .await
+}
+
+async fn wait_streaming_job_parallelism(
+    session: &mut risingwave_simulation::cluster::Session,
+    name: &str,
+    expected: &str,
+) -> Result<()> {
+    wait_query_result(
+        session,
+        &format!(
+            "select parallelism from rw_streaming_jobs where name = '{}';",
+            name
+        ),
+        expected,
+    )
+    .await
+}
+
+async fn wait_query_result(
+    session: &mut risingwave_simulation::cluster::Session,
+    query: &str,
+    expected: &str,
+) -> Result<()> {
     for _ in 0..(MAX_HEARTBEAT_INTERVAL_SECS_CONFIG_FOR_AUTO_SCALE * 10) {
-        let res = match session
-            .run(format!(
-                "select distinct parallelism from rw_fragment_parallelism where name = '{}' order by parallelism;",
-                name
-            ))
-            .await
-        {
+        let res = match session.run(query).await {
             Ok(res) => res,
             Err(err) => {
                 // Background DDL may not have notified the catalog yet; treat as transient.
-                if err.chain().any(|cause| {
-                    cause
-                        .to_report_string()
-                        .contains("table not found")
-                })
+                if err
+                    .chain()
+                    .any(|cause| cause.to_report_string().contains("table not found"))
                 {
                     sleep(Duration::from_millis(200)).await;
                     continue;
@@ -57,9 +97,9 @@ async fn wait_parallelism(
         sleep(Duration::from_millis(200)).await;
     }
     bail!(
-        "parallelism for {} did not reach expected {}",
-        name,
-        expected
+        "query did not reach expected result {}: {}",
+        expected,
+        query
     );
 }
 
@@ -100,7 +140,7 @@ async fn test_backfill_parallelism_switches_to_normal_after_completion() -> Resu
 
     session.run("set streaming_parallelism = 3;").await?;
     session
-        .run("set streaming_parallelism_for_backfill = 2;")
+        .run("set streaming_parallelism_for_backfill = 'bounded(2)';")
         .await?;
     session.run("create table t(v int);").await?;
     session
@@ -235,7 +275,7 @@ async fn test_backfill_parallelism_persists_after_recovery() -> Result<()> {
 
     session.run("set streaming_parallelism = 4;").await?;
     session
-        .run("set streaming_parallelism_for_backfill = 2;")
+        .run("set streaming_parallelism_for_backfill = 'bounded(2)';")
         .await?;
     session.run("set backfill_rate_limit = 1;").await?;
     session.run("set background_ddl = true;").await?;
@@ -342,17 +382,23 @@ async fn test_alter_backfill_parallelism_during_backfill() -> Result<()> {
 
     wait_parallelism(&mut session, "m", "2").await?;
     wait_jobs_running(&mut session).await?;
+    wait_streaming_parallelism(&mut session, "m", "2").await?;
+    wait_streaming_job_parallelism(&mut session, "m", "2").await?;
 
     session
-        .run("alter materialized view m set backfill_parallelism = 3;")
+        .run("alter materialized view m set backfill_parallelism = bounded(3);")
         .await?;
     wait_parallelism(&mut session, "m", "3").await?;
+    wait_streaming_parallelism(&mut session, "m", "bounded(3)").await?;
+    wait_streaming_job_parallelism(&mut session, "m", "bounded(3)").await?;
     session
         .run("alter materialized view m set backfill_rate_limit = default;")
         .await?;
 
     wait_jobs_finished(&mut session).await?;
     wait_parallelism(&mut session, "m", "4").await?;
+    wait_streaming_parallelism(&mut session, "m", "4").await?;
+    wait_streaming_job_parallelism(&mut session, "m", "4").await?;
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/scale/shared_source.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/shared_source.rs
@@ -124,13 +124,13 @@ async fn test_shared_source() -> Result<()> {
 
     validate_splits_aligned(&mut cluster).await?;
     expect_test::expect![[r#"
-        1 6 HASH {SOURCE} 6 256
+        1 6 HASH {SOURCE} 4 256
         2 8 HASH {MVIEW} 6 256
-        3 8 HASH {SOURCE_SCAN} 6 256"#]]
+        3 8 HASH {SOURCE_SCAN} 4 256"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
     expect_test::expect![[r#"
-        6 CREATED ADAPTIVE 256
-        8 CREATED ADAPTIVE 256"#]]
+        6 CREATED bounded(4) 256
+        8 CREATED bounded(64) 256"#]]
     .assert_eq(&cluster.run("select * from rw_table_fragments;").await?);
 
     // hash agg can be scaled independently
@@ -142,9 +142,9 @@ async fn test_shared_source() -> Result<()> {
         .await?;
 
     expect_test::expect![[r#"
-        1 6 HASH {SOURCE} 6 256
+        1 6 HASH {SOURCE} 4 256
         2 8 HASH {MVIEW} 5 256
-        3 8 HASH {SOURCE_SCAN} 6 256"#]]
+        3 8 HASH {SOURCE_SCAN} 4 256"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
 
     // source is the NoShuffle upstream. It can be scaled, and the downstream SourceBackfill will be scaled together.
@@ -162,8 +162,8 @@ async fn test_shared_source() -> Result<()> {
         3 8 HASH {SOURCE_SCAN} 3 256"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
     expect_test::expect![[r#"
-        6 CREATED FIXED(3) 256
-        8 CREATED FIXED(5) 256"#]]
+        6 CREATED 3 256
+        8 CREATED 5 256"#]]
     .assert_eq(&cluster.run("select * from rw_table_fragments;").await?);
 
     cluster.run("alter source s set parallelism = 7").await?;
@@ -175,8 +175,8 @@ async fn test_shared_source() -> Result<()> {
         3 8 HASH {SOURCE_SCAN} 7 256"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
     expect_test::expect![[r#"
-        6 CREATED FIXED(7) 256
-        8 CREATED FIXED(5) 256"#]]
+        6 CREATED 7 256
+        8 CREATED 5 256"#]]
     .assert_eq(&cluster.run("select * from rw_table_fragments;").await?);
     Ok(())
 }
@@ -213,14 +213,14 @@ CREATE SOURCE s(v1 timestamp with time zone) WITH (
 
     validate_splits_aligned(&mut cluster).await?;
     expect_test::expect![[r#"
-        1 6 HASH {SOURCE} 6 256
-        2 8 HASH {MVIEW,SOURCE_SCAN} 6 256
+        1 6 HASH {SOURCE} 4 256
+        2 8 HASH {MVIEW,SOURCE_SCAN} 4 256
         3 8 SINGLE {NOW} 1 1
         4 8 SINGLE {NOW} 1 1"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
     expect_test::expect![[r#"
-        6 CREATED ADAPTIVE 256
-        8 CREATED ADAPTIVE 256"#]]
+        6 CREATED bounded(4) 256
+        8 CREATED bounded(64) 256"#]]
     .assert_eq(&cluster.run("select * from rw_table_fragments;").await?);
 
     // source is the NoShuffle upstream. It can be scaled, and the downstream SourceBackfill/DynamicFilter will be scaled together.
@@ -234,8 +234,8 @@ CREATE SOURCE s(v1 timestamp with time zone) WITH (
         4 8 SINGLE {NOW} 1 1"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
     expect_test::expect![[r#"
-        6 CREATED FIXED(3) 256
-        8 CREATED ADAPTIVE 256"#]]
+        6 CREATED 3 256
+        8 CREATED bounded(64) 256"#]]
     .assert_eq(&cluster.run("select * from rw_table_fragments;").await?);
 
     // resolve_no_shuffle for backfill fragment is OK, which will scale the upstream together.
@@ -249,8 +249,8 @@ CREATE SOURCE s(v1 timestamp with time zone) WITH (
         4 8 SINGLE {NOW} 1 1"#]]
     .assert_eq(&cluster.run("select fragment_id, table_id, distribution_type, flags, parallelism, max_parallelism from rw_fragments;").await?);
     expect_test::expect![[r#"
-        6 CREATED FIXED(7) 256
-        8 CREATED ADAPTIVE 256"#]]
+        6 CREATED 7 256
+        8 CREATED bounded(64) 256"#]]
     .assert_eq(&cluster.run("select * from rw_table_fragments;").await?);
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/scale/streaming_parallelism.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/streaming_parallelism.rs
@@ -26,12 +26,11 @@ use crate::scale::auto_parallelism::MAX_HEARTBEAT_INTERVAL_SECS_CONFIG_FOR_AUTO_
 #[tokio::test]
 async fn test_streaming_parallelism_default() -> Result<()> {
     let mut cluster = Cluster::start(Configuration::for_scale()).await?;
-    let default_parallelism = cluster.config().compute_nodes * cluster.config().compute_node_cores;
     cluster.run("create table t1 (c1 int, c2 int);").await?;
     let materialize_fragment = cluster
         .locate_one_fragment([identity_contains("materialize")])
         .await?;
-    assert_eq!(materialize_fragment.inner.actors.len(), default_parallelism);
+    assert_eq!(materialize_fragment.inner.actors.len(), 4);
     Ok(())
 }
 
@@ -58,7 +57,7 @@ async fn test_streaming_parallelism_set_some() -> Result<()> {
 #[tokio::test]
 async fn test_streaming_parallelism_set_zero() -> Result<()> {
     let mut cluster = Cluster::start(Configuration::for_scale()).await?;
-    let default_parallelism = cluster.config().compute_nodes * cluster.config().compute_node_cores;
+    let expected_parallelism = cluster.config().compute_nodes * cluster.config().compute_node_cores;
 
     let mut session = cluster.start_session();
     session.run("set streaming_parallelism=0;").await?;
@@ -67,7 +66,10 @@ async fn test_streaming_parallelism_set_zero() -> Result<()> {
     let materialize_fragment = cluster
         .locate_one_fragment([identity_contains("materialize")])
         .await?;
-    assert_eq!(materialize_fragment.inner.actors.len(), default_parallelism);
+    assert_eq!(
+        materialize_fragment.inner.actors.len(),
+        expected_parallelism
+    );
     Ok(())
 }
 
@@ -161,11 +163,14 @@ async fn test_parallelism_exceed_virtual_node_max_create() -> Result<()> {
     .await;
 
     let mut session = cluster.start_session();
+    session
+        .run("set streaming_parallelism_for_table = adaptive")
+        .await?;
     session.run("create table t(v int)").await?;
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't'")
         .await?
-        .assert_result_eq("ADAPTIVE");
+        .assert_result_eq("adaptive");
 
     session
         .run("select distinct parallelism from rw_fragment_parallelism where name = 't'")
@@ -196,7 +201,7 @@ async fn test_parallelism_exceed_virtual_node_max_alter_fixed() -> Result<()> {
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't'")
         .await?
-        .assert_result_eq("FIXED(1)");
+        .assert_result_eq("1");
 
     {
         // Set to the max parallelism, should be accepted.
@@ -209,7 +214,7 @@ async fn test_parallelism_exceed_virtual_node_max_alter_fixed() -> Result<()> {
         session
             .run("select parallelism from rw_streaming_parallelism where name = 't'")
             .await?
-            .assert_result_eq(format!("FIXED({})", MAX_PARALLELISM));
+            .assert_result_eq(format!("{MAX_PARALLELISM}"));
     }
 
     {
@@ -239,7 +244,7 @@ async fn test_parallelism_exceed_virtual_node_max_alter_adaptive() -> Result<()>
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't'")
         .await?
-        .assert_result_eq("FIXED(1)");
+        .assert_result_eq("1");
 
     session
         .run("alter table t set parallelism = adaptive")
@@ -247,7 +252,7 @@ async fn test_parallelism_exceed_virtual_node_max_alter_adaptive() -> Result<()>
     session
         .run("select parallelism from rw_streaming_parallelism where name = 't'")
         .await?
-        .assert_result_eq("ADAPTIVE");
+        .assert_result_eq("adaptive");
 
     session
         .run("select distinct parallelism from rw_fragment_parallelism where name = 't'")


### PR DESCRIPTION
## Summary
- Add comprehensive E2E SLT tests for streaming parallelism across all job types:
  - `e2e_test/ddl/streaming_parallelism/source.slt` (848 lines)
  - `e2e_test/ddl/streaming_parallelism/sink.slt` (614 lines)
  - `e2e_test/ddl/streaming_parallelism/index.slt` (464 lines)
  - `e2e_test/ddl/streaming_parallelism/materialized_view.slt` (464 lines)
  - `e2e_test/ddl/streaming_parallelism/table.slt` (452 lines)
- Add backwards-compatibility tests (`seed.slt`, `validate_original.slt`, `validate_restart.slt`)
- Update `alter_parallelism.slt` and `max_parallelism.slt` expected output
- Update simulation test cluster config and 6 scale integration tests
- Update CI scripts for new test paths

**PR 6/6** of the streaming parallelism stack. Depends on #25129. Pure test additions.

## Test plan
- [x] `cargo check -p risingwave_simulation --tests`
- [ ] Full SLT run via CI (`./risedev d` + `./risedev slt`)
- [ ] Simulation tests via CI (`./risedev sit-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)