### PR TITLE
fix(sqlserver): fix sqlserver data type mismatch issue

### DIFF
--- a/src/connector/src/parser/sql_server.rs
+++ b/src/connector/src/parser/sql_server.rs
@@ -53,7 +53,9 @@ pub fn sql_server_row_to_owned_row(row: &mut Row, schema: &Schema) -> OwnedRow {
                 }
             },
             false => match row.try_get::<ScalarImplTiberiusWrapper, usize>(i) {
-                Ok(datum) => datum.map(|d| d.0),
+                Ok(datum) => datum
+                    .map(|d| d.0)
+                    .map(|scalar| coerce_scalar_to_target_type(scalar, &rw_field.data_type)),
                 Err(err) => {
                     log_error!(name, err, "parse column failed");
                     None
@@ -64,6 +66,19 @@ pub fn sql_server_row_to_owned_row(row: &mut Row, schema: &Schema) -> OwnedRow {
         datums.push(datum);
     }
     OwnedRow::new(datums)
+}
+
+fn coerce_scalar_to_target_type(scalar: ScalarImpl, target_type: &DataType) -> ScalarImpl {
+    match (scalar, target_type) {
+        // SQL Server validator allows integer upcast (e.g. `int` -> `BIGINT`).
+        // Coerce snapshot values to the target RW type to keep validation and execution consistent.
+        (ScalarImpl::Int16(v), DataType::Int32) => ScalarImpl::Int32(v as i32),
+        (ScalarImpl::Int16(v), DataType::Int64) => ScalarImpl::Int64(v as i64),
+        (ScalarImpl::Int32(v), DataType::Int64) => ScalarImpl::Int64(v as i64),
+        // SQL Server `real` may map to `FLOAT` in RW validator.
+        (ScalarImpl::Float32(v), DataType::Float64) => ScalarImpl::Float64((v.0 as f64).into()),
+        (scalar, _) => scalar,
+    }
 }
 
 pub fn convert_money_i64_to_type(value: i64, data_type: &DataType) -> ScalarImpl {
@@ -77,6 +92,38 @@ pub fn convert_money_i64_to_type(value: i64, data_type: &DataType) -> ScalarImpl
                 data_type
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::F32;
+
+    use super::*;
+
+    #[test]
+    fn test_integer_upcast_coercion() {
+        let v = coerce_scalar_to_target_type(ScalarImpl::Int32(7), &DataType::Int64);
+        assert_eq!(v, ScalarImpl::Int64(7));
+
+        let v = coerce_scalar_to_target_type(ScalarImpl::Int16(7), &DataType::Int32);
+        assert_eq!(v, ScalarImpl::Int32(7));
+
+        let v = coerce_scalar_to_target_type(ScalarImpl::Int16(7), &DataType::Int64);
+        assert_eq!(v, ScalarImpl::Int64(7));
+    }
+
+    #[test]
+    fn test_float_upcast_coercion() {
+        let v =
+            coerce_scalar_to_target_type(ScalarImpl::Float32(F32::from(1.25)), &DataType::Float64);
+        assert_eq!(v, ScalarImpl::Float64(1.25.into()));
+    }
+
+    #[test]
+    fn test_non_upcast_keeps_original() {
+        let v = coerce_scalar_to_target_type(ScalarImpl::Int32(7), &DataType::Int32);
+        assert_eq!(v, ScalarImpl::Int32(7));
     }
 }
 macro_rules! impl_tiberius_wrapper {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?
The fix applies safe upcasting (for example, Int32 -> Int64) during SQL Server snapshot row parsing so frontend-accepted type compatibility is honored at runtime, preventing backfill panics from type mismatches.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
