### PR TITLE
feat(sink): support altering secrets for sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12568,7 +12568,6 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "iceberg",
- "indexmap 2.13.0",
  "itertools 0.14.0",
  "jsonbb",
  "lz4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13841,7 +13841,6 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "iceberg",
- "indexmap 2.14.0",
  "itertools 0.14.0",
  "jsonbb",
  "lz4",

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_engine_alter_secret.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_engine_alter_secret.slt
@@ -1,0 +1,76 @@
+# Verify that ALTER TABLE secret rotation keeps both implicit connector objects'
+# dependencies in sync.
+statement ok
+CREATE CONNECTION iceberg_engine_alter_secret_conn WITH (
+  type = 'iceberg',
+  warehouse.path = 's3://hummock001/iceberg_engine_alter_secret',
+  catalog.type = 'storage',
+  s3.access.key = 'hummockadmin',
+  s3.secret.key = 'hummockadmin',
+  s3.endpoint = 'http://127.0.0.1:9301',
+  s3.region = 'us-west-2'
+);
+
+statement ok
+SET iceberg_engine_connection = 'public.iceberg_engine_alter_secret_conn';
+
+statement ok
+CREATE SECRET iceberg_engine_secret_dependency_1 WITH (
+  backend = 'meta'
+) AS 'hummockadmin';
+
+statement ok
+CREATE SECRET iceberg_engine_secret_dependency_2 WITH (
+  backend = 'meta'
+) AS 'hummockadmin';
+
+statement ok
+CREATE TABLE t_iceberg_secret_dependency (
+  id INT PRIMARY KEY,
+  name VARCHAR
+) WITH (
+  commit_checkpoint_interval = 1
+) ENGINE = ICEBERG;
+
+statement ok retry 5 backoff 3s
+ALTER TABLE t_iceberg_secret_dependency CONNECTOR WITH (
+  s3.secret.key = SECRET iceberg_engine_secret_dependency_1
+);
+
+statement ok retry 5 backoff 3s
+ALTER TABLE t_iceberg_secret_dependency CONNECTOR WITH (
+  s3.secret.key = SECRET iceberg_engine_secret_dependency_2
+);
+
+query TT rowsort
+SELECT owners.object_type, s.name
+FROM rw_catalog.rw_depend d
+JOIN (
+  SELECT id, 'source' AS object_type
+  FROM rw_catalog.rw_sources
+  WHERE name = '__iceberg_source_t_iceberg_secret_dependency'
+  UNION ALL
+  SELECT id, 'sink'
+  FROM rw_catalog.rw_sinks
+  WHERE name = '__iceberg_sink_t_iceberg_secret_dependency'
+) owners ON owners.id = d.objid
+JOIN rw_catalog.rw_secrets s ON s.id = d.refobjid
+WHERE s.name LIKE 'iceberg_engine_secret_dependency_%';
+----
+sink iceberg_engine_secret_dependency_2
+source iceberg_engine_secret_dependency_2
+
+statement ok
+DROP SECRET iceberg_engine_secret_dependency_1;
+
+statement error Permission denied: secret used by 2 other objects.
+DROP SECRET iceberg_engine_secret_dependency_2;
+
+statement ok
+DROP TABLE t_iceberg_secret_dependency;
+
+statement ok
+DROP SECRET iceberg_engine_secret_dependency_2;
+
+statement ok
+DROP CONNECTION iceberg_engine_alter_secret_conn;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
@@ -110,6 +110,25 @@ CREATE SOURCE iceberg_e2e_auto_create_table WITH (
 );
 
 statement ok
+CREATE SECRET iceberg_s3_secret_key_test WITH (
+  backend = 'meta'
+) as 'hummockadmin';
+
+statement ok retry 5 backoff 3s
+ALTER SINK s7 CONNECTOR WITH (
+    s3.secret.key = secret iceberg_s3_secret_key_test
+);
+
+query I
+select count(*)
+from rw_sinks
+where name = 's7'
+  and connector_props -> 's3.secret.key' ->> 'type' = 'secret'
+  and connector_props -> 's3.secret.key' -> 'value' ->> 'value' = 'iceberg_s3_secret_key_test';
+----
+1
+
+statement ok
 INSERT INTO t6 VALUES (1, 2, '1-2'), (2, 2, '2-2'), (3, 2, '3-2'), (5, 2, '5-2'), (8, 2, '8-2'), (13, 2, '13-2'), (21, 2, '21-2');
 
 statement ok

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_sink.slt
@@ -342,6 +342,25 @@ CREATE SOURCE iceberg_e2e_auto_create_table WITH (
 );
 
 statement ok
+CREATE SECRET iceberg_s3_secret_key_test WITH (
+  backend = 'meta'
+) as 'hummockadmin';
+
+statement ok retry 5 backoff 3s
+ALTER SINK s7 CONNECTOR WITH (
+    s3.secret.key = secret iceberg_s3_secret_key_test
+);
+
+query I
+select count(*)
+from rw_sinks
+where name = 's7'
+  and connector_props -> 's3.secret.key' ->> 'type' = 'secret'
+  and connector_props -> 's3.secret.key' -> 'value' ->> 'value' = 'iceberg_s3_secret_key_test';
+----
+1
+
+statement ok
 INSERT INTO t6 VALUES (1, 2, '1-2'), (2, 2, '2-2'), (3, 2, '3-2'), (5, 2, '5-2'), (8, 2, '8-2'), (13, 2, '13-2'), (21, 2, '21-2');
 
 statement ok

--- a/e2e_test/sink/remote/jdbc.alter_connector_props.slt
+++ b/e2e_test/sink/remote/jdbc.alter_connector_props.slt
@@ -1,23 +1,55 @@
 statement ok
-set sink_decouple = false;
-
-statement ok
 CREATE TABLE t_jdbc_alter_src (
     id INT PRIMARY KEY,
     v1 INT
 );
 
+statement ok
+create secret jdbc_password_1 with (backend = 'meta') as 'connector';
+
+statement ok
+create secret jdbc_password_2 with (backend = 'meta') as 'connector';
+
 # NOTE: JDBC sink currently uses `user` instead of `username`.
 statement ok
 CREATE SINK s_jdbc_alter_props FROM t_jdbc_alter_src WITH (
     connector = 'jdbc',
-    jdbc.url = 'jdbc:postgresql://db:5432/test?user=test&password=connector',
+    jdbc.url = 'jdbc:postgresql://db:5432/test',
     table.name = 't_jdbc_alter_props',
+    user = 'test',
+    password = secret jdbc_password_1,
     type = 'upsert',
     primary_key = 'id'
 );
 
+statement ok retry 5 backoff 3s
+ALTER SINK s_jdbc_alter_props CONNECTOR WITH (
+    jdbc.url = 'jdbc:postgresql://db:5432/test',
+    user = 'test',
+    password = secret jdbc_password_2
+);
+
+query I
+select count(*)
+from rw_sinks
+where name = 's_jdbc_alter_props'
+  and connector_props -> 'jdbc.url' ->> 'value' = 'jdbc:postgresql://db:5432/test'
+  and connector_props -> 'user' ->> 'value' = 'test'
+  and connector_props -> 'password' ->> 'type' = 'secret'
+  and connector_props -> 'password' -> 'value' ->> 'value' = 'jdbc_password_2';
+----
+1
+
+statement error Field 'table.name' is not allowed to be altered on the fly for sink: jdbc
+ALTER SINK s_jdbc_alter_props CONNECTOR WITH (table.name = 't_jdbc_alter_props_2');
+
 statement ok
+DROP SECRET jdbc_password_1;
+
+statement error
+DROP SECRET jdbc_password_2;
+
+statement ok retry 5 backoff 3s
 ALTER SINK s_jdbc_alter_props CONNECTOR WITH (
     jdbc.url = 'jdbc:postgresql://db:5432/test',
     user = 'test',
@@ -28,14 +60,15 @@ query I
 select count(*)
 from rw_sinks
 where name = 's_jdbc_alter_props'
-  and definition ILIKE '%jdbc.url = ''jdbc:postgresql://db:5432/test''%'
-  and definition ILIKE '%"user" = ''test''%'
-  and definition ILIKE '%password = ''connector''%';
+  and connector_props -> 'jdbc.url' ->> 'value' = 'jdbc:postgresql://db:5432/test'
+  and connector_props -> 'user' ->> 'value' = 'test'
+  and connector_props -> 'password' ->> 'type' = 'plaintext'
+  and connector_props -> 'password' ->> 'value' = 'connector';
 ----
 1
 
-statement error Field 'table.name' is not allowed to be altered on the fly for sink: jdbc
-ALTER SINK s_jdbc_alter_props CONNECTOR WITH (table.name = 't_jdbc_alter_props_2');
+statement ok
+DROP SECRET jdbc_password_2;
 
 statement ok
 DROP SINK s_jdbc_alter_props;

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
@@ -1,0 +1,84 @@
+control substitution on
+
+system ok
+rpk topic create test_alter_conn_sink_secret -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw
+
+statement ok
+create secret conn_sink_password_1 with ( backend = 'meta' ) as 'rw';
+
+statement ok
+create secret conn_sink_password_2 with ( backend = 'meta' ) as 'rw';
+
+statement ok
+create connection kafka_conn_sink_secret with (
+    type = 'kafka',
+    properties.bootstrap.server = 'message_queue_sasl_1:19092',
+    properties.security.protocol = 'SASL_PLAINTEXT',
+    properties.sasl.mechanism = 'PLAIN',
+    properties.sasl.username = 'dev',
+    properties.sasl.password = secret conn_sink_password_1
+);
+
+statement ok
+create table t_conn_sink_secret (
+    v1 int primary key,
+    v2 int
+);
+
+statement ok
+create materialized view mv_conn_sink_secret as
+select * from t_conn_sink_secret;
+
+statement ok
+create sink s_conn_sink_secret
+from mv_conn_sink_secret with (
+    connector = 'kafka',
+    connection = kafka_conn_sink_secret,
+    topic = 'test_alter_conn_sink_secret'
+) format plain encode json (
+    force_append_only = 'true'
+);
+
+statement ok
+insert into t_conn_sink_secret values (1, 10), (2, 20);
+
+statement ok
+flush;
+
+statement ok retry 5 backoff 3s
+alter connection kafka_conn_sink_secret connector with (
+    properties.sasl.password = secret conn_sink_password_2
+);
+
+query I
+select count(*)
+from rw_sinks
+where name = 's_conn_sink_secret'
+  and connector_props -> 'properties.sasl.password' ->> 'type' = 'secret'
+  and connector_props -> 'properties.sasl.password' -> 'value' ->> 'value' = 'conn_sink_password_2';
+----
+1
+
+statement ok
+drop secret conn_sink_password_1;
+
+statement error
+drop secret conn_sink_password_2;
+
+statement ok
+drop sink s_conn_sink_secret;
+
+statement ok
+drop connection kafka_conn_sink_secret;
+
+statement ok
+drop secret conn_sink_password_2;
+
+statement ok
+drop materialized view mv_conn_sink_secret;
+
+statement ok
+drop table t_conn_sink_secret;
+
+system ok
+rpk topic delete test_alter_conn_sink_secret -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
@@ -1,5 +1,8 @@
 control substitution on
 
+# ==== alter connection propagates secret rotation to dependent sink ====
+
+# prepare topic and secrets
 system ok
 rpk topic create test_alter_conn_sink_secret -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw
 
@@ -79,6 +82,75 @@ drop materialized view mv_conn_sink_secret;
 
 statement ok
 drop table t_conn_sink_secret;
+
+# ==== direct alter sink with secret rotation ====
+
+statement ok
+create secret sink_password_1 with ( backend = 'meta' ) as 'rw';
+
+statement ok
+create secret sink_password_2 with ( backend = 'meta' ) as 'rw';
+
+statement ok
+create table t_sink_secret_direct (
+    v1 int primary key,
+    v2 int
+);
+
+statement ok
+create materialized view mv_sink_secret_direct as
+select * from t_sink_secret_direct;
+
+statement ok
+create sink s_sink_secret_direct
+from mv_sink_secret_direct with (
+    connector = 'kafka',
+    topic = 'test_alter_conn_sink_secret',
+    properties.bootstrap.server = 'message_queue_sasl_1:19092',
+    properties.security.protocol = 'SASL_PLAINTEXT',
+    properties.sasl.mechanism = 'PLAIN',
+    properties.sasl.username = 'dev',
+    properties.sasl.password = secret sink_password_1
+) format plain encode json (
+    force_append_only = 'true'
+);
+
+statement ok retry 5 backoff 3s
+ALTER SINK s_sink_secret_direct CONNECTOR WITH (
+    properties.sasl.password = secret sink_password_2
+);
+
+statement ok retry 5 backoff 3s
+ALTER SINK s_sink_secret_direct CONNECTOR WITH (
+    commit_checkpoint_interval = '2'
+);
+
+query I
+select count(*)
+from rw_sinks
+where name = 's_sink_secret_direct'
+  and connector_props -> 'properties.sasl.password' ->> 'type' = 'secret'
+  and connector_props -> 'properties.sasl.password' -> 'value' ->> 'value' = 'sink_password_2';
+----
+1
+
+statement ok
+drop secret sink_password_1;
+
+statement error
+drop secret sink_password_2;
+
+statement ok
+drop sink s_sink_secret_direct;
+
+statement ok
+drop secret sink_password_2;
+
+statement ok
+drop materialized view mv_sink_secret_direct;
+
+statement ok
+drop table t_sink_secret_direct;
 
 system ok
 rpk topic delete test_alter_conn_sink_secret -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
@@ -120,9 +120,14 @@ ALTER SINK s_sink_secret_direct CONNECTOR WITH (
     properties.sasl.password = secret sink_password_2
 );
 
-statement ok retry 5 backoff 3s
+statement error
 ALTER SINK s_sink_secret_direct CONNECTOR WITH (
     commit_checkpoint_interval = '2'
+);
+
+statement ok retry 5 backoff 3s
+ALTER SINK s_sink_secret_direct CONNECTOR WITH (
+    properties.message.timeout.ms = '3000'
 );
 
 query I
@@ -131,6 +136,14 @@ from rw_sinks
 where name = 's_sink_secret_direct'
   and connector_props -> 'properties.sasl.password' ->> 'type' = 'secret'
   and connector_props -> 'properties.sasl.password' -> 'value' ->> 'value' = 'sink_password_2';
+----
+1
+
+query I
+select count(*)
+from rw_sinks
+where name = 's_sink_secret_direct'
+  and connector_props -> 'properties.message.timeout.ms' ->> 'value' = '3000';
 ----
 1
 

--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_sink.slt
@@ -120,6 +120,14 @@ ALTER SINK s_sink_secret_direct CONNECTOR WITH (
     properties.sasl.password = secret sink_password_2
 );
 
+query I
+select count(*)
+from rw_sinks
+where name = 's_sink_secret_direct'
+  and definition ILIKE '%properties.sasl.password = secret public.sink_password_2%';
+----
+1
+
 statement error
 ALTER SINK s_sink_secret_direct CONNECTOR WITH (
     commit_checkpoint_interval = '2'

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -143,6 +143,23 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
             "debezium.queue.memory.ratio".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // IcebergProperties
+    map.try_insert(
+        std::any::type_name::<IcebergProperties>().to_owned(),
+        [
+            "s3.access.key".to_owned(),
+            "s3.secret.key".to_owned(),
+            "s3.iam_role_arn".to_owned(),
+            "glue.access.key".to_owned(),
+            "glue.secret.key".to_owned(),
+            "glue.iam_role_arn".to_owned(),
+            "gcs.credential".to_owned(),
+            "adlsgen2.account_key".to_owned(),
+            "catalog.credential".to_owned(),
+            "catalog.token".to_owned(),
+            "catalog.oauth2_server_uri".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // KafkaProperties
     map.try_insert(
         std::any::type_name::<KafkaProperties>().to_owned(),
@@ -196,10 +213,19 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
 pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<String>>> = LazyLock::new(|| {
     use sink_properties::*;
     let mut map = HashMap::new();
+    // BigQueryConfig
+    map.try_insert(
+        std::any::type_name::<BigQueryConfig>().to_owned(),
+        [
+            "bigquery.credentials".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // ClickHouseConfig
     map.try_insert(
         std::any::type_name::<ClickHouseConfig>().to_owned(),
         [
+            "clickhouse.user".to_owned(),
+            "clickhouse.password".to_owned(),
             "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
@@ -207,6 +233,7 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
     map.try_insert(
         std::any::type_name::<DeltaLakeConfig>().to_owned(),
         [
+            "gcs.service.account".to_owned(),
             "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
@@ -214,13 +241,41 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
     map.try_insert(
         std::any::type_name::<DorisConfig>().to_owned(),
         [
+            "doris.user".to_owned(),
+            "doris.password".to_owned(),
             "doris.stream_load.http.timeout.ms".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // ElasticSearchConfig
+    map.try_insert(
+        std::any::type_name::<ElasticSearchConfig>().to_owned(),
+        [
+            "username".to_owned(),
+            "password".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // GooglePubSubConfig
+    map.try_insert(
+        std::any::type_name::<GooglePubSubConfig>().to_owned(),
+        [
+            "pubsub.credentials".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // IcebergConfig
     map.try_insert(
         std::any::type_name::<IcebergConfig>().to_owned(),
         [
+            "s3.access.key".to_owned(),
+            "s3.secret.key".to_owned(),
+            "s3.iam_role_arn".to_owned(),
+            "glue.access.key".to_owned(),
+            "glue.secret.key".to_owned(),
+            "glue.iam_role_arn".to_owned(),
+            "gcs.credential".to_owned(),
+            "adlsgen2.account_key".to_owned(),
+            "catalog.credential".to_owned(),
+            "catalog.token".to_owned(),
+            "catalog.oauth2_server_uri".to_owned(),
             "commit_checkpoint_interval".to_owned(),
             "enable_compaction".to_owned(),
             "compaction_interval_sec".to_owned(),
@@ -276,17 +331,55 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "properties.request.required.acks".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // OpenSearchConfig
+    map.try_insert(
+        std::any::type_name::<OpenSearchConfig>().to_owned(),
+        [
+            "username".to_owned(),
+            "password".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // PostgresConfig
+    map.try_insert(
+        std::any::type_name::<PostgresConfig>().to_owned(),
+        [
+            "password".to_owned(),
+            "ssl.root.cert".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // RedShiftConfig
+    map.try_insert(
+        std::any::type_name::<RedShiftConfig>().to_owned(),
+        [
+            "user".to_owned(),
+            "password".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // SnowflakeV2Config
     map.try_insert(
         std::any::type_name::<SnowflakeV2Config>().to_owned(),
         [
+            "username".to_owned(),
+            "password".to_owned(),
+            "private_key_file_pwd".to_owned(),
+            "private_key_pem".to_owned(),
             "commit_checkpoint_interval".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // SqlServerConfig
+    map.try_insert(
+        std::any::type_name::<SqlServerConfig>().to_owned(),
+        [
+            "sqlserver.user".to_owned(),
+            "sqlserver.password".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // StarrocksConfig
     map.try_insert(
         std::any::type_name::<StarrocksConfig>().to_owned(),
         [
+            "starrocks.user".to_owned(),
+            "starrocks.password".to_owned(),
             "starrocks.stream_load.http.timeout.ms".to_owned(),
             "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
@@ -307,6 +400,23 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
 pub static CONNECTION_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<String>>> = LazyLock::new(|| {
     use crate::connector_common::*;
     let mut map = HashMap::new();
+    // IcebergConnection
+    map.try_insert(
+        std::any::type_name::<IcebergConnection>().to_owned(),
+        [
+            "s3.access.key".to_owned(),
+            "s3.secret.key".to_owned(),
+            "s3.iam_role_arn".to_owned(),
+            "glue.access.key".to_owned(),
+            "glue.secret.key".to_owned(),
+            "glue.iam_role_arn".to_owned(),
+            "gcs.credential".to_owned(),
+            "adlsgen2.account_key".to_owned(),
+            "catalog.credential".to_owned(),
+            "catalog.token".to_owned(),
+            "catalog.oauth2_server_uri".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // KafkaConnection
     map.try_insert(
         std::any::type_name::<KafkaConnection>().to_owned(),

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -150,6 +150,23 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
             "debezium.queue.memory.ratio".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // IcebergProperties
+    map.try_insert(
+        std::any::type_name::<IcebergProperties>().to_owned(),
+        [
+            "s3.access.key".to_owned(),
+            "s3.secret.key".to_owned(),
+            "s3.iam_role_arn".to_owned(),
+            "glue.access.key".to_owned(),
+            "glue.secret.key".to_owned(),
+            "glue.iam_role_arn".to_owned(),
+            "gcs.credential".to_owned(),
+            "adlsgen2.account_key".to_owned(),
+            "catalog.credential".to_owned(),
+            "catalog.token".to_owned(),
+            "catalog.oauth2_server_uri".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // KafkaProperties
     map.try_insert(
         std::any::type_name::<KafkaProperties>().to_owned(),
@@ -211,10 +228,19 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
 pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<String>>> = LazyLock::new(|| {
     use sink_properties::*;
     let mut map = HashMap::new();
+    // BigQueryConfig
+    map.try_insert(
+        std::any::type_name::<BigQueryConfig>().to_owned(),
+        [
+            "bigquery.credentials".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // ClickHouseConfig
     map.try_insert(
         std::any::type_name::<ClickHouseConfig>().to_owned(),
         [
+            "clickhouse.user".to_owned(),
+            "clickhouse.password".to_owned(),
             "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
@@ -222,6 +248,7 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
     map.try_insert(
         std::any::type_name::<DeltaLakeConfig>().to_owned(),
         [
+            "gcs.service.account".to_owned(),
             "commit_checkpoint_interval".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
@@ -229,6 +256,8 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
     map.try_insert(
         std::any::type_name::<DorisConfig>().to_owned(),
         [
+            "doris.user".to_owned(),
+            "doris.password".to_owned(),
             "doris.stream_load.http.timeout.ms".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
@@ -236,15 +265,35 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
     map.try_insert(
         std::any::type_name::<ElasticSearchConfig>().to_owned(),
         [
+            "username".to_owned(),
+            "password".to_owned(),
             "batch_num_messages".to_owned(),
             "batch_size_kb".to_owned(),
             "concurrent_requests".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // GooglePubSubConfig
+    map.try_insert(
+        std::any::type_name::<GooglePubSubConfig>().to_owned(),
+        [
+            "pubsub.credentials".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // IcebergConfig
     map.try_insert(
         std::any::type_name::<IcebergConfig>().to_owned(),
         [
+            "s3.access.key".to_owned(),
+            "s3.secret.key".to_owned(),
+            "s3.iam_role_arn".to_owned(),
+            "glue.access.key".to_owned(),
+            "glue.secret.key".to_owned(),
+            "glue.iam_role_arn".to_owned(),
+            "gcs.credential".to_owned(),
+            "adlsgen2.account_key".to_owned(),
+            "catalog.credential".to_owned(),
+            "catalog.token".to_owned(),
+            "catalog.oauth2_server_uri".to_owned(),
             "commit_checkpoint_interval".to_owned(),
             "enable_compaction".to_owned(),
             "compaction_interval_sec".to_owned(),
@@ -311,9 +360,19 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
     map.try_insert(
         std::any::type_name::<OpenSearchConfig>().to_owned(),
         [
+            "username".to_owned(),
+            "password".to_owned(),
             "batch_num_messages".to_owned(),
             "batch_size_kb".to_owned(),
             "concurrent_requests".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // PostgresConfig
+    map.try_insert(
+        std::any::type_name::<PostgresConfig>().to_owned(),
+        [
+            "password".to_owned(),
+            "ssl.root.cert".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // PulsarConfig
@@ -329,17 +388,39 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "pulsar.properties.routing_mode".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // RedShiftConfig
+    map.try_insert(
+        std::any::type_name::<RedShiftConfig>().to_owned(),
+        [
+            "user".to_owned(),
+            "password".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // SnowflakeV2Config
     map.try_insert(
         std::any::type_name::<SnowflakeV2Config>().to_owned(),
         [
+            "username".to_owned(),
+            "password".to_owned(),
+            "private_key_file_pwd".to_owned(),
+            "private_key_pem".to_owned(),
             "commit_checkpoint_interval".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
+    // SqlServerConfig
+    map.try_insert(
+        std::any::type_name::<SqlServerConfig>().to_owned(),
+        [
+            "sqlserver.user".to_owned(),
+            "sqlserver.password".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
     // StarrocksConfig
     map.try_insert(
         std::any::type_name::<StarrocksConfig>().to_owned(),
         [
+            "starrocks.user".to_owned(),
+            "starrocks.password".to_owned(),
             "starrocks.stream_load.http.timeout.ms".to_owned(),
             "commit_checkpoint_interval".to_owned(),
             "starrocks.max_batch_size_bytes".to_owned(),
@@ -369,6 +450,23 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
 pub static CONNECTION_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<String>>> = LazyLock::new(|| {
     use crate::connector_common::*;
     let mut map = HashMap::new();
+    // IcebergConnection
+    map.try_insert(
+        std::any::type_name::<IcebergConnection>().to_owned(),
+        [
+            "s3.access.key".to_owned(),
+            "s3.secret.key".to_owned(),
+            "s3.iam_role_arn".to_owned(),
+            "glue.access.key".to_owned(),
+            "glue.secret.key".to_owned(),
+            "glue.iam_role_arn".to_owned(),
+            "gcs.credential".to_owned(),
+            "adlsgen2.account_key".to_owned(),
+            "catalog.credential".to_owned(),
+            "catalog.token".to_owned(),
+            "catalog.oauth2_server_uri".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // KafkaConnection
     map.try_insert(
         std::any::type_name::<KafkaConnection>().to_owned(),

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -62,17 +62,23 @@ pub struct IcebergCommon {
     #[serde(rename = "s3.endpoint")]
     pub s3_endpoint: Option<String>,
     #[serde(rename = "s3.access.key")]
+    #[with_option(allow_alter_on_fly)]
     pub s3_access_key: Option<String>,
     #[serde(rename = "s3.secret.key")]
+    #[with_option(allow_alter_on_fly)]
     pub s3_secret_key: Option<String>,
     #[serde(rename = "s3.iam_role_arn")]
+    #[with_option(allow_alter_on_fly)]
     pub s3_iam_role_arn: Option<String>,
 
     #[serde(rename = "glue.access.key")]
+    #[with_option(allow_alter_on_fly)]
     pub glue_access_key: Option<String>,
     #[serde(rename = "glue.secret.key")]
+    #[with_option(allow_alter_on_fly)]
     pub glue_secret_key: Option<String>,
     #[serde(rename = "glue.iam_role_arn")]
+    #[with_option(allow_alter_on_fly)]
     pub glue_iam_role_arn: Option<String>,
     #[serde(rename = "glue.region")]
     pub glue_region: Option<String>,
@@ -82,6 +88,7 @@ pub struct IcebergCommon {
     pub glue_id: Option<String>,
 
     #[serde(rename = "gcs.credential")]
+    #[with_option(allow_alter_on_fly)]
     pub gcs_credential: Option<String>,
 
     #[serde(rename = "azblob.account_name")]
@@ -94,6 +101,7 @@ pub struct IcebergCommon {
     #[serde(rename = "adlsgen2.account_name")]
     pub adlsgen2_account_name: Option<String>,
     #[serde(rename = "adlsgen2.account_key")]
+    #[with_option(allow_alter_on_fly)]
     pub adlsgen2_account_key: Option<String>,
     #[serde(rename = "adlsgen2.endpoint")]
     pub adlsgen2_endpoint: Option<String>,
@@ -110,14 +118,17 @@ pub struct IcebergCommon {
     /// Credential for accessing iceberg catalog, only applicable in rest catalog.
     /// A credential to exchange for a token in the `OAuth2` client credentials flow.
     #[serde(rename = "catalog.credential")]
+    #[with_option(allow_alter_on_fly)]
     pub catalog_credential: Option<String>,
     /// token for accessing iceberg catalog, only applicable in rest catalog.
     /// A Bearer token which will be used for interaction with the server.
     #[serde(rename = "catalog.token")]
+    #[with_option(allow_alter_on_fly)]
     pub catalog_token: Option<String>,
     /// `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
     /// Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     #[serde(rename = "catalog.oauth2_server_uri")]
+    #[with_option(allow_alter_on_fly)]
     pub catalog_oauth2_server_uri: Option<String>,
     /// scope for accessing iceberg catalog, only applicable in rest catalog.
     /// Additional scope for `OAuth2`.

--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -63,17 +63,23 @@ pub struct IcebergCommon {
     #[serde(rename = "s3.endpoint")]
     pub s3_endpoint: Option<String>,
     #[serde(rename = "s3.access.key")]
+    #[with_option(allow_alter_on_fly)]
     pub s3_access_key: Option<String>,
     #[serde(rename = "s3.secret.key")]
+    #[with_option(allow_alter_on_fly)]
     pub s3_secret_key: Option<String>,
     #[serde(rename = "s3.iam_role_arn")]
+    #[with_option(allow_alter_on_fly)]
     pub s3_iam_role_arn: Option<String>,
 
     #[serde(rename = "glue.access.key")]
+    #[with_option(allow_alter_on_fly)]
     pub glue_access_key: Option<String>,
     #[serde(rename = "glue.secret.key")]
+    #[with_option(allow_alter_on_fly)]
     pub glue_secret_key: Option<String>,
     #[serde(rename = "glue.iam_role_arn")]
+    #[with_option(allow_alter_on_fly)]
     pub glue_iam_role_arn: Option<String>,
     #[serde(rename = "glue.region")]
     pub glue_region: Option<String>,
@@ -85,6 +91,7 @@ pub struct IcebergCommon {
     pub glue_id: Option<String>,
 
     #[serde(rename = "gcs.credential")]
+    #[with_option(allow_alter_on_fly)]
     pub gcs_credential: Option<String>,
 
     #[serde(rename = "azblob.account_name")]
@@ -97,6 +104,7 @@ pub struct IcebergCommon {
     #[serde(rename = "adlsgen2.account_name")]
     pub adlsgen2_account_name: Option<String>,
     #[serde(rename = "adlsgen2.account_key")]
+    #[with_option(allow_alter_on_fly)]
     pub adlsgen2_account_key: Option<String>,
     #[serde(rename = "adlsgen2.endpoint")]
     pub adlsgen2_endpoint: Option<String>,
@@ -121,14 +129,17 @@ pub struct IcebergCommon {
     /// Credential for accessing iceberg catalog, only applicable in rest catalog.
     /// A credential to exchange for a token in the `OAuth2` client credentials flow.
     #[serde(rename = "catalog.credential")]
+    #[with_option(allow_alter_on_fly)]
     pub catalog_credential: Option<String>,
     /// token for accessing iceberg catalog, only applicable in rest catalog.
     /// A Bearer token which will be used for interaction with the server.
     #[serde(rename = "catalog.token")]
+    #[with_option(allow_alter_on_fly)]
     pub catalog_token: Option<String>,
     /// `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
     /// Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     #[serde(rename = "catalog.oauth2_server_uri")]
+    #[with_option(allow_alter_on_fly)]
     pub catalog_oauth2_server_uri: Option<String>,
     /// scope for accessing iceberg catalog, only applicable in rest catalog.
     /// Additional scope for `OAuth2`.

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -35,6 +35,7 @@ use tokio_postgres::{Client as PgClient, NoTls};
 use super::maybe_tls_connector::MaybeMakeTlsConnector;
 use crate::error::ConnectorResult;
 use crate::sink::postgres::TcpKeepaliveConfig;
+use crate::with_options::WithOptions;
 
 /// SQL query to discover primary key columns directly from PostgreSQL system tables.
 /// This bypasses querying `information_schema.table_constraints` to avoid permission issues.
@@ -171,6 +172,12 @@ pub enum SslMode {
     /// matches the name stored in the server certificate.
     #[serde(alias = "verify-full")]
     VerifyFull,
+}
+
+// Implement it for `SslMode` so structs containing this enum can be parsed
+// from `WITH (...)` options without requiring additional conversion wrappers.
+impl WithOptions for SslMode {
+    fn assert_receiver_is_with_options(&self) {}
 }
 
 pub struct PostgresExternalTable {

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -35,7 +35,6 @@ use super::TcpKeepaliveConfig;
 #[cfg(not(madsim))]
 use super::maybe_tls_connector::MaybeMakeTlsConnector;
 use crate::error::ConnectorResult;
-use crate::with_options::WithOptions;
 
 /// SQL query to discover primary key columns directly from PostgreSQL system tables.
 /// This bypasses querying `information_schema.table_constraints` to avoid permission issues.
@@ -213,12 +212,6 @@ pub enum SslMode {
     /// matches the name stored in the server certificate.
     #[serde(alias = "verify-full")]
     VerifyFull,
-}
-
-// Implement it for `SslMode` so structs containing this enum can be parsed
-// from `WITH (...)` options without requiring additional conversion wrappers.
-impl WithOptions for SslMode {
-    fn assert_receiver_is_with_options(&self) {}
 }
 
 pub struct PostgresExternalTable {

--- a/src/connector/src/connector_common/postgres.rs
+++ b/src/connector/src/connector_common/postgres.rs
@@ -35,6 +35,7 @@ use super::TcpKeepaliveConfig;
 #[cfg(not(madsim))]
 use super::maybe_tls_connector::MaybeMakeTlsConnector;
 use crate::error::ConnectorResult;
+use crate::with_options::WithOptions;
 
 /// SQL query to discover primary key columns directly from PostgreSQL system tables.
 /// This bypasses querying `information_schema.table_constraints` to avoid permission issues.
@@ -212,6 +213,12 @@ pub enum SslMode {
     /// matches the name stored in the server certificate.
     #[serde(alias = "verify-full")]
     VerifyFull,
+}
+
+// Implement it for `SslMode` so structs containing this enum can be parsed
+// from `WITH (...)` options without requiring additional conversion wrappers.
+impl WithOptions for SslMode {
+    fn assert_receiver_is_with_options(&self) {}
 }
 
 pub struct PostgresExternalTable {

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -96,6 +96,7 @@ pub struct BigQueryCommon {
     #[serde_as(as = "DisplayFromStr")]
     pub auto_create: bool,
     #[serde(rename = "bigquery.credentials")]
+    #[with_option(allow_alter_on_fly)]
     pub credentials: Option<String>,
 }
 

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -60,8 +60,10 @@ pub struct ClickHouseCommon {
     #[serde(rename = "clickhouse.url")]
     pub url: String,
     #[serde(rename = "clickhouse.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     #[serde(rename = "clickhouse.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     #[serde(rename = "clickhouse.database")]
     pub database: String,

--- a/src/connector/src/sink/clickhouse.rs
+++ b/src/connector/src/sink/clickhouse.rs
@@ -65,8 +65,10 @@ pub struct ClickHouseCommon {
     #[serde(rename = "clickhouse.url")]
     pub url: String,
     #[serde(rename = "clickhouse.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     #[serde(rename = "clickhouse.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     #[serde(rename = "clickhouse.database")]
     pub database: String,

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -68,6 +68,7 @@ pub struct DeltaLakeCommon {
     pub aws_auth_props: AwsAuthProps,
 
     #[serde(rename = "gcs.service.account")]
+    #[with_option(allow_alter_on_fly)]
     pub gcs_service_account: Option<String>,
     /// Commit every n(>0) checkpoints, default is 10.
     #[serde(default = "default_commit_checkpoint_interval")]

--- a/src/connector/src/sink/doris.rs
+++ b/src/connector/src/sink/doris.rs
@@ -48,8 +48,10 @@ pub struct DorisCommon {
     #[serde(rename = "doris.url")]
     pub url: String,
     #[serde(rename = "doris.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     #[serde(rename = "doris.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     #[serde(rename = "doris.database")]
     pub database: String,

--- a/src/connector/src/sink/doris.rs
+++ b/src/connector/src/sink/doris.rs
@@ -51,8 +51,10 @@ pub struct DorisCommon {
     #[serde(rename = "doris.url")]
     pub url: String,
     #[serde(rename = "doris.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     #[serde(rename = "doris.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     #[serde(rename = "doris.database")]
     pub database: String,

--- a/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
+++ b/src/connector/src/sink/elasticsearch_opensearch/elasticsearch_opensearch_config.rs
@@ -64,9 +64,11 @@ pub struct ElasticSearchOpenSearchConfig {
     pub delimiter: Option<String>,
     /// The username of elasticsearch or openserach
     #[serde(rename = "username")]
+    #[with_option(allow_alter_on_fly)]
     pub username: Option<String>,
     /// The username of elasticsearch or openserach
     #[serde(rename = "password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: Option<String>,
     /// It is used for dynamic index, if it is be set, the value of this column will be used as the index. It and `index` can only set one
     #[serde(rename = "index_column")]

--- a/src/connector/src/sink/google_pubsub.rs
+++ b/src/connector/src/sink/google_pubsub.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 
 use anyhow::anyhow;
 use google_cloud_gax::conn::Environment;
+use google_cloud_gax::grpc::Status;
 use google_cloud_googleapis::pubsub::v1::PubsubMessage;
 use google_cloud_pubsub::apiv1;
 use google_cloud_pubsub::client::google_cloud_auth::credentials::CredentialsFile;
@@ -27,7 +28,6 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use serde::Deserialize;
 use serde_with::serde_as;
-use google_cloud_gax::grpc::Status;
 use with_options::WithOptions;
 
 use super::catalog::SinkFormatDesc;
@@ -96,6 +96,7 @@ pub struct GooglePubSubConfig {
     /// The provided account credential must have the
     /// `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
     #[serde(rename = "pubsub.credentials")]
+    #[with_option(allow_alter_on_fly)]
     pub credentials: Option<String>,
 }
 

--- a/src/connector/src/sink/google_pubsub.rs
+++ b/src/connector/src/sink/google_pubsub.rs
@@ -96,6 +96,7 @@ pub struct GooglePubSubConfig {
     /// The provided account credential must have the
     /// `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
     #[serde(rename = "pubsub.credentials")]
+    #[with_option(allow_alter_on_fly)]
     pub credentials: Option<String>,
 
     #[serde(flatten)]

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -29,6 +29,7 @@ use serde_with::{DisplayFromStr, serde_as};
 use simd_json::prelude::ArrayTrait;
 use thiserror_ext::AsReport;
 use tokio_postgres::types::Type as PgType;
+use with_options::WithOptions;
 
 use super::{
     LogSinker, SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError, SinkLogReader,
@@ -42,12 +43,13 @@ use crate::sink::{Result, Sink, SinkParam, SinkWriterParam};
 pub const POSTGRES_SINK: &str = "postgres";
 
 #[serde_as]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct PostgresConfig {
     pub host: String,
     #[serde_as(as = "DisplayFromStr")]
     pub port: u16,
     pub user: String,
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     pub database: String,
     pub table: String,
@@ -56,6 +58,7 @@ pub struct PostgresConfig {
     #[serde(default = "Default::default")]
     pub ssl_mode: SslMode,
     #[serde(rename = "ssl.root.cert")]
+    #[with_option(allow_alter_on_fly)]
     pub ssl_root_cert: Option<String>,
     #[serde(default = "default_max_batch_rows")]
     #[serde_as(as = "DisplayFromStr")]
@@ -70,7 +73,7 @@ pub struct PostgresConfig {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, WithOptions)]
 pub struct TcpKeepaliveConfig {
     #[serde(rename = "tcp.keepalive.idle")]
     #[serde_as(as = "DisplayFromStr")]

--- a/src/connector/src/sink/postgres.rs
+++ b/src/connector/src/sink/postgres.rs
@@ -69,6 +69,7 @@ pub struct PostgresConfig {
     #[serde_as(as = "DisplayFromStr")]
     pub port: u16,
     pub user: String,
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     pub database: String,
     pub table: String,
@@ -77,6 +78,7 @@ pub struct PostgresConfig {
     #[serde(default = "Default::default")]
     pub ssl_mode: SslMode,
     #[serde(rename = "ssl.root.cert")]
+    #[with_option(allow_alter_on_fly)]
     pub ssl_root_cert: Option<String>,
     #[serde(default = "default_max_batch_rows")]
     #[serde_as(as = "DisplayFromStr")]

--- a/src/connector/src/sink/snowflake_redshift/redshift.rs
+++ b/src/connector/src/sink/snowflake_redshift/redshift.rs
@@ -79,9 +79,11 @@ pub struct RedShiftConfig {
     pub jdbc_url: String,
 
     #[serde(rename = "user")]
+    #[with_option(allow_alter_on_fly)]
     pub username: Option<String>,
 
     #[serde(rename = "password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: Option<String>,
 
     #[serde(rename = "schema")]

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -95,9 +95,11 @@ pub struct SnowflakeV2Config {
     pub jdbc_url: Option<String>,
 
     #[serde(rename = "username")]
+    #[with_option(allow_alter_on_fly)]
     pub username: Option<String>,
 
     #[serde(rename = "password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: Option<String>,
 
     // Authentication method control (password | key_pair_file | key_pair_object)
@@ -109,10 +111,12 @@ pub struct SnowflakeV2Config {
     pub private_key_file: Option<String>,
 
     #[serde(rename = "private_key_file_pwd")]
+    #[with_option(allow_alter_on_fly)]
     pub private_key_file_pwd: Option<String>,
 
     // Key-pair authentication via connection Properties (Option 1: object-based, PEM content)
     #[serde(rename = "private_key_pem")]
+    #[with_option(allow_alter_on_fly)]
     pub private_key_pem: Option<String>,
 
     /// Commit every n(>0) checkpoints, default is 10.

--- a/src/connector/src/sink/snowflake_redshift/snowflake.rs
+++ b/src/connector/src/sink/snowflake_redshift/snowflake.rs
@@ -101,9 +101,11 @@ pub struct SnowflakeV2Config {
     pub jdbc_url: Option<String>,
 
     #[serde(rename = "username")]
+    #[with_option(allow_alter_on_fly)]
     pub username: Option<String>,
 
     #[serde(rename = "password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: Option<String>,
 
     // Authentication method control (password | key_pair_file | key_pair_object)
@@ -115,10 +117,12 @@ pub struct SnowflakeV2Config {
     pub private_key_file: Option<String>,
 
     #[serde(rename = "private_key_file_pwd")]
+    #[with_option(allow_alter_on_fly)]
     pub private_key_file_pwd: Option<String>,
 
     // Key-pair authentication via connection Properties (Option 1: object-based, PEM content)
     #[serde(rename = "private_key_pem")]
+    #[with_option(allow_alter_on_fly)]
     pub private_key_pem: Option<String>,
 
     /// Commit every n(>0) checkpoints, default is 10.

--- a/src/connector/src/sink/sqlserver.rs
+++ b/src/connector/src/sink/sqlserver.rs
@@ -52,8 +52,10 @@ pub struct SqlServerConfig {
     #[serde_as(as = "DisplayFromStr")]
     pub port: u16,
     #[serde(rename = "sqlserver.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     #[serde(rename = "sqlserver.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     #[serde(rename = "sqlserver.database")]
     pub database: String,

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -74,9 +74,11 @@ pub struct StarrocksCommon {
     pub http_port: String,
     /// The user name used to access the `StarRocks` database.
     #[serde(rename = "starrocks.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     /// The password associated with the user.
     #[serde(rename = "starrocks.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     /// The `StarRocks` database where the target table is located
     #[serde(rename = "starrocks.database")]

--- a/src/connector/src/sink/starrocks.rs
+++ b/src/connector/src/sink/starrocks.rs
@@ -75,9 +75,11 @@ pub struct StarrocksCommon {
     pub http_port: String,
     /// The user name used to access the `StarRocks` database.
     #[serde(rename = "starrocks.user")]
+    #[with_option(allow_alter_on_fly)]
     pub user: String,
     /// The password associated with the user.
     #[serde(rename = "starrocks.password")]
+    #[with_option(allow_alter_on_fly)]
     pub password: String,
     /// The `StarRocks` database where the target table is located
     #[serde(rename = "starrocks.database")]

--- a/src/connector/with_options_connection.yaml
+++ b/src/connector/with_options_connection.yaml
@@ -26,21 +26,27 @@ IcebergConnection:
   - name: s3.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.region
     field_type: String
     required: false
@@ -53,6 +59,7 @@ IcebergConnection:
   - name: gcs.credential
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: azblob.account_name
     field_type: String
     required: false
@@ -68,6 +75,7 @@ IcebergConnection:
   - name: adlsgen2.account_key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: adlsgen2.endpoint
     field_type: String
     required: false
@@ -89,18 +97,21 @@ IcebergConnection:
       Credential for accessing iceberg catalog, only applicable in rest catalog.
       A credential to exchange for a token in the `OAuth2` client credentials flow.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.token
     field_type: String
     comments: |-
       token for accessing iceberg catalog, only applicable in rest catalog.
       A Bearer token which will be used for interaction with the server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.oauth2_server_uri
     field_type: String
     comments: |-
       `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
       Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.scope
     field_type: String
     comments: |-

--- a/src/connector/with_options_connection.yaml
+++ b/src/connector/with_options_connection.yaml
@@ -26,21 +26,27 @@ IcebergConnection:
   - name: s3.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.region
     field_type: String
     required: false
@@ -56,6 +62,7 @@ IcebergConnection:
   - name: gcs.credential
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: azblob.account_name
     field_type: String
     required: false
@@ -71,6 +78,7 @@ IcebergConnection:
   - name: adlsgen2.account_key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: adlsgen2.endpoint
     field_type: String
     required: false
@@ -104,18 +112,21 @@ IcebergConnection:
       Credential for accessing iceberg catalog, only applicable in rest catalog.
       A credential to exchange for a token in the `OAuth2` client credentials flow.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.token
     field_type: String
     comments: |-
       token for accessing iceberg catalog, only applicable in rest catalog.
       A Bearer token which will be used for interaction with the server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.oauth2_server_uri
     field_type: String
     comments: |-
       `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
       Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.scope
     field_type: String
     comments: |-

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -60,6 +60,7 @@ BigQueryConfig:
   - name: bigquery.credentials
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: aws.region
     field_type: String
     required: false
@@ -121,9 +122,11 @@ ClickHouseConfig:
   - name: clickhouse.user
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: clickhouse.password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: clickhouse.database
     field_type: String
     required: true
@@ -200,6 +203,7 @@ DeltaLakeConfig:
   - name: gcs.service.account
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 10.
@@ -221,9 +225,11 @@ DorisConfig:
   - name: doris.user
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: doris.password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: doris.database
     field_type: String
     required: true
@@ -328,10 +334,12 @@ ElasticSearchConfig:
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: index_column
     field_type: String
     comments: It is used for dynamic index, if it is be set, the value of this column will be used as the index. It and `index` can only set one
@@ -438,6 +446,7 @@ GooglePubSubConfig:
       The provided account credential must have the
       `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
     required: false
+    allow_alter_on_fly: true
 HttpConfig:
   fields:
   - name: url
@@ -475,21 +484,27 @@ IcebergConfig:
   - name: s3.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.region
     field_type: String
     required: false
@@ -502,6 +517,7 @@ IcebergConfig:
   - name: gcs.credential
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: azblob.account_name
     field_type: String
     required: false
@@ -517,6 +533,7 @@ IcebergConfig:
   - name: adlsgen2.account_key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: adlsgen2.endpoint
     field_type: String
     required: false
@@ -538,18 +555,21 @@ IcebergConfig:
       Credential for accessing iceberg catalog, only applicable in rest catalog.
       A credential to exchange for a token in the `OAuth2` client credentials flow.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.token
     field_type: String
     comments: |-
       token for accessing iceberg catalog, only applicable in rest catalog.
       A Bearer token which will be used for interaction with the server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.oauth2_server_uri
     field_type: String
     comments: |-
       `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
       Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.scope
     field_type: String
     comments: |-
@@ -1333,10 +1353,12 @@ OpenSearchConfig:
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: index_column
     field_type: String
     comments: It is used for dynamic index, if it is be set, the value of this column will be used as the index. It and `index` can only set one
@@ -1361,6 +1383,59 @@ OpenSearchConfig:
     field_type: String
     required: false
     default: '"upsert" . to_owned ()'
+PostgresConfig:
+  fields:
+  - name: host
+    field_type: String
+    required: true
+  - name: port
+    field_type: u16
+    required: true
+  - name: user
+    field_type: String
+    required: true
+  - name: password
+    field_type: String
+    required: true
+    allow_alter_on_fly: true
+  - name: database
+    field_type: String
+    required: true
+  - name: table
+    field_type: String
+    required: true
+  - name: schema
+    field_type: String
+    required: false
+    default: '"public" . to_owned ()'
+  - name: ssl_mode
+    field_type: SslMode
+    required: false
+    default: Default::default
+  - name: ssl.root.cert
+    field_type: String
+    required: false
+    allow_alter_on_fly: true
+  - name: max_batch_rows
+    field_type: usize
+    required: false
+    default: '1024'
+  - name: r#type
+    field_type: String
+    required: true
+  - name: tcp.keepalive.enable
+    field_type: bool
+    required: false
+    default: Default::default
+  - name: tcp.keepalive.idle
+    field_type: u32
+    required: true
+  - name: tcp.keepalive.interval
+    field_type: u32
+    required: true
+  - name: tcp.keepalive.count
+    field_type: u32
+    required: true
 PulsarConfig:
   fields:
   - name: properties.retry.max
@@ -1462,9 +1537,11 @@ RedShiftConfig:
   - name: user
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: schema
     field_type: String
     required: false
@@ -1635,9 +1712,11 @@ SnowflakeV2Config:
   - name: username
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: auth.method
     field_type: String
     required: false
@@ -1647,9 +1726,11 @@ SnowflakeV2Config:
   - name: private_key_file_pwd
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: private_key_pem
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 10.
@@ -1726,9 +1807,11 @@ SqlServerConfig:
   - name: sqlserver.user
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: sqlserver.password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: sqlserver.database
     field_type: String
     required: true
@@ -1768,10 +1851,12 @@ StarrocksConfig:
     field_type: String
     comments: The user name used to access the `StarRocks` database.
     required: true
+    allow_alter_on_fly: true
   - name: starrocks.password
     field_type: String
     comments: The password associated with the user.
     required: true
+    allow_alter_on_fly: true
   - name: starrocks.database
     field_type: String
     comments: The `StarRocks` database where the target table is located

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -62,6 +62,7 @@ BigQueryConfig:
   - name: bigquery.credentials
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: aws.region
     field_type: String
     required: false
@@ -123,9 +124,11 @@ ClickHouseConfig:
   - name: clickhouse.user
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: clickhouse.password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: clickhouse.database
     field_type: String
     required: true
@@ -202,6 +205,7 @@ DeltaLakeConfig:
   - name: gcs.service.account
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 10.
@@ -223,9 +227,11 @@ DorisConfig:
   - name: doris.user
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: doris.password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: doris.database
     field_type: String
     required: true
@@ -338,10 +344,12 @@ ElasticSearchConfig:
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: index_column
     field_type: String
     comments: It is used for dynamic index, if it is be set, the value of this column will be used as the index. It and `index` can only set one
@@ -451,6 +459,7 @@ GooglePubSubConfig:
       The provided account credential must have the
       `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
     required: false
+    allow_alter_on_fly: true
 HttpConfig:
   fields:
   - name: url
@@ -492,21 +501,27 @@ IcebergConfig:
   - name: s3.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.region
     field_type: String
     required: false
@@ -522,6 +537,7 @@ IcebergConfig:
   - name: gcs.credential
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: azblob.account_name
     field_type: String
     required: false
@@ -537,6 +553,7 @@ IcebergConfig:
   - name: adlsgen2.account_key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: adlsgen2.endpoint
     field_type: String
     required: false
@@ -570,18 +587,21 @@ IcebergConfig:
       Credential for accessing iceberg catalog, only applicable in rest catalog.
       A credential to exchange for a token in the `OAuth2` client credentials flow.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.token
     field_type: String
     comments: |-
       token for accessing iceberg catalog, only applicable in rest catalog.
       A Bearer token which will be used for interaction with the server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.oauth2_server_uri
     field_type: String
     comments: |-
       `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
       Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.scope
     field_type: String
     comments: |-
@@ -1436,10 +1456,12 @@ OpenSearchConfig:
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     comments: The username of elasticsearch or openserach
     required: false
+    allow_alter_on_fly: true
   - name: index_column
     field_type: String
     comments: It is used for dynamic index, if it is be set, the value of this column will be used as the index. It and `index` can only set one
@@ -1481,6 +1503,7 @@ PostgresConfig:
   - name: password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: database
     field_type: String
     required: true
@@ -1498,6 +1521,7 @@ PostgresConfig:
   - name: ssl.root.cert
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: max_batch_rows
     field_type: usize
     required: false
@@ -1633,9 +1657,11 @@ RedShiftConfig:
   - name: user
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: schema
     field_type: String
     required: false
@@ -1813,9 +1839,11 @@ SnowflakeV2Config:
   - name: username
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: password
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: auth.method
     field_type: String
     required: false
@@ -1825,9 +1853,11 @@ SnowflakeV2Config:
   - name: private_key_file_pwd
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: private_key_pem
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 10.
@@ -1904,9 +1934,11 @@ SqlServerConfig:
   - name: sqlserver.user
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: sqlserver.password
     field_type: String
     required: true
+    allow_alter_on_fly: true
   - name: sqlserver.database
     field_type: String
     required: true
@@ -1946,10 +1978,12 @@ StarrocksConfig:
     field_type: String
     comments: The user name used to access the `StarRocks` database.
     required: true
+    allow_alter_on_fly: true
   - name: starrocks.password
     field_type: String
     comments: The password associated with the user.
     required: true
+    allow_alter_on_fly: true
   - name: starrocks.database
     field_type: String
     comments: The `StarRocks` database where the target table is located

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -197,21 +197,27 @@ IcebergProperties:
   - name: s3.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.region
     field_type: String
     required: false
@@ -224,6 +230,7 @@ IcebergProperties:
   - name: gcs.credential
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: azblob.account_name
     field_type: String
     required: false
@@ -239,6 +246,7 @@ IcebergProperties:
   - name: adlsgen2.account_key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: adlsgen2.endpoint
     field_type: String
     required: false
@@ -260,18 +268,21 @@ IcebergProperties:
       Credential for accessing iceberg catalog, only applicable in rest catalog.
       A credential to exchange for a token in the `OAuth2` client credentials flow.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.token
     field_type: String
     comments: |-
       token for accessing iceberg catalog, only applicable in rest catalog.
       A Bearer token which will be used for interaction with the server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.oauth2_server_uri
     field_type: String
     comments: |-
       `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
       Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.scope
     field_type: String
     comments: |-

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -197,21 +197,27 @@ IcebergProperties:
   - name: s3.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: s3.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.access.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.secret.key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.iam_role_arn
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: glue.region
     field_type: String
     required: false
@@ -227,6 +233,7 @@ IcebergProperties:
   - name: gcs.credential
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: azblob.account_name
     field_type: String
     required: false
@@ -242,6 +249,7 @@ IcebergProperties:
   - name: adlsgen2.account_key
     field_type: String
     required: false
+    allow_alter_on_fly: true
   - name: adlsgen2.endpoint
     field_type: String
     required: false
@@ -275,18 +283,21 @@ IcebergProperties:
       Credential for accessing iceberg catalog, only applicable in rest catalog.
       A credential to exchange for a token in the `OAuth2` client credentials flow.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.token
     field_type: String
     comments: |-
       token for accessing iceberg catalog, only applicable in rest catalog.
       A Bearer token which will be used for interaction with the server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.oauth2_server_uri
     field_type: String
     comments: |-
       `oauth2_server_uri` for accessing iceberg catalog, only applicable in rest catalog.
       Token endpoint URI to fetch token from if the Rest Catalog is not the authorization server.
     required: false
+    allow_alter_on_fly: true
   - name: catalog.scope
     field_type: String
     comments: |-

--- a/src/frontend/src/handler/alter_table_props.rs
+++ b/src/frontend/src/handler/alter_table_props.rs
@@ -93,8 +93,8 @@ pub async fn handle_alter_iceberg_table_props(
         None,
     )?;
     let (changed_props, changed_secret_refs) = resolved_with_options.into_parts();
-    if !changed_secret_refs.is_empty() || connector_conn_ref.is_some() {
-        bail!("ALTER ICEBERG TABLE does not support SECRET or CONNECTION now")
+    if connector_conn_ref.is_some() {
+        bail!("ALTER ICEBERG TABLE does not support CONNECTION")
     }
     meta_client
         .alter_iceberg_table_props(

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -33,7 +33,6 @@ futures-async-stream = { workspace = true }
 hex = "0.4"
 http = "1"
 iceberg = { workspace = true }
-indexmap = { workspace = true }
 itertools = { workspace = true }
 jsonbb = { workspace = true }
 lz4 = "1.28.0"

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -734,25 +734,45 @@ impl StreamManagerService for StreamServiceImpl {
         let (new_props_plaintext, object_id) = match AlterConnectorPropsObject::try_from(
             request.object_type,
         ) {
-            Ok(AlterConnectorPropsObject::Sink) => (
-                self.metadata_manager
+            Ok(AlterConnectorPropsObject::Sink) => {
+                let options_with_secret = self
+                    .metadata_manager
+                    .catalog_controller
                     .update_sink_props_by_sink_id(
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),
+                        request.changed_secret_refs.clone().into_iter().collect(),
                     )
-                    .await?,
-                request.object_id.into(),
-            ),
+                    .await?;
+                let (options, secret_refs) = options_with_secret.into_parts();
+                (
+                    secret_manager
+                        .fill_secrets(options, secret_refs)
+                        .map_err(MetaError::from)?
+                        .into_iter()
+                        .collect(),
+                    request.object_id.into(),
+                )
+            }
             Ok(AlterConnectorPropsObject::IcebergTable) => {
-                let (prop, sink_id) = self
+                let (options_with_secret, sink_id) = self
                     .metadata_manager
                     .update_iceberg_table_props_by_table_id(
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),
+                        request.changed_secret_refs.clone().into_iter().collect(),
                         request.extra_options,
                     )
                     .await?;
-                (prop, sink_id.as_object_id())
+                let (options, secret_refs) = options_with_secret.into_parts();
+                (
+                    secret_manager
+                        .fill_secrets(options, secret_refs)
+                        .map_err(MetaError::from)?
+                        .into_iter()
+                        .collect(),
+                    sink_id.as_object_id(),
+                )
             }
 
             Ok(AlterConnectorPropsObject::Source) => {

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -729,25 +729,45 @@ impl StreamManagerService for StreamServiceImpl {
         let (new_props_plaintext, object_id) = match AlterConnectorPropsObject::try_from(
             request.object_type,
         ) {
-            Ok(AlterConnectorPropsObject::Sink) => (
-                self.metadata_manager
+            Ok(AlterConnectorPropsObject::Sink) => {
+                let options_with_secret = self
+                    .metadata_manager
+                    .catalog_controller
                     .update_sink_props_by_sink_id(
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),
+                        request.changed_secret_refs.clone().into_iter().collect(),
                     )
-                    .await?,
-                request.object_id.into(),
-            ),
+                    .await?;
+                let (options, secret_refs) = options_with_secret.into_parts();
+                (
+                    secret_manager
+                        .fill_secrets(options, secret_refs)
+                        .map_err(MetaError::from)?
+                        .into_iter()
+                        .collect(),
+                    request.object_id.into(),
+                )
+            }
             Ok(AlterConnectorPropsObject::IcebergTable) => {
-                let (prop, sink_id) = self
+                let (options_with_secret, sink_id) = self
                     .metadata_manager
                     .update_iceberg_table_props_by_table_id(
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),
+                        request.changed_secret_refs.clone().into_iter().collect(),
                         request.extra_options,
                     )
                     .await?;
-                (prop, sink_id.as_object_id())
+                let (options, secret_refs) = options_with_secret.into_parts();
+                (
+                    secret_manager
+                        .fill_secrets(options, secret_refs)
+                        .map_err(MetaError::from)?
+                        .into_iter()
+                        .collect(),
+                    sink_id.as_object_id(),
+                )
             }
 
             Ok(AlterConnectorPropsObject::Source) => {

--- a/src/meta/service/src/stream_service.rs
+++ b/src/meta/service/src/stream_service.rs
@@ -752,6 +752,7 @@ impl StreamManagerService for StreamServiceImpl {
             Ok(AlterConnectorPropsObject::IcebergTable) => {
                 let (options_with_secret, sink_id) = self
                     .metadata_manager
+                    .catalog_controller
                     .update_iceberg_table_props_by_table_id(
                         request.object_id.into(),
                         request.changed_props.clone().into_iter().collect(),

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3146,9 +3146,16 @@ impl CatalogController {
                         .unwrap_or_default(),
                 );
 
-                let (_sink_to_add_secret_dep, _sink_to_remove_secret_dep) =
-                    sink_options_with_secret
-                        .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
+                let (sink_to_add_secret_dep, sink_to_remove_secret_dep) = sink_options_with_secret
+                    .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
+
+                update_secret_dependencies(
+                    &txn,
+                    sink_to_add_secret_dep,
+                    sink_to_remove_secret_dep,
+                    sink_id.as_object_id(),
+                )
+                .await?;
 
                 // Prepare sink update
                 let active_sink = sink::ActiveModel {

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2402,11 +2402,8 @@ impl CatalogController {
 
         // Only check alter-on-fly restrictions for SQL ALTER SOURCE, not for admin risectl operations
         if !skip_alter_on_fly_check {
-            let prop_keys: Vec<String> = alter_props
-                .keys()
-                .chain(alter_secret_refs.keys())
-                .cloned()
-                .collect();
+            let prop_keys: Vec<String> =
+                build_altered_field_names(&alter_props, &alter_secret_refs);
             risingwave_connector::allow_alter_on_fly_fields::check_source_allow_alter_on_fly_fields(
                 &connector, &prop_keys,
             )?;
@@ -2576,8 +2573,19 @@ impl CatalogController {
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
 
-        // check if the alter-ed props are valid for all connector
-        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
+        let connector_type = sink
+            .properties
+            .inner_ref()
+            .get(CONNECTOR_TYPE_KEY)
+            .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
+            .to_lowercase();
+
+        validate_connector_type(&connector_type, &alter_props)?;
+
+        let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
+
+        check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
+            .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -2585,8 +2593,12 @@ impl CatalogController {
                 .map(|secret_ref| secret_ref.to_protobuf())
                 .unwrap_or_default(),
         );
+
         let (to_add_secret_dep, to_remove_secret_dep) =
             options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        // check if the alter-ed props are valid for all connector
+        validate_sink_props(&connector_type, options_with_secret.clone())?;
 
         tracing::info!(
             "applying new properties to sink: sink_id={}, options_with_secret={:?}",
@@ -2690,7 +2702,20 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
+
+        let connector_type = sink
+            .properties
+            .inner_ref()
+            .get(CONNECTOR_TYPE_KEY)
+            .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
+            .to_lowercase();
+
+        validate_connector_type(&connector_type, &alter_props)?;
+
+        let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
+
+        check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
+            .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -2698,8 +2723,12 @@ impl CatalogController {
                 .map(|secret_ref| secret_ref.to_protobuf())
                 .unwrap_or_default(),
         );
+
         let (to_add_secret_dep, to_remove_secret_dep) =
             options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        // check if the alter-ed props are valid for all connector
+        validate_sink_props(&connector_type, options_with_secret.clone())?;
 
         // rewrite the sql for definition field
         let rewrite_sql = {
@@ -3135,8 +3164,14 @@ impl CatalogController {
             for (sink, _obj) in sinks_with_objs {
                 let sink_id = sink.sink_id;
 
-                // Validate that sink props can be altered
-                validate_sink_props(&sink, &alter_props.clone(), &alter_secret_refs.clone())?;
+                let connector_type = sink
+                    .properties
+                    .inner_ref()
+                    .get(CONNECTOR_TYPE_KEY)
+                    .ok_or_else(|| {
+                        SinkError::Config(anyhow!("connector not specified when alter sink"))
+                    })?
+                    .to_lowercase();
 
                 let mut sink_options_with_secret = WithOptionsSecResolved::new(
                     sink.properties.0.clone(),
@@ -3148,6 +3183,9 @@ impl CatalogController {
 
                 let (sink_to_add_secret_dep, sink_to_remove_secret_dep) = sink_options_with_secret
                     .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
+
+                // check if the alter-ed props are valid for all connector
+                validate_sink_props(&connector_type, sink_options_with_secret.clone())?;
 
                 update_secret_dependencies(
                     &txn,
@@ -3417,18 +3455,39 @@ impl CatalogController {
 }
 
 fn validate_sink_props(
-    sink: &sink::Model,
+    connector_type: &str,
+    with_properties: WithOptionsSecResolved,
+) -> MetaResult<()> {
+    let (options, secret_refs) = with_properties.into_parts();
+    let resolved_props = LocalSecretManager::global()
+        .fill_secrets(options, secret_refs)
+        .map_err(MetaError::from)?;
+
+    match_sink_name_str!(
+        connector_type,
+        SinkType,
+        SinkType::validate_alter_config(&resolved_props),
+        |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
+    )?;
+
+    Ok(())
+}
+
+fn build_altered_field_names(
     alter_props: &BTreeMap<String, String>,
     alter_secret_refs: &BTreeMap<String, PbSecretRef>,
+) -> Vec<String> {
+    alter_props
+        .keys()
+        .chain(alter_secret_refs.keys())
+        .cloned()
+        .collect()
+}
+
+fn validate_connector_type(
+    connector: &str,
+    alter_props: &BTreeMap<String, String>,
 ) -> MetaResult<()> {
-    let connector = sink
-        .properties
-        .inner_ref()
-        .get(CONNECTOR_TYPE_KEY)
-        .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?;
-
-    let connector_type = connector.to_lowercase();
-
     if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
         && new_connector != connector
     {
@@ -3437,26 +3496,6 @@ fn validate_sink_props(
             connector, new_connector
         )));
     }
-
-    let field_names: Vec<String> = alter_props
-        .keys()
-        .chain(alter_secret_refs.keys())
-        .cloned()
-        .collect();
-
-    check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
-        .map_err(|e| SinkError::Config(anyhow!(e)))?;
-
-    match_sink_name_str!(
-        connector_type.as_str(),
-        SinkType,
-        {
-            let mut new_props = sink.properties.0.clone();
-            new_props.extend(alter_props.clone());
-            SinkType::validate_alter_config(&new_props)
-        },
-        |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
-    )?;
 
     Ok(())
 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2791,6 +2791,8 @@ impl CatalogController {
             properties: Set(risingwave_meta_model::Property(
                 options_with_secret.as_plaintext().clone(),
             )),
+            secret_ref: Set((!options_with_secret.as_secret().is_empty())
+                .then(|| SecretRef::from(options_with_secret.as_secret().clone()))),
             definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2580,8 +2580,6 @@ impl CatalogController {
             .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
             .to_lowercase();
 
-        validate_connector_type(&connector_type, &alter_props)?;
-
         let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
 
         check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
@@ -2709,8 +2707,6 @@ impl CatalogController {
             .get(CONNECTOR_TYPE_KEY)
             .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
             .to_lowercase();
-
-        validate_connector_type(&connector_type, &alter_props)?;
 
         let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
 
@@ -3030,27 +3026,14 @@ impl CatalogController {
                     .optional_associated_table_id
                     .map(|table_id| table_id.as_object_id())
                     .unwrap_or_else(|| source_id.as_object_id());
-                if !source_to_add_secret_dep.is_empty() {
-                    ObjectDependency::insert_many(source_to_add_secret_dep.into_iter().map(
-                        |secret_id| object_dependency::ActiveModel {
-                            oid: Set(secret_id.into()),
-                            used_by: Set(source_used_by_id),
-                            ..Default::default()
-                        },
-                    ))
-                    .exec(&txn)
-                    .await?;
-                }
-                if !source_to_remove_secret_dep.is_empty() {
-                    let _ = ObjectDependency::delete_many()
-                        .filter(
-                            object_dependency::Column::Oid
-                                .is_in(source_to_remove_secret_dep)
-                                .and(object_dependency::Column::UsedBy.eq(source_used_by_id)),
-                        )
-                        .exec(&txn)
-                        .await?;
-                }
+
+                update_secret_dependencies(
+                    &txn,
+                    source_to_add_secret_dep,
+                    source_to_remove_secret_dep,
+                    source_used_by_id,
+                )
+                .await?;
 
                 // Prepare source update
                 let active_source = source::ActiveModel {
@@ -3484,22 +3467,6 @@ fn build_altered_field_names(
         .collect()
 }
 
-fn validate_connector_type(
-    connector: &str,
-    alter_props: &BTreeMap<String, String>,
-) -> MetaResult<()> {
-    if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
-        && new_connector != connector
-    {
-        return Err(MetaError::invalid_parameter(format!(
-            "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
-            connector, new_connector
-        )));
-    }
-
-    Ok(())
-}
-
 async fn update_sink_fragment_props(
     txn: &DatabaseTransaction,
     sink_id: SinkId,
@@ -3645,7 +3612,7 @@ async fn update_secret_dependencies(
         .await?;
     }
     // Remove dependencies for secrets that are no longer referenced.
-    // This allows the secrets to be deleted after this source no longer uses them.
+    // This allows the secrets to be deleted after this source/sink no longer uses them.
     if !to_remove_secrets.is_empty() {
         let _ = ObjectDependency::delete_many()
             .filter(

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
 
 use anyhow::anyhow;
-use indexmap::IndexMap;
 use itertools::Itertools;
 use risingwave_common::catalog::{
     ColumnCatalog, FragmentTypeFlag, FragmentTypeMask, ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX,
@@ -52,7 +51,7 @@ use risingwave_meta_model::*;
 use risingwave_pb::catalog::table::PbEngine;
 use risingwave_pb::catalog::{PbConnection, PbCreateType, PbTable};
 use risingwave_pb::ddl_service::streaming_job_resource_type;
-use risingwave_pb::meta::alter_connector_props_request::AlterIcebergTableIds;
+use risingwave_pb::meta::alter_connector_props_request::{AlterIcebergTableIds, PbExtraOptions};
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
 use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::{
@@ -68,8 +67,8 @@ use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode};
 use risingwave_pb::user::PbUserInfo;
-use risingwave_sqlparser::ast::{Engine, SqlOption, Statement};
-use risingwave_sqlparser::parser::{Parser, ParserError};
+use risingwave_sqlparser::ast::{Engine, Statement};
+use risingwave_sqlparser::parser::Parser;
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::{Expr, Query, SimpleExpr};
 use sea_orm::{
@@ -86,9 +85,9 @@ use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_if_belongs_to_iceberg_table,
     check_relation_name_duplicate, check_sink_into_table_cycle, ensure_job_not_canceled,
-    ensure_object_id, ensure_user_id, fetch_target_fragments, get_internal_tables_by_id,
-    get_table_columns, grant_default_privileges_automatically, insert_fragment_relations,
-    list_object_dependencies_by_object_id, list_user_info_by_ids,
+    ensure_object_id, ensure_user_id, fetch_target_fragments, format_with_option_secret_resolved,
+    get_internal_tables_by_id, get_table_columns, grant_default_privileges_automatically,
+    insert_fragment_relations, list_object_dependencies_by_object_id, list_user_info_by_ids,
     try_get_iceberg_table_by_downstream_sink,
 };
 use crate::error::MetaErrorInner;
@@ -638,7 +637,7 @@ impl CatalogController {
             StreamingJobModel::update(job).exec(&txn).await?;
         }
 
-        let state_table_ids = fragments
+        let state_table_ids: Vec<_> = fragments
             .iter()
             .flat_map(|fragment| fragment.state_table_ids.inner_ref().clone())
             .collect_vec();
@@ -2443,42 +2442,6 @@ impl CatalogController {
                 .try_into()
                 .unwrap();
 
-            /// Formats SQL options with secret values properly resolved
-            ///
-            /// This function processes configuration options that may contain sensitive data:
-            /// - Plaintext options are directly converted to `SqlOption`
-            /// - Secret options are retrieved from the database and formatted as "SECRET {name}"
-            ///   without exposing the actual secret value
-            ///
-            /// # Arguments
-            /// * `txn` - Database transaction for retrieving secrets
-            /// * `options_with_secret` - Container of options with both plaintext and secret values
-            ///
-            /// # Returns
-            /// * `MetaResult<Vec<SqlOption>>` - List of formatted SQL options or error
-            async fn format_with_option_secret_resolved(
-                txn: &DatabaseTransaction,
-                options_with_secret: &WithOptionsSecResolved,
-            ) -> MetaResult<Vec<SqlOption>> {
-                let mut options = Vec::new();
-                for (k, v) in options_with_secret.as_plaintext() {
-                    let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
-                        .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-                    options.push(sql_option);
-                }
-                for (k, v) in options_with_secret.as_secret() {
-                    if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
-                        let sql_option =
-                            SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
-                                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-                        options.push(sql_option);
-                    } else {
-                        return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
-                    }
-                }
-                Ok(options)
-            }
-
             match &mut stmt {
                 Statement::CreateSource { stmt } => {
                     stmt.with_properties.0 =
@@ -2619,8 +2582,9 @@ impl CatalogController {
     pub async fn update_sink_props_by_sink_id(
         &self,
         sink_id: SinkId,
-        props: BTreeMap<String, String>,
-    ) -> MetaResult<HashMap<String, String>> {
+        alter_props: BTreeMap<String, String>,
+        alter_secret_refs: BTreeMap<String, PbSecretRef>,
+    ) -> MetaResult<WithOptionsSecResolved> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
@@ -2629,30 +2593,84 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &props)?;
-        let definition = sink.definition.clone();
-        let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
-            .map_err(|e| SinkError::Config(anyhow!(e)))?
-            .try_into()
-            .unwrap();
-        if let Statement::CreateSink { stmt } = &mut stmt {
-            update_stmt_with_props(&mut stmt.with_properties.0, &props)?;
-        } else {
-            panic!("definition is not a create sink statement")
-        }
-        let mut new_config = sink.properties.clone().into_inner();
-        new_config.extend(props.clone());
 
-        let definition = stmt.to_string();
+        // check if the alter-ed props are valid for all connector
+        validate_sink_props(&sink, &alter_props)?;
+
+        let mut options_with_secret = WithOptionsSecResolved::new(
+            sink.properties.0.clone(),
+            sink.secret_ref
+                .map(|secret_ref| secret_ref.to_protobuf())
+                .unwrap_or_default(),
+        );
+        let (to_add_secret_dep, to_remove_secret_dep) =
+            options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        tracing::info!(
+            "applying new properties to sink: sink_id={}, options_with_secret={:?}",
+            sink_id,
+            options_with_secret
+        );
+
+        // rewrite the sql for definition field
+        let rewrite_sql = {
+            let definition = sink.definition.clone();
+            let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
+                .map_err(|e| {
+                    MetaError::from(MetaErrorInner::Connector(ConnectorError::from(
+                        anyhow!(e).context("Failed to parse sink definition SQL"),
+                    )))
+                })?
+                .try_into()
+                .unwrap();
+            if let Statement::CreateSink { stmt } = &mut stmt {
+                stmt.with_properties.0 =
+                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+            } else {
+                panic!("definition is not a create sink statement")
+            }
+
+            stmt.to_string()
+        };
+
+        {
+            if !to_add_secret_dep.is_empty() {
+                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
+                    object_dependency::ActiveModel {
+                        oid: Set(secret_id.into()),
+                        used_by: Set(sink_id.as_object_id()),
+                        ..Default::default()
+                    }
+                }))
+                .exec(&txn)
+                .await?;
+            }
+
+            if !to_remove_secret_dep.is_empty() {
+                let _ = ObjectDependency::delete_many()
+                    .filter(
+                        object_dependency::Column::Oid
+                            .is_in(to_remove_secret_dep)
+                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+        }
+
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
-            properties: Set(risingwave_meta_model::Property(new_config.clone())),
-            definition: Set(definition),
+            properties: Set(risingwave_meta_model::Property(
+                options_with_secret.as_plaintext().clone(),
+            )),
+            secret_ref: Set((!options_with_secret.as_secret().is_empty())
+                .then(|| SecretRef::from(options_with_secret.as_secret().clone()))),
+            definition: Set(rewrite_sql),
             ..Default::default()
         };
         Sink::update(active_sink).exec(&txn).await?;
 
-        update_sink_fragment_props(&txn, sink_id, new_config).await?;
+        update_sink_fragment_props(&txn, sink_id, &options_with_secret).await?;
         let (sink, obj) = Sink::find_by_id(sink_id)
             .find_also_related(Object)
             .one(&txn)
@@ -2678,19 +2696,20 @@ impl CatalogController {
             )
             .await;
 
-        Ok(props.into_iter().collect())
+        Ok(options_with_secret)
     }
 
     pub async fn update_iceberg_table_props_by_table_id(
         &self,
         table_id: TableId,
-        props: BTreeMap<String, String>,
-        alter_iceberg_table_props: Option<
-            risingwave_pb::meta::alter_connector_props_request::PbExtraOptions,
-        >,
-    ) -> MetaResult<(HashMap<String, String>, SinkId)> {
-        let risingwave_pb::meta::alter_connector_props_request::PbExtraOptions::AlterIcebergTableIds(AlterIcebergTableIds { sink_id, source_id }) = alter_iceberg_table_props.
-            ok_or_else(|| MetaError::invalid_parameter("alter_iceberg_table_props is required"))?;
+        alter_props: BTreeMap<String, String>,
+        alter_secret_refs: BTreeMap<String, PbSecretRef>,
+        alter_iceberg_table_props: Option<PbExtraOptions>,
+    ) -> MetaResult<(WithOptionsSecResolved, SinkId)> {
+        let PbExtraOptions::AlterIcebergTableIds(AlterIcebergTableIds { sink_id, source_id }) =
+            alter_iceberg_table_props.ok_or_else(|| {
+                MetaError::invalid_parameter("alter_iceberg_table_props is required")
+            })?;
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
@@ -2699,54 +2718,97 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &props)?;
+        validate_sink_props(&sink, &alter_props)?;
 
-        let definition = sink.definition.clone();
-        let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
-            .map_err(|e| SinkError::Config(anyhow!(e)))?
-            .try_into()
-            .unwrap();
-        if let Statement::CreateTable {
-            with_options,
-            engine,
-            ..
-        } = &mut stmt
-        {
-            if !matches!(engine, Engine::Iceberg) {
-                return Err(SinkError::Config(anyhow!(
-                    "only iceberg table can be altered as sink"
-                ))
-                .into());
+        let mut options_with_secret = WithOptionsSecResolved::new(
+            sink.properties.0.clone(),
+            sink.secret_ref
+                .map(|secret_ref| secret_ref.to_protobuf())
+                .unwrap_or_default(),
+        );
+        let (to_add_secret_dep, to_remove_secret_dep) =
+            options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        // rewrite the sql for definition field
+        let rewrite_sql = {
+            let definition = sink.definition.clone();
+            let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
+                .map_err(|e| {
+                    MetaError::from(MetaErrorInner::Connector(ConnectorError::from(
+                        anyhow!(e).context("Failed to parse iceberg sink definition SQL"),
+                    )))
+                })?
+                .try_into()
+                .unwrap();
+            if let Statement::CreateTable {
+                with_options,
+                engine,
+                ..
+            } = &mut stmt
+            {
+                if !matches!(engine, Engine::Iceberg) {
+                    return Err(SinkError::Config(anyhow!(
+                        "only iceberg table can be altered as sink"
+                    ))
+                    .into());
+                }
+                *with_options =
+                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+            } else {
+                panic!("definition is not a create iceberg table statement")
             }
-            update_stmt_with_props(with_options, &props)?;
-        } else {
-            panic!("definition is not a create iceberg table statement")
-        }
-        let mut new_config = sink.properties.clone().into_inner();
-        new_config.extend(props.clone());
 
-        let definition = stmt.to_string();
+            stmt.to_string()
+        };
+
+        {
+            if !to_add_secret_dep.is_empty() {
+                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
+                    object_dependency::ActiveModel {
+                        oid: Set(secret_id.into()),
+                        used_by: Set(sink_id.as_object_id()),
+                        ..Default::default()
+                    }
+                }))
+                .exec(&txn)
+                .await?;
+            }
+
+            if !to_remove_secret_dep.is_empty() {
+                let _ = ObjectDependency::delete_many()
+                    .filter(
+                        object_dependency::Column::Oid
+                            .is_in(to_remove_secret_dep)
+                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+        }
+
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
-            properties: Set(risingwave_meta_model::Property(new_config.clone())),
-            definition: Set(definition.clone()),
+            properties: Set(risingwave_meta_model::Property(
+                options_with_secret.as_plaintext().clone(),
+            )),
+            definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };
         let active_source = source::ActiveModel {
             source_id: Set(source_id),
-            definition: Set(definition.clone()),
+            definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };
         let active_table = table::ActiveModel {
             table_id: Set(table_id),
-            definition: Set(definition),
+            definition: Set(rewrite_sql),
             ..Default::default()
         };
         Sink::update(active_sink).exec(&txn).await?;
         Source::update(active_source).exec(&txn).await?;
         Table::update(active_table).exec(&txn).await?;
 
-        update_sink_fragment_props(&txn, sink_id, new_config).await?;
+        update_sink_fragment_props(&txn, sink_id, &options_with_secret).await?;
 
         let (sink, sink_obj) = Sink::find_by_id(sink_id)
             .find_also_related(Object)
@@ -2799,7 +2861,7 @@ impl CatalogController {
             )
             .await;
 
-        Ok((props.into_iter().collect(), sink_id))
+        Ok((options_with_secret, sink_id))
     }
 
     /// Update connection properties and all dependent sources/sinks in a single transaction
@@ -3388,12 +3450,31 @@ impl CatalogController {
     }
 }
 
-fn validate_sink_props(sink: &sink::Model, props: &BTreeMap<String, String>) -> MetaResult<()> {
-    // Validate that props can be altered
+/// Validate ALTER SINK connector properties, including allowed fields
+/// and the validity of the merged configuration.
+///
+/// Steps:
+/// 1. Read the connector field from the current sink properties.
+/// 2. Validate that connector type is not being changed
+/// 3. Check whether the modified fields support on-the-fly updates.
+/// 4. Merge the existing configuration with the new properties and validate it.
+fn validate_sink_props(
+    sink: &sink::Model,
+    alter_props: &BTreeMap<String, String>,
+) -> MetaResult<()> {
     match sink.properties.inner_ref().get(CONNECTOR_TYPE_KEY) {
         Some(connector) => {
             let connector_type = connector.to_lowercase();
-            let field_names: Vec<String> = props.keys().cloned().collect();
+            let field_names: Vec<String> = alter_props.keys().cloned().collect();
+
+            if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
+                && new_connector != connector
+            {
+                return Err(MetaError::invalid_parameter(format!(
+                    "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
+                    connector, new_connector
+                )));
+            }
             check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
                 .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
@@ -3402,7 +3483,7 @@ fn validate_sink_props(sink: &sink::Model, props: &BTreeMap<String, String>) -> 
                 SinkType,
                 {
                     let mut new_props = sink.properties.0.clone();
-                    new_props.extend(props.clone());
+                    new_props.extend(alter_props.clone());
                     SinkType::validate_alter_config(&new_props)
                 },
                 |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
@@ -3417,32 +3498,10 @@ fn validate_sink_props(sink: &sink::Model, props: &BTreeMap<String, String>) -> 
     Ok(())
 }
 
-fn update_stmt_with_props(
-    with_properties: &mut Vec<SqlOption>,
-    props: &BTreeMap<String, String>,
-) -> MetaResult<()> {
-    let mut new_sql_options = with_properties
-        .iter()
-        .map(|sql_option| (&sql_option.name, sql_option))
-        .collect::<IndexMap<_, _>>();
-    let add_sql_options = props
-        .iter()
-        .map(|(k, v)| SqlOption::try_from((k, v)))
-        .collect::<Result<Vec<SqlOption>, ParserError>>()
-        .map_err(|e| SinkError::Config(anyhow!(e)))?;
-    new_sql_options.extend(
-        add_sql_options
-            .iter()
-            .map(|sql_option| (&sql_option.name, sql_option)),
-    );
-    *with_properties = new_sql_options.into_values().cloned().collect();
-    Ok(())
-}
-
 async fn update_sink_fragment_props(
     txn: &DatabaseTransaction,
     sink_id: SinkId,
-    props: BTreeMap<String, String>,
+    options_with_secret: &WithOptionsSecResolved,
 ) -> MetaResult<()> {
     let fragments: Vec<(FragmentId, i32, StreamNode)> = Fragment::find()
         .select_only()
@@ -3455,6 +3514,8 @@ async fn update_sink_fragment_props(
         .into_tuple()
         .all(txn)
         .await?;
+    let props = options_with_secret.as_plaintext();
+    let secret_refs = options_with_secret.as_secret().clone();
     let fragments = fragments
         .into_iter()
         .filter(|(_, fragment_type_mask, _)| {
@@ -3468,7 +3529,8 @@ async fn update_sink_fragment_props(
                     && let Some(sink_desc) = &mut node.sink_desc
                     && sink_desc.id == sink_id
                 {
-                    sink_desc.properties.extend(props.clone());
+                    sink_desc.properties = props.clone();
+                    sink_desc.secret_refs = secret_refs.clone();
                     found = true;
                 }
             });

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2570,7 +2570,7 @@ impl CatalogController {
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
 
         // check if the alter-ed props are valid for all connector
-        validate_sink_props(&sink, &alter_props)?;
+        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -2598,11 +2598,18 @@ impl CatalogController {
                 })?
                 .try_into()
                 .unwrap();
-            if let Statement::CreateSink { stmt } = &mut stmt {
-                stmt.with_properties.0 =
-                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
-            } else {
-                panic!("definition is not a create sink statement")
+            match &mut stmt {
+                Statement::CreateSink { stmt } => {
+                    stmt.with_properties.0 =
+                        format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+                }
+                _ => {
+                    return Err(MetaError::from(MetaErrorInner::Connector(
+                        ConnectorError::from(anyhow!(
+                            "Sink definition is not a CREATE SINK statement"
+                        )),
+                    )));
+                }
             }
 
             stmt.to_string()
@@ -2676,7 +2683,7 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &alter_props)?;
+        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -2698,22 +2705,29 @@ impl CatalogController {
                 })?
                 .try_into()
                 .unwrap();
-            if let Statement::CreateTable {
-                with_options,
-                engine,
-                ..
-            } = &mut stmt
-            {
-                if !matches!(engine, Engine::Iceberg) {
-                    return Err(SinkError::Config(anyhow!(
-                        "only iceberg table can be altered as sink"
-                    ))
-                    .into());
+
+            match &mut stmt {
+                Statement::CreateTable {
+                    with_options,
+                    engine,
+                    ..
+                } => {
+                    if !matches!(engine, Engine::Iceberg) {
+                        return Err(SinkError::Config(anyhow!(
+                            "only iceberg table can be altered as sink"
+                        ))
+                        .into());
+                    }
+                    *with_options =
+                        format_with_option_secret_resolved(&txn, &options_with_secret).await?;
                 }
-                *with_options =
-                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
-            } else {
-                panic!("definition is not a create iceberg table statement")
+                _ => {
+                    return Err(MetaError::from(MetaErrorInner::Connector(
+                        ConnectorError::from(anyhow!(
+                            "definition is not a create iceberg table statement"
+                        )),
+                    )));
+                }
             }
 
             stmt.to_string()
@@ -2739,6 +2753,11 @@ impl CatalogController {
         };
         let active_source = source::ActiveModel {
             source_id: Set(source_id),
+            with_properties: Set(risingwave_meta_model::Property(
+                options_with_secret.as_plaintext().clone(),
+            )),
+            secret_ref: Set((!options_with_secret.as_secret().is_empty())
+                .then(|| SecretRef::from(options_with_secret.as_secret().clone()))),
             definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };
@@ -3379,51 +3398,48 @@ impl CatalogController {
     }
 }
 
-/// Validate ALTER SINK connector properties, including allowed fields
-/// and the validity of the merged configuration.
-///
-/// Steps:
-/// 1. Read the connector field from the current sink properties.
-/// 2. Validate that connector type is not being changed
-/// 3. Check whether the modified fields support on-the-fly updates.
-/// 4. Merge the existing configuration with the new properties and validate it.
 fn validate_sink_props(
     sink: &sink::Model,
     alter_props: &BTreeMap<String, String>,
+    alter_secret_refs: &BTreeMap<String, PbSecretRef>,
 ) -> MetaResult<()> {
-    match sink.properties.inner_ref().get(CONNECTOR_TYPE_KEY) {
-        Some(connector) => {
-            let connector_type = connector.to_lowercase();
-            let field_names: Vec<String> = alter_props.keys().cloned().collect();
+    let connector = sink
+        .properties
+        .inner_ref()
+        .get(CONNECTOR_TYPE_KEY)
+        .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?;
 
-            if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
-                && new_connector != connector
-            {
-                return Err(MetaError::invalid_parameter(format!(
-                    "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
-                    connector, new_connector
-                )));
-            }
-            check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
-                .map_err(|e| SinkError::Config(anyhow!(e)))?;
+    let connector_type = connector.to_lowercase();
 
-            match_sink_name_str!(
-                connector_type.as_str(),
-                SinkType,
-                {
-                    let mut new_props = sink.properties.0.clone();
-                    new_props.extend(alter_props.clone());
-                    SinkType::validate_alter_config(&new_props)
-                },
-                |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
-            )?
-        }
-        None => {
-            return Err(
-                SinkError::Config(anyhow!("connector not specified when alter sink")).into(),
-            );
-        }
-    };
+    if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
+        && new_connector != connector
+    {
+        return Err(MetaError::invalid_parameter(format!(
+            "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
+            connector, new_connector
+        )));
+    }
+
+    let field_names: Vec<String> = alter_props
+        .keys()
+        .chain(alter_secret_refs.keys())
+        .cloned()
+        .collect();
+
+    check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
+        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+
+    match_sink_name_str!(
+        connector_type.as_str(),
+        SinkType,
+        {
+            let mut new_props = sink.properties.0.clone();
+            new_props.extend(alter_props.clone());
+            SinkType::validate_alter_config(&new_props)
+        },
+        |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
+    )?;
+
     Ok(())
 }
 
@@ -3556,7 +3572,7 @@ async fn update_secret_dependencies(
     txn: &DatabaseTransaction,
     to_add_secrets: Vec<SecretId>,
     to_remove_secrets: Vec<SecretId>,
-    sink_id: ObjectId,
+    object_id: ObjectId,
 ) -> MetaResult<()> {
     // Update secret dependencies atomically within the transaction.
     // Add new dependencies for secrets that are newly referenced.
@@ -3564,7 +3580,7 @@ async fn update_secret_dependencies(
         ObjectDependency::insert_many(to_add_secrets.into_iter().map(|secret_id| {
             object_dependency::ActiveModel {
                 oid: Set(secret_id.into()),
-                used_by: Set(sink_id),
+                used_by: Set(object_id),
                 ..Default::default()
             }
         }))
@@ -3578,7 +3594,7 @@ async fn update_secret_dependencies(
             .filter(
                 object_dependency::Column::Oid
                     .is_in(to_remove_secrets)
-                    .and(object_dependency::Column::UsedBy.eq(sink_id)),
+                    .and(object_dependency::Column::UsedBy.eq(object_id)),
             )
             .exec(txn)
             .await?;

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -112,6 +112,13 @@ struct DependentSourceFragmentUpdate {
 }
 
 #[derive(Debug)]
+struct DependentSinkFragmentUpdate {
+    job_id: JobId,
+    with_properties: BTreeMap<String, String>,
+    secret_refs: BTreeMap<String, PbSecretRef>,
+}
+
+#[derive(Debug)]
 struct ReplaceOriginalJobInfo {
     max_parallelism: i32,
     timezone: Option<String>,
@@ -3129,51 +3136,49 @@ impl CatalogController {
                 let sink_id = sink.sink_id;
 
                 // Validate that sink props can be altered
-                match sink.properties.inner_ref().get(CONNECTOR_TYPE_KEY) {
-                    Some(connector) => {
-                        let connector_type = connector.to_lowercase();
-                        check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
-                            .map_err(|e| SinkError::Config(anyhow!(e)))?;
+                validate_sink_props(&sink, &alter_props.clone(), &alter_secret_refs.clone())?;
 
-                        match_sink_name_str!(
-                            connector_type.as_str(),
-                            SinkType,
-                            {
-                                let mut new_sink_props = sink.properties.0.clone();
-                                new_sink_props.extend(alter_props.clone());
-                                SinkType::validate_alter_config(&new_sink_props)
-                            },
-                            |sink: &str| Err(SinkError::Config(anyhow!(
-                                "unsupported sink type {}",
-                                sink
-                            )))
-                        )?
-                    }
-                    None => {
-                        return Err(SinkError::Config(anyhow!(
-                            "connector not specified when alter sink"
-                        ))
-                        .into());
-                    }
-                };
+                let mut sink_options_with_secret = WithOptionsSecResolved::new(
+                    sink.properties.0.clone(),
+                    sink.secret_ref
+                        .clone()
+                        .map(|secret_ref| secret_ref.to_protobuf())
+                        .unwrap_or_default(),
+                );
 
-                let mut new_sink_props = sink.properties.0.clone();
-                new_sink_props.extend(alter_props.clone());
+                let (_sink_to_add_secret_dep, _sink_to_remove_secret_dep) =
+                    sink_options_with_secret
+                        .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
 
                 // Prepare sink update
                 let active_sink = sink::ActiveModel {
                     sink_id: Set(sink_id),
-                    properties: Set(risingwave_meta_model::Property(new_sink_props.clone())),
+                    properties: Set(risingwave_meta_model::Property(
+                        sink_options_with_secret.as_plaintext().clone(),
+                    )),
+                    secret_ref: Set((!sink_options_with_secret.as_secret().is_empty())
+                        .then(|| SecretRef::from(sink_options_with_secret.as_secret().clone()))),
                     ..Default::default()
                 };
                 sink_updates.push(active_sink);
 
                 // Prepare fragment updates for this sink
-                sink_fragment_updates.push((sink_id, new_sink_props.clone()));
+                sink_fragment_updates.push(DependentSinkFragmentUpdate {
+                    job_id: sink_id.as_job_id(),
+                    with_properties: sink_options_with_secret.as_plaintext().clone(),
+                    secret_refs: sink_options_with_secret.as_secret().clone(),
+                });
 
                 // Collect the complete properties for runtime broadcast
-                let complete_sink_props: HashMap<String, String> =
-                    new_sink_props.into_iter().collect();
+                let complete_sink_props = LocalSecretManager::global()
+                    .fill_secrets(
+                        sink_options_with_secret.as_plaintext().clone(),
+                        sink_options_with_secret.as_secret().clone(),
+                    )
+                    .map_err(MetaError::from)?
+                    .into_iter()
+                    .collect::<HashMap<String, String>>();
+
                 updated_sinks_with_props.push((sink_id, complete_sink_props));
             }
 
@@ -3183,17 +3188,23 @@ impl CatalogController {
             }
 
             // Batch execute sink fragment updates using the reusable function
-            for (sink_id, new_sink_props) in sink_fragment_updates {
+            for DependentSinkFragmentUpdate {
+                job_id,
+                with_properties,
+                secret_refs,
+            } in sink_fragment_updates
+            {
                 update_connector_props_fragments(
                     &txn,
-                    vec![sink_id.as_job_id()],
+                    vec![job_id],
                     FragmentTypeFlag::Sink,
                     |node, found| {
                         if let PbNodeBody::Sink(node) = node
                             && let Some(sink_desc) = &mut node.sink_desc
-                            && sink_desc.id == sink_id.as_raw_id()
+                            && sink_desc.id == job_id.as_raw_id()
                         {
-                            sink_desc.properties = new_sink_props.clone();
+                            sink_desc.properties = with_properties.clone();
+                            sink_desc.secret_refs = secret_refs.clone();
                             *found = true;
                         }
                     },

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2459,33 +2459,8 @@ impl CatalogController {
             stmt.to_string()
         };
 
-        {
-            // Update secret dependencies atomically within the transaction.
-            // Add new dependencies for secrets that are newly referenced.
-            if !to_add_secret_dep.is_empty() {
-                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                    object_dependency::ActiveModel {
-                        oid: Set(secret_id.into()),
-                        used_by: Set(preferred_id),
-                        ..Default::default()
-                    }
-                }))
-                .exec(&txn)
-                .await?;
-            }
-            // Remove dependencies for secrets that are no longer referenced.
-            // This allows the secrets to be deleted after this source no longer uses them.
-            if !to_remove_secret_dep.is_empty() {
-                let _ = ObjectDependency::delete_many()
-                    .filter(
-                        object_dependency::Column::Oid
-                            .is_in(to_remove_secret_dep)
-                            .and(object_dependency::Column::UsedBy.eq(preferred_id)),
-                    )
-                    .exec(&txn)
-                    .await?;
-            }
-        }
+        update_secret_dependencies(&txn, to_add_secret_dep, to_remove_secret_dep, preferred_id)
+            .await?;
 
         let active_source_model = source::ActiveModel {
             source_id: Set(source_id),
@@ -2633,30 +2608,13 @@ impl CatalogController {
             stmt.to_string()
         };
 
-        {
-            if !to_add_secret_dep.is_empty() {
-                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                    object_dependency::ActiveModel {
-                        oid: Set(secret_id.into()),
-                        used_by: Set(sink_id.as_object_id()),
-                        ..Default::default()
-                    }
-                }))
-                .exec(&txn)
-                .await?;
-            }
-
-            if !to_remove_secret_dep.is_empty() {
-                let _ = ObjectDependency::delete_many()
-                    .filter(
-                        object_dependency::Column::Oid
-                            .is_in(to_remove_secret_dep)
-                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
-                    )
-                    .exec(&txn)
-                    .await?;
-            }
-        }
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep,
+            to_remove_secret_dep,
+            sink_id.as_object_id(),
+        )
+        .await?;
 
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
@@ -2761,30 +2719,13 @@ impl CatalogController {
             stmt.to_string()
         };
 
-        {
-            if !to_add_secret_dep.is_empty() {
-                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                    object_dependency::ActiveModel {
-                        oid: Set(secret_id.into()),
-                        used_by: Set(sink_id.as_object_id()),
-                        ..Default::default()
-                    }
-                }))
-                .exec(&txn)
-                .await?;
-            }
-
-            if !to_remove_secret_dep.is_empty() {
-                let _ = ObjectDependency::delete_many()
-                    .filter(
-                        object_dependency::Column::Oid
-                            .is_in(to_remove_secret_dep)
-                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
-                    )
-                    .exec(&txn)
-                    .await?;
-            }
-        }
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep,
+            to_remove_secret_dep,
+            sink_id.as_object_id(),
+        )
+        .await?;
 
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
@@ -2964,27 +2905,13 @@ impl CatalogController {
         }
 
         // Update connection secret dependencies
-        if !to_add_secret_dep.is_empty() {
-            ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                object_dependency::ActiveModel {
-                    oid: Set(secret_id.into()),
-                    used_by: Set(connection_id.as_object_id()),
-                    ..Default::default()
-                }
-            }))
-            .exec(&txn)
-            .await?;
-        }
-        if !to_remove_secret_dep.is_empty() {
-            let _ = ObjectDependency::delete_many()
-                .filter(
-                    object_dependency::Column::Oid
-                        .is_in(to_remove_secret_dep)
-                        .and(object_dependency::Column::UsedBy.eq(connection_id.as_object_id())),
-                )
-                .exec(&txn)
-                .await?;
-        }
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep,
+            to_remove_secret_dep,
+            connection_id.as_object_id(),
+        )
+        .await?;
 
         // Update the connection with new properties
         let updated_connection_params = risingwave_pb::catalog::ConnectionParams {
@@ -3622,5 +3549,39 @@ where
         .await?;
     }
 
+    Ok(())
+}
+
+async fn update_secret_dependencies(
+    txn: &DatabaseTransaction,
+    to_add_secrets: Vec<SecretId>,
+    to_remove_secrets: Vec<SecretId>,
+    sink_id: ObjectId,
+) -> MetaResult<()> {
+    // Update secret dependencies atomically within the transaction.
+    // Add new dependencies for secrets that are newly referenced.
+    if !to_add_secrets.is_empty() {
+        ObjectDependency::insert_many(to_add_secrets.into_iter().map(|secret_id| {
+            object_dependency::ActiveModel {
+                oid: Set(secret_id.into()),
+                used_by: Set(sink_id),
+                ..Default::default()
+            }
+        }))
+        .exec(txn)
+        .await?;
+    }
+    // Remove dependencies for secrets that are no longer referenced.
+    // This allows the secrets to be deleted after this source no longer uses them.
+    if !to_remove_secrets.is_empty() {
+        let _ = ObjectDependency::delete_many()
+            .filter(
+                object_dependency::Column::Oid
+                    .is_in(to_remove_secrets)
+                    .and(object_dependency::Column::UsedBy.eq(sink_id)),
+            )
+            .exec(txn)
+            .await?;
+    }
     Ok(())
 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3097,7 +3097,7 @@ impl CatalogController {
             options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
 
         // check if the alter-ed props are valid for all connector
-        validate_sink_props(&connector_type, options_with_secret.clone())?;
+        validate_sink_props(&connector_type, &options_with_secret, &prop_keys)?;
 
         tracing::info!(
             "applying new properties to sink: sink_id={}, options_with_secret={:?}",
@@ -3225,7 +3225,7 @@ impl CatalogController {
             options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
 
         // check if the alter-ed props are valid for all connector
-        validate_sink_props(&connector_type, options_with_secret.clone())?;
+        validate_sink_props(&connector_type, &options_with_secret, &prop_keys)?;
 
         // rewrite the sql for definition field
         let rewrite_sql = {
@@ -3265,6 +3265,14 @@ impl CatalogController {
 
             stmt.to_string()
         };
+
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep.clone(),
+            to_remove_secret_dep.clone(),
+            source_id.as_object_id(),
+        )
+        .await?;
 
         update_secret_dependencies(
             &txn,
@@ -3328,6 +3336,10 @@ impl CatalogController {
         let table_streaming_job = streaming_job::Entity::find_by_id(table.job_id())
             .one(&txn)
             .await?;
+        let mut dependencies =
+            list_object_dependencies_by_object_id(&txn, source_id.as_object_id()).await?;
+        dependencies
+            .extend(list_object_dependencies_by_object_id(&txn, sink_id.as_object_id()).await?);
         txn.commit().await?;
         let relation_infos = vec![
             PbObject {
@@ -3351,7 +3363,7 @@ impl CatalogController {
                 NotificationOperation::Update,
                 NotificationInfo::ObjectGroup(PbObjectGroup {
                     objects: relation_infos,
-                    dependencies: vec![],
+                    dependencies,
                 }),
             )
             .await;
@@ -3669,7 +3681,7 @@ impl CatalogController {
                     .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
 
                 // check if the alter-ed props are valid for all connector
-                validate_sink_props(&connector_type, sink_options_with_secret.clone())?;
+                validate_sink_props(&connector_type, &sink_options_with_secret, &prop_keys)?;
 
                 update_secret_dependencies(
                     &txn,
@@ -3988,11 +4000,17 @@ impl CatalogController {
 
 fn validate_sink_props(
     connector_type: &str,
-    with_properties: WithOptionsSecResolved,
+    options_with_secret: &WithOptionsSecResolved,
+    altered_field_names: &[String],
 ) -> MetaResult<()> {
-    let (options, secret_refs) = with_properties.into_parts();
+    check_sink_allow_alter_on_fly_fields(connector_type, altered_field_names)
+        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+
     let resolved_props = LocalSecretManager::global()
-        .fill_secrets(options, secret_refs)
+        .fill_secrets(
+            options_with_secret.as_plaintext().clone(),
+            options_with_secret.as_secret().clone(),
+        )
         .map_err(MetaError::from)?;
 
     match_sink_name_str!(

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
 
 use anyhow::anyhow;
-use indexmap::IndexMap;
 use itertools::Itertools;
 use risingwave_common::catalog::{
     ColumnCatalog, FragmentTypeFlag, FragmentTypeMask, ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX,
@@ -52,7 +51,7 @@ use risingwave_pb::catalog::table::PbEngine;
 use risingwave_pb::catalog::{PbConnection, PbCreateType, PbTable};
 use risingwave_pb::common::ThrottleType;
 use risingwave_pb::ddl_service::streaming_job_resource_type;
-use risingwave_pb::meta::alter_connector_props_request::AlterIcebergTableIds;
+use risingwave_pb::meta::alter_connector_props_request::{AlterIcebergTableIds, PbExtraOptions};
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
 use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::{
@@ -68,8 +67,8 @@ use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbSinkLogStoreType, PbStreamNode, StreamScanType};
 use risingwave_pb::user::PbUserInfo;
-use risingwave_sqlparser::ast::{Engine, SqlOption, Statement};
-use risingwave_sqlparser::parser::{Parser, ParserError};
+use risingwave_sqlparser::ast::{Engine, Statement};
+use risingwave_sqlparser::parser::Parser;
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::{Expr, Query, SimpleExpr};
 use sea_orm::{
@@ -88,10 +87,11 @@ use crate::controller::fragment::FragmentTypeMaskExt;
 use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_if_belongs_to_iceberg_table,
     check_relation_name_duplicate, check_sink_into_table_cycle, ensure_job_not_canceled,
-    ensure_object_id, ensure_user_id, fetch_target_fragments, get_belong_objects,
-    get_belong_objects_by_ids, get_referring_objects, get_table_columns,
-    grant_default_privileges_automatically, insert_fragment_relations,
-    list_object_dependencies_by_object_id, list_user_info_by_ids, upsert_user_privileges,
+    ensure_object_id, ensure_user_id, fetch_target_fragments, format_with_option_secret_resolved,
+    get_belong_objects, get_belong_objects_by_ids, get_internal_tables_by_id,
+    get_referring_objects, get_table_columns, grant_default_privileges_automatically,
+    insert_fragment_relations, list_object_dependencies_by_object_id, list_user_info_by_ids,
+    try_get_iceberg_table_by_downstream_sink, upsert_user_privileges,
 };
 use crate::error::MetaErrorInner;
 use crate::manager::{NotificationVersion, StreamingJob, StreamingJobType};
@@ -940,7 +940,7 @@ impl CatalogController {
             StreamingJobModel::update(job).exec(&txn).await?;
         }
 
-        let state_table_ids = fragments
+        let state_table_ids: Vec<_> = fragments
             .iter()
             .flat_map(|fragment| fragment.state_table_ids.inner_ref().clone())
             .collect_vec();
@@ -2944,42 +2944,6 @@ impl CatalogController {
                 .try_into()
                 .unwrap();
 
-            /// Formats SQL options with secret values properly resolved
-            ///
-            /// This function processes configuration options that may contain sensitive data:
-            /// - Plaintext options are directly converted to `SqlOption`
-            /// - Secret options are retrieved from the database and formatted as "SECRET {name}"
-            ///   without exposing the actual secret value
-            ///
-            /// # Arguments
-            /// * `txn` - Database transaction for retrieving secrets
-            /// * `options_with_secret` - Container of options with both plaintext and secret values
-            ///
-            /// # Returns
-            /// * `MetaResult<Vec<SqlOption>>` - List of formatted SQL options or error
-            async fn format_with_option_secret_resolved(
-                txn: &DatabaseTransaction,
-                options_with_secret: &WithOptionsSecResolved,
-            ) -> MetaResult<Vec<SqlOption>> {
-                let mut options = Vec::new();
-                for (k, v) in options_with_secret.as_plaintext() {
-                    let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
-                        .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-                    options.push(sql_option);
-                }
-                for (k, v) in options_with_secret.as_secret() {
-                    if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
-                        let sql_option =
-                            SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
-                                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-                        options.push(sql_option);
-                    } else {
-                        return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
-                    }
-                }
-                Ok(options)
-            }
-
             match &mut stmt {
                 Statement::CreateSource { stmt } => {
                     stmt.with_properties.0 =
@@ -3120,8 +3084,9 @@ impl CatalogController {
     pub async fn update_sink_props_by_sink_id(
         &self,
         sink_id: SinkId,
-        props: BTreeMap<String, String>,
-    ) -> MetaResult<HashMap<String, String>> {
+        alter_props: BTreeMap<String, String>,
+        alter_secret_refs: BTreeMap<String, PbSecretRef>,
+    ) -> MetaResult<WithOptionsSecResolved> {
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
@@ -3130,30 +3095,84 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &props)?;
-        let definition = sink.definition.clone();
-        let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
-            .map_err(|e| SinkError::Config(anyhow!(e)))?
-            .try_into()
-            .unwrap();
-        if let Statement::CreateSink { stmt } = &mut stmt {
-            update_stmt_with_props(&mut stmt.with_properties.0, &props)?;
-        } else {
-            panic!("definition is not a create sink statement")
-        }
-        let mut new_config = sink.properties.clone().into_inner();
-        new_config.extend(props.clone());
 
-        let definition = stmt.to_string();
+        // check if the alter-ed props are valid for all connector
+        validate_sink_props(&sink, &alter_props)?;
+
+        let mut options_with_secret = WithOptionsSecResolved::new(
+            sink.properties.0.clone(),
+            sink.secret_ref
+                .map(|secret_ref| secret_ref.to_protobuf())
+                .unwrap_or_default(),
+        );
+        let (to_add_secret_dep, to_remove_secret_dep) =
+            options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        tracing::info!(
+            "applying new properties to sink: sink_id={}, options_with_secret={:?}",
+            sink_id,
+            options_with_secret
+        );
+
+        // rewrite the sql for definition field
+        let rewrite_sql = {
+            let definition = sink.definition.clone();
+            let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
+                .map_err(|e| {
+                    MetaError::from(MetaErrorInner::Connector(ConnectorError::from(
+                        anyhow!(e).context("Failed to parse sink definition SQL"),
+                    )))
+                })?
+                .try_into()
+                .unwrap();
+            if let Statement::CreateSink { stmt } = &mut stmt {
+                stmt.with_properties.0 =
+                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+            } else {
+                panic!("definition is not a create sink statement")
+            }
+
+            stmt.to_string()
+        };
+
+        {
+            if !to_add_secret_dep.is_empty() {
+                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
+                    object_dependency::ActiveModel {
+                        oid: Set(secret_id.into()),
+                        used_by: Set(sink_id.as_object_id()),
+                        ..Default::default()
+                    }
+                }))
+                .exec(&txn)
+                .await?;
+            }
+
+            if !to_remove_secret_dep.is_empty() {
+                let _ = ObjectDependency::delete_many()
+                    .filter(
+                        object_dependency::Column::Oid
+                            .is_in(to_remove_secret_dep)
+                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+        }
+
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
-            properties: Set(risingwave_meta_model::Property(new_config.clone())),
-            definition: Set(definition),
+            properties: Set(risingwave_meta_model::Property(
+                options_with_secret.as_plaintext().clone(),
+            )),
+            secret_ref: Set((!options_with_secret.as_secret().is_empty())
+                .then(|| SecretRef::from(options_with_secret.as_secret().clone()))),
+            definition: Set(rewrite_sql),
             ..Default::default()
         };
         Sink::update(active_sink).exec(&txn).await?;
 
-        update_sink_fragment_props(&txn, sink_id, new_config).await?;
+        update_sink_fragment_props(&txn, sink_id, &options_with_secret).await?;
         let (sink, obj) = Sink::find_by_id(sink_id)
             .find_also_related(Object)
             .one(&txn)
@@ -3179,19 +3198,20 @@ impl CatalogController {
             )
             .await;
 
-        Ok(props.into_iter().collect())
+        Ok(options_with_secret)
     }
 
     pub async fn update_iceberg_table_props_by_table_id(
         &self,
         table_id: TableId,
-        props: BTreeMap<String, String>,
-        alter_iceberg_table_props: Option<
-            risingwave_pb::meta::alter_connector_props_request::PbExtraOptions,
-        >,
-    ) -> MetaResult<(HashMap<String, String>, SinkId)> {
-        let risingwave_pb::meta::alter_connector_props_request::PbExtraOptions::AlterIcebergTableIds(AlterIcebergTableIds { sink_id, source_id }) = alter_iceberg_table_props.
-            ok_or_else(|| MetaError::invalid_parameter("alter_iceberg_table_props is required"))?;
+        alter_props: BTreeMap<String, String>,
+        alter_secret_refs: BTreeMap<String, PbSecretRef>,
+        alter_iceberg_table_props: Option<PbExtraOptions>,
+    ) -> MetaResult<(WithOptionsSecResolved, SinkId)> {
+        let PbExtraOptions::AlterIcebergTableIds(AlterIcebergTableIds { sink_id, source_id }) =
+            alter_iceberg_table_props.ok_or_else(|| {
+                MetaError::invalid_parameter("alter_iceberg_table_props is required")
+            })?;
         let inner = self.inner.read().await;
         let txn = inner.db.begin().await?;
 
@@ -3200,54 +3220,97 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &props)?;
+        validate_sink_props(&sink, &alter_props)?;
 
-        let definition = sink.definition.clone();
-        let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
-            .map_err(|e| SinkError::Config(anyhow!(e)))?
-            .try_into()
-            .unwrap();
-        if let Statement::CreateTable {
-            with_options,
-            engine,
-            ..
-        } = &mut stmt
-        {
-            if !matches!(engine, Engine::Iceberg) {
-                return Err(SinkError::Config(anyhow!(
-                    "only iceberg table can be altered as sink"
-                ))
-                .into());
+        let mut options_with_secret = WithOptionsSecResolved::new(
+            sink.properties.0.clone(),
+            sink.secret_ref
+                .map(|secret_ref| secret_ref.to_protobuf())
+                .unwrap_or_default(),
+        );
+        let (to_add_secret_dep, to_remove_secret_dep) =
+            options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        // rewrite the sql for definition field
+        let rewrite_sql = {
+            let definition = sink.definition.clone();
+            let [mut stmt]: [_; 1] = Parser::parse_sql(&definition)
+                .map_err(|e| {
+                    MetaError::from(MetaErrorInner::Connector(ConnectorError::from(
+                        anyhow!(e).context("Failed to parse iceberg sink definition SQL"),
+                    )))
+                })?
+                .try_into()
+                .unwrap();
+            if let Statement::CreateTable {
+                with_options,
+                engine,
+                ..
+            } = &mut stmt
+            {
+                if !matches!(engine, Engine::Iceberg) {
+                    return Err(SinkError::Config(anyhow!(
+                        "only iceberg table can be altered as sink"
+                    ))
+                    .into());
+                }
+                *with_options =
+                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+            } else {
+                panic!("definition is not a create iceberg table statement")
             }
-            update_stmt_with_props(with_options, &props)?;
-        } else {
-            panic!("definition is not a create iceberg table statement")
-        }
-        let mut new_config = sink.properties.clone().into_inner();
-        new_config.extend(props.clone());
 
-        let definition = stmt.to_string();
+            stmt.to_string()
+        };
+
+        {
+            if !to_add_secret_dep.is_empty() {
+                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
+                    object_dependency::ActiveModel {
+                        oid: Set(secret_id.into()),
+                        used_by: Set(sink_id.as_object_id()),
+                        ..Default::default()
+                    }
+                }))
+                .exec(&txn)
+                .await?;
+            }
+
+            if !to_remove_secret_dep.is_empty() {
+                let _ = ObjectDependency::delete_many()
+                    .filter(
+                        object_dependency::Column::Oid
+                            .is_in(to_remove_secret_dep)
+                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+        }
+
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
-            properties: Set(risingwave_meta_model::Property(new_config.clone())),
-            definition: Set(definition.clone()),
+            properties: Set(risingwave_meta_model::Property(
+                options_with_secret.as_plaintext().clone(),
+            )),
+            definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };
         let active_source = source::ActiveModel {
             source_id: Set(source_id),
-            definition: Set(definition.clone()),
+            definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };
         let active_table = table::ActiveModel {
             table_id: Set(table_id),
-            definition: Set(definition),
+            definition: Set(rewrite_sql),
             ..Default::default()
         };
         Sink::update(active_sink).exec(&txn).await?;
         Source::update(active_source).exec(&txn).await?;
         Table::update(active_table).exec(&txn).await?;
 
-        update_sink_fragment_props(&txn, sink_id, new_config).await?;
+        update_sink_fragment_props(&txn, sink_id, &options_with_secret).await?;
 
         let (sink, sink_obj) = Sink::find_by_id(sink_id)
             .find_also_related(Object)
@@ -3300,7 +3363,7 @@ impl CatalogController {
             )
             .await;
 
-        Ok((props.into_iter().collect(), sink_id))
+        Ok((options_with_secret, sink_id))
     }
 
     /// Update connection properties and all dependent sources/sinks in a single transaction
@@ -3940,12 +4003,31 @@ impl CatalogController {
     }
 }
 
-fn validate_sink_props(sink: &sink::Model, props: &BTreeMap<String, String>) -> MetaResult<()> {
-    // Validate that props can be altered
+/// Validate ALTER SINK connector properties, including allowed fields
+/// and the validity of the merged configuration.
+///
+/// Steps:
+/// 1. Read the connector field from the current sink properties.
+/// 2. Validate that connector type is not being changed
+/// 3. Check whether the modified fields support on-the-fly updates.
+/// 4. Merge the existing configuration with the new properties and validate it.
+fn validate_sink_props(
+    sink: &sink::Model,
+    alter_props: &BTreeMap<String, String>,
+) -> MetaResult<()> {
     match sink.properties.inner_ref().get(CONNECTOR_TYPE_KEY) {
         Some(connector) => {
             let connector_type = connector.to_lowercase();
-            let field_names: Vec<String> = props.keys().cloned().collect();
+            let field_names: Vec<String> = alter_props.keys().cloned().collect();
+
+            if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
+                && new_connector != connector
+            {
+                return Err(MetaError::invalid_parameter(format!(
+                    "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
+                    connector, new_connector
+                )));
+            }
             check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
                 .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
@@ -3954,8 +4036,8 @@ fn validate_sink_props(sink: &sink::Model, props: &BTreeMap<String, String>) -> 
                 SinkType,
                 {
                     let mut new_props = sink.properties.0.clone();
-                    new_props.extend(props.clone());
-                    SinkType::validate_alter_config_change(&new_props, props)
+                    new_props.extend(alter_props.clone());
+                    SinkType::validate_alter_config_change(&new_props, alter_props)
                 },
                 |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
             )?
@@ -3969,32 +4051,10 @@ fn validate_sink_props(sink: &sink::Model, props: &BTreeMap<String, String>) -> 
     Ok(())
 }
 
-fn update_stmt_with_props(
-    with_properties: &mut Vec<SqlOption>,
-    props: &BTreeMap<String, String>,
-) -> MetaResult<()> {
-    let mut new_sql_options = with_properties
-        .iter()
-        .map(|sql_option| (&sql_option.name, sql_option))
-        .collect::<IndexMap<_, _>>();
-    let add_sql_options = props
-        .iter()
-        .map(|(k, v)| SqlOption::try_from((k, v)))
-        .collect::<Result<Vec<SqlOption>, ParserError>>()
-        .map_err(|e| SinkError::Config(anyhow!(e)))?;
-    new_sql_options.extend(
-        add_sql_options
-            .iter()
-            .map(|sql_option| (&sql_option.name, sql_option)),
-    );
-    *with_properties = new_sql_options.into_values().cloned().collect();
-    Ok(())
-}
-
 async fn update_sink_fragment_props(
     txn: &DatabaseTransaction,
     sink_id: SinkId,
-    props: BTreeMap<String, String>,
+    options_with_secret: &WithOptionsSecResolved,
 ) -> MetaResult<()> {
     let fragments: Vec<(FragmentId, i32, StreamNode)> = Fragment::find()
         .select_only()
@@ -4007,6 +4067,8 @@ async fn update_sink_fragment_props(
         .into_tuple()
         .all(txn)
         .await?;
+    let props = options_with_secret.as_plaintext();
+    let secret_refs = options_with_secret.as_secret().clone();
     let fragments = fragments
         .into_iter()
         .filter(|(_, fragment_type_mask, _)| {
@@ -4020,7 +4082,8 @@ async fn update_sink_fragment_props(
                     && let Some(sink_desc) = &mut node.sink_desc
                     && sink_desc.id == sink_id
                 {
-                    sink_desc.properties.extend(props.clone());
+                    sink_desc.properties = props.clone();
+                    sink_desc.secret_refs = secret_refs.clone();
                     found = true;
                 }
             });

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -4012,11 +4012,19 @@ fn validate_sink_props(
             options_with_secret.as_secret().clone(),
         )
         .map_err(MetaError::from)?;
+    let resolved_alter_props = altered_field_names
+        .iter()
+        .filter_map(|field_name| {
+            resolved_props
+                .get(field_name)
+                .map(|value| (field_name.clone(), value.clone()))
+        })
+        .collect();
 
     match_sink_name_str!(
         connector_type,
         SinkType,
-        SinkType::validate_alter_config(&resolved_props),
+        SinkType::validate_alter_config_change(&resolved_props, &resolved_alter_props),
         |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
     )?;
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3082,8 +3082,6 @@ impl CatalogController {
             .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
             .to_lowercase();
 
-        validate_connector_type(&connector_type, &alter_props)?;
-
         let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
 
         check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
@@ -3211,8 +3209,6 @@ impl CatalogController {
             .get(CONNECTOR_TYPE_KEY)
             .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
             .to_lowercase();
-
-        validate_connector_type(&connector_type, &alter_props)?;
 
         let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
 
@@ -3532,27 +3528,14 @@ impl CatalogController {
                     .optional_associated_table_id
                     .map(|table_id| table_id.as_object_id())
                     .unwrap_or_else(|| source_id.as_object_id());
-                if !source_to_add_secret_dep.is_empty() {
-                    ObjectDependency::insert_many(source_to_add_secret_dep.into_iter().map(
-                        |secret_id| object_dependency::ActiveModel {
-                            oid: Set(secret_id.into()),
-                            used_by: Set(source_used_by_id),
-                            ..Default::default()
-                        },
-                    ))
-                    .exec(&txn)
-                    .await?;
-                }
-                if !source_to_remove_secret_dep.is_empty() {
-                    let _ = ObjectDependency::delete_many()
-                        .filter(
-                            object_dependency::Column::Oid
-                                .is_in(source_to_remove_secret_dep)
-                                .and(object_dependency::Column::UsedBy.eq(source_used_by_id)),
-                        )
-                        .exec(&txn)
-                        .await?;
-                }
+
+                update_secret_dependencies(
+                    &txn,
+                    source_to_add_secret_dep,
+                    source_to_remove_secret_dep,
+                    source_used_by_id,
+                )
+                .await?;
 
                 // Prepare source update
                 let active_source = source::ActiveModel {
@@ -4034,22 +4017,6 @@ fn build_altered_field_names(
         .collect()
 }
 
-fn validate_connector_type(
-    connector: &str,
-    alter_props: &BTreeMap<String, String>,
-) -> MetaResult<()> {
-    if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
-        && new_connector != connector
-    {
-        return Err(MetaError::invalid_parameter(format!(
-            "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
-            connector, new_connector
-        )));
-    }
-
-    Ok(())
-}
-
 async fn update_sink_fragment_props(
     txn: &DatabaseTransaction,
     sink_id: SinkId,
@@ -4195,7 +4162,7 @@ async fn update_secret_dependencies(
         .await?;
     }
     // Remove dependencies for secrets that are no longer referenced.
-    // This allows the secrets to be deleted after this source no longer uses them.
+    // This allows the secrets to be deleted after this source/sink no longer uses them.
     if !to_remove_secrets.is_empty() {
         let _ = ObjectDependency::delete_many()
             .filter(

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2961,33 +2961,8 @@ impl CatalogController {
             stmt.to_string()
         };
 
-        {
-            // Update secret dependencies atomically within the transaction.
-            // Add new dependencies for secrets that are newly referenced.
-            if !to_add_secret_dep.is_empty() {
-                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                    object_dependency::ActiveModel {
-                        oid: Set(secret_id.into()),
-                        used_by: Set(preferred_id),
-                        ..Default::default()
-                    }
-                }))
-                .exec(&txn)
-                .await?;
-            }
-            // Remove dependencies for secrets that are no longer referenced.
-            // This allows the secrets to be deleted after this source no longer uses them.
-            if !to_remove_secret_dep.is_empty() {
-                let _ = ObjectDependency::delete_many()
-                    .filter(
-                        object_dependency::Column::Oid
-                            .is_in(to_remove_secret_dep)
-                            .and(object_dependency::Column::UsedBy.eq(preferred_id)),
-                    )
-                    .exec(&txn)
-                    .await?;
-            }
-        }
+        update_secret_dependencies(&txn, to_add_secret_dep, to_remove_secret_dep, preferred_id)
+            .await?;
 
         let active_source_model = source::ActiveModel {
             source_id: Set(source_id),
@@ -3135,30 +3110,13 @@ impl CatalogController {
             stmt.to_string()
         };
 
-        {
-            if !to_add_secret_dep.is_empty() {
-                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                    object_dependency::ActiveModel {
-                        oid: Set(secret_id.into()),
-                        used_by: Set(sink_id.as_object_id()),
-                        ..Default::default()
-                    }
-                }))
-                .exec(&txn)
-                .await?;
-            }
-
-            if !to_remove_secret_dep.is_empty() {
-                let _ = ObjectDependency::delete_many()
-                    .filter(
-                        object_dependency::Column::Oid
-                            .is_in(to_remove_secret_dep)
-                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
-                    )
-                    .exec(&txn)
-                    .await?;
-            }
-        }
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep,
+            to_remove_secret_dep,
+            sink_id.as_object_id(),
+        )
+        .await?;
 
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
@@ -3263,30 +3221,13 @@ impl CatalogController {
             stmt.to_string()
         };
 
-        {
-            if !to_add_secret_dep.is_empty() {
-                ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                    object_dependency::ActiveModel {
-                        oid: Set(secret_id.into()),
-                        used_by: Set(sink_id.as_object_id()),
-                        ..Default::default()
-                    }
-                }))
-                .exec(&txn)
-                .await?;
-            }
-
-            if !to_remove_secret_dep.is_empty() {
-                let _ = ObjectDependency::delete_many()
-                    .filter(
-                        object_dependency::Column::Oid
-                            .is_in(to_remove_secret_dep)
-                            .and(object_dependency::Column::UsedBy.eq(sink_id.as_object_id())),
-                    )
-                    .exec(&txn)
-                    .await?;
-            }
-        }
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep,
+            to_remove_secret_dep,
+            sink_id.as_object_id(),
+        )
+        .await?;
 
         let active_sink = sink::ActiveModel {
             sink_id: Set(sink_id),
@@ -3466,27 +3407,13 @@ impl CatalogController {
         }
 
         // Update connection secret dependencies
-        if !to_add_secret_dep.is_empty() {
-            ObjectDependency::insert_many(to_add_secret_dep.into_iter().map(|secret_id| {
-                object_dependency::ActiveModel {
-                    oid: Set(secret_id.into()),
-                    used_by: Set(connection_id.as_object_id()),
-                    ..Default::default()
-                }
-            }))
-            .exec(&txn)
-            .await?;
-        }
-        if !to_remove_secret_dep.is_empty() {
-            let _ = ObjectDependency::delete_many()
-                .filter(
-                    object_dependency::Column::Oid
-                        .is_in(to_remove_secret_dep)
-                        .and(object_dependency::Column::UsedBy.eq(connection_id.as_object_id())),
-                )
-                .exec(&txn)
-                .await?;
-        }
+        update_secret_dependencies(
+            &txn,
+            to_add_secret_dep,
+            to_remove_secret_dep,
+            connection_id.as_object_id(),
+        )
+        .await?;
 
         // Update the connection with new properties
         let updated_connection_params = risingwave_pb::catalog::ConnectionParams {
@@ -4175,5 +4102,39 @@ where
         .await?;
     }
 
+    Ok(())
+}
+
+async fn update_secret_dependencies(
+    txn: &DatabaseTransaction,
+    to_add_secrets: Vec<SecretId>,
+    to_remove_secrets: Vec<SecretId>,
+    sink_id: ObjectId,
+) -> MetaResult<()> {
+    // Update secret dependencies atomically within the transaction.
+    // Add new dependencies for secrets that are newly referenced.
+    if !to_add_secrets.is_empty() {
+        ObjectDependency::insert_many(to_add_secrets.into_iter().map(|secret_id| {
+            object_dependency::ActiveModel {
+                oid: Set(secret_id.into()),
+                used_by: Set(sink_id),
+                ..Default::default()
+            }
+        }))
+        .exec(txn)
+        .await?;
+    }
+    // Remove dependencies for secrets that are no longer referenced.
+    // This allows the secrets to be deleted after this source no longer uses them.
+    if !to_remove_secrets.is_empty() {
+        let _ = ObjectDependency::delete_many()
+            .filter(
+                object_dependency::Column::Oid
+                    .is_in(to_remove_secrets)
+                    .and(object_dependency::Column::UsedBy.eq(sink_id)),
+            )
+            .exec(txn)
+            .await?;
+    }
     Ok(())
 }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3293,6 +3293,8 @@ impl CatalogController {
             properties: Set(risingwave_meta_model::Property(
                 options_with_secret.as_plaintext().clone(),
             )),
+            secret_ref: Set((!options_with_secret.as_secret().is_empty())
+                .then(|| SecretRef::from(options_with_secret.as_secret().clone()))),
             definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2904,11 +2904,8 @@ impl CatalogController {
 
         // Only check alter-on-fly restrictions for SQL ALTER SOURCE, not for admin risectl operations
         if !skip_alter_on_fly_check {
-            let prop_keys: Vec<String> = alter_props
-                .keys()
-                .chain(alter_secret_refs.keys())
-                .cloned()
-                .collect();
+            let prop_keys: Vec<String> =
+                build_altered_field_names(&alter_props, &alter_secret_refs);
             risingwave_connector::allow_alter_on_fly_fields::check_source_allow_alter_on_fly_fields(
                 &connector, &prop_keys,
             )?;
@@ -3078,8 +3075,19 @@ impl CatalogController {
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
 
-        // check if the alter-ed props are valid for all connector
-        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
+        let connector_type = sink
+            .properties
+            .inner_ref()
+            .get(CONNECTOR_TYPE_KEY)
+            .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
+            .to_lowercase();
+
+        validate_connector_type(&connector_type, &alter_props)?;
+
+        let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
+
+        check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
+            .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -3087,8 +3095,12 @@ impl CatalogController {
                 .map(|secret_ref| secret_ref.to_protobuf())
                 .unwrap_or_default(),
         );
+
         let (to_add_secret_dep, to_remove_secret_dep) =
             options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        // check if the alter-ed props are valid for all connector
+        validate_sink_props(&connector_type, options_with_secret.clone())?;
 
         tracing::info!(
             "applying new properties to sink: sink_id={}, options_with_secret={:?}",
@@ -3192,7 +3204,20 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
+
+        let connector_type = sink
+            .properties
+            .inner_ref()
+            .get(CONNECTOR_TYPE_KEY)
+            .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?
+            .to_lowercase();
+
+        validate_connector_type(&connector_type, &alter_props)?;
+
+        let prop_keys = build_altered_field_names(&alter_props, &alter_secret_refs);
+
+        check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
+            .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -3200,8 +3225,12 @@ impl CatalogController {
                 .map(|secret_ref| secret_ref.to_protobuf())
                 .unwrap_or_default(),
         );
+
         let (to_add_secret_dep, to_remove_secret_dep) =
             options_with_secret.handle_update(alter_props.clone(), alter_secret_refs)?;
+
+        // check if the alter-ed props are valid for all connector
+        validate_sink_props(&connector_type, options_with_secret.clone())?;
 
         // rewrite the sql for definition field
         let rewrite_sql = {
@@ -3637,8 +3666,14 @@ impl CatalogController {
             for (sink, _obj) in sinks_with_objs {
                 let sink_id = sink.sink_id;
 
-                // Validate that sink props can be altered
-                validate_sink_props(&sink, &alter_props.clone(), &alter_secret_refs.clone())?;
+                let connector_type = sink
+                    .properties
+                    .inner_ref()
+                    .get(CONNECTOR_TYPE_KEY)
+                    .ok_or_else(|| {
+                        SinkError::Config(anyhow!("connector not specified when alter sink"))
+                    })?
+                    .to_lowercase();
 
                 let mut sink_options_with_secret = WithOptionsSecResolved::new(
                     sink.properties.0.clone(),
@@ -3650,6 +3685,9 @@ impl CatalogController {
 
                 let (sink_to_add_secret_dep, sink_to_remove_secret_dep) = sink_options_with_secret
                     .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
+
+                // check if the alter-ed props are valid for all connector
+                validate_sink_props(&connector_type, sink_options_with_secret.clone())?;
 
                 update_secret_dependencies(
                     &txn,
@@ -3967,18 +4005,39 @@ impl CatalogController {
 }
 
 fn validate_sink_props(
-    sink: &sink::Model,
+    connector_type: &str,
+    with_properties: WithOptionsSecResolved,
+) -> MetaResult<()> {
+    let (options, secret_refs) = with_properties.into_parts();
+    let resolved_props = LocalSecretManager::global()
+        .fill_secrets(options, secret_refs)
+        .map_err(MetaError::from)?;
+
+    match_sink_name_str!(
+        connector_type,
+        SinkType,
+        SinkType::validate_alter_config(&resolved_props),
+        |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
+    )?;
+
+    Ok(())
+}
+
+fn build_altered_field_names(
     alter_props: &BTreeMap<String, String>,
     alter_secret_refs: &BTreeMap<String, PbSecretRef>,
+) -> Vec<String> {
+    alter_props
+        .keys()
+        .chain(alter_secret_refs.keys())
+        .cloned()
+        .collect()
+}
+
+fn validate_connector_type(
+    connector: &str,
+    alter_props: &BTreeMap<String, String>,
 ) -> MetaResult<()> {
-    let connector = sink
-        .properties
-        .inner_ref()
-        .get(CONNECTOR_TYPE_KEY)
-        .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?;
-
-    let connector_type = connector.to_lowercase();
-
     if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
         && new_connector != connector
     {
@@ -3988,25 +4047,6 @@ fn validate_sink_props(
         )));
     }
 
-    let field_names: Vec<String> = alter_props
-        .keys()
-        .chain(alter_secret_refs.keys())
-        .cloned()
-        .collect();
-
-    check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
-        .map_err(|e| SinkError::Config(anyhow!(e)))?;
-
-    match_sink_name_str!(
-        connector_type.as_str(),
-        SinkType,
-        {
-            let mut new_props = sink.properties.0.clone();
-            new_props.extend(alter_props.clone());
-            SinkType::validate_alter_config_change(&new_props, alter_props)
-        },
-        |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
-    )?;
     Ok(())
 }
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3072,7 +3072,7 @@ impl CatalogController {
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
 
         // check if the alter-ed props are valid for all connector
-        validate_sink_props(&sink, &alter_props)?;
+        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -3100,11 +3100,18 @@ impl CatalogController {
                 })?
                 .try_into()
                 .unwrap();
-            if let Statement::CreateSink { stmt } = &mut stmt {
-                stmt.with_properties.0 =
-                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
-            } else {
-                panic!("definition is not a create sink statement")
+            match &mut stmt {
+                Statement::CreateSink { stmt } => {
+                    stmt.with_properties.0 =
+                        format_with_option_secret_resolved(&txn, &options_with_secret).await?;
+                }
+                _ => {
+                    return Err(MetaError::from(MetaErrorInner::Connector(
+                        ConnectorError::from(anyhow!(
+                            "Sink definition is not a CREATE SINK statement"
+                        )),
+                    )));
+                }
             }
 
             stmt.to_string()
@@ -3178,7 +3185,7 @@ impl CatalogController {
             .one(&txn)
             .await?
             .ok_or_else(|| MetaError::catalog_id_not_found(ObjectType::Sink.as_str(), sink_id))?;
-        validate_sink_props(&sink, &alter_props)?;
+        validate_sink_props(&sink, &alter_props, &alter_secret_refs)?;
 
         let mut options_with_secret = WithOptionsSecResolved::new(
             sink.properties.0.clone(),
@@ -3200,22 +3207,29 @@ impl CatalogController {
                 })?
                 .try_into()
                 .unwrap();
-            if let Statement::CreateTable {
-                with_options,
-                engine,
-                ..
-            } = &mut stmt
-            {
-                if !matches!(engine, Engine::Iceberg) {
-                    return Err(SinkError::Config(anyhow!(
-                        "only iceberg table can be altered as sink"
-                    ))
-                    .into());
+
+            match &mut stmt {
+                Statement::CreateTable {
+                    with_options,
+                    engine,
+                    ..
+                } => {
+                    if !matches!(engine, Engine::Iceberg) {
+                        return Err(SinkError::Config(anyhow!(
+                            "only iceberg table can be altered as sink"
+                        ))
+                        .into());
+                    }
+                    *with_options =
+                        format_with_option_secret_resolved(&txn, &options_with_secret).await?;
                 }
-                *with_options =
-                    format_with_option_secret_resolved(&txn, &options_with_secret).await?;
-            } else {
-                panic!("definition is not a create iceberg table statement")
+                _ => {
+                    return Err(MetaError::from(MetaErrorInner::Connector(
+                        ConnectorError::from(anyhow!(
+                            "definition is not a create iceberg table statement"
+                        )),
+                    )));
+                }
             }
 
             stmt.to_string()
@@ -3241,6 +3255,11 @@ impl CatalogController {
         };
         let active_source = source::ActiveModel {
             source_id: Set(source_id),
+            with_properties: Set(risingwave_meta_model::Property(
+                options_with_secret.as_plaintext().clone(),
+            )),
+            secret_ref: Set((!options_with_secret.as_secret().is_empty())
+                .then(|| SecretRef::from(options_with_secret.as_secret().clone()))),
             definition: Set(rewrite_sql.clone()),
             ..Default::default()
         };
@@ -3932,51 +3951,47 @@ impl CatalogController {
     }
 }
 
-/// Validate ALTER SINK connector properties, including allowed fields
-/// and the validity of the merged configuration.
-///
-/// Steps:
-/// 1. Read the connector field from the current sink properties.
-/// 2. Validate that connector type is not being changed
-/// 3. Check whether the modified fields support on-the-fly updates.
-/// 4. Merge the existing configuration with the new properties and validate it.
 fn validate_sink_props(
     sink: &sink::Model,
     alter_props: &BTreeMap<String, String>,
+    alter_secret_refs: &BTreeMap<String, PbSecretRef>,
 ) -> MetaResult<()> {
-    match sink.properties.inner_ref().get(CONNECTOR_TYPE_KEY) {
-        Some(connector) => {
-            let connector_type = connector.to_lowercase();
-            let field_names: Vec<String> = alter_props.keys().cloned().collect();
+    let connector = sink
+        .properties
+        .inner_ref()
+        .get(CONNECTOR_TYPE_KEY)
+        .ok_or_else(|| SinkError::Config(anyhow!("connector not specified when alter sink")))?;
 
-            if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
-                && new_connector != connector
-            {
-                return Err(MetaError::invalid_parameter(format!(
-                    "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
-                    connector, new_connector
-                )));
-            }
-            check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
-                .map_err(|e| SinkError::Config(anyhow!(e)))?;
+    let connector_type = connector.to_lowercase();
 
-            match_sink_name_str!(
-                connector_type.as_str(),
-                SinkType,
-                {
-                    let mut new_props = sink.properties.0.clone();
-                    new_props.extend(alter_props.clone());
-                    SinkType::validate_alter_config_change(&new_props, alter_props)
-                },
-                |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
-            )?
-        }
-        None => {
-            return Err(
-                SinkError::Config(anyhow!("connector not specified when alter sink")).into(),
-            );
-        }
-    };
+    if let Some(new_connector) = alter_props.get(CONNECTOR_TYPE_KEY)
+        && new_connector != connector
+    {
+        return Err(MetaError::invalid_parameter(format!(
+            "Cannot change connector type from '{}' to '{}'. Drop and recreate the sink instead.",
+            connector, new_connector
+        )));
+    }
+
+    let field_names: Vec<String> = alter_props
+        .keys()
+        .chain(alter_secret_refs.keys())
+        .cloned()
+        .collect();
+
+    check_sink_allow_alter_on_fly_fields(&connector_type, &field_names)
+        .map_err(|e| SinkError::Config(anyhow!(e)))?;
+
+    match_sink_name_str!(
+        connector_type.as_str(),
+        SinkType,
+        {
+            let mut new_props = sink.properties.0.clone();
+            new_props.extend(alter_props.clone());
+            SinkType::validate_alter_config_change(&new_props, alter_props)
+        },
+        |sink: &str| Err(SinkError::Config(anyhow!("unsupported sink type {}", sink)))
+    )?;
     Ok(())
 }
 
@@ -4109,7 +4124,7 @@ async fn update_secret_dependencies(
     txn: &DatabaseTransaction,
     to_add_secrets: Vec<SecretId>,
     to_remove_secrets: Vec<SecretId>,
-    sink_id: ObjectId,
+    object_id: ObjectId,
 ) -> MetaResult<()> {
     // Update secret dependencies atomically within the transaction.
     // Add new dependencies for secrets that are newly referenced.
@@ -4117,7 +4132,7 @@ async fn update_secret_dependencies(
         ObjectDependency::insert_many(to_add_secrets.into_iter().map(|secret_id| {
             object_dependency::ActiveModel {
                 oid: Set(secret_id.into()),
-                used_by: Set(sink_id),
+                used_by: Set(object_id),
                 ..Default::default()
             }
         }))
@@ -4131,7 +4146,7 @@ async fn update_secret_dependencies(
             .filter(
                 object_dependency::Column::Oid
                     .is_in(to_remove_secrets)
-                    .and(object_dependency::Column::UsedBy.eq(sink_id)),
+                    .and(object_dependency::Column::UsedBy.eq(object_id)),
             )
             .exec(txn)
             .await?;

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -172,6 +172,13 @@ struct DependentSourceFragmentUpdate {
 }
 
 #[derive(Debug)]
+struct DependentSinkFragmentUpdate {
+    job_id: JobId,
+    with_properties: BTreeMap<String, String>,
+    secret_refs: BTreeMap<String, PbSecretRef>,
+}
+
+#[derive(Debug)]
 struct ReplaceOriginalJobInfo {
     max_parallelism: i32,
     timezone: Option<String>,
@@ -3631,54 +3638,49 @@ impl CatalogController {
                 let sink_id = sink.sink_id;
 
                 // Validate that sink props can be altered
-                match sink.properties.inner_ref().get(CONNECTOR_TYPE_KEY) {
-                    Some(connector) => {
-                        let connector_type = connector.to_lowercase();
-                        check_sink_allow_alter_on_fly_fields(&connector_type, &prop_keys)
-                            .map_err(|e| SinkError::Config(anyhow!(e)))?;
+                validate_sink_props(&sink, &alter_props.clone(), &alter_secret_refs.clone())?;
 
-                        match_sink_name_str!(
-                            connector_type.as_str(),
-                            SinkType,
-                            {
-                                let mut new_sink_props = sink.properties.0.clone();
-                                new_sink_props.extend(alter_props.clone());
-                                SinkType::validate_alter_config_change(
-                                    &new_sink_props,
-                                    &alter_props,
-                                )
-                            },
-                            |sink: &str| Err(SinkError::Config(anyhow!(
-                                "unsupported sink type {}",
-                                sink
-                            )))
-                        )?
-                    }
-                    None => {
-                        return Err(SinkError::Config(anyhow!(
-                            "connector not specified when alter sink"
-                        ))
-                        .into());
-                    }
-                };
+                let mut sink_options_with_secret = WithOptionsSecResolved::new(
+                    sink.properties.0.clone(),
+                    sink.secret_ref
+                        .clone()
+                        .map(|secret_ref| secret_ref.to_protobuf())
+                        .unwrap_or_default(),
+                );
 
-                let mut new_sink_props = sink.properties.0.clone();
-                new_sink_props.extend(alter_props.clone());
+                let (_sink_to_add_secret_dep, _sink_to_remove_secret_dep) =
+                    sink_options_with_secret
+                        .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
 
                 // Prepare sink update
                 let active_sink = sink::ActiveModel {
                     sink_id: Set(sink_id),
-                    properties: Set(risingwave_meta_model::Property(new_sink_props.clone())),
+                    properties: Set(risingwave_meta_model::Property(
+                        sink_options_with_secret.as_plaintext().clone(),
+                    )),
+                    secret_ref: Set((!sink_options_with_secret.as_secret().is_empty())
+                        .then(|| SecretRef::from(sink_options_with_secret.as_secret().clone()))),
                     ..Default::default()
                 };
                 sink_updates.push(active_sink);
 
                 // Prepare fragment updates for this sink
-                sink_fragment_updates.push((sink_id, new_sink_props.clone()));
+                sink_fragment_updates.push(DependentSinkFragmentUpdate {
+                    job_id: sink_id.as_job_id(),
+                    with_properties: sink_options_with_secret.as_plaintext().clone(),
+                    secret_refs: sink_options_with_secret.as_secret().clone(),
+                });
 
                 // Collect the complete properties for runtime broadcast
-                let complete_sink_props: HashMap<String, String> =
-                    new_sink_props.into_iter().collect();
+                let complete_sink_props = LocalSecretManager::global()
+                    .fill_secrets(
+                        sink_options_with_secret.as_plaintext().clone(),
+                        sink_options_with_secret.as_secret().clone(),
+                    )
+                    .map_err(MetaError::from)?
+                    .into_iter()
+                    .collect::<HashMap<String, String>>();
+
                 updated_sinks_with_props.push((sink_id, complete_sink_props));
             }
 
@@ -3688,17 +3690,23 @@ impl CatalogController {
             }
 
             // Batch execute sink fragment updates using the reusable function
-            for (sink_id, new_sink_props) in sink_fragment_updates {
+            for DependentSinkFragmentUpdate {
+                job_id,
+                with_properties,
+                secret_refs,
+            } in sink_fragment_updates
+            {
                 update_connector_props_fragments(
                     &txn,
-                    vec![sink_id.as_job_id()],
+                    vec![job_id],
                     FragmentTypeFlag::Sink,
                     |node, found| {
                         if let PbNodeBody::Sink(node) = node
                             && let Some(sink_desc) = &mut node.sink_desc
-                            && sink_desc.id == sink_id.as_raw_id()
+                            && sink_desc.id == job_id.as_raw_id()
                         {
-                            sink_desc.properties = new_sink_props.clone();
+                            sink_desc.properties = with_properties.clone();
+                            sink_desc.secret_refs = secret_refs.clone();
                             *found = true;
                         }
                     },

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -88,10 +88,9 @@ use crate::controller::utils::{
     PartialObject, build_object_group_for_delete, check_if_belongs_to_iceberg_table,
     check_relation_name_duplicate, check_sink_into_table_cycle, ensure_job_not_canceled,
     ensure_object_id, ensure_user_id, fetch_target_fragments, format_with_option_secret_resolved,
-    get_belong_objects, get_belong_objects_by_ids, get_internal_tables_by_id,
-    get_referring_objects, get_table_columns, grant_default_privileges_automatically,
-    insert_fragment_relations, list_object_dependencies_by_object_id, list_user_info_by_ids,
-    try_get_iceberg_table_by_downstream_sink, upsert_user_privileges,
+    get_belong_objects, get_belong_objects_by_ids, get_referring_objects, get_table_columns,
+    grant_default_privileges_automatically, insert_fragment_relations,
+    list_object_dependencies_by_object_id, list_user_info_by_ids, upsert_user_privileges,
 };
 use crate::error::MetaErrorInner;
 use crate::manager::{NotificationVersion, StreamingJob, StreamingJobType};

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3648,9 +3648,16 @@ impl CatalogController {
                         .unwrap_or_default(),
                 );
 
-                let (_sink_to_add_secret_dep, _sink_to_remove_secret_dep) =
-                    sink_options_with_secret
-                        .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
+                let (sink_to_add_secret_dep, sink_to_remove_secret_dep) = sink_options_with_secret
+                    .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
+
+                update_secret_dependencies(
+                    &txn,
+                    sink_to_add_secret_dep,
+                    sink_to_remove_secret_dep,
+                    sink_id.as_object_id(),
+                )
+                .await?;
 
                 // Prepare sink update
                 let active_sink = sink::ActiveModel {

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -502,7 +502,7 @@ pub async fn format_with_option_secret_resolved(
 ) -> MetaResult<Vec<SqlOption>> {
     let mut options = Vec::new();
     for (k, v) in options_with_secret.as_plaintext() {
-        let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
+        let sql_option = SqlOption::try_from((k, &v.to_owned()))
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
         options.push(sql_option);
     }

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -27,6 +27,7 @@ use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_common::{bail, hash};
+use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::fragment::DistributionType;
 use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::prelude::*;
@@ -57,7 +58,7 @@ use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
 use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
-use risingwave_sqlparser::ast::Statement as SqlStatement;
+use risingwave_sqlparser::ast::{SqlOption, Statement as SqlStatement};
 use risingwave_sqlparser::parser::Parser;
 use sea_orm::sea_query::{
     Alias, CommonTableExpression, Expr, Query, QueryStatementBuilder, SelectStatement, UnionType,
@@ -480,6 +481,41 @@ where
     let cnt: i64 = res.try_get_by(0)?;
 
     Ok(cnt != 0)
+}
+
+/// Formats SQL options with secret values properly resolved
+///
+/// This function processes configuration options that may contain sensitive data:
+/// - Plaintext options are directly converted to `SqlOption`
+/// - Secret options are retrieved from the database and formatted as "SECRET {name}"
+///   without exposing the actual secret value
+///
+/// # Arguments
+/// * `txn` - Database transaction for retrieving secrets
+/// * `options_with_secret` - Container of options with both plaintext and secret values
+///
+/// # Returns
+/// * `MetaResult<Vec<SqlOption>>` - List of formatted SQL options or error
+pub async fn format_with_option_secret_resolved(
+    txn: &DatabaseTransaction,
+    options_with_secret: &WithOptionsSecResolved,
+) -> MetaResult<Vec<SqlOption>> {
+    let mut options = Vec::new();
+    for (k, v) in options_with_secret.as_plaintext() {
+        let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
+            .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
+        options.push(sql_option);
+    }
+    for (k, v) in options_with_secret.as_secret() {
+        if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
+            let sql_option = SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
+                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
+            options.push(sql_option);
+        } else {
+            return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
+        }
+    }
+    Ok(options)
 }
 
 /// `ensure_object_id` ensures the existence of target object in the cluster.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -27,6 +27,7 @@ use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
 use risingwave_common::{bail, hash};
+use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::fragment::DistributionType;
 use risingwave_meta_model::object::ObjectType;
 use risingwave_meta_model::prelude::*;
@@ -57,7 +58,7 @@ use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
 use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
-use risingwave_sqlparser::ast::Statement as SqlStatement;
+use risingwave_sqlparser::ast::{SqlOption, Statement as SqlStatement};
 use risingwave_sqlparser::parser::Parser;
 use sea_orm::sea_query::{
     Alias, CommonTableExpression, Expr, OnConflict, Query, QueryStatementBuilder, SelectStatement,
@@ -544,6 +545,41 @@ where
     let cnt: i64 = res.try_get_by(0)?;
 
     Ok(cnt != 0)
+}
+
+/// Formats SQL options with secret values properly resolved
+///
+/// This function processes configuration options that may contain sensitive data:
+/// - Plaintext options are directly converted to `SqlOption`
+/// - Secret options are retrieved from the database and formatted as "SECRET {name}"
+///   without exposing the actual secret value
+///
+/// # Arguments
+/// * `txn` - Database transaction for retrieving secrets
+/// * `options_with_secret` - Container of options with both plaintext and secret values
+///
+/// # Returns
+/// * `MetaResult<Vec<SqlOption>>` - List of formatted SQL options or error
+pub async fn format_with_option_secret_resolved(
+    txn: &DatabaseTransaction,
+    options_with_secret: &WithOptionsSecResolved,
+) -> MetaResult<Vec<SqlOption>> {
+    let mut options = Vec::new();
+    for (k, v) in options_with_secret.as_plaintext() {
+        let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
+            .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
+        options.push(sql_option);
+    }
+    for (k, v) in options_with_secret.as_secret() {
+        if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
+            let sql_option = SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
+                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
+            options.push(sql_option);
+        } else {
+            return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
+        }
+    }
+    Ok(options)
 }
 
 /// `ensure_object_id` ensures the existence of target object in the cluster.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -55,10 +55,14 @@ use risingwave_pb::meta::{
 };
 use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
 use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
+use risingwave_pb::secret::PbSecretRef;
+use risingwave_pb::secret::secret_ref::PbRefAsType;
 use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
 use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
-use risingwave_sqlparser::ast::{SqlOption, Statement as SqlStatement};
+use risingwave_sqlparser::ast::{
+    Ident, ObjectName, SecretRefAsType, SecretRefValue, SqlOption, Statement as SqlStatement,
+};
 use risingwave_sqlparser::parser::Parser;
 use sea_orm::sea_query::{
     Alias, CommonTableExpression, Expr, OnConflict, Query, QueryStatementBuilder, SelectStatement,
@@ -570,16 +574,53 @@ pub async fn format_with_option_secret_resolved(
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
         options.push(sql_option);
     }
-    for (k, v) in options_with_secret.as_secret() {
-        if let Some(secret_model) = Secret::find_by_id(v.secret_id).one(txn).await? {
-            let sql_option = SqlOption::try_from((k, &format!("SECRET {}", secret_model.name)))
-                .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
-            options.push(sql_option);
-        } else {
-            return Err(MetaError::catalog_id_not_found("secret", v.secret_id));
-        }
+    for (name, secret_ref) in options_with_secret.as_secret() {
+        let secret_ref_value = resolve_secret_ref_value(txn, secret_ref).await?;
+        options.push(SqlOption::from_secret_ref(name, secret_ref_value));
     }
     Ok(options)
+}
+
+async fn resolve_secret_ref_value(
+    txn: &DatabaseTransaction,
+    secret_ref: &PbSecretRef,
+) -> MetaResult<SecretRefValue> {
+    let (secret, object) = Secret::find_by_id(secret_ref.secret_id)
+        .find_also_related(Object)
+        .one(txn)
+        .await?
+        .ok_or_else(|| MetaError::catalog_id_not_found("secret", secret_ref.secret_id))?;
+    let object =
+        object.ok_or_else(|| MetaError::catalog_id_not_found("object", secret_ref.secret_id))?;
+    let schema_id = object.schema_id.ok_or_else(|| {
+        MetaError::invalid_parameter(format!(
+            "secret {} does not belong to a schema",
+            secret_ref.secret_id
+        ))
+    })?;
+    let schema = Schema::find_by_id(schema_id)
+        .one(txn)
+        .await?
+        .ok_or_else(|| MetaError::catalog_id_not_found("schema", schema_id))?;
+
+    let ref_as = match PbRefAsType::try_from(secret_ref.ref_as) {
+        Ok(PbRefAsType::File) => SecretRefAsType::File,
+        Ok(PbRefAsType::Text | PbRefAsType::Unspecified) => SecretRefAsType::Text,
+        Err(_) => {
+            return Err(MetaError::invalid_parameter(format!(
+                "invalid reference type {} for secret {}",
+                secret_ref.ref_as, secret_ref.secret_id
+            )));
+        }
+    };
+
+    Ok(SecretRefValue {
+        secret_name: ObjectName(vec![
+            Ident::from_real_value(&schema.name),
+            Ident::from_real_value(&secret.name),
+        ]),
+        ref_as,
+    })
 }
 
 /// `ensure_object_id` ensures the existence of target object in the cluster.

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -566,7 +566,7 @@ pub async fn format_with_option_secret_resolved(
 ) -> MetaResult<Vec<SqlOption>> {
     let mut options = Vec::new();
     for (k, v) in options_with_secret.as_plaintext() {
-        let sql_option = SqlOption::try_from((k, &format!("'{}'", v)))
+        let sql_option = SqlOption::try_from((k, &v.to_owned()))
             .map_err(|e| MetaError::invalid_parameter(e.to_report_string()))?;
         options.push(sql_option);
     }

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -19,12 +19,15 @@ use anyhow::anyhow;
 use itertools::Itertools;
 use risingwave_common::catalog::{DatabaseId, TableId, TableOption};
 use risingwave_common::id::JobId;
+use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::refresh_job::{self, RefreshState};
 use risingwave_meta_model::{SinkId, SourceId, WorkerId};
 use risingwave_pb::catalog::{PbSource, PbTable};
 use risingwave_pb::common::worker_node::{PbResource, Property as AddNodeProperty, State};
 use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, WorkerNode, WorkerType};
+use risingwave_pb::meta::alter_connector_props_request::PbExtraOptions;
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
+use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::{PbDispatcherType, PbStreamScanType};
 use sea_orm::TransactionTrait;
 use sea_orm::prelude::DateTime;
@@ -570,31 +573,23 @@ impl MetadataManager {
             .await
     }
 
-    pub async fn update_sink_props_by_sink_id(
-        &self,
-        sink_id: SinkId,
-        props: BTreeMap<String, String>,
-    ) -> MetaResult<HashMap<String, String>> {
-        let new_props = self
-            .catalog_controller
-            .update_sink_props_by_sink_id(sink_id, props)
-            .await?;
-        Ok(new_props)
-    }
-
     pub async fn update_iceberg_table_props_by_table_id(
         &self,
         table_id: TableId,
         props: BTreeMap<String, String>,
-        alter_iceberg_table_props: Option<
-            risingwave_pb::meta::alter_connector_props_request::PbExtraOptions,
-        >,
-    ) -> MetaResult<(HashMap<String, String>, SinkId)> {
-        let (new_props, sink_id) = self
+        alter_secret_refs: BTreeMap<String, PbSecretRef>,
+        alter_iceberg_table_props: Option<PbExtraOptions>,
+    ) -> MetaResult<(WithOptionsSecResolved, SinkId)> {
+        let (options_with_secret, sink_id) = self
             .catalog_controller
-            .update_iceberg_table_props_by_table_id(table_id, props, alter_iceberg_table_props)
+            .update_iceberg_table_props_by_table_id(
+                table_id,
+                props,
+                alter_secret_refs,
+                alter_iceberg_table_props,
+            )
             .await?;
-        Ok((new_props, sink_id))
+        Ok((options_with_secret, sink_id))
     }
 
     pub async fn update_fragment_rate_limit_by_fragment_id(

--- a/src/meta/src/manager/metadata.rs
+++ b/src/meta/src/manager/metadata.rs
@@ -19,12 +19,15 @@ use anyhow::anyhow;
 use itertools::Itertools;
 use risingwave_common::catalog::{DatabaseId, TableId, TableOption};
 use risingwave_common::id::JobId;
+use risingwave_connector::WithOptionsSecResolved;
 use risingwave_meta_model::refresh_job::{self, RefreshState};
 use risingwave_meta_model::{SinkId, SourceId, WorkerId};
 use risingwave_pb::catalog::{PbSource, PbTable};
 use risingwave_pb::common::worker_node::{PbResource, Property as AddNodeProperty, State};
 use risingwave_pb::common::{HostAddress, PbWorkerNode, PbWorkerType, WorkerNode, WorkerType};
+use risingwave_pb::meta::alter_connector_props_request::PbExtraOptions;
 use risingwave_pb::meta::list_rate_limits_response::RateLimitInfo;
+use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::{PbDispatcherType, PbStreamNode, PbStreamScanType};
 use sea_orm::TransactionTrait;
 use sea_orm::prelude::DateTime;
@@ -577,31 +580,23 @@ impl MetadataManager {
             .await
     }
 
-    pub async fn update_sink_props_by_sink_id(
-        &self,
-        sink_id: SinkId,
-        props: BTreeMap<String, String>,
-    ) -> MetaResult<HashMap<String, String>> {
-        let new_props = self
-            .catalog_controller
-            .update_sink_props_by_sink_id(sink_id, props)
-            .await?;
-        Ok(new_props)
-    }
-
     pub async fn update_iceberg_table_props_by_table_id(
         &self,
         table_id: TableId,
         props: BTreeMap<String, String>,
-        alter_iceberg_table_props: Option<
-            risingwave_pb::meta::alter_connector_props_request::PbExtraOptions,
-        >,
-    ) -> MetaResult<(HashMap<String, String>, SinkId)> {
-        let (new_props, sink_id) = self
+        alter_secret_refs: BTreeMap<String, PbSecretRef>,
+        alter_iceberg_table_props: Option<PbExtraOptions>,
+    ) -> MetaResult<(WithOptionsSecResolved, SinkId)> {
+        let (options_with_secret, sink_id) = self
             .catalog_controller
-            .update_iceberg_table_props_by_table_id(table_id, props, alter_iceberg_table_props)
+            .update_iceberg_table_props_by_table_id(
+                table_id,
+                props,
+                alter_secret_refs,
+                alter_iceberg_table_props,
+            )
             .await?;
-        Ok((new_props, sink_id))
+        Ok((options_with_secret, sink_id))
     }
 
     pub async fn update_fragment_rate_limit_by_fragment_id(

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3295,6 +3295,16 @@ pub struct SqlOption {
     pub value: SqlOptionValue,
 }
 
+impl SqlOption {
+    /// Creates an option whose value is a typed secret reference.
+    pub fn from_secret_ref(name: &str, secret_ref: SecretRefValue) -> Self {
+        Self {
+            name: ObjectName(name.split('.').map(Ident::from_real_value).collect()),
+            value: SqlOptionValue::SecretRef(secret_ref),
+        }
+    }
+}
+
 impl fmt::Display for SqlOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let should_redact = REDACT_SQL_OPTION_KEYWORDS
@@ -4172,5 +4182,36 @@ mod tests {
             "CREATE FUNCTION foo(INT) RETURNS INT LANGUAGE python IMMUTABLE AS 'SELECT 1' WITH ( always_retry_on_network_error = true )",
             format!("{}", create_function)
         );
+    }
+
+    #[test]
+    fn test_sql_option_from_secret_ref() {
+        {
+            let option = SqlOption::from_secret_ref(
+                "password",
+                SecretRefValue {
+                    secret_name: ObjectName(vec![
+                        Ident::from_real_value("public"),
+                        Ident::from_real_value("s2"),
+                    ]),
+                    ref_as: SecretRefAsType::Text,
+                },
+            );
+
+            assert!(matches!(option.value, SqlOptionValue::SecretRef(_)));
+            assert_eq!(option.to_string(), "password = secret public.s2");
+        }
+
+        {
+            let option = SqlOption::from_secret_ref(
+                "certificate",
+                SecretRefValue {
+                    secret_name: ObjectName(vec![Ident::from_real_value("cert")]),
+                    ref_as: SecretRefAsType::File,
+                },
+            );
+
+            assert_eq!(option.to_string(), "certificate = secret cert AS FILE");
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #22181

This PR adds complete secret-aware support for altering sink connector properties, including direct `ALTER SINK`, Iceberg table connector updates, and `ALTER CONNECTION` propagation to dependent sinks.
Previously, the sink alter path mainly handled plaintext properties. Secret-backed properties could become inconsistent across the catalog, fragment metadata, runtime connector configuration, SQL definitions, and object dependency records. As a result, secret rotation could leave stale secret references, prevent old secrets from being dropped, or fail to deliver the updated secret to running sinks.
The PR makes the following changes:
- Uses `WithOptionsSecResolved::handle_update` to merge plaintext updates and Secret references while correctly handling transitions between plaintext and Secret-backed values.
- Persists plaintext properties and `secret_ref` separately, ensuring secret values are never stored in catalog definitions or connector properties as plaintext.
- Updates `sink_desc.properties` and `sink_desc.secret_refs` in stream fragments so runtime metadata remains consistent with the catalog.
- Resolves Secret references through `LocalSecretManager::fill_secrets` when validating connector configurations and broadcasting runtime property changes.
- Maintains `object_dependency` records when rotating secrets, allowing an unused old Secret to be dropped while continuing to protect the currently referenced Secret.
- Aligns the dependent-sink path in `ALTER CONNECTION` with direct `ALTER SINK` and dependent-source behavior.
- Separates alter-on-the-fly validation from full connector configuration validation: only changed fields are checked against the alterable-field allowlist, while the complete resolved configuration is used for semantic validation.
- Prevents the connector type from being changed through an ALTER operation.
- Rewrites stored SQL definitions using typed `SqlOptionValue::SecretRef` nodes instead of formatting `"SECRET ..."` as a normal string. Secret metadata is loaded by ID together with its schema and reference mode, preserving schema-qualified names and AS FILE semantics without exposing the secret value. 
- Extends Iceberg table alter handling so its implicit sink, source, table catalog entries, fragment metadata, Secret references, and dependencies remain synchronized.
- Adds end-to-end coverage for direct sink secret rotation, connection-level propagation to dependent sinks, catalog state, allowed and disallowed on-the-fly fields, and `DROP SECRET` dependency behavior.
The intention is to make Secret-backed connector properties a fully supported part of ALTER operations rather than a special case handled only during object creation. After this change, rotating a connector credential from `SECRET s1` to `SECRET s2` consistently updates catalog metadata, SQL definitions, stream fragments, runtime connector state, and dependency tracking.


## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

Now we supports updating secret-backed connector properties through `ALTER SINK ... CONNECTOR WITH` and `ALTER TABLE ... CONNECTOR WITH` for Iceberg tables.

Secret rotation is also propagated correctly when `ALTER CONNECTION ... CONNECTOR WITH` updates a connection used by dependent sinks. We updates the catalog, running fragments, and secret dependencies consistently, allowing obsolete secrets to be dropped while preventing active secrets from being removed.

Connector configurations are validated using resolved secret values, while stored SQL definitions retain typed, schema-qualified `SECRET` references, including `AS FILE`, without exposing secret contents in plaintext.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connector credentials and authentication settings can now be updated at runtime across supported sinks, sources, and Iceberg connections.
  - Added support for rotating secret-backed configuration without recreating connectors or sinks.
  - Iceberg table properties now support secret references during updates.

- **Bug Fixes**
  - Secret changes are correctly validated, resolved, persisted, and propagated to running jobs.
  - Unsupported sink properties continue to be rejected, while supported password and credential changes can switch between secrets and plaintext.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->