### PR TITLE
refactor(meta): unify barrier completion flow to partial-graph manager

### DIFF
--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::future::{Future, poll_fn};
+use std::ops::Bound::{Excluded, Unbounded};
 use std::task::Poll;
 
 use anyhow::anyhow;
 use fail::fail_point;
+use itertools::Itertools;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntGauge};
@@ -114,14 +116,22 @@ impl CheckpointControl {
         }
     }
 
-    pub(crate) fn ack_completed(&mut self, output: BarrierCompleteOutput) {
+    pub(crate) fn ack_completed(
+        &mut self,
+        partial_graph_manager: &mut PartialGraphManager,
+        output: BarrierCompleteOutput,
+    ) {
         self.hummock_version_stats = output.hummock_version_stats;
         for (database_id, (command_prev_epoch, creating_job_epochs)) in output.epochs_to_ack {
             self.databases
                 .get_mut(&database_id)
                 .expect("should exist")
                 .expect_running("should have wait for completing command before enter recovery")
-                .ack_completed(command_prev_epoch, creating_job_epochs);
+                .ack_completed(
+                    partial_graph_manager,
+                    command_prev_epoch,
+                    creating_job_epochs,
+                );
         }
     }
 
@@ -345,7 +355,9 @@ impl CheckpointControl {
                 // Skip new barrier for database which is not running.
                 return Ok(());
             };
-            if !database.can_inject_barrier(self.in_flight_barrier_nums) {
+            if partial_graph_manager.inflight_barrier_num(database.partial_graph_id)
+                >= self.in_flight_barrier_nums
+            {
                 // Skip new barrier with no explicit command when the database should pause inject additional barrier
                 return Ok(());
             }
@@ -618,10 +630,6 @@ pub(in crate::barrier) struct DatabaseCheckpointControl {
 
     finishing_jobs_collector:
         BarrierItemCollector<JobId, (Vec<BarrierCompleteResponse>, TrackingJob), ()>,
-
-    /// Save the state and message of barrier in order.
-    /// Key is the `prev_epoch`.
-    command_ctx_queue: BTreeMap<u64, BarrierEpochState>,
     /// The barrier that are completing.
     /// Some(`prev_epoch`)
     completing_barrier: Option<u64>,
@@ -639,7 +647,6 @@ impl DatabaseCheckpointControl {
             partial_graph_id: to_partial_graph_id(database_id, None),
             state: BarrierWorkerState::new(),
             finishing_jobs_collector: BarrierItemCollector::new(),
-            command_ctx_queue: Default::default(),
             completing_barrier: None,
             committed_epoch: None,
             database_info: InflightDatabaseInfo::empty(database_id, shared_actor_infos),
@@ -659,7 +666,6 @@ impl DatabaseCheckpointControl {
             partial_graph_id: to_partial_graph_id(database_id, None),
             state,
             finishing_jobs_collector: BarrierItemCollector::new(),
-            command_ctx_queue: Default::default(),
             completing_barrier: None,
             committed_epoch: Some(committed_epoch),
             database_info,
@@ -683,12 +689,6 @@ impl DatabaseCheckpointControl {
             self.finishing_jobs_collector
                 .enqueue(epoch, creating_jobs_to_wait, ());
         }
-        self.command_ctx_queue.insert(
-            prev_epoch,
-            BarrierEpochState {
-                is_collected: false,
-            },
-        );
     }
 
     /// Change the state of this `prev_epoch` to `Completed`. Return continuous nodes
@@ -707,39 +707,17 @@ impl DatabaseCheckpointControl {
         );
         let (database_id, creating_job_id) = from_partial_graph_id(partial_graph_id);
         assert_eq!(self.database_id, database_id);
-        match creating_job_id {
-            None => {
-                if let Some(state) = self.command_ctx_queue.get_mut(&prev_epoch) {
-                    assert!(!state.is_collected);
-                    state.is_collected = true;
-                } else {
-                    panic!(
-                        "collect barrier on non-existing barrier: {}, {:?}",
-                        prev_epoch, collected_barrier
-                    );
-                }
-            }
-            Some(creating_job_id) => {
-                let should_merge_to_upstream = self
-                    .creating_streaming_job_controls
-                    .get_mut(&creating_job_id)
-                    .expect("should exist")
-                    .collect(collected_barrier);
-                if should_merge_to_upstream {
-                    periodic_barriers.force_checkpoint_in_next_barrier(self.database_id);
-                }
+        if let Some(creating_job_id) = creating_job_id {
+            let should_merge_to_upstream = self
+                .creating_streaming_job_controls
+                .get_mut(&creating_job_id)
+                .expect("should exist")
+                .collect(collected_barrier);
+            if should_merge_to_upstream {
+                periodic_barriers.force_checkpoint_in_next_barrier(self.database_id);
             }
         }
         Ok(())
-    }
-
-    /// Pause inject barrier until True.
-    fn can_inject_barrier(&self, in_flight_barrier_nums: usize) -> bool {
-        self.command_ctx_queue
-            .values()
-            .filter(|state| state.is_inflight())
-            .count()
-            < in_flight_barrier_nums
     }
 }
 
@@ -847,16 +825,16 @@ impl DatabaseCheckpointControl {
         if let Some(committed_epoch) = self.committed_epoch {
             // `Vec::new` is a const fn, and do not have memory allocation, and therefore is lightweight enough
             let mut finished_jobs = Vec::new();
-            let min_upstream_inflight_barrier = self
-                .command_ctx_queue
-                .first_key_value()
-                .map(|(epoch, _)| *epoch);
+            let min_upstream_inflight_barrier = partial_graph_manager
+                .first_inflight_barrier(self.partial_graph_id)
+                .map(|epoch| epoch.prev);
             for (job_id, job) in &mut self.creating_streaming_job_controls {
                 if let Some((epoch, resps, info, is_finish_epoch)) = job.start_completing(
                     partial_graph_manager,
                     min_upstream_inflight_barrier,
                     committed_epoch,
                 ) {
+                    let resps = resps.into_values().collect_vec();
                     if is_finish_epoch {
                         assert!(info.notifiers.is_empty());
                         finished_jobs.push((*job_id, epoch, resps));
@@ -887,56 +865,48 @@ impl DatabaseCheckpointControl {
                     .collect(epoch, job_id, (resps, tracking_job));
             }
         }
-        assert!(self.completing_barrier.is_none());
+        let mut observed_non_checkpoint = false;
         self.finishing_jobs_collector.advance_collected();
-        let first_unfinished_job_epoch = self.finishing_jobs_collector.first_inflight_epoch();
-        while let Some((epoch, state)) = self.command_ctx_queue.first_key_value()
-            && !state.is_inflight()
-            && first_unfinished_job_epoch
-                .is_none_or(|first_unfinished_epoch| *epoch < first_unfinished_epoch.prev)
-        {
-            {
-                let (epoch, state) = self.command_ctx_queue.pop_first().expect("non-empty");
-                assert!(state.is_collected);
-
-                let (resps, mut info) =
-                    partial_graph_manager.take_collected_barrier(self.partial_graph_id, epoch);
-
+        let epoch_end_bound = self
+            .finishing_jobs_collector
+            .first_inflight_epoch()
+            .map_or(Unbounded, |epoch| Excluded(epoch.prev));
+        if let Some((epoch, resps, info)) = partial_graph_manager.start_completing(
+            self.partial_graph_id,
+            epoch_end_bound,
+            |_, resps, post_collect_command| {
+                observed_non_checkpoint = true;
                 self.handle_refresh_table_info(task, &resps);
                 self.database_info.apply_collected_command(
-                    &info.post_collect_command,
+                    &post_collect_command,
                     &resps,
                     hummock_version_stats,
                 );
-
-                let mut resps_to_commit = resps;
-                if !info.barrier_info.kind.is_checkpoint() {
-                    info.notifiers.drain(..).for_each(|notifier| {
-                        notifier.notify_collected();
-                    });
-                    if self.database_info.has_pending_finished_jobs()
-                        && !partial_graph_manager
-                            .has_pending_checkpoint_barrier(self.partial_graph_id)
-                    {
-                        periodic_barriers.force_checkpoint_in_next_barrier(self.database_id);
-                    }
-                    continue;
-                }
-                let mut staging_commit_info = self.database_info.take_staging_commit_info();
-                if let Some((_, finished_jobs, _)) = self
-                    .finishing_jobs_collector
+            },
+        ) {
+            self.handle_refresh_table_info(task, &resps);
+            self.database_info.apply_collected_command(
+                &info.post_collect_command,
+                &resps,
+                hummock_version_stats,
+            );
+            let mut resps_to_commit = resps.into_values().collect_vec();
+            let mut staging_commit_info = self.database_info.take_staging_commit_info();
+            if let Some((_, finished_jobs, _)) =
+                self.finishing_jobs_collector
                     .take_collected_if(|collected_epoch| {
                         assert!(epoch <= collected_epoch.prev);
                         epoch == collected_epoch.prev
                     })
-                {
-                    finished_jobs
-                        .into_iter()
-                        .for_each(|(_, (resps, tracking_job))| {
-                            resps_to_commit.extend(resps);
-                            staging_commit_info.finished_jobs.push(tracking_job);
-                        });
-                }
+            {
+                finished_jobs
+                    .into_iter()
+                    .for_each(|(_, (resps, tracking_job))| {
+                        resps_to_commit.extend(resps);
+                        staging_commit_info.finished_jobs.push(tracking_job);
+                    });
+            }
+            {
                 let task = task.get_or_insert_default();
                 Command::collect_commit_epoch_info(
                     &self.database_info,
@@ -955,8 +925,12 @@ impl DatabaseCheckpointControl {
                 task.commit_info
                     .truncate_tables
                     .extend(staging_commit_info.table_ids_to_truncate);
-                break;
             }
+        } else if observed_non_checkpoint
+            && self.database_info.has_pending_finished_jobs()
+            && !partial_graph_manager.has_pending_checkpoint_barrier(self.partial_graph_id)
+        {
+            periodic_barriers.force_checkpoint_in_next_barrier(self.database_id);
         }
         if !creating_jobs_task.is_empty() {
             let task = task.get_or_insert_default();
@@ -971,6 +945,7 @@ impl DatabaseCheckpointControl {
 
     fn ack_completed(
         &mut self,
+        partial_graph_manager: &mut PartialGraphManager,
         command_prev_epoch: Option<u64>,
         creating_job_epochs: Vec<(JobId, u64)>,
     ) {
@@ -978,14 +953,16 @@ impl DatabaseCheckpointControl {
             if let Some(prev_epoch) = self.completing_barrier.take() {
                 assert_eq!(command_prev_epoch, Some(prev_epoch));
                 self.committed_epoch = Some(prev_epoch);
+                partial_graph_manager.ack_completed(self.partial_graph_id, prev_epoch);
             } else {
                 assert_eq!(command_prev_epoch, None);
             };
             for (job_id, epoch) in creating_job_epochs {
-                self.creating_streaming_job_controls
-                    .get_mut(&job_id)
-                    .expect("should exist")
-                    .ack_completed(epoch)
+                if let Some(job) = self.creating_streaming_job_controls.get_mut(&job_id) {
+                    job.ack_completed(partial_graph_manager, epoch);
+                }
+                // If the job is not found, it was dropped and already removed
+                // by `on_partial_graph_reset` while the completing task was running.
             }
         }
     }
@@ -993,10 +970,10 @@ impl DatabaseCheckpointControl {
     fn handle_refresh_table_info(
         &self,
         task: &mut Option<CompleteBarrierTask>,
-        resps: &[BarrierCompleteResponse],
+        resps: &HashMap<WorkerId, BarrierCompleteResponse>,
     ) {
         let list_finished_info = resps
-            .iter()
+            .values()
             .flat_map(|resp| resp.list_finished_sources.clone())
             .collect::<Vec<_>>();
         if !list_finished_info.is_empty() {
@@ -1005,7 +982,7 @@ impl DatabaseCheckpointControl {
         }
 
         let load_finished_info = resps
-            .iter()
+            .values()
             .flat_map(|resp| resp.load_finished_sources.clone())
             .collect::<Vec<_>>();
         if !load_finished_info.is_empty() {
@@ -1014,7 +991,7 @@ impl DatabaseCheckpointControl {
         }
 
         let refresh_finished_table_ids: Vec<JobId> = resps
-            .iter()
+            .values()
             .flat_map(|resp| {
                 resp.refresh_finished_tables
                     .iter()
@@ -1026,18 +1003,6 @@ impl DatabaseCheckpointControl {
             task.refresh_finished_table_job_ids
                 .extend(refresh_finished_table_ids);
         }
-    }
-}
-
-#[derive(Debug)]
-/// The state of barrier.
-struct BarrierEpochState {
-    is_collected: bool,
-}
-
-impl BarrierEpochState {
-    fn is_inflight(&self) -> bool {
-        !self.is_collected
     }
 }
 
@@ -1145,7 +1110,7 @@ impl DatabaseCheckpointControl {
                             "cannot reschedule jobs {:?} when creating jobs with unreschedulable backfill fragments",
                             blocked_reschedule_job_ids
                         )
-                        .into(),
+                            .into(),
                     );
                 }
                 return Ok(());
@@ -1186,8 +1151,8 @@ impl DatabaseCheckpointControl {
         let barrier_info = self.state.next_barrier_info(checkpoint, curr_epoch);
         // Tracing related stuff
         barrier_info.prev_epoch.span().in_scope(|| {
-                tracing::info!(target: "rw_tracing", epoch = barrier_info.curr_epoch(), "new barrier enqueued");
-            });
+            tracing::info!(target: "rw_tracing", epoch = barrier_info.curr_epoch(), "new barrier enqueued");
+        });
         span.record("epoch", barrier_info.curr_epoch());
 
         let epoch = barrier_info.epoch();

--- a/src/meta/src/barrier/checkpoint/creating_job/barrier_control.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/barrier_control.rs
@@ -12,18 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::VecDeque;
-use std::ops::Bound::Unbounded;
-use std::ops::{Bound, RangeBounds};
-
 use risingwave_common::id::JobId;
 use risingwave_common::metrics::{LabelGuardedHistogram, LabelGuardedIntGauge};
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_pb::stream_service::BarrierCompleteResponse;
-use tracing::debug;
 
-use crate::barrier::notifier::Notifier;
-use crate::barrier::partial_graph::{CollectedBarrier, PartialGraphBarrierInfo, PartialGraphStat};
+use crate::barrier::partial_graph::PartialGraphStat;
 use crate::rpc::metrics::GLOBAL_META_METRICS;
 
 pub(super) struct CreatingStreamingJobBarrierStats {
@@ -64,130 +57,5 @@ impl PartialGraphStat for CreatingStreamingJobBarrierStats {
 
     fn observe_barrier_num(&self, inflight_barrier_num: usize, _collected_barrier_num: usize) {
         self.inflight_barrier_num.set(inflight_barrier_num as _);
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct CreatingStreamingJobBarrierControl {
-    job_id: JobId,
-    // newer epoch at the front. `push_front` and `pop_back`
-    inflight_barrier_queue: VecDeque<u64>,
-    max_collected_epoch: Option<u64>,
-    max_committed_epoch: Option<u64>,
-    // newer epoch at the front. `push_front` and `pop_back`
-    pending_barriers_to_complete: VecDeque<u64>,
-    completing_barrier: Option<u64>,
-}
-
-impl CreatingStreamingJobBarrierControl {
-    pub(super) fn new(job_id: JobId, committed_epoch: Option<u64>) -> Self {
-        Self {
-            job_id,
-            inflight_barrier_queue: Default::default(),
-            max_collected_epoch: committed_epoch,
-            max_committed_epoch: committed_epoch,
-            pending_barriers_to_complete: Default::default(),
-            completing_barrier: None,
-        }
-    }
-
-    pub(super) fn inflight_barrier_count(&self) -> usize {
-        self.inflight_barrier_queue.len()
-    }
-
-    fn latest_epoch(&self) -> Option<u64> {
-        self.inflight_barrier_queue
-            .front()
-            .copied()
-            .or(self.max_collected_epoch)
-    }
-
-    pub(super) fn max_committed_epoch(&self) -> Option<u64> {
-        self.max_committed_epoch
-    }
-
-    pub(super) fn is_empty(&self) -> bool {
-        self.inflight_barrier_queue.is_empty()
-            && self.pending_barriers_to_complete.is_empty()
-            && self.completing_barrier.is_none()
-    }
-
-    pub(super) fn enqueue_epoch(&mut self, epoch: u64) {
-        debug!(
-            epoch,
-            job_id = %self.job_id,
-            "creating job enqueue epoch"
-        );
-        if let Some(latest_epoch) = self.latest_epoch() {
-            assert!(epoch > latest_epoch, "{} {}", epoch, latest_epoch);
-        }
-
-        self.inflight_barrier_queue.push_front(epoch);
-    }
-
-    pub(super) fn collect(&mut self, collected_barrier: CollectedBarrier<'_>) {
-        let epoch = self
-            .inflight_barrier_queue
-            .pop_back()
-            .expect("non-empty when collected");
-        assert_eq!(epoch, collected_barrier.epoch.prev);
-        self.add_collected(collected_barrier);
-    }
-
-    /// Return Some((epoch, resps, `is_first_commit`))
-    ///
-    /// Only epoch within the `epoch_end_bound` can be started.
-    /// Usually `epoch_end_bound` is the upstream committed epoch. This is to ensure that
-    /// the creating job won't have higher committed epoch than the upstream.
-    pub(super) fn start_completing(
-        &mut self,
-        epoch_end_bound: Bound<u64>,
-        mut take_resps: impl FnMut(u64) -> (Vec<BarrierCompleteResponse>, PartialGraphBarrierInfo),
-    ) -> Option<(u64, Vec<BarrierCompleteResponse>, PartialGraphBarrierInfo)> {
-        assert!(self.completing_barrier.is_none());
-        let epoch_range: (Bound<u64>, Bound<u64>) = (Unbounded, epoch_end_bound);
-        while let Some(&epoch) = self.pending_barriers_to_complete.back()
-            && epoch_range.contains(&epoch)
-        {
-            let epoch_state = self
-                .pending_barriers_to_complete
-                .pop_back()
-                .expect("non-empty");
-            let (resps, info) = take_resps(epoch);
-            if info.post_collect_command.should_checkpoint() {
-                assert!(info.barrier_info.kind.is_checkpoint());
-            } else if !info.barrier_info.kind.is_checkpoint() {
-                info.notifiers
-                    .into_iter()
-                    .for_each(Notifier::notify_collected);
-                continue;
-            }
-            self.completing_barrier = Some(epoch_state);
-            return Some((epoch, resps, info));
-        }
-        None
-    }
-
-    /// Ack on completing a checkpoint barrier.
-    ///
-    /// Return the upstream epoch to be notified when there is any.
-    pub(super) fn ack_completed(&mut self, completed_epoch: u64) {
-        let epoch = self.completing_barrier.take().expect("should exist");
-        assert_eq!(epoch, completed_epoch);
-        if let Some(prev_max_committed_epoch) = self.max_committed_epoch.replace(completed_epoch) {
-            assert!(completed_epoch > prev_max_committed_epoch);
-        }
-    }
-
-    fn add_collected(&mut self, collected_barrier: CollectedBarrier<'_>) {
-        let epoch = collected_barrier.epoch.prev;
-        if let Some(prev_epoch) = self.pending_barriers_to_complete.front() {
-            assert!(*prev_epoch < epoch);
-        }
-        if let Some(max_collected_epoch) = self.max_collected_epoch {
-            assert!(epoch > max_collected_epoch);
-        }
-        self.max_collected_epoch = Some(epoch);
-        self.pending_barriers_to_complete.push_front(epoch);
     }
 }

--- a/src/meta/src/barrier/checkpoint/creating_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/creating_job/mod.rs
@@ -19,8 +19,8 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet, hash_map};
 use std::mem::take;
 use std::ops::Bound::{Excluded, Unbounded};
+use std::time::Duration;
 
-use barrier_control::CreatingStreamingJobBarrierControl;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::metrics::LabelGuardedIntGauge;
@@ -82,7 +82,7 @@ pub(crate) struct CreatingStreamingJobControl {
     node_actors: HashMap<WorkerId, HashSet<ActorId>>,
     state_table_ids: HashSet<TableId>,
 
-    barrier_control: CreatingStreamingJobBarrierControl,
+    max_committed_epoch: Option<u64>,
     status: CreatingStreamingJobStatus,
 
     upstream_lag: LabelGuardedIntGauge,
@@ -169,8 +169,6 @@ impl CreatingStreamingJobControl {
             &actors.actor_location,
         );
 
-        let barrier_control = CreatingStreamingJobBarrierControl::new(job_id, None);
-
         let mut prev_epoch_fake_physical_time = 0;
         let mut pending_non_checkpoint_barriers = vec![];
 
@@ -219,7 +217,7 @@ impl CreatingStreamingJobControl {
             partial_graph_id,
             job_id,
             snapshot_backfill_upstream_tables,
-            barrier_control,
+            max_committed_epoch: None,
             snapshot_epoch,
             status: CreatingStreamingJobStatus::PlaceHolder, // filled in later code
             upstream_lag: GLOBAL_META_METRICS
@@ -237,7 +235,6 @@ impl CreatingStreamingJobControl {
         if let Err(e) = Self::inject_barrier(
             partial_graph_id,
             graph_adder.manager(),
-            &mut job.barrier_control,
             &job.node_actors,
             &job.state_table_ids,
             false,
@@ -460,8 +457,6 @@ impl CreatingStreamingJobControl {
             %job_id,
             "recovered creating snapshot backfill job"
         );
-        let barrier_control =
-            CreatingStreamingJobBarrierControl::new(job_id, Some(committed_epoch));
 
         let node_actors = InflightFragmentInfo::actor_ids_to_collect(fragment_infos.values());
         let state_table_ids: HashSet<_> =
@@ -554,7 +549,7 @@ impl CreatingStreamingJobControl {
             snapshot_epoch,
             node_actors,
             state_table_ids,
-            barrier_control,
+            max_committed_epoch: Some(committed_epoch),
             status,
             upstream_lag: GLOBAL_META_METRICS
                 .snapshot_backfill_lag
@@ -593,11 +588,12 @@ impl CreatingStreamingJobControl {
                     log_store_progress_tracker.gen_backfill_progress()
                 )
             }
-            CreatingStreamingJobStatus::Finishing(..) => {
-                format!(
-                    "Finishing [epoch count: {}]",
-                    self.barrier_control.inflight_barrier_count()
-                )
+            CreatingStreamingJobStatus::Finishing(finish_epoch, ..) => {
+                let committed_epoch = self.max_committed_epoch.expect("should have committed");
+                let lag = Duration::from_millis(
+                    Epoch(*finish_epoch).physical_time() - Epoch(committed_epoch).physical_time(),
+                );
+                format!("Finishing [epoch lag: {lag:?}]",)
             }
             CreatingStreamingJobStatus::Resetting(_) => "Resetting".to_owned(),
             CreatingStreamingJobStatus::PlaceHolder => {
@@ -612,19 +608,14 @@ impl CreatingStreamingJobControl {
 
     pub(super) fn pinned_upstream_log_epoch(&self) -> (u64, HashSet<TableId>) {
         (
-            max(
-                self.barrier_control.max_committed_epoch().unwrap_or(0),
-                self.snapshot_epoch,
-            ),
+            max(self.max_committed_epoch.unwrap_or(0), self.snapshot_epoch),
             self.snapshot_backfill_upstream_tables.clone(),
         )
     }
 
-    #[expect(clippy::too_many_arguments)]
     fn inject_barrier(
         partial_graph_id: PartialGraphId,
         partial_graph_manager: &mut PartialGraphManager,
-        barrier_control: &mut CreatingStreamingJobBarrierControl,
         node_actors: &HashMap<WorkerId, HashSet<ActorId>>,
         state_table_ids: &HashSet<TableId>,
         is_finishing: bool,
@@ -639,7 +630,6 @@ impl CreatingStreamingJobControl {
         } else {
             (None, None)
         };
-        let prev_epoch = barrier_info.prev_epoch();
         partial_graph_manager.inject_barrier(
             partial_graph_id,
             mutation,
@@ -657,7 +647,6 @@ impl CreatingStreamingJobControl {
                 state_table_ids.clone(),
             ),
         )?;
-        barrier_control.enqueue_epoch(prev_epoch);
         Ok(())
     }
 
@@ -675,7 +664,6 @@ impl CreatingStreamingJobControl {
         Self::inject_barrier(
             self.partial_graph_id,
             partial_graph_manager,
-            &mut self.barrier_control,
             &self.node_actors,
             &self.state_table_ids,
             true,
@@ -702,12 +690,11 @@ impl CreatingStreamingJobControl {
         barrier_info: &BarrierInfo,
         mutation: Option<(Mutation, Vec<Notifier>)>,
     ) -> MetaResult<()> {
-        let progress_epoch =
-            if let Some(max_committed_epoch) = self.barrier_control.max_committed_epoch() {
-                max(max_committed_epoch, self.snapshot_epoch)
-            } else {
-                self.snapshot_epoch
-            };
+        let progress_epoch = if let Some(max_committed_epoch) = self.max_committed_epoch {
+            max(max_committed_epoch, self.snapshot_epoch)
+        } else {
+            self.snapshot_epoch
+        };
         self.upstream_lag.set(
             barrier_info
                 .prev_epoch
@@ -727,7 +714,6 @@ impl CreatingStreamingJobControl {
                 Self::inject_barrier(
                     self.partial_graph_id,
                     partial_graph_manager,
-                    &mut self.barrier_control,
                     &self.node_actors,
                     &self.state_table_ids,
                     false,
@@ -751,7 +737,6 @@ impl CreatingStreamingJobControl {
                 .values()
                 .flat_map(|resp| &resp.create_mview_progress),
         );
-        self.barrier_control.collect(collected_barrier);
         self.should_merge_to_upstream()
     }
 
@@ -779,7 +764,7 @@ impl CreatingStreamingJobControl {
         upstream_committed_epoch: u64,
     ) -> Option<(
         u64,
-        Vec<BarrierCompleteResponse>,
+        HashMap<WorkerId, BarrierCompleteResponse>,
         PartialGraphBarrierInfo,
         bool,
     )> {
@@ -814,16 +799,22 @@ impl CreatingStreamingJobControl {
                 unreachable!()
             }
         };
-        self.barrier_control
-            .start_completing(epoch_end_bound, |epoch| {
-                partial_graph_manager.take_collected_barrier(self.partial_graph_id, epoch)
-            })
+        partial_graph_manager
+            .start_completing(
+                self.partial_graph_id,
+                epoch_end_bound,
+                |non_checkpoint_epoch, _, _| {
+                    if let Some(finish_at_epoch) = finished_at_epoch {
+                        assert!(non_checkpoint_epoch.prev < finish_at_epoch);
+                    }
+                },
+            )
             .map(|(epoch, resps, info)| {
                 let is_finish_epoch = if let Some(finish_at_epoch) = finished_at_epoch {
                     assert!(!info.post_collect_command.should_checkpoint());
                     if epoch == finish_at_epoch {
-                        self.barrier_control.ack_completed(epoch);
-                        assert!(self.barrier_control.is_empty());
+                        // TODO: can early remove partial graph here
+                        self.ack_completed(partial_graph_manager, epoch);
                         true
                     } else {
                         false
@@ -835,8 +826,30 @@ impl CreatingStreamingJobControl {
             })
     }
 
-    pub(super) fn ack_completed(&mut self, completed_epoch: u64) {
-        self.barrier_control.ack_completed(completed_epoch);
+    pub(super) fn ack_completed(
+        &mut self,
+        partial_graph_manager: &mut PartialGraphManager,
+        completed_epoch: u64,
+    ) {
+        match &self.status {
+            CreatingStreamingJobStatus::ConsumingSnapshot { .. }
+            | CreatingStreamingJobStatus::ConsumingLogStore { .. }
+            | CreatingStreamingJobStatus::Finishing(_, _) => {
+                partial_graph_manager.ack_completed(self.partial_graph_id, completed_epoch);
+                if let Some(prev_max_committed_epoch) =
+                    self.max_committed_epoch.replace(completed_epoch)
+                {
+                    assert!(completed_epoch > prev_max_committed_epoch);
+                }
+            }
+            CreatingStreamingJobStatus::Resetting(_) => {
+                // The job was dropped while the completing task was running in the background.
+                // The partial graph has already been reset, so skip the ack.
+            }
+            CreatingStreamingJobStatus::PlaceHolder => {
+                unreachable!()
+            }
+        }
     }
 
     pub fn fragment_infos_with_job_id(
@@ -892,7 +905,6 @@ impl CreatingStreamingJobControl {
     }
 
     pub fn into_tracking_job(self) -> TrackingJob {
-        assert!(self.barrier_control.is_empty());
         match self.status {
             CreatingStreamingJobStatus::ConsumingSnapshot { .. }
             | CreatingStreamingJobStatus::ConsumingLogStore { .. }

--- a/src/meta/src/barrier/checkpoint/recovery.rs
+++ b/src/meta/src/barrier/checkpoint/recovery.rs
@@ -252,7 +252,7 @@ impl DatabaseStatusAction<'_, EnterReset> {
     ) {
         let event_log_manager_ref = self.control.env.event_log_manager_ref();
         if let Some(output) = barrier_complete_output {
-            self.control.ack_completed(output);
+            self.control.ack_completed(partial_graph_manager, output);
         }
         let database_status = self
             .control

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -601,7 +601,7 @@ impl InflightDatabaseInfo {
     pub(super) fn apply_collected_command(
         &mut self,
         command: &PostCollectCommand,
-        resps: &[BarrierCompleteResponse],
+        resps: &HashMap<WorkerId, BarrierCompleteResponse>,
         version_stats: &HummockVersionStats,
     ) {
         if let PostCollectCommand::CreateStreamingJob { info, job_type, .. } = command {
@@ -653,7 +653,7 @@ impl InflightDatabaseInfo {
                 }
             }
         }
-        for progress in resps.iter().flat_map(|resp| &resp.create_mview_progress) {
+        for progress in resps.values().flat_map(|resp| &resp.create_mview_progress) {
             let Some(job_id) = self.fragment_location.get(&progress.fragment_id) else {
                 warn!(
                     "update the progress of an non-existent creating streaming job: {progress:?}, which could be cancelled"
@@ -675,7 +675,7 @@ impl InflightDatabaseInfo {
             tracker.apply_progress(progress, version_stats);
         }
         for progress in resps
-            .iter()
+            .values()
             .flat_map(|resp| &resp.cdc_table_backfill_progress)
         {
             let Some(job_id) = self.fragment_location.get(&progress.fragment_id) else {
@@ -697,7 +697,7 @@ impl InflightDatabaseInfo {
         }
         // Handle CDC source offset updated events
         for cdc_offset_updated in resps
-            .iter()
+            .values()
             .flat_map(|resp| &resp.cdc_source_offset_updated)
         {
             use risingwave_common::id::SourceId;

--- a/src/meta/src/barrier/partial_graph.rs
+++ b/src/meta/src/barrier/partial_graph.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::Bound::Unbounded;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::mem::take;
+use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -82,6 +84,7 @@ pub(super) trait PartialGraphStat: Send + Sync + 'static {
 struct PartialGraphRunningState {
     barrier_item_collector:
         BarrierItemCollector<WorkerId, BarrierCompleteResponse, PartialGraphBarrierInfo>,
+    completing_epoch: Option<u64>,
     #[educe(Debug(ignore))]
     stat: Box<dyn PartialGraphStat>,
 }
@@ -90,12 +93,13 @@ impl PartialGraphRunningState {
     fn new(stat: Box<dyn PartialGraphStat>) -> Self {
         Self {
             barrier_item_collector: BarrierItemCollector::new(),
+            completing_epoch: None,
             stat,
         }
     }
 
     fn is_empty(&self) -> bool {
-        self.barrier_item_collector.is_empty()
+        self.barrier_item_collector.is_empty() && self.completing_epoch.is_none()
     }
 
     fn enqueue(&mut self, node_to_collect: NodeToCollect, mut info: PartialGraphBarrierInfo) {
@@ -514,20 +518,65 @@ impl PartialGraphManager {
         graph
     }
 
-    pub(super) fn take_collected_barrier(
+    pub(super) fn inflight_barrier_num(&self, partial_graph_id: PartialGraphId) -> usize {
+        self.running_graph(partial_graph_id)
+            .barrier_item_collector
+            .inflight_barrier_num()
+    }
+
+    pub(super) fn first_inflight_barrier(
+        &self,
+        partial_graph_id: PartialGraphId,
+    ) -> Option<EpochPair> {
+        self.running_graph(partial_graph_id)
+            .barrier_item_collector
+            .first_inflight_epoch()
+    }
+
+    pub(super) fn start_completing(
         &mut self,
         partial_graph_id: PartialGraphId,
-        epoch: u64,
-    ) -> (Vec<BarrierCompleteResponse>, PartialGraphBarrierInfo) {
+        epoch_end_bound: Bound<u64>,
+        mut on_non_checkpoint_epoch: impl FnMut(
+            EpochPair,
+            HashMap<WorkerId, BarrierCompleteResponse>,
+            PostCollectCommand,
+        ),
+    ) -> Option<(
+        u64,
+        HashMap<WorkerId, BarrierCompleteResponse>,
+        PartialGraphBarrierInfo,
+    )> {
         let graph = self.running_graph_mut(partial_graph_id);
-        let (_, resps, info) = graph
+        assert!(graph.completing_epoch.is_none());
+        let epoch_range: (Bound<u64>, Bound<u64>) = (Unbounded, epoch_end_bound);
+        while let Some((epoch, resps, info)) = graph
             .barrier_item_collector
-            .take_collected_if(|barrier_epoch| {
-                assert_eq!(barrier_epoch.prev, epoch);
-                true
-            })
-            .expect("true cond");
-        (resps.into_values().collect(), info)
+            .take_collected_if(|epoch| epoch_range.contains(&epoch.prev))
+        {
+            if info.post_collect_command.should_checkpoint() {
+                assert!(info.barrier_info.kind.is_checkpoint());
+            } else if !info.barrier_info.kind.is_checkpoint() {
+                info.notifiers
+                    .into_iter()
+                    .for_each(Notifier::notify_collected);
+                on_non_checkpoint_epoch(epoch, resps, info.post_collect_command);
+                continue;
+            }
+            let prev_epoch = info.barrier_info.prev_epoch();
+            graph.completing_epoch = Some(prev_epoch);
+            return Some((prev_epoch, resps, info));
+        }
+        None
+    }
+
+    pub(super) fn ack_completed(&mut self, partial_graph_id: PartialGraphId, prev_epoch: u64) {
+        assert_eq!(
+            self.running_graph_mut(partial_graph_id)
+                .completing_epoch
+                .take(),
+            Some(prev_epoch)
+        );
     }
 
     pub(super) fn has_pending_checkpoint_barrier(&self, partial_graph_id: PartialGraphId) -> bool {

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -558,7 +558,7 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                 ) => {
                     match complete_result {
                         Ok(output) => {
-                            self.checkpoint_control.ack_completed(output);
+                            self.checkpoint_control.ack_completed(&mut self.partial_graph_manager, output);
                         }
                         Err(e) => {
                             self.failure_recovery(e).await;
@@ -807,11 +807,13 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                         );
                     }
                     Ok(Ok(hummock_version_stats)) => {
-                        self.checkpoint_control
-                            .ack_completed(BarrierCompleteOutput {
+                        self.checkpoint_control.ack_completed(
+                            &mut self.partial_graph_manager,
+                            BarrierCompleteOutput {
                                 epochs_to_ack,
                                 hummock_version_stats,
-                            });
+                            },
+                        );
                     }
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR refactors meta barrier completion handling so that partial-graph barrier lifecycle management is owned by `PartialGraphManager` instead of being split across multiple ad hoc queues in checkpoint control and creating-job control.

Concretely:

- Introduce a reusable `BarrierItemCollector` utility in `src/meta/src/barrier/utils.rs` to manage ordered inflight/collected barrier items.
- Migrate partial-graph barrier tracking to the shared collector, including inflight counting, collected ordering, notifier cleanup, and completion state.
- Move checkpoint barrier completion sequencing into `PartialGraphManager` with explicit `start_completing` / `ack_completed` flow.
- Remove the dedicated creating-job barrier control queue and reuse the same partial-graph completion flow for creating streaming jobs.
- Update checkpoint control and recovery paths to acknowledge completed barriers through `PartialGraphManager`.
- Adjust barrier progress application code to consume worker responses from maps directly, matching the new collector-based flow.

The intention is to unify the barrier completion model for normal databases and creating jobs, reduce duplicated state machines, and make the ordering/ownership of barrier completion easier to reason about.

Behavior is intended to stay unchanged. This is a refactor of internal meta barrier management logic to centralize bookkeeping and reduce the risk of state divergence between different barrier control paths.

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
