### PR TITLE
feat(sink): support exactly-once Delta Lake sink

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -226,3 +226,5 @@ labels:
 - label: "ci/run-e2e-deltalake-sink-rust-tests"
   files:
   - "src\\/connector\\/src\\/sink\\/deltalake\\.rs"
+  - "ci\\/scripts\\/e2e-deltalake-sink-rust-test\\.sh"
+  - "e2e_test\\/sink\\/deltalake_rust_sink\\.slt"

--- a/ci/scripts/e2e-deltalake-sink-rust-test.sh
+++ b/ci/scripts/e2e-deltalake-sink-rust-test.sh
@@ -36,7 +36,14 @@ spark-3.3.1-bin-hadoop3/bin/spark-sql --packages $DEPENDENCIES \
     --conf 'spark.hadoop.fs.s3a.secret.key=hummockadmin' \
     --conf 'spark.hadoop.fs.s3a.endpoint=http://127.0.0.1:9301' \
     --conf 'spark.hadoop.fs.s3a.path.style.access=true' \
-    --S --e 'create table delta.`s3a://deltalake/deltalake-test`(v1 int, v2 short, v3 long, v4 float, v5 double, v6 string, v7 date, v8 Timestamp, v9 boolean, v10 decimal, v11 ARRAY<decimal>) using delta;'
+    --S --e '
+        create table delta.`s3a://deltalake/deltalake-test`(
+            v1 int, v2 short, v3 long, v4 float, v5 double, v6 string, v7 date, v8 Timestamp, v9 boolean, v10 decimal, v11 ARRAY<decimal>
+        ) using delta;
+        create table delta.`s3a://deltalake/deltalake-test-exactly-once`(
+            v1 int, v2 short, v3 long, v4 float, v5 double, v6 string, v7 date, v8 Timestamp, v9 boolean, v10 decimal, v11 ARRAY<decimal>
+        ) using delta;
+    '
 
 
 echo "--- testing sinks"
@@ -44,24 +51,32 @@ sqllogictest -p 4566 -d dev './e2e_test/sink/deltalake_rust_sink.slt'
 sleep 1
 
 
-spark-3.3.1-bin-hadoop3/bin/spark-sql --packages $DEPENDENCIES \
-    --conf 'spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension' \
-    --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog' \
-    --conf 'spark.hadoop.fs.s3a.access.key=hummockadmin' \
-    --conf 'spark.hadoop.fs.s3a.secret.key=hummockadmin' \
-    --conf 'spark.hadoop.fs.s3a.endpoint=http://localhost:9301' \
-    --conf 'spark.hadoop.fs.s3a.path.style.access=true' \
-    --S --e 'INSERT OVERWRITE DIRECTORY "./spark-output" USING CSV SELECT v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,CAST(v11 as varchar(12)) FROM delta.`s3a://deltalake/deltalake-test`;'
+check_delta_table() {
+    local table_path="$1"
+    local output_dir="$2"
 
-# check sink destination using shell
-if cat ./spark-output/*.csv | sort | awk -F "," '{
-    exit !($1 == 1 && $2 == 1 && $3 == 1 && $4 == 1.1 && $5 == 1.2 && $6 == "test" && $7 == "2013-01-01" && $8 == "2013-01-01T01:01:01.000Z" && $9 == "false" && $10 == 1 && $11 == "[1]"); }'; then
-  echo "DeltaLake sink check passed"
-else
-  cat ./spark-output/*.csv
-  echo "The output is not as expected."
-  exit 1
-fi
+    rm -rf "$output_dir"
+    spark-3.3.1-bin-hadoop3/bin/spark-sql --packages $DEPENDENCIES \
+        --conf 'spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension' \
+        --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog' \
+        --conf 'spark.hadoop.fs.s3a.access.key=hummockadmin' \
+        --conf 'spark.hadoop.fs.s3a.secret.key=hummockadmin' \
+        --conf 'spark.hadoop.fs.s3a.endpoint=http://localhost:9301' \
+        --conf 'spark.hadoop.fs.s3a.path.style.access=true' \
+        --S --e "INSERT OVERWRITE DIRECTORY \"$output_dir\" USING CSV SELECT v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,CAST(v11 as varchar(12)) FROM delta.\`$table_path\`;"
+
+    if cat "$output_dir"/*.csv | sort | awk -F "," '{
+        exit !($1 == 1 && $2 == 1 && $3 == 1 && $4 == 1.1 && $5 == 1.2 && $6 == "test" && $7 == "2013-01-01" && $8 == "2013-01-01T01:01:01.000Z" && $9 == "false" && $10 == 1 && $11 == "[1]"); }'; then
+      echo "DeltaLake sink check passed for $table_path"
+    else
+      cat "$output_dir"/*.csv
+      echo "The output is not as expected for $table_path."
+      exit 1
+    fi
+}
+
+check_delta_table 's3a://deltalake/deltalake-test' './spark-output'
+check_delta_table 's3a://deltalake/deltalake-test-exactly-once' './spark-output-exactly-once'
 
 echo "--- Kill cluster"
 risedev ci-kill

--- a/e2e_test/sink/deltalake_rust_sink.slt
+++ b/e2e_test/sink/deltalake_rust_sink.slt
@@ -16,6 +16,7 @@ statement ok
 create sink s6 as select * from mv6
 with (
     connector = 'deltalake',
+    is_exactly_once = 'true',
     type = 'append-only',
     force_append_only = 'true',
     location = 's3a://deltalake/deltalake-test',

--- a/e2e_test/sink/deltalake_rust_sink.slt
+++ b/e2e_test/sink/deltalake_rust_sink.slt
@@ -16,7 +16,6 @@ statement ok
 create sink s6 as select * from mv6
 with (
     connector = 'deltalake',
-    is_exactly_once = 'true',
     type = 'append-only',
     force_append_only = 'true',
     location = 's3a://deltalake/deltalake-test',
@@ -26,13 +25,29 @@ with (
 );
 
 statement ok
-INSERT INTO t6 VALUES (1, 1, 1, 1.1, 1.2, 'test', '2013-01-01', '2013-01-01 01:01:01+00:00' , false, 1, array[1]::decimal[]);
+create sink s7 as select * from mv6
+with (
+    connector = 'deltalake',
+    is_exactly_once = 'true',
+    type = 'append-only',
+    force_append_only = 'true',
+    location = 's3a://deltalake/deltalake-test-exactly-once',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = secret deltalake_s3_secret_key,
+    s3.endpoint = 'http://127.0.0.1:9301'
+);
+
+statement ok
+INSERT INTO t6 VALUES (1, 1, 1, 1.1, 1.2, 'test', '2013-01-01', '2013-01-01 01:01:01+00:00', false, 1, array[1]::decimal[]);
 
 statement ok
 FLUSH;
 
 statement ok
 DROP SINK s6;
+
+statement ok
+DROP SINK s7;
 
 statement ok
 DROP SECRET deltalake_s3_secret_key;

--- a/src/connector/src/sink/deltalake.rs
+++ b/src/connector/src/sink/deltalake.rs
@@ -23,8 +23,8 @@ use deltalake::aws::storage::s3_constants::{
     AWS_ACCESS_KEY_ID, AWS_ALLOW_HTTP, AWS_ENDPOINT_URL, AWS_REGION, AWS_S3_ALLOW_UNSAFE_RENAME,
     AWS_SECRET_ACCESS_KEY,
 };
-use deltalake::kernel::transaction::CommitBuilder;
-use deltalake::kernel::{Action, Add, DataType as DeltaLakeDataType, PrimitiveType};
+use deltalake::kernel::transaction::{CommitBuilder, CommitProperties};
+use deltalake::kernel::{Action, Add, DataType as DeltaLakeDataType, PrimitiveType, Transaction};
 use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::writer::{DeltaWriter, RecordBatchWriter};
 use phf::{Set, phf_set};
@@ -51,7 +51,7 @@ use crate::sink::writer::SinkWriter;
 use crate::sink::{
     Result, SINK_TYPE_APPEND_ONLY, SINK_USER_FORCE_APPEND_ONLY_OPTION,
     SinglePhaseCommitCoordinator, Sink, SinkCommitCoordinator, SinkError, SinkParam,
-    SinkWriterParam,
+    SinkWriterParam, TwoPhaseCommitCoordinator,
 };
 
 pub const DEFAULT_REGION: &str = "us-east-1";
@@ -197,6 +197,10 @@ pub struct DeltaLakeConfig {
     pub common: DeltaLakeCommon,
 
     pub r#type: String,
+
+    /// Whether to use the Delta transaction log to deduplicate replayed epoch commits.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub is_exactly_once: Option<bool>,
 }
 
 impl EnforceSecret for DeltaLakeConfig {
@@ -425,8 +429,14 @@ impl Sink for DeltaLakeSink {
     ) -> Result<SinkCommitCoordinator> {
         let coordinator = DeltaLakeSinkCommitter {
             table: self.config.common.create_deltalake_client().await?,
+            app_id: format!("risingwave-deltalake-{}", self.param.sink_id),
+            exactly_once: self.config.is_exactly_once.unwrap_or_default(),
         };
-        Ok(SinkCommitCoordinator::SinglePhase(Box::new(coordinator)))
+        if coordinator.exactly_once {
+            Ok(SinkCommitCoordinator::TwoPhase(Box::new(coordinator)))
+        } else {
+            Ok(SinkCommitCoordinator::SinglePhase(Box::new(coordinator)))
+        }
     }
 }
 
@@ -511,31 +521,48 @@ impl SinkWriter for DeltaLakeSinkWriter {
 
 pub struct DeltaLakeSinkCommitter {
     table: DeltaTable,
+    app_id: String,
+    exactly_once: bool,
 }
 
-#[async_trait::async_trait]
-impl SinglePhaseCommitCoordinator for DeltaLakeSinkCommitter {
-    async fn init(&mut self) -> Result<()> {
-        tracing::info!("DeltaLake commit coordinator inited.");
-        Ok(())
-    }
-
-    async fn commit_data(&mut self, epoch: u64, metadata: Vec<SinkMetadata>) -> Result<()> {
-        tracing::debug!("Starting DeltaLake commit in epoch {epoch}.");
-
-        let deltalake_write_result = metadata
+impl DeltaLakeSinkCommitter {
+    fn collect_write_adds(metadata: &[SinkMetadata]) -> Result<Vec<Add>> {
+        Ok(metadata
             .iter()
             .map(DeltaLakeWriteResult::try_from)
-            .collect::<Result<Vec<DeltaLakeWriteResult>>>()?;
-        let write_adds: Vec<Action> = deltalake_write_result
+            .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flat_map(|v| v.adds.into_iter())
-            .map(Action::Add)
-            .collect();
+            .collect())
+    }
 
-        if write_adds.is_empty() {
+    fn delta_txn_version(epoch: u64) -> Result<i64> {
+        Ok(i64::try_from(epoch).context("delta lake epoch exceeds i64 range")?)
+    }
+
+    async fn commit_actions(
+        &mut self,
+        epoch: u64,
+        adds: Vec<Add>,
+        txn_identity: Option<&DeltaLakeTxnIdentity>,
+    ) -> Result<()> {
+        if adds.is_empty() {
             return Ok(());
         }
+
+        if let Some(txn_identity) = txn_identity
+            && self.is_txn_committed(txn_identity).await?
+        {
+            tracing::info!(
+                "DeltaLake epoch {epoch} already committed for app id {}, txn version {}, skip committing again.",
+                txn_identity.app_id,
+                txn_identity.version
+            );
+            return Ok(());
+        }
+
+        let write_adds = adds.into_iter().map(Action::Add).collect();
+
         let partition_cols = self
             .table
             .snapshot()?
@@ -552,7 +579,18 @@ impl SinglePhaseCommitCoordinator for DeltaLakeSinkCommitter {
             partition_by,
             predicate: None,
         };
-        let version = CommitBuilder::default()
+        let commit_builder = if let Some(txn_identity) = txn_identity {
+            let commit_builder: CommitBuilder = CommitProperties::default()
+                .with_application_transaction(Transaction::new(
+                    &txn_identity.app_id,
+                    txn_identity.version,
+                ))
+                .into();
+            commit_builder
+        } else {
+            CommitBuilder::default()
+        };
+        let version = commit_builder
             .with_actions(write_adds)
             .build(
                 Some(self.table.snapshot()?),
@@ -567,11 +605,110 @@ impl SinglePhaseCommitCoordinator for DeltaLakeSinkCommitter {
         );
         Ok(())
     }
+
+    async fn is_txn_committed(&mut self, txn_identity: &DeltaLakeTxnIdentity) -> Result<bool> {
+        self.table.update_state().await?;
+        let log_store = self.table.log_store();
+        let committed_version = self
+            .table
+            .snapshot()?
+            .transaction_version(log_store.as_ref(), &txn_identity.app_id)
+            .await?;
+        Ok(committed_version.is_some_and(|version| version >= txn_identity.version))
+    }
+}
+
+#[async_trait::async_trait]
+impl SinglePhaseCommitCoordinator for DeltaLakeSinkCommitter {
+    async fn init(&mut self) -> Result<()> {
+        tracing::info!("DeltaLake commit coordinator inited.");
+        Ok(())
+    }
+
+    async fn commit_data(&mut self, epoch: u64, metadata: Vec<SinkMetadata>) -> Result<()> {
+        tracing::debug!("Starting DeltaLake commit in epoch {epoch}.");
+
+        let adds = Self::collect_write_adds(&metadata)?;
+        self.commit_actions(epoch, adds, None).await
+    }
+}
+
+#[async_trait::async_trait]
+impl TwoPhaseCommitCoordinator for DeltaLakeSinkCommitter {
+    async fn init(&mut self) -> Result<()> {
+        tracing::info!("DeltaLake commit coordinator inited.");
+        Ok(())
+    }
+
+    async fn pre_commit(
+        &mut self,
+        epoch: u64,
+        metadata: Vec<SinkMetadata>,
+        _schema_change: Option<risingwave_pb::stream_plan::PbSinkSchemaChange>,
+    ) -> Result<Option<Vec<u8>>> {
+        tracing::debug!("Starting DeltaLake pre commit in epoch {epoch}.");
+
+        let adds = Self::collect_write_adds(&metadata)?;
+        if adds.is_empty() {
+            return Ok(None);
+        }
+
+        let txn_identity = DeltaLakeTxnIdentity {
+            app_id: self.app_id.clone(),
+            version: Self::delta_txn_version(epoch)?,
+        };
+        Ok(Some(
+            DeltaLakePreCommitMetadata { adds, txn_identity }.try_into_bytes()?,
+        ))
+    }
+
+    async fn commit_data(&mut self, epoch: u64, commit_metadata: Vec<u8>) -> Result<()> {
+        tracing::debug!("Starting DeltaLake exactly-once commit in epoch {epoch}.");
+
+        if commit_metadata.is_empty() {
+            return Ok(());
+        }
+
+        let pre_commit_metadata = DeltaLakePreCommitMetadata::try_from_bytes(&commit_metadata)?;
+        self.commit_actions(
+            epoch,
+            pre_commit_metadata.adds,
+            Some(&pre_commit_metadata.txn_identity),
+        )
+        .await
+    }
+
+    async fn abort(&mut self, epoch: u64, _commit_metadata: Vec<u8>) {
+        tracing::debug!("Abort not implemented yet for DeltaLake epoch {epoch}");
+    }
 }
 
 #[derive(Serialize, Deserialize)]
 struct DeltaLakeWriteResult {
     adds: Vec<Add>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DeltaLakePreCommitMetadata {
+    adds: Vec<Add>,
+    txn_identity: DeltaLakeTxnIdentity,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DeltaLakeTxnIdentity {
+    app_id: String,
+    version: i64,
+}
+
+impl DeltaLakePreCommitMetadata {
+    fn try_into_bytes(self) -> Result<Vec<u8>> {
+        Ok(serde_json::to_vec(&self).context("cannot serialize deltalake pre commit metadata")?)
+    }
+
+    fn try_from_bytes(value: &[u8]) -> Result<Self> {
+        Ok(serde_json::from_slice(value)
+            .context("cannot deserialize deltalake pre commit metadata")?)
+    }
 }
 
 impl<'a> TryFrom<&'a DeltaLakeWriteResult> for SinkMetadata {
@@ -614,8 +751,8 @@ mod tests {
     use risingwave_common::types::DataType;
 
     use super::{DeltaLakeConfig, DeltaLakeSinkCommitter, DeltaLakeSinkWriter};
-    use crate::sink::SinglePhaseCommitCoordinator;
     use crate::sink::writer::SinkWriter;
+    use crate::sink::{SinglePhaseCommitCoordinator, TwoPhaseCommitCoordinator};
 
     #[tokio::test]
     async fn test_deltalake() {
@@ -676,10 +813,114 @@ mod tests {
         deltalake_writer.write(chunk).await.unwrap();
         let mut committer = DeltaLakeSinkCommitter {
             table: deltalake_table,
+            app_id: "test-single-phase".to_owned(),
+            exactly_once: false,
         };
         let metadata = deltalake_writer.barrier(true).await.unwrap().unwrap();
-        committer.commit_data(1, vec![metadata]).await.unwrap();
+        SinglePhaseCommitCoordinator::commit_data(&mut committer, 1, vec![metadata])
+            .await
+            .unwrap();
         let snapshot = committer.table.snapshot().unwrap();
         assert_eq!(1, snapshot.log_data().num_files());
+    }
+
+    #[tokio::test]
+    async fn test_deltalake_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        CreateBuilder::new()
+            .with_location(path)
+            .with_column(
+                "id",
+                SchemaDataType::Primitive(deltalake::kernel::PrimitiveType::Integer),
+                false,
+                Default::default(),
+            )
+            .with_column(
+                "name",
+                SchemaDataType::Primitive(deltalake::kernel::PrimitiveType::String),
+                false,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        let properties = btreemap! {
+            "connector".to_owned() => "deltalake".to_owned(),
+            "force_append_only".to_owned() => "true".to_owned(),
+            "type".to_owned() => "append-only".to_owned(),
+            "location".to_owned() => format!("file://{}", path),
+            "is_exactly_once".to_owned() => "true".to_owned(),
+        };
+
+        let schema = Schema::new(vec![
+            Field {
+                data_type: DataType::Int32,
+                name: "id".into(),
+            },
+            Field {
+                data_type: DataType::Varchar,
+                name: "name".into(),
+            },
+        ]);
+
+        let deltalake_config = DeltaLakeConfig::from_btreemap(properties).unwrap();
+        let deltalake_table = deltalake_config
+            .common
+            .create_deltalake_client()
+            .await
+            .unwrap();
+
+        let mut deltalake_writer = DeltaLakeSinkWriter::new(deltalake_config, schema, vec![0])
+            .await
+            .unwrap();
+        let chunk = StreamChunk::new(
+            vec![Op::Insert, Op::Insert, Op::Insert],
+            vec![
+                I32Array::from_iter(vec![1, 2, 3]).into_ref(),
+                Utf8Array::from_iter(vec!["Alice", "Bob", "Clare"]).into_ref(),
+            ],
+        );
+        deltalake_writer.write(chunk).await.unwrap();
+
+        let mut committer = DeltaLakeSinkCommitter {
+            table: deltalake_table,
+            app_id: "test-exactly-once".to_owned(),
+            exactly_once: true,
+        };
+        let metadata = deltalake_writer.barrier(true).await.unwrap().unwrap();
+        let pre_commit_metadata =
+            TwoPhaseCommitCoordinator::pre_commit(&mut committer, 1, vec![metadata], None)
+                .await
+                .unwrap()
+                .unwrap();
+
+        TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, pre_commit_metadata.clone())
+            .await
+            .unwrap();
+        assert_eq!(committer.table.version(), Some(1));
+        assert_eq!(
+            committer.table.snapshot().unwrap().log_data().num_files(),
+            1
+        );
+
+        let log_store = committer.table.log_store();
+        let txn_version = committer
+            .table
+            .snapshot()
+            .unwrap()
+            .transaction_version(log_store.as_ref(), &committer.app_id)
+            .await
+            .unwrap();
+        assert_eq!(txn_version, Some(1));
+
+        TwoPhaseCommitCoordinator::commit_data(&mut committer, 1, pre_commit_metadata)
+            .await
+            .unwrap();
+        assert_eq!(committer.table.version(), Some(1));
+        assert_eq!(
+            committer.table.snapshot().unwrap().log_data().num_files(),
+            1
+        );
     }
 }

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -206,13 +206,13 @@ DeltaLakeConfig:
     required: false
     default: DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
     allow_alter_on_fly: true
-  - name: is_exactly_once
-    field_type: bool
-    comments: Whether to enable exactly-once commit deduplication, the default is false.
-    required: false
   - name: r#type
     field_type: String
     required: true
+  - name: is_exactly_once
+    field_type: bool
+    comments: Whether to use the Delta transaction log to deduplicate replayed epoch commits.
+    required: false
 DorisConfig:
   fields:
   - name: doris.url

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -206,6 +206,10 @@ DeltaLakeConfig:
     required: false
     default: DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
     allow_alter_on_fly: true
+  - name: is_exactly_once
+    field_type: bool
+    comments: Whether to enable exactly-once commit deduplication, the default is false.
+    required: false
   - name: r#type
     field_type: String
     required: true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Add `is_exactly_once` support for Delta Lake sinks and switch the sink coordinator to the existing two-phase commit path when the option is enabled.
- Persist Delta transaction identity in pre-commit metadata so replayed `commit_data` calls can detect an already committed epoch from the Delta log and skip duplicate appends.
- Add Delta sink unit coverage for the exactly-once replay path and keep the existing Delta sink tests green.

- No related issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Delta Lake sinks can now opt into exactly-once coordination so replayed checkpoint commits do not append duplicate files.

</details>
