### PR TITLE
chore(release): bump version to v2.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "delta_btree_map"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "educe",
  "enum-as-inner",
@@ -8636,7 +8636,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openai_embedding_service"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "async-openai",
  "axum 0.7.4",
@@ -9341,7 +9341,7 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "auto_enums",
@@ -10952,7 +10952,7 @@ dependencies = [
 
 [[package]]
 name = "risedev"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10984,7 +10984,7 @@ dependencies = [
 
 [[package]]
 name = "risedev-config"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -10997,7 +10997,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave-fields-derive"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "expect-test",
  "indoc",
@@ -11009,7 +11009,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_backup"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11030,7 +11030,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11075,7 +11075,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch_executors"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11119,7 +11119,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_bench"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11140,7 +11140,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "clap",
  "madsim-tokio",
@@ -11160,7 +11160,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd_all"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "clap",
  "console",
@@ -11193,7 +11193,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -11315,7 +11315,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_estimate_size"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "bytes",
  "educe",
@@ -11329,7 +11329,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_heap_profiling"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -11348,7 +11348,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_log"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "governor",
  "madsim-tokio",
@@ -11358,7 +11358,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_metrics"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "auto_impl",
  "bytes",
@@ -11394,7 +11394,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_proc_macro"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "bae",
  "itertools 0.14.0",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_rate_limit"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "arc-swap",
  "madsim-tokio",
@@ -11420,7 +11420,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_secret"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -11444,7 +11444,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_service"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "async-trait",
  "axum 0.7.4",
@@ -11468,7 +11468,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compaction_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11489,7 +11489,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compactor"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -11513,7 +11513,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compute"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11559,7 +11559,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "adbc_core",
  "adbc_snowflake",
@@ -11699,7 +11699,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector_codec"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "apache-avro 0.16.0",
@@ -11734,7 +11734,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_ctl"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11774,7 +11774,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_dml"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "assert_matches",
  "futures",
@@ -11792,7 +11792,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_e2e_extended_mode_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11807,7 +11807,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_error"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -11823,7 +11823,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11861,7 +11861,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr_impl"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11929,7 +11929,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12027,7 +12027,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend_macro"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12036,7 +12036,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_sdk"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "bytes",
  "hex",
@@ -12052,7 +12052,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12084,7 +12084,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_trace"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -12156,7 +12156,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_license"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "auto_enums",
  "expect-test",
@@ -12175,7 +12175,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mem_table_spill_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "madsim-tokio",
  "risingwave_common",
@@ -12186,7 +12186,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12263,7 +12263,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_dashboard"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
@@ -12284,7 +12284,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "prost 0.13.4",
  "risingwave_common",
@@ -12296,7 +12296,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model_migration"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "easy-ext",
  "madsim-tokio",
@@ -12309,7 +12309,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_node"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "clap",
  "educe",
@@ -12336,7 +12336,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_service"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12365,7 +12365,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mysql_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "futures",
  "madsim-tokio",
@@ -12374,7 +12374,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_object_store"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -12407,7 +12407,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_pb"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "enum-as-inner",
  "fs-err",
@@ -12433,7 +12433,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_planner_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -12455,7 +12455,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_regress_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -12469,7 +12469,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rpc_client"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12500,7 +12500,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rt"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "await-tree",
  "console",
@@ -12583,7 +12583,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlparser"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "console",
@@ -12604,7 +12604,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlsmith"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12635,7 +12635,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_state_cleaning_test"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -12654,7 +12654,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_storage"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -12725,7 +12725,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_stream"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12800,7 +12800,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_telemetry_event"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "jsonbb",
  "madsim-tokio",
@@ -12814,7 +12814,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_test_runner"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "fail",
  "sync-point",
@@ -12823,7 +12823,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_variables"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "chrono",
  "workspace-hack",
@@ -17463,7 +17463,7 @@ dependencies = [
 
 [[package]]
 name = "with_options"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -17483,7 +17483,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-config"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "aws-lc-rs",
  "libz-sys",
@@ -17497,7 +17497,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-hack"
-version = "2.8.0"
+version = "2.8.1"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.0"
+version = "2.8.1"
 edition = "2024"
 homepage = "https://github.com/risingwavelabs/risingwave"
 keywords = ["sql", "database", "streaming"]

--- a/docker/docker-compose-distributed.yml
+++ b/docker/docker-compose-distributed.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   compactor-0:
     <<: *image

--- a/docker/docker-compose-with-azblob.yml
+++ b/docker/docker-compose-with-azblob.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-gcs.yml
+++ b/docker/docker-compose-with-gcs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-lakekeeper.yml
+++ b/docker/docker-compose-with-lakekeeper.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 
 x-lakekeeper-image: &lakekeeper-image
   image: ${LAKEKEEPER__SERVER_IMAGE:-quay.io/lakekeeper/catalog:latest-main}

--- a/docker/docker-compose-with-local-fs.yml
+++ b/docker/docker-compose-with-local-fs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-obs.yml
+++ b/docker/docker-compose-with-obs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-oss.yml
+++ b/docker/docker-compose-with-oss.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-s3.yml
+++ b/docker/docker-compose-with-s3.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-sqlite.yml
+++ b/docker/docker-compose-with-sqlite.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.1}
 services:
   risingwave-standalone:
     <<: *image


### PR DESCRIPTION
This PR bumps the version from v2.8.0 to v2.8.1 for the release.

## Changes

- Update Cargo.toml version to 2.8.1
- Update Docker image tags to v2.8.1
- Run \ to update workspace dependencies

## Checklist

- [x] Version bumped in Cargo.toml
- [x] Docker image tags updated
- [x] Cargo.lock updated via cargo update

## Release Notes

See [CHANGELOG](https://github.com/risingwavelabs/risingwave/blob/release-2.8/CHANGELOG.md) for detailed changes in this release.

## Related

Release version: v2.8.1
Base branch: release-2.8