### PR TITLE
fix(frontend): apply session timezone rewrite to watermark expressions

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/watermark_ttl.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/watermark_ttl.yaml
@@ -48,6 +48,16 @@
   expected_outputs:
     - explain_output
 
+- id: watermark ttl timestamptz with day interval
+  sql: |
+    explain create table t (
+      id int primary key,
+      max_event_time timestamptz,
+      watermark for max_event_time as max_event_time - interval '7' day with ttl
+    );
+  expected_outputs:
+    - explain_output
+
 - id: watermark ttl scan keeps stream key columns
   sql: |
     create table t (

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -10,14 +10,14 @@
     StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck, watermark_columns: [v1] }
     └─StreamProject { exprs: [SubtractWithTimeZone(v1, '00:00:02':Interval, 'UTC':Varchar) as $expr1, _row_id], output_watermarks: [[$expr1]] }
       └─StreamRowIdGen { row_id_index: 1 }
-        └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: (v1 - '00:00:01':Interval) }], output_watermarks: [[v1]] }
+        └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: SubtractWithTimeZone(v1, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[v1]] }
           └─StreamSource { source: t, columns: [v1, _row_id] }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck, watermark_columns: [v1] }
     └── StreamProject { exprs: [SubtractWithTimeZone(v1, '00:00:02':Interval, 'UTC':Varchar) as $expr1, _row_id], output_watermarks: [[$expr1]] }
         └── StreamRowIdGen { row_id_index: 1 }
-            └── StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: (v1 - '00:00:01':Interval) }], output_watermarks: [[v1]] }
+            └── StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: SubtractWithTimeZone(v1, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[v1]] }
                 ├── tables: [ WatermarkFilter: 0 ]
                 └── StreamSource { source: t, columns: [v1, _row_id] } { tables: [ Source: 1 ] }
 
@@ -29,19 +29,9 @@
     ├── read pk prefix len hint: 1
     └── vnode column idx: 0
 
-    Table 1
-    ├── columns: [ partition_id, offset_info, _rw_timestamp ]
-    ├── primary key: [ $0 ASC ]
-    ├── value indices: [ 0, 1 ]
-    ├── distribution key: []
-    └── read pk prefix len hint: 1
+    Table 1 { columns: [ partition_id, offset_info, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
 
-    Table 4294967294
-    ├── columns: [ v1, _row_id, _rw_timestamp ]
-    ├── primary key: [ $1 ASC ]
-    ├── value indices: [ 0, 1 ]
-    ├── distribution key: [ 1 ]
-    └── read pk prefix len hint: 1
+    Table 4294967294 { columns: [ v1, _row_id, _rw_timestamp ], primary key: [ $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
 
 - name: watermark on append only table with source
   sql: |
@@ -49,7 +39,7 @@
   explain_output: |
     StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck, watermark_columns: [v1] }
     └─StreamRowIdGen { row_id_index: 1 }
-      └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: (v1 - '00:00:01':Interval) }], output_watermarks: [[v1]] }
+      └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: SubtractWithTimeZone(v1, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[v1]] }
         └─StreamUnion { all: true }
           ├─StreamExchange [no_shuffle] { dist: SomeShard }
           │ └─StreamSource { source: t, columns: [v1, _row_id] }
@@ -63,7 +53,7 @@
   explain_output: |
     StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck, watermark_columns: [v1] }
     └─StreamRowIdGen { row_id_index: 1 }
-      └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: (v1 - '00:00:01':Interval) }], output_watermarks: [[v1]] }
+      └─StreamWatermarkFilter { watermark_descs: [Desc { column: v1, expr: SubtractWithTimeZone(v1, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[v1]] }
         └─StreamUnion { all: true }
           ├─StreamExchange [no_shuffle] { dist: SomeShard }
           │ └─StreamDml { columns: [v1, _row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/watermark_ttl.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark_ttl.yaml
@@ -78,6 +78,21 @@
           │   └─StreamDml { columns: [id, _row_id] }
           │     └─StreamSource
           └─StreamUpstreamSinkUnion
+- id: watermark ttl timestamptz with day interval
+  sql: |
+    explain create table t (
+      id int primary key,
+      max_event_time timestamptz,
+      watermark for max_event_time as max_event_time - interval '7' day with ttl
+    );
+  explain_output: |
+    StreamMaterialize { columns: [id, max_event_time], stream_key: [id, max_event_time], pk_columns: [id], pk_conflict: Overwrite, watermark_columns: [max_event_time] }
+    └─StreamWatermarkFilter [upsert] { watermark_descs: [Desc { column: max_event_time, expr: SubtractWithTimeZone(max_event_time, '7 days':Interval, 'UTC':Varchar) }], output_watermarks: [[max_event_time]] }
+      └─StreamUnion { all: true }
+        ├─StreamExchange { dist: HashShard(id) }
+        │ └─StreamDml { columns: [id, max_event_time] }
+        │   └─StreamSource
+        └─StreamUpstreamSinkUnion
 - id: watermark ttl scan keeps stream key columns
   sql: |
     create table t (

--- a/src/frontend/planner_test/tests/testdata/output/window_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/window_join.yaml
@@ -16,11 +16,11 @@
       └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, conditions_to_clean_state_in_join_key: [(ts1 = ts2)], output_watermarks: [[ts1], [ts2]], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
         ├─StreamExchange { dist: HashShard(ts1, a1) }
         │ └─StreamRowIdGen { row_id_index: 3 }
-        │   └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts1, expr: (ts1 - '00:00:01':Interval) }], output_watermarks: [[ts1]] }
+        │   └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts1, expr: SubtractWithTimeZone(ts1, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[ts1]] }
         │     └─StreamSource { source: t1, columns: [ts1, a1, b1, _row_id] }
         └─StreamExchange { dist: HashShard(ts2, a2) }
           └─StreamRowIdGen { row_id_index: 3 }
-            └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts2, expr: (ts2 - '00:00:01':Interval) }], output_watermarks: [[ts2]] }
+            └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts2, expr: SubtractWithTimeZone(ts2, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[ts2]] }
               └─StreamSource { source: t2, columns: [ts2, a2, b2, _row_id] }
 - name: Window join expression reorder
   sql: |
@@ -39,9 +39,9 @@
       └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, conditions_to_clean_state_in_join_key: [(ts1 = ts2)], output_watermarks: [[ts1], [ts2]], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
         ├─StreamExchange { dist: HashShard(ts1, a1) }
         │ └─StreamRowIdGen { row_id_index: 3 }
-        │   └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts1, expr: (ts1 - '00:00:01':Interval) }], output_watermarks: [[ts1]] }
+        │   └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts1, expr: SubtractWithTimeZone(ts1, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[ts1]] }
         │     └─StreamSource { source: t1, columns: [ts1, a1, b1, _row_id] }
         └─StreamExchange { dist: HashShard(ts2, a2) }
           └─StreamRowIdGen { row_id_index: 3 }
-            └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts2, expr: (ts2 - '00:00:01':Interval) }], output_watermarks: [[ts2]] }
+            └─StreamWatermarkFilter { watermark_descs: [Desc { column: ts2, expr: SubtractWithTimeZone(ts2, '00:00:01':Interval, 'UTC':Varchar) }], output_watermarks: [[ts2]] }
               └─StreamSource { source: t2, columns: [ts2, a2, b2, _row_id] }

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -90,7 +90,7 @@ use crate::catalog::CatalogError;
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::error::ErrorCode::{self, Deprecated, InvalidInputSyntax, NotSupported, ProtocolError};
 use crate::error::{Result, RwError};
-use crate::expr::Expr;
+use crate::expr::{Expr, ExprRewriter, SessionTimezone};
 use crate::handler::HandlerArgs;
 use crate::handler::create_table::{
     ColumnIdGenerator, bind_pk_and_row_id_on_relation, bind_sql_column_constraints,
@@ -683,6 +683,8 @@ pub(super) fn bind_source_watermark(
     let mut binder = Binder::new_for_ddl(session);
     binder.bind_columns_to_context(name.clone(), column_catalogs)?;
 
+    let mut session_tz = SessionTimezone::new(session.config().timezone());
+
     let watermark_descs = source_watermarks
         .into_iter()
         .map(|source_watermark| {
@@ -690,6 +692,10 @@ pub(super) fn bind_source_watermark(
             let watermark_idx = binder.get_column_binding_index(name.clone(), &col_name)?;
 
             let expr = binder.bind_expr(&source_watermark.expr)?;
+            // Apply session timezone rewrite so that timestamptz +/- interval operations
+            // are transformed into the timezone-aware variant (e.g. `subtract_with_time_zone`).
+            // Without this, intervals containing days/months would fail at runtime.
+            let expr = session_tz.rewrite_expr(expr);
             let watermark_col_type = column_catalogs[watermark_idx].data_type();
             let watermark_expr_type = &expr.return_type();
             if watermark_col_type != watermark_expr_type {


### PR DESCRIPTION
## Summary

**Problem:** `WATERMARK FOR col AS col - INTERVAL '7' DAY WITH TTL` on a `timestamptz` column fails at runtime with:
```
Unsupported function: timestamp with time zone +/- interval of days
```

**Root cause:** `bind_source_watermark` in `create_source.rs` serializes watermark expressions directly to proto without applying the `SessionTimezone` rewrite. This means `timestamptz - interval` stays as the legacy `subtract(timestamptz, interval)` function, which cannot handle day/month intervals because it lacks timezone context.

**Fix:** Apply `SessionTimezone::rewrite_expr` to the bound watermark expression before serialization. This transforms `subtract(timestamptz, interval)` into `subtract_with_time_zone(timestamptz, interval, <session_tz>)`, which correctly handles all interval components by converting through local time.

## Changes

- `src/frontend/src/handler/create_source.rs`: Apply session timezone rewrite to watermark expressions
- Added planner test for `timestamptz` watermark with day interval (`watermark_ttl.yaml`)
- Updated existing planner test outputs (`watermark.yaml`, `window_join.yaml`) where existing timestamptz watermarks now correctly use the timezone-aware path

## Test plan

- [x] Planner test: new case `watermark ttl timestamptz with day interval` shows `SubtractWithTimeZone(..., 'UTC':Varchar)` in the plan
- [x] All 108 planner tests pass
- [x] `cargo check -p risingwave_frontend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)