### PR TITLE
chore: default enable datafusion engine for batch query

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -502,7 +502,7 @@ pub struct SessionConfig {
 
     /// Enable DataFusion Engine
     /// When enabled, queries involving Iceberg tables will be executed using the DataFusion engine.
-    #[parameter(default = false)]
+    #[parameter(default = true)]
     enable_datafusion_engine: bool,
 
     /// Prefer hash join over sort merge join in DataFusion engine

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -10,6 +10,11 @@ repository = { workspace = true }
 [features]
 default = []
 datafusion = ["dep:datafusion", "dep:datafusion-common"]
+datafusion-backtrace = [
+    "datafusion",
+    "datafusion/backtrace",
+    "datafusion-common/backtrace",
+]
 all-sources = ["source-adbc_snowflake"]
 source-adbc_snowflake = ["risingwave_connector/source-adbc_snowflake"]
 
@@ -27,12 +32,9 @@ bytes = "1"
 chrono = { workspace = true }
 clap = { workspace = true }
 datafusion = { version = "52", optional = true, features = [
-    "backtrace",
     "nested_expressions",
 ] }
-datafusion-common = { version = "52", optional = true, features = [
-    "backtrace",
-] }
+datafusion-common = { version = "52", optional = true }
 downcast-rs = "2.0"
 dyn-clone = "1.0.14"
 easy-ext = "1"

--- a/src/frontend/src/datafusion/error.rs
+++ b/src/frontend/src/datafusion/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::backtrace::Backtrace;
+use std::backtrace::{Backtrace, BacktraceStatus};
 use std::fmt::Display;
 
 use datafusion_common::DataFusionError;
@@ -30,8 +30,9 @@ struct ToDataFusionErrorWrapper(BoxedError, Option<Backtrace>);
 impl Display for ToDataFusionErrorWrapper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)?;
+        #[cfg(debug_assertions)]
         if let Some(bt) = std::error::request_ref::<Backtrace>(self) {
-            write!(f, "{}{}", DataFusionError::BACK_TRACE_SEP, bt)?;
+            write!(f, "{}\n{}", DataFusionError::BACK_TRACE_SEP, bt)?;
         }
         Ok(())
     }
@@ -58,7 +59,10 @@ pub fn to_datafusion_error(error: impl Into<BoxedError>) -> DataFusionError {
     let error = error.into();
     let mut bt = None;
     if std::error::request_ref::<Backtrace>(error.as_ref()).is_none() {
-        bt = Some(Backtrace::capture());
+        let backtrace = Backtrace::capture();
+        if backtrace.status() == BacktraceStatus::Captured {
+            bt = Some(backtrace);
+        }
     }
     DataFusionError::External(Box::new(ToDataFusionErrorWrapper(error, bt)))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- set `enable_datafusion_engine` default value to `true`
- disable backtrace feature of datafusion by default

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

RisingWave defaults to enabling DataFusion as the execution engine for iceberg batch queries.

</details>
