### PR TITLE
feat(sink): support sink skip error and record error in table

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -377,6 +377,7 @@ message SinkNode {
   catalog.Table table = 2;
   SinkLogStoreType log_store_type = 3;
   optional uint32 rate_limit = 4;
+  optional catalog.Table error_table = 5;
 }
 
 message IcebergWithPkIndexWriterNode {

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -94,3 +94,48 @@ pub mod log_store {
         });
     }
 }
+
+pub mod sink_error {
+    use std::sync::LazyLock;
+
+    use crate::types::DataType;
+    use crate::util::sort_util::OrderType;
+
+    pub const EPOCH_COLUMN_NAME: &str = "sink_error_epoch";
+    pub const ROW_ID_COLUMN_NAME: &str = "sink_error_row_id";
+    pub const VNODE_COLUMN_NAME: &str = "sink_error_vnode";
+    pub const ROW_OP_COLUMN_NAME: &str = "sink_error_row_op";
+    pub const READ_EPOCH_COLUMN_NAME: &str = "sink_error_read_epoch";
+    pub const EXTRA_INFO_COLUMN_NAME: &str = "sink_error_extra_info";
+
+    pub const EPOCH_COLUMN_TYPE: DataType = DataType::Int64;
+    pub const ROW_ID_COLUMN_TYPE: DataType = DataType::Int32;
+    pub const VNODE_COLUMN_TYPE: DataType = DataType::Int16;
+    pub const ROW_OP_COLUMN_TYPE: DataType = DataType::Int16;
+    pub const READ_EPOCH_COLUMN_TYPE: DataType = DataType::Int64;
+    pub const EXTRA_INFO_COLUMN_TYPE: DataType = DataType::Jsonb;
+
+    pub const PREDEFINED_COLUMNS: [(&str, DataType); 6] = [
+        (EPOCH_COLUMN_NAME, EPOCH_COLUMN_TYPE),
+        (ROW_ID_COLUMN_NAME, ROW_ID_COLUMN_TYPE),
+        (VNODE_COLUMN_NAME, VNODE_COLUMN_TYPE),
+        (ROW_OP_COLUMN_NAME, ROW_OP_COLUMN_TYPE),
+        (READ_EPOCH_COLUMN_NAME, READ_EPOCH_COLUMN_TYPE),
+        (EXTRA_INFO_COLUMN_NAME, EXTRA_INFO_COLUMN_TYPE),
+    ];
+
+    pub const EPOCH_COLUMN_INDEX: usize = 0;
+    pub const ROW_ID_COLUMN_INDEX: usize = 1;
+    pub const VNODE_COLUMN_INDEX: usize = 2;
+    pub const ROW_OP_COLUMN_INDEX: usize = 3;
+    pub const READ_EPOCH_COLUMN_INDEX: usize = 4;
+    pub const EXTRA_INFO_COLUMN_INDEX: usize = 5;
+
+    pub static PK_ORDERING: LazyLock<[OrderType; 3]> = LazyLock::new(|| {
+        [
+            OrderType::ascending(),
+            OrderType::ascending(),
+            OrderType::ascending(),
+        ]
+    });
+}

--- a/src/common/src/util/stream_graph_visitor.rs
+++ b/src/common/src/util/stream_graph_visitor.rs
@@ -220,7 +220,8 @@ pub fn visit_stream_node_tables_inner<F>(
             // Sink
             NodeBody::Sink(node) => {
                 // A sink with a kv log store should have a state table.
-                optional!(node.table, "Sink")
+                optional!(node.table, "Sink");
+                optional!(node.error_table, "SinkError");
             }
 
             // Now

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -42,6 +42,7 @@ use super::derive::{derive_columns, derive_pk};
 use super::stream::prelude::*;
 use super::utils::{
     Distill, IndicesDisplay, childless_record, infer_kv_log_store_table_catalog_inner,
+    infer_sink_error_table_catalog_inner,
 };
 use super::{
     ExprRewritable, PlanBase, StreamExchange, StreamNode, StreamPlanRef as PlanRef, StreamProject,
@@ -752,6 +753,13 @@ impl StreamSink {
         infer_kv_log_store_table_catalog_inner(&self.input, &self.sink_desc().columns)
     }
 
+    /// The error table schema is:
+    /// | write epoch | error row id | vnode | row op | read epoch | extra info | visible sink columns |
+    /// Pk is: | error epoch | vnode | error row id |
+    fn infer_sink_error_table_catalog(&self) -> TableCatalog {
+        infer_sink_error_table_catalog_inner(self.sink_desc().columns.as_slice())
+    }
+
     /// Convert this `StreamSink` into a `PlanRef`.
     ///
     /// For Iceberg pk index sinks, this rewrites the plan into
@@ -837,10 +845,14 @@ impl StreamNode for StreamSink {
         let table = self
             .infer_kv_log_store_table_catalog()
             .with_id(state.gen_table_id_wrapped());
+        let error_table = self
+            .infer_sink_error_table_catalog()
+            .with_id(state.gen_table_id_wrapped());
 
         PbNodeBody::Sink(Box::new(SinkNode {
             sink_desc: Some(self.sink_desc.to_proto()),
             table: Some(table.to_internal_table_prost()),
+            error_table: Some(error_table.to_internal_table_prost()),
             log_store_type: self.log_store_type as i32,
             rate_limit: self.base.ctx().overwrite_options().sink_rate_limit,
         }))

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -23,11 +23,15 @@ use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 use pretty_xmlish::{Pretty, Str, StrAssocArr, XmlNode};
 use risingwave_common::catalog::{
-    ColumnCatalog, ColumnDesc, ConflictBehavior, CreateType, Engine, Field, FieldDisplay, Schema,
-    StreamJobStatus,
+    ColumnCatalog, ColumnDesc, ConflictBehavior, CreateType, Engine, Field, FieldDisplay,
+    INITIAL_TABLE_VERSION_ID, Schema, StreamJobStatus,
 };
 use risingwave_common::constants::log_store::v2::{
     KV_LOG_STORE_PREDEFINED_COLUMNS, PK_ORDERING, VNODE_COLUMN_INDEX,
+};
+use risingwave_common::constants::sink_error::{
+    PK_ORDERING as SINK_ERROR_PK_ORDERING, PREDEFINED_COLUMNS as SINK_ERROR_PREDEFINED_COLUMNS,
+    VNODE_COLUMN_INDEX as SINK_ERROR_VNODE_COLUMN_INDEX,
 };
 use risingwave_common::hash::VnodeCount;
 use risingwave_common::license::Feature;
@@ -42,7 +46,7 @@ use risingwave_sqlparser::ast::AsOf;
 
 use super::generic::{self, GenericPlanRef, PhysicalPlanRef};
 use super::{BatchPlanRef, StreamPlanRef, pretty_config};
-use crate::catalog::table_catalog::TableType;
+use crate::catalog::table_catalog::{TableType, TableVersion};
 use crate::catalog::{ColumnId, FragmentId, TableCatalog, TableId};
 use crate::error::{ErrorCode, Result};
 use crate::expr::InputRef;
@@ -423,6 +427,46 @@ pub fn infer_kv_log_store_table_catalog_inner(
     table_catalog_builder.build(dist_key, read_prefix_len_hint)
 }
 
+pub fn infer_sink_error_table_catalog_inner(columns: &[ColumnCatalog]) -> TableCatalog {
+    let mut table_catalog_builder = TableCatalogBuilder::default();
+
+    let mut value_indices = Vec::with_capacity(SINK_ERROR_PREDEFINED_COLUMNS.len() + columns.len());
+
+    for (name, data_type) in SINK_ERROR_PREDEFINED_COLUMNS {
+        let index = table_catalog_builder.add_column(&Field::with_name(data_type, name));
+        value_indices.push(index);
+    }
+
+    table_catalog_builder.set_vnode_col_idx(SINK_ERROR_VNODE_COLUMN_INDEX);
+
+    for (i, ordering) in SINK_ERROR_PK_ORDERING.iter().enumerate() {
+        table_catalog_builder.add_order_column(i, *ordering);
+    }
+
+    let read_prefix_len_hint = table_catalog_builder.get_current_pk_len();
+
+    for column in columns.iter().filter(|column| !column.is_hidden) {
+        let index = table_catalog_builder.add_column(&Field::from(&column.column_desc));
+        value_indices.push(index);
+    }
+
+    table_catalog_builder.set_value_indices(value_indices);
+    let mut table =
+        table_catalog_builder.build(vec![SINK_ERROR_VNODE_COLUMN_INDEX], read_prefix_len_hint);
+    let next_column_id = table
+        .columns
+        .iter()
+        .map(|column| column.column_desc.column_id)
+        .max()
+        .expect("sink error table should have columns")
+        .next();
+    table.version = Some(TableVersion {
+        version_id: INITIAL_TABLE_VERSION_ID,
+        next_column_id,
+    });
+    table
+}
+
 pub fn infer_synced_kv_log_store_table_catalog_inner(
     input: &StreamPlanRef,
     columns: &[Field],
@@ -466,6 +510,68 @@ pub fn infer_synced_kv_log_store_table_catalog_inner(
         .collect_vec();
 
     table_catalog_builder.build(dist_key, read_prefix_len_hint)
+}
+
+#[cfg(test)]
+#[expect(clippy::items_after_test_module)]
+mod tests {
+    use itertools::Itertools;
+    use risingwave_common::catalog::{ColumnCatalog, ColumnDesc};
+    use risingwave_common::constants::sink_error::{
+        EPOCH_COLUMN_NAME, EXTRA_INFO_COLUMN_NAME, PREDEFINED_COLUMNS, READ_EPOCH_COLUMN_NAME,
+        ROW_ID_COLUMN_NAME, ROW_OP_COLUMN_NAME, VNODE_COLUMN_INDEX, VNODE_COLUMN_NAME,
+    };
+    use risingwave_common::types::DataType;
+
+    use super::infer_sink_error_table_catalog_inner;
+    use crate::catalog::ColumnId;
+
+    #[test]
+    fn test_infer_sink_error_table_catalog() {
+        let columns = vec![
+            ColumnCatalog {
+                column_desc: ColumnDesc::named("name", ColumnId::new(0), DataType::Varchar),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::named("secret", ColumnId::new(1), DataType::Int64),
+                is_hidden: true,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::named("id", ColumnId::new(2), DataType::Int32),
+                is_hidden: false,
+            },
+        ];
+
+        let table = infer_sink_error_table_catalog_inner(&columns);
+
+        let column_names = table.columns.iter().map(|c| c.name()).collect_vec();
+        assert_eq!(
+            column_names,
+            vec![
+                EPOCH_COLUMN_NAME,
+                ROW_ID_COLUMN_NAME,
+                VNODE_COLUMN_NAME,
+                ROW_OP_COLUMN_NAME,
+                READ_EPOCH_COLUMN_NAME,
+                EXTRA_INFO_COLUMN_NAME,
+                "name",
+                "id",
+            ]
+        );
+        assert_eq!(table.columns.len(), PREDEFINED_COLUMNS.len() + 2);
+        assert_eq!(table.vnode_col_index, Some(VNODE_COLUMN_INDEX));
+        assert_eq!(table.distribution_key, vec![VNODE_COLUMN_INDEX]);
+        assert_eq!(table.pk.len(), 3);
+        assert_eq!(
+            table
+                .pk
+                .iter()
+                .map(|order| order.column_index)
+                .collect_vec(),
+            vec![0, 1, 2]
+        );
+    }
 }
 
 /// Check that all leaf nodes must be stream table scan,

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1441,7 +1441,7 @@ impl CatalogController {
         let txn = inner.db.begin().await?;
 
         let (objects, delete_notification_objs, old_fragment_ids, new_fragment_ids) =
-            Self::finish_replace_streaming_job_inner(
+            Box::pin(Self::finish_replace_streaming_job_inner(
                 tmp_id,
                 replace_upstream,
                 sink_into_table_context,
@@ -1449,7 +1449,7 @@ impl CatalogController {
                 streaming_job,
                 drop_table_connector_ctx,
                 auto_refresh_schema_sinks,
-            )
+            ))
             .await?;
 
         txn.commit().await?;
@@ -1914,6 +1914,33 @@ impl CatalogController {
                     .await?;
                     table.columns = new_log_store_table_columns;
                     table.value_indices = new_log_store_table_value_indices.into();
+                    objects.push(PbObject {
+                        object_info: Some(PbObjectInfo::Table(
+                            ObjectModel(table, table_obj.unwrap(), sink_streaming_job.clone())
+                                .into(),
+                        )),
+                    });
+                }
+                if let Some(new_error_table) = finish_sink_context.new_error_table {
+                    let error_table_id = new_error_table.id;
+                    let new_error_table_columns: ColumnCatalogArray =
+                        new_error_table.columns.clone().into();
+                    let new_error_table_value_indices = new_error_table.value_indices.clone();
+                    let (mut table, table_obj) = Table::find_by_id(error_table_id)
+                        .find_also_related(Object)
+                        .one(txn)
+                        .await?
+                        .ok_or_else(|| MetaError::catalog_id_not_found("table", original_job_id))?;
+                    Table::update(table::ActiveModel {
+                        table_id: Set(error_table_id),
+                        columns: Set(new_error_table_columns.clone()),
+                        value_indices: Set(new_error_table_value_indices.clone().into()),
+                        ..Default::default()
+                    })
+                    .exec(txn)
+                    .await?;
+                    table.columns = new_error_table_columns;
+                    table.value_indices = new_error_table_value_indices.into();
                     objects.push(PbObject {
                         object_info: Some(PbObjectInfo::Table(
                             ObjectModel(table, table_obj.unwrap(), sink_streaming_job.clone())
@@ -3502,6 +3529,7 @@ pub struct FinishAutoRefreshSchemaSinkContext {
     pub original_sink_id: SinkId,
     pub columns: Vec<PbColumnCatalog>,
     pub new_log_store_table: Option<Box<PbTable>>,
+    pub new_error_table: Option<PbTable>,
 }
 
 async fn update_connector_props_fragments<F>(

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1541,7 +1541,7 @@ impl DdlController {
                     let sink_ctx = sink_job_fragments.ctx;
                     let original_sink_fragment =
                         sink_job_fragments.fragments.into_values().next().unwrap();
-                    let (new_sink_fragment, new_schema, new_log_store_table) =
+                    let (new_sink_fragment, new_schema, new_log_store_table, new_error_table) =
                         rewrite_refresh_schema_sink_fragment(
                             &original_sink_fragment,
                             &sink,
@@ -1579,6 +1579,7 @@ impl DdlController {
                             .collect(),
                         new_fragment: new_sink_fragment,
                         new_log_store_table: new_log_store_table.map(Box::new),
+                        new_error_table,
                         ctx: sink_ctx,
                     });
                 }
@@ -1634,6 +1635,7 @@ impl DdlController {
                             original_sink_id: sink.original_sink.id,
                             columns: sink.new_schema.clone(),
                             new_log_store_table: sink.new_log_store_table.clone(),
+                            new_error_table: sink.new_error_table.clone(),
                         })
                         .collect()
                 });

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -522,6 +522,21 @@ fn rewrite_log_store_table(
     log_store_table.value_indices = (0..log_store_table.columns.len() as i32).collect();
 }
 
+/// Rewrite sink error table columns for schema change.
+fn rewrite_sink_error_table(
+    error_table: &mut PbTable,
+    removed_sink_column_names: &HashSet<String>,
+    newly_added_columns: &[ColumnCatalog],
+) {
+    error_table
+        .columns
+        .retain(|col| !removed_sink_column_names.contains(&col.column_desc.as_ref().unwrap().name));
+    extend_sink_columns(&mut error_table.columns, newly_added_columns, |name| {
+        name.clone()
+    });
+    error_table.value_indices = (0..error_table.columns.len() as i32).collect();
+}
+
 /// Rewrite `StreamScan` + Merge to match the new upstream schema.
 fn rewrite_stream_scan_and_merge(
     stream_scan_node: &mut StreamNode,
@@ -744,6 +759,15 @@ fn rewrite_project_node(
     Ok(())
 }
 
+/// Result of `rewrite_refresh_schema_sink_fragment`:
+/// (new fragment, new column catalogs, new log store table, new error table)
+type RewriteSinkFragmentResult = (
+    Fragment,
+    Vec<PbColumnCatalog>,
+    Option<PbTable>,
+    Option<PbTable>,
+);
+
 pub fn rewrite_refresh_schema_sink_fragment(
     original_sink_fragment: &Fragment,
     sink: &PbSink,
@@ -752,9 +776,13 @@ pub fn rewrite_refresh_schema_sink_fragment(
     upstream_table: &PbTable,
     upstream_table_fragment_id: FragmentId,
     id_generator_manager: &IdGeneratorManager,
-) -> MetaResult<(Fragment, Vec<PbColumnCatalog>, Option<PbTable>)> {
+) -> MetaResult<RewriteSinkFragmentResult> {
     let removed_column_ids: HashSet<_> =
         removed_columns.iter().map(|col| col.column_id()).collect();
+    let removed_sink_column_names: HashSet<_> = removed_columns
+        .iter()
+        .map(|col| col.column_desc.name.clone())
+        .collect();
     let removed_log_store_column_names: HashSet<_> = removed_columns
         .iter()
         .map(|col| format!("{}_{}", upstream_table.name, col.column_desc.name))
@@ -816,6 +844,12 @@ pub fn rewrite_refresh_schema_sink_fragment(
     } else {
         None
     };
+    let new_error_table = if let Some(error_table) = &mut sink_node_body.error_table {
+        rewrite_sink_error_table(error_table, &removed_sink_column_names, newly_added_columns);
+        Some(error_table.clone())
+    } else {
+        None
+    };
     sink_node_body.sink_desc.as_mut().unwrap().column_catalogs = new_sink_columns.clone();
 
     let stream_scan_node = if stream_input_is_project {
@@ -853,7 +887,12 @@ pub fn rewrite_refresh_schema_sink_fragment(
     } else {
         sink_node.fields = scan_rewrite.output_fields;
     }
-    Ok((new_sink_fragment, new_sink_columns, new_log_store_table))
+    Ok((
+        new_sink_fragment,
+        new_sink_columns,
+        new_log_store_table,
+        new_error_table,
+    ))
 }
 
 /// Adjacency list (G) of backfill orders.
@@ -2414,7 +2453,6 @@ mod tests {
             value_indices: (0..columns.len()).map(|i| i as i32).collect(),
             ..Default::default()
         };
-
         let original_fragment = Fragment {
             fragment_id: 1.into(),
             fragment_type_mask: FragmentTypeMask::default(),
@@ -2436,7 +2474,7 @@ mod tests {
             },
         };
 
-        let (new_fragment, _, _) = rewrite_refresh_schema_sink_fragment(
+        let (new_fragment, _, _, _) = rewrite_refresh_schema_sink_fragment(
             &original_fragment,
             &sink,
             std::slice::from_ref(&new_column),
@@ -2537,6 +2575,11 @@ mod tests {
             value_indices: (0..columns.len()).map(|i| i as i32).collect(),
             ..Default::default()
         };
+        let error_table = PbTable {
+            columns: columns.iter().map(|col| col.to_protobuf()).collect(),
+            value_indices: (0..columns.len()).map(|i| i as i32).collect(),
+            ..Default::default()
+        };
 
         let original_fragment = Fragment {
             fragment_id: 1.into(),
@@ -2548,6 +2591,7 @@ mod tests {
                 node_body: Some(NodeBody::Sink(Box::new(SinkNode {
                     sink_desc: Some(sink_desc),
                     table: Some(log_store_table),
+                    error_table: Some(error_table),
                     log_store_type: SinkLogStoreType::KvLogStore as i32,
                     ..Default::default()
                 }))),
@@ -2560,16 +2604,17 @@ mod tests {
             },
         };
 
-        let (new_fragment, new_schema, new_log_store_table) = rewrite_refresh_schema_sink_fragment(
-            &original_fragment,
-            &sink,
-            &[],
-            std::slice::from_ref(&removed_column),
-            &upstream_table,
-            7.into(),
-            id_gen_manager,
-        )
-        .unwrap();
+        let (new_fragment, new_schema, new_log_store_table, new_error_table) =
+            rewrite_refresh_schema_sink_fragment(
+                &original_fragment,
+                &sink,
+                &[],
+                std::slice::from_ref(&removed_column),
+                &upstream_table,
+                7.into(),
+                id_gen_manager,
+            )
+            .unwrap();
 
         assert_eq!(new_schema.len(), 2);
         assert!(
@@ -2625,6 +2670,13 @@ mod tests {
         assert_eq!(
             new_log_store_table.value_indices,
             (0..new_log_store_table.columns.len() as i32).collect::<Vec<_>>()
+        );
+        let new_error_table = new_error_table.expect("error table should be updated");
+        assert!(
+            new_error_table
+                .columns
+                .iter()
+                .all(|col| col.column_desc.as_ref().unwrap().name != "tmp")
         );
     }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -224,6 +224,7 @@ pub struct AutoRefreshSchemaSinkContext {
     pub removed_column_names: Vec<String>,
     pub new_fragment: Fragment,
     pub new_log_store_table: Option<Box<PbTable>>,
+    pub new_error_table: Option<PbTable>,
     /// The sink's own stream context (timezone, `config_override`).
     pub ctx: StreamContext,
 }

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::assert_matches::assert_matches;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::mem;
 
 use anyhow::anyhow;
@@ -24,7 +24,11 @@ use risingwave_common::array::Op;
 use risingwave_common::array::stream_chunk::StreamChunkMut;
 use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::{ColumnCatalog, Field};
+use risingwave_common::hash::table_distribution::SINGLETON_VNODE;
 use risingwave_common::metrics::{GLOBAL_ERROR_METRICS, LabelGuardedIntGauge};
+use risingwave_common::row::OwnedRow;
+use risingwave_common::types::ScalarImpl;
+use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_common_estimate_size::collections::EstimatedVec;
 use risingwave_common_rate_limit::RateLimit;
@@ -32,7 +36,7 @@ use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::catalog::{SinkId, SinkType};
 use risingwave_connector::sink::log_store::{
     FlushCurrentEpochOptions, FlushCurrentEpochResult, LogReader, LogReaderExt, LogReaderMetrics,
-    LogStoreFactory, LogWriter, LogWriterExt, LogWriterMetrics,
+    LogStoreFactory, LogWriter, LogWriterExt, LogWriterMetrics, ReportedSinkErrorRow,
 };
 use risingwave_connector::sink::{
     GLOBAL_SINK_METRICS, LogSinker, SINK_USER_FORCE_COMPACTION, Sink, SinkImpl, SinkParam,
@@ -50,8 +54,12 @@ use crate::common::change_buffer::{OutputKind, output_kind};
 use crate::common::compact_chunk::{
     InconsistencyBehavior, StreamChunkCompactor, compact_chunk_inline,
 };
+use crate::common::table::state_table::StateTableInner;
 use crate::executor::prelude::*;
-pub struct SinkExecutor<F: LogStoreFactory> {
+
+type ErrorStateTable<S> = StateTableInner<S, ColumnAwareSerde>;
+
+pub struct SinkExecutor<F: LogStoreFactory, S: StateStore> {
     actor_context: ActorContextRef,
     info: ExecutorInfo,
     input: Executor,
@@ -59,11 +67,53 @@ pub struct SinkExecutor<F: LogStoreFactory> {
     input_columns: Vec<ColumnCatalog>,
     sink_param: SinkParam,
     log_store_factory: F,
+    error_table: Option<ErrorStateTable<S>>,
     sink_writer_param: SinkWriterParam,
     chunk_size: usize,
     input_data_types: Vec<DataType>,
     non_append_only_behavior: Option<NonAppendOnlyBehavior>,
     rate_limit: Option<u32>,
+}
+
+struct PendingErrorRows {
+    rows: VecDeque<ReportedSinkErrorRow>,
+}
+
+impl PendingErrorRows {
+    fn add_reported_rows(&mut self, reported_rows: Vec<ReportedSinkErrorRow>) {
+        if let Some(last_row) = self.rows.back()
+            && let Some(first_new_row) = reported_rows.first()
+        {
+            assert!(
+                last_row.epoch <= first_new_row.epoch,
+                "reported sink error rows should be ordered by epoch"
+            );
+        }
+        self.rows.extend(reported_rows);
+    }
+
+    fn drain_ready_rows(&mut self, epoch: u64) -> Vec<(u64, ReportedSinkErrorRow)> {
+        let mut rows = vec![];
+        while self
+            .rows
+            .front()
+            .is_some_and(|reported_row| reported_row.epoch <= epoch)
+        {
+            let reported_row = self.rows.pop_front().expect("checked some");
+            rows.push((reported_row.epoch, reported_row));
+        }
+        rows
+    }
+}
+
+fn select_error_vnode(vnodes: Option<&Bitmap>) -> i16 {
+    let Some(vnodes) = vnodes else {
+        return SINGLETON_VNODE.to_index() as i16;
+    };
+    vnodes
+        .iter_ones()
+        .next()
+        .unwrap_or(SINGLETON_VNODE.to_index()) as i16
 }
 
 // Drop all the DELETE messages in this chunk and convert UPDATE INSERT into INSERT.
@@ -230,7 +280,7 @@ macro_rules! dispatch_output_kind {
     };
 }
 
-impl<F: LogStoreFactory> SinkExecutor<F> {
+impl<F: LogStoreFactory, S: StateStore> SinkExecutor<F, S> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         actor_context: ActorContextRef,
@@ -241,6 +291,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         sink_param: SinkParam,
         columns: Vec<ColumnCatalog>,
         log_store_factory: F,
+        error_table: Option<ErrorStateTable<S>>,
         chunk_size: usize,
         input_data_types: Vec<DataType>,
         rate_limit: Option<u32>,
@@ -278,12 +329,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             None
         };
 
-        tracing::info!(
-            sink_id = %sink_param.sink_id,
-            actor_id = %actor_context.id,
-            ?non_append_only_behavior,
-            "Sink executor info"
-        );
+        tracing::info!(sink_id = %sink_param.sink_id, actor_id = %actor_context.id, ?non_append_only_behavior, "Sink executor info");
 
         Ok(Self {
             actor_context,
@@ -293,6 +339,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             input_columns: columns,
             sink_param,
             log_store_factory,
+            error_table,
             sink_writer_param,
             chunk_size,
             input_data_types,
@@ -391,6 +438,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                     let write_log_stream = Self::execute_write_log(
                         processed_input,
                         log_writer.monitored(log_writer_metrics),
+                        self.error_table,
                         actor_id,
                         fragment_id,
                         sink_id,
@@ -425,10 +473,12 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_write_log<W: LogWriter>(
         input: impl MessageStream,
         mut log_writer: W,
+        mut error_table: Option<ErrorStateTable<S>>,
         actor_id: ActorId,
         fragment_id: FragmentId,
         sink_id: SinkId,
@@ -443,8 +493,20 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         yield Message::Barrier(barrier);
 
         log_writer.init(epoch_pair, is_pause_on_startup).await?;
+        if let Some(error_table) = error_table.as_mut() {
+            error_table.init_epoch(epoch_pair).await?;
+        }
 
         let mut is_paused = false;
+        let mut error_vnode = select_error_vnode(
+            error_table
+                .as_ref()
+                .map(ErrorStateTable::vnodes)
+                .map(|v| &**v),
+        );
+        let mut pending_error_rows = PendingErrorRows {
+            rows: VecDeque::new(),
+        };
 
         #[for_await]
         for msg in input {
@@ -478,12 +540,39 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             },
                         )
                         .await?;
-                    assert!(
-                        reported_error_rows.is_empty(),
-                        "sink error rows are not handled in this branch"
-                    );
+                    pending_error_rows.add_reported_rows(reported_error_rows);
+                    let ready_rows = pending_error_rows.drain_ready_rows(barrier.epoch.curr);
+                    if let Some(error_table) = error_table.as_mut() {
+                        for (row_id, (read_epoch, reported_row)) in
+                            ready_rows.into_iter().enumerate()
+                        {
+                            let mut values =
+                                Vec::with_capacity(reported_row.row.as_inner().len() + 6);
+                            values.push(Some(ScalarImpl::Int64(barrier.epoch.curr as i64)));
+                            values.push(Some(ScalarImpl::Int32(row_id as i32)));
+                            values.push(Some(ScalarImpl::Int16(error_vnode)));
+                            values.push(Some(ScalarImpl::Int16(reported_row.op.to_i16())));
+                            values.push(Some(ScalarImpl::Int64(read_epoch as i64)));
+                            values.push(reported_row.extra_info.map(ScalarImpl::Jsonb));
+                            values.extend(reported_row.row.into_inner().into_vec());
+                            error_table.insert(OwnedRow::new(values));
+                        }
+                    } else if !ready_rows.is_empty() {
+                        return Err(anyhow::anyhow!(
+                            "sink {} received {} error rows but has no error table",
+                            sink_id,
+                            ready_rows.len()
+                        )
+                        .into());
+                    }
 
                     let mutation = barrier.mutation.clone();
+                    let barrier_epoch = barrier.epoch;
+                    let post_commit = if let Some(error_table) = error_table.as_mut() {
+                        Some(error_table.commit(barrier_epoch).await?)
+                    } else {
+                        None
+                    };
                     yield Message::Barrier(barrier);
                     if F::REBUILD_SINK_ON_UPDATE_VNODE_BITMAP
                         && let Some(new_vnode_bitmap) = update_vnode_bitmap.clone()
@@ -496,6 +585,14 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             .map_err(|_| anyhow!("fail to wait rebuild sink finish"))?;
                     }
                     post_flush.post_yield_barrier().await?;
+                    if let Some(post_commit) = post_commit {
+                        post_commit
+                            .post_yield_barrier(update_vnode_bitmap.clone())
+                            .await?;
+                        if let Some(new_vnodes) = update_vnode_bitmap.clone() {
+                            error_vnode = select_error_vnode(Some(&new_vnodes));
+                        }
+                    }
 
                     if let Some(mutation) = mutation.as_deref() {
                         match mutation {
@@ -685,8 +782,8 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
     }
 
     #[expect(clippy::too_many_arguments)]
-    async fn execute_consume_log<S: Sink, R: LogReader>(
-        mut sink: S,
+    async fn execute_consume_log<SI: Sink, R: LogReader>(
+        mut sink: SI,
         log_reader: R,
         columns: Vec<ColumnCatalog>,
         mut sink_param: SinkParam,
@@ -763,10 +860,14 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         loop {
             let future = async {
                 loop {
-                    let Err(e) = sink
+                    let log_sinker = sink
                         .new_log_sinker(sink_writer_param.clone())
-                        .and_then(|log_sinker| log_sinker.consume_log_and_sink(&mut log_reader))
-                        .await;
+                        .await
+                        .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
+                    let e = match log_sinker.consume_log_and_sink(&mut log_reader).await {
+                        Ok(never) => match never {},
+                        Err(e) => e,
+                    };
                     GLOBAL_ERROR_METRICS.user_sink_error.report([
                         "sink_executor_error".to_owned(),
                         sink_param.sink_id.to_string(),
@@ -880,7 +981,7 @@ fn sink_config_has_changes(
         .any(|(key, value)| current.get(key) != Some(value))
 }
 
-impl<F: LogStoreFactory> Execute for SinkExecutor<F> {
+impl<F: LogStoreFactory, S: StateStore> Execute for SinkExecutor<F, S> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner()
     }
@@ -891,6 +992,7 @@ mod test {
     use risingwave_common::catalog::{ColumnDesc, ColumnId};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_connector::sink::build_sink;
+    use risingwave_storage::memory::MemoryStateStore;
 
     use super::*;
     use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
@@ -995,7 +1097,7 @@ mod test {
 
         let sink = build_sink(sink_param.clone()).unwrap();
 
-        let sink_executor = SinkExecutor::new(
+        let sink_executor = SinkExecutor::<_, MemoryStateStore>::new(
             ActorContext::for_test(0),
             info,
             source,
@@ -1004,6 +1106,7 @@ mod test {
             sink_param,
             columns.clone(),
             BoundedInMemLogStoreFactory::for_test(1),
+            None,
             1024,
             vec![DataType::Int32, DataType::Int32, DataType::Int32],
             None,
@@ -1133,7 +1236,7 @@ mod test {
 
         let sink = build_sink(sink_param.clone()).unwrap();
 
-        let sink_executor = SinkExecutor::new(
+        let sink_executor = SinkExecutor::<_, MemoryStateStore>::new(
             ActorContext::for_test(0),
             info,
             source,
@@ -1142,6 +1245,7 @@ mod test {
             sink_param,
             columns.clone(),
             BoundedInMemLogStoreFactory::for_test(1),
+            None,
             1024,
             vec![DataType::Int64, DataType::Int64, DataType::Int64],
             None,
@@ -1240,7 +1344,7 @@ mod test {
 
         let sink = build_sink(sink_param.clone()).unwrap();
 
-        let sink_executor = SinkExecutor::new(
+        let sink_executor = SinkExecutor::<_, MemoryStateStore>::new(
             ActorContext::for_test(0),
             info,
             source,
@@ -1249,6 +1353,7 @@ mod test {
             sink_param,
             columns,
             BoundedInMemLogStoreFactory::for_test(1),
+            None,
             1024,
             vec![DataType::Int64, DataType::Int64],
             None,
@@ -1362,7 +1467,7 @@ mod test {
 
         let sink = build_sink(sink_param.clone()).unwrap();
 
-        let sink_executor = SinkExecutor::new(
+        let sink_executor = SinkExecutor::<_, MemoryStateStore>::new(
             ActorContext::for_test(0),
             info,
             source,
@@ -1371,6 +1476,7 @@ mod test {
             sink_param,
             columns.clone(),
             BoundedInMemLogStoreFactory::for_test(1),
+            None,
             1024,
             vec![DataType::Int64, DataType::Int64, DataType::Int64],
             None,

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -21,6 +21,7 @@ use risingwave_common::bail;
 use risingwave_common::catalog::{ColumnCatalog, Schema};
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::types::DataType;
+use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_connector::match_sink_name_str;
 use risingwave_connector::sink::catalog::{SinkFormat, SinkFormatDesc, SinkId, SinkType};
 use risingwave_connector::sink::file_sink::fs::FsSink;
@@ -41,6 +42,7 @@ use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
 use crate::common::log_store_impl::kv_log_store::{
     KV_LOG_STORE_V2_INFO, KvLogStoreFactory, KvLogStoreMetrics, KvLogStorePkInfo,
 };
+use crate::common::table::state_table::StateTableBuilder;
 use crate::executor::{SinkExecutor, StreamExecutorError};
 
 /// Build [`SinkParam`] from a [`PbSinkDesc`], along with the full [`ColumnCatalog`] list for
@@ -287,6 +289,22 @@ impl ExecutorBuilder for SinkExecutorBuilder {
             "sink[{}]-[{}]-executor[{}]",
             connector, sink_id, params.executor_id
         );
+        let error_table = match node.error_table.as_ref() {
+            Some(table) => Some(
+                StateTableBuilder::<_, ColumnAwareSerde, false, ()>::new(
+                    table,
+                    state_store.clone(),
+                    params.vnode_bitmap.clone().map(Arc::new),
+                )
+                .with_op_consistency_level(
+                    crate::common::table::state_table::StateTableOpConsistencyLevel::Inconsistent,
+                )
+                .forbid_preload_all_rows()
+                .build()
+                .await,
+            ),
+            None => None,
+        };
 
         let sink = build_sink(sink_param.clone())
             .map_err(|e| StreamExecutorError::from((e, sink_param.sink_id)))?;
@@ -322,6 +340,7 @@ impl ExecutorBuilder for SinkExecutorBuilder {
                     sink_param,
                     columns,
                     factory,
+                    error_table,
                     chunk_size,
                     input_data_types,
                     node.rate_limit.map(|x| x as _),
@@ -362,6 +381,7 @@ impl ExecutorBuilder for SinkExecutorBuilder {
                     sink_param,
                     columns,
                     factory,
+                    error_table,
                     chunk_size,
                     input_data_types,
                     node.rate_limit.map(|x| x as _),

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -52,6 +52,7 @@ async fn basic_test_inner(is_decouple: bool, test_type: TestSinkType) -> Result<
             .split("\n")
             .filter(|line| {
                 line.contains(table_name_prefix)
+                    && !line.to_ascii_lowercase().contains("sinkerror")
                     && line
                         .strip_prefix(table_name_prefix)
                         .unwrap()

--- a/src/tests/simulation/tests/integration_tests/sink/error_table.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/error_table.rs
@@ -1,0 +1,323 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::Result;
+use itertools::Itertools;
+use risingwave_simulation::cluster::{Cluster, ConfigPath, Configuration, Session};
+use tempfile::NamedTempFile;
+use tokio::time::sleep;
+
+use crate::assert_eq_with_err_returned as assert_eq;
+use crate::sink::utils::*;
+
+async fn start_error_table_test_cluster() -> Result<Cluster> {
+    let config_path = {
+        let mut file = NamedTempFile::new().expect("failed to create temp config file");
+        file.write_all(include_bytes!("../../../../../config/ci-sim.toml"))
+            .expect("failed to write config file");
+        file.write_all(b"\n[streaming.developer]\nmemory_controller_update_interval_ms = 600000\n")
+            .expect("failed to write test config override");
+        file.into_temp_path()
+    };
+
+    Cluster::start(Configuration {
+        config_path: ConfigPath::Temp(config_path.into()),
+        frontend_nodes: 1,
+        compute_nodes: 1,
+        meta_nodes: 1,
+        compactor_nodes: 1,
+        compute_node_cores: 2,
+        ..Default::default()
+    })
+    .await
+}
+
+async fn find_error_table_names(session: &mut Session, sink_name: &str) -> Result<Vec<String>> {
+    let table_name_prefix = format!("public.__internal_{}_", sink_name);
+    let internal_tables = session.run("show internal tables").await?;
+    let table_names = internal_tables
+        .lines()
+        .filter(|line| {
+            line.contains(&table_name_prefix) && line.to_ascii_lowercase().contains("sinkerror")
+        })
+        .map(str::to_owned)
+        .sorted()
+        .collect_vec();
+    if table_names.is_empty() {
+        return Err(anyhow::anyhow!(
+            "failed to find sink error internal table for {sink_name}"
+        ));
+    }
+    Ok(table_names)
+}
+
+async fn find_log_store_table_name(session: &mut Session, sink_name: &str) -> Result<String> {
+    let table_name_prefix = format!("public.__internal_{}_", sink_name);
+    let internal_tables = session.run("show internal tables").await?;
+    internal_tables
+        .lines()
+        .filter(|line| {
+            line.contains(&table_name_prefix)
+                && !line.to_ascii_lowercase().contains("sinkerror")
+                && line
+                    .strip_prefix(&table_name_prefix)
+                    .is_some_and(|suffix| suffix.contains("sink"))
+        })
+        .map(str::to_owned)
+        .max()
+        .ok_or_else(|| {
+            anyhow::anyhow!("failed to find sink log store internal table for {sink_name}")
+        })
+}
+
+async fn find_error_table_name(
+    session: &mut Session,
+    sink_name: &str,
+    required_columns: &[&str],
+) -> Result<String> {
+    let mut last_describes = Vec::new();
+    for attempt in 0..100 {
+        let table_names = find_error_table_names(session, sink_name).await?;
+        last_describes.clear();
+        for table_name in table_names.iter().rev() {
+            let describe = session.run(format!("describe {}", table_name)).await?;
+            last_describes.push(format!("{table_name}:\n{describe}"));
+            if required_columns.iter().all(|column| {
+                describe
+                    .lines()
+                    .any(|line| line.split_whitespace().next() == Some(*column))
+            }) {
+                return Ok(table_name.clone());
+            }
+        }
+        if attempt % 5 == 4 {
+            session.run("flush").await?;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    Err(anyhow::anyhow!(
+        "failed to find sink error internal table for {} with required columns {:?}. candidates:\n{}",
+        sink_name,
+        required_columns,
+        last_describes.join("\n---\n")
+    ))
+}
+
+async fn wait_for_error_table_count(
+    session: &mut Session,
+    error_table_name: &str,
+    expected_count: usize,
+) -> Result<()> {
+    let count_sql = format!("select count(*) from {}", error_table_name);
+    let ids_sql = format!("select id from {} order by id", error_table_name);
+    let mut last_count = String::new();
+    for attempt in 0..100 {
+        let count_result = session.run(&count_sql).await?;
+        last_count = count_result.trim().to_owned();
+        if count_result.trim() == expected_count.to_string() {
+            return Ok(());
+        }
+        if attempt % 5 == 4 {
+            session.run("flush").await?;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    let persisted_ids = session.run(&ids_sql).await?;
+    Err(anyhow::anyhow!(
+        "timed out waiting for error table count {} in {} (last count = {}, ids = [{}])",
+        expected_count,
+        error_table_name,
+        last_count,
+        persisted_ids.trim()
+    ))
+}
+
+async fn query_error_table_rows_with_age(
+    session: &mut Session,
+    error_table_name: &str,
+) -> Result<String> {
+    let sql = format!(
+        "select sink_error_row_op, id, name, \
+                coalesce(age::varchar, 'NULL'), \
+                sink_error_extra_info->>'column_count' \
+         from {} order by id",
+        error_table_name
+    );
+    let mut last_error = None;
+    for attempt in 0..100 {
+        match session.run(&sql).await {
+            Ok(rows) => return Ok(rows),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt % 5 == 4 {
+                    session.run("flush").await?;
+                }
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(last_error.expect("should record query error"))
+}
+
+fn format_insert_rows(rows: impl IntoIterator<Item = (i32, String, Option<i32>)>) -> String {
+    rows.into_iter()
+        .map(|(id, name, age)| match age {
+            Some(age) => format!("({}, '{}', {})", id, name, age),
+            None => format!("({}, '{}')", id, name),
+        })
+        .join(", ")
+}
+
+async fn run_sink_error_table_test(decouple: bool) -> Result<()> {
+    let mut cluster = start_error_table_test_cluster().await?;
+    let test_sink = SimulationTestSink::register_new(TestSinkType::ReportError);
+
+    let mut session = cluster.start_session();
+    session.run("set streaming_parallelism = 1").await?;
+    session
+        .run(format!("set sink_decouple = {}", decouple))
+        .await?;
+    session
+        .run("create table test_table_error (id int primary key, name varchar)")
+        .await?;
+    session
+        .run("create sink test_sink_error from test_table_error with (connector = 'test', type = 'upsert', skip_error = 'true', auto.schema.change = 'true')")
+        .await?;
+
+    let initial_ids = 0..5;
+    session
+        .run(format!(
+            "insert into {} values {}",
+            "test_table_error",
+            format_insert_rows(
+                initial_ids
+                    .clone()
+                    .map(|id| (id, simple_name_of_id(id), None))
+            )
+        ))
+        .await?;
+    test_sink.store.wait_for_count(initial_ids.len()).await?;
+
+    session.run("flush").await?;
+    let initial_error_table_name =
+        find_error_table_name(&mut session, "test_sink_error", &["id", "name"]).await?;
+    wait_for_error_table_count(&mut session, &initial_error_table_name, initial_ids.len()).await?;
+
+    let initial_rows = session
+        .run(format!(
+            "select sink_error_row_op, id, name, \
+                    sink_error_extra_info->>'id', \
+                    sink_error_extra_info->>'name', \
+                    sink_error_extra_info->>'column_count' \
+             from {} order by id",
+            initial_error_table_name
+        ))
+        .await?;
+    let expected_initial_rows = initial_ids
+        .clone()
+        .map(|id| {
+            let name = simple_name_of_id(id);
+            format!("1 {} {} {} {} 2", id, name, id, name)
+        })
+        .join("\n");
+    assert_eq!(initial_rows.trim(), expected_initial_rows);
+
+    session
+        .run("alter table test_table_error add column age int")
+        .await?;
+    let mut schema_session = cluster.start_session();
+    let log_store_table_name =
+        find_log_store_table_name(&mut schema_session, "test_sink_error").await?;
+    let log_store_describe = schema_session
+        .run(format!("describe {}", log_store_table_name))
+        .await?;
+    assert!(
+        log_store_describe
+            .lines()
+            .any(|line| line.split_whitespace().next() == Some("test_table_error_age")),
+        "log store table schema is not updated:\n{}",
+        log_store_describe
+    );
+    let latest_error_table_name = find_error_table_name(
+        &mut schema_session,
+        "test_sink_error",
+        &["id", "name", "age"],
+    )
+    .await?;
+
+    let new_ids = 5..10;
+    session
+        .run(format!(
+            "insert into {} values {}",
+            "test_table_error",
+            format_insert_rows(new_ids.clone().map(|id| {
+                let age = id + 100;
+                (id, simple_name_of_id(id), Some(age))
+            }))
+        ))
+        .await?;
+    test_sink.store.wait_for_count(new_ids.end as usize).await?;
+
+    session.run("flush").await?;
+    let expected_row_count = if latest_error_table_name == initial_error_table_name {
+        new_ids.end as usize
+    } else {
+        new_ids.len()
+    };
+    wait_for_error_table_count(&mut session, &latest_error_table_name, expected_row_count).await?;
+
+    let mut verify_session = cluster.start_session();
+    let rows =
+        query_error_table_rows_with_age(&mut verify_session, &latest_error_table_name).await?;
+    let expected_rows = if latest_error_table_name == initial_error_table_name {
+        initial_ids
+            .clone()
+            .map(|id| format!("1 {} {} NULL 2", id, simple_name_of_id(id)))
+            .chain(
+                new_ids
+                    .clone()
+                    .map(|id| format!("1 {} {} {} 3", id, simple_name_of_id(id), id + 100)),
+            )
+            .join("\n")
+    } else {
+        new_ids
+            .clone()
+            .map(|id| format!("1 {} {} {} 3", id, simple_name_of_id(id), id + 100))
+            .join("\n")
+    };
+    assert_eq!(rows.trim(), expected_rows);
+
+    session.run("drop sink test_sink_error").await?;
+    session.run("drop table test_table_error").await?;
+    assert_eq!(
+        0,
+        test_sink
+            .parallelism_counter
+            .load(std::sync::atomic::Ordering::Relaxed)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sink_error_table_nondecouple() -> Result<()> {
+    run_sink_error_table_test(false).await
+}
+
+#[tokio::test]
+async fn test_sink_error_table_decouple() -> Result<()> {
+    run_sink_error_table_test(true).await
+}

--- a/src/tests/simulation/tests/integration_tests/sink/exactly_once/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/exactly_once/mod.rs
@@ -72,6 +72,7 @@ async fn test_exactly_once_sink_inner(err_rate_list: Vec<f64>) -> Result<()> {
             .split("\n")
             .filter(|line| {
                 line.contains(table_name_prefix)
+                    && !line.to_ascii_lowercase().contains("sinkerror")
                     && line
                         .strip_prefix(table_name_prefix)
                         .unwrap()

--- a/src/tests/simulation/tests/integration_tests/sink/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/mod.rs
@@ -17,6 +17,8 @@ mod basic;
 #[cfg(madsim)]
 mod err_isolation;
 #[cfg(madsim)]
+mod error_table;
+#[cfg(madsim)]
 mod rate_limit;
 #[cfg(madsim)]
 mod recovery;

--- a/src/tests/simulation/tests/integration_tests/sink/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/utils.rs
@@ -33,12 +33,12 @@ use rand::{Rng, rng as thread_rng};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Field;
 use risingwave_common::row::Row;
-use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::types::{DataType, JsonbVal, ScalarImpl};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_connector::sink::boxed::{BoxLogSinker, DynLogReader};
 use risingwave_connector::sink::coordinate::CoordinatedLogSinker;
 use risingwave_connector::sink::log_store::{
-    DeliveryFutureManagerAddFuture, LogStoreReadItem, TruncateOffset,
+    DeliveryFutureManagerAddFuture, LogStoreReadItem, ReportedSinkErrorRow, TruncateOffset,
 };
 use risingwave_connector::sink::test_sink::{
     TestSinkRegistryGuard, register_build_coordinated_sink, register_build_sink,
@@ -200,7 +200,7 @@ impl SinkWriter for TestWriter {
         }
         for (op, row) in chunk.rows() {
             assert_eq!(op, Op::Insert);
-            assert_eq!(row.len(), 2);
+            assert!(row.len() >= 2);
             let id = row.datum_at(0).unwrap().into_int32();
             let name = row.datum_at(1).unwrap().into_utf8().to_string();
             self.store.insert(id, name);
@@ -280,7 +280,7 @@ impl SinkWriter for CoordinatedTestWriter {
         }
         for (op, row) in chunk.rows() {
             assert_eq!(op, Op::Insert);
-            assert_eq!(row.len(), 2);
+            assert!(row.len() >= 2);
             let id = row.datum_at(0).unwrap().into_int32();
             let name = row.datum_at(1).unwrap().into_utf8().to_string();
             self.staging.entry(id).or_default().push(name);
@@ -441,7 +441,7 @@ impl AsyncTruncateSinkWriter for AsyncTruncateTestWriter {
         }
         for (op, row) in chunk.rows() {
             assert_eq!(op, Op::Insert);
-            assert_eq!(row.len(), 2);
+            assert!(row.len() >= 2);
             let id = row.datum_at(0).unwrap().into_int32();
             let name = row.datum_at(1).unwrap().into_utf8().to_string();
             let store = self.store.clone();
@@ -529,6 +529,53 @@ impl Drop for DelayedAsyncTruncateTestWriter {
     }
 }
 
+pub struct DelayedAsyncTruncateTestWriter {
+    store: TestSinkStore,
+    parallelism_counter: Arc<AtomicUsize>,
+}
+
+impl AsyncTruncateSinkWriter for DelayedAsyncTruncateTestWriter {
+    type DeliveryFuture = impl TryFuture<Ok = (), Error = SinkError> + Unpin + Send + 'static;
+
+    async fn write_chunk<'a>(
+        &'a mut self,
+        chunk: StreamChunk,
+        mut add_future: DeliveryFutureManagerAddFuture<'a, Self::DeliveryFuture>,
+    ) -> risingwave_connector::sink::Result<()> {
+        for (op, row) in chunk.rows() {
+            assert_eq!(op, Op::Insert);
+            assert!(row.len() >= 2);
+            let id = row.datum_at(0).unwrap().into_int32();
+            let name = row.datum_at(1).unwrap().into_utf8().to_string();
+            let store = self.store.clone();
+            add_future
+                .add_future_may_await(
+                    async move {
+                        sleep(Duration::from_secs(2)).await;
+                        store.insert(id, name);
+                        Ok(())
+                    }
+                    .boxed(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn barrier(&mut self, is_checkpoint: bool) -> risingwave_connector::sink::Result<()> {
+        if is_checkpoint {
+            self.store.inc_checkpoint();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DelayedAsyncTruncateTestWriter {
+    fn drop(&mut self) {
+        self.parallelism_counter.fetch_sub(1, Relaxed);
+    }
+}
+
 pub fn simple_name_of_id(id: i32) -> String {
     format!("name-{}", id)
 }
@@ -547,6 +594,7 @@ pub enum TestSinkType {
     AsyncTruncate,
     DelayedAsyncTruncate,
     RetainLog,
+    ReportError,
 }
 
 #[macro_export]
@@ -557,6 +605,7 @@ macro_rules! for_all_sink_types {
             SinglePhaseCoordinatedSink,
             TwoPhaseCoordinatedSink,
             AsyncTruncate,
+            ReportError,
         }
     };
 }
@@ -722,6 +771,100 @@ impl SimulationTestSink {
                         }
                         .into_log_sinker(10),
                     );
+                    async move { Ok(log_sinker) }.boxed()
+                }
+            }),
+            TestSinkType::DelayedAsyncTruncate => register_build_sink({
+                let parallelism_counter = parallelism_counter.clone();
+                let store = store.clone();
+                move |_, _| {
+                    parallelism_counter.fetch_add(1, Relaxed);
+                    let log_sinker = risingwave_connector::sink::boxed::boxed_log_sinker(
+                        DelayedAsyncTruncateTestWriter {
+                            store: store.clone(),
+                            parallelism_counter: parallelism_counter.clone(),
+                        }
+                        .into_log_sinker(10),
+                    );
+                    async move { Ok(log_sinker) }.boxed()
+                }
+            }),
+            TestSinkType::ReportError => register_build_sink({
+                let parallelism_counter = parallelism_counter.clone();
+                let store = store.clone();
+                move |_, _| {
+                    parallelism_counter.fetch_add(1, Relaxed);
+                    let store = store.clone();
+                    let parallelism_counter = parallelism_counter.clone();
+                    let log_sinker: BoxLogSinker =
+                        Box::new(move |mut log_reader: &mut dyn DynLogReader| {
+                            async move {
+                                struct ParallelismGuard(Arc<AtomicUsize>);
+
+                                impl Drop for ParallelismGuard {
+                                    fn drop(&mut self) {
+                                        self.0.fetch_sub(1, Relaxed);
+                                    }
+                                }
+
+                                let _parallelism_guard = ParallelismGuard(parallelism_counter);
+
+                                log_reader.start_from(None).await?;
+                                loop {
+                                    let (epoch, item) = log_reader.next_item().await?;
+                                    match item {
+                                        LogStoreReadItem::StreamChunk { chunk, chunk_id } => {
+                                            let mut reported_error_rows = vec![];
+                                            for (op, row) in chunk.rows() {
+                                                assert_eq!(op, Op::Insert);
+                                                assert!(row.len() >= 2);
+                                                let id = row.datum_at(0).unwrap().into_int32();
+                                                let name = row
+                                                    .datum_at(1)
+                                                    .unwrap()
+                                                    .into_utf8()
+                                                    .to_string();
+                                                store.insert(id, name.clone());
+                                                reported_error_rows.push(ReportedSinkErrorRow {
+                                                    epoch,
+                                                    op,
+                                                    row: row.to_owned_row(),
+                                                    extra_info: Some(JsonbVal::from(
+                                                        serde_json::json!({
+                                                            "id": id,
+                                                            "name": name,
+                                                            "column_count": row.len(),
+                                                        }),
+                                                    )),
+                                                });
+                                            }
+                                            log_reader.truncate(
+                                                TruncateOffset::Chunk { epoch, chunk_id },
+                                                reported_error_rows,
+                                            )?;
+                                        }
+                                        LogStoreReadItem::Barrier {
+                                            is_checkpoint,
+                                            schema_change,
+                                            ..
+                                        } => {
+                                            if is_checkpoint {
+                                                store.inc_checkpoint();
+                                            }
+                                            // The in-memory log store stalls after a checkpoint barrier
+                                            // until the reader truncates that barrier.
+                                            if is_checkpoint || schema_change.is_some() {
+                                                log_reader.truncate(
+                                                    TruncateOffset::Barrier { epoch },
+                                                    vec![],
+                                                )?;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            .boxed()
+                        });
                     async move { Ok(log_sinker) }.boxed()
                 }
             }),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds the sink-side feature work for persisting skipped sink rows into an internal error table when `skip_error = 'true'`.

Stack context:

- depends on #25885, which adds the log-store plumbing to carry reported sink error rows through truncate/flush
- depends on #25883, which fixes the async truncate ordering issue for non-decoupled sinks

On top of those prerequisites, this PR:

- extends sink planning/protobuf so a sink can own an internal error table
- defines the sink error table schema and catalog inference, with fixed metadata columns followed by visible sink columns
- makes the sink executor buffer reported rows by epoch and persist them into the error table before checkpoint barriers are yielded
- updates auto schema change rewriting so the sink error table schema stays aligned with the sink schema
- adds deterministic simulation coverage for sink error table behavior in both decoupled and non-decoupled modes, including schema change
- includes regression coverage around async truncate behavior and internal-table discovery

<details>
<summary><b>Design supplement</b></summary>

# Sink Error Table Design Supplement

## Trait Changes on `LogReader` and `LogWriter`

The sink runtime needs to carry skipped row-level errors from the sink delivery path back to the sink executor in a way that stays consistent with truncate and barrier progress.

The trait changes are:

- `LogReader::truncate(offset, error_rows)`
- `LogWriter::flush_current_epoch(...) -> FlushCurrentEpochResult { post_flush, reported_error_rows }`

`ReportedSinkErrorRow` is the row-level unit transported through this protocol. Each item contains:

- `epoch`: the read epoch the row belongs to
- `op`: the original row operation
- `row`: the original row payload
- `extra_info`: structured sink-specific error context

With this design, reported error rows are carried through the same truncate / flush path that already defines sink progress, instead of introducing a separate callback channel.

## How `SinkExecutor` Interacts with `LogWriter`

At each barrier, the sink executor calls `log_writer.flush_current_epoch(...)`.

The flush result returns:

- `post_flush`: the existing post-yield callback
- `reported_error_rows`: skipped rows that are ready to be surfaced at this point in progress

The sink executor then:

1. adds `reported_error_rows` into an internal pending queue ordered by epoch
2. drains rows with `reported_row.epoch <= barrier.epoch.curr`
3. converts each drained row into an internal error-table row
4. commits the error table for the barrier epoch
5. yields the barrier
6. runs `post_flush.post_yield_barrier()`

The error table commit must happen before yielding the barrier so that the error table follows the same state-table barrier contract as other executor-managed state.

## Error Table Schema

Each sink owns an internal error table.

The schema is:

- `sink_error_epoch`
- `sink_error_row_id`
- `sink_error_vnode`
- `sink_error_row_op`
- `sink_error_read_epoch`
- `sink_error_extra_info`
- visible sink columns

Column semantics:

- `sink_error_epoch`
  - the barrier epoch used when this error row is persisted into the internal table
  - this is the commit epoch of the error-table write, not necessarily the epoch when the original row was read
- `sink_error_row_id`
  - a per-`sink_error_epoch` sequence number assigned by the sink executor when draining ready rows for that barrier
  - together with vnode and write epoch, it makes each persisted error row unique
- `sink_error_vnode`
  - the vnode chosen for distributing the error-table row
  - this is an internal distribution column rather than source-row business data
- `sink_error_row_op`
  - the original stream operation of the skipped row
  - stored so queries can distinguish insert / delete / update-derived records
- `sink_error_read_epoch`
  - the read epoch attached to the reported sink error row when it comes back from the log-store layer
  - this identifies when the original row was read by the sink runtime
- `sink_error_extra_info`
  - structured sink-specific diagnostic information
  - intended for fields such as connector error details, raw payload metadata, or column-level decode context
- visible sink columns
  - the original visible sink payload columns copied from the skipped row
  - hidden/internal sink columns are not persisted into this part of the schema

The visible sink columns are appended after the metadata prefix so the original sink payload can be queried directly.

Primary key:

- `(sink_error_epoch, sink_error_row_id, sink_error_vnode)`

Distribution key:

- `sink_error_vnode`

## Schema Change Handling

The error table schema is derived from the sink schema, so it must be rewritten when sink auto schema refresh changes the visible sink columns.

The rewrite rule is:

- keep the fixed metadata prefix unchanged
- remove dropped visible sink columns
- append newly added visible sink columns
- rebuild `value_indices` to match the rewritten column layout

This rewrite is applied both to:

- the sink fragment definition
- the persisted catalog table definition

That keeps the internal error table aligned with the sink schema after auto schema change.

## Future Work

### Querying the error table

The current design stores skipped rows in an internal table, but the user-facing query surface is still minimal.

One future direction is to expose a dedicated query interface instead of making users discover internal table names manually. Two possible shapes are:

- a table-valued function, for example:
  - `select * from rw_sink_errors('my_sink')`
  - `select * from rw_sink_errors(sink_id => 1001, from_epoch => 123456)`
- a system catalog relation that resolves sink identity to the internal error table automatically

I checked current ClickHouse documentation as a reference point. Their Kafka engine supports:

- `kafka_handle_error_mode = 'stream'`, which exposes `_error` and `_raw_message` virtual columns on the stream source
- `kafka_handle_error_mode = 'dead_letter_queue'`, which persists error-related data into `system.dead_letter_queue`

That suggests two reasonable directions for RisingWave:

- expose a dedicated read surface on top of the persisted error rows
- keep the internal storage table hidden and avoid forcing users to depend on generated internal table names

The table-valued-function shape above is a proposal for RisingWave, not existing ClickHouse syntax.

### Truncating the error table

The current design appends skipped rows but does not yet define a first-class retention or truncation interface.

One future direction is to support controlled deletion through SQL, but only in a monotonic form that matches storage behavior. For example:

- `delete from rw_sink_errors('my_sink') where sink_error_epoch < 123456`
- or equivalent deletion against the internal error table with strict predicate validation

The intended restriction is:

- only allow predicates that advance a lower bound on retained epochs
- reject arbitrary row-level deletes or non-monotonic predicates

This can then be implemented as a storage-level watermark on the error table id in Hummock, instead of a general-purpose row rewrite path. In other words:

- SQL delete is only the user-facing control plane
- the execution path becomes "advance retained epoch watermark for this error table"

That keeps the retention model simple and aligned with append-only error-table semantics.

</details>

## Validation

- `cargo test -p risingwave_connector test_truncate_barrier_reader -- --nocapture`
- `cargo test -p risingwave_stream test_in_memory_log_store -- --nocapture`
- `cargo clippy --all-targets --all-features`
- `./risedev sit-test test_sink_error_table_nondecouple`
- `./risedev sit-test test_sink_error_table_decouple`
- `./risedev sit-test test_async_truncate_nondecouple_waits_for_checkpoint_truncate`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Sinks with `skip_error = 'true'` can now persist skipped rows into an internal error table, and that table stays aligned when the sink schema is refreshed automatically.

</details>
