### PR TITLE
feat(stream): add no-cache path for AsOf join 

### DIFF
--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -122,6 +122,12 @@ download_old_connector_artifact() {
 setup_old_cluster() {
   echo "--- Build risedev for $OLD_VERSION, it may not be backwards compatible"
   git config --global --add safe.directory /risingwave
+  # `common.sh` exports GIT_SHA=$BUILDKITE_COMMIT (the PR tip). After we
+  # check out an old tag, vergen's VERGEN_GIT_SHA reflects the old commit,
+  # and the compile-time assertion in src/cmd_all/src/bin/risingwave.rs
+  # panics because the two SHAs disagree. Drop GIT_SHA so the old build
+  # only relies on VERGEN_GIT_SHA.
+  unset GIT_SHA
   git checkout "v${OLD_VERSION}"
   cargo build -p risedev
   echo "--- Get RisingWave binary for $OLD_VERSION"

--- a/e2e_test/backwards-compat-tests/README.md
+++ b/e2e_test/backwards-compat-tests/README.md
@@ -14,7 +14,8 @@ The backwards compatibility tests run in the following manner:
 We currently cover the following:
 1. Basic mv
 2. Hash join with watermark / EOWC
-3. EOWC over window numbering functions
-4. Nexmark (on rw table not nexmark source)
+3. Nexmark (on rw table not nexmark source)
+4. EOWC over window numbering functions
 5. TPC-H
 6. Kafka Source
+7. AsOf join

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -283,6 +283,12 @@ seed_old_cluster() {
   echo "--- SINK INTO TABLE TEST: Validating old cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/sink_into_table/validate_original.slt"
 
+  echo "--- ASOF JOIN TEST: Seeding old cluster with data"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/asof-join/seed.slt"
+
+  echo "--- ASOF JOIN TEST: Validating old cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/asof-join/validate_original.slt"
+
   echo "--- CDC TEST: Seeding old cluster with data"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/cdc/seed.slt"
 
@@ -342,6 +348,9 @@ validate_new_cluster() {
 
   echo "--- SINK INTO TABLE TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/sink_into_table/validate_restart.slt"
+
+  echo "--- ASOF JOIN TEST: Validating new cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/asof-join/validate_restart.slt"
 
   echo "--- CDC TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/cdc/validate_restart.slt"

--- a/e2e_test/backwards-compat-tests/slt/asof-join/seed.slt
+++ b/e2e_test/backwards-compat-tests/slt/asof-join/seed.slt
@@ -1,0 +1,36 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+CREATE TABLE asof_left (
+    id INT,
+    ts INT,
+    v INT
+);
+
+statement ok
+CREATE TABLE asof_right (
+    id INT,
+    ts INT,
+    v INT
+);
+
+statement ok
+CREATE MATERIALIZED VIEW asof_inner_mv AS
+SELECT l.id AS l_id, l.ts AS l_ts, l.v AS l_v, r.id AS r_id, r.ts AS r_ts, r.v AS r_v
+FROM asof_left l
+ASOF JOIN asof_right r
+ON l.id = r.id AND l.ts >= r.ts;
+
+statement ok
+CREATE MATERIALIZED VIEW asof_left_outer_mv AS
+SELECT l.id AS l_id, l.ts AS l_ts, l.v AS l_v, r.id AS r_id, r.ts AS r_ts, r.v AS r_v
+FROM asof_left l
+ASOF LEFT JOIN asof_right r
+ON l.id = r.id AND l.ts >= r.ts;
+
+statement ok
+INSERT INTO asof_right VALUES (1, 10, 100), (1, 20, 200), (1, 30, 300);
+
+statement ok
+INSERT INTO asof_left VALUES (1, 15, 1), (1, 25, 2), (1, 35, 3), (2, 10, 4);

--- a/e2e_test/backwards-compat-tests/slt/asof-join/validate_original.slt
+++ b/e2e_test/backwards-compat-tests/slt/asof-join/validate_original.slt
@@ -1,0 +1,14 @@
+query IIIIII rowsort
+SELECT * FROM asof_inner_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 30 300
+
+query IIIIII rowsort
+SELECT * FROM asof_left_outer_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 30 300
+2 10 4 NULL NULL NULL

--- a/e2e_test/backwards-compat-tests/slt/asof-join/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/asof-join/validate_restart.slt
@@ -1,0 +1,57 @@
+# Rerun original validation after upgrade
+query IIIIII rowsort
+SELECT * FROM asof_inner_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 30 300
+
+query IIIIII rowsort
+SELECT * FROM asof_left_outer_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 30 300
+2 10 4 NULL NULL NULL
+
+# Test updates after upgrade
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+INSERT INTO asof_right VALUES (2, 5, 500);
+
+query IIIIII rowsort
+SELECT * FROM asof_inner_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 30 300
+2 10 4 2 5 500
+
+query IIIIII rowsort
+SELECT * FROM asof_left_outer_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 30 300
+2 10 4 2 5 500
+
+statement ok
+DELETE FROM asof_right WHERE ts = 30;
+
+query IIIIII rowsort
+SELECT * FROM asof_inner_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 20 200
+2 10 4 2 5 500
+
+query IIIIII rowsort
+SELECT * FROM asof_left_outer_mv;
+----
+1 15 1 1 10 100
+1 25 2 1 20 200
+1 35 3 1 20 200
+2 10 4 2 5 500

--- a/e2e_test/batch/catalog/pg_settings.slt.part
+++ b/e2e_test/batch/catalog/pg_settings.slt.part
@@ -71,6 +71,7 @@ user source_rate_limit
 user standard_conforming_strings
 user statement_timeout
 user streaming_allow_jsonb_in_stream_key
+user streaming_asof_join_use_cache
 user streaming_enable_bushy_join
 user streaming_enable_delta_join
 user streaming_enable_unaligned_join

--- a/e2e_test/streaming/join/asof_join.slt.part
+++ b/e2e_test/streaming/join/asof_join.slt.part
@@ -84,6 +84,479 @@ statement ok
 drop table t2;
 
 
+# asof inner join: right-row delete triggers rematch to next-best candidate
+
+statement ok
+create table t1 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t2 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_rematch as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 <= t2.v2;
+
+# Insert left row and two right candidates
+statement ok
+insert into t1 values (1, 5, 100);
+
+statement ok
+insert into t2 values (1, 5, 10);
+
+statement ok
+insert into t2 values (1, 8, 20);
+
+# Should match the closest: (1, 5, 10) since 5 <= 5
+query IIIIII
+select * from mv_rematch;
+----
+1 5 100 1 5 10
+
+# Delete the currently matched right row
+statement ok
+delete from t2 where v3 = 10;
+
+# Should rematch to the next-best candidate: (1, 8, 20) since 5 <= 8
+query IIIIII
+select * from mv_rematch;
+----
+1 5 100 1 8 20
+
+# Delete the remaining right row
+statement ok
+delete from t2 where v3 = 20;
+
+# No match available — inner join produces no output
+query IIIIII
+select * from mv_rematch;
+----
+
+# Insert a new right row to verify re-join
+statement ok
+insert into t2 values (1, 6, 30);
+
+query IIIIII
+select * from mv_rematch;
+----
+1 5 100 1 6 30
+
+statement ok
+drop materialized view mv_rematch;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+
+# asof inner join: one right-side change affects multiple left rows
+
+statement ok
+create table t1 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t2 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_multi as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 <= t2.v2;
+
+# Insert multiple left rows with different inequality keys
+statement ok
+insert into t1 values (1, 3, 101), (1, 5, 102), (1, 7, 103);
+
+# Insert a right row that matches all three left rows (3 <= 10, 5 <= 10, 7 <= 10)
+statement ok
+insert into t2 values (1, 10, 200);
+
+query IIIIII rowsort
+select * from mv_multi;
+----
+1 3 101 1 10 200
+1 5 102 1 10 200
+1 7 103 1 10 200
+
+# Insert a closer right row for left rows with v2=3 and v2=5 (but not v2=7)
+statement ok
+insert into t2 values (1, 6, 201);
+
+# Left rows v2=3 and v2=5 should rematch to (1, 6, 201), v2=7 stays with (1, 10, 200)
+query IIIIII rowsort
+select * from mv_multi;
+----
+1 3 101 1 6 201
+1 5 102 1 6 201
+1 7 103 1 10 200
+
+# Delete the closer right row — left rows v2=3 and v2=5 should fall back to (1, 10, 200)
+statement ok
+delete from t2 where v3 = 201;
+
+query IIIIII rowsort
+select * from mv_multi;
+----
+1 3 101 1 10 200
+1 5 102 1 10 200
+1 7 103 1 10 200
+
+statement ok
+drop materialized view mv_multi;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+
+# asof inner join: PK tie-breaking with <= (lower_bound path, same inequality key, different PKs)
+
+statement ok
+create table t1 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t2 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_pk_le as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 <= t2.v2;
+
+statement ok
+insert into t1 values (1, 5, 100);
+
+# Insert right rows with same inequality key (v2=5), different PKs
+statement ok
+insert into t2 values (1, 5, 30);
+
+query IIIIII
+select * from mv_pk_le;
+----
+1 5 100 1 5 30
+
+# Insert another right row with same inequality key but smaller PK — should take over
+statement ok
+insert into t2 values (1, 5, 10);
+
+query IIIIII
+select * from mv_pk_le;
+----
+1 5 100 1 5 10
+
+# Insert yet another with even smaller PK
+statement ok
+insert into t2 values (1, 5, 5);
+
+query IIIIII
+select * from mv_pk_le;
+----
+1 5 100 1 5 5
+
+# Delete the current best (smallest PK=5) — should fall back to PK=10
+statement ok
+delete from t2 where v3 = 5;
+
+query IIIIII
+select * from mv_pk_le;
+----
+1 5 100 1 5 10
+
+# Delete PK=10 — should fall back to PK=30
+statement ok
+delete from t2 where v3 = 10;
+
+query IIIIII
+select * from mv_pk_le;
+----
+1 5 100 1 5 30
+
+# Delete last one — no match
+statement ok
+delete from t2 where v3 = 30;
+
+query IIIIII
+select * from mv_pk_le;
+----
+
+# Re-insert to verify recovery
+statement ok
+insert into t2 values (1, 5, 20);
+
+query IIIIII
+select * from mv_pk_le;
+----
+1 5 100 1 5 20
+
+statement ok
+drop materialized view mv_pk_le;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+
+# asof left join: PK tie-breaking with > (upper_bound path, same inequality key, different PKs)
+
+statement ok
+create table t1 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t2 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_pk_gt as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF LEFT JOIN t2 ON t1.v1 = t2.v1 and t1.v2 > t2.v2;
+
+statement ok
+insert into t1 values (1, 10, 100);
+
+# Insert right rows with same inequality key (v2=5), different PKs
+statement ok
+insert into t2 values (1, 5, 30);
+
+# 10 > 5, matches
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 5 30
+
+statement ok
+insert into t2 values (1, 5, 10);
+
+# Two right rows with v2=5, PK=10 and PK=30. eq_join_right picks the smallest PK.
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 5 10
+
+statement ok
+insert into t2 values (1, 5, 5);
+
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 5 5
+
+# Delete PK=5 — should fall back to next
+statement ok
+delete from t2 where v3 = 5;
+
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 5 10
+
+# Delete PK=10 — should fall back to PK=30
+statement ok
+delete from t2 where v3 = 10;
+
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 5 30
+
+# Delete PK=30 — no match, left outer shows NULLs
+statement ok
+delete from t2 where v3 = 30;
+
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 NULL NULL NULL
+
+# Insert a right row with a different inequality key closer to left (v2=8, still < 10)
+statement ok
+insert into t2 values (1, 8, 40);
+
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 8 40
+
+# Insert another at v2=8 with smaller PK
+statement ok
+insert into t2 values (1, 8, 15);
+
+query IIIIII
+select * from mv_pk_gt;
+----
+1 10 100 1 8 15
+
+statement ok
+drop materialized view mv_pk_gt;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+
+# asof inner join: PK tie-breaking with >= (upper_bound path)
+
+statement ok
+create table t1 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t2 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_pk_ge as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF JOIN t2 ON t1.v1 = t2.v1 and t1.v2 >= t2.v2;
+
+statement ok
+insert into t1 values (1, 5, 100);
+
+# Insert right row with v2=5 (5 >= 5 matches)
+statement ok
+insert into t2 values (1, 5, 20);
+
+query IIIIII
+select * from mv_pk_ge;
+----
+1 5 100 1 5 20
+
+# Insert another at same inequality key v2=5 with smaller PK
+statement ok
+insert into t2 values (1, 5, 10);
+
+query IIIIII
+select * from mv_pk_ge;
+----
+1 5 100 1 5 10
+
+# Insert at v2=3 (also matches since 5 >= 3), but v2=5 is closer
+statement ok
+insert into t2 values (1, 3, 50);
+
+# Should still match v2=5 (closest to left v2=5)
+query IIIIII
+select * from mv_pk_ge;
+----
+1 5 100 1 5 10
+
+# Delete both v2=5 rows — should fall back to v2=3
+statement ok
+delete from t2 where v2 = 5;
+
+query IIIIII
+select * from mv_pk_ge;
+----
+1 5 100 1 3 50
+
+# Insert two rows at v2=4 with different PKs
+statement ok
+insert into t2 values (1, 4, 8), (1, 4, 25);
+
+# v2=4 is closer than v2=3, should match v2=4
+query IIIIII
+select * from mv_pk_ge;
+----
+1 5 100 1 4 8
+
+# Delete PK=8 — should switch to PK=25 within same inequality key
+statement ok
+delete from t2 where v3 = 8;
+
+query IIIIII
+select * from mv_pk_ge;
+----
+1 5 100 1 4 25
+
+statement ok
+drop materialized view mv_pk_ge;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+
+# asof left join: PK tie-breaking with < (lower_bound path)
+
+statement ok
+create table t1 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t2 (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_pk_lt as SELECT t1.v1 t1_v1, t1.v2 t1_v2, t1.v3 t1_v3, t2.v1 t2_v1, t2.v2 t2_v2, t2.v3 t2_v3 FROM t1 ASOF LEFT JOIN t2 ON t1.v1 = t2.v1 and t1.v2 < t2.v2;
+
+statement ok
+insert into t1 values (1, 5, 100);
+
+# v2=5 not < 5, no match
+statement ok
+insert into t2 values (1, 5, 20);
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 NULL NULL NULL
+
+# v2=6 > 5, matches
+statement ok
+insert into t2 values (1, 6, 30);
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 1 6 30
+
+# Insert another at v2=6 with smaller PK
+statement ok
+insert into t2 values (1, 6, 10);
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 1 6 10
+
+# Insert at v2=6 with even smaller PK
+statement ok
+insert into t2 values (1, 6, 5);
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 1 6 5
+
+# Delete PK=5 — should fall back to PK=10
+statement ok
+delete from t2 where v3 = 5;
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 1 6 10
+
+# Delete PK=10 — should fall back to PK=30
+statement ok
+delete from t2 where v3 = 10;
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 1 6 30
+
+# Delete PK=30 — no match, left outer NULLs
+statement ok
+delete from t2 where v3 = 30;
+
+query IIIIII
+select * from mv_pk_lt;
+----
+1 5 100 NULL NULL NULL
+
+statement ok
+drop materialized view mv_pk_lt;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+
 # asof left join
 
 statement ok
@@ -157,3 +630,124 @@ drop table t1;
 
 statement ok
 drop table t2;
+
+
+# eq_join_left PK tie with > (upper_bound path)
+# When multiple right rows share the same inequality key, eq_join_left picks the
+# row with the smallest PK. eq_join_right must agree on this tie-breaking rule.
+
+statement ok
+create table t_left_gt (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t_right_gt (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_left_pktie_gt as SELECT t_left_gt.v1 t1_v1, t_left_gt.v2 t1_v2, t_left_gt.v3 t1_v3, t_right_gt.v1 t2_v1, t_right_gt.v2 t2_v2, t_right_gt.v3 t2_v3 FROM t_left_gt ASOF JOIN t_right_gt ON t_left_gt.v1 = t_right_gt.v1 and t_left_gt.v2 > t_right_gt.v2;
+
+# Insert multiple right rows with same inequality key FIRST
+statement ok
+insert into t_right_gt values (1, 5, 10), (1, 5, 30);
+
+# Now insert left row — eq_join_left calls upper_bound, returns smallest PK
+statement ok
+insert into t_left_gt values (1, 10, 100);
+
+# Smallest PK=10 among right rows with v2=5
+query IIIIII
+select * from mv_left_pktie_gt;
+----
+1 10 100 1 5 10
+
+# Insert another right row with smaller PK at same inequality key
+statement ok
+insert into t_right_gt values (1, 5, 5);
+
+# eq_join_right replaces current match with smaller PK=5
+query IIIIII
+select * from mv_left_pktie_gt;
+----
+1 10 100 1 5 5
+
+# Delete PK=5 — eq_join_right falls back to PK=10
+statement ok
+delete from t_right_gt where v3 = 5;
+
+query IIIIII
+select * from mv_left_pktie_gt;
+----
+1 10 100 1 5 10
+
+# Delete left row and re-insert to re-trigger eq_join_left with remaining ties (PK=10,30)
+statement ok
+delete from t_left_gt where v3 = 100;
+
+statement ok
+insert into t_left_gt values (1, 10, 100);
+
+# Smallest PK=10 again
+query IIIIII
+select * from mv_left_pktie_gt;
+----
+1 10 100 1 5 10
+
+statement ok
+drop materialized view mv_left_pktie_gt;
+
+statement ok
+drop table t_left_gt;
+
+statement ok
+drop table t_right_gt;
+
+
+# eq_join_left PK tie with >= (upper_bound path)
+
+statement ok
+create table t_left_ge (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create table t_right_ge (v1 int, v2 int, v3 int primary key);
+
+statement ok
+create materialized view mv_left_pktie_ge as SELECT t_left_ge.v1 t1_v1, t_left_ge.v2 t1_v2, t_left_ge.v3 t1_v3, t_right_ge.v1 t2_v1, t_right_ge.v2 t2_v2, t_right_ge.v3 t2_v3 FROM t_left_ge ASOF JOIN t_right_ge ON t_left_ge.v1 = t_right_ge.v1 and t_left_ge.v2 >= t_right_ge.v2;
+
+# Insert multiple right rows with same inequality key (v2=5) FIRST
+statement ok
+insert into t_right_ge values (1, 5, 10), (1, 5, 30), (1, 5, 20);
+
+# Insert left row with v2=5 (5 >= 5 matches) — eq_join_left calls upper_bound
+statement ok
+insert into t_left_ge values (1, 5, 100);
+
+# Smallest PK=10
+query IIIIII
+select * from mv_left_pktie_ge;
+----
+1 5 100 1 5 10
+
+# Delete left and re-insert to re-exercise eq_join_left
+statement ok
+delete from t_left_ge where v3 = 100;
+
+# Delete PK=10, leaving PK=20 and PK=30
+statement ok
+delete from t_right_ge where v3 = 10;
+
+statement ok
+insert into t_left_ge values (1, 5, 100);
+
+# Smallest remaining PK=20
+query IIIIII
+select * from mv_left_pktie_ge;
+----
+1 5 100 1 5 20
+
+statement ok
+drop materialized view mv_left_pktie_ge;
+
+statement ok
+drop table t_left_ge;
+
+statement ok
+drop table t_right_ge;

--- a/e2e_test/streaming/join/main.slt
+++ b/e2e_test/streaming/join/main.slt
@@ -20,3 +20,12 @@ include ./full_outer_join_global_agg.slt.part
 
 statement ok
 set streaming_join_encoding to default;
+
+# Test no-cache AsOf join (v2)
+statement ok
+set streaming_asof_join_use_cache to false;
+
+include ./asof_join.slt.part
+
+statement ok
+set streaming_asof_join_use_cache to true;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -666,6 +666,10 @@ message AsOfJoinNode {
   // Which encoding will be used to encode join rows in operator cache.
   // Deprecated. Use the one from `StreamingDeveloperConfig` instead.
   JoinEncodingType join_encoding_type = 11 [deprecated = true];
+  // Whether to use the cache-based implementation (true) or the no-cache implementation (false).
+  // Controlled by session variable `streaming_asof_join_use_cache`.
+  // Optional so that legacy plans (without this field) default to true (cache-based).
+  optional bool use_cache = 12;
 }
 
 message TemporalJoinNode {

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -392,6 +392,15 @@ pub struct SessionConfig {
     #[parameter(default = true)]
     streaming_use_shared_source: bool,
 
+    /// Enable in-memory cache for `AsOf` join executor.
+    ///
+    /// When enabled (default), `AsOf` join uses the cache-based implementation.
+    ///
+    /// When disabled, `AsOf` join uses a no-cache implementation that directly queries
+    /// the state table on-demand, reducing unnecessary data fetches for cache.
+    #[parameter(default = true)]
+    streaming_asof_join_use_cache: bool,
+
     /// Shows the server-side character set encoding. At present, this parameter can be shown but not set, because the encoding is determined at database creation time.
     #[parameter(default = SERVER_ENCODING)]
     server_encoding: String,

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -581,6 +581,23 @@ pub fn cmp_rows(lhs: impl Row, rhs: impl Row, order_types: &[OrderType]) -> Orde
         })
 }
 
+/// Compare two rows column-by-column, assuming all columns are in ascending order.
+/// This function avoids the allocation of `order_types` before each call.
+///
+/// # Panics
+///
+/// See [`cmp_rows`]
+pub fn cmp_rows_ascending(lhs: impl Row, rhs: impl Row) -> Ordering {
+    assert_eq!(lhs.len(), rhs.len());
+    let order_type = OrderType::ascending();
+    lhs.iter()
+        .zip_eq_debug(rhs.iter())
+        .fold(Ordering::Equal, |acc, (l, r)| match acc {
+            Ordering::Equal => cmp_datum(l, r, order_type),
+            acc => acc,
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;

--- a/src/frontend/src/optimizer/plan_node/stream_asof_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_asof_join.rs
@@ -300,6 +300,13 @@ impl StreamNode for StreamAsOfJoin {
             _ => unreachable!(),
         };
 
+        let use_cache = self
+            .base
+            .ctx()
+            .session_ctx()
+            .config()
+            .streaming_asof_join_use_cache();
+
         NodeBody::AsOfJoin(Box::new(AsOfJoinNode {
             join_type: asof_join_type.into(),
             left_key: left_jk_indices_prost,
@@ -314,6 +321,7 @@ impl StreamNode for StreamAsOfJoin {
             // Join encoding type should now be read from per-job config override.
             #[allow(deprecated)]
             join_encoding_type: PbJoinEncodingType::Unspecified as _,
+            use_cache: Some(use_cache),
         }))
     }
 }

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -2101,6 +2101,18 @@ where
         )
     }
 
+    pub async fn rev_iter_keyed_row_with_prefix(
+        &self,
+        pk_prefix: impl Row,
+        sub_range: &(Bound<impl Row>, Bound<impl Row>),
+        prefetch_options: PrefetchOptions,
+    ) -> StreamExecutorResult<impl KeyedRowStream<'_>> {
+        Ok(
+            self.iter_with_prefix_inner::</* REVERSE */ true, Bytes>(pk_prefix, sub_range, prefetch_options)
+            .await?.map_ok(|(key, row)| KeyedRow::new(TableKey(key), row)),
+        )
+    }
+
     /// This function scans the table just like `iter_with_prefix`, but in reverse order.
     pub async fn rev_iter_with_prefix(
         &self,

--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashSet};
-use std::marker::PhantomData;
+//! `AsOf` join executor with optional LRU cache.
+//!
+//! When `use_cache` is false, the executor directly queries the state table.
+//! When `use_cache` is true, the `AsOfJoinHashMap` maintains an LRU cache.
+//! Controlled by the session variable `streaming_asof_join_use_cache`.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::time::Duration;
 
@@ -21,23 +27,19 @@ use either::Either;
 use itertools::Itertools;
 use multimap::MultiMap;
 use risingwave_common::array::Op;
-use risingwave_common::hash::{HashKey, NullBitmap};
+use risingwave_common::row::RowExt;
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_common::util::iter_util::ZipEqDebug;
+use risingwave_common::util::sort_util::cmp_rows_ascending;
 use tokio::time::Instant;
 
-use self::builder::JoinChunkBuilder;
 use super::barrier_align::*;
-use super::join::hash_join::*;
+use super::join::asof_join::*;
+use super::join::builder::JoinStreamChunkBuilder;
+use super::join::row::JoinRow;
 use super::join::*;
 use super::watermark::*;
-use crate::executor::join::builder::JoinStreamChunkBuilder;
-use crate::executor::join::row::JoinEncoding;
+use crate::executor::join::builder::JoinChunkBuilder;
 use crate::executor::prelude::*;
-
-fn is_subset(vec1: Vec<usize>, vec2: Vec<usize>) -> bool {
-    HashSet::<usize>::from_iter(vec1).is_subset(&vec2.into_iter().collect())
-}
 
 pub struct JoinParams {
     /// Indices of the join keys
@@ -55,65 +57,42 @@ impl JoinParams {
     }
 }
 
-struct JoinSide<K: HashKey, S: StateStore, E: JoinEncoding> {
+struct JoinSide<S: StateStore, E: AsOfRowEncoding> {
     /// Store all data from a one side stream
-    ht: JoinHashMap<K, S, E>,
+    ht: AsOfJoinHashMap<S, E>,
     /// Indices of the join key columns
     join_key_indices: Vec<usize>,
     /// The data type of all columns without degree.
     all_data_types: Vec<DataType>,
-    /// The start position for the side in output new columns
-    start_pos: usize,
     /// The mapping from input indices of a side to output columns.
     i2o_mapping: Vec<(usize, usize)>,
     i2o_mapping_indexed: MultiMap<usize, usize>,
-    /// Whether degree table is needed for this side.
-    need_degree_table: bool,
-    _marker: std::marker::PhantomData<E>,
+    /// The index of the inequality column.
+    inequal_key_idx: usize,
 }
 
-impl<K: HashKey, S: StateStore, E: JoinEncoding> std::fmt::Debug for JoinSide<K, S, E> {
+impl<S: StateStore, E: AsOfRowEncoding> std::fmt::Debug for JoinSide<S, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JoinSide")
             .field("join_key_indices", &self.join_key_indices)
             .field("col_types", &self.all_data_types)
-            .field("start_pos", &self.start_pos)
             .field("i2o_mapping", &self.i2o_mapping)
-            .field("need_degree_table", &self.need_degree_table)
             .finish()
     }
 }
 
-impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinSide<K, S, E> {
-    // WARNING: Please do not call this until we implement it.
-    fn is_dirty(&self) -> bool {
-        unimplemented!()
-    }
-
-    #[expect(dead_code)]
-    fn clear_cache(&mut self) {
-        assert!(
-            !self.is_dirty(),
-            "cannot clear cache while states of hash join are dirty"
-        );
-
-        // TODO: not working with rearranged chain
-        // self.ht.clear();
-    }
-
+impl<S: StateStore, E: AsOfRowEncoding> JoinSide<S, E> {
     pub async fn init(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
         self.ht.init(epoch).await
     }
 }
 
-/// `AsOfJoinExecutor` takes two input streams and runs equal hash join on them.
-/// The output columns are the concatenation of left and right columns.
-pub struct AsOfJoinExecutor<
-    K: HashKey,
-    S: StateStore,
-    const T: AsOfJoinTypePrimitive,
-    E: JoinEncoding,
-> {
+/// `AsOfJoinExecutor` for streaming as-of joins.
+///
+/// This executor uses `AsOfJoinHashMap` to support both execution modes:
+/// it can either maintain an LRU cache or query the state table directly,
+/// depending on the `use_cache` configuration.
+pub struct AsOfJoinExecutor<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> {
     ctx: ActorContextRef,
     info: ExecutorInfo,
 
@@ -124,28 +103,30 @@ pub struct AsOfJoinExecutor<
     /// The data types of the formed new columns
     actual_output_data_types: Vec<DataType>,
     /// The parameters of the left join executor
-    side_l: JoinSide<K, S, E>,
+    side_l: JoinSide<S, E>,
     /// The parameters of the right join executor
-    side_r: JoinSide<K, S, E>,
+    side_r: JoinSide<S, E>,
+
+    /// Whether nulls are considered equal for each join key column
+    null_safe: Vec<bool>,
 
     metrics: Arc<StreamingMetrics>,
     /// The maximum size of the chunk produced by executor at a time
     chunk_size: usize,
-    /// Count the messages received, clear to 0 when counted to `EVICT_EVERY_N_MESSAGES`
-    cnt_rows_received: u32,
-
     /// watermark column index -> `BufferedWatermarks`
     watermark_buffers: BTreeMap<usize, BufferedWatermarks<SideTypePrimitive>>,
-
-    high_join_amplification_threshold: usize,
-    /// Number of processed rows between periodic manual evictions of the join cache.
-    join_cache_evict_interval_rows: u32,
     /// `AsOf` join description
     asof_desc: AsOfDesc,
+    /// Row counter for periodic cache eviction
+    cnt_rows_received: u32,
+    /// Number of processed rows between periodic manual evictions of the join cache.
+    join_cache_evict_interval_rows: u32,
+    /// Threshold for logging high join amplification warnings.
+    high_join_amplification_threshold: usize,
 }
 
-impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding> std::fmt::Debug
-    for AsOfJoinExecutor<K, S, T, E>
+impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> std::fmt::Debug
+    for AsOfJoinExecutor<S, T, E>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AsOfJoinExecutor")
@@ -157,39 +138,33 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
             .field("stream_key", &self.info.stream_key)
             .field("schema", &self.info.schema)
             .field("actual_output_data_types", &self.actual_output_data_types)
-            .field(
-                "join_cache_evict_interval_rows",
-                &self.join_cache_evict_interval_rows,
-            )
             .finish()
     }
 }
 
-impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding> Execute
-    for AsOfJoinExecutor<K, S, T, E>
+impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> Execute
+    for AsOfJoinExecutor<S, T, E>
 {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.into_stream().boxed()
     }
 }
 
-struct EqJoinArgs<'a, K: HashKey, S: StateStore, E: JoinEncoding> {
+struct EqJoinArgs<'a, S: StateStore, E: AsOfRowEncoding> {
     ctx: &'a ActorContextRef,
-    side_l: &'a mut JoinSide<K, S, E>,
-    side_r: &'a mut JoinSide<K, S, E>,
+    side_l: &'a mut JoinSide<S, E>,
+    side_r: &'a mut JoinSide<S, E>,
+    null_safe: &'a [bool],
     asof_desc: &'a AsOfDesc,
     actual_output_data_types: &'a [DataType],
-    // inequality_watermarks: &'a Watermark,
     chunk: StreamChunk,
     chunk_size: usize,
     cnt_rows_received: &'a mut u32,
-    high_join_amplification_threshold: usize,
     join_cache_evict_interval_rows: u32,
+    high_join_amplification_threshold: usize,
 }
 
-impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
-    AsOfJoinExecutor<K, S, T, E>
-{
+impl<S: StateStore, const T: AsOfJoinTypePrimitive, E: AsOfRowEncoding> AsOfJoinExecutor<S, T, E> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: ActorContextRef,
@@ -205,16 +180,20 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
         watermark_epoch: AtomicU64Ref,
         metrics: Arc<StreamingMetrics>,
         chunk_size: usize,
-        high_join_amplification_threshold: usize,
         asof_desc: AsOfDesc,
+        use_cache: bool,
+        high_join_amplification_threshold: usize,
     ) -> Self {
         let join_cache_evict_interval_rows = ctx
             .config
             .developer
             .join_hash_map_evict_interval_rows
             .max(1);
-        let side_l_column_n = input_l.schema().len();
-
+        let cache_epoch = if use_cache {
+            Some(watermark_epoch)
+        } else {
+            None
+        };
         let schema_fields = [
             input_l.schema().fields.clone(),
             input_r.schema().fields.clone(),
@@ -230,19 +209,11 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
             .map(|&idx| original_output_data_types[idx].clone())
             .collect_vec();
 
-        // Data types of of hash join state.
         let state_all_data_types_l = input_l.schema().data_types();
         let state_all_data_types_r = input_r.schema().data_types();
 
-        let state_pk_indices_l = input_l.stream_key().to_vec();
-        let state_pk_indices_r = input_r.stream_key().to_vec();
-
         let state_join_key_indices_l = params_l.join_key_indices;
         let state_join_key_indices_r = params_r.join_key_indices;
-
-        // If pk is contained in join key.
-        let pk_contained_in_jk_l = is_subset(state_pk_indices_l, state_join_key_indices_l.clone());
-        let pk_contained_in_jk_r = is_subset(state_pk_indices_r, state_join_key_indices_r.clone());
 
         let join_key_data_types_l = state_join_key_indices_l
             .iter()
@@ -255,8 +226,6 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
             .collect_vec();
 
         assert_eq!(join_key_data_types_l, join_key_data_types_r);
-
-        let null_matched = K::Bitmap::from_bool_vec(null_safe);
 
         let (left_to_output, right_to_output) = {
             let (left_len, right_len) = if is_left_semi_or_anti(T) {
@@ -272,13 +241,10 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
         let l2o_indexed = MultiMap::from_iter(left_to_output.iter().copied());
         let r2o_indexed = MultiMap::from_iter(right_to_output.iter().copied());
 
-        // handle inequality watermarks
-        // https://github.com/risingwavelabs/risingwave/issues/18503
-        // let inequality_watermarks = None;
         let watermark_buffers = BTreeMap::new();
 
-        let inequal_key_idx_l = Some(asof_desc.left_idx);
-        let inequal_key_idx_r = Some(asof_desc.right_idx);
+        let inequal_key_idx_l = asof_desc.left_idx;
+        let inequal_key_idx_r = asof_desc.right_idx;
 
         Self {
             ctx: ctx.clone(),
@@ -286,18 +252,15 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
             input_l: Some(input_l),
             input_r: Some(input_r),
             actual_output_data_types,
+            null_safe,
             side_l: JoinSide {
-                ht: JoinHashMap::new(
-                    watermark_epoch.clone(),
-                    join_key_data_types_l,
+                ht: AsOfJoinHashMap::new(
                     state_join_key_indices_l.clone(),
-                    state_all_data_types_l.clone(),
                     state_table_l,
                     params_l.deduped_pk_indices,
-                    None,
-                    null_matched.clone(),
-                    pk_contained_in_jk_l,
                     inequal_key_idx_l,
+                    state_all_data_types_l.clone(),
+                    cache_epoch.clone(),
                     metrics.clone(),
                     ctx.id,
                     ctx.fragment_id,
@@ -307,22 +270,16 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 all_data_types: state_all_data_types_l,
                 i2o_mapping: left_to_output,
                 i2o_mapping_indexed: l2o_indexed,
-                start_pos: 0,
-                need_degree_table: false,
-                _marker: PhantomData,
+                inequal_key_idx: inequal_key_idx_l,
             },
             side_r: JoinSide {
-                ht: JoinHashMap::new(
-                    watermark_epoch,
-                    join_key_data_types_r,
+                ht: AsOfJoinHashMap::new(
                     state_join_key_indices_r.clone(),
-                    state_all_data_types_r.clone(),
                     state_table_r,
                     params_r.deduped_pk_indices,
-                    None,
-                    null_matched,
-                    pk_contained_in_jk_r,
                     inequal_key_idx_r,
+                    state_all_data_types_r.clone(),
+                    cache_epoch,
                     metrics.clone(),
                     ctx.id,
                     ctx.fragment_id,
@@ -330,19 +287,32 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 ),
                 join_key_indices: state_join_key_indices_r,
                 all_data_types: state_all_data_types_r,
-                start_pos: side_l_column_n,
                 i2o_mapping: right_to_output,
                 i2o_mapping_indexed: r2o_indexed,
-                need_degree_table: false,
-                _marker: PhantomData,
+                inequal_key_idx: inequal_key_idx_r,
             },
             metrics,
             chunk_size,
-            cnt_rows_received: 0,
             watermark_buffers,
-            high_join_amplification_threshold,
-            join_cache_evict_interval_rows,
             asof_desc,
+            cnt_rows_received: 0,
+            join_cache_evict_interval_rows,
+            high_join_amplification_threshold,
+        }
+    }
+
+    /// Periodically evict the LRU cache to prevent memory buildup between barriers.
+    fn evict_cache(
+        side_l: &mut JoinSide<S, E>,
+        side_r: &mut JoinSide<S, E>,
+        cnt_rows_received: &mut u32,
+        join_cache_evict_interval_rows: u32,
+    ) {
+        *cnt_rows_received += 1;
+        if *cnt_rows_received >= join_cache_evict_interval_rows {
+            side_l.ht.evict_cache();
+            side_r.ht.evict_cache();
+            *cnt_rows_received = 0;
         }
     }
 
@@ -363,7 +333,6 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
 
         let barrier = expect_first_barrier_from_aligned_stream(&mut aligned_stream).await?;
         let first_epoch = barrier.epoch;
-        // The first barrier message should be propagated.
         yield Message::Barrier(barrier);
         self.side_l.init(first_epoch).await?;
         self.side_r.init(first_epoch).await?;
@@ -371,7 +340,6 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
         let actor_id_str = self.ctx.id.to_string();
         let fragment_id_str = self.ctx.fragment_id.to_string();
 
-        // initialized some metrics
         let join_actor_input_waiting_duration_ns = self
             .metrics
             .join_actor_input_waiting_duration_ns
@@ -431,14 +399,14 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                         ctx: &self.ctx,
                         side_l: &mut self.side_l,
                         side_r: &mut self.side_r,
+                        null_safe: &self.null_safe,
                         asof_desc: &self.asof_desc,
                         actual_output_data_types: &self.actual_output_data_types,
-                        // inequality_watermarks: &self.inequality_watermarks,
                         chunk,
                         chunk_size: self.chunk_size,
                         cnt_rows_received: &mut self.cnt_rows_received,
-                        high_join_amplification_threshold: self.high_join_amplification_threshold,
                         join_cache_evict_interval_rows: self.join_cache_evict_interval_rows,
+                        high_join_amplification_threshold: self.high_join_amplification_threshold,
                     }) {
                         left_time += left_start_time.elapsed();
                         yield Message::Chunk(chunk?);
@@ -456,14 +424,14 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                         ctx: &self.ctx,
                         side_l: &mut self.side_l,
                         side_r: &mut self.side_r,
+                        null_safe: &self.null_safe,
                         asof_desc: &self.asof_desc,
                         actual_output_data_types: &self.actual_output_data_types,
-                        // inequality_watermarks: &self.inequality_watermarks,
                         chunk,
                         chunk_size: self.chunk_size,
                         cnt_rows_received: &mut self.cnt_rows_received,
-                        high_join_amplification_threshold: self.high_join_amplification_threshold,
                         join_cache_evict_interval_rows: self.join_cache_evict_interval_rows,
+                        high_join_amplification_threshold: self.high_join_amplification_threshold,
                     }) {
                         right_time += right_start_time.elapsed();
                         yield Message::Chunk(chunk?);
@@ -515,37 +483,18 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
         &mut self,
         epoch: EpochPair,
     ) -> StreamExecutorResult<(
-        JoinHashMapPostCommit<'_, K, S, E>,
-        JoinHashMapPostCommit<'_, K, S, E>,
+        AsOfJoinHashMapPostCommit<'_, S, E>,
+        AsOfJoinHashMapPostCommit<'_, S, E>,
     )> {
-        // All changes to the state has been buffered in the mem-table of the state table. Just
-        // `commit` them here.
         let left = self.side_l.ht.flush(epoch).await?;
         let right = self.side_r.ht.flush(epoch).await?;
         Ok((left, right))
     }
 
     async fn try_flush_data(&mut self) -> StreamExecutorResult<()> {
-        // All changes to the state has been buffered in the mem-table of the state table. Just
-        // `commit` them here.
         self.side_l.ht.try_flush().await?;
         self.side_r.ht.try_flush().await?;
         Ok(())
-    }
-
-    // We need to manually evict the cache.
-    fn evict_cache(
-        side_update: &mut JoinSide<K, S, E>,
-        side_match: &mut JoinSide<K, S, E>,
-        cnt_rows_received: &mut u32,
-        join_cache_evict_interval_rows: u32,
-    ) {
-        *cnt_rows_received += 1;
-        if *cnt_rows_received >= join_cache_evict_interval_rows {
-            side_update.ht.evict();
-            side_match.ht.evict();
-            *cnt_rows_received = 0;
-        }
     }
 
     fn handle_watermark(
@@ -596,33 +545,20 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
         Ok(watermarks_to_emit)
     }
 
-    /// the data the hash table and match the coming
-    /// data chunk with the executor state
-    async fn hash_eq_match(
-        key: &K,
-        ht: &mut JoinHashMap<K, S, E>,
-    ) -> StreamExecutorResult<Option<HashValueType<E>>> {
-        if !key.null_bitmap().is_subset(ht.null_matched()) {
-            Ok(None)
-        } else {
-            ht.take_state(key).await.map(Some)
-        }
-    }
-
     #[try_stream(ok = StreamChunk, error = StreamExecutorError)]
-    async fn eq_join_left(args: EqJoinArgs<'_, K, S, E>) {
+    async fn eq_join_left(args: EqJoinArgs<'_, S, E>) {
         let EqJoinArgs {
             ctx: _,
             side_l,
             side_r,
+            null_safe,
             asof_desc,
             actual_output_data_types,
-            // inequality_watermarks,
             chunk,
             chunk_size,
             cnt_rows_received,
-            high_join_amplification_threshold: _,
             join_cache_evict_interval_rows,
+            high_join_amplification_threshold: _,
         } = args;
 
         let (side_update, side_match) = (side_l, side_r);
@@ -635,8 +571,10 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 side_match.i2o_mapping.clone(),
             ));
 
-        let keys = K::build_many(&side_update.join_key_indices, chunk.data_chunk());
-        for (r, key) in chunk.rows_with_holes().zip_eq_debug(keys.iter()) {
+        // The inequality key is always a single column; wrap in an array for `project()`.
+        let inequal_key_idx_update = [side_update.inequal_key_idx];
+
+        for r in chunk.rows_with_holes() {
             let Some((op, row)) = r else {
                 continue;
             };
@@ -647,37 +585,81 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 join_cache_evict_interval_rows,
             );
 
-            let matched_rows = if !side_update.ht.check_inequal_key_null(&row) {
-                Self::hash_eq_match(key, &mut side_match.ht).await?
-            } else {
-                None
-            };
-            let inequal_key = side_update.ht.serialize_inequal_key_from_row(row);
-
-            if let Some(matched_rows) = matched_rows {
-                let matched_row_by_inequality = match asof_desc.inequality_type {
-                    AsOfInequalityType::Lt => matched_rows.lower_bound_by_inequality(
-                        Bound::Excluded(&inequal_key),
-                        &side_match.all_data_types,
-                    ),
-                    AsOfInequalityType::Le => matched_rows.lower_bound_by_inequality(
-                        Bound::Included(&inequal_key),
-                        &side_match.all_data_types,
-                    ),
-                    AsOfInequalityType::Gt => matched_rows.upper_bound_by_inequality(
-                        Bound::Excluded(&inequal_key),
-                        &side_match.all_data_types,
-                    ),
-                    AsOfInequalityType::Ge => matched_rows.upper_bound_by_inequality(
-                        Bound::Included(&inequal_key),
-                        &side_match.all_data_types,
-                    ),
-                };
+            // Check null-safe: if any non-null-safe join key column is NULL, skip matching.
+            // Rows that can never match are not stored in state (consistent with old behavior).
+            let join_key_null_not_safe = side_update
+                .join_key_indices
+                .iter()
+                .zip_eq(null_safe.iter())
+                .any(|(idx, ns)| !ns && row.datum_at(*idx).is_none());
+            if join_key_null_not_safe {
                 match op {
                     Op::Insert | Op::UpdateInsert => {
-                        if let Some(matched_row_by_inequality) = matched_row_by_inequality {
-                            let matched_row = matched_row_by_inequality?;
+                        if let Some(chunk) =
+                            join_chunk_builder.forward_if_not_matched(Op::Insert, row)
+                        {
+                            yield chunk;
+                        }
+                    }
+                    Op::Delete | Op::UpdateDelete => {
+                        if let Some(chunk) =
+                            join_chunk_builder.forward_if_not_matched(Op::Delete, row)
+                        {
+                            yield chunk;
+                        }
+                    }
+                }
+                continue;
+            }
 
+            let join_key = row.project(&side_update.join_key_indices);
+
+            let inequal_key_is_null = side_update.ht.check_inequal_key_null(&row);
+            let inequal_key = row.project(&inequal_key_idx_update);
+
+            if !inequal_key_is_null {
+                let matched_row_by_inequality = match asof_desc.inequality_type {
+                    AsOfInequalityType::Lt => {
+                        side_match
+                            .ht
+                            .lower_bound_by_inequality_with_jk_prefix(
+                                &join_key,
+                                Bound::Excluded(&inequal_key),
+                            )
+                            .await
+                    }
+                    AsOfInequalityType::Le => {
+                        side_match
+                            .ht
+                            .lower_bound_by_inequality_with_jk_prefix(
+                                &join_key,
+                                Bound::Included(&inequal_key),
+                            )
+                            .await
+                    }
+                    AsOfInequalityType::Gt => {
+                        side_match
+                            .ht
+                            .upper_bound_by_inequality_with_jk_prefix(
+                                &join_key,
+                                Bound::Excluded(&inequal_key),
+                            )
+                            .await
+                    }
+                    AsOfInequalityType::Ge => {
+                        side_match
+                            .ht
+                            .upper_bound_by_inequality_with_jk_prefix(
+                                &join_key,
+                                Bound::Included(&inequal_key),
+                            )
+                            .await
+                    }
+                }?
+                .map(|row| JoinRow::new(row, 0));
+                match op {
+                    Op::Insert | Op::UpdateInsert => {
+                        if let Some(matched_row) = matched_row_by_inequality {
                             if let Some(chunk) =
                                 join_chunk_builder.with_match_on_insert(&row, &matched_row)
                             {
@@ -688,12 +670,10 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                         {
                             yield chunk;
                         }
-                        side_update.ht.insert_row(key, row)?;
+                        side_update.ht.insert(row)?;
                     }
                     Op::Delete | Op::UpdateDelete => {
-                        if let Some(matched_row_by_inequality) = matched_row_by_inequality {
-                            let matched_row = matched_row_by_inequality?;
-
+                        if let Some(matched_row) = matched_row_by_inequality {
                             if let Some(chunk) =
                                 join_chunk_builder.with_match_on_delete(&row, &matched_row)
                             {
@@ -704,14 +684,12 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                         {
                             yield chunk;
                         }
-                        side_update.ht.delete_row(key, row)?;
+                        side_update.ht.delete(row)?;
                     }
                 }
-                // Insert back the state taken from ht.
-                side_match.ht.update_state(key, matched_rows);
             } else {
-                // Row which violates null-safe bitmap will never be matched so we need not
-                // store.
+                // Inequality key is NULL, which can never satisfy the inequality predicate,
+                // so we skip storing and only forward as unmatched for left outer join.
                 match op {
                     Op::Insert | Op::UpdateInsert => {
                         if let Some(chunk) =
@@ -735,20 +713,24 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
         }
     }
 
+    fn cmp_pk_rows(pk1: &impl Row, pk2: &impl Row) -> Ordering {
+        cmp_rows_ascending(pk1, pk2)
+    }
+
     #[try_stream(ok = StreamChunk, error = StreamExecutorError)]
-    async fn eq_join_right(args: EqJoinArgs<'_, K, S, E>) {
+    async fn eq_join_right(args: EqJoinArgs<'_, S, E>) {
         let EqJoinArgs {
             ctx,
             side_l,
             side_r,
+            null_safe,
             asof_desc,
             actual_output_data_types,
-            // inequality_watermarks,
             chunk,
             chunk_size,
             cnt_rows_received,
-            high_join_amplification_threshold,
             join_cache_evict_interval_rows,
+            high_join_amplification_threshold,
         } = args;
 
         let (side_update, side_match) = (side_r, side_l);
@@ -760,7 +742,7 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
             side_match.i2o_mapping.clone(),
         );
 
-        let join_matched_rows_metrics = ctx
+        let join_matched_join_keys = ctx
             .streaming_metrics
             .join_matched_join_keys
             .with_guarded_label_values(&[
@@ -769,13 +751,13 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 &side_update.ht.table_id().to_string(),
             ]);
 
-        let keys = K::build_many(&side_update.join_key_indices, chunk.data_chunk());
-        for (r, key) in chunk.rows_with_holes().zip_eq_debug(keys.iter()) {
+        // The inequality key is always a single column; wrap in an array for `project()`.
+        let inequal_key_idx_update = [side_update.inequal_key_idx];
+
+        for r in chunk.rows_with_holes() {
             let Some((op, row)) = r else {
                 continue;
             };
-            let mut join_matched_rows_cnt = 0;
-
             Self::evict_cache(
                 side_update,
                 side_match,
@@ -783,58 +765,47 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 join_cache_evict_interval_rows,
             );
 
-            let matched_rows = if !side_update.ht.check_inequal_key_null(&row) {
-                Self::hash_eq_match(key, &mut side_match.ht).await?
-            } else {
-                None
-            };
-            let inequal_key = side_update.ht.serialize_inequal_key_from_row(row);
+            // Check null-safe: if any non-null-safe join key column is NULL, skip.
+            // Rows that can never match are not stored in state (consistent with old behavior).
+            let join_key_null_not_safe = side_update
+                .join_key_indices
+                .iter()
+                .zip_eq(null_safe.iter())
+                .any(|(idx, ns)| !ns && row.datum_at(*idx).is_none());
+            if join_key_null_not_safe {
+                continue;
+            }
 
-            if let Some(matched_rows) = matched_rows {
-                let update_rows = Self::hash_eq_match(key, &mut side_update.ht).await?.expect("None is not expected because we have checked null in key when getting matched_rows");
-                let right_inequality_index = update_rows.inequality_index();
-                let (row_to_delete_r, row_to_insert_r) =
-                    if let Some(pks) = right_inequality_index.get(&inequal_key) {
-                        assert!(!pks.is_empty());
-                        let row_pk = side_update.ht.serialize_pk_from_row(row);
+            let join_key = row.project(&side_update.join_key_indices);
+
+            let inequal_key_is_null = side_update.ht.check_inequal_key_null(&row);
+            let inequal_key = row.project(&inequal_key_idx_update);
+
+            let mut join_matched_rows_cnt = 0;
+
+            if !inequal_key_is_null {
+                let (row_to_delete_r, row_to_insert_r) = {
+                    let (first_row, second_row) = side_update
+                        .ht
+                        .first_two_by_inequality_with_jk_prefix(&join_key, &inequal_key)
+                        .await?;
+                    if let Some(first_row) = first_row {
+                        let row_pk = side_update.ht.get_pk_from_row(row);
+                        let first_pk = side_update.ht.get_pk_from_row(&first_row).to_owned_row();
                         match op {
                             Op::Insert | Op::UpdateInsert => {
                                 // If there are multiple rows match the inequality key in the right table, we use one with smallest pk.
-                                let smallest_pk = pks.first_key_sorted().unwrap();
-                                if smallest_pk > &row_pk {
-                                    // smallest_pk is in the cache index, so it must exist in the cache.
-                                    if let Some(to_delete_row) = update_rows
-                                        .get_by_indexed_pk(smallest_pk, &side_update.all_data_types)
-                                    {
-                                        (
-                                            Some(Either::Left(to_delete_row?.row)),
-                                            Some(Either::Right(row)),
-                                        )
-                                    } else {
-                                        // Something wrong happened. Ignore this row in non strict consistency mode.
-                                        (None, None)
-                                    }
+                                if Self::cmp_pk_rows(&first_pk, &row_pk) == Ordering::Greater {
+                                    (Some(Either::Left(first_row)), Some(Either::Right(row)))
                                 } else {
                                     // No affected row in the right table.
                                     (None, None)
                                 }
                             }
                             Op::Delete | Op::UpdateDelete => {
-                                let smallest_pk = pks.first_key_sorted().unwrap();
-                                if smallest_pk == &row_pk {
-                                    if let Some(second_smallest_pk) = pks.second_key_sorted() {
-                                        if let Some(to_insert_row) = update_rows.get_by_indexed_pk(
-                                            second_smallest_pk,
-                                            &side_update.all_data_types,
-                                        ) {
-                                            (
-                                                Some(Either::Right(row)),
-                                                Some(Either::Left(to_insert_row?.row)),
-                                            )
-                                        } else {
-                                            // Something wrong happened. Ignore this row in non strict consistency mode.
-                                            (None, None)
-                                        }
+                                if Self::cmp_pk_rows(&first_pk, &row_pk) == Ordering::Equal {
+                                    if let Some(second_row) = second_row {
+                                        (Some(Either::Right(row)), Some(Either::Left(second_row)))
                                     } else {
                                         (Some(Either::Right(row)), None)
                                     }
@@ -851,8 +822,8 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                             // Decide the row_to_insert later
                             Op::Delete | Op::UpdateDelete => (Some(Either::Right(row)), None),
                         }
-                    };
-
+                    }
+                };
                 // 4 cases for row_to_delete_r and row_to_insert_r:
                 // 1. Some(_), Some(_): delete row_to_delete_r and insert row_to_insert_r
                 // 2. None, Some(_)   : row_to_delete to be decided by the nearest inequality key
@@ -861,22 +832,40 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                 if row_to_delete_r.is_none() && row_to_insert_r.is_none() {
                     // no row to delete or insert.
                 } else {
-                    let prev_inequality_key =
-                        right_inequality_index.upper_bound_key(Bound::Excluded(&inequal_key));
-                    let next_inequality_key =
-                        right_inequality_index.lower_bound_key(Bound::Excluded(&inequal_key));
-                    let affected_row_r = match asof_desc.inequality_type {
-                        AsOfInequalityType::Lt | AsOfInequalityType::Le => next_inequality_key
-                            .and_then(|k| {
-                                update_rows.get_first_by_inequality(k, &side_update.all_data_types)
-                            }),
-                        AsOfInequalityType::Gt | AsOfInequalityType::Ge => prev_inequality_key
-                            .and_then(|k| {
-                                update_rows.get_first_by_inequality(k, &side_update.all_data_types)
-                            }),
-                    }
-                    .transpose()?
-                    .map(|r| Either::Left(r.row));
+                    let prev_inequality_key = side_update
+                        .ht
+                        .upper_bound_by_inequality_with_jk_prefix(
+                            &join_key,
+                            Bound::Excluded(&inequal_key),
+                        )
+                        .await?
+                        .map(|r| r.project(&inequal_key_idx_update));
+                    let next_inequality_key = side_update
+                        .ht
+                        .lower_bound_by_inequality_with_jk_prefix(
+                            &join_key,
+                            Bound::Excluded(&inequal_key),
+                        )
+                        .await?
+                        .map(|r| r.project(&inequal_key_idx_update));
+
+                    let affected_inequality_key_r = match asof_desc.inequality_type {
+                        AsOfInequalityType::Lt | AsOfInequalityType::Le => &next_inequality_key,
+                        AsOfInequalityType::Gt | AsOfInequalityType::Ge => &prev_inequality_key,
+                    };
+                    let affected_row_r =
+                        if let Some(affected_inequality_key_r) = affected_inequality_key_r {
+                            side_update
+                                .ht
+                                .first_by_inequality_with_jk_prefix(
+                                    &join_key,
+                                    &affected_inequality_key_r,
+                                )
+                                .await?
+                        } else {
+                            None
+                        }
+                        .map(Either::Left);
 
                     let (row_to_delete_r, row_to_insert_r) =
                         match (&row_to_delete_r, &row_to_insert_r) {
@@ -887,28 +876,39 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                         };
                     let range = match asof_desc.inequality_type {
                         AsOfInequalityType::Lt => (
-                            prev_inequality_key.map_or_else(|| Bound::Unbounded, Bound::Included),
-                            Bound::Excluded(&inequal_key),
+                            prev_inequality_key
+                                .map(Either::Left)
+                                .map_or_else(|| Bound::Unbounded, Bound::Included),
+                            Bound::Excluded(Either::Right(&inequal_key)),
                         ),
                         AsOfInequalityType::Le => (
-                            prev_inequality_key.map_or_else(|| Bound::Unbounded, Bound::Excluded),
-                            Bound::Included(&inequal_key),
+                            prev_inequality_key
+                                .map(Either::Left)
+                                .map_or_else(|| Bound::Unbounded, Bound::Excluded),
+                            Bound::Included(Either::Right(&inequal_key)),
                         ),
                         AsOfInequalityType::Gt => (
-                            Bound::Excluded(&inequal_key),
-                            next_inequality_key.map_or_else(|| Bound::Unbounded, Bound::Included),
+                            Bound::Excluded(Either::Right(&inequal_key)),
+                            next_inequality_key
+                                .map(Either::Left)
+                                .map_or_else(|| Bound::Unbounded, Bound::Included),
                         ),
                         AsOfInequalityType::Ge => (
-                            Bound::Included(&inequal_key),
-                            next_inequality_key.map_or_else(|| Bound::Unbounded, Bound::Excluded),
+                            Bound::Included(Either::Right(&inequal_key)),
+                            next_inequality_key
+                                .map(Either::Left)
+                                .map_or_else(|| Bound::Unbounded, Bound::Excluded),
                         ),
                     };
 
-                    let rows_l =
-                        matched_rows.range_by_inequality(range, &side_match.all_data_types);
-                    for row_l in rows_l {
+                    let rows_l_stream = side_match
+                        .ht
+                        .range_by_inequality_with_jk_prefix(&join_key, &range)
+                        .await?;
+                    #[for_await]
+                    for row_l in rows_l_stream {
+                        let row_l = row_l?;
                         join_matched_rows_cnt += 1;
-                        let row_l = row_l?.row;
                         if let Some(row_to_delete_r) = &row_to_delete_r {
                             if let Some(chunk) =
                                 join_chunk_builder.append_row(Op::Delete, row_to_delete_r, &row_l)
@@ -935,32 +935,27 @@ impl<K: HashKey, S: StateStore, const T: AsOfJoinTypePrimitive, E: JoinEncoding>
                         }
                     }
                 }
-                // Insert back the state taken from ht.
-                side_match.ht.update_state(key, matched_rows);
-                side_update.ht.update_state(key, update_rows);
 
                 match op {
                     Op::Insert | Op::UpdateInsert => {
-                        side_update.ht.insert_row(key, row)?;
+                        side_update.ht.insert(row)?;
                     }
                     Op::Delete | Op::UpdateDelete => {
-                        side_update.ht.delete_row(key, row)?;
+                        side_update.ht.delete(row)?;
                     }
                 }
             } else {
-                // Row which violates null-safe bitmap will never be matched so we need not
-                // store.
-                // Noop here because we only support left outer AsOf join.
+                // Inequality key is NULL, which can never satisfy the inequality predicate,
+                // so we skip storing. No action needed on the right side.
             }
-            join_matched_rows_metrics.observe(join_matched_rows_cnt as _);
+            join_matched_join_keys.observe(join_matched_rows_cnt as _);
             if join_matched_rows_cnt > high_join_amplification_threshold {
-                let join_key_data_types = side_update.ht.join_key_data_types();
-                let key = key.deserialize(join_key_data_types)?;
+                let join_key = row.project(&side_update.join_key_indices);
                 tracing::warn!(target: "high_join_amplification",
                     matched_rows_len = join_matched_rows_cnt,
                     update_table_id = %side_update.ht.table_id(),
                     match_table_id = %side_match.ht.table_id(),
-                    join_key = ?key,
+                    join_key = ?join_key,
                     actor_id = %ctx.id,
                     fragment_id = %ctx.fragment_id,
                     "large rows matched for join key when AsOf join updating right side",
@@ -979,14 +974,12 @@ mod tests {
 
     use risingwave_common::array::*;
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, TableId};
-    use risingwave_common::hash::Key64;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_storage::memory::MemoryStateStore;
 
     use super::*;
     use crate::common::table::test_utils::gen_pbtable;
-    use crate::executor::MemoryEncoding;
     use crate::executor::test_utils::{MessageSender, MockSource, StreamExecutorTestExt};
 
     async fn create_in_memory_state_table(
@@ -1065,9 +1058,9 @@ mod tests {
             .into_iter()
             .collect();
         let schema_len = schema.len();
-        let info = ExecutorInfo::for_test(schema, vec![1], "HashJoinExecutor".to_owned(), 0);
+        let info = ExecutorInfo::for_test(schema, vec![1], "AsOfJoinExecutor".to_owned(), 0);
 
-        let executor = AsOfJoinExecutor::<Key64, MemoryStateStore, T, MemoryEncoding>::new(
+        let executor = AsOfJoinExecutor::<MemoryStateStore, T, AsOfCpuEncoding>::new(
             ActorContext::for_test(123),
             info,
             source_l,
@@ -1081,14 +1074,15 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(StreamingMetrics::unused()),
             1024,
-            2048,
             asof_desc,
+            false,
+            2048, // high_join_amplification_threshold
         );
         (tx_l, tx_r, executor.boxed().execute())
     }
 
     #[tokio::test]
-    async fn test_as_of_inner_join() -> StreamExecutorResult<()> {
+    async fn test_asof_inner_join() -> StreamExecutorResult<()> {
         let asof_desc = AsOfDesc {
             left_idx: 0,
             right_idx: 2,
@@ -1236,7 +1230,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_as_of_left_outer_join() -> StreamExecutorResult<()> {
+    async fn test_asof_left_outer_join() -> StreamExecutorResult<()> {
         let asof_desc = AsOfDesc {
             left_idx: 1,
             right_idx: 2,

--- a/src/stream/src/executor/asof_join.rs
+++ b/src/stream/src/executor/asof_join.rs
@@ -1010,6 +1010,7 @@ mod tests {
 
     async fn create_executor<const T: AsOfJoinTypePrimitive>(
         asof_desc: AsOfDesc,
+        use_cache: bool,
     ) -> (MessageSender, MessageSender, BoxedMessageStream) {
         let schema = Schema {
             fields: vec![
@@ -1075,7 +1076,7 @@ mod tests {
             Arc::new(StreamingMetrics::unused()),
             1024,
             asof_desc,
-            false,
+            use_cache,
             2048, // high_join_amplification_threshold
         );
         (tx_l, tx_r, executor.boxed().execute())
@@ -1083,6 +1084,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_asof_inner_join() -> StreamExecutorResult<()> {
+        test_asof_inner_join_impl(false).await
+    }
+
+    #[tokio::test]
+    async fn test_asof_inner_join_with_cache() -> StreamExecutorResult<()> {
+        test_asof_inner_join_impl(true).await
+    }
+
+    async fn test_asof_inner_join_impl(use_cache: bool) -> StreamExecutorResult<()> {
         let asof_desc = AsOfDesc {
             left_idx: 0,
             right_idx: 2,
@@ -1132,7 +1142,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ AsOfJoinType::Inner }>(asof_desc).await;
+            create_executor::<{ AsOfJoinType::Inner }>(asof_desc, use_cache).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(test_epoch(1), false);
@@ -1231,6 +1241,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_asof_left_outer_join() -> StreamExecutorResult<()> {
+        test_asof_left_outer_join_impl(false).await
+    }
+
+    #[tokio::test]
+    async fn test_asof_left_outer_join_with_cache() -> StreamExecutorResult<()> {
+        test_asof_left_outer_join_impl(true).await
+    }
+
+    async fn test_asof_left_outer_join_impl(use_cache: bool) -> StreamExecutorResult<()> {
         let asof_desc = AsOfDesc {
             left_idx: 1,
             right_idx: 2,
@@ -1272,7 +1291,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ AsOfJoinType::LeftOuter }>(asof_desc).await;
+            create_executor::<{ AsOfJoinType::LeftOuter }>(asof_desc, use_cache).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(test_epoch(1), false);

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -520,7 +520,6 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     degree_state_l,
                     null_matched.clone(),
                     pk_contained_in_jk_l,
-                    None,
                     metrics.clone(),
                     ctx.id,
                     ctx.fragment_id,
@@ -548,7 +547,6 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     degree_state_r,
                     null_matched,
                     pk_contained_in_jk_r,
-                    None,
                     metrics.clone(),
                     ctx.id,
                     ctx.fragment_id,
@@ -1175,7 +1173,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     // cache refill
                     if entry_state_count <= entry_state_max_rows {
                         let row_ref = entry_state
-                            .insert(encoded_pk, E::encode(&matched_row), None) // TODO(kwannoel): handle ineq key for asof join.
+                            .insert(encoded_pk, E::encode(&matched_row)) // TODO(kwannoel): handle ineq key for asof join.
                             .with_context(|| format!("row: {}", row.display(),))?;
                         matched_row_ref = Some(row_ref);
                         entry_state_count += 1;

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -1173,7 +1173,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, E: JoinEncoding>
                     // cache refill
                     if entry_state_count <= entry_state_max_rows {
                         let row_ref = entry_state
-                            .insert(encoded_pk, E::encode(&matched_row)) // TODO(kwannoel): handle ineq key for asof join.
+                            .insert(encoded_pk, E::encode(&matched_row))
                             .with_context(|| format!("row: {}", row.display(),))?;
                         matched_row_ref = Some(row_ref);
                         entry_state_count += 1;

--- a/src/stream/src/executor/join/asof_join.rs
+++ b/src/stream/src/executor/join/asof_join.rs
@@ -1,0 +1,725 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hash map for `AsOf` join with optional LRU cache support.
+//!
+//! When cache is disabled, the hash map directly queries the state table.
+//! When cache is enabled, it maintains a `ManagedLruCache` that caches all rows for
+//! each join key, indexed by (`inequality_key`, `pk_suffix`) for efficient range queries.
+
+use std::collections::BTreeMap;
+use std::ops::Bound;
+use std::sync::Arc;
+
+use anyhow::Context;
+use futures::StreamExt;
+use risingwave_common::bitmap::Bitmap;
+use risingwave_common::catalog::TableId;
+use risingwave_common::row::{CompactedRow, OwnedRow, Row, RowExt};
+use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::epoch::EpochPair;
+use risingwave_common::util::row_serde::OrderedRowSerde;
+use risingwave_common::util::sort_util::OrderType;
+use risingwave_common_estimate_size::{EstimateSize, KvSize};
+use risingwave_storage::StateStore;
+use risingwave_storage::store::PrefetchOptions;
+
+use super::hash_join::{JoinEntryError, JoinHashMapMetrics, TableInner};
+use super::join_row_set::JoinRowSet;
+use crate::cache::ManagedLruCache;
+use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::{RowStream, StateTable, StateTablePostCommit};
+use crate::consistency::{consistency_error, enable_strict_consistency};
+use crate::executor::error::StreamExecutorResult;
+use crate::executor::monitor::StreamingMetrics;
+use crate::task::{ActorId, AtomicU64Ref, FragmentId};
+
+/// Memcomparable encoding for inequality key and pk suffix.
+type InequalKeyBytes = Vec<u8>;
+type PkSuffixBytes = Vec<u8>;
+
+/// Trait for encoding/decoding cached `AsOf` join rows.
+/// Unlike `JoinEncoding`, this doesn't carry degree since `AsOf` join has no degree tracking.
+pub trait AsOfRowEncoding: 'static + Send + Sync {
+    type Encoded: EstimateSize + Clone + Send + Sync;
+    fn encode(row: &OwnedRow) -> Self::Encoded;
+    /// Decode an encoded value back to `OwnedRow`.
+    fn decode(encoded: &Self::Encoded, data_types: &[DataType]) -> OwnedRow;
+}
+
+/// CPU-optimized encoding: stores full `OwnedRow` in cache (no encode/decode cost).
+pub struct AsOfCpuEncoding;
+
+impl AsOfRowEncoding for AsOfCpuEncoding {
+    type Encoded = OwnedRow;
+
+    fn encode(row: &OwnedRow) -> OwnedRow {
+        // TODO: Avoid this clone
+        row.clone()
+    }
+
+    fn decode(encoded: &OwnedRow, _data_types: &[DataType]) -> OwnedRow {
+        // TODO: Avoid this clone
+        encoded.clone()
+    }
+}
+
+/// Memory-optimized encoding: stores `CompactedRow` (serialized bytes) in cache.
+pub struct AsOfMemoryEncoding;
+
+impl AsOfRowEncoding for AsOfMemoryEncoding {
+    type Encoded = CompactedRow;
+
+    fn encode(row: &OwnedRow) -> CompactedRow {
+        row.into()
+    }
+
+    fn decode(encoded: &CompactedRow, data_types: &[DataType]) -> OwnedRow {
+        encoded
+            .deserialize(data_types)
+            .expect("failed to decode compacted row in AsOf join cache")
+    }
+}
+
+/// A cache entry for a single join key, storing all encoded rows indexed by (`inequality_key`, `pk_suffix`).
+/// The outer `BTreeMap` gives efficient range queries on inequality keys;
+/// the inner `JoinRowSet` adaptively uses `Vec` for small pk sets and `BTreeMap` for larger ones.
+///
+/// `V` is the encoded row type: `OwnedRow` for CPU encoding, `CompactedRow` for memory encoding.
+pub struct AsOfJoinCacheEntry<V: EstimateSize + Clone> {
+    /// `inequality_key_bytes` -> { `pk_suffix_bytes` -> `encoded_row` }
+    inner: BTreeMap<InequalKeyBytes, JoinRowSet<PkSuffixBytes, V>>,
+    /// Incrementally tracked heap size of all keys and values.
+    kv_heap_size: KvSize,
+}
+
+impl<V: EstimateSize + Clone> Default for AsOfJoinCacheEntry<V> {
+    fn default() -> Self {
+        Self {
+            inner: BTreeMap::new(),
+            kv_heap_size: KvSize::new(),
+        }
+    }
+}
+
+impl<V: EstimateSize + Clone> EstimateSize for AsOfJoinCacheEntry<V> {
+    fn estimated_heap_size(&self) -> usize {
+        // TODO: Add btreemap internal size.
+        // https://github.com/risingwavelabs/risingwave/issues/9713
+        self.kv_heap_size.size()
+    }
+}
+
+impl<V: EstimateSize + Clone> AsOfJoinCacheEntry<V> {
+    /// Find the encoded row with the greatest inequality key <= bound (upper bound query).
+    /// Returns the first entry by pk order in the pk sub-map for that inequality key.
+    fn upper_bound(&self, bound: Bound<&[u8]>) -> Option<&V> {
+        self.inner
+            .range::<[u8], _>((Bound::Unbounded, bound))
+            .next_back()
+            .and_then(|(_, pk_map)| pk_map.first_key_sorted().and_then(|k| pk_map.get(k)))
+    }
+
+    /// Find the encoded row with the smallest inequality key >= bound (lower bound query).
+    /// Returns the first entry by pk order in the pk sub-map for that inequality key.
+    fn lower_bound(&self, bound: Bound<&[u8]>) -> Option<&V> {
+        self.inner
+            .range::<[u8], _>((bound, Bound::Unbounded))
+            .next()
+            .and_then(|(_, pk_map)| pk_map.first_key_sorted().and_then(|k| pk_map.get(k)))
+    }
+
+    /// Iterate all encoded rows within an inequality key range.
+    fn range(
+        &self,
+        range: (Bound<&[u8]>, Bound<&[u8]>),
+    ) -> impl Iterator<Item = &V> + '_ + use<'_, V> {
+        self.inner
+            .range::<[u8], _>(range)
+            .flat_map(|(_, pk_map)| pk_map.values())
+    }
+
+    /// Find the first encoded row (by pk order) with exact inequality key match.
+    fn first_by_inequality(&self, ineq_key_bytes: &[u8]) -> Option<&V> {
+        self.inner
+            .get(ineq_key_bytes)
+            .and_then(|pk_map| pk_map.first_key_sorted().and_then(|k| pk_map.get(k)))
+    }
+
+    /// Find the first two encoded rows (by PK order) with exact inequality key match.
+    fn first_two_by_inequality(&self, ineq_key_bytes: &[u8]) -> (Option<&V>, Option<&V>) {
+        if let Some(pk_map) = self.inner.get(ineq_key_bytes) {
+            let (first_key, second_key) = pk_map.first_two_key_sorted();
+            let first = first_key.and_then(|k| pk_map.get(k));
+            let second = second_key.and_then(|k| pk_map.get(k));
+            (first, second)
+        } else {
+            (None, None)
+        }
+    }
+
+    /// Insert an encoded row into the cache entry.
+    fn insert(
+        &mut self,
+        ineq_key_bytes: InequalKeyBytes,
+        pk_suffix_bytes: PkSuffixBytes,
+        val: V,
+    ) -> Result<(), JoinEntryError> {
+        use std::collections::btree_map::Entry;
+        let pk_map = match self.inner.entry(ineq_key_bytes) {
+            Entry::Vacant(e) => {
+                self.kv_heap_size.add_val(e.key());
+                e.insert(JoinRowSet::default())
+            }
+            Entry::Occupied(e) => e.into_mut(),
+        };
+        if !enable_strict_consistency()
+            && let Some(old_val) = pk_map.remove(&pk_suffix_bytes)
+        {
+            self.kv_heap_size.sub(&pk_suffix_bytes, &old_val);
+        }
+        self.kv_heap_size.add(&pk_suffix_bytes, &val);
+        let ret = pk_map.try_insert(pk_suffix_bytes.clone(), val);
+        if !enable_strict_consistency() {
+            assert!(ret.is_ok(), "we have removed existing entry, if any");
+        }
+        ret.map(|_| ()).map_err(|_| JoinEntryError::Occupied)
+    }
+
+    /// Delete an encoded row from the cache entry.
+    fn delete(
+        &mut self,
+        ineq_key_bytes: &InequalKeyBytes,
+        pk_suffix_bytes: &PkSuffixBytes,
+    ) -> Result<(), JoinEntryError> {
+        if let Some(pk_map) = self.inner.get_mut(ineq_key_bytes) {
+            if let Some(old_val) = pk_map.remove(pk_suffix_bytes) {
+                self.kv_heap_size.sub(pk_suffix_bytes, &old_val);
+                if pk_map.is_empty() {
+                    self.kv_heap_size.sub_val(ineq_key_bytes);
+                    self.inner.remove(ineq_key_bytes);
+                }
+                Ok(())
+            } else if enable_strict_consistency() {
+                Err(JoinEntryError::Remove)
+            } else {
+                consistency_error!(
+                    ?pk_suffix_bytes,
+                    "removing an asof join cache entry but it's not in the cache"
+                );
+                Ok(())
+            }
+        } else if enable_strict_consistency() {
+            Err(JoinEntryError::Remove)
+        } else {
+            consistency_error!(
+                ?pk_suffix_bytes,
+                "removing an asof join cache entry but it's not in the cache"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// A hash map for `AsOf` join with optional LRU cache support.
+///
+/// When `cache` is `None`, it directly queries the state table (no-cache mode).
+/// When `cache` is `Some`, it maintains a `ManagedLruCache` keyed by join key,
+/// caching all rows for each join key indexed by (`inequality_key`, `pk_suffix`).
+///
+/// `E` controls row encoding in the cache: `AsOfCpuEncoding` (full `OwnedRow`) or
+/// `AsOfMemoryEncoding` (compact `CompactedRow`).
+pub struct AsOfJoinHashMap<S: StateStore, E: AsOfRowEncoding> {
+    /// State table. Contains the data from upstream.
+    state: TableInner<S>,
+    /// The index of the inequality key column.
+    inequality_key_idx: usize,
+    /// Serializer for inequality key (single column value -> ordered bytes).
+    inequality_key_serializer: OrderedRowSerde,
+    /// Serializer for pk suffix (deduped pk columns -> ordered bytes).
+    pk_suffix_serializer: OrderedRowSerde,
+    /// The indices of the deduped pk columns in the input row (for projecting pk suffix).
+    pk_suffix_indices: Vec<usize>,
+    /// LRU cache: `join_key` (`OwnedRow`) -> encoded cache entry. None if cache is disabled.
+    cache: Option<ManagedLruCache<OwnedRow, AsOfJoinCacheEntry<E::Encoded>>>,
+    /// The indices of join key columns in the input row (for projecting join key).
+    join_key_indices: Vec<usize>,
+    /// All data types of the state table rows, needed for decoding `CompactedRow`.
+    state_all_data_types: Vec<DataType>,
+    /// Metrics of the hash map
+    metrics: JoinHashMapMetrics,
+}
+
+impl<S: StateStore, E: AsOfRowEncoding> AsOfJoinHashMap<S, E> {
+    /// Create a [`AsOfJoinHashMap`] for `AsOf` join with optional cache.
+    ///
+    /// If `watermark_epoch` is `Some`, an LRU cache is enabled.
+    /// If `watermark_epoch` is `None`, the hash map directly queries the state table.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        state_join_key_indices: Vec<usize>,
+        state_table: StateTable<S>,
+        state_pk_indices: Vec<usize>,
+        inequality_key_idx: usize,
+        state_all_data_types: Vec<DataType>,
+        watermark_epoch: Option<AtomicU64Ref>,
+        metrics: Arc<StreamingMetrics>,
+        actor_id: ActorId,
+        fragment_id: FragmentId,
+        side: &'static str,
+    ) -> Self {
+        let join_table_id = state_table.table_id();
+
+        // Build serializer for inequality key (single column).
+        let inequality_key_serializer = OrderedRowSerde::new(
+            vec![state_all_data_types[inequality_key_idx].clone()],
+            vec![OrderType::ascending()],
+        );
+
+        // Build serializer for pk suffix (deduped pk columns).
+        let pk_suffix_serializer = OrderedRowSerde::new(
+            state_pk_indices
+                .iter()
+                .map(|idx| state_all_data_types[*idx].clone())
+                .collect(),
+            vec![OrderType::ascending(); state_pk_indices.len()],
+        );
+
+        let pk_suffix_indices = state_pk_indices.clone();
+        let join_key_indices = state_join_key_indices.clone();
+
+        let cache = watermark_epoch.map(|epoch_ref| {
+            let metrics_info = MetricsInfo::new(
+                metrics.clone(),
+                join_table_id,
+                actor_id,
+                format!("asof join {}", side),
+            );
+            ManagedLruCache::unbounded(epoch_ref, metrics_info)
+        });
+
+        let state = TableInner::new(state_pk_indices, state_join_key_indices, state_table, None);
+
+        Self {
+            state,
+            inequality_key_idx,
+            inequality_key_serializer,
+            pk_suffix_serializer,
+            pk_suffix_indices,
+            cache,
+            join_key_indices,
+            state_all_data_types,
+            metrics: JoinHashMapMetrics::new(&metrics, actor_id, fragment_id, side, join_table_id),
+        }
+    }
+
+    pub async fn init(&mut self, epoch: EpochPair) -> StreamExecutorResult<()> {
+        self.state.table.init_epoch(epoch).await?;
+        Ok(())
+    }
+
+    pub fn update_watermark(&mut self, watermark: ScalarImpl) {
+        self.state.table.update_watermark(watermark);
+    }
+
+    pub fn table_id(&self) -> TableId {
+        self.state.table.table_id()
+    }
+
+    /// Cached entry count (number of distinct join keys in the LRU cache).
+    /// Returns 0 if cache is disabled.
+    pub fn entry_count(&self) -> usize {
+        self.cache.as_ref().map_or(0, |c| c.len())
+    }
+
+    /// Serialize a row as an inequality key for cache lookup.
+    /// The row should already be the inequality column(s) (e.g. a projected single-column row).
+    fn serialize_inequal_key(&self, row: &impl Row) -> Vec<u8> {
+        row.memcmp_serialize(&self.inequality_key_serializer)
+    }
+
+    /// Serialize the inequality key from a full state table row for cache key.
+    fn serialize_inequal_key_from_state_row(&self, row: &impl Row) -> Vec<u8> {
+        row.project(&[self.inequality_key_idx])
+            .memcmp_serialize(&self.inequality_key_serializer)
+    }
+
+    /// Serialize the pk suffix from a row for cache key.
+    fn serialize_pk_suffix(&self, row: &impl Row) -> Vec<u8> {
+        row.project(&self.pk_suffix_indices)
+            .memcmp_serialize(&self.pk_suffix_serializer)
+    }
+
+    /// Ensure the cache entry for the given join key is populated.
+    /// Does nothing if cache is disabled or the entry is already present.
+    async fn ensure_cache_populated(&mut self, join_key: &OwnedRow) -> StreamExecutorResult<()> {
+        let needs_populate = match &self.cache {
+            Some(cache) => !cache.contains(join_key),
+            None => return Ok(()),
+        };
+        self.metrics.inc_lookup();
+        if !needs_populate {
+            return Ok(());
+        }
+        self.metrics.inc_lookup_miss();
+
+        // Cache miss - load all rows for this join key from state table.
+        let sub_range: (Bound<OwnedRow>, Bound<OwnedRow>) = (Bound::Unbounded, Bound::Unbounded);
+        let table_iter = self
+            .state
+            .table
+            .iter_with_prefix(join_key, &sub_range, PrefetchOptions::default())
+            .await?;
+        let mut pinned = std::pin::pin!(table_iter);
+        let mut entry = AsOfJoinCacheEntry::<E::Encoded>::default();
+        while let Some(row) = pinned.next().await.transpose()? {
+            let ineq_key = self.serialize_inequal_key_from_state_row(&row);
+            let pk_suffix = self.serialize_pk_suffix(&row);
+            entry
+                .insert(ineq_key, pk_suffix, E::encode(&row))
+                .with_context(|| format!("row: {}", row.display()))?;
+        }
+        self.cache.as_mut().unwrap().put(join_key.clone(), entry);
+        Ok(())
+    }
+
+    /// Insert a row into the state table and optionally update the cache.
+    pub fn insert(&mut self, value: impl Row) -> StreamExecutorResult<()> {
+        if self.cache.is_some() {
+            // Convert to OwnedRow first to avoid move issues with `impl Row`.
+            let owned_row = value.to_owned_row();
+            let ineq_key = self.serialize_inequal_key_from_state_row(&owned_row);
+            let pk_suffix = self.serialize_pk_suffix(&owned_row);
+            // Use reference to avoid moving owned_row.
+            let join_key = (&owned_row).project(&self.join_key_indices).to_owned_row();
+            // Update cache if the join key is cached.
+            if let Some(cache) = &mut self.cache
+                && let Some(mut entry) = cache.get_mut(&join_key)
+            {
+                entry
+                    .insert(ineq_key, pk_suffix, E::encode(&owned_row))
+                    .with_context(|| format!("row: {}", owned_row.display()))?;
+            } else {
+                self.metrics.inc_insert_cache_miss();
+            }
+            self.state.table.insert(owned_row);
+        } else {
+            self.state.table.insert(value);
+        }
+        Ok(())
+    }
+
+    /// Delete a row from the state table and optionally update the cache.
+    pub fn delete(&mut self, value: impl Row) -> StreamExecutorResult<()> {
+        if self.cache.is_some() {
+            // Convert to OwnedRow first to avoid move issues with `impl Row`.
+            let owned_row = value.to_owned_row();
+            let ineq_key = self.serialize_inequal_key_from_state_row(&owned_row);
+            let pk_suffix = self.serialize_pk_suffix(&owned_row);
+            // Use reference to avoid moving owned_row.
+            let join_key = (&owned_row).project(&self.join_key_indices).to_owned_row();
+            // Update cache if the join key is cached.
+            if let Some(cache) = &mut self.cache
+                && let Some(mut entry) = cache.get_mut(&join_key)
+            {
+                entry
+                    .delete(&ineq_key, &pk_suffix)
+                    .with_context(|| format!("row: {}", owned_row.display()))?;
+            }
+            self.state.table.delete(owned_row);
+        } else {
+            self.state.table.delete(value);
+        }
+        Ok(())
+    }
+
+    /// Evict the LRU cache. No-op if cache is not enabled.
+    pub fn evict_cache(&mut self) {
+        if let Some(cache) = &mut self.cache {
+            cache.evict();
+        }
+    }
+
+    /// Flush the state table.
+    pub async fn flush(
+        &mut self,
+        epoch: EpochPair,
+    ) -> StreamExecutorResult<AsOfJoinHashMapPostCommit<'_, S, E>> {
+        self.metrics.flush();
+        if let Some(cache) = &mut self.cache {
+            cache.evict();
+        }
+        let state_post_commit = self.state.table.commit(epoch).await?;
+        Ok(AsOfJoinHashMapPostCommit {
+            state: state_post_commit,
+            cache: self.cache.as_mut(),
+        })
+    }
+
+    pub async fn try_flush(&mut self) -> StreamExecutorResult<()> {
+        self.state.table.try_flush().await?;
+        Ok(())
+    }
+
+    pub async fn upper_bound_by_inequality_with_jk_prefix(
+        &mut self,
+        join_key: impl Row,
+        bound: Bound<&impl Row>,
+    ) -> StreamExecutorResult<Option<OwnedRow>> {
+        if self.cache.is_some() {
+            let join_key_owned = join_key.to_owned_row();
+            // Serialize bound bytes before borrowing cache to avoid borrow conflicts.
+            let bound_bytes = match &bound {
+                Bound::Included(r) => Bound::Included(self.serialize_inequal_key(r)),
+                Bound::Excluded(r) => Bound::Excluded(self.serialize_inequal_key(r)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            self.ensure_cache_populated(&join_key_owned).await?;
+            let cache = self.cache.as_mut().unwrap();
+            if let Some(entry) = cache.get(&join_key_owned) {
+                let bound_ref = match &bound_bytes {
+                    Bound::Included(b) => Bound::Included(b.as_slice()),
+                    Bound::Excluded(b) => Bound::Excluded(b.as_slice()),
+                    Bound::Unbounded => Bound::Unbounded,
+                };
+                return Ok(entry
+                    .upper_bound(bound_ref)
+                    .map(|v| E::decode(v, &self.state_all_data_types)));
+            }
+            // Not in cache (shouldn't happen after ensure_cache_populated, but fallback)
+        }
+        // Non-cached path: use rev_iter to find the largest inequality key within the
+        // bound, then forward-scan for the smallest PK at that inequality key. This
+        // matches the cached path's behavior (smallest PK wins on tie), which is
+        // required for consistency with eq_join_right's first_two_by_inequality logic.
+        let sub_range = (Bound::<OwnedRow>::Unbounded, bound);
+        let table_iter = self
+            .state
+            .table
+            .rev_iter_with_prefix(&join_key, &sub_range, PrefetchOptions::default())
+            .await?;
+        let mut pinned_table_iter = std::pin::pin!(table_iter);
+        let Some(rev_row) = pinned_table_iter.next().await.transpose()? else {
+            return Ok(None);
+        };
+        // Extract the inequality key from the found row and forward-scan for smallest PK.
+        let found_ineq_key = (&rev_row)
+            .project(&[self.inequality_key_idx])
+            .to_owned_row();
+        let exact_range = (
+            Bound::Included(&found_ineq_key),
+            Bound::Included(&found_ineq_key),
+        );
+        let fwd_iter = self
+            .state
+            .table
+            .iter_with_prefix(&join_key, &exact_range, PrefetchOptions::default())
+            .await?;
+        let mut pinned_fwd = std::pin::pin!(fwd_iter);
+        // Forward scan returns smallest PK first; fall back to rev_row if empty (shouldn't happen).
+        let row = pinned_fwd.next().await.transpose()?;
+        Ok(row.or(Some(rev_row)))
+    }
+
+    pub async fn lower_bound_by_inequality_with_jk_prefix(
+        &mut self,
+        join_key: &impl Row,
+        bound: Bound<&impl Row>,
+    ) -> StreamExecutorResult<Option<OwnedRow>> {
+        if self.cache.is_some() {
+            let join_key_owned = join_key.to_owned_row();
+            // Serialize bound bytes before borrowing cache to avoid borrow conflicts.
+            let bound_bytes = match &bound {
+                Bound::Included(r) => Bound::Included(self.serialize_inequal_key(r)),
+                Bound::Excluded(r) => Bound::Excluded(self.serialize_inequal_key(r)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            self.ensure_cache_populated(&join_key_owned).await?;
+            let cache = self.cache.as_mut().unwrap();
+            if let Some(entry) = cache.get(&join_key_owned) {
+                let bound_ref = match &bound_bytes {
+                    Bound::Included(b) => Bound::Included(b.as_slice()),
+                    Bound::Excluded(b) => Bound::Excluded(b.as_slice()),
+                    Bound::Unbounded => Bound::Unbounded,
+                };
+                return Ok(entry
+                    .lower_bound(bound_ref)
+                    .map(|v| E::decode(v, &self.state_all_data_types)));
+            }
+        }
+        // Non-cached path
+        let sub_range = (bound, Bound::<OwnedRow>::Unbounded);
+        let table_iter = self
+            .state
+            .table
+            .iter_with_prefix(join_key, &sub_range, PrefetchOptions::default())
+            .await?;
+        let mut pinned_table_iter = std::pin::pin!(table_iter);
+        let row = pinned_table_iter.next().await.transpose()?;
+        Ok(row)
+    }
+
+    async fn table_iter_by_inequality_with_jk_prefix<'a>(
+        &'a self,
+        join_key: &'a impl Row,
+        range: &'a (Bound<impl Row>, Bound<impl Row>),
+    ) -> StreamExecutorResult<impl RowStream<'a>> {
+        self.state
+            .table
+            .iter_with_prefix(join_key, range, PrefetchOptions::default())
+            .await
+    }
+
+    pub async fn first_by_inequality_with_jk_prefix(
+        &mut self,
+        join_key: &impl Row,
+        inequality_key: &impl Row,
+    ) -> StreamExecutorResult<Option<OwnedRow>> {
+        if self.cache.is_some() {
+            let join_key_owned = join_key.to_owned_row();
+            // Serialize before borrowing cache to avoid borrow conflicts.
+            let ineq_key_bytes = self.serialize_inequal_key(inequality_key);
+            self.ensure_cache_populated(&join_key_owned).await?;
+            let cache = self.cache.as_mut().unwrap();
+            if let Some(entry) = cache.get(&join_key_owned) {
+                return Ok(entry
+                    .first_by_inequality(&ineq_key_bytes)
+                    .map(|v| E::decode(v, &self.state_all_data_types)));
+            }
+        }
+        // Non-cached path
+        let range = (
+            Bound::Included(inequality_key),
+            Bound::Included(inequality_key),
+        );
+        let table_iter = self
+            .table_iter_by_inequality_with_jk_prefix(join_key, &range)
+            .await?;
+        let mut pinned_table_iter = std::pin::pin!(table_iter);
+        let row = pinned_table_iter.next().await.transpose()?;
+        Ok(row)
+    }
+
+    /// Return the first two rows (by PK order) with exact inequality key match.
+    /// Used by `eq_join_right` to determine replacement: Insert needs first row
+    /// for comparison, Delete needs first + second for fallback.
+    pub async fn first_two_by_inequality_with_jk_prefix(
+        &mut self,
+        join_key: &impl Row,
+        inequality_key: &impl Row,
+    ) -> StreamExecutorResult<(Option<OwnedRow>, Option<OwnedRow>)> {
+        if self.cache.is_some() {
+            let join_key_owned = join_key.to_owned_row();
+            let ineq_key_bytes = self.serialize_inequal_key(inequality_key);
+            self.ensure_cache_populated(&join_key_owned).await?;
+            let cache = self.cache.as_mut().unwrap();
+            if let Some(entry) = cache.get(&join_key_owned) {
+                let (first, second) = entry.first_two_by_inequality(&ineq_key_bytes);
+                return Ok((
+                    first.map(|v| E::decode(v, &self.state_all_data_types)),
+                    second.map(|v| E::decode(v, &self.state_all_data_types)),
+                ));
+            }
+        }
+        // Non-cached path
+        let range = (
+            Bound::Included(inequality_key),
+            Bound::Included(inequality_key),
+        );
+        let table_iter = self
+            .table_iter_by_inequality_with_jk_prefix(join_key, &range)
+            .await?;
+        let mut pinned_table_iter = std::pin::pin!(table_iter);
+        let first = pinned_table_iter.next().await.transpose()?;
+        let second = if first.is_some() {
+            pinned_table_iter.next().await.transpose()?
+        } else {
+            None
+        };
+        Ok((first, second))
+    }
+
+    pub async fn range_by_inequality_with_jk_prefix<'a>(
+        &'a mut self,
+        join_key: &'a impl Row,
+        inequality_key_range: &'a (Bound<impl Row>, Bound<impl Row>),
+    ) -> StreamExecutorResult<impl RowStream<'a>> {
+        if self.cache.is_some() {
+            let join_key_owned = join_key.to_owned_row();
+            // Serialize bound bytes before borrowing cache.
+            let bound_lo = match &inequality_key_range.0 {
+                Bound::Included(r) => Bound::Included(self.serialize_inequal_key(r)),
+                Bound::Excluded(r) => Bound::Excluded(self.serialize_inequal_key(r)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            let bound_hi = match &inequality_key_range.1 {
+                Bound::Included(r) => Bound::Included(self.serialize_inequal_key(r)),
+                Bound::Excluded(r) => Bound::Excluded(self.serialize_inequal_key(r)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            self.ensure_cache_populated(&join_key_owned).await?;
+            let cache = self.cache.as_mut().unwrap();
+            if let Some(entry) = cache.get(&join_key_owned) {
+                let range = (
+                    bound_lo.as_ref().map(|b| b.as_slice()),
+                    bound_hi.as_ref().map(|b| b.as_slice()),
+                );
+                // Cached: lazily decode cloned rows from cache and wrap as stream.
+                let data_types = &self.state_all_data_types;
+                return Ok(futures::future::Either::Left(futures::stream::iter(
+                    entry.range(range).map(|v| Ok(E::decode(v, data_types))),
+                )));
+            }
+        }
+        // Non-cached path: stream directly from state table without collecting.
+        let table_iter = self
+            .state
+            .table
+            .iter_with_prefix(join_key, inequality_key_range, PrefetchOptions::default())
+            .await?;
+        Ok(futures::future::Either::Right(table_iter))
+    }
+
+    /// Return true if the inequality key is null.
+    pub fn check_inequal_key_null(&self, row: &impl Row) -> bool {
+        row.datum_at(self.inequality_key_idx).is_none()
+    }
+
+    pub fn get_pk_from_row<'a>(&'a self, row: impl Row + 'a) -> impl Row + 'a {
+        row.project(&self.state.pk_indices)
+    }
+}
+
+#[must_use]
+pub struct AsOfJoinHashMapPostCommit<'a, S: StateStore, E: AsOfRowEncoding> {
+    state: StateTablePostCommit<'a, S>,
+    cache: Option<&'a mut ManagedLruCache<OwnedRow, AsOfJoinCacheEntry<E::Encoded>>>,
+}
+
+impl<S: StateStore, E: AsOfRowEncoding> AsOfJoinHashMapPostCommit<'_, S, E> {
+    pub async fn post_yield_barrier(
+        self,
+        vnode_bitmap: Option<Arc<Bitmap>>,
+    ) -> StreamExecutorResult<Option<bool>> {
+        let cache_may_stale = self.state.post_yield_barrier(vnode_bitmap.clone()).await?;
+        let keyed_cache_may_stale = cache_may_stale.map(|(_, changed)| changed);
+        // Clear cache if the keyed cache may be stale after the barrier update.
+        if keyed_cache_may_stale.unwrap_or(false)
+            && let Some(cache) = self.cache
+        {
+            cache.clear();
+        }
+        Ok(keyed_cache_may_stale)
+    }
+}

--- a/src/stream/src/executor/join/hash_join.rs
+++ b/src/stream/src/executor/join/hash_join.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Ordering;
-use std::ops::{Bound, Deref, DerefMut, RangeBounds};
+use std::ops::{Bound, Deref, DerefMut};
 use std::sync::Arc;
 
-use anyhow::{Context, anyhow};
-use futures::future::{join, try_join};
-use futures::{StreamExt, pin_mut, stream};
+use anyhow::Context;
+use futures::StreamExt;
 use futures_async_stream::for_await;
 use join_row_set::JoinRowSet;
 use risingwave_common::bitmap::Bitmap;
@@ -27,20 +25,17 @@ use risingwave_common::metrics::LabelGuardedIntCounter;
 use risingwave_common::row::{OwnedRow, Row, RowExt};
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::row_serde::OrderedRowSerde;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_common_estimate_size::EstimateSize;
 use risingwave_storage::StateStore;
 use risingwave_storage::store::PrefetchOptions;
-use risingwave_storage::table::KeyedRow;
-use thiserror_ext::AsReport;
 
 use super::row::{CachedJoinRow, DegreeType, build_degree_row};
 use crate::cache::ManagedLruCache;
 use crate::common::metrics::MetricsInfo;
 use crate::common::table::state_table::{StateTable, StateTablePostCommit};
-use crate::consistency::{consistency_error, consistency_panic, enable_strict_consistency};
+use crate::consistency::{consistency_error, enable_strict_consistency};
 use crate::executor::error::StreamExecutorResult;
 use crate::executor::join::row::JoinRow;
 use crate::executor::monitor::StreamingMetrics;
@@ -49,8 +44,6 @@ use crate::task::{ActorId, AtomicU64Ref, FragmentId};
 
 /// Memcomparable encoding.
 type PkType = Vec<u8>;
-type InequalKeyType = Vec<u8>;
-
 pub type HashValueType<E> = Box<JoinEntryState<E>>;
 
 impl<E: JoinEncoding> EstimateSize for Box<JoinEntryState<E>> {
@@ -148,6 +141,18 @@ impl JoinHashMapMetrics {
         }
     }
 
+    pub fn inc_lookup(&mut self) {
+        self.total_lookup_count += 1;
+    }
+
+    pub fn inc_lookup_miss(&mut self) {
+        self.lookup_miss_count += 1;
+    }
+
+    pub fn inc_insert_cache_miss(&mut self) {
+        self.insert_cache_miss_count += 1;
+    }
+
     pub fn flush(&mut self) {
         self.join_lookup_total_count_metric
             .inc_by(self.total_lookup_count as u64);
@@ -158,21 +163,6 @@ impl JoinHashMapMetrics {
         self.total_lookup_count = 0;
         self.lookup_miss_count = 0;
         self.insert_cache_miss_count = 0;
-    }
-}
-
-/// Inequality key description for `AsOf` join.
-struct InequalityKeyDesc {
-    idx: usize,
-    serializer: OrderedRowSerde,
-}
-
-impl InequalityKeyDesc {
-    /// Serialize the inequality key from a row.
-    pub fn serialize_inequal_key_from_row(&self, row: impl Row) -> InequalKeyType {
-        let indices = vec![self.idx];
-        let inequality_key = row.project(&indices);
-        inequality_key.memcmp_serialize(&self.serializer)
     }
 }
 
@@ -223,8 +213,6 @@ pub struct JoinHashMap<K: HashKey, S: StateStore, E: JoinEncoding> {
     need_degree_table: bool,
     /// Pk is part of the join key.
     pk_contained_in_jk: bool,
-    /// Inequality key description for `AsOf` join.
-    inequality_key_desc: Option<InequalityKeyDesc>,
     /// Metrics of the hash map
     metrics: JoinHashMapMetrics,
     _marker: std::marker::PhantomData<E>,
@@ -393,7 +381,7 @@ pub(crate) fn update_degree<S: StateStore, const INCREMENT: bool>(
 
 pub struct TableInner<S: StateStore> {
     /// Indices of the (cache) pk in a state row
-    pk_indices: Vec<usize>,
+    pub(crate) pk_indices: Vec<usize>,
     /// Indices of the join key in a state row
     join_key_indices: Vec<usize>,
     /// The order key of the join side has the following format:
@@ -451,7 +439,6 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
         degree_state: Option<TableInner<S>>,
         null_matched: K::Bitmap,
         pk_contained_in_jk: bool,
-        inequality_key_idx: Option<usize>,
         metrics: Arc<StreamingMetrics>,
         actor_id: ActorId,
         fragment_id: FragmentId,
@@ -467,20 +454,12 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
             vec![OrderType::ascending(); state_pk_indices.len()],
         );
 
-        let inequality_key_desc = inequality_key_idx.map(|idx| {
-            let serializer = OrderedRowSerde::new(
-                vec![state_all_data_types[idx].clone()],
-                vec![OrderType::ascending()],
-            );
-            InequalityKeyDesc { idx, serializer }
-        });
-
         let join_table_id = state_table.table_id();
         let state = TableInner {
             pk_indices: state_pk_indices,
             join_key_indices: state_join_key_indices,
             order_key_indices: state_table.pk_indices().to_vec(),
-            degree_inequality_idx: inequality_key_idx,
+            degree_inequality_idx: None,
             table: state_table,
         };
 
@@ -508,7 +487,6 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
             degree_state,
             need_degree_table,
             pk_contained_in_jk,
-            inequality_key_desc,
             metrics: JoinHashMapMetrics::new(&metrics, actor_id, fragment_id, side, join_table_id),
             _marker: std::marker::PhantomData,
         }
@@ -571,212 +549,6 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
         }
     }
 
-    /// Take the state for the given `key` out of the hash table and return it. One **MUST** call
-    /// `update_state` after some operations to put the state back.
-    ///
-    /// If the state does not exist in the cache, fetch the remote storage and return. If it still
-    /// does not exist in the remote storage, a [`JoinEntryState`] with empty cache will be
-    /// returned.
-    ///
-    /// Note: This will NOT remove anything from remote storage.
-    pub async fn take_state(&mut self, key: &K) -> StreamExecutorResult<HashValueType<E>> {
-        self.metrics.total_lookup_count += 1;
-        let state = if self.inner.contains(key) {
-            // Do not update the LRU statistics here with `peek_mut` since we will put the state
-            // back.
-            let mut state = self.inner.peek_mut(key).unwrap();
-            state.take()
-        } else {
-            self.metrics.lookup_miss_count += 1;
-            self.fetch_cached_state(key).await?.into()
-        };
-        Ok(state)
-    }
-
-    /// Fetch cache from the state store. Should only be called if the key does not exist in memory.
-    /// Will return a empty `JoinEntryState` even when state does not exist in remote.
-    async fn fetch_cached_state(&self, key: &K) -> StreamExecutorResult<JoinEntryState<E>> {
-        let key = key.deserialize(&self.join_key_data_types)?;
-
-        let mut entry_state: JoinEntryState<E> = JoinEntryState::default();
-
-        if self.need_degree_table {
-            let sub_range: &(Bound<OwnedRow>, Bound<OwnedRow>) =
-                &(Bound::Unbounded, Bound::Unbounded);
-            let table_iter_fut = self.state.table.iter_keyed_row_with_prefix(
-                &key,
-                sub_range,
-                PrefetchOptions::default(),
-            );
-            let degree_state = self.degree_state.as_ref().unwrap();
-            let degree_col_idx = degree_col_idx_in_row(&degree_state.table);
-            let degree_table_iter_fut = degree_state.table.iter_keyed_row_with_prefix(
-                &key,
-                sub_range,
-                PrefetchOptions::default(),
-            );
-
-            let (table_iter, degree_table_iter) =
-                try_join(table_iter_fut, degree_table_iter_fut).await?;
-
-            let mut pinned_table_iter = std::pin::pin!(table_iter);
-            let mut pinned_degree_table_iter = std::pin::pin!(degree_table_iter);
-
-            // For better tolerating inconsistent stream, we have to first buffer all rows and
-            // degree rows, and check the number of them, then iterate on them.
-            let mut rows = vec![];
-            let mut degree_rows = vec![];
-            let mut inconsistency_happened = false;
-            loop {
-                let (row, degree_row) =
-                    join(pinned_table_iter.next(), pinned_degree_table_iter.next()).await;
-                let (row, degree_row) = match (row, degree_row) {
-                    (None, None) => break,
-                    (None, Some(_)) => {
-                        inconsistency_happened = true;
-                        consistency_panic!(
-                            "mismatched row and degree table of join key: {:?}, degree table has more rows",
-                            &key
-                        );
-                        break;
-                    }
-                    (Some(_), None) => {
-                        inconsistency_happened = true;
-                        consistency_panic!(
-                            "mismatched row and degree table of join key: {:?}, input table has more rows",
-                            &key
-                        );
-                        break;
-                    }
-                    (Some(r), Some(d)) => (r, d),
-                };
-
-                let row = row?;
-                let degree_row = degree_row?;
-                rows.push(row);
-                degree_rows.push(degree_row);
-            }
-
-            if inconsistency_happened {
-                // Pk-based row-degree pairing.
-                assert_ne!(rows.len(), degree_rows.len());
-
-                let row_iter = stream::iter(rows.into_iter()).peekable();
-                let degree_row_iter = stream::iter(degree_rows.into_iter()).peekable();
-                pin_mut!(row_iter);
-                pin_mut!(degree_row_iter);
-
-                loop {
-                    match join(row_iter.as_mut().peek(), degree_row_iter.as_mut().peek()).await {
-                        (None, _) | (_, None) => break,
-                        (Some(row), Some(degree_row)) => match row.key().cmp(degree_row.key()) {
-                            Ordering::Greater => {
-                                degree_row_iter.next().await;
-                            }
-                            Ordering::Less => {
-                                row_iter.next().await;
-                            }
-                            Ordering::Equal => {
-                                let row =
-                                    row_iter.next().await.expect("we matched some(row) above");
-                                let degree_row = degree_row_iter
-                                    .next()
-                                    .await
-                                    .expect("we matched some(degree_row) above");
-                                let pk = row
-                                    .as_ref()
-                                    .project(&self.state.pk_indices)
-                                    .memcmp_serialize(&self.pk_serializer);
-                                let degree_i64 = degree_row
-                                    .datum_at(degree_col_idx)
-                                    .expect("degree should not be NULL");
-                                let inequality_key = self
-                                    .inequality_key_desc
-                                    .as_ref()
-                                    .map(|desc| desc.serialize_inequal_key_from_row(row.row()));
-                                entry_state
-                                    .insert(
-                                        pk,
-                                        E::encode(&JoinRow::new(
-                                            row.row(),
-                                            degree_i64.into_int64() as u64,
-                                        )),
-                                        inequality_key,
-                                    )
-                                    .with_context(|| self.state.error_context(row.row()))?;
-                            }
-                        },
-                    }
-                }
-            } else {
-                // 1 to 1 row-degree pairing.
-                // Actually it's possible that both the input data table and the degree table missed
-                // some equal number of rows, but let's ignore this case because it should be rare.
-
-                assert_eq!(rows.len(), degree_rows.len());
-
-                #[for_await]
-                for (row, degree_row) in
-                    stream::iter(rows.into_iter().zip_eq_fast(degree_rows.into_iter()))
-                {
-                    let row: KeyedRow<_> = row;
-                    let degree_row: KeyedRow<_> = degree_row;
-
-                    let pk1 = row.key();
-                    let pk2 = degree_row.key();
-                    debug_assert_eq!(
-                        pk1, pk2,
-                        "mismatched pk in degree table: pk1: {pk1:?}, pk2: {pk2:?}",
-                    );
-                    let pk = row
-                        .as_ref()
-                        .project(&self.state.pk_indices)
-                        .memcmp_serialize(&self.pk_serializer);
-                    let inequality_key = self
-                        .inequality_key_desc
-                        .as_ref()
-                        .map(|desc| desc.serialize_inequal_key_from_row(row.row()));
-                    let degree_i64 = degree_row
-                        .datum_at(degree_col_idx)
-                        .expect("degree should not be NULL");
-                    entry_state
-                        .insert(
-                            pk,
-                            E::encode(&JoinRow::new(row.row(), degree_i64.into_int64() as u64)),
-                            inequality_key,
-                        )
-                        .with_context(|| self.state.error_context(row.row()))?;
-                }
-            }
-        } else {
-            let sub_range: &(Bound<OwnedRow>, Bound<OwnedRow>) =
-                &(Bound::Unbounded, Bound::Unbounded);
-            let table_iter = self
-                .state
-                .table
-                .iter_keyed_row_with_prefix(&key, sub_range, PrefetchOptions::default())
-                .await?;
-
-            #[for_await]
-            for entry in table_iter {
-                let row: KeyedRow<_> = entry?;
-                let pk = row
-                    .as_ref()
-                    .project(&self.state.pk_indices)
-                    .memcmp_serialize(&self.pk_serializer);
-                let inequality_key = self
-                    .inequality_key_desc
-                    .as_ref()
-                    .map(|desc| desc.serialize_inequal_key_from_row(row.row()));
-                entry_state
-                    .insert(pk, E::encode(&JoinRow::new(row.row(), 0)), inequality_key)
-                    .with_context(|| self.state.error_context(row.row()))?;
-            }
-        };
-
-        Ok(entry_state)
-    }
-
     pub async fn flush(
         &mut self,
         epoch: EpochPair,
@@ -819,25 +591,20 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
     pub fn insert(&mut self, key: &K, value: JoinRow<impl Row>) -> StreamExecutorResult<()> {
         let pk = self.serialize_pk_from_row(&value.row);
 
-        let inequality_key = self
-            .inequality_key_desc
-            .as_ref()
-            .map(|desc| desc.serialize_inequal_key_from_row(&value.row));
-
         // TODO(yuhao): avoid this `contains`.
         // https://github.com/risingwavelabs/risingwave/issues/9233
         if self.inner.contains(key) {
             // Update cache
             let mut entry = self.inner.get_mut(key).expect("checked contains");
             entry
-                .insert(pk, E::encode(&value), inequality_key)
+                .insert(pk, E::encode(&value))
                 .with_context(|| self.state.error_context(&value.row))?;
         } else if self.pk_contained_in_jk {
             // Refill cache when the join key exist in neither cache or storage.
             self.metrics.insert_cache_miss_count += 1;
             let mut entry: JoinEntryState<E> = JoinEntryState::default();
             entry
-                .insert(pk, E::encode(&value), inequality_key)
+                .insert(pk, E::encode(&value))
                 .with_context(|| self.state.error_context(&value.row))?;
             self.update_state(key, entry.into());
         }
@@ -869,13 +636,8 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
             let pk = (&value)
                 .project(&self.state.pk_indices)
                 .memcmp_serialize(&self.pk_serializer);
-
-            let inequality_key = self
-                .inequality_key_desc
-                .as_ref()
-                .map(|desc| desc.serialize_inequal_key_from_row(value));
             entry
-                .remove(pk, inequality_key.as_ref())
+                .remove(pk)
                 .with_context(|| self.state.error_context(&value))?;
         }
         Ok(())
@@ -945,27 +707,6 @@ impl<K: HashKey, S: StateStore, E: JoinEncoding> JoinHashMap<K, S, E> {
         &self.join_key_data_types
     }
 
-    /// Return true if the inequality key is null.
-    /// # Panics
-    /// Panics if the inequality key is not set.
-    pub fn check_inequal_key_null(&self, row: &impl Row) -> bool {
-        let desc = self
-            .inequality_key_desc
-            .as_ref()
-            .expect("inequality key desc missing");
-        row.datum_at(desc.idx).is_none()
-    }
-
-    /// Serialize the inequality key from a row.
-    /// # Panics
-    /// Panics if the inequality key is not set.
-    pub fn serialize_inequal_key_from_row(&self, row: impl Row) -> InequalKeyType {
-        self.inequality_key_desc
-            .as_ref()
-            .expect("inequality key desc missing")
-            .serialize_inequal_key_from_row(&row)
-    }
-
     pub fn serialize_pk_from_row(&self, row: impl Row) -> PkType {
         row.project(&self.state.pk_indices)
             .memcmp_serialize(&self.pk_serializer)
@@ -995,8 +736,6 @@ use crate::executor::prelude::{Stream, try_stream};
 pub struct JoinEntryState<E: JoinEncoding> {
     /// The full copy of the state.
     cached: JoinRowSet<PkType, E::EncodedRow>,
-    /// Index used for AS OF join. The key is inequal column value. The value is the primary key in `cached`.
-    inequality_index: JoinRowSet<InequalKeyType, JoinRowSet<PkType, ()>>,
     kv_heap_size: KvSize,
 }
 
@@ -1014,8 +753,6 @@ pub enum JoinEntryError {
     Occupied,
     #[error("removing a join state entry but it is not in the cache")]
     Remove,
-    #[error("retrieving a pk from the inequality index but it is not in the cache")]
-    InequalIndex,
 }
 
 impl<E: JoinEncoding> JoinEntryState<E> {
@@ -1024,15 +761,11 @@ impl<E: JoinEncoding> JoinEntryState<E> {
         &mut self,
         key: PkType,
         value: E::EncodedRow,
-        inequality_key: Option<InequalKeyType>,
     ) -> Result<&mut E::EncodedRow, JoinEntryError> {
         let mut removed = false;
         if !enable_strict_consistency() {
             // strict consistency is off, let's remove existing (if any) first
             if let Some(old_value) = self.cached.remove(&key) {
-                if let Some(inequality_key) = inequality_key.as_ref() {
-                    self.remove_pk_from_inequality_index(&key, inequality_key);
-                }
                 self.kv_heap_size.sub(&key, &old_value);
                 removed = true;
             }
@@ -1040,9 +773,6 @@ impl<E: JoinEncoding> JoinEntryState<E> {
 
         self.kv_heap_size.add(&key, &value);
 
-        if let Some(inequality_key) = inequality_key {
-            self.insert_pk_to_inequality_index(key.clone(), inequality_key);
-        }
         let ret = self.cached.try_insert(key.clone(), value);
 
         if !enable_strict_consistency() {
@@ -1057,60 +787,15 @@ impl<E: JoinEncoding> JoinEntryState<E> {
     }
 
     /// Delete from the cache.
-    pub fn remove(
-        &mut self,
-        pk: PkType,
-        inequality_key: Option<&InequalKeyType>,
-    ) -> Result<(), JoinEntryError> {
+    pub fn remove(&mut self, pk: PkType) -> Result<(), JoinEntryError> {
         if let Some(value) = self.cached.remove(&pk) {
             self.kv_heap_size.sub(&pk, &value);
-            if let Some(inequality_key) = inequality_key {
-                self.remove_pk_from_inequality_index(&pk, inequality_key);
-            }
             Ok(())
         } else if enable_strict_consistency() {
             Err(JoinEntryError::Remove)
         } else {
             consistency_error!(?pk, "removing a join state entry but it's not in the cache");
             Ok(())
-        }
-    }
-
-    fn remove_pk_from_inequality_index(&mut self, pk: &PkType, inequality_key: &InequalKeyType) {
-        if let Some(pk_set) = self.inequality_index.get_mut(inequality_key) {
-            if pk_set.remove(pk).is_none() {
-                if enable_strict_consistency() {
-                    panic!("removing a pk that it not in the inequality index");
-                } else {
-                    consistency_error!(?pk, "removing a pk that it not in the inequality index");
-                };
-            } else {
-                self.kv_heap_size.sub(pk, &());
-            }
-            if pk_set.is_empty() {
-                self.inequality_index.remove(inequality_key);
-            }
-        }
-    }
-
-    fn insert_pk_to_inequality_index(&mut self, pk: PkType, inequality_key: InequalKeyType) {
-        if let Some(pk_set) = self.inequality_index.get_mut(&inequality_key) {
-            let pk_size = pk.estimated_size();
-            if pk_set.try_insert(pk, ()).is_err() {
-                if enable_strict_consistency() {
-                    panic!("inserting a pk that it already in the inequality index");
-                } else {
-                    consistency_error!("inserting a pk that it already in the inequality index");
-                };
-            } else {
-                self.kv_heap_size.add_size(pk_size);
-            }
-        } else {
-            let mut pk_set = JoinRowSet::default();
-            pk_set.try_insert(pk, ()).expect("pk set should be empty");
-            self.inequality_index
-                .try_insert(inequality_key, pk_set)
-                .expect("pk set should be empty");
         }
     }
 
@@ -1147,92 +832,6 @@ impl<E: JoinEncoding> JoinEntryState<E> {
     pub fn len(&self) -> usize {
         self.cached.len()
     }
-
-    /// Range scan the cache using the inequality index.
-    pub fn range_by_inequality<'a, R>(
-        &'a self,
-        range: R,
-        data_types: &'a [DataType],
-    ) -> impl Iterator<Item = StreamExecutorResult<JoinRow<E::DecodedRow>>> + 'a
-    where
-        R: RangeBounds<InequalKeyType> + 'a,
-    {
-        self.inequality_index.range(range).flat_map(|(_, pk_set)| {
-            pk_set
-                .keys()
-                .flat_map(|pk| self.get_by_indexed_pk(pk, data_types))
-        })
-    }
-
-    /// Get the records whose inequality key upper bound satisfy the given bound.
-    pub fn upper_bound_by_inequality<'a>(
-        &'a self,
-        bound: Bound<&InequalKeyType>,
-        data_types: &'a [DataType],
-    ) -> Option<StreamExecutorResult<JoinRow<E::DecodedRow>>> {
-        if let Some((_, pk_set)) = self.inequality_index.upper_bound(bound) {
-            if let Some(pk) = pk_set.first_key_sorted() {
-                self.get_by_indexed_pk(pk, data_types)
-            } else {
-                panic!("pk set for a index record must has at least one element");
-            }
-        } else {
-            None
-        }
-    }
-
-    pub fn get_by_indexed_pk(
-        &self,
-        pk: &PkType,
-        data_types: &[DataType],
-    ) -> Option<StreamExecutorResult<JoinRow<E::DecodedRow>>>
-where {
-        if let Some(value) = self.cached.get(pk) {
-            Some(value.decode(data_types))
-        } else if enable_strict_consistency() {
-            Some(Err(anyhow!(JoinEntryError::InequalIndex).into()))
-        } else {
-            consistency_error!(?pk, "{}", JoinEntryError::InequalIndex.as_report());
-            None
-        }
-    }
-
-    /// Get the records whose inequality key lower bound satisfy the given bound.
-    pub fn lower_bound_by_inequality<'a>(
-        &'a self,
-        bound: Bound<&InequalKeyType>,
-        data_types: &'a [DataType],
-    ) -> Option<StreamExecutorResult<JoinRow<E::DecodedRow>>> {
-        if let Some((_, pk_set)) = self.inequality_index.lower_bound(bound) {
-            if let Some(pk) = pk_set.first_key_sorted() {
-                self.get_by_indexed_pk(pk, data_types)
-            } else {
-                panic!("pk set for a index record must has at least one element");
-            }
-        } else {
-            None
-        }
-    }
-
-    pub fn get_first_by_inequality<'a>(
-        &'a self,
-        inequality_key: &InequalKeyType,
-        data_types: &'a [DataType],
-    ) -> Option<StreamExecutorResult<JoinRow<E::DecodedRow>>> {
-        if let Some(pk_set) = self.inequality_index.get(inequality_key) {
-            if let Some(pk) = pk_set.first_key_sorted() {
-                self.get_by_indexed_pk(pk, data_types)
-            } else {
-                panic!("pk set for a index record must has at least one element");
-            }
-        } else {
-            None
-        }
-    }
-
-    pub fn inequality_index(&self) -> &JoinRowSet<InequalKeyType, JoinRowSet<PkType, ()>> {
-        &self.inequality_index
-    }
 }
 
 #[cfg(test)]
@@ -1249,7 +848,6 @@ mod tests {
         managed_state: &mut JoinEntryState<E>,
         pk_indices: &[usize],
         col_types: &[DataType],
-        inequality_key_idx: Option<usize>,
         data_chunk: &DataChunk,
     ) {
         let pk_col_type = pk_indices
@@ -1258,9 +856,6 @@ mod tests {
             .collect_vec();
         let pk_serializer =
             OrderedRowSerde::new(pk_col_type, vec![OrderType::ascending(); pk_indices.len()]);
-        let inequality_key_type = inequality_key_idx.map(|idx| col_types[idx].clone());
-        let inequality_key_serializer = inequality_key_type
-            .map(|data_type| OrderedRowSerde::new(vec![data_type], vec![OrderType::ascending()]));
         for row_ref in data_chunk.rows() {
             let row: OwnedRow = row_ref.into_owned_row();
             let value_indices = (0..row.len() - 1).collect_vec();
@@ -1269,15 +864,8 @@ mod tests {
             let pk = OwnedRow::new(pk)
                 .project(&value_indices)
                 .memcmp_serialize(&pk_serializer);
-            let inequality_key = inequality_key_idx.map(|idx| {
-                (&row)
-                    .project(&[idx])
-                    .memcmp_serialize(inequality_key_serializer.as_ref().unwrap())
-            });
             let join_row = JoinRow { row, degree: 0 };
-            managed_state
-                .insert(pk, E::encode(&join_row), inequality_key)
-                .unwrap();
+            managed_state.insert(pk, E::encode(&join_row)).unwrap();
         }
     }
 
@@ -1314,13 +902,7 @@ mod tests {
         );
 
         // `Vec` in state
-        insert_chunk::<MemoryEncoding>(
-            &mut managed_state,
-            &pk_indices,
-            &col_types,
-            None,
-            &data_chunk1,
-        );
+        insert_chunk::<MemoryEncoding>(&mut managed_state, &pk_indices, &col_types, &data_chunk1);
         check::<MemoryEncoding>(&mut managed_state, &col_types, &col1, &col2);
 
         // `BtreeMap` in state
@@ -1331,76 +913,7 @@ mod tests {
              5 8
              4 9",
         );
-        insert_chunk(
-            &mut managed_state,
-            &pk_indices,
-            &col_types,
-            None,
-            &data_chunk2,
-        );
+        insert_chunk(&mut managed_state, &pk_indices, &col_types, &data_chunk2);
         check(&mut managed_state, &col_types, &col1, &col2);
-    }
-
-    #[tokio::test]
-    async fn test_managed_join_state_w_inequality_index() {
-        let mut managed_state: JoinEntryState<MemoryEncoding> = JoinEntryState::default();
-        let col_types = vec![DataType::Int64, DataType::Int64];
-        let pk_indices = [0];
-        let inequality_key_idx = Some(1);
-        let inequality_key_serializer =
-            OrderedRowSerde::new(vec![DataType::Int64], vec![OrderType::ascending()]);
-
-        let col1 = [3, 2, 1];
-        let col2 = [4, 5, 5];
-        let data_chunk1 = DataChunk::from_pretty(
-            "I I
-             3 4
-             2 5
-             1 5",
-        );
-
-        // `Vec` in state
-        insert_chunk(
-            &mut managed_state,
-            &pk_indices,
-            &col_types,
-            inequality_key_idx,
-            &data_chunk1,
-        );
-        check(&mut managed_state, &col_types, &col1, &col2);
-        let bound = OwnedRow::new(vec![Some(ScalarImpl::Int64(5))])
-            .memcmp_serialize(&inequality_key_serializer);
-        let row = managed_state
-            .upper_bound_by_inequality(Bound::Included(&bound), &col_types)
-            .unwrap()
-            .unwrap();
-        assert_eq!(row.row[0], Some(ScalarImpl::Int64(1)));
-        let row = managed_state
-            .upper_bound_by_inequality(Bound::Excluded(&bound), &col_types)
-            .unwrap()
-            .unwrap();
-        assert_eq!(row.row[0], Some(ScalarImpl::Int64(3)));
-
-        // `BtreeMap` in state
-        let col1 = [1, 2, 3, 4, 5];
-        let col2 = [5, 5, 4, 4, 8];
-        let data_chunk2 = DataChunk::from_pretty(
-            "I I
-             5 8
-             4 4",
-        );
-        insert_chunk(
-            &mut managed_state,
-            &pk_indices,
-            &col_types,
-            inequality_key_idx,
-            &data_chunk2,
-        );
-        check(&mut managed_state, &col_types, &col1, &col2);
-
-        let bound = OwnedRow::new(vec![Some(ScalarImpl::Int64(8))])
-            .memcmp_serialize(&inequality_key_serializer);
-        let row = managed_state.lower_bound_by_inequality(Bound::Excluded(&bound), &col_types);
-        assert!(row.is_none());
     }
 }

--- a/src/stream/src/executor/join/join_row_set.rs
+++ b/src/stream/src/executor/join/join_row_set.rs
@@ -17,7 +17,6 @@ use std::collections::BTreeMap;
 use std::collections::btree_map::OccupiedError as BTreeMapOccupiedError;
 use std::fmt::Debug;
 use std::mem;
-use std::ops::{Bound, RangeBounds};
 
 use auto_enums::auto_enum;
 use enum_as_inner::EnumAsInner;
@@ -87,12 +86,16 @@ impl<K: Ord, V> JoinRowSet<K, V> {
         }
     }
 
-    pub fn remove(&mut self, key: &K) -> Option<V> {
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         let ret = match self {
             Self::BTree(inner) => inner.remove(key),
             Self::Vec(inner) => inner
                 .iter()
-                .position(|elem| &elem.0 == key)
+                .position(|elem| elem.0.borrow() == key)
                 .map(|pos| inner.swap_remove(pos).1),
         };
         if let Self::BTree(inner) = self
@@ -120,71 +123,18 @@ impl<K: Ord, V> JoinRowSet<K, V> {
     }
 
     #[auto_enum(Iterator)]
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        match self {
+            Self::BTree(inner) => inner.values(),
+            Self::Vec(inner) => inner.iter().map(|(_, v)| v),
+        }
+    }
+
+    #[auto_enum(Iterator)]
     pub fn values_mut(&mut self) -> impl Iterator<Item = &'_ mut V> {
         match self {
             Self::BTree(inner) => inner.values_mut(),
             Self::Vec(inner) => inner.iter_mut().map(|(_, v)| v),
-        }
-    }
-
-    #[auto_enum(Iterator)]
-    pub fn keys(&self) -> impl Iterator<Item = &K> {
-        match self {
-            Self::BTree(inner) => inner.keys(),
-            Self::Vec(inner) => inner.iter().map(|(k, _v)| k),
-        }
-    }
-
-    #[auto_enum(Iterator)]
-    pub fn range<T, R>(&self, range: R) -> impl Iterator<Item = (&K, &V)>
-    where
-        T: Ord + ?Sized,
-        K: Borrow<T> + Ord,
-        R: RangeBounds<T>,
-    {
-        match self {
-            Self::BTree(inner) => inner.range(range),
-            Self::Vec(inner) => inner
-                .iter()
-                .filter(move |(k, _)| range.contains(k.borrow()))
-                .map(|(k, v)| (k, v)),
-        }
-    }
-
-    pub fn lower_bound_key(&self, bound: Bound<&K>) -> Option<&K> {
-        self.lower_bound(bound).map(|(k, _v)| k)
-    }
-
-    pub fn upper_bound_key(&self, bound: Bound<&K>) -> Option<&K> {
-        self.upper_bound(bound).map(|(k, _v)| k)
-    }
-
-    pub fn lower_bound(&self, bound: Bound<&K>) -> Option<(&K, &V)> {
-        match self {
-            Self::BTree(inner) => inner.lower_bound(bound).next(),
-            Self::Vec(inner) => inner
-                .iter()
-                .filter(|(k, _)| (bound, Bound::Unbounded).contains(k))
-                .min_by_key(|(k, _)| k)
-                .map(|(k, v)| (k, v)),
-        }
-    }
-
-    pub fn upper_bound(&self, bound: Bound<&K>) -> Option<(&K, &V)> {
-        match self {
-            Self::BTree(inner) => inner.upper_bound(bound).prev(),
-            Self::Vec(inner) => inner
-                .iter()
-                .filter(|(k, _)| (Bound::Unbounded, bound).contains(k))
-                .max_by_key(|(k, _)| k)
-                .map(|(k, v)| (k, v)),
-        }
-    }
-
-    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-        match self {
-            Self::BTree(inner) => inner.get_mut(key),
-            Self::Vec(inner) => inner.iter_mut().find(|(k, _)| k == key).map(|(_, v)| v),
         }
     }
 
@@ -203,30 +153,29 @@ impl<K: Ord, V> JoinRowSet<K, V> {
         }
     }
 
-    /// Returns the key-value pair with the second smallest key in the map.
-    pub fn second_key_sorted(&self) -> Option<&K> {
+    /// Returns the smallest and second-smallest keys in the map.
+    pub fn first_two_key_sorted(&self) -> (Option<&K>, Option<&K>) {
         match self {
-            Self::BTree(inner) => inner.iter().nth(1).map(|(k, _)| k),
+            Self::BTree(inner) => {
+                let mut iter = inner.keys();
+                (iter.next(), iter.next())
+            }
             Self::Vec(inner) => {
-                let mut res = None;
                 let mut smallest = None;
+                let mut second = None;
                 for (k, _) in inner {
                     if let Some(smallest_k) = smallest {
                         if k < smallest_k {
-                            res = Some(smallest_k);
+                            second = Some(smallest_k);
                             smallest = Some(k);
-                        } else if let Some(res_k) = res {
-                            if k < res_k {
-                                res = Some(k);
-                            }
-                        } else {
-                            res = Some(k);
+                        } else if second.is_none_or(|s| k < s) {
+                            second = Some(k);
                         }
                     } else {
                         smallest = Some(k);
                     }
                 }
-                res
+                (smallest, second)
             }
         }
     }
@@ -235,26 +184,9 @@ impl<K: Ord, V> JoinRowSet<K, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn test_join_row_set_bounds() {
-        let mut join_row_set: JoinRowSet<i32, i32> = JoinRowSet::default();
-
-        // Insert elements
-        assert!(join_row_set.try_insert(1, 10).is_ok());
-        assert!(join_row_set.try_insert(2, 20).is_ok());
-        assert!(join_row_set.try_insert(3, 30).is_ok());
-
-        // Check lower bound
-        assert_eq!(join_row_set.lower_bound_key(Bound::Included(&2)), Some(&2));
-        assert_eq!(join_row_set.lower_bound_key(Bound::Excluded(&2)), Some(&3));
-
-        // Check upper bound
-        assert_eq!(join_row_set.upper_bound_key(Bound::Included(&2)), Some(&2));
-        assert_eq!(join_row_set.upper_bound_key(Bound::Excluded(&2)), Some(&1));
-    }
 
     #[test]
-    fn test_join_row_set_first_and_second_key_sorted() {
+    fn test_join_row_set_first_two_key_sorted() {
         {
             let mut join_row_set: JoinRowSet<i32, i32> = JoinRowSet::default();
 
@@ -263,11 +195,7 @@ mod tests {
             assert!(join_row_set.try_insert(1, 10).is_ok());
             assert!(join_row_set.try_insert(2, 20).is_ok());
 
-            // Check first key sorted
-            assert_eq!(join_row_set.first_key_sorted(), Some(&1));
-
-            // Check second key sorted
-            assert_eq!(join_row_set.second_key_sorted(), Some(&2));
+            assert_eq!(join_row_set.first_two_key_sorted(), (Some(&1), Some(&2)));
         }
         {
             let mut join_row_set: JoinRowSet<i32, i32> = JoinRowSet::default();
@@ -276,11 +204,14 @@ mod tests {
             assert!(join_row_set.try_insert(1, 10).is_ok());
             assert!(join_row_set.try_insert(2, 20).is_ok());
 
-            // Check first key sorted
-            assert_eq!(join_row_set.first_key_sorted(), Some(&1));
+            assert_eq!(join_row_set.first_two_key_sorted(), (Some(&1), Some(&2)));
+        }
+        {
+            let mut join_row_set: JoinRowSet<i32, i32> = JoinRowSet::default();
 
-            // Check second key sorted
-            assert_eq!(join_row_set.second_key_sorted(), Some(&2));
+            assert!(join_row_set.try_insert(1, 10).is_ok());
+
+            assert_eq!(join_row_set.first_two_key_sorted(), (Some(&1), None));
         }
     }
 }

--- a/src/stream/src/executor/join/mod.rs
+++ b/src/stream/src/executor/join/mod.rs
@@ -17,6 +17,7 @@ use risingwave_pb::plan_common::{AsOfJoinDesc, AsOfJoinInequalityType};
 
 use crate::error::StreamResult;
 
+pub mod asof_join;
 pub mod builder;
 pub mod hash_join;
 pub mod join_row_set;

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -153,6 +153,7 @@ pub use filter::{FilterExecutor, UpsertFilterExecutor};
 pub use gap_fill::{GapFillExecutor, GapFillExecutorArgs};
 pub use hash_join::*;
 pub use hop_window::HopWindowExecutor;
+pub use join::asof_join::{AsOfCpuEncoding, AsOfMemoryEncoding};
 pub use join::row::{CachedJoinRow, CpuEncoding, JoinEncoding, MemoryEncoding};
 pub use join::{AsOfDesc, AsOfJoinType, JoinType};
 pub use lookup::*;

--- a/src/stream/src/from_proto/asof_join.rs
+++ b/src/stream/src/from_proto/asof_join.rs
@@ -15,19 +15,13 @@
 use std::sync::Arc;
 
 use risingwave_common::config::streaming::JoinEncodingType;
-use risingwave_common::hash::{HashKey, HashKeyDispatcher};
-use risingwave_common::types::DataType;
 use risingwave_pb::plan_common::AsOfJoinType as JoinTypeProto;
 use risingwave_pb::stream_plan::AsOfJoinNode;
 
 use super::*;
-use crate::common::table::state_table::{StateTable, StateTableBuilder};
+use crate::common::table::state_table::StateTableBuilder;
 use crate::executor::asof_join::*;
-use crate::executor::monitor::StreamingMetrics;
-use crate::executor::{
-    ActorContextRef, AsOfDesc, AsOfJoinType, CpuEncoding, JoinType, MemoryEncoding,
-};
-use crate::task::AtomicU64Ref;
+use crate::executor::{AsOfCpuEncoding, AsOfDesc, AsOfJoinType, AsOfMemoryEncoding, JoinType};
 
 pub struct AsOfJoinExecutorBuilder;
 
@@ -69,17 +63,10 @@ impl ExecutorBuilder for AsOfJoinExecutorBuilder {
                 .map(|key| *key as usize)
                 .collect_vec(),
         );
-        let null_safe = node.get_null_safe().clone();
         let output_indices = node
             .get_output_indices()
             .iter()
             .map(|&x| x as usize)
-            .collect_vec();
-
-        let join_key_data_types = params_l
-            .join_key_indices
-            .iter()
-            .map(|idx| source_l.schema().fields[*idx].data_type())
             .collect_vec();
 
         let state_table_l = StateTableBuilder::new(table_l, store.clone(), Some(vnodes.clone()))
@@ -96,6 +83,9 @@ impl ExecutorBuilder for AsOfJoinExecutorBuilder {
         let as_of_desc_proto = node.get_asof_desc()?;
         let asof_desc = AsOfDesc::from_protobuf(as_of_desc_proto)?;
 
+        let null_safe = node.get_null_safe().clone();
+        let use_cache = node.use_cache.unwrap_or(true);
+
         // Previously, the `join_encoding_type` is persisted in the plan node.
         // Now it's always `Unspecified` and we should refer to the job's config override.
         #[allow(deprecated)]
@@ -103,103 +93,45 @@ impl ExecutorBuilder for AsOfJoinExecutorBuilder {
             .get_join_encoding_type()
             .map_or(params.config.developer.join_encoding_type, Into::into);
 
-        let args = AsOfJoinExecutorDispatcherArgs {
-            ctx: params.actor_context,
-            info: params.info.clone(),
-            source_l,
-            source_r,
-            params_l,
-            params_r,
-            null_safe,
-            output_indices,
-            state_table_l,
-            state_table_r,
-            lru_manager: params.watermark_epoch,
-            metrics: params.executor_stats,
-            join_type_proto,
-            join_key_data_types,
-            chunk_size: params.config.developer.chunk_size,
-            high_join_amplification_threshold: (params.config.developer)
-                .high_join_amplification_threshold,
-            asof_desc,
-            join_encoding_type,
-        };
-
-        let exec = args.dispatch()?;
-        Ok((params.info, exec).into())
-    }
-}
-
-struct AsOfJoinExecutorDispatcherArgs<S: StateStore> {
-    ctx: ActorContextRef,
-    info: ExecutorInfo,
-    source_l: Executor,
-    source_r: Executor,
-    params_l: JoinParams,
-    params_r: JoinParams,
-    null_safe: Vec<bool>,
-    output_indices: Vec<usize>,
-    state_table_l: StateTable<S>,
-    state_table_r: StateTable<S>,
-    lru_manager: AtomicU64Ref,
-    metrics: Arc<StreamingMetrics>,
-    join_type_proto: JoinTypeProto,
-    join_key_data_types: Vec<DataType>,
-    chunk_size: usize,
-    high_join_amplification_threshold: usize,
-    asof_desc: AsOfDesc,
-    join_encoding_type: JoinEncodingType,
-}
-
-impl<S: StateStore> HashKeyDispatcher for AsOfJoinExecutorDispatcherArgs<S> {
-    type Output = StreamResult<Box<dyn Execute>>;
-
-    fn dispatch_impl<K: HashKey>(self) -> Self::Output {
-        /// This macro helps to fill the const generic type parameter.
         macro_rules! build {
-            ($join_type:ident, $join_encoding:ident) => {
-                Ok(
-                    AsOfJoinExecutor::<K, S, { AsOfJoinType::$join_type }, $join_encoding>::new(
-                        self.ctx,
-                        self.info,
-                        self.source_l,
-                        self.source_r,
-                        self.params_l,
-                        self.params_r,
-                        self.null_safe,
-                        self.output_indices,
-                        self.state_table_l,
-                        self.state_table_r,
-                        self.lru_manager,
-                        self.metrics,
-                        self.chunk_size,
-                        self.high_join_amplification_threshold,
-                        self.asof_desc,
-                    )
-                    .boxed(),
+            ($join_type:ident, $encoding:ident) => {
+                AsOfJoinExecutor::<_, { AsOfJoinType::$join_type }, $encoding>::new(
+                    params.actor_context,
+                    params.info.clone(),
+                    source_l,
+                    source_r,
+                    params_l,
+                    params_r,
+                    null_safe,
+                    output_indices,
+                    state_table_l,
+                    state_table_r,
+                    params.watermark_epoch,
+                    params.executor_stats,
+                    params.config.developer.chunk_size,
+                    asof_desc,
+                    use_cache,
+                    params.config.developer.high_join_amplification_threshold,
                 )
+                .boxed()
             };
         }
 
-        macro_rules! build_match {
-            ($($join_type:ident),*) => {
-                match (self.join_type_proto, self.join_encoding_type) {
-                    (JoinTypeProto::Unspecified, _) => unreachable!(),
-                    $(
-                        (JoinTypeProto::$join_type, JoinEncodingType::Memory) => build!($join_type, MemoryEncoding),
-                        (JoinTypeProto::$join_type, JoinEncodingType::Cpu) => build!($join_type, CpuEncoding),
-                    )*
-                }
-            };
-        }
-
-        build_match! {
-            Inner,
-            LeftOuter
-        }
-    }
-
-    fn data_types(&self) -> &[DataType] {
-        &self.join_key_data_types
+        let exec = match (join_type_proto, join_encoding_type) {
+            (JoinTypeProto::Inner, JoinEncodingType::Memory) => {
+                build!(Inner, AsOfMemoryEncoding)
+            }
+            (JoinTypeProto::Inner, JoinEncodingType::Cpu) => {
+                build!(Inner, AsOfCpuEncoding)
+            }
+            (JoinTypeProto::LeftOuter, JoinEncodingType::Memory) => {
+                build!(LeftOuter, AsOfMemoryEncoding)
+            }
+            (JoinTypeProto::LeftOuter, JoinEncodingType::Cpu) => {
+                build!(LeftOuter, AsOfCpuEncoding)
+            }
+            (JoinTypeProto::Unspecified, _) => unreachable!(),
+        };
+        Ok((params.info, exec).into())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).


This pull request introduces a new session-level configuration to control whether the AsOf join executor uses a cache-based or no-cache implementation, and refactors related code to support this feature.

cache and non-cache impl are unified via `AsOfJoinHashMap`, which provided unified api and handle cache internally. 

 It also simplifies and cleans up the `JoinRowSet` utility, removing unused methods and improving its API.

**AsOf Join Cache Control and Refactoring:**

- Added a session parameter `streaming_asof_join_use_cache` (default `true`) to enable or disable the cache-based implementation of the AsOf join executor, allowing users to switch between cache and no-cache implementations for performance tuning. This is now plumbed through the optimizer, protobuf plan, and executor builder. [[1]](diffhunk://#diff-4e19861816f5cf913890db3abd8088d01fa135d85f43080d5e6ee5c6c8ac40aaR395-R402) [[2]](diffhunk://#diff-596df18be8f0436c450a415331c053c8ce03101401f1787dd4d0f0be9514a681R74) [[3]](diffhunk://#diff-d1326c460dad73afa8d2fa2794bc37e49dc8ae3cdbf2b66edcbc6bf864e72a79R303-R309) [[4]](diffhunk://#diff-d1326c460dad73afa8d2fa2794bc37e49dc8ae3cdbf2b66edcbc6bf864e72a79R324) [[5]](diffhunk://#diff-548bcb845b3db0225b2c6ab9d843234320a813af3a44855b764aaa284eda2dd8R669-R672) [[6]](diffhunk://#diff-69e28b1993a8725ba7d682525b128782ca6ca5083de17e433cb7a1fc5290e0adL99-R92) [[7]](diffhunk://#diff-69e28b1993a8725ba7d682525b128782ca6ca5083de17e433cb7a1fc5290e0adL117-R116) [[8]](diffhunk://#diff-eaae63fa6b4b86350ab10b1d023dd1581e5acbeb6129ea00c5f0444dabb77e0cR23-R31)
- Updated the AsOf join executor builder to construct the executor directly based on the new `use_cache` flag, removing unnecessary abstraction and legacy join encoding logic. [[1]](diffhunk://#diff-69e28b1993a8725ba7d682525b128782ca6ca5083de17e433cb7a1fc5290e0adL17-R23) [[2]](diffhunk://#diff-69e28b1993a8725ba7d682525b128782ca6ca5083de17e433cb7a1fc5290e0adL72-L84) [[3]](diffhunk://#diff-69e28b1993a8725ba7d682525b128782ca6ca5083de17e433cb7a1fc5290e0adL99-R92) [[4]](diffhunk://#diff-69e28b1993a8725ba7d682525b128782ca6ca5083de17e433cb7a1fc5290e0adL117-R116)
- Added a reverse iterator method to `StateTable` to support efficient no-cache AsOf join implementation.

**JoinRowSet Utility Simplification:**

- Removed unused and complex range/bound methods from `JoinRowSet`, and replaced the `second_key_sorted` method with a simpler `first_two_key_sorted` that returns the smallest and second-smallest keys. Updated related tests accordingly. [[1]](diffhunk://#diff-b489ba8914c7425371838563b5adc1b5e4ab052e5acd6913668fac6a0d4541bdL90-R98) [[2]](diffhunk://#diff-b489ba8914c7425371838563b5adc1b5e4ab052e5acd6913668fac6a0d4541bdL123-R137) [[3]](diffhunk://#diff-b489ba8914c7425371838563b5adc1b5e4ab052e5acd6913668fac6a0d4541bdL206-R178) [[4]](diffhunk://#diff-b489ba8914c7425371838563b5adc1b5e4ab052e5acd6913668fac6a0d4541bdR187-R214)
- Cleaned up imports and code structure in `join_row_set.rs` for clarity.

These changes make the AsOf join executor more configurable and maintainable, and simplify the join row set utility for future development.

### Regression change

The hashmap key no longer use `HashKey` but use OwnedRow. It should not cause any major problem. It's not a breaking change.

### Review
This PR was already reviewed by codex for multiple rounds.

Main changes are switching to use AsOfJoinHashMap for both cache and non-cache based read/write. AsOfJoinHashMap handles the cache.

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
