### PR TITLE
feat(optimizer): support general multi range for selective backfill

### DIFF
--- a/e2e_test/backfill/snapshot_backfill/pk_predicate_pushdown.slt
+++ b/e2e_test/backfill/snapshot_backfill/pk_predicate_pushdown.slt
@@ -322,3 +322,237 @@ SELECT * FROM t_in WHERE a IN (2, 5, 8) EXCEPT SELECT * FROM mv_in;
 
 statement ok
 DROP TABLE t_in cascade;
+
+# ============================================================
+# Multi-range OR predicate tests (generalized UNION of scans)
+# ============================================================
+
+statement ok
+CREATE TABLE t_or(a INT, b INT, c INT, PRIMARY KEY(a, b));
+
+statement ok
+INSERT INTO t_or SELECT
+  i / 10 AS a,
+  i % 10 AS b,
+  i * 10 AS c
+FROM generate_series(0, 99) AS s(i);
+
+statement ok
+flush;
+
+# ---- Test 12: OR of eq + range on different PK prefixes ----
+# (a = 1 AND b > 5) OR (a = 3 AND b < 3)
+# Should produce 2 UNION branches with range bounds
+
+statement ok
+CREATE MATERIALIZED VIEW mv_or_range AS SELECT * FROM t_or WHERE (a = 1 AND b > 5) OR (a = 3 AND b < 3);
+
+query III rowsort
+SELECT * FROM mv_or_range;
+----
+1 6 160
+1 7 170
+1 8 180
+1 9 190
+3 0 300
+3 1 310
+3 2 320
+
+query T
+SELECT * FROM mv_or_range EXCEPT SELECT * FROM t_or WHERE (a = 1 AND b > 5) OR (a = 3 AND b < 3);
+----
+
+query T
+SELECT * FROM t_or WHERE (a = 1 AND b > 5) OR (a = 3 AND b < 3) EXCEPT SELECT * FROM mv_or_range;
+----
+
+# ---- Test 13: OR of equality-only arms (equivalent to IN) ----
+# (a = 2 AND b = 5) OR (a = 7 AND b = 3)
+
+statement ok
+CREATE MATERIALIZED VIEW mv_or_eq AS SELECT * FROM t_or WHERE (a = 2 AND b = 5) OR (a = 7 AND b = 3);
+
+query III rowsort
+SELECT * FROM mv_or_eq;
+----
+2 5 250
+7 3 730
+
+query T
+SELECT * FROM mv_or_eq EXCEPT SELECT * FROM t_or WHERE (a = 2 AND b = 5) OR (a = 7 AND b = 3);
+----
+
+query T
+SELECT * FROM t_or WHERE (a = 2 AND b = 5) OR (a = 7 AND b = 3) EXCEPT SELECT * FROM mv_or_eq;
+----
+
+# ---- Test 14: Verify post-backfill correctness with OR ----
+# New rows matching the predicate should appear; non-matching should not
+
+statement ok
+INSERT INTO t_or VALUES (1, 7, 999), (3, 1, 888), (5, 5, 777);
+
+statement ok
+flush;
+
+# (1,7,999) replaces (1,7,170) — matches first arm
+# (3,1,888) replaces (3,1,310) — matches second arm
+# (5,5,777) should NOT appear — doesn't match predicate
+query T
+SELECT * FROM mv_or_range EXCEPT SELECT * FROM t_or WHERE (a = 1 AND b > 5) OR (a = 3 AND b < 3);
+----
+
+query T
+SELECT * FROM t_or WHERE (a = 1 AND b > 5) OR (a = 3 AND b < 3) EXCEPT SELECT * FROM mv_or_range;
+----
+
+query T
+SELECT * FROM mv_or_eq EXCEPT SELECT * FROM t_or WHERE (a = 2 AND b = 5) OR (a = 7 AND b = 3);
+----
+
+query T
+SELECT * FROM t_or WHERE (a = 2 AND b = 5) OR (a = 7 AND b = 3) EXCEPT SELECT * FROM mv_or_eq;
+----
+
+statement ok
+DROP TABLE t_or cascade;
+
+# ============================================================
+# Range merge tests
+# When OR arms produce overlapping scan ranges with the same
+# eq_conds prefix, split_to_scan_ranges merges them into a
+# single wider range. This tests that merged ranges still
+# produce correct results.
+# ============================================================
+
+statement ok
+CREATE TABLE t_merge(a INT, b INT, c INT, PRIMARY KEY(a, b));
+
+statement ok
+INSERT INTO t_merge SELECT
+  i / 10 AS a,
+  i % 10 AS b,
+  i * 10 AS c
+FROM generate_series(0, 99) AS s(i);
+
+statement ok
+flush;
+
+# ---- Test 15: Overlapping ranges with same eq_conds prefix ----
+# (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8)
+# These overlap on b in [3,5], so they merge into a single range:
+# a = 1 AND b >= 1 AND b <= 8 (single scan, not UNION)
+
+statement ok
+CREATE MATERIALIZED VIEW mv_merge AS SELECT * FROM t_merge
+  WHERE (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8);
+
+query III rowsort
+SELECT * FROM mv_merge;
+----
+1 1 110
+1 2 120
+1 3 130
+1 4 140
+1 5 150
+1 6 160
+1 7 170
+1 8 180
+
+query T
+SELECT * FROM mv_merge EXCEPT SELECT * FROM t_merge WHERE (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8);
+----
+
+query T
+SELECT * FROM t_merge WHERE (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8) EXCEPT SELECT * FROM mv_merge;
+----
+
+# ---- Test 16: Non-overlapping ranges with same eq_conds (no merge) ----
+# (a = 2 AND b >= 0 AND b <= 2) OR (a = 2 AND b >= 7 AND b <= 9)
+# These do NOT overlap, so they remain as 2 separate scan ranges (UNION)
+
+statement ok
+CREATE MATERIALIZED VIEW mv_no_merge AS SELECT * FROM t_merge
+  WHERE (a = 2 AND b >= 0 AND b <= 2) OR (a = 2 AND b >= 7 AND b <= 9);
+
+query III rowsort
+SELECT * FROM mv_no_merge;
+----
+2 0 200
+2 1 210
+2 2 220
+2 7 270
+2 8 280
+2 9 290
+
+query T
+SELECT * FROM mv_no_merge EXCEPT SELECT * FROM t_merge WHERE (a = 2 AND b >= 0 AND b <= 2) OR (a = 2 AND b >= 7 AND b <= 9);
+----
+
+query T
+SELECT * FROM t_merge WHERE (a = 2 AND b >= 0 AND b <= 2) OR (a = 2 AND b >= 7 AND b <= 9) EXCEPT SELECT * FROM mv_no_merge;
+----
+
+# ---- Test 17: Merged range + separate range (partial merge) ----
+# (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5)
+# First two arms merge into a = 3 AND b >= 0 AND b <= 6
+# Third arm has different eq_conds (a = 5), stays separate → UNION of 2
+
+statement ok
+CREATE MATERIALIZED VIEW mv_partial_merge AS SELECT * FROM t_merge
+  WHERE (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5);
+
+query III rowsort
+SELECT * FROM mv_partial_merge;
+----
+3 0 300
+3 1 310
+3 2 320
+3 3 330
+3 4 340
+3 5 350
+3 6 360
+5 5 550
+
+query T
+SELECT * FROM mv_partial_merge EXCEPT SELECT * FROM t_merge WHERE (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5);
+----
+
+query T
+SELECT * FROM t_merge WHERE (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5) EXCEPT SELECT * FROM mv_partial_merge;
+----
+
+# ---- Test 18: Verify post-backfill correctness with merged ranges ----
+
+statement ok
+INSERT INTO t_merge VALUES (1, 4, 999), (2, 8, 888), (3, 3, 777), (5, 5, 666);
+
+statement ok
+flush;
+
+query T
+SELECT * FROM mv_merge EXCEPT SELECT * FROM t_merge WHERE (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8);
+----
+
+query T
+SELECT * FROM t_merge WHERE (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8) EXCEPT SELECT * FROM mv_merge;
+----
+
+query T
+SELECT * FROM mv_no_merge EXCEPT SELECT * FROM t_merge WHERE (a = 2 AND b >= 0 AND b <= 2) OR (a = 2 AND b >= 7 AND b <= 9);
+----
+
+query T
+SELECT * FROM t_merge WHERE (a = 2 AND b >= 0 AND b <= 2) OR (a = 2 AND b >= 7 AND b <= 9) EXCEPT SELECT * FROM mv_no_merge;
+----
+
+query T
+SELECT * FROM mv_partial_merge EXCEPT SELECT * FROM t_merge WHERE (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5);
+----
+
+query T
+SELECT * FROM t_merge WHERE (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5) EXCEPT SELECT * FROM mv_partial_merge;
+----
+
+statement ok
+DROP TABLE t_merge cascade;

--- a/src/frontend/planner_test/tests/testdata/input/backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/backfill.yaml
@@ -164,6 +164,29 @@
     select * from t where b IN (1, 2, 3);
   expected_outputs:
     - stream_plan
+- name: snapshot backfill multi-range OR predicate produces UNION of scans
+  sql: |
+    create table t(a int, b int, c int, primary key(a, b));
+    select * from t where (a = 1 AND b > 10) OR (a = 2 AND b < 5);
+  expected_outputs:
+    - stream_plan
+- name: |
+    snapshot backfill overlapping ranges merge into single scan.
+    TODO: scan range should be `a = 1 AND b >= 1 AND b <= 8` after merge, but currently
+    only pushes `a = 1`. Root cause: expression simplification factors out `a = 1` before
+    split_to_scan_ranges, leaving an OR on b that analyze_group cannot extract as a range.
+    Fix: teach analyze_group in condition.rs to handle OR-of-ranges on a single PK column.
+  sql: |
+    create table t(a int, b int, c int, primary key(a, b));
+    select * from t where (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8);
+  expected_outputs:
+    - stream_plan
+- name: snapshot backfill partial merge with separate range produces UNION
+  sql: |
+    create table t(a int, b int, c int, primary key(a, b));
+    select * from t where (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5);
+  expected_outputs:
+    - stream_plan
 - name: snapshot backfill index selection without explicit include
   sql: |
     create table t(a int, b int, c int, primary key(a));

--- a/src/frontend/planner_test/tests/testdata/output/backfill.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/backfill.yaml
@@ -323,6 +323,49 @@
         └─StreamProject { exprs: [idx_b.a, idx_b.b, idx_b.c, 2:Int32] }
           └─StreamFilter { predicate: (idx_b.b = 3:Int32) }
             └─StreamTableScan { table: idx_b, columns: [idx_b.a, idx_b.b, idx_b.c], pk_scan_range: b = Some(Int32(3)), stream_scan_type: SnapshotBackfill, stream_key: [idx_b.b, idx_b.a], pk: [b, a], dist: UpstreamHashShard(idx_b.b) }
+- name: snapshot backfill multi-range OR predicate produces UNION of scans
+  sql: |
+    create table t(a int, b int, c int, primary key(a, b));
+    select * from t where (a = 1 AND b > 10) OR (a = 2 AND b < 5);
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, c, $src(hidden)], stream_key: [a, b, $src], pk_columns: [a, b, $src], pk_conflict: NoCheck }
+    └─StreamUnion { all: true }
+      ├─StreamExchange { dist: HashShard(t.a, t.b, 0:Int32) }
+      │ └─StreamProject { exprs: [t.a, t.b, t.c, 0:Int32] }
+      │   └─StreamFilter { predicate: (t.a = 1:Int32) AND (t.b > 10:Int32) AND (((t.a = 1:Int32) AND (t.b > 10:Int32)) OR ((t.a = 2:Int32) AND (t.b < 5:Int32))) }
+      │     └─StreamTableScan { table: t, columns: [t.a, t.b, t.c], pk_scan_range: a = Some(Int32(1)) AND b > Some(Int32(10)), stream_scan_type: SnapshotBackfill, stream_key: [t.a, t.b], pk: [a, b], dist: UpstreamHashShard(t.a, t.b) }
+      └─StreamExchange { dist: HashShard(t.a, t.b, 1:Int32) }
+        └─StreamProject { exprs: [t.a, t.b, t.c, 1:Int32] }
+          └─StreamFilter { predicate: (t.a = 2:Int32) AND (t.b < 5:Int32) AND (((t.a = 1:Int32) AND (t.b > 10:Int32)) OR ((t.a = 2:Int32) AND (t.b < 5:Int32))) }
+            └─StreamTableScan { table: t, columns: [t.a, t.b, t.c], pk_scan_range: a = Some(Int32(2)) AND b < Some(Int32(5)), stream_scan_type: SnapshotBackfill, stream_key: [t.a, t.b], pk: [a, b], dist: UpstreamHashShard(t.a, t.b) }
+- name: |
+    snapshot backfill overlapping ranges merge into single scan.
+    TODO: scan range should be `a = 1 AND b >= 1 AND b <= 8` after merge, but currently
+    only pushes `a = 1`. Root cause: expression simplification factors out `a = 1` before
+    split_to_scan_ranges, leaving an OR on b that analyze_group cannot extract as a range.
+    Fix: teach analyze_group in condition.rs to handle OR-of-ranges on a single PK column.
+  sql: |
+    create table t(a int, b int, c int, primary key(a, b));
+    select * from t where (a = 1 AND b >= 1 AND b <= 5) OR (a = 1 AND b >= 3 AND b <= 8);
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, c], stream_key: [a, b], pk_columns: [a, b], pk_conflict: NoCheck }
+    └─StreamFilter { predicate: (t.a = 1:Int32) AND (((t.b >= 1:Int32) AND (t.b <= 5:Int32)) OR ((t.b >= 3:Int32) AND (t.b <= 8:Int32))) }
+      └─StreamTableScan { table: t, columns: [t.a, t.b, t.c], pk_scan_range: a = Some(Int32(1)), stream_scan_type: SnapshotBackfill, stream_key: [t.a, t.b], pk: [a, b], dist: UpstreamHashShard(t.a, t.b) }
+- name: snapshot backfill partial merge with separate range produces UNION
+  sql: |
+    create table t(a int, b int, c int, primary key(a, b));
+    select * from t where (a = 3 AND b >= 0 AND b <= 4) OR (a = 3 AND b >= 2 AND b <= 6) OR (a = 5 AND b = 5);
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, c, $src(hidden)], stream_key: [a, b, $src], pk_columns: [a, b, $src], pk_conflict: NoCheck }
+    └─StreamUnion { all: true }
+      ├─StreamExchange { dist: HashShard(t.a, t.b, 0:Int32) }
+      │ └─StreamProject { exprs: [t.a, t.b, t.c, 0:Int32] }
+      │   └─StreamFilter { predicate: (t.a = 3:Int32) AND (t.b >= 0:Int32) AND (t.b <= 6:Int32) AND (((((t.a = 3:Int32) AND (t.b >= 0:Int32)) AND (t.b <= 4:Int32)) OR (((t.a = 3:Int32) AND (t.b >= 2:Int32)) AND (t.b <= 6:Int32))) OR ((t.a = 5:Int32) AND (t.b = 5:Int32))) }
+      │     └─StreamTableScan { table: t, columns: [t.a, t.b, t.c], pk_scan_range: a = Some(Int32(3)) AND b >= Some(Int32(0)) AND b <= Some(Int32(6)), stream_scan_type: SnapshotBackfill, stream_key: [t.a, t.b], pk: [a, b], dist: UpstreamHashShard(t.a, t.b) }
+      └─StreamExchange { dist: HashShard(t.a, t.b, 1:Int32) }
+        └─StreamProject { exprs: [t.a, t.b, t.c, 1:Int32] }
+          └─StreamFilter { predicate: (t.a = 5:Int32) AND (t.b = 5:Int32) AND (((((t.a = 3:Int32) AND (t.b >= 0:Int32)) AND (t.b <= 4:Int32)) OR (((t.a = 3:Int32) AND (t.b >= 2:Int32)) AND (t.b <= 6:Int32))) OR ((t.a = 5:Int32) AND (t.b = 5:Int32))) }
+            └─StreamTableScan { table: t, columns: [t.a, t.b, t.c], pk_scan_range: a = Some(Int32(5)) AND b = Some(Int32(5)), stream_scan_type: SnapshotBackfill, stream_key: [t.a, t.b], pk: [a, b], dist: UpstreamHashShard(t.a, t.b) }
 - name: snapshot backfill index selection without explicit include
   sql: |
     create table t(a int, b int, c int, primary key(a));

--- a/src/frontend/src/optimizer/rule/streaming_index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/streaming_index_selection_rule.rs
@@ -16,8 +16,9 @@
 //!
 //! Unlike the batch [`IndexSelectionRule`](IndexSelectionRule), this rule:
 //! - Only considers **covering** indexes (no lookup join in streaming backfill)
-//! - Handles IN predicates by expanding into a `LogicalUnion` of `LogicalScan`s,
-//!   each with a branch-local equality predicate for correct post-backfill routing
+//! - Expands multi-range predicates (IN, OR, range splits) into a `LogicalUnion`
+//!   of `LogicalScan`s, each with a branch-local predicate reconstructed from the
+//!   scan range for correct post-backfill routing
 
 use std::ops::Bound;
 
@@ -36,18 +37,19 @@ impl StreamingIndexSelectionRule {
     ///
     /// Applies two optimizations in order:
     /// 1. **Covering index selection**: picks the lowest-cost covering index
-    /// 2. **IN expansion**: splits IN predicates into a `LogicalUnion` of `LogicalScan`s,
-    ///    each with a single-value equality predicate
+    /// 2. **Multi-range expansion**: splits predicates that produce multiple scan ranges
+    ///    into a `LogicalUnion` of `LogicalScan`s, each with a complete branch-local
+    ///    predicate reconstructed from the scan range
     ///
     /// Returns `Some(PlanRef)` which is either a `LogicalScan` (index only) or a
-    /// `LogicalUnion` of `LogicalScan`s (IN expansion, possibly on an index).
+    /// `LogicalUnion` of `LogicalScan`s (multi-range expansion, possibly on an index).
     pub fn rewrite(logical_scan: &LogicalScan) -> Option<PlanRef> {
         // Step 1: Try covering index selection.
         let best_scan =
             Self::select_covering_index(logical_scan).unwrap_or_else(|| logical_scan.clone());
 
-        // Step 2: Try IN expansion on the (possibly index-backed) scan.
-        if let Some(union) = Self::try_expand_in(&best_scan) {
+        // Step 2: Try multi-range expansion on the (possibly index-backed) scan.
+        if let Some(union) = Self::try_expand_multi_range(&best_scan) {
             return Some(union);
         }
 
@@ -97,11 +99,17 @@ impl StreamingIndexSelectionRule {
         best_scan
     }
 
-    /// Expands an IN predicate into a `LogicalUnion` of `LogicalScan`s.
+    /// Expands a predicate with multiple scan ranges into a `LogicalUnion` of `LogicalScan`s.
     ///
-    /// Each branch gets a single-value equality predicate (e.g., `a = 1`) plus residual
-    /// conditions. Only applies when all scan ranges are non-trivial.
-    fn try_expand_in(logical_scan: &LogicalScan) -> Option<PlanRef> {
+    /// Each branch gets a complete predicate reconstructed from the scan range's eq_conds
+    /// and range bounds, plus residual conditions. This handles:
+    /// - IN predicates: `a IN (1, 2, 3)` → 3 branches with `a = 1`, `a = 2`, `a = 3`
+    /// - Multi-range: `a >= 1 AND a < 5 OR a >= 10 AND a < 20` → 2 branches with range bounds
+    /// - Mixed: eq_conds prefix + range bound on next column
+    ///
+    /// Only applies when all scan ranges are non-trivial (selective).
+    /// `split_to_scan_ranges` guarantees the ranges are non-overlapping.
+    fn try_expand_multi_range(logical_scan: &LogicalScan) -> Option<PlanRef> {
         let (scan_ranges, residual) = logical_scan
             .predicate()
             .clone()
@@ -116,13 +124,7 @@ impl StreamingIndexSelectionRule {
             )
             .ok()?;
 
-        if scan_ranges.len() <= 1
-            || !scan_ranges.iter().all(|r| {
-                !r.is_full_table_scan()
-                    && matches!(r.range.0, Bound::Unbounded)
-                    && matches!(r.range.1, Bound::Unbounded)
-            })
-        {
+        if scan_ranges.len() <= 1 || !scan_ranges.iter().all(|r| !r.is_full_table_scan()) {
             return None;
         }
 
@@ -132,23 +134,41 @@ impl StreamingIndexSelectionRule {
         let branches: Vec<PlanRef> = scan_ranges
             .into_iter()
             .map(|range| -> Option<PlanRef> {
-                // Build a branch predicate from this scan range's eq_conds.
-                // InputRef indices are in table-column space.
-                let mut conjunctions: Vec<ExprImpl> = range
-                    .eq_conds
-                    .iter()
-                    .enumerate()
-                    .map(|(i, datum)| {
-                        let table_col_idx = pk[i].column_index;
-                        let col_type = table_cols[table_col_idx].data_type().clone();
-                        let input_ref = InputRef::new(table_col_idx, col_type.clone());
-                        let literal = Literal::new(datum.clone(), col_type);
-                        FunctionCall::new(ExprType::Equal, vec![input_ref.into(), literal.into()])
-                            .map(ExprImpl::from)
-                    })
-                    .collect::<Result<_, _>>()
-                    .ok()?;
-                // Add residual conditions so each branch is self-contained.
+                let mut conjunctions = Vec::new();
+
+                // 1. Build equality predicates from eq_conds (PK prefix).
+                for (i, datum) in range.eq_conds.iter().enumerate() {
+                    let table_col_idx = pk[i].column_index;
+                    let col_type = table_cols[table_col_idx].data_type().clone();
+                    let input_ref: ExprImpl =
+                        InputRef::new(table_col_idx, col_type.clone()).into();
+                    let literal: ExprImpl = Literal::new(datum.clone(), col_type).into();
+                    let eq = FunctionCall::new(ExprType::Equal, vec![input_ref, literal])
+                        .ok()
+                        .map(ExprImpl::from)?;
+                    conjunctions.push(eq);
+                }
+
+                // 2. Build range bound predicates on the next PK column(s) after eq_conds.
+                let range_col_start = range.eq_conds.len();
+                Self::build_bound_expr(
+                    &range.range.0,
+                    range_col_start,
+                    pk,
+                    table_cols,
+                    true, // is_lower
+                    &mut conjunctions,
+                )?;
+                Self::build_bound_expr(
+                    &range.range.1,
+                    range_col_start,
+                    pk,
+                    table_cols,
+                    false, // is_lower
+                    &mut conjunctions,
+                )?;
+
+                // 3. Add residual conditions so each branch is self-contained.
                 conjunctions.extend(residual.conjunctions.iter().cloned());
                 let branch_predicate = Condition { conjunctions };
                 Some(logical_scan.clone_with_predicate(branch_predicate).into())
@@ -156,5 +176,63 @@ impl StreamingIndexSelectionRule {
             .collect::<Option<_>>()?;
 
         Some(LogicalUnion::create(true, branches))
+    }
+
+    /// Builds comparison expression(s) from a scan range bound.
+    ///
+    /// For `Included(v)` lower bound → `col >= v`
+    /// For `Excluded(v)` lower bound → `col > v`
+    /// For `Included(v)` upper bound → `col <= v`
+    /// For `Excluded(v)` upper bound → `col < v`
+    /// For `Unbounded` → no expression added
+    ///
+    /// Returns `Some(())` on success, `None` if expression construction fails.
+    fn build_bound_expr(
+        bound: &Bound<Vec<risingwave_common::types::Datum>>,
+        range_col_start: usize,
+        pk: &[risingwave_common::util::sort_util::ColumnOrder],
+        table_cols: &[risingwave_common::catalog::ColumnCatalog],
+        is_lower: bool,
+        conjunctions: &mut Vec<ExprImpl>,
+    ) -> Option<()> {
+        let datums = match bound {
+            Bound::Unbounded => return Some(()),
+            Bound::Included(d) => d,
+            Bound::Excluded(d) => d,
+        };
+        let is_inclusive = matches!(bound, Bound::Included(_));
+
+        for (j, datum) in datums.iter().enumerate() {
+            let pk_idx = range_col_start + j;
+            if pk_idx >= pk.len() {
+                break;
+            }
+            let table_col_idx = pk[pk_idx].column_index;
+            let col_type = table_cols[table_col_idx].data_type().clone();
+            let input_ref: ExprImpl = InputRef::new(table_col_idx, col_type.clone()).into();
+            let literal: ExprImpl = Literal::new(datum.clone(), col_type).into();
+
+            // For multi-datum bounds, only the last datum gets the actual bound operator;
+            // preceding datums are equalities (they form part of the composite prefix).
+            let expr_type = if j < datums.len() - 1 {
+                ExprType::Equal
+            } else if is_lower {
+                if is_inclusive {
+                    ExprType::GreaterThanOrEqual
+                } else {
+                    ExprType::GreaterThan
+                }
+            } else if is_inclusive {
+                ExprType::LessThanOrEqual
+            } else {
+                ExprType::LessThan
+            };
+
+            let expr = FunctionCall::new(expr_type, vec![input_ref, literal])
+                .ok()
+                .map(ExprImpl::from)?;
+            conjunctions.push(expr);
+        }
+        Some(())
     }
 }

--- a/src/frontend/src/optimizer/rule/streaming_index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/streaming_index_selection_rule.rs
@@ -101,11 +101,11 @@ impl StreamingIndexSelectionRule {
 
     /// Expands a predicate with multiple scan ranges into a `LogicalUnion` of `LogicalScan`s.
     ///
-    /// Each branch gets a complete predicate reconstructed from the scan range's eq_conds
+    /// Each branch gets a complete predicate reconstructed from the scan range's `eq_conds`
     /// and range bounds, plus residual conditions. This handles:
     /// - IN predicates: `a IN (1, 2, 3)` → 3 branches with `a = 1`, `a = 2`, `a = 3`
     /// - Multi-range: `a >= 1 AND a < 5 OR a >= 10 AND a < 20` → 2 branches with range bounds
-    /// - Mixed: eq_conds prefix + range bound on next column
+    /// - Mixed: `eq_conds` prefix + range bound on next column
     ///
     /// Only applies when all scan ranges are non-trivial (selective).
     /// `split_to_scan_ranges` guarantees the ranges are non-overlapping.
@@ -140,8 +140,7 @@ impl StreamingIndexSelectionRule {
                 for (i, datum) in range.eq_conds.iter().enumerate() {
                     let table_col_idx = pk[i].column_index;
                     let col_type = table_cols[table_col_idx].data_type().clone();
-                    let input_ref: ExprImpl =
-                        InputRef::new(table_col_idx, col_type.clone()).into();
+                    let input_ref: ExprImpl = InputRef::new(table_col_idx, col_type.clone()).into();
                     let literal: ExprImpl = Literal::new(datum.clone(), col_type).into();
                     let eq = FunctionCall::new(ExprType::Equal, vec![input_ref, literal])
                         .ok()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's intention?

This PR extends the streaming index selection rule to handle multi-range predicates beyond just IN clauses, specifically adding support for OR predicates and range merging during snapshot backfill.

**Key changes:**

- **Expanded multi-range predicate support**: The streaming index selection rule now handles OR predicates that produce multiple scan ranges, not just IN predicates. For example, `(a = 1 AND b > 5) OR (a = 3 AND b < 3)` now gets split into a UNION of two optimized scans.



## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Improved snapshot backfill performance for materialized views with complex WHERE clauses containing OR predicates. The query planner now automatically splits OR conditions into optimized parallel scans during backfill, similar to the existing IN predicate optimization. This reduces the amount of data scanned and improves backfill performance for queries like `WHERE (a = 1 AND b > 5) OR (a = 3 AND b < 3)`.

</details>