### PR TITLE
chore: retain barrier complete logs per database

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -919,6 +919,7 @@ message EventLog {
     double duration_sec = 3;
     string command = 4;
     string barrier_kind = 5;
+    uint32 database_id = 6;
   }
   message EventInjectBarrierFail {
     uint64 prev_epoch = 1;

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -143,6 +143,7 @@ impl CompleteBarrierTask {
                 if job_id.is_none() {
                     Self::report_complete_event(
                         &env,
+                        database_id,
                         elapsed_secs,
                         &info.barrier_info,
                         command_name,
@@ -193,6 +194,7 @@ impl CompleteBarrierTask {
 impl CompleteBarrierTask {
     fn report_complete_event(
         env: &MetaSrvEnv,
+        database_id: DatabaseId,
         duration_sec: f64,
         barrier_info: &BarrierInfo,
         command: String,
@@ -205,6 +207,7 @@ impl CompleteBarrierTask {
             duration_sec,
             command,
             barrier_kind: barrier_info.kind.as_str_name().to_owned(),
+            database_id: database_id.as_raw_id(),
         };
         if cfg!(debug_assertions) || Deployment::current().is_ci() {
             // Add a warning log so that debug mode / CI can observe it

--- a/src/meta/src/manager/event_log.rs
+++ b/src/meta/src/manager/event_log.rs
@@ -65,14 +65,10 @@ pub fn start_event_log_manager(enabled: bool, event_log_channel_max_size: u32) -
                     };
                     let mut write = event_logs_shared.write();
                     let channel_id: ChannelId = (&event_log).into();
-                    let max_n = match &channel_id {
-                        ChannelId::BarrierComplete(_) => 10,
-                        ChannelId::EventType(_) => event_log_channel_max_size as usize,
-                    };
                     let channel = write.entry(channel_id).or_default();
                     channel.push_back(event_log);
                     // Apply expiration strategies.
-                    keep_latest_n(channel, max_n);
+                    keep_latest_n(channel, event_log_channel_max_size as _);
                 },
             }
         }

--- a/src/meta/src/manager/event_log.rs
+++ b/src/meta/src/manager/event_log.rs
@@ -28,7 +28,7 @@ type ShutdownSender = tokio::sync::oneshot::Sender<()>;
 /// Channel determines expiration strategy.
 ///
 /// Currently all channels apply the same one strategy: keep latest N events.
-/// 
+///
 /// `BarrierComplete` is retained separately per database
 #[derive(Hash, PartialEq, Eq)]
 enum ChannelId {

--- a/src/meta/src/manager/event_log.rs
+++ b/src/meta/src/manager/event_log.rs
@@ -27,10 +27,9 @@ type ShutdownSender = tokio::sync::oneshot::Sender<()>;
 
 /// Channel determines expiration strategy.
 ///
-/// Most channels keep the latest configurable number of events.
-///
-/// `BarrierComplete` is retained separately per database and keeps the latest 10 events for each
-/// database.
+/// Currently all channels apply the same one strategy: keep latest N events.
+/// 
+/// `BarrierComplete` is retained separately per database
 #[derive(Hash, PartialEq, Eq)]
 enum ChannelId {
     EventType(u32),

--- a/src/meta/src/manager/event_log.rs
+++ b/src/meta/src/manager/event_log.rs
@@ -27,10 +27,15 @@ type ShutdownSender = tokio::sync::oneshot::Sender<()>;
 
 /// Channel determines expiration strategy.
 ///
-/// Currently all channels apply the same one strategy: keep latest N events.
+/// Most channels keep the latest configurable number of events.
 ///
-/// Currently each event type has its own channel.
-type ChannelId = u32;
+/// `BarrierComplete` is retained separately per database and keeps the latest 10 events for each
+/// database.
+#[derive(Hash, PartialEq, Eq)]
+enum ChannelId {
+    EventType(u32),
+    BarrierComplete(u32),
+}
 type Channel = VecDeque<EventLog>;
 type EventStoreRef = Arc<RwLock<HashMap<ChannelId, Channel>>>;
 
@@ -60,10 +65,14 @@ pub fn start_event_log_manager(enabled: bool, event_log_channel_max_size: u32) -
                     };
                     let mut write = event_logs_shared.write();
                     let channel_id: ChannelId = (&event_log).into();
+                    let max_n = match &channel_id {
+                        ChannelId::BarrierComplete(_) => 10,
+                        ChannelId::EventType(_) => event_log_channel_max_size as usize,
+                    };
                     let channel = write.entry(channel_id).or_default();
                     channel.push_back(event_log);
                     // Apply expiration strategies.
-                    keep_latest_n(channel, event_log_channel_max_size as _);
+                    keep_latest_n(channel, max_n);
                 },
             }
         }
@@ -164,16 +173,16 @@ fn keep_latest_n(channel: &mut Channel, max_n: usize) {
 impl From<&EventLog> for ChannelId {
     fn from(value: &EventLog) -> Self {
         match value.payload.event.as_ref().unwrap() {
-            Event::CreateStreamJobFail(_) => 1,
-            Event::DirtyStreamJobClear(_) => 2,
-            Event::MetaNodeStart(_) => 3,
-            Event::BarrierComplete(_) => 4,
-            Event::InjectBarrierFail(_) => 5,
-            Event::CollectBarrierFail(_) => 6,
-            Event::WorkerNodePanic(_) => 7,
-            Event::AutoSchemaChangeFail(_) => 8,
-            Event::SinkFail(_) => 9,
-            Event::Recovery(_) => 10,
+            Event::CreateStreamJobFail(_) => ChannelId::EventType(1),
+            Event::DirtyStreamJobClear(_) => ChannelId::EventType(2),
+            Event::MetaNodeStart(_) => ChannelId::EventType(3),
+            Event::BarrierComplete(event) => ChannelId::BarrierComplete(event.database_id),
+            Event::InjectBarrierFail(_) => ChannelId::EventType(5),
+            Event::CollectBarrierFail(_) => ChannelId::EventType(6),
+            Event::WorkerNodePanic(_) => ChannelId::EventType(7),
+            Event::AutoSchemaChangeFail(_) => ChannelId::EventType(8),
+            Event::SinkFail(_) => ChannelId::EventType(9),
+            Event::Recovery(_) => ChannelId::EventType(10),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `database_id` to `BarrierComplete` event log entries
- retain the latest 10 barrier-complete events per database in the meta event log manager
- keep other event log channels on the existing configurable retention behavior

## Testing
- cargo check -p risingwave_meta
- cargo check -p risingwave_frontend