### PR TITLE
feat(meta): add database_info metric for database id to name mapping

### DIFF
--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -219,6 +219,8 @@ pub struct MetaMetrics {
     pub sink_info: IntGaugeVec,
     /// A dummy gauge metrics with its label to be relation info
     pub relation_info: IntGaugeVec,
+    /// A dummy gauge metrics with its label to be the mapping from database id to database name
+    pub database_info: IntGaugeVec,
     /// Backfill progress per fragment
     pub backfill_fragment_progress: IntGaugeVec,
 
@@ -747,6 +749,14 @@ impl MetaMetrics {
         )
         .unwrap();
 
+        let database_info = register_int_gauge_vec_with_registry!(
+            "database_info",
+            "Mapping from database id to database name",
+            &["database_id", "database_name"],
+            registry
+        )
+        .unwrap();
+
         let backfill_fragment_progress = register_int_gauge_vec_with_registry!(
             "backfill_fragment_progress",
             "Backfill progress per fragment",
@@ -1001,6 +1011,7 @@ impl MetaMetrics {
             table_info,
             sink_info,
             relation_info,
+            database_info,
             backfill_fragment_progress,
             system_param_info,
             l0_compact_level_count,
@@ -1315,6 +1326,28 @@ pub async fn refresh_relation_info_metrics(
     }
 }
 
+pub async fn refresh_database_info_metrics(
+    catalog_controller: &CatalogControllerRef,
+    meta_metrics: Arc<MetaMetrics>,
+) {
+    let databases = match catalog_controller.list_databases().await {
+        Ok(databases) => databases,
+        Err(err) => {
+            tracing::warn!(error=%err.as_report(), "fail to get databases");
+            return;
+        }
+    };
+
+    meta_metrics.database_info.reset();
+
+    for db in databases {
+        meta_metrics
+            .database_info
+            .with_label_values(&[&db.id.to_string(), &db.name])
+            .set(1);
+    }
+}
+
 fn extract_backfill_fragment_info(
     distribution: &FragmentDistribution,
 ) -> Option<BackfillFragmentInfo> {
@@ -1546,6 +1579,12 @@ pub fn start_info_monitor(
             .await;
 
             refresh_relation_info_metrics(
+                &metadata_manager.catalog_controller,
+                meta_metrics.clone(),
+            )
+            .await;
+
+            refresh_database_info_metrics(
                 &metadata_manager.catalog_controller,
                 meta_metrics.clone(),
             )


### PR DESCRIPTION
## Summary
- Add a new `database_info` info-style gauge metric with labels `database_id` and `database_name`
- Enables PromQL joins to resolve database names for barrier metrics (e.g. `meta_barrier_duration_seconds`, `all_barrier_nums`) that only expose `database_id`
- Refreshed every 60s alongside existing info metrics (`relation_info`, `actor_info`, etc.)

## Test plan
- [ ] `cargo check -p risingwave_meta` passes
- [ ] Deploy and verify `database_info` metric is emitted with correct labels
- [ ] Verify PromQL join: `some_metric * on(database_id) group_left(database_name) database_info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)