### PR TITLE
fix(risedev): make generate-example-config work in worktrees

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1519,6 +1519,7 @@ set -euo pipefail
 WORKDIR="${CARGO_MAKE_WORKING_DIRECTORY:-$(pwd)}"
 
 UPDATE_EXPECT=1 \
+CARGO_WORKSPACE_DIR="${WORKDIR}" \
 CARGO_TARGET_DIR="${WORKDIR}/target" \
 cargo test --manifest-path "${WORKDIR}/Cargo.toml" --package risingwave_common --lib -- \
   config::tests::test_example_up_to_date


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR fixes `./risedev generate-example-config` behavior in git worktrees when developers have a globally shared `CARGO_TARGET_DIR`.

Previously, if the test binary was reused from another checkout, `expect_file!` updates (driven by `UPDATE_EXPECT=1`) could land in the *other* checkout’s `src/config/example.toml` / `src/config/docs.md`.

Changes:
- Pin the workspace root to the current cargo-make working directory (`CARGO_MAKE_WORKING_DIRECTORY`, fallback `pwd`).
- Run cargo via `--manifest-path $WORKDIR/Cargo.toml`.
- Force `CARGO_TARGET_DIR=$WORKDIR/target` so the test binary is built/run against the current checkout.

- Closes N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A

</details>
