### PR TITLE
refactor(meta): decouple serving fragment mapping notification from streaming fragment mapping

### DIFF
--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -214,7 +214,7 @@ impl SharedActorInfos {
                 .collect_vec();
             if !mapping.is_empty() {
                 self.notification_manager
-                    .notify_fragment_mapping(Operation::Delete, mapping);
+                    .notify_streaming_fragment_mapping(Operation::Delete, mapping);
             }
         }
     }
@@ -234,7 +234,7 @@ impl SharedActorInfos {
         }
         if !mapping.is_empty() {
             self.notification_manager
-                .notify_fragment_mapping(Operation::Delete, mapping);
+                .notify_streaming_fragment_mapping(Operation::Delete, mapping);
         }
     }
 
@@ -348,15 +348,15 @@ impl SharedActorInfoWriter<'_> {
     pub(super) fn finish(self) {
         if let Some(mapping) = self.added_fragment_mapping {
             self.notification_manager
-                .notify_fragment_mapping(Operation::Add, mapping);
+                .notify_streaming_fragment_mapping(Operation::Add, mapping);
         }
         if let Some(mapping) = self.updated_fragment_mapping {
             self.notification_manager
-                .notify_fragment_mapping(Operation::Update, mapping);
+                .notify_streaming_fragment_mapping(Operation::Update, mapping);
         }
         if let Some(mapping) = self.deleted_fragment_mapping {
             self.notification_manager
-                .notify_fragment_mapping(Operation::Delete, mapping);
+                .notify_streaming_fragment_mapping(Operation::Delete, mapping);
         }
     }
 }

--- a/src/meta/src/controller/fragment.rs
+++ b/src/meta/src/controller/fragment.rs
@@ -173,16 +173,17 @@ pub struct StreamingJobInfo {
 }
 
 impl NotificationManager {
-    pub(crate) fn notify_fragment_mapping(
+    /// Notify frontend about streaming worker slot mapping changes.
+    ///
+    /// This only sends streaming mapping updates to frontends. Serving mapping
+    /// notifications are decoupled and driven by fragment model changes (insert/delete)
+    /// instead of barrier-driven actor set changes.
+    pub(crate) fn notify_streaming_fragment_mapping(
         &self,
         operation: NotificationOperation,
         fragment_mappings: Vec<PbFragmentWorkerSlotMapping>,
     ) {
-        let fragment_ids = fragment_mappings
-            .iter()
-            .map(|mapping| mapping.fragment_id)
-            .collect_vec();
-        if fragment_ids.is_empty() {
+        if fragment_mappings.is_empty() {
             return;
         }
         // notify all fragment mappings to frontend.
@@ -192,23 +193,38 @@ impl NotificationManager {
                 NotificationInfo::StreamingWorkerSlotMapping(fragment_mapping),
             );
         }
+    }
 
-        // update serving vnode mappings.
-        match operation {
-            NotificationOperation::Add | NotificationOperation::Update => {
-                self.notify_local_subscribers(LocalNotification::FragmentMappingsUpsert(
-                    fragment_ids,
-                ));
-            }
-            NotificationOperation::Delete => {
-                self.notify_local_subscribers(LocalNotification::FragmentMappingsDelete(
-                    fragment_ids,
-                ));
-            }
-            op => {
-                tracing::warn!("unexpected fragment mapping op: {}", op.as_str_name());
-            }
+    /// Notify the serving module about fragment mapping changes.
+    ///
+    /// This should be called when fragments are inserted into or deleted from the meta store,
+    /// so that serving vnode mappings are kept in sync with the fragment model.
+    pub(crate) fn notify_serving_fragment_mapping_update(
+        &self,
+        fragment_ids: Vec<crate::model::FragmentId>,
+    ) {
+        if fragment_ids.is_empty() {
+            return;
         }
+        self.notify_local_subscribers(LocalNotification::ServingFragmentMappingsUpsert(
+            fragment_ids,
+        ));
+    }
+
+    /// Notify the serving module about fragment mapping deletions.
+    ///
+    /// This should be called when fragments are deleted from the meta store,
+    /// so that serving vnode mappings are cleaned up.
+    pub(crate) fn notify_serving_fragment_mapping_delete(
+        &self,
+        fragment_ids: Vec<crate::model::FragmentId>,
+    ) {
+        if fragment_ids.is_empty() {
+            return;
+        }
+        self.notify_local_subscribers(LocalNotification::ServingFragmentMappingsDelete(
+            fragment_ids,
+        ));
     }
 }
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -599,6 +599,12 @@ impl CatalogController {
             .flat_map(|fragment| fragment.state_table_ids.inner_ref().clone())
             .collect_vec();
 
+        // Collect fragment IDs before consuming `fragments` for serving mapping notification.
+        let inserted_fragment_ids: Vec<crate::model::FragmentId> = fragments
+            .iter()
+            .map(|f| f.fragment_id as crate::model::FragmentId)
+            .collect();
+
         if !fragments.is_empty() {
             let fragment_models = fragments
                 .into_iter()
@@ -681,6 +687,13 @@ impl CatalogController {
         }
 
         txn.commit().await?;
+
+        // Notify serving module about newly inserted fragments so it can establish
+        // serving vnode mappings. This is driven by the fragment model insertion,
+        // decoupled from the barrier-driven streaming mapping notifications.
+        self.env
+            .notification_manager()
+            .notify_serving_fragment_mapping_update(inserted_fragment_ids);
 
         // FIXME: there's a gap between the catalog creation and notification, which may lead to
         // frontend receiving duplicate notifications if the frontend restarts right in this gap. We
@@ -887,41 +900,14 @@ impl CatalogController {
             objs.extend(internal_table_objs);
         }
 
-        // Check if the job is creating sink into table.
-        if table_obj.is_none()
-            && let Some(Some(target_table_id)) = Sink::find_by_id(job_id.as_sink_id())
-                .select_only()
-                .column(sink::Column::TargetTable)
-                .into_tuple::<Option<TableId>>()
-                .one(&txn)
-                .await?
-        {
-            let tmp_id: Option<ObjectId> = ObjectDependency::find()
-                .select_only()
-                .column(object_dependency::Column::UsedBy)
-                .join(
-                    JoinType::InnerJoin,
-                    object_dependency::Relation::Object1.def(),
-                )
-                .join(JoinType::InnerJoin, object::Relation::StreamingJob.def())
-                .filter(
-                    object_dependency::Column::Oid
-                        .eq(target_table_id)
-                        .and(object::Column::ObjType.eq(ObjectType::Table))
-                        .and(streaming_job::Column::JobStatus.ne(JobStatus::Created)),
-                )
-                .into_tuple()
-                .one(&txn)
-                .await?;
-            if let Some(tmp_id) = tmp_id {
-                tracing::warn!(
-                    id = %tmp_id,
-                    "aborting temp streaming job for sink into table"
-                );
-
-                Object::delete_by_id(tmp_id).exec(&txn).await?;
-            }
-        }
+        // Query fragment IDs before cascade-deleting them, for serving mapping cleanup.
+        let abort_fragment_ids: Vec<FragmentId> = Fragment::find()
+            .select_only()
+            .column(fragment::Column::FragmentId)
+            .filter(fragment::Column::JobId.eq(job_id))
+            .into_tuple()
+            .all(&txn)
+            .await?;
 
         Object::delete_by_id(job_id).exec(&txn).await?;
         if !internal_table_ids.is_empty() {
@@ -953,6 +939,13 @@ impl CatalogController {
             let _ = tx.send(Err(abort_reason.clone()));
         }
         txn.commit().await?;
+
+        // Notify serving module about deleted fragments from the aborted job.
+        self.env
+            .notification_manager()
+            .notify_serving_fragment_mapping_delete(
+                abort_fragment_ids.iter().map(|id| *id as _).collect(),
+            );
 
         if !objs.is_empty() {
             // We also have notified the frontend about these objects,
@@ -1376,18 +1369,28 @@ impl CatalogController {
         let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
-        let (objects, delete_notification_objs) = Self::finish_replace_streaming_job_inner(
-            tmp_id,
-            replace_upstream,
-            sink_into_table_context,
-            &txn,
-            streaming_job,
-            drop_table_connector_ctx,
-            auto_refresh_schema_sinks,
-        )
-        .await?;
+        let (objects, delete_notification_objs, old_fragment_ids, new_fragment_ids) =
+            Self::finish_replace_streaming_job_inner(
+                tmp_id,
+                replace_upstream,
+                sink_into_table_context,
+                &txn,
+                streaming_job,
+                drop_table_connector_ctx,
+                auto_refresh_schema_sinks,
+            )
+            .await?;
 
         txn.commit().await?;
+
+        // Notify serving module: delete old fragment mappings, upsert new ones.
+        let notification_manager = self.env.notification_manager();
+        notification_manager.notify_serving_fragment_mapping_delete(
+            old_fragment_ids.iter().map(|id| *id as _).collect(),
+        );
+        notification_manager.notify_serving_fragment_mapping_update(
+            new_fragment_ids.iter().map(|id| *id as _).collect(),
+        );
 
         let mut version = self
             .notify_frontend(
@@ -1478,9 +1481,30 @@ impl CatalogController {
         streaming_job: StreamingJob,
         drop_table_connector_ctx: Option<&DropTableConnectorContext>,
         auto_refresh_schema_sinks: Option<Vec<FinishAutoRefreshSchemaSinkContext>>,
-    ) -> MetaResult<(Vec<PbObject>, Option<(Vec<PbUserInfo>, Vec<PartialObject>)>)> {
+    ) -> MetaResult<(
+        Vec<PbObject>,
+        Option<(Vec<PbUserInfo>, Vec<PartialObject>)>,
+        Vec<FragmentId>,
+        Vec<FragmentId>,
+    )> {
         let original_job_id = streaming_job.id();
         let job_type = streaming_job.job_type();
+
+        // Query old fragment IDs (will be deleted) and new fragment IDs (will be reassigned).
+        let old_fragment_ids: Vec<FragmentId> = Fragment::find()
+            .select_only()
+            .column(fragment::Column::FragmentId)
+            .filter(fragment::Column::JobId.eq(original_job_id))
+            .into_tuple()
+            .all(txn)
+            .await?;
+        let new_fragment_ids: Vec<FragmentId> = Fragment::find()
+            .select_only()
+            .column(fragment::Column::FragmentId)
+            .filter(fragment::Column::JobId.eq(tmp_id))
+            .into_tuple()
+            .all(txn)
+            .await?;
 
         let mut index_item_rewriter = None;
         let mut updated_iceberg_source_id: Option<SourceId> = None;
@@ -1832,7 +1856,12 @@ impl CatalogController {
                 Some(Self::drop_table_associated_source(txn, drop_table_connector_ctx).await?);
         }
 
-        Ok((objects, notification_objs))
+        Ok((
+            objects,
+            notification_objs,
+            old_fragment_ids,
+            new_fragment_ids,
+        ))
     }
 
     /// Abort the replacing streaming job by deleting the temporary job object.
@@ -1843,6 +1872,20 @@ impl CatalogController {
     ) -> MetaResult<()> {
         let inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
+
+        // Query fragment IDs of the temp job and temp sinks before cascade-deleting them.
+        let mut all_job_ids: Vec<ObjectId> = vec![tmp_job_id.into()];
+        if let Some(ref sink_ids) = tmp_sink_ids {
+            all_job_ids.extend(sink_ids.iter().copied());
+        }
+        let abort_fragment_ids: Vec<FragmentId> = Fragment::find()
+            .select_only()
+            .column(fragment::Column::FragmentId)
+            .filter(fragment::Column::JobId.is_in(all_job_ids))
+            .into_tuple()
+            .all(&txn)
+            .await?;
+
         Object::delete_by_id(tmp_job_id).exec(&txn).await?;
         if let Some(tmp_sink_ids) = tmp_sink_ids {
             for tmp_sink_id in tmp_sink_ids {
@@ -1850,6 +1893,14 @@ impl CatalogController {
             }
         }
         txn.commit().await?;
+
+        // Notify serving module about deleted fragments from the aborted replace job.
+        self.env
+            .notification_manager()
+            .notify_serving_fragment_mapping_delete(
+                abort_fragment_ids.iter().map(|id| *id as _).collect(),
+            );
+
         Ok(())
     }
 

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -48,8 +48,8 @@ pub enum LocalNotification {
     WorkerNodeActivated(WorkerNode),
     SystemParamsChange(SystemParamsReader),
     BatchParallelismChange,
-    FragmentMappingsUpsert(Vec<FragmentId>),
-    FragmentMappingsDelete(Vec<FragmentId>),
+    ServingFragmentMappingsUpsert(Vec<FragmentId>),
+    ServingFragmentMappingsDelete(Vec<FragmentId>),
     SourceDropped(ObjectId),
     StreamingJobBackfillFinished(JobId),
 }

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1302,6 +1302,15 @@ impl DdlController {
             removed_iceberg_table_sinks,
         } = release_ctx;
 
+        // Notify serving module about deleted fragments so it can clean up serving vnode mappings.
+        // This is driven by the fragment model deletion (cascade from Object::delete_many),
+        // decoupled from the barrier-driven streaming mapping notifications.
+        self.env
+            .notification_manager_ref()
+            .notify_serving_fragment_mapping_delete(
+                removed_fragments.iter().map(|id| *id as _).collect(),
+            );
+
         self.stream_manager
             .drop_streaming_jobs(
                 database_id,

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -220,7 +220,7 @@ pub fn start_serving_vnode_mapping_worker(
                                 LocalNotification::BatchParallelismChange => {
                                     reset().await;
                                 }
-                                LocalNotification::FragmentMappingsUpsert(fragment_ids) => {
+                                LocalNotification::ServingFragmentMappingsUpsert(fragment_ids) => {
                                     if fragment_ids.is_empty() {
                                         continue;
                                     }
@@ -249,7 +249,7 @@ pub fn start_serving_vnode_mapping_worker(
                                         notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(&failed)}));
                                     }
                                 }
-                                LocalNotification::FragmentMappingsDelete(fragment_ids) => {
+                                LocalNotification::ServingFragmentMappingsDelete(fragment_ids) => {
                                     if fragment_ids.is_empty() {
                                         continue;
                                     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR decouples serving fragment mapping notifications from streaming fragment mapping notifications.

### Problem

Previously, `NotificationManager::notify_fragment_mapping()` bundled both streaming and serving mapping notifications together, both triggered by `SharedActorInfoWriter::finish()` whenever the barrier-driven running actor set changed. This caused a bug: during recovery, fragments that exist in the meta store but are not currently running (e.g., idle batch refresh jobs) get removed from `SharedActorInfos`, which triggered `FragmentMappingsDelete` → the serving module deleted the serving mapping → the frontend could no longer resolve queries for that fragment. However, the fragment still exists in the meta store and its serving mapping should persist.

### Solution

- **Split `notify_fragment_mapping`** into two separate paths:
  - `notify_streaming_fragment_mapping()` — only sends `StreamingWorkerSlotMapping` to frontends, called from `SharedActorInfoWriter::finish()` (barrier-driven).
  - `notify_serving_fragment_mapping_update()`/`notify_serving_fragment_mapping_delete()` — sends local notifications to the serving module, now driven by **fragment model changes** (insert/delete of the `fragment` table) instead of barrier-driven actor set changes.

- **Added serving mapping notifications at each fragment model mutation point:**
  - **Job creation** (`prepare_streaming_job`): `ServingFragmentMappingsUpsert` after fragment insert commits.
  - **Job drop** (`drop_object`): `ServingFragmentMappingsDelete` using `removed_fragments` from `ReleaseContext`.
  - **Replace job** (`finish_replace_streaming_job`): delete old + upsert new, with fragment IDs queried inside `finish_replace_streaming_job_inner`.
  - **Abort creating job** (`try_abort_creating_streaming_job`): delete fragments before cascade delete.
  - **Abort replacing job** (`try_abort_replacing_streaming_job`): delete fragments of both temp job and temp sinks.

- **Renamed `LocalNotification` variants** from `FragmentMappingsUpsert`/`Delete` to `ServingFragmentMappingsUpsert`/`Delete` to clarify intent.

- **Removed dead code** in `try_abort_creating_streaming_job`: the `tmp_id` cleanup block for sink-into-table was dead code since the Sept 2025 refactor that simplified sink-into-table with the dynamic operator approach (no longer creates a temporary replacement table job).

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
