### PR TITLE
debug(stream): add source backfill state/emit logs for duplicate diagnosis

### DIFF
--- a/e2e_test/nexmark/produce_kafka.slt.part
+++ b/e2e_test/nexmark/produce_kafka.slt.part
@@ -56,11 +56,11 @@ DROP SINK nexmark_bid;
 # If count > 50, the sink produced duplicates (at-least-once delivery).
 system ok
 echo "[nexmark-diag] nexmark-bid messages (expected 50):" && \
-rpk topic consume nexmark-bid -o start:end -f '%v\n' 2>/dev/null | wc -l
+rpk topic consume nexmark-bid --offset start --num 100 -f '%v\n' 2>/dev/null | wc -l
 
 system ok
 echo "[nexmark-diag] nexmark-bid duplicate payload samples:" && \
-rpk topic consume nexmark-bid -o start:end -f '%v\n' 2>/dev/null | sort | uniq -c | sort -nr | head
+rpk topic consume nexmark-bid --offset start --num 100 -f '%v\n' 2>/dev/null | sort | uniq -c | sort -nr | head
 
 statement ok
 DROP SINK nexmark_person;

--- a/e2e_test/nexmark/produce_kafka.slt.part
+++ b/e2e_test/nexmark/produce_kafka.slt.part
@@ -52,12 +52,14 @@ DROP SINK nexmark_auction;
 statement ok
 DROP SINK nexmark_bid;
 
+# Diagnostic: verify Kafka message count matches the 50-row INSERT.
+# If count > 50, the sink produced duplicates (at-least-once delivery).
 system ok
-echo "[nexmark-debug] nexmark-bid total messages:" && \
+echo "[nexmark-diag] nexmark-bid messages (expected 50):" && \
 rpk topic consume nexmark-bid -o start:end -f '%v\n' 2>/dev/null | wc -l
 
 system ok
-echo "[nexmark-debug] nexmark-bid duplicate payload samples:" && \
+echo "[nexmark-diag] nexmark-bid duplicate payload samples:" && \
 rpk topic consume nexmark-bid -o start:end -f '%v\n' 2>/dev/null | sort | uniq -c | sort -nr | head
 
 statement ok

--- a/e2e_test/nexmark/produce_kafka.slt.part
+++ b/e2e_test/nexmark/produce_kafka.slt.part
@@ -52,15 +52,18 @@ DROP SINK nexmark_auction;
 statement ok
 DROP SINK nexmark_bid;
 
-# Diagnostic: verify Kafka message count matches the 50-row INSERT.
+# Diagnostic point A: verify Kafka message count after sink drop.
 # If count > 50, the sink produced duplicates (at-least-once delivery).
 system ok
-echo "[nexmark-diag] nexmark-bid messages (expected 50):" && \
-rpk topic consume nexmark-bid --offset start --num 100 -f '%v\n' 2>/dev/null | wc -l
+echo "[nexmark-diag-A] topic watermarks after sink drop:" && rpk topic describe nexmark-bid -p
 
 system ok
-echo "[nexmark-diag] nexmark-bid duplicate payload samples:" && \
-rpk topic consume nexmark-bid --offset start --num 100 -f '%v\n' 2>/dev/null | sort | uniq -c | sort -nr | head
+tmp=$(mktemp /tmp/nexmark-diag-A.XXXXXX) && \
+echo "[nexmark-diag-A] consuming messages:" && \
+timeout 15s rpk topic consume nexmark-bid --offset start --num 1000 -f '%p\t%o\t%v\n' > "$tmp" 2>/dev/null || true && \
+echo "[nexmark-diag-A] message count (expected 50):" && wc -l < "$tmp" && \
+echo "[nexmark-diag-A] duplicate payloads:" && cut -f3 "$tmp" | sort | uniq -c | sort -nr | head && \
+rm -f "$tmp"
 
 statement ok
 DROP SINK nexmark_person;

--- a/e2e_test/nexmark/produce_kafka.slt.part
+++ b/e2e_test/nexmark/produce_kafka.slt.part
@@ -52,6 +52,14 @@ DROP SINK nexmark_auction;
 statement ok
 DROP SINK nexmark_bid;
 
+system ok
+echo "[nexmark-debug] nexmark-bid total messages:" && \
+rpk topic consume nexmark-bid -o start:end -f '%v\n' 2>/dev/null | wc -l
+
+system ok
+echo "[nexmark-debug] nexmark-bid duplicate payload samples:" && \
+rpk topic consume nexmark-bid -o start:end -f '%v\n' 2>/dev/null | sort | uniq -c | sort -nr | head
+
 statement ok
 DROP SINK nexmark_person;
 

--- a/e2e_test/source_inline/kafka/nexmark.slt
+++ b/e2e_test/source_inline/kafka/nexmark.slt
@@ -4,6 +4,12 @@ include ../../nexmark/create_sources_kafka.slt.part
 control substitution off
 
 include ../../streaming/nexmark/create_views.slt.part
+
+# Diagnostic point C: check topic watermarks before q0 assertion.
+# Compare with point A to detect unexpected writes during source/MV processing.
+system ok
+echo "[nexmark-diag-C] topic watermarks before q0 assertion:" && rpk topic describe nexmark-bid -p
+
 include ../../streaming/nexmark/test_mv_result.slt.part
 
 include ../../nexmark/drop_sources_kafka.slt.part

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -273,6 +273,7 @@ fn state_backfill_offset(state: &BackfillState) -> Option<&str> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn log_backfill_stage_transition(
     actor_id: &str,
     split_id: &str,

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -20,7 +20,7 @@ use anyhow::anyhow;
 use either::Either;
 use futures::stream::{PollNext, select_with_strategy};
 use itertools::Itertools;
-use risingwave_common::bitmap::BitmapBuilder;
+use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::id::SourceId;
 use risingwave_common::metrics::{GLOBAL_ERROR_METRICS, LabelGuardedIntCounter};
@@ -257,6 +257,71 @@ impl BackfillStage {
     }
 }
 
+fn stage_name(state: &BackfillState) -> &'static str {
+    match state {
+        BackfillState::Backfilling(_) => "Backfilling",
+        BackfillState::SourceCachingUp(_) => "SourceCachingUp",
+        BackfillState::Finished => "Finished",
+    }
+}
+
+fn state_backfill_offset(state: &BackfillState) -> Option<&str> {
+    match state {
+        BackfillState::Backfilling(Some(offset)) => Some(offset.as_str()),
+        BackfillState::SourceCachingUp(offset) => Some(offset.as_str()),
+        BackfillState::Backfilling(None) | BackfillState::Finished => None,
+    }
+}
+
+fn log_backfill_stage_transition(
+    actor_id: &str,
+    split_id: &str,
+    path: &'static str,
+    before: &BackfillState,
+    after: &BackfillState,
+    upstream_offset: Option<&str>,
+    backfill_offset: Option<&str>,
+    target_offset: Option<&str>,
+) {
+    if before == after {
+        return;
+    }
+    tracing::debug!(
+        actor_id,
+        split_id,
+        path,
+        stage_from = stage_name(before),
+        stage_to = stage_name(after),
+        upstream_offset,
+        backfill_offset,
+        target_offset,
+        "source backfill stage transition"
+    );
+}
+
+fn summarize_visible_offset_bounds(
+    chunk: &StreamChunk,
+    visible: &Bitmap,
+    split_idx: usize,
+    offset_idx: usize,
+) -> Option<(String, String)> {
+    let mut first = None;
+    let mut last = None;
+    for (row_idx, (_, row)) in chunk.rows().enumerate() {
+        if !visible.is_set(row_idx) {
+            continue;
+        }
+        let split = row.datum_at(split_idx).unwrap().into_utf8();
+        let offset = row.datum_at(offset_idx).unwrap().into_utf8();
+        let cur = format!("{split}:{offset}");
+        if first.is_none() {
+            first = Some(cur.clone());
+        }
+        last = Some(cur);
+    }
+    first.zip(last)
+}
+
 impl<S: StateStore> SourceBackfillExecutorInner<S> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
@@ -337,6 +402,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute(mut self, input: Executor) {
+        let actor_id_str = self.actor_ctx.id.to_string();
         let mut input = input.execute();
 
         // Poll the upstream to get the first barrier.
@@ -755,12 +821,57 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                 for (i, (_, row)) in chunk.rows().enumerate() {
                                     let split = row.datum_at(split_idx).unwrap().into_utf8();
                                     let offset = row.datum_at(offset_idx).unwrap().into_utf8();
+                                    let before = backfill_stage.states.get(split).unwrap();
+                                    let before_state = before.state.clone();
+                                    let before_target_offset = before.target_offset.clone();
                                     let vis = backfill_stage.handle_upstream_row(split, offset);
+                                    let after = backfill_stage.states.get(split).unwrap();
+                                    let after_state = after.state.clone();
+                                    let after_target_offset = after.target_offset.clone();
+                                    log_backfill_stage_transition(
+                                        actor_id_str.as_str(),
+                                        split,
+                                        "upstream",
+                                        &before_state,
+                                        &after_state,
+                                        Some(offset),
+                                        state_backfill_offset(&after_state)
+                                            .or(state_backfill_offset(&before_state)),
+                                        after_target_offset
+                                            .as_deref()
+                                            .or(before_target_offset.as_deref()),
+                                    );
+                                    if vis {
+                                        tracing::debug!(
+                                            actor_id = actor_id_str.as_str(),
+                                            split_id = split,
+                                            path = "upstream",
+                                            stage = stage_name(&after_state),
+                                            upstream_offset = offset,
+                                            target_offset = after_target_offset.as_deref(),
+                                            "source backfill row selected for emit"
+                                        );
+                                    }
                                     new_vis.set(i, vis);
                                 }
                                 // emit chunk if vis is not empty. i.e., some splits finished backfilling.
                                 let new_vis = new_vis.finish();
-                                if new_vis.count_ones() != 0 {
+                                let card = new_vis.count_ones();
+                                if card != 0 {
+                                    if let Some((first_visible, last_visible)) =
+                                        summarize_visible_offset_bounds(
+                                            &chunk, &new_vis, split_idx, offset_idx,
+                                        )
+                                    {
+                                        tracing::debug!(
+                                            actor_id = actor_id_str.as_str(),
+                                            path = "upstream",
+                                            visible_rows = card,
+                                            first_visible,
+                                            last_visible,
+                                            "source backfill yielding chunk"
+                                        );
+                                    }
                                     let new_chunk = chunk.clone_with_vis(new_vis);
                                     yield Message::Chunk(new_chunk);
                                 }
@@ -802,13 +913,56 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                         for (i, (_, row)) in chunk.rows().enumerate() {
                             let split_id = row.datum_at(split_idx).unwrap().into_utf8();
                             let offset = row.datum_at(offset_idx).unwrap().into_utf8();
+                            let before = backfill_stage.states.get(split_id).unwrap();
+                            let before_state = before.state.clone();
+                            let before_target_offset = before.target_offset.clone();
                             let vis = backfill_stage.handle_backfill_row(split_id, offset);
+                            let after = backfill_stage.states.get(split_id).unwrap();
+                            let after_state = after.state.clone();
+                            let after_target_offset = after.target_offset.clone();
+                            log_backfill_stage_transition(
+                                actor_id_str.as_str(),
+                                split_id,
+                                "backfill",
+                                &before_state,
+                                &after_state,
+                                None,
+                                Some(offset),
+                                after_target_offset
+                                    .as_deref()
+                                    .or(before_target_offset.as_deref()),
+                            );
+                            if vis {
+                                tracing::debug!(
+                                    actor_id = actor_id_str.as_str(),
+                                    split_id,
+                                    path = "backfill",
+                                    stage = stage_name(&after_state),
+                                    backfill_offset = offset,
+                                    target_offset = after_target_offset.as_deref(),
+                                    "source backfill row selected for emit"
+                                );
+                            }
                             new_vis.set(i, vis);
                         }
 
                         let new_vis = new_vis.finish();
                         let card = new_vis.count_ones();
                         if card != 0 {
+                            if let Some((first_visible, last_visible)) =
+                                summarize_visible_offset_bounds(
+                                    &chunk, &new_vis, split_idx, offset_idx,
+                                )
+                            {
+                                tracing::debug!(
+                                    actor_id = actor_id_str.as_str(),
+                                    path = "backfill",
+                                    visible_rows = card,
+                                    first_visible,
+                                    last_visible,
+                                    "source backfill yielding chunk"
+                                );
+                            }
                             let new_chunk = chunk.clone_with_vis(new_vis);
                             yield Message::Chunk(new_chunk);
                             source_backfill_row_count.inc_by(card as u64);

--- a/src/stream/src/executor/source/source_backfill_executor.rs
+++ b/src/stream/src/executor/source/source_backfill_executor.rs
@@ -277,21 +277,18 @@ fn log_backfill_stage_transition(
     actor_id: &str,
     split_id: &str,
     path: &'static str,
-    before: &BackfillState,
-    after: &BackfillState,
+    stage_from: &'static str,
+    stage_to: &'static str,
     upstream_offset: Option<&str>,
     backfill_offset: Option<&str>,
     target_offset: Option<&str>,
 ) {
-    if before == after {
-        return;
-    }
-    tracing::debug!(
+    tracing::info!(
         actor_id,
         split_id,
         path,
-        stage_from = stage_name(before),
-        stage_to = stage_name(after),
+        stage_from,
+        stage_to,
         upstream_offset,
         backfill_offset,
         target_offset,
@@ -451,6 +448,14 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                         num_consumed_rows: 0,
                         target_offset: None, // init with None
                     });
+                tracing::info!(
+                    actor_id = actor_id_str.as_str(),
+                    split_id = split_id.as_ref(),
+                    restored_stage = stage_name(&backfill_state.state),
+                    restored_offset = state_backfill_offset(&backfill_state.state),
+                    target_offset = backfill_state.target_offset.as_deref(),
+                    "source backfill restored state"
+                );
                 backfill_states.insert(split_id, backfill_state);
             }
         }
@@ -821,34 +826,33 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                 for (i, (_, row)) in chunk.rows().enumerate() {
                                     let split = row.datum_at(split_idx).unwrap().into_utf8();
                                     let offset = row.datum_at(offset_idx).unwrap().into_utf8();
-                                    let before = backfill_stage.states.get(split).unwrap();
-                                    let before_state = before.state.clone();
-                                    let before_target_offset = before.target_offset.clone();
+                                    let before_stage = {
+                                        let before = backfill_stage.states.get(split).unwrap();
+                                        stage_name(&before.state)
+                                    };
                                     let vis = backfill_stage.handle_upstream_row(split, offset);
                                     let after = backfill_stage.states.get(split).unwrap();
-                                    let after_state = after.state.clone();
-                                    let after_target_offset = after.target_offset.clone();
-                                    log_backfill_stage_transition(
-                                        actor_id_str.as_str(),
-                                        split,
-                                        "upstream",
-                                        &before_state,
-                                        &after_state,
-                                        Some(offset),
-                                        state_backfill_offset(&after_state)
-                                            .or(state_backfill_offset(&before_state)),
-                                        after_target_offset
-                                            .as_deref()
-                                            .or(before_target_offset.as_deref()),
-                                    );
+                                    let after_stage = stage_name(&after.state);
+                                    if before_stage != after_stage {
+                                        log_backfill_stage_transition(
+                                            actor_id_str.as_str(),
+                                            split,
+                                            "upstream",
+                                            before_stage,
+                                            after_stage,
+                                            Some(offset),
+                                            state_backfill_offset(&after.state),
+                                            after.target_offset.as_deref(),
+                                        );
+                                    }
                                     if vis {
                                         tracing::debug!(
                                             actor_id = actor_id_str.as_str(),
                                             split_id = split,
                                             path = "upstream",
-                                            stage = stage_name(&after_state),
+                                            stage = after_stage,
                                             upstream_offset = offset,
-                                            target_offset = after_target_offset.as_deref(),
+                                            target_offset = after.target_offset.as_deref(),
                                             "source backfill row selected for emit"
                                         );
                                     }
@@ -863,7 +867,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                             &chunk, &new_vis, split_idx, offset_idx,
                                         )
                                     {
-                                        tracing::debug!(
+                                        tracing::info!(
                                             actor_id = actor_id_str.as_str(),
                                             path = "upstream",
                                             visible_rows = card,
@@ -913,33 +917,33 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                         for (i, (_, row)) in chunk.rows().enumerate() {
                             let split_id = row.datum_at(split_idx).unwrap().into_utf8();
                             let offset = row.datum_at(offset_idx).unwrap().into_utf8();
-                            let before = backfill_stage.states.get(split_id).unwrap();
-                            let before_state = before.state.clone();
-                            let before_target_offset = before.target_offset.clone();
+                            let before_stage = {
+                                let before = backfill_stage.states.get(split_id).unwrap();
+                                stage_name(&before.state)
+                            };
                             let vis = backfill_stage.handle_backfill_row(split_id, offset);
                             let after = backfill_stage.states.get(split_id).unwrap();
-                            let after_state = after.state.clone();
-                            let after_target_offset = after.target_offset.clone();
-                            log_backfill_stage_transition(
-                                actor_id_str.as_str(),
-                                split_id,
-                                "backfill",
-                                &before_state,
-                                &after_state,
-                                None,
-                                Some(offset),
-                                after_target_offset
-                                    .as_deref()
-                                    .or(before_target_offset.as_deref()),
-                            );
+                            let after_stage = stage_name(&after.state);
+                            if before_stage != after_stage {
+                                log_backfill_stage_transition(
+                                    actor_id_str.as_str(),
+                                    split_id,
+                                    "backfill",
+                                    before_stage,
+                                    after_stage,
+                                    None,
+                                    Some(offset),
+                                    after.target_offset.as_deref(),
+                                );
+                            }
                             if vis {
                                 tracing::debug!(
                                     actor_id = actor_id_str.as_str(),
                                     split_id,
                                     path = "backfill",
-                                    stage = stage_name(&after_state),
+                                    stage = after_stage,
                                     backfill_offset = offset,
-                                    target_offset = after_target_offset.as_deref(),
+                                    target_offset = after.target_offset.as_deref(),
                                     "source backfill row selected for emit"
                                 );
                             }
@@ -954,7 +958,7 @@ impl<S: StateStore> SourceBackfillExecutorInner<S> {
                                     &chunk, &new_vis, split_idx, offset_idx,
                                 )
                             {
-                                tracing::debug!(
+                                tracing::info!(
                                     actor_id = actor_id_str.as_str(),
                                     path = "backfill",
                                     visible_rows = card,


### PR DESCRIPTION
## Summary
Add targeted debug logs in `source_backfill_executor` to make duplicate-row root cause diagnosable from one run.

## Added logs
- Stage transition logs when split state changes:
  - `stage_from`, `stage_to`
  - `upstream_offset`, `backfill_offset`, `target_offset`
  - `actor_id`, `split_id`, `path` (`upstream`/`backfill`)
- Row-level "selected for emit" logs on both paths before visibility is applied.
- Chunk-level "yielding chunk" logs on both paths, including:
  - `visible_rows`
  - `first_visible`, `last_visible` (`split:offset` bounds)

## Why
This is for CI flake diagnosis where `nexmark_q0` showed duplicates (50 expected, 70 actual). The new logs let us verify whether the same offset is emitted on both paths around `Backfilling -> SourceCachingUp -> Finished` transitions.

## Validation
- `cargo fmt --all -- src/stream/src/executor/source/source_backfill_executor.rs`
- `cargo check -p risingwave_stream --lib`
