### PR TITLE
feat(sink): support CSV and XML encode for file sinks

### DIFF
--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -199,6 +199,7 @@ enum EncodeType {
   ENCODE_TYPE_NONE = 8;
   ENCODE_TYPE_TEXT = 9;
   ENCODE_TYPE_PARQUET = 10;
+  ENCODE_TYPE_XML = 11;
 }
 
 enum RowFormatType {

--- a/src/connector/src/sink/catalog/mod.rs
+++ b/src/connector/src/sink/catalog/mod.rs
@@ -126,6 +126,8 @@ pub enum SinkEncode {
     Parquet,
     Text,
     Bytes,
+    Csv,
+    Xml,
 }
 
 impl Display for SinkEncode {
@@ -184,6 +186,8 @@ impl SinkFormatDesc {
             SinkEncode::Parquet => E::Parquet,
             SinkEncode::Text => E::Text,
             SinkEncode::Bytes => E::Bytes,
+            SinkEncode::Csv => E::Csv,
+            SinkEncode::Xml => E::Xml,
         };
 
         let encode = mapping_encode(&self.encode);
@@ -247,7 +251,9 @@ impl TryFrom<PbSinkFormatDesc> for SinkFormatDesc {
             E::Avro => SinkEncode::Avro,
             E::Parquet => SinkEncode::Parquet,
             E::Bytes => SinkEncode::Bytes,
-            e @ (E::Unspecified | E::Native | E::Csv | E::None | E::Text) => {
+            E::Csv => SinkEncode::Csv,
+            E::Xml => SinkEncode::Xml,
+            e @ (E::Unspecified | E::Native | E::None | E::Text) => {
                 return Err(SinkError::Config(anyhow!(
                     "sink encode unsupported: {}",
                     e.as_str_name()
@@ -265,6 +271,7 @@ impl TryFrom<PbSinkFormatDesc> for SinkFormatDesc {
             | E::Template
             | E::Native
             | E::Parquet
+            | E::Xml
             | E::None) => {
                 return Err(SinkError::Config(anyhow!(
                     "unsupported {} as sink key encode",

--- a/src/connector/src/sink/encoder/csv.rs
+++ b/src/connector/src/sink/encoder/csv.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/connector/src/sink/encoder/csv.rs
+++ b/src/connector/src/sink/encoder/csv.rs
@@ -1,0 +1,217 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::catalog::Schema;
+use risingwave_common::row::Row;
+use risingwave_common::types::ToText;
+
+use super::{Result, RowEncoder, SerTo};
+
+/// Encodes a row as a CSV line (RFC 4180 style).
+pub struct CsvEncoder {
+    schema: Schema,
+    col_indices: Option<Vec<usize>>,
+}
+
+impl CsvEncoder {
+    pub fn new(schema: Schema, col_indices: Option<Vec<usize>>) -> Self {
+        Self {
+            schema,
+            col_indices,
+        }
+    }
+}
+
+/// A wrapper around a CSV-encoded `String` that implements `SerTo`.
+pub struct CsvLine(pub String);
+
+impl SerTo<String> for CsvLine {
+    fn ser_to(self) -> Result<String> {
+        Ok(self.0)
+    }
+}
+
+impl RowEncoder for CsvEncoder {
+    type Output = CsvLine;
+
+    fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    fn col_indices(&self) -> Option<&[usize]> {
+        self.col_indices.as_deref()
+    }
+
+    fn encode_cols(
+        &self,
+        row: impl Row,
+        col_indices: impl Iterator<Item = usize>,
+    ) -> Result<Self::Output> {
+        let mut buf = String::new();
+        let mut first = true;
+        for idx in col_indices {
+            if !first {
+                buf.push(',');
+            }
+            first = false;
+            match row.datum_at(idx) {
+                None => {
+                    // NULL is represented as empty (unquoted) field in CSV
+                }
+                Some(scalar) => {
+                    let text = scalar.to_text();
+                    // Quote the field if it contains comma, double-quote, or newline
+                    if text.contains(',')
+                        || text.contains('"')
+                        || text.contains('\n')
+                        || text.contains('\r')
+                    {
+                        buf.push('"');
+                        for ch in text.chars() {
+                            if ch == '"' {
+                                buf.push('"'); // escape double-quote by doubling
+                            }
+                            buf.push(ch);
+                        }
+                        buf.push('"');
+                    } else {
+                        buf.push_str(&text);
+                    }
+                }
+            }
+        }
+        Ok(CsvLine(buf))
+    }
+}
+
+/// Returns a CSV header line for the given schema and column indices.
+pub fn csv_header_line(schema: &Schema, col_indices: Option<&[usize]>) -> String {
+    let mut buf = String::new();
+    let indices: Box<dyn Iterator<Item = usize>> = match col_indices {
+        Some(indices) => Box::new(indices.iter().copied()),
+        None => Box::new(0..schema.len()),
+    };
+    let mut first = true;
+    for idx in indices {
+        if !first {
+            buf.push(',');
+        }
+        first = false;
+        let name = &schema[idx].name;
+        if name.contains(',') || name.contains('"') || name.contains('\n') {
+            buf.push('"');
+            for ch in name.chars() {
+                if ch == '"' {
+                    buf.push('"');
+                }
+                buf.push(ch);
+            }
+            buf.push('"');
+        } else {
+            buf.push_str(name);
+        }
+    }
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::Field;
+    use risingwave_common::row::OwnedRow;
+    use risingwave_common::types::{DataType, ScalarImpl};
+
+    use super::*;
+
+    fn test_schema() -> Schema {
+        Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Varchar, "name"),
+            Field::with_name(DataType::Float64, "score"),
+        ])
+    }
+
+    #[test]
+    fn test_csv_encode_basic() {
+        let schema = test_schema();
+        let encoder = CsvEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(1)),
+            Some(ScalarImpl::Utf8("Alice".into())),
+            Some(ScalarImpl::Float64(99.5.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "1,Alice,99.5");
+    }
+
+    #[test]
+    fn test_csv_encode_with_null() {
+        let schema = test_schema();
+        let encoder = CsvEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(2)),
+            None,
+            Some(ScalarImpl::Float64(88.0.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "2,,88");
+    }
+
+    #[test]
+    fn test_csv_encode_quoting() {
+        let schema = test_schema();
+        let encoder = CsvEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(3)),
+            Some(ScalarImpl::Utf8("hello, \"world\"".into())),
+            Some(ScalarImpl::Float64(77.0.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "3,\"hello, \"\"world\"\"\",77");
+    }
+
+    #[test]
+    fn test_csv_encode_col_indices() {
+        let schema = test_schema();
+        let encoder = CsvEncoder::new(schema, Some(vec![0, 2]));
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(4)),
+            Some(ScalarImpl::Utf8("Bob".into())),
+            Some(ScalarImpl::Float64(66.0.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "4,66");
+    }
+
+    #[test]
+    fn test_csv_header_line() {
+        let schema = test_schema();
+        assert_eq!(csv_header_line(&schema, None), "id,name,score");
+        assert_eq!(csv_header_line(&schema, Some(&[0, 2])), "id,score");
+    }
+
+    #[test]
+    fn test_csv_encode_newline_in_field() {
+        let schema = Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Varchar, "text"),
+        ]);
+        let encoder = CsvEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(1)),
+            Some(ScalarImpl::Utf8("line1\nline2".into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "1,\"line1\nline2\"");
+    }
+}

--- a/src/connector/src/sink/encoder/mod.rs
+++ b/src/connector/src/sink/encoder/mod.rs
@@ -23,15 +23,19 @@ use crate::sink::Result;
 mod avro;
 mod bson;
 pub mod bytes;
+pub mod csv;
 mod json;
 mod proto;
 pub mod template;
 pub mod text;
+pub mod xml;
 
 pub use avro::{AvroEncoder, AvroHeader};
 pub use bson::BsonEncoder;
+pub use csv::CsvEncoder;
 pub use json::JsonEncoder;
 pub use proto::{ProtoEncoder, ProtoHeader};
+pub use xml::XmlEncoder;
 
 /// Encode a row of a relation into
 /// * an object in json

--- a/src/connector/src/sink/encoder/xml.rs
+++ b/src/connector/src/sink/encoder/xml.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/connector/src/sink/encoder/xml.rs
+++ b/src/connector/src/sink/encoder/xml.rs
@@ -1,0 +1,194 @@
+// Copyright 2024 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Write;
+
+use risingwave_common::catalog::Schema;
+use risingwave_common::row::Row;
+use risingwave_common::types::ToText;
+
+use super::{Result, RowEncoder, SerTo};
+
+/// The XML element name used to wrap each row.
+const DEFAULT_ROW_ELEMENT: &str = "row";
+
+/// Encodes a row as an XML element.
+///
+/// Output format:
+/// ```xml
+/// <row><col_name>value</col_name><col_name2>value2</col_name2></row>
+/// ```
+///
+/// NULL values are omitted (the element is not emitted).
+/// Special characters (`<`, `>`, `&`, `"`, `'`) are escaped.
+pub struct XmlEncoder {
+    schema: Schema,
+    col_indices: Option<Vec<usize>>,
+    row_element: String,
+}
+
+impl XmlEncoder {
+    pub fn new(schema: Schema, col_indices: Option<Vec<usize>>) -> Self {
+        Self {
+            schema,
+            col_indices,
+            row_element: DEFAULT_ROW_ELEMENT.to_owned(),
+        }
+    }
+}
+
+/// A wrapper around an XML-encoded `String` that implements `SerTo`.
+pub struct XmlLine(pub String);
+
+impl SerTo<String> for XmlLine {
+    fn ser_to(self) -> Result<String> {
+        Ok(self.0)
+    }
+}
+
+/// Escape XML special characters.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+impl RowEncoder for XmlEncoder {
+    type Output = XmlLine;
+
+    fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    fn col_indices(&self) -> Option<&[usize]> {
+        self.col_indices.as_deref()
+    }
+
+    fn encode_cols(
+        &self,
+        row: impl Row,
+        col_indices: impl Iterator<Item = usize>,
+    ) -> Result<Self::Output> {
+        let mut buf = String::new();
+        write!(buf, "<{}>", self.row_element).unwrap();
+        for idx in col_indices {
+            let field = &self.schema[idx];
+            match row.datum_at(idx) {
+                None => {
+                    // Omit NULL fields
+                }
+                Some(scalar) => {
+                    let text = scalar.to_text();
+                    let escaped = xml_escape(&text);
+                    write!(buf, "<{0}>{1}</{0}>", field.name, escaped).unwrap();
+                }
+            }
+        }
+        write!(buf, "</{}>", self.row_element).unwrap();
+        Ok(XmlLine(buf))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::Field;
+    use risingwave_common::row::OwnedRow;
+    use risingwave_common::types::{DataType, ScalarImpl};
+
+    use super::*;
+
+    fn test_schema() -> Schema {
+        Schema::new(vec![
+            Field::with_name(DataType::Int32, "id"),
+            Field::with_name(DataType::Varchar, "name"),
+            Field::with_name(DataType::Float64, "score"),
+        ])
+    }
+
+    #[test]
+    fn test_xml_encode_basic() {
+        let schema = test_schema();
+        let encoder = XmlEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(1)),
+            Some(ScalarImpl::Utf8("Alice".into())),
+            Some(ScalarImpl::Float64(99.5.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(
+            result,
+            "<row><id>1</id><name>Alice</name><score>99.5</score></row>"
+        );
+    }
+
+    #[test]
+    fn test_xml_encode_with_null() {
+        let schema = test_schema();
+        let encoder = XmlEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(2)),
+            None,
+            Some(ScalarImpl::Float64(88.0.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "<row><id>2</id><score>88</score></row>");
+    }
+
+    #[test]
+    fn test_xml_encode_escaping() {
+        let schema = test_schema();
+        let encoder = XmlEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(3)),
+            Some(ScalarImpl::Utf8("<b>Bob & \"friends\"</b>".into())),
+            Some(ScalarImpl::Float64(77.0.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(
+            result,
+            "<row><id>3</id><name>&lt;b&gt;Bob &amp; &quot;friends&quot;&lt;/b&gt;</name><score>77</score></row>"
+        );
+    }
+
+    #[test]
+    fn test_xml_encode_col_indices() {
+        let schema = test_schema();
+        let encoder = XmlEncoder::new(schema, Some(vec![0, 2]));
+        let row = OwnedRow::new(vec![
+            Some(ScalarImpl::Int32(4)),
+            Some(ScalarImpl::Utf8("Charlie".into())),
+            Some(ScalarImpl::Float64(66.0.into())),
+        ]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "<row><id>4</id><score>66</score></row>");
+    }
+
+    #[test]
+    fn test_xml_encode_all_null() {
+        let schema = test_schema();
+        let encoder = XmlEncoder::new(schema, None);
+        let row = OwnedRow::new(vec![None, None, None]);
+        let result: String = encoder.encode(row).unwrap().ser_to().unwrap();
+        assert_eq!(result, "<row></row>");
+    }
+}

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -353,8 +353,7 @@ impl OpenDalSinkWriter {
                     assert_eq!(op, Op::Insert, "expect all `op(s)` to be `Op::Insert`");
                     match &self.row_encoder {
                         TextRowEncoder::Json(encoder) => {
-                            writeln!(chunk_buf, "{}", Value::Object(encoder.encode(row)?))
-                                .unwrap();
+                            writeln!(chunk_buf, "{}", Value::Object(encoder.encode(row)?)).unwrap();
                         }
                         TextRowEncoder::Csv(encoder) => {
                             let line: String = encoder.encode(row)?.ser_to()?;
@@ -388,8 +387,7 @@ impl OpenDalSinkWriter {
         let arrow_schema = convert_rw_schema_to_arrow_schema(rw_schema.clone())?;
         let row_encoder = match &format_desc.encode {
             SinkEncode::Json => {
-                let jsonb_handling_mode =
-                    JsonbHandlingMode::from_options(&format_desc.options)?;
+                let jsonb_handling_mode = JsonbHandlingMode::from_options(&format_desc.options)?;
                 TextRowEncoder::Json(JsonEncoder::new(
                     rw_schema,
                     None,
@@ -404,8 +402,7 @@ impl OpenDalSinkWriter {
             SinkEncode::Xml => TextRowEncoder::Xml(XmlEncoder::new(rw_schema, None)),
             _ => {
                 // Parquet does not use a row encoder; use a dummy JSON encoder.
-                let jsonb_handling_mode =
-                    JsonbHandlingMode::from_options(&format_desc.options)?;
+                let jsonb_handling_mode = JsonbHandlingMode::from_options(&format_desc.options)?;
                 TextRowEncoder::Json(JsonEncoder::new(
                     rw_schema,
                     None,
@@ -503,8 +500,10 @@ impl OpenDalSinkWriter {
                 let mut writer = object_writer;
                 // Write CSV header line
                 if let TextRowEncoder::Csv(encoder) = &self.row_encoder {
-                    let header =
-                        crate::sink::encoder::csv::csv_header_line(encoder.schema(), encoder.col_indices());
+                    let header = crate::sink::encoder::csv::csv_header_line(
+                        encoder.schema(),
+                        encoder.col_indices(),
+                    );
                     let header_bytes = format!("{}\n", header);
                     writer.write(header_bytes).await?;
                 }

--- a/src/connector/src/sink/file_sink/opendal_sink.rs
+++ b/src/connector/src/sink/file_sink/opendal_sink.rs
@@ -41,8 +41,8 @@ use with_options::WithOptions;
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::catalog::SinkEncode;
 use crate::sink::encoder::{
-    JsonEncoder, JsonbHandlingMode, RowEncoder, TimeHandlingMode, TimestampHandlingMode,
-    TimestamptzHandlingMode,
+    CsvEncoder, JsonEncoder, JsonbHandlingMode, RowEncoder, SerTo, TimeHandlingMode,
+    TimestampHandlingMode, TimestamptzHandlingMode, XmlEncoder,
 };
 use crate::sink::file_sink::batching_log_sink::BatchingLogSinker;
 use crate::sink::{Result, Sink, SinkError, SinkFormatDesc, SinkParam};
@@ -139,11 +139,12 @@ impl<S: OpendalSinkBackend> Sink for FileSink<S> {
             )));
         }
 
-        if self.format_desc.encode != SinkEncode::Parquet
-            && self.format_desc.encode != SinkEncode::Json
-        {
+        if !matches!(
+            self.format_desc.encode,
+            SinkEncode::Parquet | SinkEncode::Json | SinkEncode::Csv | SinkEncode::Xml
+        ) {
             return Err(SinkError::Config(anyhow!(
-                "File sink only supports `PARQUET` and `JSON` encode at present."
+                "File sink only supports `PARQUET`, `JSON`, `CSV` and `XML` encode at present."
             )));
         }
 
@@ -203,6 +204,13 @@ impl<S: OpendalSinkBackend> TryFrom<SinkParam> for FileSink<S> {
     }
 }
 
+/// The row encoder used for text-based file formats (JSON, CSV, XML).
+enum TextRowEncoder {
+    Json(JsonEncoder),
+    Csv(CsvEncoder),
+    Xml(XmlEncoder),
+}
+
 pub struct OpenDalSinkWriter {
     schema: SchemaRef,
     operator: Operator,
@@ -211,7 +219,7 @@ pub struct OpenDalSinkWriter {
     executor_id: ExecutorId,
     unique_writer_id: Uuid,
     encode_type: SinkEncode,
-    row_encoder: JsonEncoder,
+    row_encoder: TextRowEncoder,
     engine_type: EngineType,
     pub(crate) batching_strategy: BatchingStrategy,
     current_bached_row_num: usize,
@@ -268,6 +276,10 @@ impl OpenDalSinkWriter {
                     }
                 }
                 FileWriterEnum::FileWriter(mut w) => {
+                    // Write closing XML root element before closing the file.
+                    if self.encode_type == SinkEncode::Xml {
+                        w.write("</rows>\n").await?;
+                    }
                     w.close().await?;
                 }
             };
@@ -337,17 +349,22 @@ impl OpenDalSinkWriter {
             FileWriterEnum::FileWriter(w) => {
                 let mut chunk_buf = BytesMut::new();
                 let batch_row_nums = chunk.data_chunk().capacity();
-                // write the json representations of the row(s) in current chunk to `chunk_buf`
                 for (op, row) in chunk.rows() {
                     assert_eq!(op, Op::Insert, "expect all `op(s)` to be `Op::Insert`");
-                    // to prevent temporary string allocation,
-                    // so we directly write to `chunk_buf` implicitly via `write_fmt`.
-                    writeln!(
-                        chunk_buf,
-                        "{}",
-                        Value::Object(self.row_encoder.encode(row)?)
-                    )
-                    .unwrap(); // write to a `BytesMut` should never fail
+                    match &self.row_encoder {
+                        TextRowEncoder::Json(encoder) => {
+                            writeln!(chunk_buf, "{}", Value::Object(encoder.encode(row)?))
+                                .unwrap();
+                        }
+                        TextRowEncoder::Csv(encoder) => {
+                            let line: String = encoder.encode(row)?.ser_to()?;
+                            writeln!(chunk_buf, "{}", line).unwrap();
+                        }
+                        TextRowEncoder::Xml(encoder) => {
+                            let line: String = encoder.encode(row)?.ser_to()?;
+                            writeln!(chunk_buf, "{}", line).unwrap();
+                        }
+                    }
                 }
                 w.write(chunk_buf.freeze()).await?;
                 self.current_bached_row_num += batch_row_nums;
@@ -369,16 +386,37 @@ impl OpenDalSinkWriter {
         batching_strategy: BatchingStrategy,
     ) -> Result<Self> {
         let arrow_schema = convert_rw_schema_to_arrow_schema(rw_schema.clone())?;
-        let jsonb_handling_mode = JsonbHandlingMode::from_options(&format_desc.options)?;
-        let row_encoder = JsonEncoder::new(
-            rw_schema,
-            None,
-            crate::sink::encoder::DateHandlingMode::String,
-            TimestampHandlingMode::String,
-            TimestamptzHandlingMode::UtcString,
-            TimeHandlingMode::String,
-            jsonb_handling_mode,
-        );
+        let row_encoder = match &format_desc.encode {
+            SinkEncode::Json => {
+                let jsonb_handling_mode =
+                    JsonbHandlingMode::from_options(&format_desc.options)?;
+                TextRowEncoder::Json(JsonEncoder::new(
+                    rw_schema,
+                    None,
+                    crate::sink::encoder::DateHandlingMode::String,
+                    TimestampHandlingMode::String,
+                    TimestamptzHandlingMode::UtcString,
+                    TimeHandlingMode::String,
+                    jsonb_handling_mode,
+                ))
+            }
+            SinkEncode::Csv => TextRowEncoder::Csv(CsvEncoder::new(rw_schema, None)),
+            SinkEncode::Xml => TextRowEncoder::Xml(XmlEncoder::new(rw_schema, None)),
+            _ => {
+                // Parquet does not use a row encoder; use a dummy JSON encoder.
+                let jsonb_handling_mode =
+                    JsonbHandlingMode::from_options(&format_desc.options)?;
+                TextRowEncoder::Json(JsonEncoder::new(
+                    rw_schema,
+                    None,
+                    crate::sink::encoder::DateHandlingMode::String,
+                    TimestampHandlingMode::String,
+                    TimestamptzHandlingMode::UtcString,
+                    TimeHandlingMode::String,
+                    jsonb_handling_mode,
+                ))
+            }
+        };
         Ok(Self {
             schema: Arc::new(arrow_schema),
             write_path: write_path.to_owned(),
@@ -397,10 +435,11 @@ impl OpenDalSinkWriter {
     }
 
     async fn create_object_writer(&mut self) -> Result<OpendalWriter> {
-        // Todo: specify more file suffixes based on encode_type.
         let suffix = match self.encode_type {
             SinkEncode::Parquet => "parquet",
             SinkEncode::Json => "json",
+            SinkEncode::Csv => "csv",
+            SinkEncode::Xml => "xml",
             _ => unimplemented!(),
         };
 
@@ -459,6 +498,25 @@ impl OpenDalSinkWriter {
                         Some(props.build()),
                     )?,
                 ));
+            }
+            SinkEncode::Csv => {
+                let mut writer = object_writer;
+                // Write CSV header line
+                if let TextRowEncoder::Csv(encoder) = &self.row_encoder {
+                    let header =
+                        crate::sink::encoder::csv::csv_header_line(encoder.schema(), encoder.col_indices());
+                    let header_bytes = format!("{}\n", header);
+                    writer.write(header_bytes).await?;
+                }
+                self.sink_writer = Some(FileWriterEnum::FileWriter(writer));
+            }
+            SinkEncode::Xml => {
+                let mut writer = object_writer;
+                // Write XML prolog and opening root element
+                writer
+                    .write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rows>\n")
+                    .await?;
+                self.sink_writer = Some(FileWriterEnum::FileWriter(writer));
             }
             _ => {
                 self.sink_writer = Some(FileWriterEnum::FileWriter(object_writer));

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -583,8 +583,8 @@ impl SinkFormatterImpl {
                 | (F::Upsert, E::Bytes, _)
                 | (F::Debezium, E::Json, Some(_))
                 | (F::Debezium, E::Avro | E::Protobuf | E::Template | E::Text | E::Bytes, _)
-                | (_, E::Parquet, _)
-                | (_, _, Some(E::Parquet))
+                | (_, E::Parquet | E::Csv | E::Xml, _)
+                | (_, _, Some(E::Parquet | E::Csv | E::Xml))
                 | (F::AppendOnly, E::Bytes, Some(_))
                 | (F::AppendOnly | F::Upsert, _, Some(E::Template) | Some(E::Json) | Some(E::Avro) | Some(E::Protobuf)) // reject other encode as key encode
                 => {

--- a/src/frontend/src/handler/alter_source_with_sr.rs
+++ b/src/frontend/src/handler/alter_source_with_sr.rs
@@ -67,6 +67,7 @@ fn encode_type_to_encode(from: EncodeType) -> Option<Encode> {
         EncodeType::Parquet => Encode::Parquet,
         EncodeType::None => Encode::None,
         EncodeType::Text => Encode::Text,
+        EncodeType::Xml => Encode::Xml,
     })
 }
 

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -795,7 +795,9 @@ fn bind_sink_format_desc(
         E::Template => SinkEncode::Template,
         E::Parquet => SinkEncode::Parquet,
         E::Bytes => SinkEncode::Bytes,
-        e @ (E::Native | E::Csv | E::None | E::Text) => {
+        E::Csv => SinkEncode::Csv,
+        E::Xml => SinkEncode::Xml,
+        e @ (E::Native | E::None | E::Text) => {
             return Err(ErrorCode::BindError(format!("sink encode unsupported: {e}")).into());
         }
     };
@@ -866,22 +868,22 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
                     Format::Debezium => vec![Encode::Json],
                 ),
                 FileSink::<S3Sink>::SINK_NAME => hashmap!(
-                    Format::Plain => vec![Encode::Parquet, Encode::Json],
+                    Format::Plain => vec![Encode::Parquet, Encode::Json, Encode::Csv, Encode::Xml],
                 ),
                 FileSink::<SnowflakeSink>::SINK_NAME => hashmap!(
-                    Format::Plain => vec![Encode::Parquet, Encode::Json],
+                    Format::Plain => vec![Encode::Parquet, Encode::Json, Encode::Csv, Encode::Xml],
                 ),
                 FileSink::<GcsSink>::SINK_NAME => hashmap!(
-                    Format::Plain => vec![Encode::Parquet, Encode::Json],
+                    Format::Plain => vec![Encode::Parquet, Encode::Json, Encode::Csv, Encode::Xml],
                 ),
                 FileSink::<AzblobSink>::SINK_NAME => hashmap!(
-                    Format::Plain => vec![Encode::Parquet, Encode::Json],
+                    Format::Plain => vec![Encode::Parquet, Encode::Json, Encode::Csv, Encode::Xml],
                 ),
                 FileSink::<WebhdfsSink>::SINK_NAME => hashmap!(
-                    Format::Plain => vec![Encode::Parquet, Encode::Json],
+                    Format::Plain => vec![Encode::Parquet, Encode::Json, Encode::Csv, Encode::Xml],
                 ),
                 FileSink::<FsSink>::SINK_NAME => hashmap!(
-                    Format::Plain => vec![Encode::Parquet, Encode::Json],
+                    Format::Plain => vec![Encode::Parquet, Encode::Json, Encode::Csv, Encode::Xml],
                 ),
                 KinesisSink::SINK_NAME => hashmap!(
                     Format::Plain => vec![Encode::Json],

--- a/src/frontend/src/handler/create_source/external_schema.rs
+++ b/src/frontend/src/handler/create_source/external_schema.rs
@@ -439,6 +439,7 @@ fn row_encode_to_prost(row_encode: &Encode) -> EncodeType {
         Encode::Parquet => EncodeType::Parquet,
         Encode::None => EncodeType::None,
         Encode::Text => EncodeType::Text,
+        Encode::Xml => EncodeType::Xml,
     }
 }
 

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -169,6 +169,7 @@ pub enum Encode {
     Native,
     Template,
     Parquet,
+    Xml,
 }
 
 // TODO: unify with `from_keyword`
@@ -188,6 +189,7 @@ impl fmt::Display for Encode {
                 Encode::None => "NONE",
                 Encode::Parquet => "PARQUET",
                 Encode::Text => "TEXT",
+                Encode::Xml => "XML",
             }
         )
     }
@@ -206,8 +208,9 @@ impl Encode {
             "PARQUET" => Encode::Parquet,
             "NATIVE" => Encode::Native,
             "NONE" => Encode::None,
+            "XML" => Encode::Xml,
             _ => parser_err!(
-                "expected AVRO | BYTES | CSV | PROTOBUF | JSON | NATIVE | TEMPLATE | PARQUET | NONE after Encode"
+                "expected AVRO | BYTES | CSV | PROTOBUF | JSON | NATIVE | TEMPLATE | PARQUET | XML | NONE after Encode"
             ),
         })
     }


### PR DESCRIPTION
## Summary

- Add **CSV** and **XML** as new encode formats for all file sinks (S3, GCS, Azure Blob, WebHDFS, local FS, Snowflake)
- Previously file sinks only supported `PARQUET` and `JSON`
- New `CsvEncoder` (RFC 4180 style, with header line) and `XmlEncoder` (with XML prolog and root element)
- Wired through the full stack: protobuf → SQL parser → frontend → connector

### Usage

```sql
-- CSV
CREATE SINK my_csv_sink AS SELECT * FROM my_table
WITH (connector = 's3', ...) FORMAT PLAIN ENCODE CSV;

-- XML
CREATE SINK my_xml_sink AS SELECT * FROM my_table
WITH (connector = 's3', ...) FORMAT PLAIN ENCODE XML;
```

## Notes

> ⚠️ **Draft PR** — not ready for merge yet.

1. **No end-to-end / system tests yet** — only unit tests for encoders (11 tests, all passing)
2. Full workspace `cargo check` passes
3. Needs manual testing with MinIO / S3 before merging

## Test plan

- [x] Unit tests for `CsvEncoder` (6 tests: basic, null, quoting, col_indices, header, newline)
- [x] Unit tests for `XmlEncoder` (5 tests: basic, null, escaping, col_indices, all_null)
- [x] `cargo check --workspace` passes
- [ ] Manual e2e test with MinIO (script prepared at `wcy-tools/test_file_sink_csv_xml.sh`)
- [ ] Add SLT e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)