### PR TITLE
fix(cdc): allow SQL Server tables with multiple CDC capture instances

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/SqlServerValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/SqlServerValidator.java
@@ -162,7 +162,7 @@ public class SqlServerValidator extends DatabaseValidator implements AutoCloseab
             stmt.setString(2, tableName);
             var res = stmt.executeQuery();
             while (res.next()) {
-                if (res.getInt(1) != 1) {
+                if (res.getInt(1) < 1) {
                     throw ValidatorUtils.invalidArgument(
                             "Table '"
                                     + schemaName


### PR DESCRIPTION
## Summary

- Fix SQL Server CDC table validation that incorrectly rejects tables with multiple capture instances
- The validation query counts capture instances via `COUNT(*)` on `cdc.change_tables`, but the check used `!= 1` instead of `< 1`, so tables with 2 capture instances were rejected with a misleading "has not enabled CDC" error
- Changed the condition from `!= 1` to `< 1` to allow any table with at least one capture instance

## Root Cause

In `SqlServerValidator.java:165`, the CDC-enabled check was:
```java
if (res.getInt(1) != 1) { // only passes when count is exactly 1
```

SQL Server allows up to 2 capture instances per table (commonly used during schema migrations). When a table has 2 instances, `COUNT(*)` returns 2, which fails the `!= 1` check.

## Fix

```java
if (res.getInt(1) < 1) { // passes when count >= 1
```

Closes #25281

🤖 Generated with [Claude Code](https://claude.com/claude-code)