### PR TITLE
feat(connector): support INCLUDE header for webhook sources

### DIFF
--- a/e2e_test/webhook/check_1.slt.part
+++ b/e2e_test/webhook/check_1.slt.part
@@ -41,3 +41,21 @@ github hmac_sha1
 github hmac_sha1
 github hmac_sha1
 github hmac_sha1
+
+query TTT
+select data ->> 'source', event_type, event_timestamp from with_include_header order by data ->> 'source';
+----
+include_header_missing_test NULL NULL
+include_header_test order.created 2024-01-15T10:30:00Z
+
+query TT
+select data ->> 'source', source_id from include_with_validate;
+----
+include_validate_test src-42
+
+query TT
+select data ->> 'source', batch_id from batched_include;
+----
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001

--- a/e2e_test/webhook/check_2.slt.part
+++ b/e2e_test/webhook/check_2.slt.part
@@ -62,3 +62,27 @@ github hmac_sha1
 github hmac_sha1
 github hmac_sha1
 github hmac_sha1
+
+query TTT
+select data ->> 'source', event_type, event_timestamp from with_include_header order by data ->> 'source';
+----
+include_header_missing_test NULL NULL
+include_header_missing_test NULL NULL
+include_header_test order.created 2024-01-15T10:30:00Z
+include_header_test order.created 2024-01-15T10:30:00Z
+
+query TT
+select data ->> 'source', source_id from include_with_validate;
+----
+include_validate_test src-42
+include_validate_test src-42
+
+query TT
+select data ->> 'source', batch_id from batched_include;
+----
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001

--- a/e2e_test/webhook/check_3.slt.part
+++ b/e2e_test/webhook/check_3.slt.part
@@ -78,3 +78,33 @@ github hmac_sha1
 github hmac_sha1
 github hmac_sha1
 github hmac_sha1
+
+query TTT
+select data ->> 'source', event_type, event_timestamp from with_include_header order by data ->> 'source';
+----
+include_header_missing_test NULL NULL
+include_header_missing_test NULL NULL
+include_header_missing_test NULL NULL
+include_header_test order.created 2024-01-15T10:30:00Z
+include_header_test order.created 2024-01-15T10:30:00Z
+include_header_test order.created 2024-01-15T10:30:00Z
+
+query TT
+select data ->> 'source', source_id from include_with_validate;
+----
+include_validate_test src-42
+include_validate_test src-42
+include_validate_test src-42
+
+query TT
+select data ->> 'source', batch_id from batched_include;
+----
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001
+batched_include_test batch-001

--- a/e2e_test/webhook/create_table.slt.part
+++ b/e2e_test/webhook/create_table.slt.part
@@ -105,12 +105,32 @@ WITH (
   connector = 'webhook'
 );
 
-# Negative test: INCLUDE header with unsupported data type should fail
+# Negative test: INCLUDE header with unsupported data type (INT) should fail
 statement error invalid additional column data type
 create table bad_include_type (
   data JSONB
 )
 INCLUDE header 'x-event-type' AS event_type INT
+WITH (
+  connector = 'webhook'
+);
+
+# Negative test: INCLUDE header with BYTEA should fail for webhook
+statement error Webhook INCLUDE header columns must be VARCHAR
+create table bad_include_bytea (
+  data JSONB
+)
+INCLUDE header 'x-event-type' AS event_type BYTEA
+WITH (
+  connector = 'webhook'
+);
+
+# Negative test: INCLUDE header (all-headers form) should fail for webhook
+statement error all-headers column.*not supported for webhook
+create table bad_include_all_headers (
+  data JSONB
+)
+INCLUDE header AS all_headers
 WITH (
   connector = 'webhook'
 );

--- a/e2e_test/webhook/create_table.slt.part
+++ b/e2e_test/webhook/create_table.slt.part
@@ -94,3 +94,47 @@ create table batched (
   headers->>'x-hub-signature',
   'sha1=' || encode(hmac('TEST_WEBHOOK', data, 'sha1'), 'hex')
 );
+
+statement ok
+create table with_include_header (
+  data JSONB
+)
+INCLUDE header 'x-event-type' AS event_type VARCHAR
+INCLUDE header 'x-event-timestamp' AS event_timestamp VARCHAR
+WITH (
+  connector = 'webhook'
+);
+
+# Negative test: INCLUDE header with unsupported data type should fail
+statement error invalid additional column data type
+create table bad_include_type (
+  data JSONB
+)
+INCLUDE header 'x-event-type' AS event_type INT
+WITH (
+  connector = 'webhook'
+);
+
+# INCLUDE header combined with VALIDATE SECRET
+statement ok
+create table include_with_validate (
+  data JSONB
+)
+INCLUDE header 'x-source-id' AS source_id VARCHAR
+WITH (
+  connector = 'webhook',
+) VALIDATE SECRET test_secret AS secure_compare(
+  headers->>'x-hub-signature',
+  'sha1=' || encode(hmac(test_secret, data, 'sha1'), 'hex')
+);
+
+# Batched webhook with INCLUDE header columns
+statement ok
+create table batched_include (
+  data JSONB
+)
+INCLUDE header 'x-batch-id' AS batch_id VARCHAR
+WITH (
+  connector = 'webhook',
+  is_batched = true,
+);

--- a/e2e_test/webhook/drop_table.slt.part
+++ b/e2e_test/webhook/drop_table.slt.part
@@ -21,3 +21,12 @@ DROP TABLE rudderstack;
 
 statement ok
 DROP TABLE batched;
+
+statement ok
+DROP TABLE with_include_header;
+
+statement ok
+DROP TABLE include_with_validate;
+
+statement ok
+DROP TABLE batched_include;

--- a/e2e_test/webhook/sender.py
+++ b/e2e_test/webhook/sender.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import requests
 import json
 import sys
@@ -175,6 +176,69 @@ def send_batched(secret):
     }
     send_webhook(url, headers, payload_jsonl)
 
+
+def send_with_include_header():
+    payload = copy.deepcopy(message)
+    payload['source'] = "include_header_test"
+    payload['auth_algo'] = "none"
+    url = SERVER_URL + "with_include_header"
+
+    payload_json = json.dumps(payload)
+    headers = {
+        "Content-Type": "application/json",
+        "x-event-type": "order.created",
+        "x-event-timestamp": "2024-01-15T10:30:00Z",
+    }
+    send_webhook(url, headers, payload_json)
+
+
+def send_with_include_header_missing():
+    """Send a request that omits declared INCLUDE headers — columns should be NULL."""
+    payload = copy.deepcopy(message)
+    payload['source'] = "include_header_missing_test"
+    payload['auth_algo'] = "none"
+    url = SERVER_URL + "with_include_header"
+
+    payload_json = json.dumps(payload)
+    headers = {
+        "Content-Type": "application/json",
+        # intentionally omitting x-event-type and x-event-timestamp
+    }
+    send_webhook(url, headers, payload_json)
+
+
+def send_include_with_validate(secret):
+    """INCLUDE header combined with VALIDATE SECRET."""
+    payload = copy.deepcopy(message)
+    payload['source'] = "include_validate_test"
+    payload['auth_algo'] = "hmac_sha1"
+    url = SERVER_URL + "include_with_validate"
+
+    payload_json = json.dumps(payload)
+    signature = generate_signature_hmac(secret, payload_json, 'sha1', "sha1=")
+    headers = {
+        "Content-Type": "application/json",
+        "X-Hub-Signature": signature,
+        "x-source-id": "src-42",
+    }
+    send_webhook(url, headers, payload_json)
+
+
+def send_batched_include():
+    """Batched webhook with INCLUDE header columns — header replicated across rows."""
+    payload = copy.deepcopy(message)
+    payload['source'] = "batched_include_test"
+    payload['auth_algo'] = "none"
+    url = SERVER_URL + "batched_include"
+
+    payload_jsonl = '\n'.join([json.dumps(payload) for _ in range(3)])
+    headers = {
+        "Content-Type": "application/json",
+        "x-batch-id": "batch-001",
+    }
+    send_webhook(url, headers, payload_jsonl)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Simulate sending Webhook messages")
     parser.add_argument("--secret", required=True, help="Secret key for generating signature")
@@ -197,3 +261,11 @@ if __name__ == "__main__":
     send_validate_raw_string(secret)
     # batch multiple rows per request
     send_batched(secret)
+    # INCLUDE header test (no secret needed)
+    send_with_include_header()
+    # INCLUDE header with missing headers (should produce NULLs)
+    send_with_include_header_missing()
+    # INCLUDE header combined with VALIDATE SECRET
+    send_include_with_validate(secret)
+    # Batched webhook with INCLUDE header columns
+    send_batched_include()

--- a/src/connector/src/parser/additional_columns.rs
+++ b/src/connector/src/parser/additional_columns.rs
@@ -32,6 +32,7 @@ use crate::source::cdc::MONGODB_CDC_CONNECTOR;
 use crate::source::{
     AZBLOB_CONNECTOR, GCS_CONNECTOR, KAFKA_CONNECTOR, KINESIS_CONNECTOR, MQTT_CONNECTOR,
     NATS_CONNECTOR, OPENDAL_S3_CONNECTOR, POSIX_FS_CONNECTOR, PULSAR_CONNECTOR,
+    WEBHOOK_CONNECTOR,
 };
 
 // Hidden additional columns connectors which do not support `include` syntax.
@@ -89,6 +90,7 @@ pub static COMPATIBLE_ADDITIONAL_COLUMNS: LazyLock<HashMap<&'static str, HashSet
                 ]),
             ),
             (MQTT_CONNECTOR, HashSet::from(["offset", "partition"])),
+            (WEBHOOK_CONNECTOR, HashSet::from(["header"])),
         ])
     });
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -32,6 +32,7 @@ use risingwave_common::catalog::{
 use risingwave_common::config::MetaBackend;
 use risingwave_common::global_jvm::Jvm;
 use risingwave_common::session_config::sink_decouple::SinkDecouple;
+use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_common::util::value_encoding::DatumToProtoExt;
 use risingwave_common::{bail, bail_not_implemented};
@@ -1170,6 +1171,29 @@ pub(super) async fn handle_create_table_plan(
             let context = OptimizerContext::new(handler_args, explain_options);
 
             if !include_column_options.is_empty() && props.webhook_info.is_some() {
+                // Validate webhook-specific INCLUDE restrictions before processing.
+                for item in &include_column_options {
+                    if item.column_type.real_value().eq_ignore_ascii_case("header")
+                        && item.inner_field.is_none()
+                    {
+                        return Err(ErrorCode::InvalidInputSyntax(
+                            "INCLUDE header (all-headers column) is not supported for webhook sources. Use INCLUDE header '<header-name>' AS <column> VARCHAR to extract individual headers."
+                                .to_owned(),
+                        )
+                        .into());
+                    }
+                    if let Some(ref dt) = item.header_inner_expect_type {
+                        let bound = bind_data_type(dt)?;
+                        if bound != DataType::Varchar {
+                            return Err(ErrorCode::InvalidInputSyntax(format!(
+                                "Webhook INCLUDE header columns must be VARCHAR, got {}. Use: INCLUDE header '<header-name>' AS <column> VARCHAR",
+                                bound
+                            ))
+                            .into());
+                        }
+                    }
+                }
+
                 // Webhook table with INCLUDE header columns: process them before
                 // generating the plan so they appear in the table catalog.
                 let mut columns = bind_sql_columns(&column_defs, false)?;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -75,8 +75,8 @@ use crate::error::{ErrorCode, Result, RwError, bail_bind_error};
 use crate::expr::{Expr, ExprImpl, ExprRewriter};
 use crate::handler::HandlerArgs;
 use crate::handler::create_source::{
-    UPSTREAM_SOURCE_KEY, bind_connector_props, bind_create_source_or_table_with_connector,
-    bind_source_watermark, handle_addition_columns,
+    UPSTREAM_SOURCE_KEY, WEBHOOK_CONNECTOR, bind_connector_props,
+    bind_create_source_or_table_with_connector, bind_source_watermark, handle_addition_columns,
 };
 use crate::handler::util::{
     LongRunningNotificationAction, SourceSchemaCompatExt, execute_with_long_running_notification,
@@ -1123,7 +1123,7 @@ pub(super) async fn handle_create_table_plan(
     TableJobType,
     Option<SourceId>,
 )> {
-    let col_id_gen = ColumnIdGenerator::new_initial();
+    let mut col_id_gen = ColumnIdGenerator::new_initial();
     let format_encode = check_create_table_with_source(
         &handler_args.with_options,
         format_encode,
@@ -1168,18 +1168,57 @@ pub(super) async fn handle_create_table_plan(
         ),
         (None, None) => {
             let context = OptimizerContext::new(handler_args, explain_options);
-            let (plan, table) = gen_create_table_plan(
-                context,
-                table_name.clone(),
-                column_defs,
-                constraints,
-                col_id_gen,
-                source_watermarks,
-                props,
-                false,
-            )?;
 
-            ((plan, None, table), TableJobType::General, None)
+            if !include_column_options.is_empty() && props.webhook_info.is_some() {
+                // Webhook table with INCLUDE header columns: process them before
+                // generating the plan so they appear in the table catalog.
+                let mut columns = bind_sql_columns(&column_defs, false)?;
+                for c in &mut columns {
+                    col_id_gen.generate(c)?;
+                }
+
+                let mut with_properties = BTreeMap::new();
+                with_properties
+                    .insert(UPSTREAM_SOURCE_KEY.to_owned(), WEBHOOK_CONNECTOR.to_owned());
+                handle_addition_columns(
+                    None,
+                    &with_properties,
+                    include_column_options,
+                    &mut columns,
+                    false,
+                )?;
+
+                // Assign column IDs to newly added INCLUDE columns
+                for c in &mut columns {
+                    if c.column_id() == ColumnId::placeholder() {
+                        col_id_gen.generate(c)?;
+                    }
+                }
+
+                let (plan, table) = gen_create_table_plan_without_source(
+                    context,
+                    table_name.clone(),
+                    columns,
+                    column_defs,
+                    constraints,
+                    source_watermarks,
+                    col_id_gen.into_version(),
+                    props,
+                )?;
+                ((plan, None, table), TableJobType::General, None)
+            } else {
+                let (plan, table) = gen_create_table_plan(
+                    context,
+                    table_name.clone(),
+                    column_defs,
+                    constraints,
+                    col_id_gen,
+                    source_watermarks,
+                    props,
+                    false,
+                )?;
+                ((plan, None, table), TableJobType::General, None)
+            }
         }
 
         (None, Some(cdc_table)) => {
@@ -2424,7 +2463,8 @@ pub fn check_create_table_with_source(
     }
     let defined_source = with_options.is_source_connector();
 
-    if !include_column_options.is_empty() && !defined_source {
+    if !include_column_options.is_empty() && !defined_source && !with_options.is_webhook_connector()
+    {
         return Err(ErrorCode::InvalidInputSyntax(
             "INCLUDE should be used with a connector".to_owned(),
         )

--- a/src/frontend/src/utils/with_options.rs
+++ b/src/frontend/src/utils/with_options.rs
@@ -216,6 +216,10 @@ impl WithOptions {
             && self.inner.get(UPSTREAM_SOURCE_KEY).unwrap() != WEBHOOK_CONNECTOR
     }
 
+    pub fn is_webhook_connector(&self) -> bool {
+        self.inner.get(UPSTREAM_SOURCE_KEY).map(|v| v.as_str()) == Some(WEBHOOK_CONNECTOR)
+    }
+
     pub fn backfill_order_strategy(&self) -> BackfillOrderStrategy {
         self.backfill_order_strategy.clone()
     }

--- a/src/frontend/src/webhook/mod.rs
+++ b/src/frontend/src/webhook/mod.rs
@@ -22,7 +22,7 @@ use axum::body::Bytes;
 use axum::extract::{Extension, Path};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::routing::post;
-use risingwave_common::array::{Array, ArrayBuilder, ArrayRef, DataChunk};
+use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::catalog::TableId;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::types::{DataType, JsonbVal, Scalar};
@@ -296,8 +296,15 @@ pub(super) mod handlers {
                         }
                         body_col_idx = Some(table_col_idx as u32);
                     }
-                    _ => {
-                        // Other additional column types — skip for now.
+                    Some(other) => {
+                        return Err(err(
+                            anyhow!(
+                                "Webhook table `{}` contains unsupported additional column type {:?}",
+                                table,
+                                other
+                            ),
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        ));
                     }
                 }
             }

--- a/src/frontend/src/webhook/mod.rs
+++ b/src/frontend/src/webhook/mod.rs
@@ -22,7 +22,8 @@ use axum::body::Bytes;
 use axum::extract::{Extension, Path};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::routing::post;
-use risingwave_common::array::{Array, ArrayBuilder, DataChunk};
+use risingwave_common::array::{Array, ArrayBuilder, ArrayRef, DataChunk};
+use risingwave_common::catalog::TableId;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_common::types::{DataType, JsonbVal, Scalar};
 use risingwave_pb::catalog::WebhookSourceInfo;
@@ -42,9 +43,35 @@ pub type Service = Arc<WebhookService>;
 // We always use the `root` user to connect to the database to allow the webhook service to access all tables.
 const USER: &str = "root";
 
+/// Metadata for an INCLUDE header column, used to extract header values at request time.
+///
+/// At request time, the header value is looked up via `HeaderMap::get`, which is
+/// **case-insensitive** per HTTP semantics. The column is always produced as VARCHAR;
+/// if the header is absent from the request, the column value will be NULL.
+#[derive(Clone)]
+pub struct HeaderColumnInfo {
+    /// The HTTP header name to look up (from `AdditionalColumnHeader.inner_field`).
+    pub header_name: String,
+}
+
+/// Resolved table metadata needed to fast-insert a webhook request.
+#[derive(Clone)]
+pub struct WebhookTableMeta {
+    pub webhook_source_info: WebhookSourceInfo,
+    pub table_id: TableId,
+    pub version_id: u64,
+    pub row_id_index: Option<u32>,
+    /// Maps each DataChunk column position to its table column index.
+    /// Layout: `[body_col, header_col_0, header_col_1, ...]`.
+    pub column_indices: Vec<u32>,
+    /// Ordered list of INCLUDE header columns; positions align with
+    /// `column_indices[1..]`.
+    pub header_columns: Vec<HeaderColumnInfo>,
+}
+
 #[derive(Clone)]
 pub struct FastInsertContext {
-    pub webhook_source_info: WebhookSourceInfo,
+    pub table_meta: WebhookTableMeta,
     pub fast_insert_request: FastInsertRequest,
     pub compute_client: ComputeClient,
 }
@@ -56,9 +83,10 @@ pub struct WebhookService {
 
 pub(super) mod handlers {
     use jsonbb::Value;
-    use risingwave_common::array::JsonbArrayBuilder;
+    use risingwave_common::array::{JsonbArrayBuilder, Utf8ArrayBuilder};
     use risingwave_common::session_config::SearchPath;
     use risingwave_pb::catalog::WebhookSourceInfo;
+    use risingwave_pb::plan_common::additional_column::ColumnType as AdditionalColumnType;
     use risingwave_pb::task_service::fast_insert_response;
     use utils::{header_map_to_json, verify_signature};
 
@@ -77,7 +105,7 @@ pub(super) mod handlers {
             .counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let FastInsertContext {
-            webhook_source_info,
+            table_meta,
             mut fast_insert_request,
             compute_client,
         } = acquire_table_info(request_id, &database, &schema, &table).await?;
@@ -87,7 +115,7 @@ pub(super) mod handlers {
             secret_ref,
             wait_for_persistence: _,
             is_batched,
-        } = webhook_source_info;
+        } = table_meta.webhook_source_info;
 
         let is_valid = if let Some(signature_expr) = signature_expr {
             let secret_string = if let Some(secret_ref) = secret_ref {
@@ -120,7 +148,7 @@ pub(super) mod handlers {
             ));
         }
 
-        let data_chunk = generate_data_chunk(is_batched, &body)?;
+        let data_chunk = generate_data_chunk(is_batched, &body, &headers, &table_meta.header_columns)?;
 
         // fill the data_chunk
         fast_insert_request.data_chunk = Some(data_chunk.to_protobuf());
@@ -137,25 +165,46 @@ pub(super) mod handlers {
         }
     }
 
-    fn generate_data_chunk(is_batched: bool, body: &Bytes) -> Result<DataChunk> {
-        let mut builder = JsonbArrayBuilder::with_type(1, DataType::Jsonb);
+    /// Build a `DataChunk` from the webhook request body and headers.
+    ///
+    /// Columns are ordered as: `[body_jsonb, header_col_0, header_col_1, ...]`.
+    /// Header columns are always VARCHAR; if the header is absent the value is NULL.
+    fn generate_data_chunk(
+        is_batched: bool,
+        body: &Bytes,
+        headers: &HeaderMap,
+        header_columns: &[HeaderColumnInfo],
+    ) -> Result<DataChunk> {
+        let mut columns: Vec<ArrayRef> = Vec::new();
 
         if !is_batched {
-            // Use builder to obtain a single column & single row DataChunk
+            // Build JSONB body column (single row)
+            let mut jsonb_builder = JsonbArrayBuilder::with_type(1, DataType::Jsonb);
             let json_value = Value::from_text(body).map_err(|e| {
                 err(
                     anyhow!(e).context("Failed to parse body"),
                     StatusCode::UNPROCESSABLE_ENTITY,
                 )
             })?;
-
             let jsonb_val = JsonbVal::from(json_value);
-            builder.append(Some(jsonb_val.as_scalar_ref()));
+            jsonb_builder.append(Some(jsonb_val.as_scalar_ref()));
+            columns.push(jsonb_builder.finish().into_ref());
 
-            Ok(DataChunk::new(vec![builder.finish().into_ref()], 1))
+            // Build VARCHAR columns for each INCLUDE header
+            for hdr in header_columns {
+                let mut varchar_builder = Utf8ArrayBuilder::new(1);
+                let value = headers.get(&hdr.header_name).and_then(|v| v.to_str().ok());
+                varchar_builder.append(value);
+                columns.push(varchar_builder.finish().into_ref());
+            }
+
+            Ok(DataChunk::new(columns, 1))
         } else {
             let rows: Vec<_> = body.split(|&b| b == b'\n').collect();
+            let num_rows = rows.len();
 
+            // Build JSONB body column (multiple rows)
+            let mut jsonb_builder = JsonbArrayBuilder::with_type(num_rows, DataType::Jsonb);
             for row in &rows {
                 let json_value = Value::from_text(row).map_err(|e| {
                     err(
@@ -164,22 +213,30 @@ pub(super) mod handlers {
                     )
                 })?;
                 let jsonb_val = JsonbVal::from(json_value);
+                jsonb_builder.append(Some(jsonb_val.as_scalar_ref()));
+            }
+            columns.push(jsonb_builder.finish().into_ref());
 
-                builder.append(Some(jsonb_val.as_scalar_ref()));
+            // Build VARCHAR columns for each INCLUDE header
+            // (same value replicated across all rows — headers are per-request)
+            for hdr in header_columns {
+                let mut varchar_builder = Utf8ArrayBuilder::new(num_rows);
+                let value = headers.get(&hdr.header_name).and_then(|v| v.to_str().ok());
+                for _ in 0..num_rows {
+                    varchar_builder.append(value);
+                }
+                columns.push(varchar_builder.finish().into_ref());
             }
 
-            Ok(DataChunk::new(
-                vec![builder.finish().into_ref()],
-                rows.len(),
-            ))
+            Ok(DataChunk::new(columns, num_rows))
         }
     }
 
     async fn acquire_table_info(
         request_id: u32,
-        database: &String,
-        schema: &String,
-        table: &String,
+        database: &str,
+        schema: &str,
+        table: &str,
     ) -> Result<FastInsertContext> {
         let session_mgr = SESSION_MANAGER
             .get()
@@ -188,12 +245,12 @@ pub(super) mod handlers {
         let frontend_env = session_mgr.env();
 
         let search_path = SearchPath::default();
-        let schema_path = SchemaPath::new(Some(schema.as_str()), &search_path, USER);
+        let schema_path = SchemaPath::new(Some(schema), &search_path, USER);
 
-        let (webhook_source_info, table_id, version_id, row_id_index) = {
+        let table_meta = {
             let reader = frontend_env.catalog_reader().read_guard();
             let (table_catalog, _schema) = reader
-                .get_any_table_by_name(database.as_str(), schema_path, table)
+                .get_any_table_by_name(database, schema_path, table)
                 .map_err(|e| err(e, StatusCode::NOT_FOUND))?;
 
             let webhook_source_info = table_catalog
@@ -206,31 +263,87 @@ pub(super) mod handlers {
                     )
                 })?
                 .clone();
-            (
+
+            // Build column_indices and header_columns from the catalog.
+            // The DataChunk will have: [body_jsonb, header_col_0, header_col_1, ...]
+            // and column_indices maps each chunk position to its table column index.
+            let mut body_col_idx: Option<u32> = None;
+            let mut hdr_col_indices = Vec::new();
+            let mut hdr_cols = Vec::new();
+
+            for (table_col_idx, col) in table_catalog.columns().iter().enumerate() {
+                if col.is_hidden() {
+                    continue;
+                }
+                match &col.column_desc.additional_column.column_type {
+                    Some(AdditionalColumnType::HeaderInner(header_inner)) => {
+                        hdr_col_indices.push(table_col_idx as u32);
+                        hdr_cols.push(HeaderColumnInfo {
+                            header_name: header_inner.inner_field.clone(),
+                        });
+                    }
+                    None => {
+                        // User-defined column (the body JSONB column).
+                        // Webhook tables must have exactly one user-defined body column.
+                        if body_col_idx.is_some() {
+                            return Err(err(
+                                anyhow!(
+                                    "Webhook table `{}` has multiple user-defined columns; expected exactly one body column",
+                                    table
+                                ),
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                            ));
+                        }
+                        body_col_idx = Some(table_col_idx as u32);
+                    }
+                    _ => {
+                        // Other additional column types — skip for now.
+                    }
+                }
+            }
+
+            let body_col_idx = body_col_idx.ok_or_else(|| {
+                err(
+                    anyhow!(
+                        "Webhook table `{}` has no visible body column",
+                        table
+                    ),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                )
+            })?;
+
+            // column_indices layout: [body, header_0, header_1, ...]
+            let mut col_indices = Vec::with_capacity(1 + hdr_col_indices.len());
+            col_indices.push(body_col_idx);
+            col_indices.extend(hdr_col_indices);
+
+            WebhookTableMeta {
                 webhook_source_info,
-                table_catalog.id(),
-                table_catalog.version_id().expect("table must be versioned"),
-                table_catalog.row_id_index.map(|idx| idx as u32),
-            )
+                table_id: table_catalog.id(),
+                version_id: table_catalog.version_id().expect("table must be versioned"),
+                row_id_index: table_catalog.row_id_index.map(|idx| idx as u32),
+                column_indices: col_indices,
+                header_columns: hdr_cols,
+            }
         };
 
         let fast_insert_request = FastInsertRequest {
-            table_id,
-            table_version_id: version_id,
-            column_indices: vec![0],
+            table_id: table_meta.table_id,
+            table_version_id: table_meta.version_id,
+            column_indices: table_meta.column_indices.clone(),
             // leave the data_chunk empty for now
             data_chunk: None,
-            row_id_index,
+            row_id_index: table_meta.row_id_index,
             request_id,
-            wait_for_persistence: webhook_source_info.wait_for_persistence,
+            wait_for_persistence: table_meta.webhook_source_info.wait_for_persistence,
         };
 
-        let compute_client = choose_fast_insert_client(table_id, frontend_env, request_id)
+        let compute_client = choose_fast_insert_client(table_meta.table_id, frontend_env, request_id)
             .await
             .unwrap();
 
         Ok(FastInsertContext {
-            webhook_source_info,
+            table_meta,
             fast_insert_request,
             compute_client,
         })


### PR DESCRIPTION
## Summary

Extends the existing `INCLUDE header` syntax — already supported for Kafka sources — to webhook sources, resolving #25321.

HTTP webhooks commonly carry meaningful metadata in request headers (event type, source system, upstream timestamp, tenant ID). Currently RisingWave discards the `HeaderMap` after `VALIDATE AS` evaluation, with no path for header values into table rows. This PR wires headers through to `INCLUDE` columns.

### Changes

- Register `webhook` in `COMPATIBLE_ADDITIONAL_COLUMNS` with header support
- Add `is_webhook_connector()` helper to `WithOptions`
- Relax the `INCLUDE` guard in `check_create_table_with_source` for webhook
- Process `INCLUDE` columns via `handle_addition_columns` in the DDL path
- Build dynamic `column_indices` from the table catalog at request time
- Generate multi-column `DataChunk` (JSONB body + VARCHAR header cols)
- NULL for missing headers; case-insensitive lookup via `HeaderMap`
- Add `WebhookTableMeta` struct to replace fragile tuple-based column tracking
- Use `WEBHOOK_CONNECTOR` constant throughout; `&str` params for idiomatic Rust
- E2E tests: basic INCLUDE header, missing-header NULL, INCLUDE+VALIDATE combined, batched INCLUDE, and negative case (unsupported column type)

### Example DDL

```sql
CREATE TABLE events (
    data JSONB
)
INCLUDE header 'x-event-type'      AS event_type      VARCHAR
INCLUDE header 'x-event-timestamp' AS event_timestamp VARCHAR
WITH (connector = 'webhook');
```

`event_type` and `event_timestamp` are populated from the corresponding HTTP request headers on each POST. Missing headers produce NULL.

### Limitations

- Header values are always `VARCHAR` (consistent with webhook's text-oriented design; Kafka returns `bytea`)
- `INCLUDE headers` (all-headers column) is not implemented in this PR

Closes #25321