### PR TITLE
refactor(streaming): replace BatchTable with ReplicatedStateTable in lookup executor

### DIFF
--- a/e2e_test/streaming/delta_join/delta_join_upstream.slt
+++ b/e2e_test/streaming/delta_join/delta_join_upstream.slt
@@ -51,5 +51,46 @@ drop table a;
 statement ok
 drop table b;
 
+# Test non-trivial output indices conversion in delta join. The MV output reorders
+# right-side and left-side columns instead of using the trivial join output order.
+
+statement ok
+create table a (a1 int, a2 int);
+
+statement ok
+create index i_a1 on a(a1);
+
+statement ok
+create table b (b1 int, b2 int);
+
+statement ok
+create index i_b1 on b(b1);
+
+statement ok
+create materialized view v as select b.b2, a.a2, b.b1, a.a1 from a join b on a.a1 = b.b1;
+
+statement ok
+insert into a values (1,2), (1,3);
+
+statement ok
+insert into b values (1,4), (1,5);
+
+query IIII rowsort
+select * from v order by a2, b2;
+----
+4 2 1 1
+4 3 1 1
+5 2 1 1
+5 3 1 1
+
+statement ok
+drop materialized view v;
+
+statement ok
+drop table a;
+
+statement ok
+drop table b;
+
 statement ok
 set rw_streaming_enable_delta_join = false;

--- a/e2e_test/streaming/temporal_join/append_only/nested_loop.slt
+++ b/e2e_test/streaming/temporal_join/append_only/nested_loop.slt
@@ -94,3 +94,36 @@ drop table stream;
 
 statement ok
 drop table version;
+
+# Test non-trivial output indices conversion in nested-loop temporal join. The
+# right stream key `id2` appears after `b2` in the projected right-side output.
+
+statement ok
+create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+
+statement ok
+create table version(id2 int, a2 int, b2 int, primary key (id2));
+
+statement ok
+create materialized view v as select id1, b2, id2 from stream join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 > a2;
+
+statement ok
+insert into version values(1, 12, 122), (2, 10, 102);
+
+statement ok
+insert into stream values(1, 14, 111), (2, 9, 222);
+
+query III rowsort
+select * from v;
+----
+1 102 2
+1 122 1
+
+statement ok
+drop materialized view v;
+
+statement ok
+drop table stream;
+
+statement ok
+drop table version;

--- a/e2e_test/streaming/temporal_join/append_only/temporal_join.slt
+++ b/e2e_test/streaming/temporal_join/append_only/temporal_join.slt
@@ -62,3 +62,36 @@ drop table stream;
 
 statement ok
 drop table version;
+
+# Test non-trivial output indices conversion in hash temporal join. The right
+# stream key `id2` appears after `b2` in the projected right-side output.
+
+statement ok
+create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+
+statement ok
+create table version(id2 int, a2 int, b2 int, primary key (id2));
+
+statement ok
+create materialized view v as select id1, b2, id2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+
+statement ok
+insert into version values(3, 30, 300);
+
+statement ok
+insert into stream values(3, 33, 333), (4, 44, 444);
+
+query III rowsort
+select * from v;
+----
+3 300 3
+4 NULL NULL
+
+statement ok
+drop materialized view v;
+
+statement ok
+drop table stream;
+
+statement ok
+drop table version;

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -670,11 +670,6 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAllRow>
         self
     }
 
-    pub fn with_output_column_ids(mut self, output_column_ids: Vec<ColumnId>) -> Self {
-        self.output_column_ids = Some(output_column_ids);
-        self
-    }
-
     pub fn enable_vnode_key_stats(mut self, enable: bool, config: &StreamingConfig) -> Self {
         self.enable_vnode_key_stats = Some(enable);
         self.enable_state_table_vnode_stats_pruning =
@@ -684,6 +679,15 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAllRow>
 
     pub fn with_metrics(mut self, metrics: StateTableMetrics) -> Self {
         self.metrics = Some(metrics);
+        self
+    }
+}
+
+impl<S: StateStore, SD: ValueRowSerde, PreloadAllRow>
+    StateTableBuilder<S, SD, true, PreloadAllRow>
+{
+    pub fn with_output_column_ids(mut self, output_column_ids: Vec<ColumnId>) -> Self {
+        self.output_column_ids = Some(output_column_ids);
         self
     }
 }
@@ -1065,7 +1069,7 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
         table_desc: &StorageTableDesc,
         store: S,
         vnodes: Option<Arc<Bitmap>>,
-        fragment_id: u32,
+        fragment_id: FragmentId,
     ) -> Self {
         let table_id = table_desc.table_id;
         let table_columns: Vec<ColumnDesc> =
@@ -1107,7 +1111,7 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
             prefix_hint_len: table_desc.read_prefix_len_hint as usize,
             retention_seconds: table_desc.retention_seconds,
             versioned: table_desc.versioned,
-            fragment_id: fragment_id.into(),
+            fragment_id,
             clean_watermark_index: None,
             store,
             vnodes,
@@ -1841,7 +1845,13 @@ where
         Ok(self
             .iter_kv_with_pk_range::<()>(pk_range, vnode, prefetch_options)
             .await?
-            .map_ok(|(_, row)| row))
+            .map_ok(|(_, row)| {
+                if IS_REPLICATED {
+                    row.project(&self.output_indices).into_owned_row()
+                } else {
+                    row
+                }
+            }))
     }
 
     pub async fn iter_keyed_row_with_vnode(
@@ -1854,19 +1864,6 @@ where
             .iter_kv_with_pk_range(pk_range, vnode, prefetch_options)
             .await?
             .map_ok(|(key, row)| KeyedRow::new(TableKey(key), row)))
-    }
-
-    pub async fn iter_with_vnode_and_output_indices(
-        &self,
-        vnode: VirtualNode,
-        pk_range: &(Bound<impl Row>, Bound<impl Row>),
-        prefetch_options: PrefetchOptions,
-    ) -> StreamExecutorResult<impl RowStream<'_>> {
-        assert!(IS_REPLICATED);
-        let stream = self
-            .iter_with_vnode(vnode, pk_range, prefetch_options)
-            .await?;
-        Ok(stream.map(|row| row.map(|row| row.project(&self.output_indices).into_owned_row())))
     }
 }
 
@@ -2069,7 +2066,13 @@ where
     ) -> StreamExecutorResult<impl RowStream<'_>> {
         let stream = self.iter_with_prefix_inner::</* REVERSE */ false, ()>(pk_prefix, sub_range, prefetch_options)
             .await?;
-        Ok(stream.map_ok(|(_, row)| row))
+        Ok(stream.map_ok(|(_, row)| {
+            if IS_REPLICATED {
+                row.project(&self.output_indices).into_owned_row()
+            } else {
+                row
+            }
+        }))
     }
 
     /// This function scans rows from the relational table with specific `prefix` and `sub_range` under the same

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -1580,7 +1580,7 @@ async fn test_replicated_state_table_replication() {
             .await
             .unwrap();
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(iter);
@@ -1648,7 +1648,7 @@ async fn test_replicated_state_table_replication() {
             std::ops::Bound::Unbounded,
         );
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(iter);
@@ -1679,7 +1679,7 @@ async fn test_replicated_state_table_replication() {
         let range_bounds: (Bound<OwnedRow>, Bound<OwnedRow>) =
             (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded);
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(replicated_iter);

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -773,10 +773,10 @@ where
                 vnode = ?vnode,
                 current_pos = ?current_pos,
                 range_bounds = ?range_bounds,
-                "iter_with_vnode_and_output_indices"
+                "iter_with_vnode"
             );
             let vnode_row_iter = upstream_table
-                .iter_with_vnode_and_output_indices(
+                .iter_with_vnode(
                     vnode,
                     &range_bounds,
                     PrefetchOptions::prefetch_for_small_range_scan(),

--- a/src/stream/src/executor/lookup.rs
+++ b/src/stream/src/executor/lookup.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
 mod cache;
 mod sides;
@@ -33,14 +34,14 @@ mod tests;
 ///
 /// The output schema is `| stream columns | arrangement columns |`.
 /// The input is required to be first stream and then arrangement.
-pub struct LookupExecutor<S: StateStore> {
+pub struct LookupExecutor<S: StateStore, SD: ValueRowSerde> {
     ctx: ActorContextRef,
 
     /// the data types of the produced data chunk inside lookup (before reordering)
     chunk_data_types: Vec<DataType>,
 
     /// The join side of the arrangement
-    arrangement: ArrangeJoinSide<S>,
+    arrangement: ArrangeJoinSide<S, SD>,
 
     /// The join side of the stream
     stream: StreamJoinSide,
@@ -75,7 +76,7 @@ pub struct LookupExecutor<S: StateStore> {
 }
 
 #[async_trait]
-impl<S: StateStore> Execute for LookupExecutor<S> {
+impl<S: StateStore, SD: ValueRowSerde> Execute for LookupExecutor<S, SD> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner().boxed()
     }

--- a/src/stream/src/executor/lookup.rs
+++ b/src/stream/src/executor/lookup.rs
@@ -52,9 +52,6 @@ pub struct LookupExecutor<S: StateStore, SD: ValueRowSerde> {
     /// The executor for stream.
     stream_executor: Option<Executor>,
 
-    /// The last received barrier.
-    last_barrier: Option<Barrier>,
-
     /// Information of column reordering
     column_mapping: Vec<usize>,
 

--- a/src/stream/src/executor/lookup/cache.rs
+++ b/src/stream/src/executor/lookup/cache.rs
@@ -70,11 +70,6 @@ impl LookupCache {
         self.data.len()
     }
 
-    /// Clear the cache.
-    pub fn clear(&mut self) {
-        self.data.clear();
-    }
-
     pub fn new(watermark_sequence: AtomicU64Ref, metrics_info: MetricsInfo) -> Self {
         let cache = ManagedLruCache::unbounded(watermark_sequence, metrics_info);
         Self { data: cache }

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -12,21 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Bound;
+
 use itertools::Itertools;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::row::RowExt;
-use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_common_estimate_size::collections::EstimatedVec;
-use risingwave_hummock_sdk::HummockReadEpoch;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 use risingwave_storage::store::PrefetchOptions;
-use risingwave_storage::table::TableIter;
-use risingwave_storage::table::batch_table::BatchTable;
 
 use super::sides::{stream_lookup_arrange_prev_epoch, stream_lookup_arrange_this_epoch};
-use crate::cache::keyed_cache_may_stale;
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::join::builder::JoinStreamChunkBuilder;
 use crate::executor::lookup::LookupExecutor;
 use crate::executor::lookup::cache::LookupCache;
@@ -35,7 +34,7 @@ use crate::executor::monitor::LookupExecutorMetrics;
 use crate::executor::prelude::*;
 
 /// Parameters for [`LookupExecutor`].
-pub struct LookupExecutorParams<S: StateStore> {
+pub struct LookupExecutorParams<S: StateStore, SD: ValueRowSerde> {
     pub ctx: ActorContextRef,
     pub info: ExecutorInfo,
 
@@ -89,15 +88,15 @@ pub struct LookupExecutorParams<S: StateStore> {
     /// The join keys on the arrangement side.
     pub arrange_join_key_indices: Vec<usize>,
 
-    pub batch_table: BatchTable<S>,
+    pub state_table: ReplicatedStateTable<S, SD>,
 
     pub watermark_epoch: AtomicU64Ref,
 
     pub chunk_size: usize,
 }
 
-impl<S: StateStore> LookupExecutor<S> {
-    pub fn new(params: LookupExecutorParams<S>) -> Self {
+impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
+    pub fn new(params: LookupExecutorParams<S, SD>) -> Self {
         let LookupExecutorParams {
             ctx,
             info,
@@ -109,7 +108,7 @@ impl<S: StateStore> LookupExecutor<S> {
             stream_join_key_indices,
             arrange_join_key_indices,
             column_mapping,
-            batch_table: storage_table,
+            state_table: storage_table,
             watermark_epoch,
             chunk_size,
         } = params;
@@ -209,7 +208,7 @@ impl<S: StateStore> LookupExecutor<S> {
                 order_rules: arrangement_order_rules,
                 key_indices: arrange_join_key_indices,
                 use_current_epoch,
-                batch_table: storage_table,
+                state_table: storage_table,
             },
             column_mapping,
             key_indices_mapping,
@@ -240,7 +239,7 @@ impl<S: StateStore> LookupExecutor<S> {
         };
 
         let metrics = self.ctx.streaming_metrics.new_lookup_executor_metrics(
-            self.arrangement.batch_table.table_id(),
+            self.arrangement.state_table.table_id(),
             self.ctx.id,
             self.ctx.fragment_id,
         );
@@ -257,24 +256,66 @@ impl<S: StateStore> LookupExecutor<S> {
             .map(|x| self.chunk_data_types[*x].clone())
             .collect_vec();
 
+        let mut wait_first_barrier = true;
+        let mut wait_first_arrange_ready = false;
+
         #[for_await]
         for msg in input {
             let msg = msg?;
             self.lookup_cache.evict();
             match msg {
                 ArrangeMessage::Barrier(barrier) => {
-                    self.process_barrier(&barrier);
+                    if wait_first_barrier {
+                        wait_first_barrier = false;
+                        // Must yield the barrier BEFORE calling init_epoch, because
+                        // init_epoch calls wait_for_epoch(epoch.prev) which blocks
+                        // until the previous epoch is committed — and that can only
+                        // happen after all actors yield the barrier.
+                        yield Message::Barrier(barrier.clone());
+                        self.arrangement
+                            .state_table
+                            .init_epoch(barrier.epoch)
+                            .await?;
+                        self.last_barrier = Some(barrier);
 
-                    if self.arrangement.use_current_epoch {
-                        // When lookup this epoch, stream side barrier always come after arrangement
-                        // ready, so we can forward barrier now.
-                        yield Message::Barrier(barrier);
+                        if !self.arrangement.use_current_epoch {
+                            // For !use_current_epoch, the barrier would normally be
+                            // yielded in the ArrangeReady handler. Since we already
+                            // yielded it here, skip the first ArrangeReady yield.
+                            wait_first_arrange_ready = true;
+                        }
+                    } else {
+                        let post_commit =
+                            self.arrangement.state_table.commit(barrier.epoch).await?;
+
+                        if self.arrangement.use_current_epoch {
+                            yield Message::Barrier(barrier.clone());
+                        }
+
+                        let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
+                        if let Some((_, true)) =
+                            post_commit.post_yield_barrier(update_vnode_bitmap).await?
+                        {
+                            self.lookup_cache.clear();
+                        }
+
+                        self.last_barrier = Some(barrier);
                     }
                 }
                 ArrangeMessage::ArrangeReady(arrangement_chunks, barrier) => {
-                    // The arrangement is ready, and we will receive a bunch of stream messages for
-                    // the next poll.
-                    // TODO: apply chunk as soon as we receive them, instead of batching.
+                    for chunk in &arrangement_chunks {
+                        self.arrangement.state_table.write_chunk(chunk.clone());
+                    }
+
+                    // For `!use_current_epoch`, the cache was populated during
+                    // Stream processing by reading from the shared state store,
+                    // which already contains data committed by the upstream
+                    // MaterializeExecutor. `apply_batch` would attempt to insert
+                    // the same rows, causing inconsistency. Clear the cache to
+                    // avoid this — it will be repopulated on the next lookup.
+                    if !self.arrangement.use_current_epoch {
+                        self.lookup_cache.clear();
+                    }
 
                     for chunk in arrangement_chunks {
                         self.lookup_cache
@@ -282,9 +323,13 @@ impl<S: StateStore> LookupExecutor<S> {
                     }
 
                     if !self.arrangement.use_current_epoch {
-                        // When look prev epoch, arrange ready will always come after stream
-                        // barrier. So we yield barrier now.
-                        yield Message::Barrier(barrier);
+                        if wait_first_arrange_ready {
+                            // First ArrangeReady after init: barrier was already
+                            // yielded in the first-barrier handler above.
+                            wait_first_arrange_ready = false;
+                        } else {
+                            yield Message::Barrier(barrier);
+                        }
                     }
                 }
                 ArrangeMessage::Stream(chunk) => {
@@ -299,14 +344,7 @@ impl<S: StateStore> LookupExecutor<S> {
                     );
 
                     for (op, row) in ops.iter().zip_eq_debug(chunk.rows()) {
-                        for matched_row in self
-                            .lookup_one_row(
-                                &row,
-                                self.last_barrier.as_ref().unwrap().epoch,
-                                &metrics,
-                            )
-                            .await?
-                        {
+                        for matched_row in self.lookup_one_row(&row, &metrics).await? {
                             tracing::debug!(target: "events::stream::lookup::put", "{:?} {:?}", row, matched_row);
 
                             if let Some(chunk) = builder.append_row(*op, row, &matched_row) {
@@ -324,29 +362,10 @@ impl<S: StateStore> LookupExecutor<S> {
         }
     }
 
-    /// Process the barrier and apply changes if necessary.
-    fn process_barrier(&mut self, barrier: &Barrier) {
-        if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {
-            let previous_vnode_bitmap = self
-                .arrangement
-                .batch_table
-                .update_vnode_bitmap(vnode_bitmap.clone());
-
-            // Manipulate the cache if necessary.
-            if keyed_cache_may_stale(&previous_vnode_bitmap, &vnode_bitmap) {
-                self.lookup_cache.clear();
-            }
-        }
-
-        // Use the new stream barrier epoch as new cache epoch
-        self.last_barrier = Some(barrier.clone());
-    }
-
-    /// Lookup all rows corresponding to a join key in shared buffer.
+    /// Lookup all rows corresponding to a join key in the replicated state table.
     async fn lookup_one_row(
         &mut self,
         stream_row: &RowRef<'_>,
-        epoch_pair: EpochPair,
         metrics: &LookupExecutorMetrics,
     ) -> StreamExecutorResult<Vec<OwnedRow>> {
         // stream_row is the row from stream side, we need to transform into the correct order of
@@ -366,39 +385,23 @@ impl<S: StateStore> LookupExecutor<S> {
         tracing::debug!(target: "events::stream::lookup::lookup_row", "{:?}", lookup_row);
 
         let mut all_rows = EstimatedVec::new();
-        // Drop the stream.
         {
-            let all_data_iter = match self.arrangement.use_current_epoch {
-                true => {
-                    self.arrangement
-                        .batch_table
-                        .batch_iter_with_pk_bounds(
-                            HummockReadEpoch::NoWait(epoch_pair.curr),
-                            &lookup_row,
-                            ..,
-                            false,
-                            PrefetchOptions::default(),
-                        )
-                        .await?
-                }
-                false => {
-                    self.arrangement
-                        .batch_table
-                        .batch_iter_with_pk_bounds(
-                            HummockReadEpoch::NoWait(epoch_pair.prev),
-                            &lookup_row,
-                            ..,
-                            false,
-                            PrefetchOptions::default(),
-                        )
-                        .await?
-                }
-            };
+            let all_data_iter = self
+                .arrangement
+                .state_table
+                .iter_with_prefix(
+                    &lookup_row,
+                    &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
+                    PrefetchOptions::default(),
+                )
+                .await?;
 
+            let output_indices = &self.arrangement.state_table.output_indices;
             pin_mut!(all_data_iter);
-            while let Some(row) = all_data_iter.next_row().await? {
-                // Only need value (include storage pk).
-                all_rows.push(row);
+            while let Some(row) = all_data_iter.next().await {
+                // iter_with_prefix returns all value columns from the serde;
+                // project to output_indices to match arrangement_col_descs.
+                all_rows.push(row?.project(output_indices).into_owned_row());
             }
         }
 

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -14,6 +14,7 @@
 
 use std::ops::Bound;
 
+use futures::TryStreamExt;
 use itertools::Itertools;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::row::RowExt;
@@ -193,7 +194,6 @@ impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
         Self {
             ctx,
             chunk_data_types,
-            last_barrier: None,
             stream_executor: Some(stream),
             arrangement_executor: Some(arrangement),
             stream: StreamJoinSide {
@@ -224,18 +224,22 @@ impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
     /// If we can use `async_stream` to write this part, things could be easier.
     #[try_stream(ok = Message, error = StreamExecutorError)]
     pub async fn execute_inner(mut self: Box<Self>) {
+        let mut stream_input = self.stream_executor.take().unwrap().execute();
+        let mut arrangement_input = self.arrangement_executor.take().unwrap().execute();
+
+        let first_barrier = expect_first_barrier(&mut stream_input).await?;
+        let arrangement_first_barrier = expect_first_barrier(&mut arrangement_input).await?;
+        if first_barrier.epoch != arrangement_first_barrier.epoch {
+            return Err(StreamExecutorError::align_barrier(
+                first_barrier.clone(),
+                arrangement_first_barrier,
+            ));
+        }
+
         let input = if self.arrangement.use_current_epoch {
-            stream_lookup_arrange_this_epoch(
-                self.stream_executor.take().unwrap(),
-                self.arrangement_executor.take().unwrap(),
-            )
-            .boxed()
+            stream_lookup_arrange_this_epoch(stream_input, arrangement_input).boxed()
         } else {
-            stream_lookup_arrange_prev_epoch(
-                self.stream_executor.take().unwrap(),
-                self.arrangement_executor.take().unwrap(),
-            )
-            .boxed()
+            stream_lookup_arrange_prev_epoch(stream_input, arrangement_input).boxed()
         };
 
         let metrics = self.ctx.streaming_metrics.new_lookup_executor_metrics(
@@ -256,8 +260,14 @@ impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
             .map(|x| self.chunk_data_types[*x].clone())
             .collect_vec();
 
-        let mut wait_first_barrier = true;
-        let mut wait_first_arrange_ready = false;
+        // Yield the barrier before init_epoch: init_epoch calls wait_for_epoch(epoch.prev)
+        // which blocks until the previous epoch is committed, and that requires all actors
+        // to have already forwarded this barrier downstream.
+        yield Message::Barrier(first_barrier.clone());
+        self.arrangement
+            .state_table
+            .init_epoch(first_barrier.epoch)
+            .await?;
 
         #[for_await]
         for msg in input {
@@ -265,56 +275,24 @@ impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
             self.lookup_cache.evict();
             match msg {
                 ArrangeMessage::Barrier(barrier) => {
-                    if wait_first_barrier {
-                        wait_first_barrier = false;
-                        // Must yield the barrier BEFORE calling init_epoch, because
-                        // init_epoch calls wait_for_epoch(epoch.prev) which blocks
-                        // until the previous epoch is committed — and that can only
-                        // happen after all actors yield the barrier.
+                    barrier.assume_no_update_vnode_bitmap(self.ctx.id)?;
+                    self.arrangement
+                        .state_table
+                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                        .await?;
+
+                    if self.arrangement.use_current_epoch {
+                        // When lookup this epoch, stream side barrier always come after arrangement
+                        // ready, so we can forward barrier now.
                         yield Message::Barrier(barrier.clone());
-                        self.arrangement
-                            .state_table
-                            .init_epoch(barrier.epoch)
-                            .await?;
-                        self.last_barrier = Some(barrier);
-
-                        if !self.arrangement.use_current_epoch {
-                            // For !use_current_epoch, the barrier would normally be
-                            // yielded in the ArrangeReady handler. Since we already
-                            // yielded it here, skip the first ArrangeReady yield.
-                            wait_first_arrange_ready = true;
-                        }
-                    } else {
-                        let post_commit =
-                            self.arrangement.state_table.commit(barrier.epoch).await?;
-
-                        if self.arrangement.use_current_epoch {
-                            yield Message::Barrier(barrier.clone());
-                        }
-
-                        let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
-                        if let Some((_, true)) =
-                            post_commit.post_yield_barrier(update_vnode_bitmap).await?
-                        {
-                            self.lookup_cache.clear();
-                        }
-
-                        self.last_barrier = Some(barrier);
                     }
                 }
                 ArrangeMessage::ArrangeReady(arrangement_chunks, barrier) => {
+                    // The arrangement is ready, and we will receive a bunch of stream messages for
+                    // the next poll.
+                    // TODO: apply chunk as soon as we receive them, instead of batching.
                     for chunk in &arrangement_chunks {
                         self.arrangement.state_table.write_chunk(chunk.clone());
-                    }
-
-                    // For `!use_current_epoch`, the cache was populated during
-                    // Stream processing by reading from the shared state store,
-                    // which already contains data committed by the upstream
-                    // MaterializeExecutor. `apply_batch` would attempt to insert
-                    // the same rows, causing inconsistency. Clear the cache to
-                    // avoid this — it will be repopulated on the next lookup.
-                    if !self.arrangement.use_current_epoch {
-                        self.lookup_cache.clear();
                     }
 
                     for chunk in arrangement_chunks {
@@ -323,13 +301,9 @@ impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
                     }
 
                     if !self.arrangement.use_current_epoch {
-                        if wait_first_arrange_ready {
-                            // First ArrangeReady after init: barrier was already
-                            // yielded in the first-barrier handler above.
-                            wait_first_arrange_ready = false;
-                        } else {
-                            yield Message::Barrier(barrier);
-                        }
+                        // When look prev epoch, arrange ready will always come after stream
+                        // barrier. So we yield barrier now.
+                        yield Message::Barrier(barrier);
                     }
                 }
                 ArrangeMessage::Stream(chunk) => {
@@ -396,12 +370,9 @@ impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
                 )
                 .await?;
 
-            let output_indices = &self.arrangement.state_table.output_indices;
             pin_mut!(all_data_iter);
-            while let Some(row) = all_data_iter.next().await {
-                // iter_with_prefix returns all value columns from the serde;
-                // project to output_indices to match arrangement_col_descs.
-                all_rows.push(row?.project(output_indices).into_owned_row());
+            while let Some(row) = all_data_iter.try_next().await? {
+                all_rows.push(row);
             }
         }
 

--- a/src/stream/src/executor/lookup/sides.rs
+++ b/src/stream/src/executor/lookup/sides.rs
@@ -25,8 +25,9 @@ use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_storage::StateStore;
-use risingwave_storage::table::batch_table::BatchTable;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
+use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::error::StreamExecutorError;
 use crate::executor::{Barrier, BoxedMessageStream, Executor, Message, MessageStream};
 
@@ -53,7 +54,7 @@ impl std::fmt::Debug for StreamJoinSide {
 }
 
 /// Join side of Arrange Executor's stream
-pub(crate) struct ArrangeJoinSide<S: StateStore> {
+pub(crate) struct ArrangeJoinSide<S: StateStore, SD: ValueRowSerde> {
     /// The primary key indices of this side, used for state store
     pub pk_indices: Vec<usize>,
 
@@ -76,7 +77,7 @@ pub(crate) struct ArrangeJoinSide<S: StateStore> {
     /// Whether to join with the arrangement of the current epoch
     pub use_current_epoch: bool,
 
-    pub batch_table: BatchTable<S>,
+    pub state_table: ReplicatedStateTable<S, SD>,
 }
 
 /// Message from the `arrange_join_stream`.
@@ -390,7 +391,7 @@ pub async fn stream_lookup_arrange_this_epoch(stream: Executor, arrangement: Exe
     }
 }
 
-impl<S: StateStore> std::fmt::Debug for ArrangeJoinSide<S> {
+impl<S: StateStore, SD: ValueRowSerde> std::fmt::Debug for ArrangeJoinSide<S, SD> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ArrangeJoinSide")
             .field("pk_indices", &self.pk_indices)

--- a/src/stream/src/executor/lookup/sides.rs
+++ b/src/stream/src/executor/lookup/sides.rs
@@ -29,7 +29,7 @@ use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
 use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::error::StreamExecutorError;
-use crate::executor::{Barrier, BoxedMessageStream, Executor, Message, MessageStream};
+use crate::executor::{Barrier, BoxedMessageStream, Message, MessageStream};
 
 /// Join side of Lookup Executor's stream
 pub(crate) struct StreamJoinSide {
@@ -212,8 +212,11 @@ pub async fn align_barrier(mut left: BoxedMessageStream, mut right: BoxedMessage
 /// * Barrier (prev = `[2`], current = `[3`])
 /// * `[Msg`] Arrangement (batch)
 #[try_stream(ok = ArrangeMessage, error = StreamExecutorError)]
-pub async fn stream_lookup_arrange_prev_epoch(stream: Executor, arrangement: Executor) {
-    let mut input = pin!(align_barrier(stream.execute(), arrangement.execute()));
+pub async fn stream_lookup_arrange_prev_epoch(
+    stream: BoxedMessageStream,
+    arrangement: BoxedMessageStream,
+) {
+    let mut input = pin!(align_barrier(stream, arrangement));
     let mut arrange_buf = vec![];
     let mut stream_side_end = false;
 
@@ -293,8 +296,11 @@ pub async fn stream_lookup_arrange_prev_epoch(stream: Executor, arrangement: Exe
 /// * `[Do`] lookup `a` in arrangement of epoch `[2`] (current epoch)
 /// * Barrier (prev = `[2`], current = `[3`])
 #[try_stream(ok = ArrangeMessage, error = StreamExecutorError)]
-pub async fn stream_lookup_arrange_this_epoch(stream: Executor, arrangement: Executor) {
-    let mut input = pin!(align_barrier(stream.execute(), arrangement.execute()));
+pub async fn stream_lookup_arrange_this_epoch(
+    stream: BoxedMessageStream,
+    arrangement: BoxedMessageStream,
+) {
+    let mut input = pin!(align_barrier(stream, arrangement));
     let mut stream_buf = vec![];
     let mut arrange_buf = vec![];
 
@@ -437,7 +443,8 @@ mod tests {
             .stop_on_finish(false)
             .into_executor(schema, vec![1]);
 
-        let mut stream = stream_lookup_arrange_this_epoch(source_l, source_r).boxed();
+        let mut stream =
+            stream_lookup_arrange_this_epoch(source_l.execute(), source_r.execute()).boxed();
 
         // Simulate recovery test
         drop(tx_r);

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -24,9 +24,10 @@ use risingwave_common::catalog::{ColumnDesc, ConflictBehavior, Field, Schema, Ta
 use risingwave_common::types::DataType;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
+use risingwave_common::util::value_encoding::BasicSerde;
 use risingwave_storage::memory::MemoryStateStore;
-use risingwave_storage::table::batch_table::BatchTable;
 
+use crate::common::table::state_table::{StateTableBuilder, StateTableOpConsistencyLevel};
 use crate::executor::lookup::LookupExecutor;
 use crate::executor::lookup::impl_::LookupExecutorParams;
 use crate::executor::test_utils::*;
@@ -182,6 +183,46 @@ fn check_chunk_eq(chunk1: &StreamChunk, chunk2: &StreamChunk) {
     assert_eq!(format!("{:?}", chunk1), format!("{:?}", chunk2));
 }
 
+fn create_storage_table_desc(table_id: TableId) -> risingwave_pb::plan_common::StorageTableDesc {
+    let col_descs = arrangement_col_descs();
+    let order_rules = arrangement_col_arrange_rules();
+    risingwave_pb::plan_common::StorageTableDesc {
+        table_id,
+        columns: col_descs.iter().map(|c| c.to_protobuf()).collect(),
+        pk: order_rules.iter().map(|o| o.to_protobuf()).collect(),
+        dist_key_in_pk_indices: vec![],
+        value_indices: vec![0, 1],
+        read_prefix_len_hint: 0,
+        versioned: false,
+        stream_key: vec![1, 0],
+        vnode_col_idx_in_pk: None,
+        retention_seconds: None,
+        maybe_vnode_count: None,
+    }
+}
+
+async fn create_replicated_state_table(
+    store: MemoryStateStore,
+    table_id: TableId,
+) -> crate::common::table::state_table::ReplicatedStateTable<MemoryStateStore, BasicSerde> {
+    let table_desc = create_storage_table_desc(table_id);
+    let column_ids = arrangement_col_descs()
+        .iter()
+        .map(|c| c.column_id)
+        .collect_vec();
+    StateTableBuilder::<_, BasicSerde, true, _>::new_from_storage_table_desc(
+        &table_desc,
+        store,
+        None,
+        0,
+    )
+    .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+    .with_output_column_ids(column_ids)
+    .forbid_preload_all_rows()
+    .build()
+    .await
+}
+
 #[tokio::test]
 async fn test_lookup_this_epoch() {
     // TODO: memory state store doesn't support read epoch yet, so it is possible that this test
@@ -212,17 +253,7 @@ async fn test_lookup_this_epoch() {
         stream_join_key_indices: vec![0],
         arrange_join_key_indices: vec![1],
         column_mapping: vec![2, 3, 0, 1],
-        batch_table: BatchTable::for_test(
-            store.clone(),
-            table_id,
-            arrangement_col_descs(),
-            arrangement_col_arrange_rules()
-                .iter()
-                .map(|x| x.order_type)
-                .collect_vec(),
-            vec![1, 0],
-            vec![0, 1],
-        ),
+        state_table: create_replicated_state_table(store.clone(), table_id).await,
         watermark_epoch: Arc::new(AtomicU64::new(0)),
         chunk_size: 1024,
     }));
@@ -287,39 +318,44 @@ async fn test_lookup_last_epoch() {
         stream_join_key_indices: vec![0],
         arrange_join_key_indices: vec![1],
         column_mapping: vec![0, 1, 2, 3],
-        batch_table: BatchTable::for_test(
-            store.clone(),
-            table_id,
-            arrangement_col_descs(),
-            arrangement_col_arrange_rules()
-                .iter()
-                .map(|x| x.order_type)
-                .collect_vec(),
-            vec![1, 0],
-            vec![0, 1],
-        ),
+        state_table: create_replicated_state_table(store.clone(), table_id).await,
         watermark_epoch: Arc::new(AtomicU64::new(0)),
         chunk_size: 1024,
     }));
     let mut lookup_executor = lookup_executor.execute();
 
     let mut msgs = vec![];
+    next_msg(&mut msgs, &mut lookup_executor).await;
+    next_msg(&mut msgs, &mut lookup_executor).await;
+    next_msg(&mut msgs, &mut lookup_executor).await;
+    next_msg(&mut msgs, &mut lookup_executor).await;
+    next_msg(&mut msgs, &mut lookup_executor).await;
 
-    next_msg(&mut msgs, &mut lookup_executor).await;
-    next_msg(&mut msgs, &mut lookup_executor).await;
-    next_msg(&mut msgs, &mut lookup_executor).await;
-    next_msg(&mut msgs, &mut lookup_executor).await;
-
-    assert_eq!(msgs.len(), 4);
+    // NOTE: With MemoryStateStore (shared state, no epoch isolation), the lookup
+    // in "prev epoch" mode sees MaterializeExecutor's committed data immediately
+    // because MemoryStateStore is a shared-everything store. In production Hummock,
+    // each LocalHummockStorage has isolated staging, so prev-epoch lookup would not
+    // see the current epoch's arrangement data. The test expectations below reflect
+    // MemoryStateStore behavior.
+    assert_eq!(msgs.len(), 5);
     assert_matches!(msgs[0], Message::Barrier(_));
-    assert_matches!(msgs[1], Message::Barrier(_));
-    assert_matches!(msgs[3], Message::Barrier(_));
+    assert_matches!(msgs[2], Message::Barrier(_));
+    assert_matches!(msgs[4], Message::Barrier(_));
 
-    let chunk2 = msgs[2].as_chunk().unwrap();
+    let chunk1 = msgs[1].as_chunk().unwrap();
+    let expected_chunk1 = StreamChunk::from_pretty(
+        " I I    I I
+        + 6 1 2333 6
+        + 6 1 2334 6",
+    );
+    check_chunk_eq(chunk1, &expected_chunk1);
+
+    let chunk2 = msgs[3].as_chunk().unwrap();
     let expected_chunk2 = StreamChunk::from_pretty(
         " I I    I I
         - 6 1 2333 6
-        - 6 1 2334 6",
+        - 6 1 2334 6
+        - 6 1 2335 6",
     );
     check_chunk_eq(chunk2, &expected_chunk2);
 }

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
@@ -25,7 +26,9 @@ use risingwave_common::types::DataType;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_common::util::value_encoding::BasicSerde;
-use risingwave_storage::memory::MemoryStateStore;
+use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
+use risingwave_storage::StateStore;
+use risingwave_storage::hummock::HummockStorage;
 
 use crate::common::table::state_table::{StateTableBuilder, StateTableOpConsistencyLevel};
 use crate::executor::lookup::LookupExecutor;
@@ -70,7 +73,7 @@ fn arrangement_col_arrange_rules_join_key() -> Vec<ColumnOrder> {
 /// | +  | 2337  | 8    | 3       |
 /// | -  | 2333  | 6    | 3       |
 /// | b  |       |      | 3 -> 4  |
-async fn create_arrangement(table_id: TableId, memory_state_store: MemoryStateStore) -> Executor {
+async fn create_arrangement<S: StateStore>(table_id: TableId, store: S) -> Executor {
     // Two columns of int32 type, the second column is arrange key.
     let columns = arrangement_col_descs();
 
@@ -118,7 +121,7 @@ async fn create_arrangement(table_id: TableId, memory_state_store: MemoryStateSt
         ),
         MaterializeExecutor::for_test(
             source,
-            memory_state_store,
+            store,
             table_id,
             arrangement_col_arrange_rules(),
             column_ids,
@@ -201,10 +204,10 @@ fn create_storage_table_desc(table_id: TableId) -> risingwave_pb::plan_common::S
     }
 }
 
-async fn create_replicated_state_table(
-    store: MemoryStateStore,
+async fn create_replicated_state_table<S: StateStore>(
+    store: S,
     table_id: TableId,
-) -> crate::common::table::state_table::ReplicatedStateTable<MemoryStateStore, BasicSerde> {
+) -> crate::common::table::state_table::ReplicatedStateTable<S, BasicSerde> {
     let table_desc = create_storage_table_desc(table_id);
     let column_ids = arrangement_col_descs()
         .iter()
@@ -214,7 +217,7 @@ async fn create_replicated_state_table(
         &table_desc,
         store,
         None,
-        0,
+        0.into(),
     )
     .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
     .with_output_column_ids(column_ids)
@@ -223,12 +226,21 @@ async fn create_replicated_state_table(
     .await
 }
 
+async fn prepare_hummock_store(table_id: TableId) -> HummockStorage {
+    let test_env = prepare_hummock_test_env().await;
+    test_env.register_table_id(table_id).await;
+    // Commit the initial epoch so that init_epoch's wait_for_epoch(prev) returns immediately.
+    test_env
+        .storage
+        .start_epoch(test_epoch(1), HashSet::from_iter([table_id]));
+    test_env.commit_epoch(test_epoch(1)).await;
+    test_env.storage
+}
+
 #[tokio::test]
 async fn test_lookup_this_epoch() {
-    // TODO: memory state store doesn't support read epoch yet, so it is possible that this test
-    // fails because read epoch doesn't take effect in memory state store.
-    let store = MemoryStateStore::new();
     let table_id = TableId::new(1);
+    let store = prepare_hummock_store(table_id).await;
     let arrangement = create_arrangement(table_id, store.clone()).await;
     let stream = create_source();
     let info = ExecutorInfo::for_test(
@@ -253,7 +265,7 @@ async fn test_lookup_this_epoch() {
         stream_join_key_indices: vec![0],
         arrange_join_key_indices: vec![1],
         column_mapping: vec![2, 3, 0, 1],
-        state_table: create_replicated_state_table(store.clone(), table_id).await,
+        state_table: create_replicated_state_table(store, table_id).await,
         watermark_epoch: Arc::new(AtomicU64::new(0)),
         chunk_size: 1024,
     }));
@@ -292,8 +304,8 @@ async fn test_lookup_this_epoch() {
 
 #[tokio::test]
 async fn test_lookup_last_epoch() {
-    let store = MemoryStateStore::new();
     let table_id = TableId::new(1);
+    let store = prepare_hummock_store(table_id).await;
     let arrangement = create_arrangement(table_id, store.clone()).await;
     let stream = create_source();
     let info = ExecutorInfo::for_test(
@@ -318,7 +330,7 @@ async fn test_lookup_last_epoch() {
         stream_join_key_indices: vec![0],
         arrange_join_key_indices: vec![1],
         column_mapping: vec![0, 1, 2, 3],
-        state_table: create_replicated_state_table(store.clone(), table_id).await,
+        state_table: create_replicated_state_table(store, table_id).await,
         watermark_epoch: Arc::new(AtomicU64::new(0)),
         chunk_size: 1024,
     }));
@@ -329,33 +341,21 @@ async fn test_lookup_last_epoch() {
     next_msg(&mut msgs, &mut lookup_executor).await;
     next_msg(&mut msgs, &mut lookup_executor).await;
     next_msg(&mut msgs, &mut lookup_executor).await;
-    next_msg(&mut msgs, &mut lookup_executor).await;
 
-    // NOTE: With MemoryStateStore (shared state, no epoch isolation), the lookup
-    // in "prev epoch" mode sees MaterializeExecutor's committed data immediately
-    // because MemoryStateStore is a shared-everything store. In production Hummock,
-    // each LocalHummockStorage has isolated staging, so prev-epoch lookup would not
-    // see the current epoch's arrangement data. The test expectations below reflect
-    // MemoryStateStore behavior.
-    assert_eq!(msgs.len(), 5);
+    // With HummockStateStore, the lookup table is isolated from the arrangement's store.
+    // Stream chunks in epoch 1 see no arrangement data (the lookup table is empty until
+    // the first ArrangeReady writes data). Stream chunks in epoch 2 see arrangement
+    // data replicated from epoch 1, matching the expected prev-epoch semantics.
+    assert_eq!(msgs.len(), 4);
     assert_matches!(msgs[0], Message::Barrier(_));
-    assert_matches!(msgs[2], Message::Barrier(_));
-    assert_matches!(msgs[4], Message::Barrier(_));
+    assert_matches!(msgs[1], Message::Barrier(_));
+    assert_matches!(msgs[3], Message::Barrier(_));
 
-    let chunk1 = msgs[1].as_chunk().unwrap();
-    let expected_chunk1 = StreamChunk::from_pretty(
-        " I I    I I
-        + 6 1 2333 6
-        + 6 1 2334 6",
-    );
-    check_chunk_eq(chunk1, &expected_chunk1);
-
-    let chunk2 = msgs[3].as_chunk().unwrap();
+    let chunk2 = msgs[2].as_chunk().unwrap();
     let expected_chunk2 = StreamChunk::from_pretty(
         " I I    I I
         - 6 1 2333 6
-        - 6 1 2334 6
-        - 6 1 2335 6",
+        - 6 1 2334 6",
     );
     check_chunk_eq(chunk2, &expected_chunk2);
 }

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -234,6 +234,11 @@ async fn prepare_hummock_store(table_id: TableId) -> HummockStorage {
         .storage
         .start_epoch(test_epoch(1), HashSet::from_iter([table_id]));
     test_env.commit_epoch(test_epoch(1)).await;
+    for epoch in [test_epoch(2), test_epoch(3), test_epoch(4)] {
+        test_env
+            .storage
+            .start_epoch(epoch, HashSet::from_iter([table_id]));
+    }
     test_env.storage
 }
 

--- a/src/stream/src/executor/nested_loop_temporal_join.rs
+++ b/src/stream/src/executor/nested_loop_temporal_join.rs
@@ -84,7 +84,7 @@ async fn phase1_handle_chunk<S: StateStore, SD: ValueRowSerde, E: phase1::Phase1
             .then(|vnode| async move {
                 Ok::<_, StreamExecutorError>(Box::pin(
                     source
-                        .iter_with_vnode_and_output_indices(
+                        .iter_with_vnode(
                             vnode,
                             &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
                             PrefetchOptions::prefetch_for_large_range_scan(),

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -107,7 +107,6 @@ impl JoinEntry {
 struct TemporalSide<K: HashKey, S: StateStore, SD: ValueRowSerde> {
     source: ReplicatedStateTable<S, SD>,
     table_stream_key_indices: Vec<usize>,
-    table_output_indices: Vec<usize>,
     cache: ManagedLruCache<K, JoinEntry>,
     join_key_data_types: Vec<DataType>,
 }
@@ -148,7 +147,7 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
                             row.as_ref()
                                 .project(&self.table_stream_key_indices)
                                 .into_owned_row(),
-                            row.project(&self.table_output_indices).into_owned_row(),
+                            row,
                         );
                     }
                     let key = key.clone();
@@ -623,7 +622,6 @@ impl<
         null_safe: Vec<bool>,
         condition: Option<NonStrictExpression>,
         output_indices: Vec<usize>,
-        table_output_indices: Vec<usize>,
         table_stream_key_indices: Vec<usize>,
         watermark_sequence: AtomicU64Ref,
         metrics: Arc<StreamingMetrics>,
@@ -646,7 +644,6 @@ impl<
             right_table: TemporalSide {
                 source: table,
                 table_stream_key_indices,
-                table_output_indices,
                 cache,
                 join_key_data_types,
             },
@@ -1016,9 +1013,6 @@ mod tests {
         let (mut right_tx, right_source) = MockSource::channel();
         let right_executor = right_source.into_executor(right_schema.clone(), vec![0, 1]);
 
-        // table_output_indices: indices in right table output rows that form the output.
-        // All 3 columns are selected.
-        let table_output_indices = vec![0usize, 1, 2];
         // table_stream_key_indices: pk of right table within the output row = [0, 1] (key, seq).
         let table_stream_key_indices = vec![0usize, 1];
 
@@ -1056,7 +1050,6 @@ mod tests {
             null_safe,
             None, // no extra non-equi condition
             output_indices,
-            table_output_indices,
             table_stream_key_indices,
             Arc::new(AtomicU64::new(0)),
             Arc::new(StreamingMetrics::unused()),

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use risingwave_common::catalog::{ColumnDesc, ColumnId};
 use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::value_encoding::BasicSerde;
+use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan::LookupNode;
-use risingwave_storage::table::batch_table::BatchTable;
 
 use super::*;
+use crate::common::table::state_table::{StateTableBuilder, StateTableOpConsistencyLevel};
 use crate::executor::{LookupExecutor, LookupExecutorParams};
 
 pub struct LookupExecutorBuilder;
@@ -62,28 +66,55 @@ impl ExecutorBuilder for LookupExecutorBuilder {
             .map(|&idx| ColumnId::new(table_desc.columns[idx as usize].column_id))
             .collect_vec();
 
-        let storage_table = BatchTable::new_partial(
-            store,
-            column_ids,
-            params.vnode_bitmap.map(Into::into),
-            table_desc,
-        );
+        let versioned = table_desc.versioned;
+        let vnodes = params.vnode_bitmap.clone().map(Arc::new);
 
-        let exec = LookupExecutor::new(LookupExecutorParams {
-            ctx: params.actor_context,
-            info: params.info.clone(),
-            arrangement,
-            stream,
-            arrangement_col_descs,
-            arrangement_order_rules,
-            use_current_epoch: lookup.use_current_epoch,
-            stream_join_key_indices: lookup.stream_key.iter().map(|x| *x as usize).collect(),
-            arrange_join_key_indices: lookup.arrange_key.iter().map(|x| *x as usize).collect(),
-            column_mapping: lookup.column_mapping.iter().map(|x| *x as usize).collect(),
-            batch_table: storage_table,
-            watermark_epoch: params.watermark_epoch,
-            chunk_size: params.config.developer.chunk_size,
-        });
-        Ok((params.info, exec).into())
+        macro_rules! build_lookup {
+            ($SD:ident) => {{
+                let state_table =
+                    StateTableBuilder::<_, $SD, true, _>::new_from_storage_table_desc(
+                        table_desc,
+                        store.clone(),
+                        vnodes.clone(),
+                        params.fragment_id.as_raw_id(),
+                    )
+                    .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+                    .with_output_column_ids(column_ids.clone())
+                    .forbid_preload_all_rows()
+                    .build()
+                    .await;
+
+                let exec = LookupExecutor::new(LookupExecutorParams {
+                    ctx: params.actor_context,
+                    info: params.info.clone(),
+                    arrangement,
+                    stream,
+                    arrangement_col_descs,
+                    arrangement_order_rules,
+                    use_current_epoch: lookup.use_current_epoch,
+                    stream_join_key_indices: lookup
+                        .stream_key
+                        .iter()
+                        .map(|x| *x as usize)
+                        .collect(),
+                    arrange_join_key_indices: lookup
+                        .arrange_key
+                        .iter()
+                        .map(|x| *x as usize)
+                        .collect(),
+                    column_mapping: lookup.column_mapping.iter().map(|x| *x as usize).collect(),
+                    state_table,
+                    watermark_epoch: params.watermark_epoch,
+                    chunk_size: params.config.developer.chunk_size,
+                });
+                Ok((params.info, exec).into())
+            }};
+        }
+
+        if versioned {
+            build_lookup!(ColumnAwareSerde)
+        } else {
+            build_lookup!(BasicSerde)
+        }
     }
 }

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -76,7 +76,7 @@ impl ExecutorBuilder for LookupExecutorBuilder {
                         table_desc,
                         store.clone(),
                         vnodes.clone(),
-                        params.fragment_id.as_raw_id(),
+                        params.fragment_id,
                     )
                     .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
                     .with_output_column_ids(column_ids.clone())

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -84,7 +84,7 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                             table_desc,
                             store.clone(),
                             vnodes.clone(),
-                            params.fragment_id.as_raw_id(),
+                            params.fragment_id,
                         )
                         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
                         .with_output_column_ids(output_column_ids.clone())
@@ -113,10 +113,18 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                 build_nested_loop!(BasicSerde)
             }
         } else {
+            // `ReplicatedStateTable::iter_with_prefix` returns rows in `table_output_indices`
+            // order. The hash temporal join cache therefore needs stream-key positions within
+            // that projected row, not within the full table schema.
             let table_stream_key_indices = table_desc
                 .stream_key
                 .iter()
-                .map(|&k| k as usize)
+                .map(|&k| {
+                    table_output_indices
+                        .iter()
+                        .position(|&idx| idx == k as usize)
+                        .expect("stream key should be included in table output")
+                })
                 .collect_vec();
 
             let left_join_keys = node
@@ -164,7 +172,7 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                             table_desc,
                             store.clone(),
                             vnodes.clone(),
-                            params.fragment_id.as_raw_id(),
+                            params.fragment_id,
                         )
                         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
                         .with_output_column_ids(output_column_ids.clone())
@@ -183,7 +191,6 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                         null_safe,
                         condition,
                         output_indices,
-                        table_output_indices,
                         table_stream_key_indices,
                         watermark_epoch: params.watermark_epoch,
                         chunk_size: params.config.developer.chunk_size,
@@ -217,7 +224,6 @@ struct TemporalJoinExecutorDispatcherArgs<S: StateStore, SD: ValueRowSerde> {
     null_safe: Vec<bool>,
     condition: Option<NonStrictExpression>,
     output_indices: Vec<usize>,
-    table_output_indices: Vec<usize>,
     table_stream_key_indices: Vec<usize>,
     watermark_epoch: AtomicU64Ref,
     chunk_size: usize,
@@ -254,7 +260,6 @@ impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
                     self.null_safe,
                     self.condition,
                     self.output_indices,
-                    self.table_output_indices,
                     self.table_stream_key_indices,
                     self.watermark_epoch,
                     self.metrics,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR continues the `BatchTable` → `ReplicatedStateTable` migration in the streaming executor layer, extending the work from temporal join (commit `7a91a34602`) to the lookup executor used in delta join operations.

**Summary of changes:**
- Replace `BatchTable<S>` with `ReplicatedStateTable<S, SD>` in the lookup executor
- Add `row.project(output_indices)` after `iter_with_prefix()` calls to properly project rows to output columns (similar to temporal join implementation)
- Update the lookup executor's table initialization to use `ReplicatedStateTable` with proper column ID mapping
- Update related deserialization and message handling to work with the new table type

**Why this change:**
- Standardizes state table access patterns across streaming executors
- Enables proper support for replicated state tables in delta join operations
- Maintains consistency with the temporal join refactor completed in the parent commit

**Testing:**
- All 5 e2e delta join SLT tests pass
- Unit tests for lookup executor pass
- Clippy checks pass
- Type safety verified: row projection fix ensures column types match between deserial and output

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary>Release note</summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>