### PR TITLE
chore(iceberg): bump iceberg chain to fb290e4c/bd254371

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6848,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=96a69c09dbc410358ed44a9e789c4ffa0b2d2871#96a69c09dbc410358ed44a9e789c4ffa0b2d2871"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1a07913eea091c3d07c4a4c31e09d5bfaec4e498#1a07913eea091c3d07c4a4c31e09d5bfaec4e498"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=96a69c09dbc410358ed44a9e789c4ffa0b2d2871#96a69c09dbc410358ed44a9e789c4ffa0b2d2871"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1a07913eea091c3d07c4a4c31e09d5bfaec4e498#1a07913eea091c3d07c4a4c31e09d5bfaec4e498"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6921,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=96a69c09dbc410358ed44a9e789c4ffa0b2d2871#96a69c09dbc410358ed44a9e789c4ffa0b2d2871"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1a07913eea091c3d07c4a4c31e09d5bfaec4e498#1a07913eea091c3d07c4a4c31e09d5bfaec4e498"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6943,7 +6943,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=bdd3ee39b51f5085861ee6778c80da46837cc115#bdd3ee39b51f5085861ee6778c80da46837cc115"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=57af477fe0149ef1ba416caedb42a4d1ca9b472c#57af477fe0149ef1ba416caedb42a4d1ca9b472c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6961,7 +6961,6 @@ dependencies = [
  "parquet 57.3.0",
  "port_scanner",
  "rand 0.9.2",
- "sqlx",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -6973,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=96a69c09dbc410358ed44a9e789c4ffa0b2d2871#96a69c09dbc410358ed44a9e789c4ffa0b2d2871"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1a07913eea091c3d07c4a4c31e09d5bfaec4e498#1a07913eea091c3d07c4a4c31e09d5bfaec4e498"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,14 +161,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20251111
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "96a69c09dbc410358ed44a9e789c4ffa0b2d2871", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1a07913eea091c3d07c4a4c31e09d5bfaec4e498", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "96a69c09dbc410358ed44a9e789c4ffa0b2d2871" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "96a69c09dbc410358ed44a9e789c4ffa0b2d2871" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1a07913eea091c3d07c4a4c31e09d5bfaec4e498" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1a07913eea091c3d07c4a4c31e09d5bfaec4e498" }
 
 adbc_core = { version = "0.22" }
 adbc_snowflake = { version = "0.22", default-features = false }

--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ The row store and Iceberg layer serve different purposes: the row store is for l
 ## Design decisions
 
 ### Ultimate cost efficiency
- 
+
 Internal state, tables, and materialized views are stored in object storage (S3 or equivalent), which is roughly 100x cheaper than RAM. This enables elastic scaling without data rebalancing and failure recovery in seconds. For latency-sensitive workloads, [elastic disk cache](https://docs.risingwave.com/get-started/disk-cache) pins hot data on local SSD or EBS, keeping p99 query latency at 10-20 ms.
- 
+
 ### Native experience for both humans and agents
- 
+
 RisingWave connects via the PostgreSQL wire protocol and works with psql, JDBC, and any Postgres-compatible tooling. For agents, RisingWave provides a MCP server, a CLI, and Skills, so agents can query and operate RisingWave without custom integration.
- 
+
 ### Openness
- 
+
 RisingWave [natively integrates with Apache Iceberg™](https://docs.risingwave.com/iceberg/overview) for continuous stream ingestion, direct reads via DataFusion, and automated table maintenance. Data in Iceberg is in an open format and accessible to any compatible query engine.
 
 ---

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "bdd3ee39b51f5085861ee6778c80da46837cc115" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "57af477fe0149ef1ba416caedb42a4d1ca9b472c" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"

--- a/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/iceberg_compaction/iceberg_compactor_runner.rs
@@ -31,9 +31,8 @@ use iceberg_compaction_core::executor::RewriteFilesStat;
 use mixtrics::registry::prometheus::PrometheusMetricsRegistry;
 use parquet_57::file::properties::WriterProperties;
 use risingwave_common::config::storage::default::storage::{
-    iceberg_compaction_enable_dynamic_size_estimation,
     iceberg_compaction_enable_heuristic_output_parallelism,
-    iceberg_compaction_max_concurrent_closes, iceberg_compaction_size_estimation_smoothing_factor,
+    iceberg_compaction_max_concurrent_closes,
 };
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_connector::sink::iceberg::{
@@ -71,10 +70,6 @@ pub struct IcebergCompactorRunnerConfig {
     pub enable_heuristic_output_parallelism: bool,
     #[builder(default = "iceberg_compaction_max_concurrent_closes()")]
     pub max_concurrent_closes: usize,
-    #[builder(default = "iceberg_compaction_enable_dynamic_size_estimation()")]
-    pub enable_dynamic_size_estimation: bool,
-    #[builder(default = "iceberg_compaction_size_estimation_smoothing_factor()")]
-    pub size_estimation_smoothing_factor: f64,
     #[builder]
     pub target_binpack_group_size_mb: Option<u64>,
     #[builder]
@@ -251,8 +246,6 @@ impl IcebergCompactionPlanRunner {
             .write_parquet_properties(write_parquet_properties)
             .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
             .max_concurrent_closes(config.max_concurrent_closes)
-            .enable_dynamic_size_estimation(config.enable_dynamic_size_estimation)
-            .size_estimation_smoothing_factor(config.size_estimation_smoothing_factor)
             .build()
             .unwrap_or_else(|e| {
                 panic!(
@@ -469,7 +462,8 @@ pub async fn create_plan_runners(
         TaskType::SmallFiles => {
             let mut builder = SmallFilesConfigBuilder::default();
             builder
-                .max_parallelism(config.max_parallelism as usize)
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
                 .min_size_per_partition(config.min_size_per_partition)
                 .max_file_count_per_partition(config.max_file_count_per_partition as usize)
                 .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
@@ -489,7 +483,8 @@ pub async fn create_plan_runners(
         }
         TaskType::Full => {
             let config = FullCompactionConfigBuilder::default()
-                .max_parallelism(config.max_parallelism as usize)
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
                 .min_size_per_partition(config.min_size_per_partition)
                 .max_file_count_per_partition(config.max_file_count_per_partition as usize)
                 .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)
@@ -503,7 +498,8 @@ pub async fn create_plan_runners(
 
         TaskType::FilesWithDelete => {
             let config = FilesWithDeletesConfigBuilder::default()
-                .max_parallelism(config.max_parallelism as usize)
+                .max_input_parallelism(config.max_parallelism as usize)
+                .max_output_parallelism(config.max_parallelism as usize)
                 .min_size_per_partition(config.min_size_per_partition)
                 .max_file_count_per_partition(config.max_file_count_per_partition as usize)
                 .target_file_size_bytes(iceberg_config.target_file_size_mb() * 1024 * 1024)

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -501,8 +501,6 @@ pub fn start_iceberg_compactor(
                                     .max_record_batch_rows(compactor_context.storage_opts.iceberg_compaction_max_record_batch_rows)
                                     .enable_heuristic_output_parallelism(compactor_context.storage_opts.iceberg_compaction_enable_heuristic_output_parallelism)
                                     .max_concurrent_closes(compactor_context.storage_opts.iceberg_compaction_max_concurrent_closes)
-                                    .enable_dynamic_size_estimation(compactor_context.storage_opts.iceberg_compaction_enable_dynamic_size_estimation)
-                                    .size_estimation_smoothing_factor(compactor_context.storage_opts.iceberg_compaction_size_estimation_smoothing_factor)
                                     .target_binpack_group_size_mb(
                                         compactor_context.storage_opts.iceberg_compaction_target_binpack_group_size_mb
                                     )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwave-labs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- Bump workspace `iceberg-rust` dependencies (`iceberg`, `iceberg-catalog-glue`, `iceberg-catalog-rest`) from `1a07913eea091c3d07c4a4c31e09d5bfaec4e498` to `fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef`.
- Bump `iceberg-compaction-core` in `risingwave_storage` from `57af477fe0149ef1ba416caedb42a4d1ca9b472c` to `bd254371c42bb73ba10195e599c1ff2b0b9105a8`.
- Align RisingWave with the upstream Arrow/Parquet 58 upgrade required by the new `iceberg-rust` revision.
- Port RisingWave's Iceberg sink / compaction parquet writer settings away from the deprecated row-count API: introduce `compaction.write_parquet_max_row_group_bytes`, keep `compaction.write_parquet_max_row_group_rows` as a compatibility-only option, and ignore it with a warning.
- Keep the storage-side compaction planning config aligned with upstream execution config changes by mapping the existing RW parallelism setting to both `max_input_parallelism` and `max_output_parallelism`, and remove the no-op dynamic size estimation plumbing.
- Validation for this change is `cargo fmt --all` plus `cargo check -p risingwave_connector -p risingwave_storage -p risingwave_frontend`.

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

- Iceberg compaction now uses a byte-based parquet row-group limit (`compaction.write_parquet_max_row_group_bytes`) and ignores the legacy row-count limit.

</details>
