### PR TITLE
feat: allow streaming_max_parallelism = 1 without singleton confusion

### DIFF
--- a/docs/dev/src/design/streaming-max-parallelism-singleton.md
+++ b/docs/dev/src/design/streaming-max-parallelism-singleton.md
@@ -1,0 +1,57 @@
+# `streaming_max_parallelism = 1` and singleton semantics
+
+## Goal
+
+Allow `SET streaming_max_parallelism = 1` without making the system treat
+`hash-distributed with vnode_count = 1` as a true singleton.
+
+## Background
+
+Today the codebase already distinguishes two concepts:
+
+- `singleton`: encoded by distribution semantics such as
+  `Distribution::Single` / `PbFragmentDistributionType::Single`, and by
+  `requires_singleton` in the stream fragmenter.
+- `hash(1)`: a hash-distributed table or fragment whose vnode count happens to
+  be `1`.
+
+However, some abstractions still blur the boundary. In particular, the
+stream-graph scheduler models `AnySingleton` as `AnyVnodeCount(1)`, which makes
+the distinction harder to reason about when `streaming_max_parallelism = 1` is
+allowed.
+
+## Correctness requirements
+
+After this change:
+
+1. `streaming_max_parallelism = 1` must be accepted by session config.
+2. A fragment with default parallelism/vnode count `1` but without singleton
+   requirements must still be scheduled as hash-distributed.
+3. A fragment with explicit singleton requirements must still be scheduled as
+   singleton.
+4. Persisted metadata must continue to distinguish singleton from hash(1) by
+   `distribution_type`, even though both can carry `maybe_vnode_count = 1`.
+5. Existing special cases that require true singleton semantics
+   (`Simple` edges, `Now`, `Values`, non-parallel CDC backfill, etc.) must keep
+   using singleton semantics instead of relying on vnode count.
+
+## Implementation plan
+
+1. Make scheduler requirements model singleton explicitly instead of aliasing it
+   to `AnyVnodeCount(1)`.
+2. Keep `AnyVnodeCount(1)` valid and mergeable with singleton when the fragment
+   is required to be singleton, because singleton fragments also have vnode
+   count `1`.
+3. Allow `streaming_max_parallelism = 1`.
+4. Add focused tests that exercise:
+   - scheduler output for default hash(1) vs singleton;
+   - vnode-count compatibility for singleton vs non-singleton protobuf objects;
+   - session config validation for value `1`.
+5. Keep runtime semantics unchanged for true singleton operators and tables.
+
+## Expected non-goals
+
+- This change does not redefine singleton as “any fragment with vnode count 1”.
+- This change does not try to remove all historical uses of vnode count `1` in
+  comments or compatibility code, except where they are misleading for the new
+  behavior.

--- a/src/common/src/hash/consistent_hash/vnode.rs
+++ b/src/common/src/hash/consistent_hash/vnode.rs
@@ -58,7 +58,6 @@ impl VirtualNode {
     /// - As the default value for the session configuration.
     /// - As the vnode count for all streaming jobs, fragments, and tables that were created before
     ///   the variable vnode count support was introduced.
-    /// - As the vnode count for singletons.
     pub const COUNT_FOR_COMPAT: usize = 1 << 8;
 }
 

--- a/src/common/src/hash/consistent_hash/vnode_count.rs
+++ b/src/common/src/hash/consistent_hash/vnode_count.rs
@@ -33,6 +33,10 @@ pub enum VnodeCount {
 
 impl VnodeCount {
     /// Creates a `VnodeCount` set to the given value.
+    ///
+    /// Note that `VnodeCount::set(1)` is still different from [`VnodeCount::Singleton`].
+    /// The former means hash-distributed with a single vnode, while the latter means true
+    /// singleton semantics and must be interpreted together with distribution metadata.
     pub fn set(v: impl TryInto<usize> + Copy + std::fmt::Debug) -> Self {
         let v = v.try_into().ok();
         if v == Some(0) {
@@ -159,5 +163,26 @@ impl IsSingleton for risingwave_pb::plan_common::StorageTableDesc {
 impl VnodeCountCompat for risingwave_pb::plan_common::StorageTableDesc {
     fn vnode_count_inner(&self) -> VnodeCount {
         VnodeCount::from_protobuf(self.maybe_vnode_count, || self.is_singleton())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VnodeCount;
+
+    #[test]
+    fn test_vnode_count_one_is_not_singleton_for_non_singleton_objects() {
+        assert_eq!(
+            VnodeCount::from_protobuf(Some(1), || false),
+            VnodeCount::set(1)
+        );
+    }
+
+    #[test]
+    fn test_singleton_objects_ignore_numeric_vnode_count_semantics() {
+        assert_eq!(
+            VnodeCount::from_protobuf(Some(1), || true),
+            VnodeCount::Singleton
+        );
     }
 }

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -536,10 +536,8 @@ fn check_bytea_output(val: &str) -> Result<(), String> {
 /// Check if the provided value is a valid max parallelism.
 fn check_streaming_max_parallelism(val: &usize) -> Result<(), String> {
     match val {
-        // TODO(var-vnode): this is to prevent confusion with singletons, after we distinguish
-        // them better, we may allow 1 as the max parallelism (though not much point).
-        0 | 1 => Err("STREAMING_MAX_PARALLELISM must be greater than 1".to_owned()),
-        2..=VirtualNode::MAX_COUNT => Ok(()),
+        0 => Err("STREAMING_MAX_PARALLELISM must be greater than 0".to_owned()),
+        1..=VirtualNode::MAX_COUNT => Ok(()),
         _ => Err(format!(
             "STREAMING_MAX_PARALLELISM must be less than or equal to {}",
             VirtualNode::MAX_COUNT
@@ -846,6 +844,43 @@ mod test {
                 }
                 other => panic!("unexpected error: {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn test_streaming_max_parallelism_accepts_one() {
+        let mut config = SessionConfig::default();
+
+        config
+            .set("streaming_max_parallelism", "1".to_owned(), &mut ())
+            .unwrap();
+
+        assert_eq!(config.streaming_max_parallelism(), 1);
+        assert_eq!(config.get("streaming_max_parallelism").unwrap(), "1");
+    }
+
+    #[test]
+    fn test_streaming_max_parallelism_rejects_zero() {
+        let mut config = SessionConfig::default();
+
+        let err = config
+            .set("streaming_max_parallelism", "0".to_owned(), &mut ())
+            .unwrap_err();
+
+        match err {
+            SessionConfigError::InvalidValue {
+                entry,
+                value,
+                source,
+            } => {
+                assert_eq!(entry, "streaming_max_parallelism");
+                assert_eq!(value, "0");
+                assert_eq!(
+                    source.to_string(),
+                    "STREAMING_MAX_PARALLELISM must be greater than 0"
+                );
+            }
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 }

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -48,18 +48,16 @@ type HashMappingId = usize;
 enum Req {
     /// The fragment must be singleton and is scheduled to the given worker id.
     Singleton,
+    /// The fragment must be singleton, but can be scheduled anywhere.
+    AnySingleton,
     /// The fragment must be hash-distributed and is scheduled by the given hash mapping.
     Hash(HashMappingId),
     /// The fragment must have the given vnode count, but can be scheduled anywhere.
-    /// When the vnode count is 1, it means the fragment must be singleton.
+    /// A vnode count of `1` still does not imply singleton semantics by itself.
     AnyVnodeCount(usize),
 }
 
 impl Req {
-    /// Equivalent to `Req::AnyVnodeCount(1)`.
-    #[allow(non_upper_case_globals)]
-    const AnySingleton: Self = Self::AnyVnodeCount(1);
-
     /// Merge two requirements. Returns an error if the requirements are incompatible.
     ///
     /// The `mapping_len` function is used to get the vnode count of a hash mapping by its id.
@@ -67,6 +65,8 @@ impl Req {
         // Note that a and b are always different, as they come from a set.
         let merge = |a, b| match (a, b) {
             (Self::AnySingleton, Self::Singleton) => Some(Self::Singleton),
+            (Self::AnySingleton, Self::AnyVnodeCount(1)) => Some(Self::AnySingleton),
+            (Self::AnyVnodeCount(1), Self::Singleton) => Some(Self::Singleton),
             (Self::AnyVnodeCount(count), Self::Hash(id)) if mapping_len(id) == count => {
                 Some(Self::Hash(id))
             }
@@ -594,6 +594,22 @@ mod tests {
 
         let expected = maplit::hashmap! {
             101.into() => Result::Required(Req::Singleton),
+        };
+
+        test_success(facts, expected);
+    }
+
+    // 1
+    #[test]
+    fn test_singleton_requirement_is_not_just_vnode_count_one() {
+        #[rustfmt::skip]
+        let facts = [
+            Fact::Req { id: 101.into(), req: Req::AnySingleton },
+            Fact::Req { id: 101.into(), req: Req::AnyVnodeCount(1) },
+        ];
+
+        let expected = maplit::hashmap! {
+            101.into() => Result::DefaultSingleton,
         };
 
         test_success(facts, expected);

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -28,6 +28,7 @@ use risingwave_pb::expr::agg_call::PbKind as PbAggKind;
 use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::expr_node::Type::{Add, GreaterThan};
 use risingwave_pb::expr::{AggCall, ExprNode, FunctionCall, PbInputRef};
+use risingwave_pb::meta::table_fragments::fragment::PbFragmentDistributionType;
 use risingwave_pb::plan_common::{ColumnCatalog, ColumnDesc, Field};
 use risingwave_pb::stream_plan::stream_fragment_graph::{StreamFragment, StreamFragmentEdge};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -403,7 +404,7 @@ fn make_fragment_edges() -> Vec<StreamFragmentEdge> {
     ]
 }
 
-fn make_stream_graph() -> StreamFragmentGraphProto {
+fn make_stream_graph_with_max_parallelism(max_parallelism: usize) -> StreamFragmentGraphProto {
     let fragments = make_stream_fragments();
     StreamFragmentGraphProto {
         fragments: HashMap::from_iter(fragments.into_iter().map(|f| (f.fragment_id, f))),
@@ -413,9 +414,13 @@ fn make_stream_graph() -> StreamFragmentGraphProto {
         table_ids_cnt: 3,
         parallelism: None,
         backfill_parallelism: None,
-        max_parallelism: VirtualNode::COUNT_FOR_TEST as _,
+        max_parallelism: max_parallelism as _,
         backfill_order: Default::default(),
     }
+}
+
+fn make_stream_graph() -> StreamFragmentGraphProto {
+    make_stream_graph_with_max_parallelism(VirtualNode::COUNT_FOR_TEST)
 }
 
 #[tokio::test]
@@ -480,6 +485,66 @@ async fn test_graph_builder() -> MetaResult<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_graph_builder_with_max_parallelism_one_keeps_hash_fragments_hash() -> MetaResult<()> {
+    let env = MetaSrvEnv::for_test().await;
+    let job = StreamingJob::Table(None, make_materialize_table(888), TableJobType::General);
+
+    let graph = make_stream_graph_with_max_parallelism(1);
+    let fragment_graph = StreamFragmentGraph::new(&env, graph, &job)?;
+
+    let actor_graph_builder = ActorGraphBuilder::new(
+        job.id(),
+        CompleteStreamFragmentGraph::for_test(fragment_graph),
+        NonZeroUsize::new(1).unwrap(),
+    )?;
+    let ActorGraphBuildResult { graph, .. } = actor_graph_builder.generate_graph()?;
+
+    let source_fragment = graph
+        .values()
+        .find(|fragment| matches!(fragment.nodes.get_node_body().unwrap(), NodeBody::Source(_)))
+        .expect("source fragment not found");
+    assert_eq!(
+        source_fragment.distribution_type,
+        PbFragmentDistributionType::Hash,
+        "source fragment: {source_fragment:#?}"
+    );
+    assert_eq!(source_fragment.maybe_vnode_count, Some(1));
+
+    let middle_fragment = graph
+        .values()
+        .find(|fragment| {
+            matches!(
+                fragment.nodes.get_node_body().unwrap(),
+                NodeBody::SimpleAgg(_)
+            )
+        })
+        .expect("middle fragment not found");
+    assert_eq!(
+        middle_fragment.distribution_type,
+        PbFragmentDistributionType::Hash,
+        "middle fragment: {middle_fragment:#?}"
+    );
+    assert_eq!(middle_fragment.maybe_vnode_count, Some(1));
+
+    let singleton_fragment = graph
+        .values()
+        .find(|fragment| {
+            matches!(
+                fragment.nodes.get_node_body().unwrap(),
+                NodeBody::Materialize(_)
+            )
+        })
+        .expect("singleton fragment not found");
+    assert_eq!(
+        singleton_fragment.distribution_type,
+        PbFragmentDistributionType::Single
+    );
+    assert_eq!(singleton_fragment.maybe_vnode_count, Some(1));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- allow `streaming_max_parallelism = 1` in session config
- explicitly distinguish singleton requirements from `vnode_count = 1` in stream graph scheduling
- add regression tests for `VnodeCount`, scheduler behavior, and actor graph building with `max_parallelism = 1`
- record the design in `docs/dev/src/design/streaming-max-parallelism-singleton.md`

## Testing
- cargo test -p risingwave_common test_streaming_max_parallelism
- cargo test -p risingwave_common vnode_count_one_is_not_singleton
- cargo test -p risingwave_common singleton_objects_ignore_numeric_vnode_count_semantics
- cargo test -p risingwave_meta stream::stream_graph::schedule::tests::
- cargo test -p risingwave_meta test_graph_builder_with_max_parallelism_one_keeps_hash_fragments_hash