### PR TITLE
fix(common): [BREAK] `Hash for jsonbb::StringRef` shall be same as `&str`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7416,8 +7416,7 @@ dependencies = [
 [[package]]
 name = "jsonbb"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8b46684788e8fce542d6ee3cde00ffbe31818a19d605d6d292f24f38c5a41c"
+source = "git+https://github.com/risingwavelabs/jsonbb.git?rev=f618cd8c9bc517f35dec192d4e7553650894a011#f618cd8c9bc517f35dec192d4e7553650894a011"
 dependencies = [
  "bytes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -427,6 +427,8 @@ tokio-postgres = { git = "https://github.com/madsim-rs/rust-postgres.git", rev =
 sqlx = { git = "https://github.com/madsim-rs/sqlx.git", rev = "3efe6d0065963db2a2b7f30dee69f647e28dec81" }
 # patch to remove preserve_order from serde_json
 bson = { git = "https://github.com/risingwavelabs/bson-rust", tag = "v2.15.0-json-no-preserve_order" }
+# patch to revert `Hash for StringRef` for compatibility with `&str` in vnode
+jsonbb = { git = "https://github.com/risingwavelabs/jsonbb.git", rev = "f618cd8c9bc517f35dec192d4e7553650894a011" }
 
 # patch to make zstd version compatible:
 # desired v4.9.0+2.10.0 requires: zstd-sys >= 2.0.15

--- a/src/common/src/types/jsonb.rs
+++ b/src/common/src/types/jsonb.rs
@@ -636,3 +636,24 @@ impl ToSql for JsonbRef<'_> {
         Ok(IsNull::No)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_backward_compatible() {
+        use std::hash::Hasher as _;
+
+        // Hash of sample input `"foo"` required to be the the magic number below.
+        // See #25336 for how the backward compatibility is doomed.
+        let s = r#""foo""#;
+        let j: JsonbVal = s.parse().unwrap();
+        let expected = expect_test::expect!["10172337927241793445"];
+
+        let mut state = std::hash::DefaultHasher::new();
+        j.hash(&mut state);
+        let actual = state.finish();
+        expected.assert_eq(&actual.to_string());
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

See #25336. In short, it is unfortunate that hash of `Jsonb` (rather than its memcomparable encoding) is persisted and can NEVER change for backward compatibility. This PR patches the `jsonbb` crate to revert its hashing behavior to the same as `&str` before introducing `StringRef` - which was supposed to be an internal change.

**NOTE**:
This "fix" means we are restoring compatibility with <2.7, BUT BREAKING compatibility with 2.7.x and 2.8.x series.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [x] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
