### PR TITLE
feat(frontend): support iceberg V3 sink with PK index on frontend

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -378,6 +378,15 @@ message SinkNode {
   optional uint32 rate_limit = 4;
 }
 
+message IcebergWithPkIndexWriterNode {
+  SinkDesc sink_desc = 1;
+  catalog.Table pk_index_table = 2;
+}
+
+message IcebergWithPkIndexDvMergerNode {
+  SinkDesc sink_desc = 1;
+}
+
 message ProjectNode {
   repeated expr.ExprNode select_list = 1;
   // this two field is expressing a list of usize pair, which means when project receives a
@@ -1178,6 +1187,8 @@ message StreamNode {
     EowcGapFillNode eowc_gap_fill = 153;
     GapFillNode gap_fill = 154;
     VectorIndexLookupJoinNode vector_index_lookup_join = 155;
+    IcebergWithPkIndexWriterNode iceberg_with_pk_index_writer = 156;
+    IcebergWithPkIndexDvMergerNode iceberg_with_pk_index_dv_merger = 157;
   }
   // The id for the operator. This is local per mview.
   // TODO: should better be a uint32.

--- a/src/common/src/util/stream_graph_visitor.rs
+++ b/src/common/src/util/stream_graph_visitor.rs
@@ -326,6 +326,11 @@ pub fn visit_stream_node_tables_inner<F>(
                 always!(node.state_table, "LocalityProviderState");
                 always!(node.progress_table, "LocalityProviderProgress");
             }
+
+            NodeBody::IcebergWithPkIndexWriter(node) => {
+                always!(node.pk_index_table, "IcebergWithPkIndexWriter");
+            }
+
             _ => {}
         }
     };

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -129,6 +129,7 @@ pub const COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: &str = "commit_checkpoint_size_th
 pub const ORDER_KEY: &str = "order_key";
 pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: u64 = 128;
 pub const ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES: usize = 128 * 1024 * 1024;
+pub const ENABLE_PK_INDEX: &str = "enable_pk_index";
 
 pub(super) const PARQUET_CREATED_BY: &str =
     concat!("risingwave version ", env!("CARGO_PKG_VERSION"));
@@ -461,6 +462,15 @@ pub struct IcebergConfig {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
     pub write_parquet_max_row_group_bytes: Option<usize>,
+
+    /// Whether to enable PK index for upsert sink. Default is false.
+    /// It's used for V3 upsert iceberg sink to generate delete vectors.
+    #[serde(
+        rename = "enable_pk_index",
+        default,
+        deserialize_with = "deserialize_bool_from_string"
+    )]
+    pub enable_pk_index: bool,
 }
 
 impl EnforceSecret for IcebergConfig {
@@ -491,6 +501,38 @@ impl IcebergConfig {
                  Please use 'merge-on-read' instead, which is strictly better for append-only workloads."
             )));
         }
+        Ok(())
+    }
+
+    pub(crate) fn validate_enable_pk_index(&self) -> Result<()> {
+        if !self.enable_pk_index {
+            return Ok(());
+        }
+
+        if self.r#type != SINK_TYPE_UPSERT {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` is only supported for upsert iceberg sink"
+            )));
+        }
+
+        if self.write_mode != IcebergWriteMode::MergeOnRead {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` is only supported for upsert iceberg sink with merge-on-read mode"
+            )));
+        }
+
+        if self.format_version < FormatVersion::V3 {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` is only supported for upsert iceberg sink with format version >= 3"
+            )));
+        }
+
+        if self.force_append_only {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` cannot be true when `force_append_only` is true"
+            )));
+        }
+
         Ok(())
     }
 
@@ -526,6 +568,7 @@ impl IcebergConfig {
 
         // Enforce merge-on-read for append-only sinks
         Self::validate_append_only_write_mode(&config.r#type, config.write_mode)?;
+        config.validate_enable_pk_index()?;
 
         // All configs start with "catalog." will be treated as java configs.
         config.java_catalog_props = values

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -125,6 +125,7 @@ pub const COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS: &str =
     "compaction.write_parquet_max_row_group_rows";
 pub const COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: &str = "commit_checkpoint_size_threshold_mb";
 pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: u64 = 128;
+pub const ENABLE_PK_INDEX: &str = "enable_pk_index";
 
 pub(super) const PARQUET_CREATED_BY: &str =
     concat!("risingwave version ", env!("CARGO_PKG_VERSION"));
@@ -447,6 +448,15 @@ pub struct IcebergConfig {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
     pub write_parquet_max_row_group_rows: Option<usize>,
+
+    /// Whether to enable PK index for upsert sink. Default is false.
+    /// It's used for V3 upsert iceberg sink to generate delete vectors.
+    #[serde(
+        rename = "enable_pk_index",
+        default,
+        deserialize_with = "deserialize_bool_from_string"
+    )]
+    pub enable_pk_index: bool,
 }
 
 impl EnforceSecret for IcebergConfig {
@@ -477,6 +487,38 @@ impl IcebergConfig {
                  Please use 'merge-on-read' instead, which is strictly better for append-only workloads."
             )));
         }
+        Ok(())
+    }
+
+    pub(crate) fn validate_enable_pk_index(&self) -> Result<()> {
+        if !self.enable_pk_index {
+            return Ok(());
+        }
+
+        if self.r#type != SINK_TYPE_UPSERT {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` is only supported for upsert iceberg sink"
+            )));
+        }
+
+        if self.write_mode != IcebergWriteMode::MergeOnRead {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` is only supported for upsert iceberg sink with merge-on-read mode"
+            )));
+        }
+
+        if self.format_version < FormatVersion::V3 {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` is only supported for upsert iceberg sink with format version >= 3"
+            )));
+        }
+
+        if self.force_append_only {
+            return Err(SinkError::Config(anyhow!(
+                "`enable_pk_index` cannot be true when `force_append_only` is true"
+            )));
+        }
+
         Ok(())
     }
 
@@ -512,6 +554,7 @@ impl IcebergConfig {
 
         // Enforce merge-on-read for append-only sinks
         Self::validate_append_only_write_mode(&config.r#type, config.write_mode)?;
+        config.validate_enable_pk_index()?;
 
         // All configs start with "catalog." will be treated as java configs.
         config.java_catalog_props = values

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -337,6 +337,7 @@ fn test_parse_iceberg_config() {
             write_parquet_compression: None,
             write_parquet_max_row_group_rows: None,
             write_parquet_max_row_group_bytes: None,
+            enable_pk_index: false,
         };
 
     assert_eq!(iceberg_config, expected_iceberg_config);

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -292,6 +292,7 @@ fn test_parse_iceberg_config() {
             compaction_type: None,
             write_parquet_compression: None,
             write_parquet_max_row_group_rows: None,
+            enable_pk_index: false,
         };
 
     assert_eq!(iceberg_config, expected_iceberg_config);

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -782,6 +782,13 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+  - name: enable_pk_index
+    field_type: bool
+    comments: |-
+      Whether to enable PK index for upsert sink. Default is false.
+      It's used for V3 upsert iceberg sink to generate delete vectors.
+    required: false
+    default: Default::default
 KafkaConfig:
   fields:
   - name: topic

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -754,6 +754,13 @@ IcebergConfig:
     required: false
     default: Default::default
     allow_alter_on_fly: true
+  - name: enable_pk_index
+    field_type: bool
+    comments: |-
+      Whether to enable PK index for upsert sink. Default is false.
+      It's used for V3 upsert iceberg sink to generate delete vectors.
+    required: false
+    default: Default::default
 KafkaConfig:
   fields:
   - name: topic

--- a/src/frontend/planner_test/tests/testdata/input/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/sink.yaml
@@ -157,6 +157,50 @@
     );
   expected_outputs:
     - explain_output
+- id: create_mock_iceberg_sink_with_pk_index_sparse_partition
+  sql: |
+    create table t1 (v1 int, v2 bigint, v3 varchar, v4 time);
+    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'sparse_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      primary_key = 'v1',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      enable_pk_index = 'true'
+    );
+  expected_outputs:
+    - explain_output
+- id: create_mock_iceberg_sink_with_pk_index_range_partition
+  sql: |
+    create table t1 (v1 date, v2 timestamp, v3 timestamp with time zone, v4 timestamp);
+    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'range_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      primary_key = 'v1',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      enable_pk_index = 'true'
+    );
+  expected_outputs:
+    - explain_output
 - id: create_upsert_jdbc_sink_with_downstream_pk1_separate_sink
   sql: |
     set streaming_separate_sink to true;

--- a/src/frontend/planner_test/tests/testdata/output/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink.yaml
@@ -284,8 +284,8 @@
     );
   explain_output: |
     StreamIcebergWithPkIndexDvMerger
-    └─StreamExchange { dist: Single }
-      └─StreamIcebergWithPkIndexWriter
+    └─StreamExchange { dist: HashShard(file_path) }
+      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id(hidden)], downstream_pk: [t1.v1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [t1.v1, t1.v2, t1.v3, t1.v4, t1._row_id, Row(t1.v1, IcebergTransform('bucket[1]':Varchar, t1.v2), IcebergTransform('truncate[1]':Varchar, t1.v3), null:Time) as $expr1] }
             └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
@@ -311,8 +311,8 @@
     );
   explain_output: |
     StreamIcebergWithPkIndexDvMerger
-    └─StreamExchange { dist: Single }
-      └─StreamIcebergWithPkIndexWriter
+    └─StreamExchange { dist: HashShard(file_path) }
+      └─StreamIcebergWithPkIndexWriter { columns: [v1, v2, v3, v4, t1._row_id(hidden)], downstream_pk: [t1.v1] }
         └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
 - id: create_upsert_jdbc_sink_with_downstream_pk1_separate_sink
   sql: |

--- a/src/frontend/planner_test/tests/testdata/output/sink.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sink.yaml
@@ -262,6 +262,58 @@
   explain_output: |
     StreamSink { type: upsert, columns: [v1, v2, v3, v4, t1._row_id(hidden)], downstream_pk: [t1.v1] }
     └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
+- id: create_mock_iceberg_sink_with_pk_index_sparse_partition
+  sql: |
+    create table t1 (v1 int, v2 bigint, v3 varchar, v4 time);
+    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'sparse_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      primary_key = 'v1',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      enable_pk_index = 'true'
+    );
+  explain_output: |
+    StreamIcebergWithPkIndexDvMerger
+    └─StreamExchange { dist: Single }
+      └─StreamIcebergWithPkIndexWriter
+        └─StreamExchange { dist: HashShard($expr1) }
+          └─StreamProject { exprs: [t1.v1, t1.v2, t1.v3, t1.v4, t1._row_id, Row(t1.v1, IcebergTransform('bucket[1]':Varchar, t1.v2), IcebergTransform('truncate[1]':Varchar, t1.v3), null:Time) as $expr1] }
+            └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
+- id: create_mock_iceberg_sink_with_pk_index_range_partition
+  sql: |
+    create table t1 (v1 date, v2 timestamp, v3 timestamp with time zone, v4 timestamp);
+    explain create sink s1 as select v1 as v1, v2 as v2, v3 as v3, v4 as v4 from t1 WITH (
+      connector = 'iceberg',
+      type = 'upsert',
+      catalog.type = 'mock',
+      catalog.name = 'demo',
+      database.name = 'demo_db',
+      table.name = 'range_table',
+      warehouse.path = 's3://icebergdata/demo',
+      s3.endpoint = 'http://127.0.0.1:9301',
+      s3.region = 'us-east-1',
+      s3.access.key = 'hummockadmin',
+      s3.secret.key = 'hummockadmin',
+      primary_key = 'v1',
+      write_mode = 'merge-on-read',
+      format_version = '3',
+      enable_pk_index = 'true'
+    );
+  explain_output: |
+    StreamIcebergWithPkIndexDvMerger
+    └─StreamExchange { dist: Single }
+      └─StreamIcebergWithPkIndexWriter
+        └─StreamTableScan { table: t1, columns: [v1, v2, v3, v4, _row_id] }
 - id: create_upsert_jdbc_sink_with_downstream_pk1_separate_sink
   sql: |
     set streaming_separate_sink to true;

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -443,7 +443,7 @@ pub async fn gen_sink_plan(
 
     let sink_desc = sink_plan.sink_desc().clone();
 
-    let mut sink_plan: PlanRef = sink_plan.into();
+    let mut sink_plan: PlanRef = sink_plan.into_stream_plan()?;
 
     let ctx = sink_plan.ctx();
     let explain_trace = ctx.is_explain_trace();

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -441,7 +441,7 @@ pub async fn gen_sink_plan(
 
     let sink_desc = sink_plan.sink_desc().clone();
 
-    let mut sink_plan: PlanRef = sink_plan.into();
+    let mut sink_plan: PlanRef = sink_plan.into_stream_plan()?;
 
     let ctx = sink_plan.ctx();
     let explain_trace = ctx.is_explain_trace();

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1763,7 +1763,15 @@ pub async fn create_iceberg_engine_table(
     let mut sink_handler_args = handler_args.clone();
 
     let mut sink_with = with_common.clone();
-    sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
+
+    // TODO: Iceberg with pk index doesn't support auto schema change
+    if !handler_args
+        .with_options
+        .get(ENABLE_COMPACTION)
+        .is_some_and(|val| val.eq_ignore_ascii_case("true"))
+    {
+        sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
+    }
 
     if table.append_only {
         sink_with.insert("type".to_owned(), "append-only".to_owned());

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1762,7 +1762,15 @@ pub async fn create_iceberg_engine_table(
     let mut sink_handler_args = handler_args.clone();
 
     let mut sink_with = with_common.clone();
-    sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
+
+    // TODO: Iceberg with pk index doesn't support auto schema change
+    if !handler_args
+        .with_options
+        .get(ENABLE_COMPACTION)
+        .is_some_and(|val| val.eq_ignore_ascii_case("true"))
+    {
+        sink_with.insert(AUTO_SCHEMA_CHANGE_KEY.to_owned(), "true".to_owned());
+    }
 
     if table.append_only {
         sink_with.insert("type".to_owned(), "append-only".to_owned());

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -1093,6 +1093,8 @@ mod stream_group_topn;
 mod stream_hash_agg;
 mod stream_hash_join;
 mod stream_hop_window;
+mod stream_iceberg_with_pk_index_dv_merger;
+mod stream_iceberg_with_pk_index_writer;
 mod stream_join_common;
 mod stream_local_approx_percentile;
 mod stream_locality_provider;
@@ -1236,6 +1238,8 @@ pub use stream_group_topn::StreamGroupTopN;
 pub use stream_hash_agg::StreamHashAgg;
 pub use stream_hash_join::StreamHashJoin;
 pub use stream_hop_window::StreamHopWindow;
+pub use stream_iceberg_with_pk_index_dv_merger::StreamIcebergWithPkIndexDvMerger;
+pub use stream_iceberg_with_pk_index_writer::StreamIcebergWithPkIndexWriter;
 use stream_join_common::StreamJoinCommon;
 pub use stream_local_approx_percentile::StreamLocalApproxPercentile;
 pub use stream_locality_provider::StreamLocalityProvider;
@@ -1413,6 +1417,8 @@ macro_rules! for_all_plan_nodes {
             , { Stream, LocalityProvider }
             , { Stream, EowcGapFill }
             , { Stream, GapFill }
+            , { Stream, IcebergWithPkIndexWriter }
+            , { Stream, IcebergWithPkIndexDvMerger }
             $(,$rest)*
         }
     };

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_dv_merger.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_dv_merger.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pretty_xmlish::XmlNode;
+use risingwave_connector::sink::catalog::desc::SinkDesc;
+use risingwave_pb::stream_plan::IcebergWithPkIndexDvMergerNode;
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+
+use super::stream::prelude::*;
+use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
+use crate::optimizer::plan_node::utils::{Distill, childless_record};
+use crate::optimizer::plan_node::{
+    ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamNode, StreamPlanRef as PlanRef,
+};
+use crate::optimizer::property::RequiredDist;
+use crate::stream_fragmenter::BuildFragmentGraphState;
+
+/// `StreamIcebergWithPkIndexDvMerger` is the stateless singleton executor for the Iceberg
+/// with pk index sink. It merges delete-position messages from the upstream `WriterExecutor`
+/// with historical deletion vectors and writes merged DV files.
+///
+/// This node enforces `Distribution::Single` (singleton) — an `Exchange` node is automatically
+/// inserted if the input is not already single-distributed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamIcebergWithPkIndexDvMerger {
+    pub base: PlanBase<Stream>,
+    pub input: PlanRef,
+    pub sink_desc: SinkDesc,
+}
+
+impl StreamIcebergWithPkIndexDvMerger {
+    pub fn new(input: PlanRef, sink_desc: SinkDesc) -> Self {
+        // Enforce singleton distribution — inserts Exchange if needed.
+        // `streaming_enforce_if_not_satisfies` is infallible.
+        let input = RequiredDist::single()
+            .streaming_enforce_if_not_satisfies(input)
+            .expect("single distribution enforcement is infallible");
+
+        let base = PlanBase::new_stream(
+            input.ctx(),
+            input.schema().clone(),
+            input.stream_key().map(|keys| keys.to_vec()),
+            input.functional_dependency().clone(),
+            input.distribution().clone(),
+            input.stream_kind(),
+            input.emit_on_window_close(),
+            input.watermark_columns().clone(),
+            input.columns_monotonicity().clone(),
+        );
+        Self {
+            base,
+            input,
+            sink_desc,
+        }
+    }
+}
+
+impl Distill for StreamIcebergWithPkIndexDvMerger {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        childless_record("StreamIcebergWithPkIndexDvMerger", vec![])
+    }
+}
+
+impl PlanTreeNodeUnary<Stream> for StreamIcebergWithPkIndexDvMerger {
+    fn input(&self) -> PlanRef {
+        self.input.clone()
+    }
+
+    fn clone_with_input(&self, input: PlanRef) -> Self {
+        Self::new(input, self.sink_desc.clone())
+    }
+}
+
+impl_plan_tree_node_for_unary! { Stream, StreamIcebergWithPkIndexDvMerger }
+
+impl StreamNode for StreamIcebergWithPkIndexDvMerger {
+    fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> NodeBody {
+        NodeBody::IcebergWithPkIndexDvMerger(Box::new(IcebergWithPkIndexDvMergerNode {
+            sink_desc: Some(self.sink_desc.to_proto()),
+        }))
+    }
+}
+
+impl ExprRewritable<Stream> for StreamIcebergWithPkIndexDvMerger {}
+
+impl ExprVisitable for StreamIcebergWithPkIndexDvMerger {}

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_dv_merger.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_dv_merger.rs
@@ -41,9 +41,8 @@ pub struct StreamIcebergWithPkIndexDvMerger {
 
 impl StreamIcebergWithPkIndexDvMerger {
     pub fn new(input: PlanRef, sink_desc: SinkDesc) -> Self {
-        // Enforce singleton distribution — inserts Exchange if needed.
-        // `streaming_enforce_if_not_satisfies` is infallible.
-        let input = RequiredDist::single()
+        debug_assert_eq!(input.schema().len(), 2); // Expecting `[file_path, position]` from the Writer.
+        let input = RequiredDist::shard_by_key(2, &[0])
             .streaming_enforce_if_not_satisfies(input)
             .expect("single distribution enforcement is infallible");
 

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
@@ -1,0 +1,146 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pretty_xmlish::XmlNode;
+use risingwave_common::catalog::Field;
+use risingwave_common::types::DataType;
+use risingwave_connector::sink::catalog::desc::SinkDesc;
+use risingwave_pb::stream_plan::IcebergWithPkIndexWriterNode;
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+
+use super::stream::prelude::*;
+use crate::TableCatalog;
+use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
+use crate::optimizer::plan_node::utils::{Distill, TableCatalogBuilder, childless_record};
+use crate::optimizer::plan_node::{
+    ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamNode, StreamPlanRef as PlanRef,
+};
+use crate::optimizer::property::{
+    Distribution, FunctionalDependencySet, MonotonicityMap, WatermarkColumns,
+};
+use crate::stream_fragmenter::BuildFragmentGraphState;
+
+/// `StreamIcebergWithPkIndexWriter` is the stateful writer executor for the Iceberg
+/// with pk index sink. It maintains a PK index and writes data files to Iceberg.
+///
+/// Output schema: `[file_path: Varchar, position: Int64]` — delete-position info for
+/// the downstream `DvMerger`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamIcebergWithPkIndexWriter {
+    pub base: PlanBase<Stream>,
+    pub input: PlanRef,
+    pub sink_desc: SinkDesc,
+    pub pk_index_table: TableCatalog,
+}
+
+impl StreamIcebergWithPkIndexWriter {
+    pub fn new(input: PlanRef, sink_desc: SinkDesc) -> Self {
+        let pk_index_table = build_iceberg_pk_state_table(&sink_desc);
+        Self::new_with_pk_index_table(input, sink_desc, pk_index_table)
+    }
+
+    fn new_with_pk_index_table(
+        input: PlanRef,
+        sink_desc: SinkDesc,
+        pk_index_table: TableCatalog,
+    ) -> Self {
+        let output_schema = output_schema();
+        let fd_set = FunctionalDependencySet::new(output_schema.len());
+        let distribution = match input.distribution() {
+            Distribution::Single => Distribution::Single,
+            _ => Distribution::SomeShard,
+        };
+        let base = PlanBase::new_stream(
+            input.ctx(),
+            output_schema,
+            Some(vec![]), // no stream key
+            fd_set,
+            distribution,
+            StreamKind::AppendOnly,
+            input.emit_on_window_close(),
+            WatermarkColumns::new(),
+            MonotonicityMap::new(),
+        );
+        Self {
+            base,
+            input,
+            sink_desc,
+            pk_index_table,
+        }
+    }
+}
+
+fn output_schema() -> risingwave_common::catalog::Schema {
+    risingwave_common::catalog::Schema::new(vec![
+        Field::with_name(DataType::Varchar, "file_path"),
+        Field::with_name(DataType::Int64, "position"),
+    ])
+}
+
+fn build_iceberg_pk_state_table(sink_desc: &SinkDesc) -> TableCatalog {
+    let mut builder = TableCatalogBuilder::default();
+
+    for order in &sink_desc.plan_pk {
+        builder.add_column(&Field::from(
+            &sink_desc.columns[order.column_index].column_desc,
+        ));
+    }
+    builder.add_column(&Field::with_name(DataType::Varchar, "file_path"));
+    builder.add_column(&Field::with_name(DataType::Int64, "position"));
+
+    for (idx, order) in sink_desc.plan_pk.iter().enumerate() {
+        builder.add_order_column(idx, order.order_type);
+    }
+
+    builder.build(
+        (0..sink_desc.plan_pk.len()).collect(),
+        sink_desc.plan_pk.len(),
+    )
+}
+
+impl Distill for StreamIcebergWithPkIndexWriter {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        childless_record("StreamIcebergWithPkIndexWriter", vec![])
+    }
+}
+
+impl PlanTreeNodeUnary<Stream> for StreamIcebergWithPkIndexWriter {
+    fn input(&self) -> PlanRef {
+        self.input.clone()
+    }
+
+    fn clone_with_input(&self, input: PlanRef) -> Self {
+        Self::new_with_pk_index_table(input, self.sink_desc.clone(), self.pk_index_table.clone())
+    }
+}
+
+impl_plan_tree_node_for_unary! { Stream, StreamIcebergWithPkIndexWriter }
+
+impl StreamNode for StreamIcebergWithPkIndexWriter {
+    fn to_stream_prost_body(&self, state: &mut BuildFragmentGraphState) -> NodeBody {
+        let pk_index_table = self
+            .pk_index_table
+            .clone()
+            .with_id(state.gen_table_id_wrapped());
+
+        NodeBody::IcebergWithPkIndexWriter(Box::new(IcebergWithPkIndexWriterNode {
+            sink_desc: Some(self.sink_desc.to_proto()),
+            pk_index_table: Some(pk_index_table.to_internal_table_prost()),
+        }))
+    }
+}
+
+impl ExprRewritable<Stream> for StreamIcebergWithPkIndexWriter {}
+
+impl ExprVisitable for StreamIcebergWithPkIndexWriter {}

--- a/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_iceberg_with_pk_index_writer.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use pretty_xmlish::XmlNode;
+use anyhow::Context;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::Field;
 use risingwave_common::types::DataType;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
@@ -22,7 +23,9 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use super::stream::prelude::*;
 use crate::TableCatalog;
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
-use crate::optimizer::plan_node::utils::{Distill, TableCatalogBuilder, childless_record};
+use crate::optimizer::plan_node::utils::{
+    Distill, IndicesDisplay, TableCatalogBuilder, childless_record,
+};
 use crate::optimizer::plan_node::{
     ExprRewritable, PlanBase, PlanTreeNodeUnary, Stream, StreamNode, StreamPlanRef as PlanRef,
 };
@@ -45,39 +48,31 @@ pub struct StreamIcebergWithPkIndexWriter {
 }
 
 impl StreamIcebergWithPkIndexWriter {
-    pub fn new(input: PlanRef, sink_desc: SinkDesc) -> Self {
-        let pk_index_table = build_iceberg_pk_state_table(&sink_desc);
-        Self::new_with_pk_index_table(input, sink_desc, pk_index_table)
-    }
-
-    fn new_with_pk_index_table(
-        input: PlanRef,
-        sink_desc: SinkDesc,
-        pk_index_table: TableCatalog,
-    ) -> Self {
+    pub fn from_stream_sink(sink: &super::StreamSink) -> Result<Self> {
         let output_schema = output_schema();
         let fd_set = FunctionalDependencySet::new(output_schema.len());
-        let distribution = match input.distribution() {
+        let dist = match sink.distribution() {
             Distribution::Single => Distribution::Single,
             _ => Distribution::SomeShard,
         };
         let base = PlanBase::new_stream(
-            input.ctx(),
+            sink.ctx(),
             output_schema,
-            Some(vec![]), // no stream key
+            Some(vec![]),
             fd_set,
-            distribution,
+            dist,
             StreamKind::AppendOnly,
-            input.emit_on_window_close(),
+            sink.emit_on_window_close(),
             WatermarkColumns::new(),
             MonotonicityMap::new(),
         );
-        Self {
+        let pk_index_table = build_iceberg_pk_state_table(sink.sink_desc())?;
+        Ok(Self {
             base,
-            input,
-            sink_desc,
+            input: sink.input(),
+            sink_desc: sink.sink_desc().clone(),
             pk_index_table,
-        }
+        })
     }
 }
 
@@ -88,10 +83,15 @@ fn output_schema() -> risingwave_common::catalog::Schema {
     ])
 }
 
-fn build_iceberg_pk_state_table(sink_desc: &SinkDesc) -> TableCatalog {
+fn build_iceberg_pk_state_table(sink_desc: &SinkDesc) -> Result<TableCatalog> {
     let mut builder = TableCatalogBuilder::default();
 
-    for order in &sink_desc.plan_pk {
+    let downstream_pk = sink_desc
+        .downstream_pk
+        .as_ref()
+        .context("Missing downstream PK in Iceberg sink desc")?;
+    for &idx in downstream_pk {
+        let order = &sink_desc.plan_pk[idx];
         builder.add_column(&Field::from(
             &sink_desc.columns[order.column_index].column_desc,
         ));
@@ -103,15 +103,34 @@ fn build_iceberg_pk_state_table(sink_desc: &SinkDesc) -> TableCatalog {
         builder.add_order_column(idx, order.order_type);
     }
 
-    builder.build(
+    let res = builder.build(
         (0..sink_desc.plan_pk.len()).collect(),
         sink_desc.plan_pk.len(),
-    )
+    );
+    Ok(res)
 }
 
 impl Distill for StreamIcebergWithPkIndexWriter {
     fn distill<'a>(&self) -> XmlNode<'a> {
-        childless_record("StreamIcebergWithPkIndexWriter", vec![])
+        let column_names = self
+            .sink_desc
+            .columns
+            .iter()
+            .map(|col| col.name_with_hidden().to_string())
+            .map(Pretty::from)
+            .collect();
+        let column_names = Pretty::Array(column_names);
+        let mut vec = Vec::with_capacity(2);
+        vec.push(("columns", column_names));
+        if let Some(pk) = &self.sink_desc.downstream_pk {
+            let sink_pk = IndicesDisplay {
+                indices: pk,
+                schema: self.input.schema(),
+            };
+            vec.push(("downstream_pk", sink_pk.distill()));
+        }
+
+        childless_record("StreamIcebergWithPkIndexWriter", vec)
     }
 }
 
@@ -121,7 +140,12 @@ impl PlanTreeNodeUnary<Stream> for StreamIcebergWithPkIndexWriter {
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        Self::new_with_pk_index_table(input, self.sink_desc.clone(), self.pk_index_table.clone())
+        Self {
+            base: self.base.clone(),
+            input,
+            sink_desc: self.sink_desc.clone(),
+            pk_index_table: self.pk_index_table.clone(),
+        }
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -26,7 +26,7 @@ use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
 use risingwave_connector::sink::catalog::{SinkFormat, SinkFormatDesc, SinkId, SinkType};
 use risingwave_connector::sink::file_sink::fs::FsSink;
-use risingwave_connector::sink::iceberg::ICEBERG_SINK;
+use risingwave_connector::sink::iceberg::{ICEBERG_SINK, IcebergConfig};
 use risingwave_connector::sink::trivial::TABLE_SINK;
 use risingwave_connector::sink::{
     CONNECTOR_TYPE_KEY, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION,
@@ -751,6 +751,38 @@ impl StreamSink {
     fn infer_kv_log_store_table_catalog(&self) -> TableCatalog {
         infer_kv_log_store_table_catalog_inner(&self.input, &self.sink_desc().columns)
     }
+
+    /// Convert this `StreamSink` into a `PlanRef`.
+    ///
+    /// For Iceberg pk index sinks, this rewrites the plan into
+    /// `Upstream → Writer → Exchange(Single) → DvMerger` instead of a single `SinkNode`.
+    /// For all other sinks, returns `self` as-is.
+    pub fn into_stream_plan(self) -> Result<PlanRef> {
+        use super::{StreamIcebergWithPkIndexDvMerger, StreamIcebergWithPkIndexWriter};
+
+        if !is_iceberg_with_pk_index_sink(&self.sink_desc)? {
+            return Ok(self.into());
+        }
+
+        let writer: PlanRef =
+            StreamIcebergWithPkIndexWriter::new(self.input, self.sink_desc.clone()).into();
+        let dv_merger: PlanRef =
+            StreamIcebergWithPkIndexDvMerger::new(writer, self.sink_desc).into();
+        Ok(dv_merger)
+    }
+}
+
+pub fn is_iceberg_with_pk_index_sink(sink_desc: &SinkDesc) -> Result<bool> {
+    if !sink_desc
+        .properties
+        .get(CONNECTOR_TYPE_KEY)
+        .is_some_and(|connector| connector.eq_ignore_ascii_case(ICEBERG_SINK))
+    {
+        return Ok(false);
+    }
+
+    let iceberg_config = IcebergConfig::from_btreemap(sink_desc.properties.clone())?;
+    Ok(iceberg_config.enable_pk_index)
 }
 
 impl PlanTreeNodeUnary<Stream> for StreamSink {

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -764,8 +764,7 @@ impl StreamSink {
             return Ok(self.into());
         }
 
-        let writer: PlanRef =
-            StreamIcebergWithPkIndexWriter::new(self.input, self.sink_desc.clone()).into();
+        let writer: PlanRef = StreamIcebergWithPkIndexWriter::from_stream_sink(&self)?.into();
         let dv_merger: PlanRef =
             StreamIcebergWithPkIndexDvMerger::new(writer, self.sink_desc).into();
         Ok(dv_merger)

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -26,6 +26,7 @@ use risingwave_common::id::{ObjectId, TableId};
 use risingwave_common::types::DataType;
 use risingwave_common::util::stream_graph_visitor;
 use risingwave_connector::sink::catalog::SinkId;
+use risingwave_connector::sink::iceberg::ENABLE_PK_INDEX;
 use risingwave_meta::barrier::{BarrierScheduler, Command, ResumeBackfillTarget};
 use risingwave_meta::manager::{EventLogManagerRef, MetadataManager, iceberg_compaction};
 use risingwave_meta::model::TableParallelism as ModelTableParallelism;
@@ -1642,7 +1643,15 @@ impl DdlService for DdlServiceImpl {
 
         // Mark sink as background creation, so that it won't block source creation.
         sink.create_type = PbCreateType::Background as _;
-        sink.auto_refresh_schema_from_table = Some(table_catalog.id);
+
+        // TODO: Iceberg with pk index doesn't support auto schema change
+        if !sink
+            .properties
+            .get(ENABLE_PK_INDEX)
+            .is_some_and(|v| v.eq_ignore_ascii_case("true"))
+        {
+            sink.auto_refresh_schema_from_table = Some(table_catalog.id);
+        }
 
         let mut fragment_graph = fragment_graph.unwrap();
 

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -1181,6 +1181,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .boxed(".stream_plan.StreamNode.node_body.eowc_gap_fill")
         .boxed(".stream_plan.StreamNode.node_body.gap_fill")
         .boxed(".stream_plan.StreamNode.node_body.vector_index_lookup_join")
+        .boxed(".stream_plan.StreamNode.node_body.iceberg_with_pk_index_writer")
+        .boxed(".stream_plan.StreamNode.node_body.iceberg_with_pk_index_dv_merger")
         // `Udf` is 248 bytes, while 2nd largest field is 32 bytes.
         .boxed(".expr.ExprNode.rex_node.udf")
         // prost-build 0.14+ only derives `Eq`/`Hash` for a subset of messages/oneofs.

--- a/src/stream/src/from_proto/iceberg_with_pk_index/dv_merger.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/dv_merger.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::stream_plan::IcebergWithPkIndexDvMergerNode;
+use risingwave_storage::StateStore;
+
+use crate::error::StreamResult;
+use crate::executor::Executor;
+use crate::from_proto::ExecutorBuilder;
+use crate::task::ExecutorParams;
+
+pub struct IcebergWithPkIndexDvMergerExecutorBuilder;
+
+impl ExecutorBuilder for IcebergWithPkIndexDvMergerExecutorBuilder {
+    type Node = IcebergWithPkIndexDvMergerNode;
+
+    async fn new_boxed_executor(
+        _params: ExecutorParams,
+        _node: &Self::Node,
+        _store: impl StateStore,
+    ) -> StreamResult<Executor> {
+        todo!()
+    }
+}

--- a/src/stream/src/from_proto/iceberg_with_pk_index/mod.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod dv_merger;
+mod writer;
+
+pub use dv_merger::IcebergWithPkIndexDvMergerExecutorBuilder;
+pub use writer::IcebergWithPkIndexWriterExecutorBuilder;

--- a/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::stream_plan::IcebergWithPkIndexWriterNode;
+use risingwave_storage::StateStore;
+
+use crate::error::StreamResult;
+use crate::executor::Executor;
+use crate::from_proto::ExecutorBuilder;
+use crate::task::ExecutorParams;
+
+pub struct IcebergWithPkIndexWriterExecutorBuilder;
+
+impl ExecutorBuilder for IcebergWithPkIndexWriterExecutorBuilder {
+    type Node = IcebergWithPkIndexWriterNode;
+
+    async fn new_boxed_executor(
+        _params: ExecutorParams,
+        _node: &Self::Node,
+        _store: impl StateStore,
+    ) -> StreamResult<Executor> {
+        todo!()
+    }
+}

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -32,6 +32,7 @@ mod group_top_n;
 mod hash_agg;
 mod hash_join;
 mod hop_window;
+mod iceberg_with_pk_index;
 mod locality_provider;
 mod lookup;
 mod lookup_union;
@@ -91,6 +92,7 @@ use self::group_top_n::GroupTopNExecutorBuilder;
 use self::hash_agg::*;
 use self::hash_join::*;
 use self::hop_window::*;
+use self::iceberg_with_pk_index::*;
 use self::locality_provider::*;
 use self::lookup::*;
 use self::lookup_union::*;
@@ -213,5 +215,7 @@ pub async fn create_executor(
         NodeBody::EowcGapFill => EowcGapFillExecutorBuilder,
         NodeBody::GapFill => GapFillExecutorBuilder,
         NodeBody::VectorIndexLookupJoin => VectorIndexLookupJoinBuilder,
+        NodeBody::IcebergWithPkIndexWriter => IcebergWithPkIndexWriterExecutorBuilder,
+        NodeBody::IcebergWithPkIndexDvMerger => IcebergWithPkIndexDvMergerExecutorBuilder,
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds frontend planning support for Iceberg V3 upsert sinks with PK index enabled.
When iceberg sink config has `enable_pk_index = 'true'`, the frontend now rewrites the
sink plan from a single `StreamSink` into a dedicated two-stage pipeline:

`Upstream -> IcebergWithPkIndexWriter -> Exchange(Hash(file_path)) -> IcebergWithPkIndexDvMerger`

The new sinker currently doesn't support auto schema change, and related iceberg table/sink creation flow have updated.

The actual streaming executors will be implemented in the next PR.

### What Changed

- Added `enable_pk_index` to `IcebergConfig`
- Validated that PK index is only allowed for:
  - Iceberg upsert sink
  - merge-on-read mode
  - format version >= 3
  - non-append-only mode
- Added two new frontend stream plan nodes:
  - `StreamIcebergWithPkIndexWriter`
  - `StreamIcebergWithPkIndexDvMerger`
- Added protobuf definitions and stream executor builder wiring for the new nodes
- Added planner test coverage for Iceberg PK index sink plans, including partitioned cases

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
