### PR TITLE
feat(storage): add local write attempt counters for MonitoredTableStateStore

### DIFF
--- a/src/storage/src/monitor/monitored_storage_metrics.rs
+++ b/src/storage/src/monitor/monitored_storage_metrics.rs
@@ -60,6 +60,10 @@ pub struct MonitoredStorageMetrics {
     // [table_id, top_n, ef_search]
     pub vector_nearest_duration: LabelGuardedHistogramVec,
 
+    /// [table_id, op_type] — op_type: `insert`, `delete`, `seal_epoch`, `vector_insert`.
+    /// Counts **attempted** wrapper calls (incremented before delegating to inner), not guaranteed successes.
+    pub local_write_counts: LabelGuardedIntCounterVec,
+
     pub sync_duration: Histogram,
     pub sync_size: Histogram,
 }
@@ -270,6 +274,14 @@ impl MonitoredStorageMetrics {
         )
         .unwrap();
 
+        let local_write_counts = register_guarded_int_counter_vec_with_registry!(
+            "state_store_local_write_counts",
+            "Attempted write calls through MonitoredTableStateStore (insert/delete/seal_epoch/vector_insert); incremented before inner runs, not success-only.",
+            &["table_id", "op_type"],
+            registry
+        )
+        .unwrap();
+
         Self {
             get_duration,
             get_key_size,
@@ -282,6 +294,7 @@ impl MonitoredStorageMetrics {
             iter_in_progress_counts,
             iter_log_op_type_counts,
             vector_nearest_duration,
+            local_write_counts,
             sync_duration,
             sync_size,
         }

--- a/src/storage/src/monitor/monitored_storage_metrics.rs
+++ b/src/storage/src/monitor/monitored_storage_metrics.rs
@@ -60,7 +60,7 @@ pub struct MonitoredStorageMetrics {
     // [table_id, top_n, ef_search]
     pub vector_nearest_duration: LabelGuardedHistogramVec,
 
-    /// [table_id, op_type] — op_type: `insert`, `delete`, `seal_epoch`, `vector_insert`.
+    /// Prometheus label dimensions `table_id` and `op_type` (`insert`, `delete`, `seal_epoch`, `vector_insert`).
     /// Counts **attempted** wrapper calls (incremented before delegating to inner), not guaranteed successes.
     pub local_write_counts: LabelGuardedIntCounterVec,
 

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -273,12 +273,20 @@ impl<S: LocalStateStore> LocalStateStore for MonitoredTableStateStore<S> {
         new_val: Bytes,
         old_val: Option<Bytes>,
     ) -> StorageResult<()> {
-        // TODO: collect metrics
+        let table_id_label = self.table_id().to_string();
+        self.storage_metrics
+            .local_write_counts
+            .with_guarded_label_values(&[table_id_label.as_str(), "insert"])
+            .inc();
         self.inner.insert(key, new_val, old_val)
     }
 
     fn delete(&mut self, key: TableKey<Bytes>, old_val: Bytes) -> StorageResult<()> {
-        // TODO: collect metrics
+        let table_id_label = self.table_id().to_string();
+        self.storage_metrics
+            .local_write_counts
+            .with_guarded_label_values(&[table_id_label.as_str(), "delete"])
+            .inc();
         self.inner.delete(key, old_val)
     }
 
@@ -309,7 +317,11 @@ impl<S: StateStoreWriteEpochControl> StateStoreWriteEpochControl for MonitoredTa
     }
 
     fn seal_current_epoch(&mut self, next_epoch: u64, opts: SealCurrentEpochOptions) {
-        // TODO: may collect metrics
+        let table_id_label = self.table_id().to_string();
+        self.storage_metrics
+            .local_write_counts
+            .with_guarded_label_values(&[table_id_label.as_str(), "seal_epoch"])
+            .inc();
         self.inner.seal_current_epoch(next_epoch, opts)
     }
 
@@ -322,7 +334,11 @@ impl<S: StateStoreWriteEpochControl> StateStoreWriteEpochControl for MonitoredTa
 
 impl<S: StateStoreWriteVector> StateStoreWriteVector for MonitoredTableStateStore<S> {
     fn insert(&mut self, vec: VectorRef<'_>, info: Bytes) -> StorageResult<()> {
-        // TODO: monitor
+        let table_id_label = self.table_id().to_string();
+        self.storage_metrics
+            .local_write_counts
+            .with_guarded_label_values(&[table_id_label.as_str(), "vector_insert"])
+            .inc();
         self.inner.insert(vec, info)
     }
 }


### PR DESCRIPTION
## Summary
- Add Prometheus counter `state_store_local_write_counts` with labels `table_id`, `op_type` (`insert`, `delete`, `seal_epoch`, `vector_insert`) for `MonitoredTableStateStore` write APIs.
- Counters increment **before** delegating to the inner store: they measure **attempted wrapper calls**, not success-only writes (documented in metric help and field docs).

## Context
- Fills long-standing `TODO: collect metrics` / `TODO: monitor` on local insert/delete/seal/vector insert paths.
- Semantics intentionally distinct from `state_store_write_batch_*` (hummock flush/upload) and `state_store_iter_log_op_type_counts` (iter log row ops).

## Test plan
- [x] `cargo check -p risingwave_storage`
- [x] `cargo test -p risingwave_storage --lib hitmap::tests`


Made with [Cursor](https://cursor.com)