### PR TITLE
WIP: feat(storage): gate streaming cache refill locality

### DIFF
--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -338,7 +338,12 @@ impl HummockEventHandler {
             spawn_upload_task,
             buffer_tracker,
         );
-        let refiller = CacheRefiller::new(refill_config, sstable_store, spawn_refill_task);
+        let refiller = CacheRefiller::new(
+            refill_config,
+            sstable_store,
+            spawn_refill_task,
+            read_version_mapping.clone(),
+        );
 
         Self {
             hummock_event_tx,

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -15,7 +15,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::poll_fn;
 use std::ops::{Bound, Range};
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, LazyLock};
 use std::task::Poll;
 use std::time::{Duration, Instant};
@@ -35,6 +35,7 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::TableId;
 use risingwave_common::license::Feature;
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
+use risingwave_common::util::panic::rw_catch_unwind;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::SstDeltaInfo;
 use risingwave_hummock_sdk::key::{FullKey, vnode_range};
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
@@ -470,7 +471,7 @@ struct CacheRefillTask {
 
 impl CacheRefillTask {
     fn with_fail_open_locality_gate(gate_name: &'static str, check: impl FnOnce() -> bool) -> bool {
-        match catch_unwind(AssertUnwindSafe(check)) {
+        match rw_catch_unwind(AssertUnwindSafe(check)) {
             Ok(admit) => admit,
             Err(_) => {
                 tracing::warn!(

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -14,7 +14,8 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::poll_fn;
-use std::ops::Range;
+use std::ops::{Bound, Range};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{Arc, LazyLock};
 use std::task::Poll;
 use std::time::{Duration, Instant};
@@ -23,19 +24,26 @@ use foyer::{HybridCacheEntry, RangeBoundsExt};
 use futures::future::{join_all, try_join_all};
 use futures::{Future, FutureExt};
 use itertools::Itertools;
+use parking_lot::RwLock;
 use prometheus::core::{AtomicU64, GenericCounter, GenericCounterVec};
 use prometheus::{
     Histogram, HistogramVec, IntGauge, Registry, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, register_int_gauge_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry,
 };
+use risingwave_common::bitmap::Bitmap;
+use risingwave_common::catalog::TableId;
 use risingwave_common::license::Feature;
 use risingwave_common::monitor::GLOBAL_METRICS_REGISTRY;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::SstDeltaInfo;
+use risingwave_hummock_sdk::key::{FullKey, vnode_range};
+use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::{HummockSstableObjectId, KeyComparator};
 use thiserror_ext::AsReport;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
+use super::ReadVersionMappingType;
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::{
     Block, HummockError, HummockResult, RecentFilterTrait, Sstable, SstableBlockIndex,
@@ -70,6 +78,10 @@ pub struct CacheRefillMetrics {
 
     pub data_refill_ideal_bytes: GenericCounter<AtomicU64>,
     pub data_refill_success_bytes: GenericCounter<AtomicU64>,
+
+    pub data_refill_locality_filtered_total: GenericCounter<AtomicU64>,
+    pub meta_refill_locality_skipped_total: GenericCounter<AtomicU64>,
+    pub meta_refill_locality_saved_remote_bytes_total: GenericCounter<AtomicU64>,
 
     pub refill_queue_total: IntGauge,
 }
@@ -144,6 +156,24 @@ impl CacheRefillMetrics {
         let data_refill_success_bytes = refill_bytes
             .get_metric_with_label_values(&["data", "success"])
             .unwrap();
+        let data_refill_locality_filtered_total = register_int_counter_with_registry!(
+            "data_refill_locality_filtered_total",
+            "Total number of blocks filtered by streaming-only data refill locality gating.",
+            registry,
+        )
+        .unwrap();
+        let meta_refill_locality_skipped_total = register_int_counter_with_registry!(
+            "meta_refill_locality_skipped_total",
+            "Total number of SSTs skipped by streaming-only meta refill locality gating.",
+            registry,
+        )
+        .unwrap();
+        let meta_refill_locality_saved_remote_bytes_total = register_int_counter_with_registry!(
+            "meta_refill_locality_saved_remote_bytes_total",
+            "Total estimated remote bytes saved by streaming-only meta refill locality gating.",
+            registry,
+        )
+        .unwrap();
 
         let refill_queue_total = register_int_gauge_with_registry!(
             "refill_queue_total",
@@ -174,6 +204,9 @@ impl CacheRefillMetrics {
 
             data_refill_ideal_bytes,
             data_refill_success_bytes,
+            data_refill_locality_filtered_total,
+            meta_refill_locality_skipped_total,
+            meta_refill_locality_saved_remote_bytes_total,
 
             refill_queue_total,
         }
@@ -245,6 +278,79 @@ pub(crate) type SpawnRefillTask = Arc<
         + 'static,
 >;
 
+pub struct TableCacheRefillContext {
+    pub read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
+}
+
+#[derive(Default)]
+struct StreamingTableCacheRefillView {
+    streaming: HashMap<TableId, Bitmap>,
+}
+
+impl TableCacheRefillContext {
+    fn build_streaming_view(&self) -> StreamingTableCacheRefillView {
+        let read_version_mapping = self.read_version_mapping.read();
+        let mut streaming = HashMap::new();
+        for (table_id, mapping) in &*read_version_mapping {
+            for read_version in mapping.values() {
+                let vnodes = read_version.read().vnodes();
+                streaming
+                    .entry(*table_id)
+                    .and_modify(|bitmap: &mut Bitmap| *bitmap |= vnodes.as_ref())
+                    .or_insert_with(|| vnodes.as_ref().clone());
+            }
+        }
+        StreamingTableCacheRefillView { streaming }
+    }
+}
+
+impl StreamingTableCacheRefillView {
+    fn contains_table(&self, table_id: &TableId) -> bool {
+        self.streaming.contains_key(table_id)
+    }
+
+    fn check_table_refill_vnodes(&self, sstable: &Sstable, block_index: usize) -> bool {
+        let block_smallest_key =
+            FullKey::decode(&sstable.meta.block_metas[block_index].smallest_key)
+                .to_vec()
+                .into_bytes();
+        let table_id = block_smallest_key.user_key.table_id;
+        let Some(streaming_bitmap) = self.streaming.get(&table_id) else {
+            return false;
+        };
+
+        let block_largest_key =
+            if let Some(next_block_meta) = sstable.meta.block_metas.get(block_index + 1) {
+                if next_block_meta.table_id() != table_id {
+                    // The next block belongs to another table, so we no longer have a safe upper
+                    // bound for vnode_range. Admit to avoid false negative filtering.
+                    return true;
+                }
+                FullKey::decode(&next_block_meta.smallest_key)
+                    .to_vec()
+                    .into_bytes()
+            } else {
+                let largest_key = FullKey::decode(&sstable.meta.largest_key)
+                    .to_vec()
+                    .into_bytes();
+                if largest_key.user_key.table_id != table_id {
+                    // Multi-table SSTs can end with another table's largest key. Admit when the local
+                    // table is present to avoid false negative filtering on the boundary block.
+                    return true;
+                }
+                largest_key
+            };
+
+        let table_key_range = (
+            Bound::Included(block_smallest_key.user_key.table_key),
+            Bound::Excluded(block_largest_key.user_key.table_key),
+        );
+        let vnode_range = vnode_range(&table_key_range);
+        let bitmap = Bitmap::from_range(streaming_bitmap.len(), vnode_range.0..vnode_range.1);
+        (&bitmap & streaming_bitmap).any()
+    }
+}
+
 /// A cache refiller for hummock data.
 pub(crate) struct CacheRefiller {
     /// order: old => new
@@ -260,6 +366,7 @@ impl CacheRefiller {
         config: CacheRefillConfig,
         sstable_store: SstableStoreRef,
         spawn_refill_task: SpawnRefillTask,
+        read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
     ) -> Self {
         let config = Arc::new(config);
         let concurrency = Arc::new(Semaphore::new(config.concurrency));
@@ -275,6 +382,9 @@ impl CacheRefiller {
                 meta_refill_concurrency,
                 concurrency,
                 sstable_store,
+                table_cache_refill_context: Arc::new(RwLock::new(TableCacheRefillContext {
+                    read_version_mapping,
+                })),
             },
             spawn_refill_task,
         }
@@ -350,6 +460,7 @@ pub(crate) struct CacheRefillContext {
     meta_refill_concurrency: Option<Arc<Semaphore>>,
     concurrency: Arc<Semaphore>,
     sstable_store: SstableStoreRef,
+    table_cache_refill_context: Arc<RwLock<TableCacheRefillContext>>,
 }
 
 struct CacheRefillTask {
@@ -358,6 +469,54 @@ struct CacheRefillTask {
 }
 
 impl CacheRefillTask {
+    fn with_fail_open_locality_gate(gate_name: &'static str, check: impl FnOnce() -> bool) -> bool {
+        match catch_unwind(AssertUnwindSafe(check)) {
+            Ok(admit) => admit,
+            Err(_) => {
+                tracing::warn!(
+                    gate = gate_name,
+                    "cache refill locality gate panicked, admit"
+                );
+                true
+            }
+        }
+    }
+
+    fn should_admit_meta_refill(
+        context: &StreamingTableCacheRefillView,
+        info: &SstableInfo,
+    ) -> bool {
+        info.table_ids
+            .iter()
+            .any(|table_id| context.contains_table(table_id))
+    }
+
+    fn filter_by_streaming_vnodes(
+        streaming_view: &StreamingTableCacheRefillView,
+        tasks: Vec<DataCacheRefillTask>,
+    ) -> Vec<DataCacheRefillTask> {
+        let mut filtered_blocks = 0;
+        let mut retained = Vec::with_capacity(tasks.len());
+
+        for task in tasks {
+            let admit = Self::with_fail_open_locality_gate("data_refill", || {
+                (task.blks.start..task.blks.end)
+                    .any(|blk| streaming_view.check_table_refill_vnodes(&task.sst, blk))
+            });
+
+            if admit {
+                retained.push(task);
+            } else {
+                filtered_blocks += task.blks.end - task.blks.start;
+            }
+        }
+
+        GLOBAL_CACHE_REFILL_METRICS
+            .data_refill_locality_filtered_total
+            .inc_by(filtered_blocks as u64);
+        retained
+    }
+
     async fn run(self) {
         let tasks = self
             .deltas
@@ -385,9 +544,27 @@ impl CacheRefillTask {
         context: &CacheRefillContext,
         delta: &SstDeltaInfo,
     ) -> HummockResult<Vec<TableHolder>> {
+        let streaming_view = context
+            .table_cache_refill_context
+            .read()
+            .build_streaming_view();
         let tasks = delta
             .insert_sst_infos
             .iter()
+            .filter(|info| {
+                let admit = Self::with_fail_open_locality_gate("meta_refill", || {
+                    Self::should_admit_meta_refill(&streaming_view, info)
+                });
+                if !admit {
+                    GLOBAL_CACHE_REFILL_METRICS
+                        .meta_refill_locality_skipped_total
+                        .inc();
+                    GLOBAL_CACHE_REFILL_METRICS
+                        .meta_refill_locality_saved_remote_bytes_total
+                        .inc_by(info.file_size.saturating_sub(info.meta_offset));
+                }
+                admit
+            })
             .map(|info| async {
                 let mut stats = StoreLocalStatistic::default();
                 GLOBAL_CACHE_REFILL_METRICS.meta_refill_attempts_total.inc();
@@ -542,7 +719,7 @@ impl CacheRefillTask {
                     .sum::<u64>(),
             );
 
-        if delta.insert_sst_level == 0 || context.config.skip_recent_filter {
+        if delta.insert_sst_level == 0 {
             Self::data_file_cache_refill_full_impl(context, delta, holders).await;
         } else {
             Self::data_file_cache_impl(context, delta, holders).await;
@@ -555,21 +732,18 @@ impl CacheRefillTask {
         holders: Vec<TableHolder>,
     ) {
         let unit = context.config.unit;
-
-        let mut futures = vec![];
-
-        for sst in &holders {
-            for blk_start in (0..sst.block_count()).step_by(unit) {
-                let blk_end = std::cmp::min(sst.block_count(), blk_start + unit);
-                let unit = SstableUnit {
-                    sst_obj_id: sst.id,
-                    blks: blk_start..blk_end,
-                };
-                futures.push(
-                    async move { Self::data_file_cache_refill_unit(context, sst, unit).await },
-                );
-            }
-        }
+        let futures = holders.into_iter().flat_map(|sst| {
+            (0..sst.block_count()).step_by(unit).map(move |blk_start| {
+                let task_sst = sst.clone();
+                async move {
+                    let unit = SstableUnit {
+                        sst_obj_id: task_sst.id,
+                        blks: blk_start..std::cmp::min(task_sst.block_count(), blk_start + unit),
+                    };
+                    Self::data_file_cache_refill_unit(context, &task_sst, unit).await
+                }
+            })
+        });
         join_all(futures).await;
     }
 
@@ -605,13 +779,25 @@ impl CacheRefillTask {
 
         let ssts: HashMap<HummockSstableObjectId, TableHolder> =
             holders.into_iter().map(|meta| (meta.id, meta)).collect();
-        let futures = units.into_iter().map(|unit| {
-            let ssts = &ssts;
-            async move {
-                let sst = ssts.get(&unit.sst_obj_id).unwrap();
-                if let Err(e) = Self::data_file_cache_refill_unit(context, sst, unit).await {
-                    tracing::error!(error = %e.as_report(), "data file cache unit refill error");
-                }
+        let tasks = units
+            .into_iter()
+            .map(|unit| DataCacheRefillTask {
+                sst: ssts.get(&unit.sst_obj_id).unwrap().clone(),
+                blks: unit.blks,
+            })
+            .collect_vec();
+        let streaming_view = context
+            .table_cache_refill_context
+            .read()
+            .build_streaming_view();
+        let tasks = Self::filter_by_streaming_vnodes(&streaming_view, tasks);
+        let futures = tasks.into_iter().map(|task| async move {
+            let unit = SstableUnit {
+                sst_obj_id: task.sst.id,
+                blks: task.blks.clone(),
+            };
+            if let Err(e) = Self::data_file_cache_refill_unit(context, &task.sst, unit).await {
+                tracing::error!(error = %e.as_report(), "data file cache unit refill error");
             }
         });
         join_all(futures).await;
@@ -715,6 +901,12 @@ impl CacheRefillTask {
     }
 }
 
+#[derive(Debug, Clone)]
+struct DataCacheRefillTask {
+    sst: TableHolder,
+    blks: Range<usize>,
+}
+
 #[derive(Debug)]
 pub struct SstableBlock {
     pub sst_obj_id: HummockSstableObjectId,
@@ -779,5 +971,435 @@ impl<'a> Unit<'a> {
             } else {
                 1
             }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use parking_lot::RwLock;
+    use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
+    use risingwave_hummock_sdk::key::{FullKey, gen_key_from_str};
+    use risingwave_hummock_sdk::sstable_info::SstableInfoInner;
+    use risingwave_hummock_sdk::version::HummockVersion;
+    use risingwave_pb::hummock::{PbHummockVersion, StateTableInfo};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::*;
+    use crate::hummock::HummockValue;
+    use crate::hummock::iterator::test_utils::{iterator_test_key_of, mock_sstable_store};
+    use crate::hummock::local_version::pinned_version::PinnedVersion;
+    use crate::hummock::sstable::{BlockMeta, SstableMeta};
+    use crate::hummock::store::version::HummockReadVersion;
+    use crate::hummock::test_utils::{default_builder_opt_for_test, gen_test_sstable_info};
+    use crate::monitor::StoreLocalStatistic;
+
+    fn test_bitmap(bits: &[usize]) -> Bitmap {
+        let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+        for bit in bits {
+            builder.set(*bit, true);
+        }
+        builder.finish()
+    }
+
+    fn test_full_key(table_id: TableId, vnode: usize, suffix: &str) -> Vec<u8> {
+        FullKey::new(
+            table_id,
+            gen_key_from_str(VirtualNode::from_index(vnode), suffix),
+            0,
+        )
+        .encode()
+    }
+
+    fn test_sstable_meta(blocks: &[(TableId, usize, &str)]) -> SstableMeta {
+        let block_metas = blocks
+            .iter()
+            .enumerate()
+            .map(|(idx, (table_id, vnode, suffix))| BlockMeta {
+                smallest_key: test_full_key(*table_id, *vnode, suffix),
+                offset: idx as u32,
+                len: 1,
+                uncompressed_size: 1,
+                total_key_count: 1,
+                stale_key_count: 0,
+            })
+            .collect_vec();
+        let (last_table_id, last_vnode, last_suffix) = blocks.last().copied().unwrap();
+        SstableMeta {
+            block_metas,
+            smallest_key: test_full_key(blocks[0].0, blocks[0].1, blocks[0].2),
+            largest_key: test_full_key(last_table_id, last_vnode, &format!("{last_suffix}_end")),
+            estimated_size: 1024,
+            key_count: blocks.len() as u32,
+            meta_offset: 512,
+            ..Default::default()
+        }
+    }
+
+    fn test_pinned_version(table_ids: impl IntoIterator<Item = TableId>) -> PinnedVersion {
+        PinnedVersion::new(
+            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+                id: 1.into(),
+                state_table_info: HashMap::from_iter(table_ids.into_iter().map(|table_id| {
+                    (
+                        table_id,
+                        StateTableInfo {
+                            committed_epoch: test_epoch(233),
+                            compaction_group_id: StaticCompactionGroupId::StateDefault,
+                        },
+                    )
+                })),
+                ..Default::default()
+            }),
+            unbounded_channel().0,
+        )
+    }
+
+    fn test_read_version(
+        table_id: TableId,
+        instance_id: u64,
+        vnodes: Bitmap,
+    ) -> Arc<RwLock<HummockReadVersion>> {
+        Arc::new(RwLock::new(
+            HummockReadVersion::new_with_replication_option(
+                table_id,
+                instance_id,
+                test_pinned_version([table_id]),
+                false,
+                Arc::new(vnodes),
+            ),
+        ))
+    }
+
+    fn test_refill_context(
+        sstable_store: SstableStoreRef,
+        read_version_mapping: ReadVersionMappingType,
+    ) -> CacheRefillContext {
+        test_refill_context_with_options(sstable_store, read_version_mapping, HashSet::new(), true)
+    }
+
+    fn test_refill_context_with_options(
+        sstable_store: SstableStoreRef,
+        read_version_mapping: ReadVersionMappingType,
+        data_refill_levels: HashSet<u32>,
+        skip_recent_filter: bool,
+    ) -> CacheRefillContext {
+        CacheRefillContext {
+            config: Arc::new(CacheRefillConfig {
+                timeout: Duration::from_secs(1),
+                data_refill_levels,
+                meta_refill_concurrency: 0,
+                concurrency: 1,
+                unit: 2,
+                threshold: 0.0,
+                skip_recent_filter,
+            }),
+            meta_refill_concurrency: None,
+            concurrency: Arc::new(Semaphore::new(1)),
+            sstable_store,
+            table_cache_refill_context: Arc::new(RwLock::new(TableCacheRefillContext {
+                read_version_mapping: Arc::new(RwLock::new(read_version_mapping)),
+            })),
+        }
+    }
+
+    #[test]
+    fn test_live_streaming_view_tracks_read_version_updates() {
+        let local_table = TableId::new(1);
+        let context = TableCacheRefillContext {
+            read_version_mapping: Arc::new(RwLock::new(HashMap::from_iter([(
+                local_table,
+                HashMap::from_iter([
+                    (1, test_read_version(local_table, 1, test_bitmap(&[0]))),
+                    (2, test_read_version(local_table, 2, test_bitmap(&[1]))),
+                ]),
+            )]))),
+        };
+        let read_version_1 = context
+            .read_version_mapping
+            .read()
+            .get(&local_table)
+            .unwrap()
+            .get(&1)
+            .unwrap()
+            .clone();
+
+        let view = context.build_streaming_view();
+        assert_eq!(
+            view.streaming.get(&local_table),
+            Some(&test_bitmap(&[0, 1]))
+        );
+
+        read_version_1
+            .write()
+            .update_vnode_bitmap(Arc::new(test_bitmap(&[2])));
+        let view = context.build_streaming_view();
+        assert_eq!(
+            view.streaming.get(&local_table),
+            Some(&test_bitmap(&[1, 2]))
+        );
+    }
+
+    #[test]
+    fn test_meta_gate_filters_by_table_overlap() {
+        let local_table = TableId::new(1);
+        let remote_table = TableId::new(2);
+        let context = TableCacheRefillContext {
+            read_version_mapping: Arc::new(RwLock::new(HashMap::from_iter([(
+                local_table,
+                HashMap::from_iter([(1, test_read_version(local_table, 1, test_bitmap(&[0])))]),
+            )]))),
+        };
+        let streaming_view = context.build_streaming_view();
+        let local_info: SstableInfo = SstableInfoInner {
+            object_id: 1.into(),
+            sst_id: 1.into(),
+            table_ids: vec![local_table],
+            file_size: 1024,
+            meta_offset: 512,
+            ..Default::default()
+        }
+        .into();
+        let remote_info: SstableInfo = SstableInfoInner {
+            object_id: 2.into(),
+            sst_id: 2.into(),
+            table_ids: vec![remote_table],
+            file_size: 1024,
+            meta_offset: 512,
+            ..Default::default()
+        }
+        .into();
+        let mixed_info: SstableInfo = SstableInfoInner {
+            object_id: 3.into(),
+            sst_id: 3.into(),
+            table_ids: vec![remote_table, local_table],
+            file_size: 1024,
+            meta_offset: 512,
+            ..Default::default()
+        }
+        .into();
+
+        assert!(CacheRefillTask::should_admit_meta_refill(
+            &streaming_view,
+            &local_info
+        ));
+        assert!(!CacheRefillTask::should_admit_meta_refill(
+            &streaming_view,
+            &remote_info
+        ));
+        assert!(CacheRefillTask::should_admit_meta_refill(
+            &streaming_view,
+            &mixed_info
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_data_gate_uses_unit_or_semantics() {
+        let remote_table_id = TableId::new(1);
+        let local_table_id = TableId::new(2);
+        let sstable_store = mock_sstable_store().await;
+        sstable_store.insert_meta_cache(
+            1.into(),
+            test_sstable_meta(&[(remote_table_id, 0, "a"), (local_table_id, 1, "b")]),
+        );
+        let sst = sstable_store
+            .sstable_cached(1.into())
+            .await
+            .unwrap()
+            .unwrap();
+        let context = test_refill_context(
+            sstable_store,
+            HashMap::from_iter([(
+                local_table_id,
+                HashMap::from_iter([(1, test_read_version(local_table_id, 1, test_bitmap(&[1])))]),
+            )]),
+        );
+        let streaming_view = context
+            .table_cache_refill_context
+            .read()
+            .build_streaming_view();
+
+        let retained = CacheRefillTask::filter_by_streaming_vnodes(
+            &streaming_view,
+            vec![
+                DataCacheRefillTask {
+                    sst: sst.clone(),
+                    blks: 0..2,
+                },
+                DataCacheRefillTask { sst, blks: 0..1 },
+            ],
+        );
+
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].blks, 0..2);
+    }
+
+    #[tokio::test]
+    async fn test_data_gate_handles_high_vnode_boundary() {
+        let table_id = TableId::new(1);
+        let high_vnode = VirtualNode::COUNT_FOR_TEST - 1;
+        let sstable_store = mock_sstable_store().await;
+        sstable_store
+            .insert_meta_cache(1.into(), test_sstable_meta(&[(table_id, high_vnode, "z")]));
+        let sst = sstable_store
+            .sstable_cached(1.into())
+            .await
+            .unwrap()
+            .unwrap();
+        let streaming_view = StreamingTableCacheRefillView {
+            streaming: HashMap::from_iter([(table_id, test_bitmap(&[high_vnode]))]),
+        };
+
+        assert!(streaming_view.check_table_refill_vnodes(&sst, 0));
+    }
+
+    #[tokio::test]
+    async fn test_data_gate_fail_open_on_cross_table_next_block_boundary() {
+        let local_table_id = TableId::new(1);
+        let remote_table_id = TableId::new(2);
+        let sstable_store = mock_sstable_store().await;
+        sstable_store.insert_meta_cache(
+            1.into(),
+            test_sstable_meta(&[(local_table_id, 0, "a"), (remote_table_id, 1, "b")]),
+        );
+        let sst = sstable_store
+            .sstable_cached(1.into())
+            .await
+            .unwrap()
+            .unwrap();
+        let streaming_view = StreamingTableCacheRefillView {
+            streaming: HashMap::from_iter([(local_table_id, test_bitmap(&[0]))]),
+        };
+
+        assert!(streaming_view.check_table_refill_vnodes(&sst, 0));
+    }
+
+    #[tokio::test]
+    async fn test_data_gate_fail_open_on_cross_table_largest_key_boundary() {
+        let local_table_id = TableId::new(1);
+        let remote_table_id = TableId::new(2);
+        let sstable_store = mock_sstable_store().await;
+        let mut meta = test_sstable_meta(&[(local_table_id, 0, "a")]);
+        meta.largest_key = test_full_key(remote_table_id, 1, "remote_end");
+        sstable_store.insert_meta_cache(1.into(), meta);
+        let sst = sstable_store
+            .sstable_cached(1.into())
+            .await
+            .unwrap()
+            .unwrap();
+        let streaming_view = StreamingTableCacheRefillView {
+            streaming: HashMap::from_iter([(local_table_id, test_bitmap(&[0]))]),
+        };
+
+        assert!(streaming_view.check_table_refill_vnodes(&sst, 0));
+    }
+
+    #[tokio::test]
+    async fn test_non_l0_skip_recent_filter_still_applies_streaming_gate() {
+        let local_table_id = TableId::new(1);
+        let remote_table_id = TableId::new(2);
+        let sstable_store = mock_sstable_store().await;
+        let inserted_sst_id = 11;
+        let parent_sst_id = 22;
+        let remote_only_meta =
+            test_sstable_meta(&[(remote_table_id, 0, "a"), (remote_table_id, 1, "b")]);
+        sstable_store.insert_meta_cache(inserted_sst_id.into(), remote_only_meta.clone());
+        sstable_store.insert_meta_cache(parent_sst_id.into(), remote_only_meta);
+        let holder = sstable_store
+            .sstable_cached(inserted_sst_id.into())
+            .await
+            .unwrap()
+            .unwrap();
+        let context = test_refill_context_with_options(
+            sstable_store,
+            HashMap::from_iter([(
+                local_table_id,
+                HashMap::from_iter([(1, test_read_version(local_table_id, 1, test_bitmap(&[7])))]),
+            )]),
+            HashSet::from_iter([1]),
+            true,
+        );
+        let delta = SstDeltaInfo {
+            insert_sst_infos: vec![
+                SstableInfoInner {
+                    object_id: inserted_sst_id.into(),
+                    sst_id: inserted_sst_id.into(),
+                    table_ids: vec![remote_table_id],
+                    ..Default::default()
+                }
+                .into(),
+            ],
+            delete_sst_object_ids: vec![parent_sst_id.into()],
+            insert_sst_level: 1,
+            ..Default::default()
+        };
+        let recent_filter = context.sstable_store.recent_filter();
+        assert!(!recent_filter.contains(&(inserted_sst_id.into(), usize::MAX)));
+
+        CacheRefillTask::data_cache_refill(&context, &delta, vec![holder]).await;
+
+        assert!(!recent_filter.contains(&(inserted_sst_id.into(), usize::MAX)));
+    }
+
+    #[tokio::test]
+    async fn test_meta_gate_skip_still_allows_miss_load() {
+        let local_table = TableId::new(1);
+        let sstable_store = mock_sstable_store().await;
+        let sst_info = gen_test_sstable_info(
+            default_builder_opt_for_test(),
+            1,
+            (0..2).map(|idx| {
+                (
+                    iterator_test_key_of(idx),
+                    HummockValue::put(vec![idx as u8]),
+                )
+            }),
+            sstable_store.clone(),
+        )
+        .await;
+        sstable_store.clear_meta_cache().await.unwrap();
+        let delta = SstDeltaInfo {
+            insert_sst_infos: vec![sst_info.clone()],
+            ..Default::default()
+        };
+        let context = test_refill_context(
+            sstable_store.clone(),
+            HashMap::from_iter([(
+                local_table,
+                HashMap::from_iter([(1, test_read_version(local_table, 1, test_bitmap(&[0])))]),
+            )]),
+        );
+
+        let holders = CacheRefillTask::meta_cache_refill(&context, &delta)
+            .await
+            .unwrap();
+        assert!(holders.is_empty());
+        assert!(
+            sstable_store
+                .sstable_cached(sst_info.object_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let holder = sstable_store
+            .sstable(&sst_info, &mut StoreLocalStatistic::default())
+            .await
+            .unwrap();
+        assert_eq!(holder.id, sst_info.object_id);
+        assert!(
+            sstable_store
+                .sstable_cached(sst_info.object_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a streaming-only cache refill context backed by live `read_version_mapping`
- gate meta cache refill before SST meta fetch and cache admission using local streaming table overlap
- gate non-L0 data cache refill units using streaming table/vnode overlap and add metrics/tests for locality filtering

## Relation to #24452
This is the streaming-only first-stage split of the table refill gating work.

Included in this PR:
- streaming locality source from `read_version_mapping`
- meta refill gating
- data refill gating for non-L0 paths

Explicitly not included:
- `Role`
- serving vnode mapping
- table cache refill policy / default policy
- online updates / observer / proto / config wiring

## Notes
- locality view is rebuilt from live `read_version_mapping` inside refiller instead of maintaining a separate long-lived cache
- meta gating is intentionally table-level only; it does not use `vnode_statistics` for whole-SST rejection
- vnode gating uses fail-open semantics on cross-table boundaries to avoid false negatives

## Testing
- `cargo fmt --all`
- `cargo test -p risingwave_storage refiller::tests -- --nocapture`
- `cargo test -p risingwave_storage --no-run`
