### PR TITLE
feat: table with connector wait for backfill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ You may need to learn how to build and test RisingWave when implementing feature
   - You can connect right after the command finishes.
   - Logs are written to files in `.risingwave/log` folder.
 - Use `./risedev k` to stop a RisingWave instance started by `./risedev d`.
+- After modifying any Rust source code, you must run `./risedev k` to kill the running instance and then `./risedev d` to rebuild and restart before running tests again; otherwise tests will exercise the old binary.
 - Only when a RisingWave instance is running, you can use `./risedev psql -c "<your query>"` to run SQL queries in RW.
 - Only when a RisingWave instance is running, you can use `./risedev slt './path/to/e2e-test-file.slt'` to run end-to-end SLT tests.
   - File globs like `/**/*.slt` is allowed.

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -66,10 +66,10 @@ flush;
 system ok
 internal_table.mjs --name s0 --type source
 ----
-0,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 0, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-1,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 1, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 2, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 3, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+0,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 0, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+1,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 1, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 2, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 3, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 statement ok
@@ -152,10 +152,10 @@ sleep 2s
 system ok
 internal_table.mjs --name s0 --type source
 ----
-0,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 0, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-1,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 1, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 2, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 3, ""start_offset"": 3, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+0,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 0, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+1,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 1, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 2, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 3, ""start_offset"": 3, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 query ?? rowsort
@@ -241,10 +241,10 @@ select v1, count(*) from mv_before_produce group by v1;
 system ok
 internal_table.mjs --name s0 --type source
 ----
-0,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 0, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-1,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 1, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 2, ""start_offset"": 12, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 3, ""start_offset"": 13, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+0,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 0, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+1,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 1, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 2, ""start_offset"": 12, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""backfill_wait_state"": ""Disabled"", ""partition"": 3, ""start_offset"": 13, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 # Test: rate limit and resume won't lose data

--- a/e2e_test/source_inline/kafka/shared_source.slt.serial
+++ b/e2e_test/source_inline/kafka/shared_source.slt.serial
@@ -66,10 +66,10 @@ flush;
 system ok
 internal_table.mjs --name s0 --type source
 ----
-0,"{""split_info"": {""partition"": 0, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-1,"{""split_info"": {""partition"": 1, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""partition"": 2, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""partition"": 3, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+0,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 0, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+1,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 1, ""start_offset"": 0, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 2, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 3, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 statement ok
@@ -152,10 +152,10 @@ sleep 2s
 system ok
 internal_table.mjs --name s0 --type source
 ----
-0,"{""split_info"": {""partition"": 0, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-1,"{""split_info"": {""partition"": 1, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""partition"": 2, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""partition"": 3, ""start_offset"": 3, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+0,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 0, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+1,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 1, ""start_offset"": 1, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 2, ""start_offset"": 2, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 3, ""start_offset"": 3, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 query ?? rowsort
@@ -241,10 +241,10 @@ select v1, count(*) from mv_before_produce group by v1;
 system ok
 internal_table.mjs --name s0 --type source
 ----
-0,"{""split_info"": {""partition"": 0, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-1,"{""split_info"": {""partition"": 1, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-2,"{""split_info"": {""partition"": 2, ""start_offset"": 12, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
-3,"{""split_info"": {""partition"": 3, ""start_offset"": 13, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+0,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 0, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+1,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 1, ""start_offset"": 11, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+2,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 2, ""start_offset"": 12, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
+3,"{""split_info"": {""backfill_target_offset"": null, ""partition"": 3, ""start_offset"": 13, ""stop_offset"": null, ""topic"": ""shared_source""}, ""split_type"": ""kafka""}"
 
 
 # Test: rate limit and resume won't lose data

--- a/e2e_test/source_inline/kafka/wait_for_backfill.slt
+++ b/e2e_test/source_inline/kafka/wait_for_backfill.slt
@@ -78,6 +78,16 @@ create table t_bad (v1 int) with (
 ) FORMAT PLAIN ENCODE JSON;
 
 
+# Test: backfill.wait is not supported for CREATE SOURCE (even with kafka)
+statement error backfill.wait is not supported for CREATE SOURCE
+create source s_bad (v1 int) with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test_wait_for_backfill',
+  scan.startup.mode = 'earliest',
+  backfill.wait = 'true'
+) FORMAT PLAIN ENCODE JSON;
+
+
 # Test: wait_for_backfill with empty topic should return immediately
 system ok
 rpk topic delete test_wait_for_backfill_empty || true

--- a/e2e_test/source_inline/kafka/wait_for_backfill.slt
+++ b/e2e_test/source_inline/kafka/wait_for_backfill.slt
@@ -1,0 +1,104 @@
+control substitution on
+
+# Test wait_for_backfill option for CREATE TABLE WITH CONNECTOR.
+# When wait_for_backfill='true', foreground DDL should block until all existing
+# Kafka data (up to the high watermark at creation time) is consumed.
+
+# Clean up any previous state
+system ok
+rpk topic delete test_wait_for_backfill || true
+
+system ok
+rpk topic create test_wait_for_backfill -p 3
+
+# Produce data BEFORE creating the table.
+# This data represents the "backfill" portion that should be consumed before DDL returns.
+system ok
+cat <<EOF | rpk topic produce test_wait_for_backfill -f "%p %v\n"
+0 {"v1": 1, "v2": "a"}
+0 {"v1": 2, "v2": "b"}
+1 {"v1": 3, "v2": "c"}
+1 {"v1": 4, "v2": "d"}
+2 {"v1": 5, "v2": "e"}
+2 {"v1": 6, "v2": "f"}
+EOF
+
+# Create table with wait_for_backfill.
+# This DDL should block until all 6 messages above are consumed.
+statement ok
+create table t_backfill (v1 int, v2 varchar) with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test_wait_for_backfill',
+  scan.startup.mode = 'earliest',
+  backfill.wait = 'true'
+) FORMAT PLAIN ENCODE JSON;
+
+# Since wait_for_backfill blocks until backfill is done, we should immediately
+# see all pre-existing data after the DDL returns, without needing retry/sleep.
+query IT rowsort
+select v1, v2 from t_backfill;
+----
+1 a
+2 b
+3 c
+4 d
+5 e
+6 f
+
+# Produce more data after table creation. This should be consumed normally.
+system ok
+cat <<EOF | rpk topic produce test_wait_for_backfill -f "%p %v\n"
+0 {"v1": 7, "v2": "g"}
+EOF
+
+# New data needs some time to arrive.
+query IT rowsort retry 5 backoff 2s
+select v1, v2 from t_backfill;
+----
+1 a
+2 b
+3 c
+4 d
+5 e
+6 f
+7 g
+
+statement ok
+drop table t_backfill;
+
+system ok
+rpk topic delete test_wait_for_backfill
+
+
+# Test: backfill.wait is not supported for non-kafka connectors
+statement error backfill.wait is not supported for this connector
+create table t_bad (v1 int) with (
+  connector = 'datagen',
+  backfill.wait = 'true'
+) FORMAT PLAIN ENCODE JSON;
+
+
+# Test: wait_for_backfill with empty topic should return immediately
+system ok
+rpk topic delete test_wait_for_backfill_empty || true
+
+system ok
+rpk topic create test_wait_for_backfill_empty -p 2
+
+statement ok
+create table t_empty (v1 int, v2 varchar) with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test_wait_for_backfill_empty',
+  scan.startup.mode = 'earliest',
+  backfill.wait = 'true'
+) FORMAT PLAIN ENCODE JSON;
+
+query IT
+select v1, v2 from t_empty;
+----
+
+statement ok
+drop table t_empty;
+
+system ok
+rpk topic delete test_wait_for_backfill_empty

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -284,6 +284,9 @@ message StreamSource {
   optional Columns downstream_columns = 11;
   plan_common.SourceRefreshMode refresh_mode = 12;
   optional uint32 associated_table_id = 13;
+  // Whether to wait for backfill to complete before returning from DDL.
+  // When true, the source executor will track progress and report backfill completion.
+  bool wait_for_backfill = 14;
 }
 
 // copy contents from StreamSource to prevent compatibility issues in the future

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -598,6 +598,11 @@ mod tests {
                     131072,
                     "LOCALITY_PROVIDER",
                 ),
+                (
+                    SourceWaitForBackfill,
+                    262144,
+                    "SOURCE_WAIT_FOR_BACKFILL",
+                ),
             ]
         "#]]
         .assert_debug_eq(

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -445,6 +445,15 @@ impl FragmentTypeFlag {
     }
 }
 
+/// Fragments that perform backfill and report progress via `CreateMviewProgressReporter`.
+/// Note: `Values` reports progress too but has no upstream to backfill, so it's excluded.
+pub const BACKFILL_FRAGMENTS: [FragmentTypeFlag; 4] = [
+    FragmentTypeFlag::StreamScan,
+    FragmentTypeFlag::SourceScan,
+    FragmentTypeFlag::LocalityProvider,
+    FragmentTypeFlag::SourceWaitForBackfill,
+];
+
 #[derive(Clone, Copy, Debug, Hash, PartialOrd, PartialEq, Eq, Default)]
 pub struct FragmentTypeMask(u32);
 

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -337,7 +337,8 @@ macro_rules! for_all_fragment_type_flags {
                 StreamCdcScan,
                 VectorIndexWrite,
                 UpstreamSinkUnion,
-                LocalityProvider
+                LocalityProvider,
+                SourceWaitForBackfill
             },
             {},
             0

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -300,6 +300,7 @@ impl From<KafkaConfig> for KafkaProperties {
             privatelink_common: val.privatelink_common,
             aws_auth_props: val.aws_auth_props,
             group_id_prefix: None,
+            backfill_wait: None,
             unknown_fields: Default::default(),
         }
     }

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -895,6 +895,10 @@ impl SplitImpl {
     pub fn current_offset(&self) -> Option<String> {
         dispatch_split_impl!(self, |inner| inner.current_offset())
     }
+
+    pub fn mark_backfill_finished(&mut self) {
+        dispatch_split_impl!(self, |inner| inner.mark_backfill_finished())
+    }
 }
 
 use risingwave_common::types::DataType;
@@ -981,8 +985,9 @@ pub trait SplitMetaData: Sized {
     fn restore_from_json(value: JsonbVal) -> Result<Self>;
     fn update_offset(&mut self, last_seen_offset: String) -> crate::error::ConnectorResult<()>;
 
-    /// Returns the backfill target offset for this split, if set.
-    /// Used by `wait_for_backfill` to determine when backfill is complete.
+    /// Returns the backfill target offset for this split, if the split is still waiting to
+    /// catch up. Used by `wait_for_backfill` to determine when backfill is complete.
+    /// Returns `None` if the split is not tracked (disabled) or has already finished.
     fn backfill_target_offset(&self) -> Option<String> {
         None
     }
@@ -992,6 +997,11 @@ pub trait SplitMetaData: Sized {
     fn current_offset(&self) -> Option<String> {
         None
     }
+
+    /// Transition this split's `wait_for_backfill` tracking to the finished state.
+    /// Called by the source executor after reporting `finish` so that the split is no longer
+    /// tracked on subsequent actor restarts. No-op for splits that don't track backfill state.
+    fn mark_backfill_finished(&mut self) {}
 }
 
 /// [`ConnectorState`] maintains the consuming splits' info. In specific split readers,

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -887,6 +887,14 @@ impl SplitImpl {
     pub fn encode_to_json_inner(&self) -> JsonbVal {
         dispatch_split_impl!(self, |inner| inner.encode_to_json())
     }
+
+    pub fn backfill_target_offset(&self) -> Option<String> {
+        dispatch_split_impl!(self, |inner| inner.backfill_target_offset())
+    }
+
+    pub fn current_offset(&self) -> Option<String> {
+        dispatch_split_impl!(self, |inner| inner.current_offset())
+    }
 }
 
 use risingwave_common::types::DataType;
@@ -972,6 +980,18 @@ pub trait SplitMetaData: Sized {
     fn encode_to_json(&self) -> JsonbVal;
     fn restore_from_json(value: JsonbVal) -> Result<Self>;
     fn update_offset(&mut self, last_seen_offset: String) -> crate::error::ConnectorResult<()>;
+
+    /// Returns the backfill target offset for this split, if set.
+    /// Used by `wait_for_backfill` to determine when backfill is complete.
+    fn backfill_target_offset(&self) -> Option<String> {
+        None
+    }
+
+    /// Returns the current consumed offset for this split, if available.
+    /// Used by `wait_for_backfill` to check whether the split has reached its target offset.
+    fn current_offset(&self) -> Option<String> {
+        None
+    }
 }
 
 /// [`ConnectorState`] maintains the consuming splits' info. In specific split readers,

--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -34,7 +34,7 @@ use crate::connector_common::read_kafka_log_level;
 use crate::error::{ConnectorError, ConnectorResult};
 use crate::source::SourceEnumeratorContextRef;
 use crate::source::base::SplitEnumerator;
-use crate::source::kafka::split::KafkaSplit;
+use crate::source::kafka::split::{KafkaBackfillWaitState, KafkaSplit};
 use crate::source::kafka::{
     KAFKA_ISOLATION_LEVEL, KafkaConnectionProps, KafkaContextCommon, KafkaProperties,
     RwConsumerContext,
@@ -231,25 +231,25 @@ impl SplitEnumerator for KafkaSplitEnumerator {
         let ret: Vec<_> = topic_partitions
             .into_iter()
             .map(|partition| {
-                let backfill_target_offset = if self.wait_for_backfill {
+                let backfill_wait_state = if self.wait_for_backfill {
                     let (low, high) = watermarks.get(&partition).unwrap();
                     if high > low {
                         // high_watermark - 1 is the offset of the last available message.
                         // This matches the "last seen offset" convention used by start_offset.
-                        Some(*high - 1)
+                        KafkaBackfillWaitState::Pending { target: *high - 1 }
                     } else {
-                        // Empty partition: no data to backfill.
-                        None
+                        // Empty partition: nothing to backfill.
+                        KafkaBackfillWaitState::Finished
                     }
                 } else {
-                    None
+                    KafkaBackfillWaitState::Disabled
                 };
                 KafkaSplit {
                     topic: self.topic.clone(),
                     partition,
                     start_offset: start_offsets.remove(&partition).unwrap(),
                     stop_offset: stop_offsets.remove(&partition).unwrap(),
-                    backfill_target_offset,
+                    backfill_wait_state,
                 }
             })
             .collect();
@@ -403,7 +403,7 @@ impl KafkaSplitEnumerator {
                     partition: *partition,
                     start_offset: Some(start_offset),
                     stop_offset: Some(stop_offset),
-                    backfill_target_offset: None,
+                    backfill_wait_state: KafkaBackfillWaitState::Disabled,
                 }
             })
             .collect::<Vec<KafkaSplit>>())

--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -75,6 +75,8 @@ pub struct KafkaSplitEnumerator {
     sync_call_timeout: Duration,
     high_watermark_metrics: HashMap<i32, LabelGuardedIntGauge>,
 
+    wait_for_backfill: bool,
+
     properties: KafkaProperties,
     config: rdkafka::ClientConfig,
 }
@@ -172,6 +174,8 @@ impl SplitEnumerator for KafkaSplitEnumerator {
             })
             .await?;
 
+        let wait_for_backfill = properties.backfill_wait.unwrap_or(false);
+
         Ok(Self {
             context,
             broker_address,
@@ -181,6 +185,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
             stop_offset: KafkaEnumeratorOffset::None,
             sync_call_timeout: properties.common.sync_call_timeout,
             high_watermark_metrics: HashMap::new(),
+            wait_for_backfill,
             properties,
             config,
         })
@@ -225,11 +230,27 @@ impl SplitEnumerator for KafkaSplitEnumerator {
 
         let ret: Vec<_> = topic_partitions
             .into_iter()
-            .map(|partition| KafkaSplit {
-                topic: self.topic.clone(),
-                partition,
-                start_offset: start_offsets.remove(&partition).unwrap(),
-                stop_offset: stop_offsets.remove(&partition).unwrap(),
+            .map(|partition| {
+                let backfill_target_offset = if self.wait_for_backfill {
+                    let (low, high) = watermarks.get(&partition).unwrap();
+                    if high > low {
+                        // high_watermark - 1 is the offset of the last available message.
+                        // This matches the "last seen offset" convention used by start_offset.
+                        Some(*high - 1)
+                    } else {
+                        // Empty partition: no data to backfill.
+                        None
+                    }
+                } else {
+                    None
+                };
+                KafkaSplit {
+                    topic: self.topic.clone(),
+                    partition,
+                    start_offset: start_offsets.remove(&partition).unwrap(),
+                    stop_offset: stop_offsets.remove(&partition).unwrap(),
+                    backfill_target_offset,
+                }
             })
             .collect();
 
@@ -382,6 +403,7 @@ impl KafkaSplitEnumerator {
                     partition: *partition,
                     start_offset: Some(start_offset),
                     stop_offset: Some(stop_offset),
+                    backfill_target_offset: None,
                 }
             })
             .collect::<Vec<KafkaSplit>>())

--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -74,6 +74,8 @@ pub struct KafkaSplitEnumerator {
     sync_call_timeout: Duration,
     high_watermark_metrics: HashMap<i32, LabelGuardedIntGauge>,
 
+    wait_for_backfill: bool,
+
     properties: KafkaProperties,
     config: rdkafka::ClientConfig,
 }
@@ -167,6 +169,8 @@ impl SplitEnumerator for KafkaSplitEnumerator {
             })
             .await?;
 
+        let wait_for_backfill = properties.backfill_wait.unwrap_or(false);
+
         Ok(Self {
             context,
             broker_address,
@@ -176,6 +180,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
             stop_offset: KafkaEnumeratorOffset::None,
             sync_call_timeout: properties.common.sync_call_timeout,
             high_watermark_metrics: HashMap::new(),
+            wait_for_backfill,
             properties,
             config,
         })
@@ -200,11 +205,27 @@ impl SplitEnumerator for KafkaSplitEnumerator {
 
         let ret: Vec<_> = topic_partitions
             .into_iter()
-            .map(|partition| KafkaSplit {
-                topic: self.topic.clone(),
-                partition,
-                start_offset: start_offsets.remove(&partition).unwrap(),
-                stop_offset: stop_offsets.remove(&partition).unwrap(),
+            .map(|partition| {
+                let backfill_target_offset = if self.wait_for_backfill {
+                    let (low, high) = watermarks.get(&partition).unwrap();
+                    if high > low {
+                        // high_watermark - 1 is the offset of the last available message.
+                        // This matches the "last seen offset" convention used by start_offset.
+                        Some(*high - 1)
+                    } else {
+                        // Empty partition: no data to backfill.
+                        None
+                    }
+                } else {
+                    None
+                };
+                KafkaSplit {
+                    topic: self.topic.clone(),
+                    partition,
+                    start_offset: start_offsets.remove(&partition).unwrap(),
+                    stop_offset: stop_offsets.remove(&partition).unwrap(),
+                    backfill_target_offset,
+                }
             })
             .collect();
 
@@ -357,6 +378,7 @@ impl KafkaSplitEnumerator {
                     partition: *partition,
                     start_offset: Some(start_offset),
                     stop_offset: Some(stop_offset),
+                    backfill_target_offset: None,
                 }
             })
             .collect::<Vec<KafkaSplit>>())

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
 
 use crate::connector_common::{AwsAuthProps, KafkaConnectionProps, KafkaPrivateLinkCommon};
+use crate::deserialize_optional_bool_from_string;
 use crate::enforce_secret::EnforceSecret;
 use crate::error::ConnectorResult;
 
@@ -171,6 +172,14 @@ pub struct KafkaProperties {
 
     #[serde(flatten)]
     pub rdkafka_properties_consumer: RdKafkaPropertiesConsumer,
+
+    /// Whether to wait for backfill completion when creating the table.
+    #[serde(
+        rename = "backfill.wait",
+        default,
+        deserialize_with = "deserialize_optional_bool_from_string"
+    )]
+    pub backfill_wait: Option<bool>,
 
     #[serde(flatten)]
     pub privatelink_common: KafkaPrivateLinkCommon,

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -173,7 +173,7 @@ pub struct KafkaProperties {
     #[serde(flatten)]
     pub rdkafka_properties_consumer: RdKafkaPropertiesConsumer,
 
-    /// Whether to wait for backfill completion when creating the table.
+    /// Whether to wait for backfill completion when creating the table with connector.
     #[serde(
         rename = "backfill.wait",
         default,

--- a/src/connector/src/source/kafka/split.rs
+++ b/src/connector/src/source/kafka/split.rs
@@ -18,6 +18,23 @@ use serde::{Deserialize, Serialize};
 use crate::error::ConnectorResult;
 use crate::source::{SplitId, SplitMetaData};
 
+/// Per-split state machine for the `backfill.wait` feature.
+///
+/// - `Disabled`: `backfill.wait` was not enabled, or the partition was empty at creation time.
+/// - `Pending { target }`: the split must catch up to `target` (`high_watermark - 1` captured
+///   at the moment the enumerator saw this partition) before `CREATE TABLE` can return.
+/// - `Finished`: the split has already reached its target in a previous actor lifetime. No
+///   further tracking is needed; on restart the executor can immediately report finish.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Hash, Default)]
+pub enum KafkaBackfillWaitState {
+    #[default]
+    Disabled,
+    Pending {
+        target: i64,
+    },
+    Finished,
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Hash)]
 pub struct KafkaSplit {
     pub(crate) topic: String,
@@ -32,12 +49,10 @@ pub struct KafkaSplit {
     /// A better approach would be to make it **inclusive**. <https://github.com/risingwavelabs/risingwave/pull/16257>
     pub(crate) start_offset: Option<i64>,
     pub(crate) stop_offset: Option<i64>,
-    /// The target offset for backfill completion. When `wait_for_backfill` is enabled,
-    /// this is set to `high_watermark - 1` at table creation time. The source executor
-    /// reports backfill as complete when all splits' current offsets reach their targets.
-    /// Uses `serde(default)` for backward compatibility with existing state.
+    /// Tracks the `backfill.wait` state of this split. `#[serde(default)]` makes old persisted
+    /// state deserialize as [`KafkaBackfillWaitState::Disabled`] for backward compatibility.
     #[serde(default)]
-    pub(crate) backfill_target_offset: Option<i64>,
+    pub(crate) backfill_wait_state: KafkaBackfillWaitState,
 }
 
 impl SplitMetaData for KafkaSplit {
@@ -60,11 +75,23 @@ impl SplitMetaData for KafkaSplit {
     }
 
     fn backfill_target_offset(&self) -> Option<String> {
-        self.backfill_target_offset.map(|o| o.to_string())
+        match &self.backfill_wait_state {
+            KafkaBackfillWaitState::Pending { target } => Some(target.to_string()),
+            KafkaBackfillWaitState::Disabled | KafkaBackfillWaitState::Finished => None,
+        }
     }
 
     fn current_offset(&self) -> Option<String> {
         self.start_offset.map(|o| o.to_string())
+    }
+
+    fn mark_backfill_finished(&mut self) {
+        if matches!(
+            self.backfill_wait_state,
+            KafkaBackfillWaitState::Pending { .. }
+        ) {
+            self.backfill_wait_state = KafkaBackfillWaitState::Finished;
+        }
     }
 }
 
@@ -80,7 +107,7 @@ impl KafkaSplit {
             partition,
             start_offset,
             stop_offset,
-            backfill_target_offset: None,
+            backfill_wait_state: KafkaBackfillWaitState::Disabled,
         }
     }
 }

--- a/src/connector/src/source/kafka/split.rs
+++ b/src/connector/src/source/kafka/split.rs
@@ -32,6 +32,12 @@ pub struct KafkaSplit {
     /// A better approach would be to make it **inclusive**. <https://github.com/risingwavelabs/risingwave/pull/16257>
     pub(crate) start_offset: Option<i64>,
     pub(crate) stop_offset: Option<i64>,
+    /// The target offset for backfill completion. When `wait_for_backfill` is enabled,
+    /// this is set to `high_watermark - 1` at table creation time. The source executor
+    /// reports backfill as complete when all splits' current offsets reach their targets.
+    /// Uses `serde(default)` for backward compatibility with existing state.
+    #[serde(default)]
+    pub(crate) backfill_target_offset: Option<i64>,
 }
 
 impl SplitMetaData for KafkaSplit {
@@ -52,6 +58,14 @@ impl SplitMetaData for KafkaSplit {
         self.start_offset = Some(last_seen_offset.as_str().parse::<i64>().unwrap());
         Ok(())
     }
+
+    fn backfill_target_offset(&self) -> Option<String> {
+        self.backfill_target_offset.map(|o| o.to_string())
+    }
+
+    fn current_offset(&self) -> Option<String> {
+        self.start_offset.map(|o| o.to_string())
+    }
 }
 
 impl KafkaSplit {
@@ -66,6 +80,7 @@ impl KafkaSplit {
             partition,
             start_offset,
             stop_offset,
+            backfill_target_offset: None,
         }
     }
 }

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -602,6 +602,11 @@ KafkaProperties:
       default: true
     required: false
     allow_alter_on_fly: true
+  - name: backfill.wait
+    field_type: bool
+    comments: Whether to wait for backfill completion when creating the table with connector.
+    required: false
+    default: Default::default
   - name: broker.rewrite.endpoints
     field_type: BTreeMap<String,String>
     comments: This is generated from `private_link_targets` and `private_link_endpoint` in frontend, instead of given by users.

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -743,6 +743,30 @@ pub fn bind_connector_props(
 ) -> Result<(WithOptions, SourceRefreshMode)> {
     let mut with_properties = handler_args.with_options.clone().into_connector_props();
     validate_compatibility(format_encode, &mut with_properties)?;
+
+    // `backfill.wait` is currently only supported for `CREATE TABLE WITH connector` on kafka.
+    if with_properties
+        .get("backfill.wait")
+        .is_some_and(|v| v.eq_ignore_ascii_case("true"))
+    {
+        if !with_properties.is_kafka_connector() {
+            return Err(ErrorCode::NotSupported(
+                "backfill.wait is not supported for this connector, currently only 'kafka' is supported"
+                    .to_owned(),
+                "Use a kafka connector or remove the backfill.wait option".to_owned(),
+            )
+            .into());
+        }
+        if is_create_source {
+            return Err(ErrorCode::NotSupported(
+                "backfill.wait is not supported for CREATE SOURCE".to_owned(),
+                "Use CREATE TABLE WITH connector instead, or remove the backfill.wait option"
+                    .to_owned(),
+            )
+            .into());
+        }
+    }
+
     let refresh_mode = {
         let refresh_mode = resolve_source_refresh_mode_in_with_option(&mut with_properties)?;
         if is_create_source && refresh_mode.is_some() {

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -489,6 +489,20 @@ pub(crate) async fn gen_create_table_plan_with_source(
     let session = &handler_args.session;
     let (with_properties, refresh_mode) =
         bind_connector_props(&handler_args, &format_encode, false)?;
+
+    // Validate backfill.wait option: only supported for kafka connector currently.
+    if with_properties
+        .get("backfill.wait")
+        .is_some_and(|v| v.eq_ignore_ascii_case("true"))
+        && !with_properties.is_kafka_connector()
+    {
+        return Err(ErrorCode::NotSupported(
+            "backfill.wait is not supported for this connector, currently only 'kafka' is supported".to_owned(),
+            "Use a kafka connector or remove the backfill.wait option".to_owned(),
+        )
+        .into());
+    }
+
     if with_properties.is_shareable_cdc_connector() {
         generated_columns_check_for_cdc_table(&column_defs)?;
         not_null_check_for_cdc_table(&wildcard_idx, &column_defs)?;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -490,19 +490,6 @@ pub(crate) async fn gen_create_table_plan_with_source(
     let (with_properties, refresh_mode) =
         bind_connector_props(&handler_args, &format_encode, false)?;
 
-    // Validate backfill.wait option: only supported for kafka connector currently.
-    if with_properties
-        .get("backfill.wait")
-        .is_some_and(|v| v.eq_ignore_ascii_case("true"))
-        && !with_properties.is_kafka_connector()
-    {
-        return Err(ErrorCode::NotSupported(
-            "backfill.wait is not supported for this connector, currently only 'kafka' is supported".to_owned(),
-            "Use a kafka connector or remove the backfill.wait option".to_owned(),
-        )
-        .into());
-    }
-
     if with_properties.is_shareable_cdc_connector() {
         generated_columns_check_for_cdc_table(&column_defs)?;
         not_null_check_for_cdc_table(&wildcard_idx, &column_defs)?;

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -99,6 +99,9 @@ impl StreamNode for StreamSource {
         let source_inner = source_catalog.map(|source_catalog| {
             let (with_properties, secret_refs) =
                 source_catalog.with_properties.clone().into_parts();
+            let wait_for_backfill = with_properties
+                .get("backfill.wait")
+                .is_some_and(|v| v.eq_ignore_ascii_case("true"));
             PbStreamSource {
                 source_id: source_catalog.id,
                 source_name: source_catalog.name.clone(),
@@ -123,6 +126,7 @@ impl StreamNode for StreamSource {
                 }),
                 refresh_mode: source_catalog.refresh_mode,
                 associated_table_id: None, // fill the actual associated table id in `BuildingFragment::fill_job`
+                wait_for_backfill,
             }
         });
         PbNodeBody::Source(Box::new(SourceNode { source_inner }))

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -392,12 +392,18 @@ fn build_fragment(
                     .fragment_type_mask
                     .add(FragmentTypeFlag::Source);
 
-                if let Some(source) = node.source_inner.as_ref()
-                    && let Some(source_info) = source.info.as_ref()
-                    && ((source_info.is_shared() && !source_info.is_distributed)
-                        || source.with_properties.requires_singleton())
-                {
-                    current_fragment.requires_singleton = true;
+                if let Some(source) = node.source_inner.as_ref() {
+                    if let Some(source_info) = source.info.as_ref()
+                        && ((source_info.is_shared() && !source_info.is_distributed)
+                            || source.with_properties.requires_singleton())
+                    {
+                        current_fragment.requires_singleton = true;
+                    }
+                    if source.wait_for_backfill {
+                        current_fragment
+                            .fragment_type_mask
+                            .add(FragmentTypeFlag::SourceWaitForBackfill);
+                    }
                 }
             }
 

--- a/src/meta/src/barrier/backfill_order_control.rs
+++ b/src/meta/src/barrier/backfill_order_control.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use risingwave_common::catalog::{FragmentTypeFlag, TableId};
+use risingwave_common::catalog::{BACKFILL_FRAGMENTS, TableId};
 pub use risingwave_common::id::ActorId;
 
 use crate::controller::fragment::InflightFragmentInfo;
@@ -77,11 +77,7 @@ impl BackfillOrderState {
         let mut backfill_nodes: HashMap<FragmentId, BackfillNode> = HashMap::new();
 
         for fragment in fragment_infos.values() {
-            if fragment.fragment_type_mask.contains_any([
-                FragmentTypeFlag::StreamScan,
-                FragmentTypeFlag::SourceScan,
-                FragmentTypeFlag::LocalityProvider,
-            ]) {
+            if fragment.fragment_type_mask.contains_any(BACKFILL_FRAGMENTS) {
                 let fragment_id = fragment.fragment_id;
                 backfill_nodes.insert(
                     fragment_id,
@@ -145,11 +141,7 @@ impl BackfillOrderState {
         let mut backfill_nodes: HashMap<FragmentId, BackfillNode> = HashMap::new();
 
         for (fragment_id, fragment) in fragment_infos {
-            if fragment.fragment_type_mask.contains_any([
-                FragmentTypeFlag::StreamScan,
-                FragmentTypeFlag::SourceScan,
-                FragmentTypeFlag::LocalityProvider,
-            ]) {
+            if fragment.fragment_type_mask.contains_any(BACKFILL_FRAGMENTS) {
                 backfill_nodes.insert(
                     *fragment_id,
                     BackfillNode {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -21,7 +21,9 @@ use itertools::Itertools;
 use parking_lot::RawRwLock;
 use parking_lot::lock_api::RwLockReadGuard;
 use risingwave_common::bitmap::Bitmap;
-use risingwave_common::catalog::{DatabaseId, FragmentTypeFlag, FragmentTypeMask, TableId};
+use risingwave_common::catalog::{
+    BACKFILL_FRAGMENTS, DatabaseId, FragmentTypeFlag, FragmentTypeMask, TableId,
+};
 use risingwave_common::id::JobId;
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::stream_graph_visitor::visit_stream_node_mut;
@@ -491,11 +493,7 @@ impl InflightDatabaseInfo {
             .filter_map(|(fragment_id, fragment)| {
                 fragment
                     .fragment_type_mask
-                    .contains_any([
-                        FragmentTypeFlag::StreamScan,
-                        FragmentTypeFlag::SourceScan,
-                        FragmentTypeFlag::LocalityProvider,
-                    ])
+                    .contains_any(BACKFILL_FRAGMENTS)
                     .then_some(*fragment_id)
             })
             .collect())
@@ -512,11 +510,7 @@ impl InflightDatabaseInfo {
             .fragment_infos
             .get(&fragment_id)
             .expect("should exist");
-        Ok(fragment.fragment_type_mask.contains_any([
-            FragmentTypeFlag::StreamScan,
-            FragmentTypeFlag::SourceScan,
-            FragmentTypeFlag::LocalityProvider,
-        ]))
+        Ok(fragment.fragment_type_mask.contains_any(BACKFILL_FRAGMENTS))
     }
 
     pub fn gen_backfill_progress(&self) -> impl Iterator<Item = (JobId, BackfillProgress)> + '_ {

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::mem::take;
 
-use risingwave_common::catalog::{FragmentTypeFlag, TableId};
+use risingwave_common::catalog::{BACKFILL_FRAGMENTS, TableId};
 use risingwave_common::id::JobId;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::hummock::HummockVersionStats;
@@ -921,13 +921,7 @@ pub(crate) fn collect_done_fragments(
 ) -> Vec<FragmentBackfillProgress> {
     fragment_infos
         .iter()
-        .filter(|(_, fragment)| {
-            fragment.fragment_type_mask.contains_any([
-                FragmentTypeFlag::StreamScan,
-                FragmentTypeFlag::SourceScan,
-                FragmentTypeFlag::LocalityProvider,
-            ])
-        })
+        .filter(|(_, fragment)| fragment.fragment_type_mask.contains_any(BACKFILL_FRAGMENTS))
         .map(|(fragment_id, fragment)| FragmentBackfillProgress {
             job_id,
             fragment_id: *fragment_id,

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::bitmap::Bitmap;
-use risingwave_common::catalog::{FragmentTypeFlag, FragmentTypeMask, TableId};
+use risingwave_common::catalog::{BACKFILL_FRAGMENTS, FragmentTypeFlag, FragmentTypeMask, TableId};
 use risingwave_common::hash::{IsSingleton, VirtualNode, VnodeCount, VnodeCountCompat};
 use risingwave_common::id::JobId;
 use risingwave_common::system_param::AdaptiveParallelismStrategy;
@@ -481,13 +481,11 @@ impl StreamJobFragments {
                 // We don't track any fragments' progress.
                 return vec![];
             }
-            if fragment_type_mask.contains_any([
-                FragmentTypeFlag::Values,
-                FragmentTypeFlag::StreamScan,
-                FragmentTypeFlag::SourceScan,
-                FragmentTypeFlag::LocalityProvider,
-                FragmentTypeFlag::SourceWaitForBackfill,
-            ]) {
+            if fragment_type_mask.contains_any(
+                BACKFILL_FRAGMENTS
+                    .into_iter()
+                    .chain([FragmentTypeFlag::Values]),
+            ) {
                 actor_ids.extend(actors.map(|actor_id| {
                     (
                         actor_id,

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -486,6 +486,7 @@ impl StreamJobFragments {
                 FragmentTypeFlag::StreamScan,
                 FragmentTypeFlag::SourceScan,
                 FragmentTypeFlag::LocalityProvider,
+                FragmentTypeFlag::SourceWaitForBackfill,
             ]) {
                 actor_ids.extend(actors.map(|actor_id| {
                     (
@@ -707,12 +708,18 @@ impl BackfillUpstreamType {
         let is_values = mask.contains(FragmentTypeFlag::Values);
         let is_source = mask.contains(FragmentTypeFlag::SourceScan);
         let is_locality_provider = mask.contains(FragmentTypeFlag::LocalityProvider);
+        let is_source_wait_for_backfill = mask.contains(FragmentTypeFlag::SourceWaitForBackfill);
 
         // Note: in theory we can have multiple backfill executors in one fragment, but currently it's not possible.
         // See <https://github.com/risingwavelabs/risingwave/issues/6236>.
         debug_assert!(
-            is_mview as u8 + is_values as u8 + is_source as u8 + is_locality_provider as u8 == 1,
-            "a backfill fragment should either be mview, value, source, or locality provider, found {:?}",
+            is_mview as u8
+                + is_values as u8
+                + is_source as u8
+                + is_locality_provider as u8
+                + is_source_wait_for_backfill as u8
+                == 1,
+            "a backfill fragment should either be mview, value, source, locality provider, or source_wait_for_backfill, found {:?}",
             mask
         );
 
@@ -720,7 +727,7 @@ impl BackfillUpstreamType {
             BackfillUpstreamType::MView
         } else if is_values {
             BackfillUpstreamType::Values
-        } else if is_source {
+        } else if is_source || is_source_wait_for_backfill {
             BackfillUpstreamType::Source
         } else if is_locality_provider {
             BackfillUpstreamType::LocalityProvider

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -51,6 +51,7 @@ use crate::executor::prelude::*;
 use crate::executor::source::reader_stream::{SourceReaderEventWithState, StreamReaderBuilder};
 use crate::executor::stream_reader::StreamReaderWithPause;
 use crate::task::LocalBarrierManager;
+use crate::task::progress::CreateMviewProgressReporter;
 
 /// A constant to multiply when calculating the maximum time to wait for a barrier. This is due to
 /// some latencies in network and cost in meta.
@@ -82,6 +83,11 @@ pub struct SourceExecutor<S: StateStore> {
 
     /// Local barrier manager for reporting source load finished events
     barrier_manager: LocalBarrierManager,
+
+    /// Progress reporter for `wait_for_backfill`. When set, the executor tracks
+    /// whether all splits have reached their backfill target offsets and reports
+    /// completion to the meta service.
+    backfill_progress: Option<CreateMviewProgressReporter>,
 }
 
 impl<S: StateStore> SourceExecutor<S> {
@@ -95,6 +101,7 @@ impl<S: StateStore> SourceExecutor<S> {
         rate_limit_rps: Option<u32>,
         is_shared_non_cdc: bool,
         barrier_manager: LocalBarrierManager,
+        backfill_progress: Option<CreateMviewProgressReporter>,
     ) -> Self {
         Self {
             actor_ctx,
@@ -105,6 +112,7 @@ impl<S: StateStore> SourceExecutor<S> {
             rate_limit_rps,
             is_shared_non_cdc,
             barrier_manager,
+            backfill_progress,
         }
     }
 
@@ -528,6 +536,65 @@ impl<S: StateStore> SourceExecutor<S> {
             .extend(latest_state);
     }
 
+    /// Extract backfill target offsets from splits.
+    fn build_backfill_target_offsets(
+        split_info: &HashMap<SplitId, SplitImpl>,
+    ) -> HashMap<SplitId, i64> {
+        split_info
+            .iter()
+            .filter_map(|(split_id, split)| {
+                split.backfill_target_offset().and_then(|target_str| {
+                    target_str
+                        .parse::<i64>()
+                        .ok()
+                        .map(|target| (split_id.clone(), target))
+                })
+            })
+            .collect()
+    }
+
+    /// Check and report backfill progress for `wait_for_backfill`.
+    fn maybe_report_backfill_progress(
+        &mut self,
+        epoch: EpochPair,
+        backfill_finished: &mut bool,
+        backfill_target_offsets: &HashMap<SplitId, i64>,
+        consumed_rows: u64,
+    ) {
+        let Some(progress) = &mut self.backfill_progress else {
+            return;
+        };
+        if *backfill_finished {
+            return;
+        }
+
+        // Check if all splits with a target offset have reached their target.
+        let all_reached = backfill_target_offsets.iter().all(|(split_id, target)| {
+            if let Some(split) = self.stream_source_core.latest_split_info.get(split_id) {
+                if let Some(current_offset_str) = split.current_offset()
+                    && let Ok(current_offset) = current_offset_str.parse::<i64>()
+                {
+                    return current_offset >= *target;
+                }
+                false
+            } else {
+                false
+            }
+        });
+
+        if backfill_target_offsets.is_empty() || all_reached {
+            progress.finish(epoch, consumed_rows);
+            *backfill_finished = true;
+            tracing::info!(
+                actor_id = %self.actor_ctx.id,
+                source_id = %self.stream_source_core.source_id,
+                "Source backfill finished, all splits reached target offsets"
+            );
+        } else {
+            progress.update_for_source_backfill(epoch, consumed_rows);
+        }
+    }
+
     /// Report CDC source offset updated only the first time.
     fn maybe_report_cdc_source_offset(
         &self,
@@ -652,6 +719,18 @@ impl<S: StateStore> SourceExecutor<S> {
 
         // init in-memory split states with persisted state if any
         core.init_split_state(boot_state.clone());
+
+        // Initialize backfill target offsets from splits (for wait_for_backfill).
+        // The backfill_target_offset is set by the enumerator at table creation time
+        // and persisted with the split state, so it survives restarts.
+        let mut backfill_target_offsets: HashMap<SplitId, i64> = if self.backfill_progress.is_some()
+        {
+            Self::build_backfill_target_offsets(&core.latest_split_info)
+        } else {
+            HashMap::new()
+        };
+        let mut backfill_finished = false;
+        let mut backfill_consumed_rows: u64 = 0;
 
         // Return the ownership of `stream_source_core` to the source executor.
         self.stream_source_core = core;
@@ -976,6 +1055,13 @@ impl<S: StateStore> SourceExecutor<S> {
                         must_wait_cdc_offset_before_report,
                     );
 
+                    self.maybe_report_backfill_progress(
+                        epoch,
+                        &mut backfill_finished,
+                        &backfill_target_offsets,
+                        backfill_consumed_rows,
+                    );
+
                     // when handle a checkpoint barrier, spawn a task to wait for epoch commit notification
                     if barrier.kind.is_checkpoint()
                         && let Some(task_builder) = &mut wait_checkpoint_task_builder
@@ -997,6 +1083,14 @@ impl<S: StateStore> SourceExecutor<S> {
                             to_apply_mutation,
                         )
                         .await?;
+
+                        // Rebuild backfill target offsets after split change, so that
+                        // removed splits don't block completion and added splits are tracked.
+                        if self.backfill_progress.is_some() && !backfill_finished {
+                            backfill_target_offsets = Self::build_backfill_target_offsets(
+                                &self.stream_source_core.latest_split_info,
+                            );
+                        }
                     }
                 }
                 Either::Left(_) => {
@@ -1061,6 +1155,9 @@ impl<S: StateStore> SourceExecutor<S> {
                         continue;
                     }
                     source_output_row_count.inc_by(card as u64);
+                    if !backfill_finished {
+                        backfill_consumed_rows += card as u64;
+                    }
                     let to_remove_col_indices =
                         if let Some(pulsar_message_id_idx) = pulsar_message_id_idx {
                             vec![split_idx, offset_idx, pulsar_message_id_idx]
@@ -1345,6 +1442,7 @@ mod tests {
             None,
             false,
             LocalBarrierManager::for_test(),
+            None,
         );
         let mut executor = executor.boxed().execute();
 
@@ -1433,6 +1531,7 @@ mod tests {
             None,
             false,
             LocalBarrierManager::for_test(),
+            None,
         );
         let mut handler = executor.boxed().execute();
 

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -251,6 +251,11 @@ impl<S: StateStore> SourceExecutor<S> {
                 {
                     recover_state
                 } else {
+                    // No persisted state => partition discovered after DDL started.
+                    // Mark `Finished` so `wait_for_backfill` doesn't extend its criteria
+                    // beyond the creation-time backlog. No-op for non-Pending states.
+                    let mut split = split;
+                    split.mark_backfill_finished();
                     split
                 };
 
@@ -585,9 +590,21 @@ impl<S: StateStore> SourceExecutor<S> {
         if backfill_target_offsets.is_empty() || all_reached {
             progress.finish(epoch, consumed_rows);
             *backfill_finished = true;
+            // Transition splits to `Finished`; persisted on the next barrier.
+            // Edge case: if the actor crashes between this in-memory transition and
+            // the next persist, a post-DDL split whose `Finished` mark was not yet
+            // persisted re-appears as `Pending` at init and causes one `done=false`
+            // warn (`update the progress of an created streaming job`) on meta after
+            // restart, then self-heals.
+            let core = &mut self.stream_source_core;
+            for (split_id, split) in &mut core.latest_split_info {
+                split.mark_backfill_finished();
+                core.updated_splits_in_epoch
+                    .insert(split_id.clone(), split.clone());
+            }
             tracing::info!(
                 actor_id = %self.actor_ctx.id,
-                source_id = %self.stream_source_core.source_id,
+                source_id = %core.source_id,
                 "Source backfill finished, all splits reached target offsets"
             );
         } else {
@@ -1084,8 +1101,9 @@ impl<S: StateStore> SourceExecutor<S> {
                         )
                         .await?;
 
-                        // Rebuild backfill target offsets after split change, so that
-                        // removed splits don't block completion and added splits are tracked.
+                        // Rebuild target offsets so removed splits don't block completion.
+                        // Post-DDL splits are marked `Finished` in `update_state_if_changed`,
+                        // so the rebuild only picks up creation-time / migrated Pending splits.
                         if self.backfill_progress.is_some() && !backfill_finished {
                             backfill_target_offsets = Self::build_backfill_target_offsets(
                                 &self.stream_source_core.latest_split_info,

--- a/src/stream/src/from_proto/source/trad_source.rs
+++ b/src/stream/src/from_proto/source/trad_source.rs
@@ -291,6 +291,15 @@ impl ExecutorBuilder for SourceExecutorBuilder {
                     }
                 } else {
                     let is_shared = source.info.as_ref().is_some_and(|info| info.is_shared());
+                    let backfill_progress = if source.wait_for_backfill {
+                        Some(
+                            params
+                                .local_barrier_manager
+                                .register_create_mview_progress(&params.actor_context),
+                        )
+                    } else {
+                        None
+                    };
                     SourceExecutor::new(
                         params.actor_context.clone(),
                         stream_source_core,
@@ -300,6 +309,7 @@ impl ExecutorBuilder for SourceExecutorBuilder {
                         source.rate_limit,
                         is_shared && !source.with_properties.is_cdc_connector(),
                         params.local_barrier_manager.clone(),
+                        backfill_progress,
                     )
                     .boxed()
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR introduces a new `backfill.wait` WITH option for `CREATE TABLE ... WITH (connector = 'kafka', ...)`. When set to `'true'`, the DDL is executed as a foreground job and blocks until all pre-existing Kafka data (up to the high watermark captured at table creation time) has been consumed into the table. This makes it easy for users to write queries against the table right after `CREATE TABLE` returns, without having to poll/retry until historical data is ingested.

### How it works

1. **Frontend validation** (`create_source.rs`): `backfill.wait = 'true'` is only accepted for `CREATE TABLE WITH connector` on the `kafka` connector. Using it with `CREATE SOURCE` or other connectors returns a clear error.
2. **Enumerator captures target offset** (`kafka/enumerator.rs`): when `backfill.wait` is enabled, the Kafka split enumerator captures `high_watermark - 1` per partition at table creation time and stores it on each split as `KafkaBackfillWaitState::Pending { target }`. Partitions that are empty at creation time get `Finished` directly, and when `backfill.wait` is off all splits get `Disabled`.
3. **Split persistence** (`kafka/split.rs`): a new `KafkaBackfillWaitState` enum (`Disabled | Pending { target } | Finished`) is added to `KafkaSplit` with `#[serde(default)]` so old persisted state deserializes as `Disabled`. The per-split state is persisted with split state and survives restarts, so completion is reported at most once across actor lifetimes. A generic `backfill_target_offset` / `current_offset` / `mark_backfill_finished` API is exposed on `SplitMetaData` so the source executor stays connector-agnostic; non-Kafka splits get the default no-op implementations.
4. **Plan / fragmenter** (`stream_source.rs`, `stream_fragmenter/mod.rs`): the frontend plumbs `wait_for_backfill` onto `PbStreamSource`, and fragments with this flag are tagged with a new `FragmentTypeFlag::SourceWaitForBackfill`. A shared `BACKFILL_FRAGMENTS` constant (in `common::catalog`) groups this flag with `StreamScan`, `SourceScan`, and `LocalityProvider` so every meta call site that enumerates backfill fragments (`backfill_order_control`, `info`, `progress`, `model/stream`) picks it up uniformly.
5. **Source executor tracks progress** (`source_executor.rs`, `trad_source.rs`): when `wait_for_backfill` is set, the executor is given a `CreateMviewProgressReporter`. On each barrier it compares each split's current offset against its target; once every tracked split has reached its target, it reports `finish` so foreground DDL can return, transitions those splits to `Finished` in memory, and stages them for persistence so that after a restart the executor reports completion immediately instead of re-waiting. Target offsets are rebuilt on split changes so removed splits no longer block completion. Splits discovered after DDL started (no persisted state) are marked `Finished` at assignment time so they do not extend the creation-time backlog.
6. **Backward compatibility**: the new field is opt-in; existing sources and existing persisted state are unaffected (old splits deserialize as `Disabled`).

### Limitations / follow-ups

- Supported only on `kafka` + `CREATE TABLE WITH connector` in this PR.
- Targets are captured once at DDL time. Splits that appear later (via split discovery / split change) are immediately treated as finished for `wait_for_backfill` purposes — they are not added to the backlog and do not backfill to their own discovery-time watermark.

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Added a new `backfill.wait` WITH option for `CREATE TABLE ... WITH (connector = 'kafka', ...)`. When set to `'true'`, the `CREATE TABLE` statement runs as a foreground DDL and only returns after all pre-existing Kafka messages (up to the high watermark at creation time) have been ingested into the table. This lets users query complete historical data immediately after the DDL returns, without polling. The option is currently only supported on the `kafka` connector and only with `CREATE TABLE WITH connector` (not `CREATE SOURCE`).

</details>