### PR TITLE
Reduce repeated SLT helper plumbing without widening test frameworks

### DIFF
--- a/e2e_test/__init__.py
+++ b/e2e_test/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers and fixtures for RisingWave end-to-end tests."""

--- a/e2e_test/commands/psql_validate.py
+++ b/e2e_test/commands/psql_validate.py
@@ -25,12 +25,22 @@ Wildcard Matching:
 """
 
 import argparse
-import psycopg2
-import re
-import os
-import sys
 import logging  # Import logging module
+import re
+import sys
+from pathlib import Path
+
+import psycopg2
 from psycopg2 import sql
+
+for parent in Path(__file__).resolve().parents:
+    if (parent / "e2e_test").is_dir():
+        parent_str = str(parent)
+        if parent_str not in sys.path:
+            sys.path.insert(0, parent_str)
+        break
+
+from e2e_test.py_utils.risingwave import connect_risingwave  # noqa: E402
 
 
 # Configure logging
@@ -115,13 +125,13 @@ def create_regex_from_template(template: str, wildcard="%"):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Execute SQL and validate output against a template using '%s' wildcards."
+        description="Execute SQL and validate output against a template using '%%' wildcards."
     )
     parser.add_argument("--sql", required=True, help="SQL query to execute.")
     parser.add_argument(
         "--expected",
         required=True,
-        help="Expected output template with '%' as wildcard.",
+        help="Expected output template with '%%' as wildcard.",
     )
     parser.add_argument(
         "--db", default="dev", help="Database name to connect to (default: dev)."
@@ -145,11 +155,11 @@ def main():
     actual_output_raw = ""  # Initialize to handle potential errors before assignment
     try:
         dbname = args.db
-        conn_string = f"host='{os.environ.get("RISEDEV_RW_FRONTEND_LISTEN_ADDRESS")}' port='{os.environ.get('RISEDEV_RW_FRONTEND_PORT')}' dbname='{dbname}' user='root' password=''"
         logger.debug(
-            f"Connecting to: {conn_string.replace('password=\'\'', 'password=***')}..."
-        )  # Hide password if any
-        conn = psycopg2.connect(conn_string)
+            "Connecting to RisingWave database %s via environment frontend settings...",
+            dbname,
+        )
+        conn = connect_risingwave(dbname)
         conn.autocommit = True
         cur = conn.cursor()
 

--- a/e2e_test/commands/pulsar_util.py
+++ b/e2e_test/commands/pulsar_util.py
@@ -14,6 +14,61 @@ class PulsarCat:
         self.admin_url = admin_url
         self.client = None
 
+    @staticmethod
+    def _topic_resource_path(topic: str) -> str:
+        """Convert a Pulsar topic into the admin API resource path format."""
+        return topic.replace("://", "/")
+
+    def _topic_admin_url(self, topic: str, *parts: str) -> str:
+        """Build an admin API URL for a topic resource."""
+        path_parts = [self._topic_resource_path(topic), *parts]
+        return f"{self.admin_url}/admin/v2/{'/'.join(path_parts)}"
+
+    @staticmethod
+    def _force_delete_params(force: bool) -> dict[str, str]:
+        """Build delete parameters for forced topic removal."""
+        return {"force": "true"} if force else {}
+
+    @staticmethod
+    def _is_partitioned_topic_conflict(response) -> bool:
+        """Check whether a delete conflict means the topic is partitioned."""
+        if response.status_code != 409:
+            return False
+
+        try:
+            error_info = response.json()
+        except Exception:
+            return False
+
+        return "partitioned topic" in error_info.get("reason", "").lower()
+
+    def _delete_topic_request(
+        self,
+        topic: str,
+        *,
+        force: bool,
+        partitioned: bool = False,
+    ):
+        """Delete a topic or partitioned topic via the admin API."""
+        if partitioned:
+            url = self._topic_admin_url(topic, "partitions")
+        else:
+            url = self._topic_admin_url(topic)
+        return requests.delete(url, params=self._force_delete_params(force))
+
+    @staticmethod
+    def _iter_input_messages(key_delimiter: str | None):
+        """Yield parsed messages from stdin for the produce command."""
+        for line in sys.stdin:
+            line = line.rstrip('\n\r')
+            if not line:
+                continue
+
+            if key_delimiter and key_delimiter in line:
+                yield line.split(key_delimiter, 1)
+            else:
+                yield None, line
+
     def _normalize_topic(self, topic: str, default_persistent: bool = True) -> str:
         """Normalize topic name by adding scheme and default namespace if missing.
 
@@ -30,7 +85,11 @@ class PulsarCat:
         scheme = 'persistent://' if default_persistent else 'non-persistent://'
         return f'{scheme}public/default/{topic}'
 
-    def _normalize_topic_with_persistence(self, topic: str, non_persistent: bool = False) -> str:
+    def _normalize_topic_with_persistence(
+        self,
+        topic: str,
+        non_persistent: bool = False,
+    ) -> str:
         """Normalize topic name and handle persistence type conversion.
 
         Args:
@@ -73,11 +132,11 @@ class PulsarCat:
 
         if partitions > 0:
             # Create partitioned topic
-            url = f"{self.admin_url}/admin/v2/{topic.replace('://', '/')}/partitions"
+            url = self._topic_admin_url(topic, "partitions")
             response = requests.put(url, json=partitions)
         else:
             # Create non-partitioned topic
-            url = f"{self.admin_url}/admin/v2/{topic.replace('://', '/')}"
+            url = self._topic_admin_url(topic)
             response = requests.put(url)
 
         if response.status_code in [200, 204, 409]:  # 409 means already exists
@@ -99,33 +158,21 @@ class PulsarCat:
         print(f"Dropping topic: {topic}")
 
         # Try to delete as non-partitioned topic first
-        url = f"{self.admin_url}/admin/v2/{topic.replace('://', '/')}"
-        params = {}
-        if force:
-            params['force'] = 'true'
-        response = requests.delete(url, params=params)
+        response = self._delete_topic_request(topic, force=force)
 
         # If we get a 409 error saying it's a partitioned topic, try deleting as partitioned
-        if response.status_code == 409:
-            try:
-                error_info = response.json()
-                if "partitioned topic" in error_info.get("reason", "").lower():
-                    print("Detected partitioned topic, trying partitioned topic deletion...")
+        if self._is_partitioned_topic_conflict(response):
+            print("Detected partitioned topic, trying partitioned topic deletion...")
+            response = self._delete_topic_request(
+                topic,
+                force=force,
+                partitioned=True,
+            )
 
-                    # Delete as partitioned topic
-                    partitioned_url = f"{self.admin_url}/admin/v2/{topic.replace('://', '/')}/partitions"
-                    partitioned_params = {}
-                    if force:
-                        partitioned_params['force'] = 'true'
-                    response = requests.delete(partitioned_url, params=partitioned_params)
-
-                    if response.status_code in [200, 204]:
-                        print(f"Partitioned topic {topic} dropped successfully")
-                        print("All partitions have been deleted")
-                        return
-            except:
-                # If we can't parse the error, fall through to general error handling
-                pass
+            if response.status_code in [200, 204]:
+                print(f"Partitioned topic {topic} dropped successfully")
+                print("All partitions have been deleted")
+                return
 
         # Handle the response
         if response.status_code in [200, 204]:
@@ -168,24 +215,18 @@ class PulsarCat:
 
         try:
             line_count = 0
-            for line in sys.stdin:
-                line = line.rstrip('\n\r')
-                if line:  # Only send non-empty lines
-                    if key_delimiter and key_delimiter in line:
-                        # Split only on first occurrence
-                        parts = line.split(key_delimiter, 1)
-                        message_key = parts[0]
-                        message_payload = parts[1] if len(parts) > 1 else ''
-                        producer.send(
-                            message_payload.encode('utf-8'),
-                            partition_key=message_key
-                        )
-                        line_count += 1
-                        print(f"Sent message {line_count}: key='{message_key}', payload='{message_payload}'")
-                    else:
-                        producer.send(line.encode('utf-8'))
-                        line_count += 1
-                        print(f"Sent message {line_count}: {line}")
+            for message_key, message_payload in self._iter_input_messages(key_delimiter):
+                if message_key is not None:
+                    producer.send(
+                        message_payload.encode('utf-8'),
+                        partition_key=message_key
+                    )
+                    line_count += 1
+                    print(f"Sent message {line_count}: key='{message_key}', payload='{message_payload}'")
+                else:
+                    producer.send(message_payload.encode('utf-8'))
+                    line_count += 1
+                    print(f"Sent message {line_count}: {message_payload}")
         except KeyboardInterrupt:
             print(f"\nProduced {line_count} messages")
         finally:
@@ -279,8 +320,7 @@ class PulsarCat:
         print(f"Compacting topic: {topic}")
 
         # Use admin API to compact topic
-        encoded_topic = topic.replace('://', '/')
-        url = f"{self.admin_url}/admin/v2/{encoded_topic}/compaction"
+        url = self._topic_admin_url(topic, "compaction")
         for method_name, method in (("PUT", requests.put), ("POST", requests.post)):
             response = method(url)
             if response.status_code in [200, 204]:
@@ -299,8 +339,7 @@ class PulsarCat:
         print(f"Checking compaction status for topic: {topic}")
 
         # Use admin API to get compaction status
-        encoded_topic = topic.replace('://', '/')
-        url = f"{self.admin_url}/admin/v2/{encoded_topic}/compaction"
+        url = self._topic_admin_url(topic, "compaction")
 
         try:
             response = requests.get(url)

--- a/e2e_test/py_utils/__init__.py
+++ b/e2e_test/py_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared Python utilities for e2e_test helper scripts."""

--- a/e2e_test/py_utils/kafka.py
+++ b/e2e_test/py_utils/kafka.py
@@ -1,0 +1,46 @@
+from confluent_kafka import Producer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+
+
+def create_kafka_producer(producer_conf):
+    """Create a Kafka producer from the provided configuration."""
+    return Producer(producer_conf)
+
+
+def create_schema_registry_client(schema_registry_conf):
+    """Create a schema registry client from the provided configuration."""
+    return SchemaRegistryClient(schema_registry_conf)
+
+
+def delivery_report(err, msg):
+    if err is not None:
+        print(f"Delivery failed for record {msg.value()}: {err}")
+
+
+def produce_serialized_messages(
+    producer,
+    topic,
+    messages,
+    *,
+    partition=0,
+    on_delivery=delivery_report,
+):
+    """Produce pre-serialized Kafka messages and flush once at the end."""
+    for message in messages:
+        produce_kwargs = {
+            "topic": topic,
+            "partition": partition,
+            "on_delivery": on_delivery,
+        }
+
+        key = message.get("key")
+        value = message.get("value")
+
+        if key is not None:
+            produce_kwargs["key"] = key
+        if value is not None:
+            produce_kwargs["value"] = value
+
+        producer.produce(**produce_kwargs)
+
+    producer.flush()

--- a/e2e_test/py_utils/risingwave.py
+++ b/e2e_test/py_utils/risingwave.py
@@ -1,0 +1,35 @@
+import os
+
+import psycopg2
+
+
+def connect_risingwave(
+    database,
+    *,
+    default_host=None,
+    default_port=None,
+    user="root",
+    password="",
+):
+    """Create a RisingWave/Postgres connection using the standard env vars."""
+    host = os.environ.get("RISEDEV_RW_FRONTEND_LISTEN_ADDRESS", default_host)
+    port = os.environ.get("RISEDEV_RW_FRONTEND_PORT", default_port)
+    return psycopg2.connect(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=database,
+    )
+
+
+def fetchone(cursor, query):
+    """Execute a query and return the first row."""
+    cursor.execute(query)
+    return cursor.fetchone()
+
+
+def fetchall(cursor, query):
+    """Execute a query and return all rows."""
+    cursor.execute(query)
+    return cursor.fetchall()

--- a/e2e_test/source_inline/kafka/kafka_startup_millis.py
+++ b/e2e_test/source_inline/kafka/kafka_startup_millis.py
@@ -2,11 +2,25 @@
 
 import argparse
 import json
-import time
-import sys
 import os
+import sys
+import time
+from pathlib import Path
+
 from confluent_kafka import Producer
-import psycopg2
+
+for parent in Path(__file__).resolve().parents:
+    if (parent / "e2e_test").is_dir():
+        parent_str = str(parent)
+        if parent_str not in sys.path:
+            sys.path.insert(0, parent_str)
+        break
+
+from e2e_test.py_utils.risingwave import (  # noqa: E402
+    connect_risingwave,
+    fetchall,
+    fetchone,
+)
 
 
 def produce_records(producer, topic, records):
@@ -64,13 +78,7 @@ def main():
 
         # Connect to RisingWave
         try:
-            conn = psycopg2.connect(
-                host=os.environ.get("RISEDEV_RW_FRONTEND_LISTEN_ADDRESS"),
-                port=os.environ.get("RISEDEV_RW_FRONTEND_PORT"),
-                user='root',
-                password='',
-                database=args.db_name
-            )
+            conn = connect_risingwave(args.db_name)
             cur = conn.cursor()
             print(f"Connected to RisingWave database: {args.db_name}")
         except Exception as e:
@@ -106,13 +114,11 @@ def main():
             time.sleep(3)
 
             # Step 6: Select count(*) from the table
-            cur.execute(f"SELECT COUNT(*) FROM {table_name}")
-            count_result = cur.fetchone()[0]
+            count_result = fetchone(cur, f"SELECT COUNT(*) FROM {table_name}")[0]
             print(f"Count from table {table_name}: {count_result}")
 
             # Also show the actual records for verification
-            cur.execute(f"SELECT * FROM {table_name} ORDER BY id")
-            records = cur.fetchall()
+            records = fetchall(cur, f"SELECT * FROM {table_name} ORDER BY id")
             print(f"Records in table:")
             for record in records:
                 print(f"  {record}")

--- a/e2e_test/source_inline/kafka/protobuf/pb.py
+++ b/e2e_test/source_inline/kafka/protobuf/pb.py
@@ -1,19 +1,27 @@
-import sys
 import json
 import importlib
+import sys
+from pathlib import Path
+
 from google.protobuf.source_context_pb2 import SourceContext
-from confluent_kafka import Producer
 from confluent_kafka.serialization import (
     SerializationContext,
     MessageField,
 )
-from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.protobuf import ProtobufSerializer
 
+for parent in Path(__file__).resolve().parents:
+    if (parent / "e2e_test").is_dir():
+        parent_str = str(parent)
+        if parent_str not in sys.path:
+            sys.path.insert(0, parent_str)
+        break
 
-def delivery_report(err, msg):
-    if err is not None:
-        print("Delivery failed for User record {}: {}".format(msg.value(), err))
+from e2e_test.py_utils.kafka import (  # noqa: E402
+    create_kafka_producer,
+    create_schema_registry_client,
+    produce_serialized_messages,
+)
 
 
 def get_user(i):
@@ -42,25 +50,28 @@ def get_user_with_more_fields(i):
 def send_to_kafka(
     producer_conf, schema_registry_conf, topic, num_records, get_user_fn, pb_message
 ):
-    schema_registry_client = SchemaRegistryClient(schema_registry_conf)
+    schema_registry_client = create_schema_registry_client(schema_registry_conf)
     serializer = ProtobufSerializer(
         pb_message,
         schema_registry_client,
         {"use.deprecated.format": False, "skip.known.types": True},
     )
 
-    producer = Producer(producer_conf)
-    for i in range(num_records):
-        user = get_user_fn(i)
+    producer = create_kafka_producer(producer_conf)
 
-        producer.produce(
-            topic=topic,
-            partition=0,
-            key=json.dumps({"id": i}), # RisingWave does not handle key schema, so we use json
-            value=serializer(user, SerializationContext(topic, MessageField.VALUE)),
-            on_delivery=delivery_report,
-        )
-    producer.flush()
+    def build_messages():
+        for i in range(num_records):
+            user = get_user_fn(i)
+            yield {
+                # RisingWave does not handle key schema, so we use json.
+                "key": json.dumps({"id": i}),
+                "value": serializer(
+                    user,
+                    SerializationContext(topic, MessageField.VALUE),
+                ),
+            }
+
+    produce_serialized_messages(producer, topic, build_messages())
     print("Send {} records to kafka\n".format(num_records))
 
 

--- a/e2e_test/source_legacy/basic/scripts/schema_registry_producer.py
+++ b/e2e_test/source_legacy/basic/scripts/schema_registry_producer.py
@@ -1,27 +1,34 @@
-from confluent_kafka import Producer
 from confluent_kafka.admin import AdminClient, NewTopic
 from confluent_kafka.serialization import SerializationContext, MessageField
-from confluent_kafka.schema_registry import SchemaRegistryClient, record_subject_name_strategy, \
-    topic_record_subject_name_strategy
+from confluent_kafka.schema_registry import (
+    record_subject_name_strategy,
+    topic_record_subject_name_strategy,
+)
 from confluent_kafka.schema_registry.avro import AvroSerializer
 from confluent_kafka.schema_registry.json_schema import JSONSerializer
-import sys
 import json
 import os
+import sys
+from pathlib import Path
+
+for parent in Path(__file__).resolve().parents:
+    if (parent / "e2e_test").is_dir():
+        parent_str = str(parent)
+        if parent_str not in sys.path:
+            sys.path.insert(0, parent_str)
+        break
+
+from e2e_test.py_utils.kafka import (  # noqa: E402
+    create_kafka_producer,
+    create_schema_registry_client,
+    produce_serialized_messages,
+)
 
 
 def create_topic(kafka_conf, topic_name):
     client = AdminClient(kafka_conf)
-    topic_list = []
-    topic_list.append(
-        NewTopic(topic_name, num_partitions=1, replication_factor=1))
+    topic_list = [NewTopic(topic_name, num_partitions=1, replication_factor=1)]
     client.create_topics(topic_list)
-
-
-def delivery_report(err, msg):
-    if err is not None:
-        print("Delivery failed for User record {}: {}".format(msg.value(), err))
-        return
 
 
 def load_avro_json(encoded, schema):
@@ -38,6 +45,93 @@ def load_avro_json(encoded, schema):
         return next(reader)
 
 
+def iter_serialized_messages(
+    file_path,
+    schema_type,
+    schema_registry_client,
+    avro_ser_conf,
+    topic,
+):
+    key_serializer = None
+    value_serializer = None
+    key_schema = None
+    value_schema = None
+
+    with open(file_path) as source_file:
+        for (i, line) in enumerate(source_file):
+            parts = line.split("^")
+            if i == 0:
+                if len(parts) > 1:
+                    if schema_type == "avro":
+                        key_serializer = AvroSerializer(
+                            schema_registry_client=schema_registry_client,
+                            schema_str=parts[0],
+                            conf=avro_ser_conf,
+                        )
+                        value_serializer = AvroSerializer(
+                            schema_registry_client=schema_registry_client,
+                            schema_str=parts[1],
+                            conf=avro_ser_conf,
+                        )
+                        key_schema = json.loads(parts[0])
+                        value_schema = json.loads(parts[1])
+                    else:
+                        key_serializer = JSONSerializer(
+                            schema_registry_client=schema_registry_client,
+                            schema_str=parts[0],
+                        )
+                        value_serializer = JSONSerializer(
+                            schema_registry_client=schema_registry_client,
+                            schema_str=parts[1],
+                        )
+                else:
+                    if schema_type == "avro":
+                        value_serializer = AvroSerializer(
+                            schema_registry_client=schema_registry_client,
+                            schema_str=parts[0],
+                        )
+                        value_schema = json.loads(parts[0])
+                    else:
+                        value_serializer = JSONSerializer(
+                            schema_registry_client=schema_registry_client,
+                            schema_str=parts[0],
+                        )
+                continue
+
+            key_idx = None
+            value_idx = None
+            if len(parts) > 1:
+                key_idx = 0
+                if len(parts[1].strip()) > 0:
+                    value_idx = 1
+            else:
+                value_idx = 0
+
+            if schema_type == "avro":
+                if key_idx is not None:
+                    key_json = load_avro_json(parts[key_idx], key_schema)
+                if value_idx is not None:
+                    value_json = load_avro_json(parts[value_idx], value_schema)
+            else:
+                if key_idx is not None:
+                    key_json = json.loads(parts[key_idx])
+                if value_idx is not None:
+                    value_json = json.loads(parts[value_idx])
+
+            message = {}
+            if key_idx is not None:
+                message["key"] = key_serializer(
+                    key_json,
+                    SerializationContext(topic, MessageField.KEY),
+                )
+            if value_idx is not None:
+                message["value"] = value_serializer(
+                    value_json,
+                    SerializationContext(topic, MessageField.VALUE),
+                )
+            yield message
+
+
 if __name__ == '__main__':
     if len(sys.argv) <= 5:
         print(
@@ -46,102 +140,43 @@ if __name__ == '__main__':
         exit(1)
     broker_list = sys.argv[1]
     schema_registry_url = sys.argv[2]
-    file = sys.argv[3]
-    topic = os.path.basename(file).split(".")[0]
-    type = sys.argv[5]
-    if sys.argv[4] not in ['topic', 'record', 'topic-record', '', None]:
+    file_path = sys.argv[3]
+    topic = os.path.basename(file_path).split(".")[0]
+    name_strategy = sys.argv[4]
+    schema_type = sys.argv[5]
+    if name_strategy not in ['topic', 'record', 'topic-record', '', None]:
         print("name strategy must be one of: topic, record, topic_record")
         exit(1)
-    if sys.argv[4] != 'topic':
-        topic = topic + "-" + sys.argv[4]
+    if name_strategy != 'topic':
+        topic = topic + "-" + name_strategy
 
     print("broker_list: {}".format(broker_list))
     print("schema_registry_url: {}".format(schema_registry_url))
     print("topic: {}".format(topic))
     print("name strategy: {}".format(
-        sys.argv[4] if sys.argv[4] is not None else 'topic'))
-    print("type: {}".format(type))
+        name_strategy if name_strategy is not None else 'topic'))
+    print("type: {}".format(schema_type))
 
     schema_registry_conf = {'url': schema_registry_url}
     kafka_conf = {'bootstrap.servers': broker_list}
-    schema_registry_client = SchemaRegistryClient(schema_registry_conf)
+    schema_registry_client = create_schema_registry_client(schema_registry_conf)
 
     avro_ser_conf = dict()
-    if sys.argv[4] == 'record':
+    if name_strategy == 'record':
         avro_ser_conf['subject.name.strategy'] = record_subject_name_strategy
-    elif sys.argv[4] == 'topic-record':
+    elif name_strategy == 'topic-record':
         avro_ser_conf['subject.name.strategy'] = topic_record_subject_name_strategy
 
     create_topic(kafka_conf=kafka_conf, topic_name=topic)
-    producer = Producer(kafka_conf)
-    key_serializer = None
-    value_serializer = None
-    key_schema = None
-    value_schema = None
-    with open(file) as file:
-        for (i, line) in enumerate(file):
-            if i == 0:
-                parts = line.split("^")
-                if len(parts) > 1:
-                    if type == 'avro':
-                        key_serializer = AvroSerializer(schema_registry_client=schema_registry_client,
-                                                        schema_str=parts[0],
-                                                        conf=avro_ser_conf)
-                        value_serializer = AvroSerializer(schema_registry_client=schema_registry_client,
-                                                          schema_str=parts[1],
-                                                          conf=avro_ser_conf)
-                        key_schema = json.loads(parts[0])
-                        value_schema = json.loads(parts[1])
-                    else:
-                        key_serializer = JSONSerializer(schema_registry_client=schema_registry_client,
-                                                        schema_str=parts[0])
-                        value_serializer = JSONSerializer(schema_registry_client=schema_registry_client,
-                                                          schema_str=parts[1])
-                else:
-                    if type == 'avro':
-                        value_serializer = AvroSerializer(schema_registry_client=schema_registry_client,
-                                                          schema_str=parts[0])
-                        value_schema = json.loads(parts[0])
-                    else:
-                        value_serializer = JSONSerializer(schema_registry_client=schema_registry_client,
-                                                          schema_str=parts[0])
-            else:
-                parts = line.split("^")
-                key_idx = None
-                value_idx = None
-                if len(parts) > 1:
-                    key_idx = 0
-                    if len(parts[1].strip()) > 0:
-                        value_idx = 1
-                else:
-                    value_idx = 0
-                if type == 'avro':
-                    if key_idx is not None:
-                        key_json = load_avro_json(parts[key_idx], key_schema)
-                    if value_idx is not None:
-                        value_json = load_avro_json(parts[value_idx], value_schema)
-                else:
-                    if key_idx is not None:
-                        key_json = json.loads(parts[key_idx])
-                    if value_idx is not None:
-                        value_json = json.loads(parts[value_idx])
-                if len(parts) > 1:
-                    if len(parts[1].strip()) > 0:
-                        producer.produce(topic=topic, partition=0,
-                                         key=key_serializer(key_json,
-                                                            SerializationContext(topic, MessageField.KEY)),
-                                         value=value_serializer(
-                                             value_json, SerializationContext(topic, MessageField.VALUE)),
-                                         on_delivery=delivery_report)
-                    else:
-                        producer.produce(topic=topic, partition=0,
-                                         key=key_serializer(key_json,
-                                                            SerializationContext(topic, MessageField.KEY)),
-                                         on_delivery=delivery_report)
-                else:
-                    producer.produce(topic=topic, partition=0,
-                                     value=value_serializer(
-                                         value_json, SerializationContext(topic, MessageField.VALUE)),
-                                     on_delivery=delivery_report)
-
-    producer.flush()
+    producer = create_kafka_producer(kafka_conf)
+    produce_serialized_messages(
+        producer,
+        topic,
+        iter_serialized_messages(
+            file_path,
+            schema_type,
+            schema_registry_client,
+            avro_ser_conf,
+            topic,
+        ),
+    )


### PR DESCRIPTION
## Summary
- extract thin shared Python helpers for Kafka/schema-registry bootstrap and RisingWave DB connections used by SLT helper scripts
- refactor the existing Kafka helper scripts to reuse those thin helpers while keeping direct script entrypoints intact
- narrow `pulsar_util.py` cleanup to the currently exercised command lane without widening into `consume`/`unacked` or a broader framework

## Testing
- `python3 -m py_compile e2e_test/__init__.py e2e_test/py_utils/__init__.py e2e_test/py_utils/kafka.py e2e_test/py_utils/risingwave.py e2e_test/source_inline/kafka/protobuf/pb.py e2e_test/source_legacy/basic/scripts/schema_registry_producer.py e2e_test/source_inline/kafka/kafka_startup_millis.py e2e_test/commands/psql_validate.py e2e_test/commands/pulsar_util.py`
- `./risedev slt './e2e_test/batch/describe_fragment.slt'`
- `./risedev slt './e2e_test/batch/describe_fragments.slt'`
- `./risedev slt './e2e_test/source_inline/kafka/protobuf/basic.slt'`
- `./risedev slt './e2e_test/source_inline/kafka/kafka_startup_millis.slt'`
- `./risedev slt './e2e_test/source_inline/kafka/issue_22387.slt'`
- `./risedev slt './e2e_test/source_inline/pulsar/basic.slt'` (with local Pulsar env override)
- `./risedev slt './e2e_test/source_inline/pulsar/check_ack.slt'` (with local Pulsar env override)
- `./risedev slt './e2e_test/source_inline/pulsar/read_compact.slt'` (with local Pulsar env override)

## Notes
- `e2e_test/source_inline/pulsar/issue-22486.slt.serial` remained unstable under the local recovery/environment setup and is not included as a passing verification result in this PR.
