### PR TITLE
fix(optimizer): remove spurious BatchSort above BatchTopN on index with eq-prefix

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -517,6 +517,20 @@
     select * from t1 where a = 1 order by b desc limit 10
   expected_outputs:
     - batch_plan
+- name: topn index selection + limit pushdown with point get + offset
+  sql: |
+    create table t1 (a int, b int);
+    create index idx1 on t1(a, b desc);
+    select * from t1 where a = 1 order by b desc limit 10 offset 5
+  expected_outputs:
+    - batch_plan
+- name: topn index selection + limit pushdown with point get + with ties
+  sql: |
+    create table t1 (a int, b int);
+    create index idx1 on t1(a, b desc);
+    select * from t1 where a = 1 order by b desc fetch next 10 rows with ties
+  expected_outputs:
+    - batch_plan
 - name: topn index selection + limit pushdown with multi point get
   sql: |
     create table t1 (a int, b int, c int);
@@ -598,6 +612,13 @@
     create table t (c int, b int, a int);
     create index idx on t(a, b desc, c desc);
     select b from t where a = 1 order by b desc, c desc limit 1;
+  expected_outputs:
+    - batch_plan
+- name: topn index selection for scan with output column idx + offset
+  sql: |
+    create table t (c int, b int, a int);
+    create index idx on t(a, b desc, c desc);
+    select b from t where a = 1 order by b desc, c desc limit 2 offset 1;
   expected_outputs:
     - batch_plan
 - name: topn index selection for scan with output column idx

--- a/src/frontend/planner_test/tests/testdata/output/basic_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/basic_query.yaml
@@ -193,8 +193,8 @@
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 limit 1
   batch_plan: |-
-    BatchTopN { order: [t.v1 ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [t.v1 ASC], dist: Single }
       └─BatchTopN { order: [t.v1 ASC], limit: 1, offset: 0 }
         └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |

--- a/src/frontend/planner_test/tests/testdata/output/functional_dependency.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/functional_dependency.yaml
@@ -8,8 +8,8 @@
     └─LogicalProject { exprs: [t1.id, t1.i] }
       └─LogicalScan { table: t1, columns: [t1.id, t1.i, t1._rw_timestamp] }
   batch_plan: |-
-    BatchTopN { order: [t1.id ASC], limit: 2, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 2, offset: 0 }
+    └─BatchExchange { order: [t1.id ASC], dist: Single }
       └─BatchLimit { limit: 2, offset: 0 }
         └─BatchScan { table: t1, columns: [t1.id, t1.i], limit: 2, distribution: UpstreamHashShard(t1.id) }
   stream_plan: |-
@@ -29,8 +29,8 @@
     └─LogicalProject { exprs: [t1.id, t1.i] }
       └─LogicalScan { table: t1, columns: [t1.id, t1.i, t1._rw_timestamp] }
   batch_plan: |-
-    BatchTopN { order: [t1.i ASC, t1.id ASC], limit: 2, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 2, offset: 0 }
+    └─BatchExchange { order: [t1.i ASC, t1.id ASC], dist: Single }
       └─BatchTopN { order: [t1.i ASC, t1.id ASC], limit: 2, offset: 0 }
         └─BatchScan { table: t1, columns: [t1.id, t1.i], distribution: UpstreamHashShard(t1.id) }
   stream_plan: |-

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -665,8 +665,8 @@
     create index idx1 on t1(a);
     select * from t1 order by a limit 1
   batch_plan: |-
-    BatchTopN { order: [idx1.a ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [idx1.a ASC], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], limit: 1, distribution: UpstreamHashShard(idx1.a) }
 - name: topn on primary key
@@ -675,8 +675,8 @@
     create index idx1 on t1(a);
     select * from t1 order by a limit 1
   batch_plan: |-
-    BatchTopN { order: [t1.a ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [t1.a ASC], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: t1, columns: [t1.a, t1.b], limit: 1, distribution: UpstreamHashShard(t1.a) }
 - name: topn on index with descending ordering
@@ -685,8 +685,8 @@
     create index idx1 on t1(a desc);
     select * from t1 order by a desc limit 1
   batch_plan: |-
-    BatchTopN { order: [idx1.a DESC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [idx1.a DESC], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], limit: 1, distribution: UpstreamHashShard(idx1.a) }
 - name: topn on pk streaming case, should NOT optimized
@@ -862,8 +862,8 @@
     create index idx1 on t1(a);
     select * from t1 order by a limit 10
   batch_plan: |-
-    BatchTopN { order: [idx1.a ASC], limit: 10, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx1.a ASC], dist: Single }
       └─BatchLimit { limit: 10, offset: 0 }
         └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], limit: 10, distribution: UpstreamHashShard(idx1.a) }
 - name: topn index selection + limit pushdown fails due to b desc != b asc
@@ -872,8 +872,8 @@
     create index idx1 on t1(a, b desc);
     select * from t1 order by a, b limit 10
   batch_plan: |-
-    BatchTopN { order: [t1.a ASC, t1.b ASC], limit: 10, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [t1.a ASC, t1.b ASC], dist: Single }
       └─BatchTopN { order: [t1.a ASC, t1.b ASC], limit: 10, offset: 0 }
         └─BatchScan { table: t1, columns: [t1.a, t1.b], distribution: SomeShard }
 - name: topn index selection + limit pushdown with point get
@@ -882,34 +882,51 @@
     create index idx1 on t1(a, b desc);
     select * from t1 where a = 1 order by b desc limit 10
   batch_plan: |-
-    BatchSort { order: [idx1.b DESC] }
-    └─BatchTopN { order: [idx1.a ASC, idx1.b DESC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], scan_ranges: [idx1.a = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx1.b DESC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], scan_ranges: [idx1.a = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
+- name: topn index selection + limit pushdown with point get + offset
+  sql: |
+    create table t1 (a int, b int);
+    create index idx1 on t1(a, b desc);
+    select * from t1 where a = 1 order by b desc limit 10 offset 5
+  batch_plan: |-
+    BatchLimit { limit: 10, offset: 5 }
+    └─BatchExchange { order: [idx1.b DESC], dist: Single }
+      └─BatchLimit { limit: 15, offset: 0 }
+        └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], scan_ranges: [idx1.a = Int32(1)], limit: 15, distribution: UpstreamHashShard(idx1.a) }
+- name: topn index selection + limit pushdown with point get + with ties
+  sql: |
+    create table t1 (a int, b int);
+    create index idx1 on t1(a, b desc);
+    select * from t1 where a = 1 order by b desc fetch next 10 rows with ties
+  batch_plan: |-
+    BatchTopN { order: [idx1.b DESC], limit: 10, offset: 0, with_ties: true }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: [idx1.b DESC], limit: 10, offset: 0, with_ties: true }
+        └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a) }
 - name: topn index selection + limit pushdown with multi point get
   sql: |
     create table t1 (a int, b int, c int);
     create index idx1 on t1(a, c, b desc);
     select * from t1 where c = 1 and a = 2 order by b desc limit 10
   batch_plan: |-
-    BatchSort { order: [idx1.b DESC] }
-    └─BatchTopN { order: [idx1.a ASC, idx1.c ASC, idx1.b DESC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(2) AND idx1.c = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx1.b DESC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(2) AND idx1.c = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
 - name: topn index selection + limit pushdown with multi point get + unindexed point get
   sql: |
     create table t1 (a int, b int, c int, d int);
     create index idx1 on t1(a, c, b desc);
     select * from t1 where c = 1 and a = 2 and d = 3 order by b desc limit 10
   batch_plan: |-
-    BatchSort { order: [idx1.b DESC] }
-    └─BatchTopN { order: [idx1.a ASC, idx1.c ASC, idx1.b DESC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchFilter { predicate: (idx1.d = 3:Int32) }
-            └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c, idx1.d], scan_ranges: [idx1.a = Int32(2) AND idx1.c = Int32(1)], distribution: UpstreamHashShard(idx1.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx1.b DESC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchFilter { predicate: (idx1.d = 3:Int32) }
+          └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c, idx1.d], scan_ranges: [idx1.a = Int32(2) AND idx1.c = Int32(1)], distribution: UpstreamHashShard(idx1.a) }
 - name: topn index selection + limit pushdown with multi index
   sql: |
     create table t1 (a int, b int, c int, d int);
@@ -919,22 +936,20 @@
     create index idx4 on t1(b, a desc);
     select * from t1 where c = 1 and a = 2 and d = 3 order by b desc limit 10
   batch_plan: |-
-    BatchSort { order: [idx3.b DESC] }
-    └─BatchTopN { order: [idx3.a ASC, idx3.c ASC, idx3.d ASC, idx3.b DESC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c, idx3.d], scan_ranges: [idx3.a = Int32(2) AND idx3.c = Int32(1) AND idx3.d = Int32(3)], limit: 10, distribution: UpstreamHashShard(idx3.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx3.b DESC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c, idx3.d], scan_ranges: [idx3.a = Int32(2) AND idx3.c = Int32(1) AND idx3.d = Int32(3)], limit: 10, distribution: UpstreamHashShard(idx3.a) }
 - name: topn index selection + limit pushdown with point get + descending order point get
   sql: |
     create table t1 (a int, b int, c int);
     create index idx1 on t1(a asc, b);
     select * from t1 where a = 1 order by b limit 10;
   batch_plan: |-
-    BatchSort { order: [idx1.b ASC] }
-    └─BatchTopN { order: [idx1.a ASC, idx1.b ASC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx1.b ASC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
 - name: topn index selection + limit pushdown with multi point get + various order combination point get
   sql: |
     create table t1 (a int, b int, c int);
@@ -943,32 +958,29 @@
     create index idx3 on t1(a desc nulls last, c asc nulls first, b desc nulls last);
     select * from t1 where c = 2 and a = 2 order by b desc nulls last limit 10;
   batch_plan: |-
-    BatchSort { order: [idx3.b DESC NULLS LAST] }
-    └─BatchTopN { order: [idx3.a DESC NULLS LAST, idx3.c ASC NULLS FIRST, idx3.b DESC NULLS LAST], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c], scan_ranges: [idx3.a = Int32(2) AND idx3.c = Int32(2)], limit: 10, distribution: UpstreamHashShard(idx3.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx3.b DESC NULLS LAST], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c], scan_ranges: [idx3.a = Int32(2) AND idx3.c = Int32(2)], limit: 10, distribution: UpstreamHashShard(idx3.a) }
 - name: topn index selection + limit pushdown with multi point get + various order combination point get for primary table
   sql: |
     create table t1 (a int, b int, c int, primary key (a, b, c));
     select * from t1 where a = 1 and b = 2 order by c limit 10;
   batch_plan: |-
-    BatchSort { order: [t1.c ASC] }
-    └─BatchTopN { order: [t1.a ASC, t1.b ASC, t1.c ASC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], scan_ranges: [t1.a = Int32(1) AND t1.b = Int32(2)], limit: 10, distribution: UpstreamHashShard(t1.a, t1.b, t1.c) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [t1.c ASC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], scan_ranges: [t1.a = Int32(1) AND t1.b = Int32(2)], limit: 10, distribution: UpstreamHashShard(t1.a, t1.b, t1.c) }
 - name: topn index selection + limit pushdown with multi point get + various order combination point get for primary table
   sql: |
     create table t1 (a int, b int, c int, primary key (a, b, c));
     create index idx1 on t1(a, b, c desc);
     select * from t1 where a = 1 and b = 2 order by c desc limit 10;
   batch_plan: |-
-    BatchSort { order: [idx1.c DESC] }
-    └─BatchTopN { order: [idx1.a ASC, idx1.b ASC, idx1.c DESC], limit: 10, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 10, offset: 0 }
-          └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) AND idx1.b = Int32(2)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [idx1.c DESC], dist: Single }
+      └─BatchLimit { limit: 10, offset: 0 }
+        └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) AND idx1.b = Int32(2)], limit: 10, distribution: UpstreamHashShard(idx1.a) }
 - name: Use primary table instead of indexes if possible
   sql: |
     CREATE TABLE t1(id INT, t2_id INT, PRIMARY KEY(id));
@@ -1014,11 +1026,24 @@
   batch_plan: |-
     BatchProject { exprs: [idx.b] }
     └─BatchProject { exprs: [idx.b, idx.c] }
-      └─BatchSort { order: [idx.b DESC, idx.c DESC] }
-        └─BatchTopN { order: [idx.a ASC, idx.b DESC, idx.c DESC], limit: 1, offset: 0 }
-          └─BatchExchange { order: [], dist: Single }
-            └─BatchLimit { limit: 1, offset: 0 }
-              └─BatchScan { table: idx, columns: [idx.c, idx.b, idx.a], scan_ranges: [idx.a = Int32(1)], limit: 1, distribution: UpstreamHashShard(idx.a) }
+      └─BatchLimit { limit: 1, offset: 0 }
+        └─BatchExchange { order: [idx.b DESC, idx.c DESC], dist: Single }
+          └─BatchLimit { limit: 1, offset: 0 }
+            └─BatchProject { exprs: [idx.c, idx.b] }
+              └─BatchScan { table: idx, columns: [idx.c, idx.b, idx.a], scan_ranges: [idx.a = Int32(1)], distribution: UpstreamHashShard(idx.a) }
+- name: topn index selection for scan with output column idx + offset
+  sql: |
+    create table t (c int, b int, a int);
+    create index idx on t(a, b desc, c desc);
+    select b from t where a = 1 order by b desc, c desc limit 2 offset 1;
+  batch_plan: |-
+    BatchProject { exprs: [idx.b] }
+    └─BatchProject { exprs: [idx.b, idx.c] }
+      └─BatchLimit { limit: 2, offset: 1 }
+        └─BatchExchange { order: [idx.b DESC, idx.c DESC], dist: Single }
+          └─BatchLimit { limit: 3, offset: 0 }
+            └─BatchProject { exprs: [idx.c, idx.b] }
+              └─BatchScan { table: idx, columns: [idx.c, idx.b, idx.a], scan_ranges: [idx.a = Int32(1)], distribution: UpstreamHashShard(idx.a) }
 - name: topn index selection for scan with output column idx
   sql: |
     create table t (c int, b int, a int, primary key (a, b, c));
@@ -1026,11 +1051,11 @@
   batch_plan: |-
     BatchProject { exprs: [t.b] }
     └─BatchProject { exprs: [t.b, t.c] }
-      └─BatchSort { order: [t.b ASC, t.c ASC] }
-        └─BatchTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 1, offset: 0 }
-          └─BatchExchange { order: [], dist: Single }
-            └─BatchLimit { limit: 1, offset: 0 }
-              └─BatchScan { table: t, columns: [t.c, t.b, t.a], scan_ranges: [t.a = Int32(1)], limit: 1, distribution: UpstreamHashShard(t.a, t.b, t.c) }
+      └─BatchLimit { limit: 1, offset: 0 }
+        └─BatchExchange { order: [t.b ASC, t.c ASC], dist: Single }
+          └─BatchLimit { limit: 1, offset: 0 }
+            └─BatchProject { exprs: [t.c, t.b] }
+              └─BatchScan { table: t, columns: [t.c, t.b, t.a], scan_ranges: [t.a = Int32(1)], distribution: UpstreamHashShard(t.a, t.b, t.c) }
 - name: batch sort elimination with eq-prefix-derived orders
   sql: |
     create table t (a int, b int, c int, d int, primary key (a, b, c, d));
@@ -1043,11 +1068,10 @@
     create table t (a int, b int, c int, d int, primary key (a, b, c, d));
     select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by c limit 5;
   batch_plan: |-
-    BatchSort { order: [t.c ASC] }
-    └─BatchTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 5, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 5, offset: 0 }
-          └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], limit: 5, distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }
+    BatchLimit { limit: 5, offset: 0 }
+    └─BatchExchange { order: [t.c ASC], dist: Single }
+      └─BatchLimit { limit: 5, offset: 0 }
+        └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], limit: 5, distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }
 - name: batch sort elimination with eq-prefix-derived orders
   sql: |
     create table t (a int, b int, c int, d int, primary key (a, b, c, d));
@@ -1060,8 +1084,7 @@
     create table t (a int, b int, c int, d int, primary key (a, b, c, d));
     select a, b, c, d from t where a = 1 and b = 2 and c between 3 and 5 order by a, b, c limit 5;
   batch_plan: |-
-    BatchSort { order: [t.c ASC] }
-    └─BatchTopN { order: [t.a ASC, t.b ASC, t.c ASC], limit: 5, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchLimit { limit: 5, offset: 0 }
-          └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], limit: 5, distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }
+    BatchLimit { limit: 5, offset: 0 }
+    └─BatchExchange { order: [t.c ASC], dist: Single }
+      └─BatchLimit { limit: 5, offset: 0 }
+        └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d], scan_ranges: [t.a = Int32(1) AND t.b = Int32(2) AND t.c >= Int32(3) AND t.c <= Int32(5)], limit: 5, distribution: UpstreamHashShard(t.a, t.b, t.c, t.d) }

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -2287,8 +2287,8 @@
     ORDER BY bid_count DESC
     LIMIT 1000;
   batch_plan: |-
-    BatchTopN { order: [count(bid.auction) DESC], limit: 1000, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1000, offset: 0 }
+    └─BatchExchange { order: [count(bid.auction) DESC], dist: Single }
       └─BatchTopN { order: [count(bid.auction) DESC], limit: 1000, offset: 0 }
         └─BatchHashAgg { group_key: [auction.id], aggs: [internal_last_seen_value(auction.item_name), count(bid.auction)] }
           └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
@@ -2219,8 +2219,8 @@
     ORDER BY bid_count DESC
     LIMIT 1000;
   batch_plan: |-
-    BatchTopN { order: [count(auction) DESC], limit: 1000, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1000, offset: 0 }
+    └─BatchExchange { order: [count(auction) DESC], dist: Single }
       └─BatchTopN { order: [count(auction) DESC], limit: 1000, offset: 0 }
         └─BatchHashAgg { group_key: [id, item_name], aggs: [count(auction)] }
           └─BatchHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction] }

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source_kafka.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source_kafka.yaml
@@ -2241,8 +2241,8 @@
     ORDER BY bid_count DESC
     LIMIT 1000;
   batch_plan: |-
-    BatchTopN { order: [count(auction) DESC], limit: 1000, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1000, offset: 0 }
+    └─BatchExchange { order: [count(auction) DESC], dist: Single }
       └─BatchTopN { order: [count(auction) DESC], limit: 1000, offset: 0 }
         └─BatchHashAgg { group_key: [id, item_name], aggs: [count(auction)] }
           └─BatchHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction] }

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -2338,8 +2338,8 @@
     ORDER BY bid_count DESC
     LIMIT 1000;
   batch_plan: |-
-    BatchTopN { order: [count($expr5) DESC], limit: 1000, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1000, offset: 0 }
+    └─BatchExchange { order: [count($expr5) DESC], dist: Single }
       └─BatchTopN { order: [count($expr5) DESC], limit: 1000, offset: 0 }
         └─BatchHashAgg { group_key: [$expr2, $expr3], aggs: [count($expr5)] }
           └─BatchHashJoin { type: Inner, predicate: $expr2 = $expr5, output: all }

--- a/src/frontend/planner_test/tests/testdata/output/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/order_by.yaml
@@ -90,8 +90,8 @@
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc limit 5;
   batch_plan: |-
-    BatchTopN { order: [t.v1 DESC], limit: 5, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 5, offset: 0 }
+    └─BatchExchange { order: [t.v1 DESC], dist: Single }
       └─BatchTopN { order: [t.v1 DESC], limit: 5, offset: 0 }
         └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |-
@@ -122,8 +122,8 @@
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc limit 5 offset 7;
   batch_plan: |-
-    BatchTopN { order: [t.v1 DESC], limit: 5, offset: 7 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 5, offset: 7 }
+    └─BatchExchange { order: [t.v1 DESC], dist: Single }
       └─BatchTopN { order: [t.v1 DESC], limit: 12, offset: 0 }
         └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |-

--- a/src/frontend/planner_test/tests/testdata/output/project_set.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/project_set.yaml
@@ -91,8 +91,8 @@
     select unnest(x) as unnest from t order by unnest limit 1;
   batch_plan: |-
     BatchProject { exprs: [Unnest($0)] }
-    └─BatchTopN { order: [_rw_projected_row_id ASC], limit: 1, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
+    └─BatchLimit { limit: 1, offset: 0 }
+      └─BatchExchange { order: [_rw_projected_row_id ASC], dist: Single }
         └─BatchTopN { order: [_rw_projected_row_id ASC], limit: 1, offset: 0 }
           └─BatchProjectSet { select_list: [Unnest($0)] }
             └─BatchScan { table: t, columns: [t.x], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/output/singleton.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/singleton.yaml
@@ -38,8 +38,8 @@
   sql: |
     select mv1.v from mv mv1, mv mv2 where mv1.v = mv2.v order by mv1.v limit 10;
   batch_plan: |-
-    BatchTopN { order: [mv.v ASC], limit: 10, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [mv.v ASC], dist: Single }
       └─BatchTopN { order: [mv.v ASC], limit: 10, offset: 0 }
         └─BatchHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v] }
           ├─BatchExchange { order: [], dist: HashShard(mv.v) }

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -917,8 +917,8 @@
       ├─BatchExchange { order: [], dist: HashShard(t1.v1) }
       │ └─BatchScan { table: t1, columns: [t1.v1, t1.k1], distribution: SomeShard }
       └─BatchExchange { order: [], dist: HashShard(t2.v2) }
-        └─BatchTopN { order: [t2.v2 ASC], limit: 1, offset: 0 }
-          └─BatchExchange { order: [], dist: Single }
+        └─BatchLimit { limit: 1, offset: 0 }
+          └─BatchExchange { order: [t2.v2 ASC], dist: Single }
             └─BatchTopN { order: [t2.v2 ASC], limit: 1, offset: 0 }
               └─BatchScan { table: t2, columns: [t2.v2], distribution: SomeShard }
   stream_plan: |-

--- a/src/frontend/planner_test/tests/testdata/output/topn.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/topn.yaml
@@ -13,8 +13,8 @@
     CREATE MATERIALIZED VIEW t1_mv AS SELECT * from t1;
     SELECT * FROM t1_mv ORDER BY a DESC LIMIT 50 OFFSET 50;
   batch_plan: |-
-    BatchTopN { order: [t1_mv.a DESC], limit: 50, offset: 50 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 50, offset: 50 }
+    └─BatchExchange { order: [t1_mv.a DESC], dist: Single }
       └─BatchTopN { order: [t1_mv.a DESC], limit: 100, offset: 0 }
         └─BatchScan { table: t1_mv, columns: [t1_mv.pk, t1_mv.a, t1_mv.b, t1_mv.c, t1_mv.d], distribution: SomeShard }
 - sql: |
@@ -22,8 +22,8 @@
     CREATE MATERIALIZED VIEW t1_mv AS SELECT * from t1 order by a desc;
     SELECT * FROM t1_mv ORDER BY a DESC LIMIT 50 OFFSET 50;
   batch_plan: |-
-    BatchTopN { order: [t1_mv.a DESC], limit: 50, offset: 50 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 50, offset: 50 }
+    └─BatchExchange { order: [t1_mv.a DESC], dist: Single }
       └─BatchLimit { limit: 100, offset: 0 }
         └─BatchScan { table: t1_mv, columns: [t1_mv.pk, t1_mv.a, t1_mv.b, t1_mv.c, t1_mv.d], limit: 100, distribution: SomeShard }
 - sql: |

--- a/src/frontend/planner_test/tests/testdata/output/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch.yaml
@@ -134,8 +134,8 @@
           └─LogicalProject { exprs: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, (lineitem.l_extendedprice * (1:Int32::Decimal - lineitem.l_discount)) as $expr1] }
             └─LogicalScan { table: lineitem, output_columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus], required_columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate], predicate: (lineitem.l_shipdate <= ('1998-12-01':Date - '71 days':Interval)) }
   batch_plan: |-
-    BatchTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], dist: Single }
       └─BatchTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
         └─BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal) as $expr3, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal) as $expr4, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal) as $expr5, count] }
           └─BatchHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
@@ -283,8 +283,8 @@
       │ └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
       └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [region.r_regionkey, region.r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC], limit: 100, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 100, offset: 0 }
+    └─BatchExchange { order: [supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC], dist: Single }
       └─BatchTopN { order: [supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC], limit: 100, offset: 0 }
         └─BatchLookupJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey AND (region.r_name = 'AFRICA':Varchar), output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment], lookup table: region }
           └─BatchExchange { order: [], dist: UpstreamHashShard(nation.n_regionkey) }
@@ -602,8 +602,8 @@
             │ └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], predicate: (orders.o_orderdate < '1995-03-29':Date) }
             └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], predicate: (lineitem.l_shipdate > '1995-03-29':Date) }
   batch_plan: |-
-    BatchTopN { order: [sum($expr1) DESC, orders.o_orderdate ASC], limit: 10, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 10, offset: 0 }
+    └─BatchExchange { order: [sum($expr1) DESC, orders.o_orderdate ASC], dist: Single }
       └─BatchTopN { order: [sum($expr1) DESC, orders.o_orderdate ASC], limit: 10, offset: 0 }
         └─BatchProject { exprs: [lineitem.l_orderkey, sum($expr1), orders.o_orderdate, orders.o_shippriority] }
           └─BatchHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum($expr1)] }
@@ -769,8 +769,8 @@
         ├─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_orderpriority], required_columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], predicate: (orders.o_orderdate >= '1997-07-01':Date) AND (orders.o_orderdate < ('1997-07-01':Date + '3 mons':Interval)) }
         └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey], required_columns: [lineitem.l_orderkey, lineitem.l_commitdate, lineitem.l_receiptdate], predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
   batch_plan: |-
-    BatchTopN { order: [orders.o_orderpriority ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [orders.o_orderpriority ASC], dist: Single }
       └─BatchTopN { order: [orders.o_orderpriority ASC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [orders.o_orderpriority], aggs: [count] }
           └─BatchExchange { order: [], dist: HashShard(orders.o_orderpriority) }
@@ -918,8 +918,8 @@
           │ └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
           └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [region.r_regionkey, region.r_name], predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [sum($expr1) DESC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [sum($expr1) DESC], dist: Single }
       └─BatchTopN { order: [sum($expr1) DESC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [nation.n_name], aggs: [sum($expr1)] }
           └─BatchExchange { order: [], dist: HashShard(nation.n_name) }
@@ -1263,8 +1263,8 @@
           │ └─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
           └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
   batch_plan: |-
-    BatchTopN { order: [nation.n_name ASC, nation.n_name ASC, $expr1 ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [nation.n_name ASC, nation.n_name ASC, $expr1 ASC], dist: Single }
       └─BatchTopN { order: [nation.n_name ASC, nation.n_name ASC, $expr1 ASC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [nation.n_name, nation.n_name, $expr1], aggs: [sum($expr2)] }
           └─BatchExchange { order: [], dist: HashShard(nation.n_name, nation.n_name, $expr1) }
@@ -1535,8 +1535,8 @@
               │ └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
               └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [region.r_regionkey, region.r_name], predicate: (region.r_name = 'ASIA':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [$expr1 ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [$expr1 ASC], dist: Single }
       └─BatchTopN { order: [$expr1 ASC], limit: 1, offset: 0 }
         └─BatchProject { exprs: [$expr1, (sum($expr3) / sum($expr2)) as $expr4] }
           └─BatchHashAgg { group_key: [$expr1], aggs: [sum($expr3), sum($expr2)] }
@@ -1864,8 +1864,8 @@
           │ └─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
           └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate] }
   batch_plan: |-
-    BatchTopN { order: [nation.n_name ASC, $expr1 DESC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [nation.n_name ASC, $expr1 DESC], dist: Single }
       └─BatchTopN { order: [nation.n_name ASC, $expr1 DESC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [nation.n_name, $expr1], aggs: [sum($expr2)] }
           └─BatchExchange { order: [], dist: HashShard(nation.n_name, $expr1) }
@@ -2113,8 +2113,8 @@
             │ └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
             └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_returnflag], predicate: (lineitem.l_returnflag = 'R':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [sum($expr1) DESC], limit: 20, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 20, offset: 0 }
+    └─BatchExchange { order: [sum($expr1) DESC], dist: Single }
       └─BatchTopN { order: [sum($expr1) DESC], limit: 20, offset: 0 }
         └─BatchProject { exprs: [customer.c_custkey, customer.c_name, sum($expr1), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
           └─BatchHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum($expr1)] }
@@ -2550,8 +2550,8 @@
           ├─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority] }
           └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_shipmode], required_columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Date) AND (lineitem.l_receiptdate < ('1994-01-01':Date + '1 year':Interval)) }
   batch_plan: |-
-    BatchTopN { order: [lineitem.l_shipmode ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [lineitem.l_shipmode ASC], dist: Single }
       └─BatchTopN { order: [lineitem.l_shipmode ASC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [lineitem.l_shipmode], aggs: [sum($expr1), sum($expr2)] }
           └─BatchExchange { order: [], dist: HashShard(lineitem.l_shipmode) }
@@ -2676,8 +2676,8 @@
           ├─LogicalScan { table: customer, columns: [customer.c_custkey] }
           └─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
   batch_plan: |-
-    BatchTopN { order: [count DESC, count(orders.o_orderkey) DESC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [count DESC, count(orders.o_orderkey) DESC], dist: Single }
       └─BatchTopN { order: [count DESC, count(orders.o_orderkey) DESC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
           └─BatchExchange { order: [], dist: HashShard(count(orders.o_orderkey)) }
@@ -3113,8 +3113,8 @@
           │ └─LogicalScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], predicate: (part.p_brand <> 'Brand#45':Varchar) AND (Not((part.p_type >= 'SMALL PLATED':Varchar)) OR Not((part.p_type < 'SMALL PLATEE':Varchar))) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
           └─LogicalScan { table: supplier, output_columns: [supplier.s_suppkey], required_columns: [supplier.s_suppkey, supplier.s_comment], predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [count(partsupp.ps_suppkey) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [count(partsupp.ps_suppkey) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC], dist: Single }
       └─BatchTopN { order: [count(partsupp.ps_suppkey) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(partsupp.ps_suppkey)] }
           └─BatchExchange { order: [], dist: HashShard(part.p_brand, part.p_type, part.p_size) }
@@ -3452,8 +3452,8 @@
             └─LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
               └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
   batch_plan: |-
-    BatchTopN { order: [orders.o_totalprice DESC, orders.o_orderdate ASC], limit: 100, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 100, offset: 0 }
+    └─BatchExchange { order: [orders.o_totalprice DESC, orders.o_orderdate ASC], dist: Single }
       └─BatchTopN { order: [orders.o_totalprice DESC, orders.o_orderdate ASC], limit: 100, offset: 0 }
         └─BatchHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
           └─BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
@@ -3769,8 +3769,8 @@
         │     └─LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity], required_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Date) AND (lineitem.l_shipdate < ('1994-01-01':Date + '1 year':Interval)) }
         └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [part.p_partkey, part.p_name], predicate: (part.p_name >= 'forest':Varchar) AND (part.p_name < 'foresu':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [supplier.s_name ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [supplier.s_name ASC], dist: Single }
       └─BatchTopN { order: [supplier.s_name ASC], limit: 1, offset: 0 }
         └─BatchHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address] }
           ├─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
@@ -4025,8 +4025,8 @@
         │ └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey] }
         └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
   batch_plan: |-
-    BatchTopN { order: [count DESC, supplier.s_name ASC], limit: 100, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 100, offset: 0 }
+    └─BatchExchange { order: [count DESC, supplier.s_name ASC], dist: Single }
       └─BatchTopN { order: [count DESC, supplier.s_name ASC], limit: 100, offset: 0 }
         └─BatchHashAgg { group_key: [supplier.s_name], aggs: [count] }
           └─BatchExchange { order: [], dist: HashShard(supplier.s_name) }
@@ -4299,8 +4299,8 @@
             └─LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
               └─LogicalScan { table: customer, output_columns: [customer.c_acctbal], required_columns: [customer.c_acctbal, customer.c_phone], predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
   batch_plan: |-
-    BatchTopN { order: [$expr2 ASC], limit: 1, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [$expr2 ASC], dist: Single }
       └─BatchTopN { order: [$expr2 ASC], limit: 1, offset: 0 }
         └─BatchHashAgg { group_key: [$expr2], aggs: [count, sum(customer.c_acctbal)] }
           └─BatchExchange { order: [], dist: HashShard($expr2) }

--- a/src/frontend/planner_test/tests/testdata/output/vector_search.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/vector_search.yaml
@@ -18,8 +18,8 @@
       └─LogicalScan { table: items, columns: [items.id, items.embedding] }
   batch_plan: |-
     BatchProject { exprs: [items.id, items.embedding] }
-    └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 1 }
-      └─BatchExchange { order: [], dist: Single }
+    └─BatchLimit { limit: 5, offset: 1 }
+      └─BatchExchange { order: [$expr1 ASC], dist: Single }
         └─BatchTopN { order: [$expr1 ASC], limit: 6, offset: 0 }
           └─BatchProject { exprs: [items.id, items.embedding, L2Distance(items.embedding, '[3,1,2]':Vector(3)) as $expr1] }
             └─BatchScan { table: items, columns: [items.id, items.embedding], distribution: UpstreamHashShard(items.id) }
@@ -37,8 +37,8 @@
     └─LogicalScan { table: items, columns: [items.id, items.embedding] }
   batch_plan: |-
     BatchProject { exprs: [items.id, items.embedding] }
-    └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
+    └─BatchLimit { limit: 5, offset: 0 }
+      └─BatchExchange { order: [$expr1 ASC], dist: Single }
         └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
           └─BatchProject { exprs: [items.id, items.embedding, L2Distance(items.embedding, '[3,1,2]':Vector(3)) as $expr1] }
             └─BatchScan { table: items, columns: [items.id, items.embedding], distribution: UpstreamHashShard(items.id) }
@@ -55,8 +55,8 @@
     LogicalVectorSearch { distance_type: L2Sqr, top_n: 5, left: $1, right: '[3,1,2]':Vector(3), output_columns: [items.id:Int32, items.embedding:Vector(3), items._rw_timestamp:Timestamptz] }
     └─LogicalScan { table: items, columns: [items.id, items.embedding, items._rw_timestamp] }
   batch_plan: |-
-    BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
-    └─BatchExchange { order: [], dist: Single }
+    BatchLimit { limit: 5, offset: 0 }
+    └─BatchExchange { order: [$expr1 ASC], dist: Single }
       └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
         └─BatchProject { exprs: [items.id, items.embedding, items._rw_timestamp, L2Distance(items.embedding, '[3,1,2]':Vector(3)) as $expr1] }
           └─BatchScan { table: items, columns: [items.id, items.embedding, items._rw_timestamp], distribution: UpstreamHashShard(items.id) }
@@ -76,8 +76,8 @@
       └─LogicalScan { table: items, columns: [items.embedding] }
   batch_plan: |-
     BatchProject { exprs: [$expr1, (L2Distance(items.embedding, '[3,1,2]':Vector(3)) + 1:Float64) as $expr2] }
-    └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
+    └─BatchLimit { limit: 5, offset: 0 }
+      └─BatchExchange { order: [$expr1 ASC], dist: Single }
         └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
           └─BatchProject { exprs: [items.embedding, L2Distance(items.embedding, '[3,1,2]':Vector(3)) as $expr1] }
             └─BatchScan { table: items, columns: [items.embedding], distribution: SomeShard }
@@ -104,8 +104,8 @@
     └─BatchProject { exprs: [count, items.id] }
       └─BatchHashAgg { group_key: [items.id], aggs: [count] }
         └─BatchExchange { order: [], dist: HashShard(items.id) }
-          └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
-            └─BatchExchange { order: [], dist: Single }
+          └─BatchLimit { limit: 5, offset: 0 }
+            └─BatchExchange { order: [$expr1 ASC], dist: Single }
               └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
                 └─BatchProject { exprs: [items.id, CosineDistance(items.embedding, '[3,1,2]':Vector(3)) as $expr1] }
                   └─BatchScan { table: items, columns: [items.id, items.embedding], distribution: UpstreamHashShard(items.id) }
@@ -124,8 +124,8 @@
       └─LogicalScan { table: items, columns: [items.id, items.embedding] }
   batch_plan: |-
     BatchProject { exprs: [items.embedding, $expr1, items.id] }
-    └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
+    └─BatchLimit { limit: 5, offset: 0 }
+      └─BatchExchange { order: [$expr1 ASC], dist: Single }
         └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
           └─BatchProject { exprs: [items.id, items.embedding, Neg(InnerProduct(items.embedding, '[3,1,2]':Vector(3))) as $expr1] }
             └─BatchScan { table: items, columns: [items.id, items.embedding], distribution: UpstreamHashShard(items.id) }
@@ -178,8 +178,8 @@
     └─LogicalScan { table: items, columns: [items.id, items.name, items.embedding], predicate: (items.id > 0:Int32) }
   batch_plan: |-
     BatchProject { exprs: [items.id, items.name] }
-    └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
-      └─BatchExchange { order: [], dist: Single }
+    └─BatchLimit { limit: 5, offset: 0 }
+      └─BatchExchange { order: [$expr1 ASC], dist: Single }
         └─BatchTopN { order: [$expr1 ASC], limit: 5, offset: 0 }
           └─BatchProject { exprs: [items.id, items.name, Neg(InnerProduct(items.embedding, '[1,2,3]':Vector(3))) as $expr1] }
             └─BatchScan { table: items, columns: [items.id, items.name, items.embedding], scan_ranges: [items.id > Int32(0)], distribution: UpstreamHashShard(items.id) }

--- a/src/frontend/src/optimizer/plan_node/batch_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_limit.rs
@@ -37,10 +37,10 @@ const LIMIT_SEQUENTIAL_EXCHANGE_THRESHOLD: u64 = 1024;
 
 impl BatchLimit {
     pub fn new(core: generic::Limit<PlanRef>) -> Self {
-        let base = PlanBase::new_batch_with_core(
+        let base = PlanBase::new_batch_with_core_and_orders(
             &core,
             core.input.distribution().clone(),
-            core.input.order().clone(),
+            core.input.orders(),
         );
         BatchLimit { base, core }
     }

--- a/src/frontend/src/optimizer/plan_node/batch_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_topn.rs
@@ -52,7 +52,7 @@ impl BatchTopN {
             self.core.limit_attr.with_ties(),
         );
         let new_offset = 0;
-        let partial_input: PlanRef = if input.order().satisfies(&self.core.order)
+        let partial_input: PlanRef = if input.orders().iter().any(|o| o.satisfies(&self.core.order))
             && !self.core.limit_attr.with_ties()
         {
             let logical_partial_limit = generic::Limit::new(input, new_limit.limit(), new_offset);
@@ -65,15 +65,26 @@ impl BatchTopN {
             batch_partial_topn.into()
         };
 
-        let ensure_single_dist =
-            RequiredDist::single().batch_enforce_if_not_satisfies(partial_input, &Order::any())?;
+        let exchange_order = if self.core.limit_attr.with_ties() {
+            Order::any()
+        } else {
+            self.core.order.clone()
+        };
+        let ensure_single_dist = RequiredDist::single()
+            .batch_enforce_if_not_satisfies(partial_input, &exchange_order)?;
 
-        let batch_global_topn = self.clone_with_input(ensure_single_dist);
-        Ok(batch_global_topn.into())
+        if self.core.limit_attr.with_ties() {
+            let batch_global_topn = self.clone_with_input(ensure_single_dist);
+            Ok(batch_global_topn.into())
+        } else {
+            self.one_phase_topn(ensure_single_dist)
+        }
     }
 
     fn one_phase_topn(&self, input: PlanRef) -> Result<PlanRef> {
-        if input.order().satisfies(&self.core.order) && !self.core.limit_attr.with_ties() {
+        if input.orders().iter().any(|o| o.satisfies(&self.core.order))
+            && !self.core.limit_attr.with_ties()
+        {
             let logical_limit =
                 generic::Limit::new(input, self.core.limit_attr.limit(), self.core.offset);
             let batch_limit = BatchLimit::new(logical_limit);

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -172,12 +172,6 @@ impl LogicalTopN {
         Ok(project.into())
     }
 
-    pub fn clone_with_input_and_prefix(&self, input: PlanRef, prefix: Order) -> Self {
-        let mut core = self.core.clone();
-        core.input = input;
-        core.order = prefix.concat(core.order);
-        core.into()
-    }
 }
 
 impl PlanTreeNodeUnary<Logical> for LogicalTopN {

--- a/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
+++ b/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
@@ -63,7 +63,6 @@ impl TopNOnIndexRule {
                     selected_index = Some(Self::finish_top_n(
                         logical_top_n,
                         index_scan.into(),
-                        prefix,
                         output_len,
                         scan_output_len,
                     ));
@@ -98,21 +97,9 @@ impl TopNOnIndexRule {
                 .collect::<Vec<_>>(),
         };
         let mut pk_orders_iter = primary_key_order.column_orders.iter().cloned().peekable();
-        let fixed_prefix = {
-            let mut fixed_prefix = vec![];
-            loop {
-                match pk_orders_iter.peek() {
-                    Some(order) if prefix.contains(order) => {
-                        let order = pk_orders_iter.next().unwrap();
-                        fixed_prefix.push(order);
-                    }
-                    _ => break,
-                }
-            }
-            Order {
-                column_orders: fixed_prefix,
-            }
-        };
+        while matches!(pk_orders_iter.peek(), Some(order) if prefix.contains(order)) {
+            pk_orders_iter.next();
+        }
         let remaining_orders = Order {
             column_orders: pk_orders_iter.collect(),
         };
@@ -122,7 +109,6 @@ impl TopNOnIndexRule {
         Some(Self::finish_top_n(
             logical_top_n,
             scan_for_pk.into(),
-            fixed_prefix,
             output_len,
             scan_output_len,
         ))
@@ -184,11 +170,14 @@ impl TopNOnIndexRule {
     fn finish_top_n(
         logical_top_n: &LogicalTopN,
         input: PlanRef,
-        prefix: Order,
         output_len: usize,
         scan_output_len: usize,
     ) -> PlanRef {
-        let top_n = logical_top_n.clone_with_input_and_prefix(input, prefix);
+        // Keep the original TopN order instead of prepending the equality-constrained prefix.
+        // BatchScan already exposes trimmed provided orders for equality prefixes, so adding the
+        // fixed prefix here only makes later order matching less precise and introduces a
+        // redundant BatchSort above the BatchTopN.
+        let top_n = logical_top_n.clone_with_input(input);
         if scan_output_len == output_len {
             top_n.into()
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fixes #22570. Supersedes #22581.

When `TopNOnIndexRule` rewrites `LogicalTopN + LogicalScan` into an index scan with equality predicates (e.g. `WHERE a = 1 ORDER BY b LIMIT 10`), the old `clone_with_input_and_prefix` helper prepended the eq-prefix columns to `core.order` (turning `[b ASC]` into `[a ASC, b ASC]`). `BatchTopN::new` then advertised that inflated order as its output order. The parent `BatchSort` insertion logic saw this as "not yet satisfying" the user-requested `[b ASC]` and inserted a redundant `BatchSort` above `BatchTopN`.

The root fix is to stop prepending the eq-prefix in `top_n_on_index_rule.rs` and instead rely on the fact that `BatchSeqScan` already exposes prefix-trimmed order candidates via `orders()`. Concretely:

- **`top_n_on_index_rule.rs`**: `finish_top_n` now calls `clone_with_input` (keeps the original user-requested TopN order) instead of `clone_with_input_and_prefix`. `try_on_pk` simplified to just skip the fixed prefix without collecting it.
- **`logical_topn.rs`**: deleted the now-dead `clone_with_input_and_prefix` helper that was the source of the bug.
- **`batch_topn.rs`**: `one_phase_topn` and `two_phase_topn` now use `input.orders().iter().any(|o| o.satisfies(...))` instead of `input.order().satisfies(...)`, so they recognise the prefix-trimmed order candidates that `BatchSeqScan` already exposes in `orders()`. `two_phase_topn` also passes the TopN order (not `Order::any()`) to the exchange so the global phase can further collapse to `BatchLimit`.
- **`batch_limit.rs`**: `BatchLimit::new` propagates `input.orders()` (all candidates) via `new_batch_with_core_and_orders` so order information flows through limit nodes.

Before this fix, `SELECT * FROM t WHERE a = 1 ORDER BY b LIMIT 10` on an index `(a, b)` produced:
```
BatchSort { order: [b ASC] }          ← spurious
└─BatchTopN { order: [a ASC, b ASC] }
  └─BatchExchange
    └─BatchScan { scan_ranges: [a=1] }
```

After:
```
BatchLimit { limit: 10, offset: 0 }
└─BatchExchange { order: [b ASC] }
  └─BatchLimit { limit: 10, offset: 0 }
    └─BatchScan { scan_ranges: [a=1], limit: 10 }
```

- Closes #22570

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Queries of the form `SELECT ... FROM t WHERE pk_prefix = const ORDER BY remaining_key LIMIT n` on a table with a matching index no longer generate a redundant `BatchSort` above `BatchTopN`. The optimizer now correctly collapses the plan to `BatchLimit → BatchExchange → BatchLimit → BatchScan`, improving query performance.

</details>