### PR TITLE
feat(sink): add HTTP sink

### DIFF
--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -48,11 +48,12 @@ risedev slt './e2e_test/sink/http_sink.slt'
 # Allow a moment for in-flight requests to complete
 sleep 1
 # Verify bodies reached the mock server
+grep -Fx 'before update' "$HTTP_SINK_OUTPUT"
 grep -Fx 'hello world' "$HTTP_SINK_OUTPUT"
 grep -Fx '{"key":"value"}' "$HTTP_SINK_OUTPUT"
 grep -q '"event"' "$HTTP_SINK_OUTPUT"
-# Exactly 2 lines from varchar test (NULL was skipped) + 1 from jsonb
-test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 3
+# Exactly 1 line from ignore_delete test + 2 from varchar test (NULL was skipped) + 1 from jsonb
+test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 4
 # Verify the custom header set via header.x_test = 'rw-http-sink' was sent
 grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
 # Verify inferred default content types for varchar and jsonb payloads

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -35,6 +35,30 @@ risedev slt './e2e_test/sink/sink_into_table/*.slt'
 risedev slt './e2e_test/sink/sink_vector_columns.slt'
 risedev slt './e2e_test/sink/force_compaction_sink.slt'
 
+echo "--- e2e, http sink"
+HTTP_SINK_OUTPUT=$(mktemp)
+HTTP_SINK_HEADERS=$(mktemp)
+python3 e2e_test/sink/http_sink_mock_server.py "$HTTP_SINK_OUTPUT" 18081 "$HTTP_SINK_HEADERS" &
+HTTP_SINK_SERVER_PID=$!
+# Wait for the server to be ready
+for i in $(seq 1 20); do curl -sf http://localhost:18081/ && break; sleep 0.5; done
+
+risedev slt './e2e_test/sink/http_sink.slt'
+
+# Allow a moment for in-flight requests to complete
+sleep 1
+# Verify bodies reached the mock server
+grep -Fx 'hello world' "$HTTP_SINK_OUTPUT"
+grep -Fx '{"key":"value"}' "$HTTP_SINK_OUTPUT"
+grep -q '"event"' "$HTTP_SINK_OUTPUT"
+# Exactly 2 lines from varchar test (NULL was skipped) + 1 from jsonb
+test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 3
+# Verify the custom header set via header.x_test = 'rw-http-sink' was sent
+grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
+
+kill "$HTTP_SINK_SERVER_PID" || true
+rm -f "$HTTP_SINK_OUTPUT" "$HTTP_SINK_HEADERS"
+
 echo "--- Kill cluster"
 risedev ci-kill
 

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -55,6 +55,9 @@ grep -q '"event"' "$HTTP_SINK_OUTPUT"
 test "$(wc -l < "$HTTP_SINK_OUTPUT")" -eq 3
 # Verify the custom header set via header.x_test = 'rw-http-sink' was sent
 grep -q '"x_test": "rw-http-sink"' "$HTTP_SINK_HEADERS"
+# Verify inferred default content types for varchar and jsonb payloads
+grep -q '"content-type": "text/plain"' "$HTTP_SINK_HEADERS"
+grep -q '"content-type": "application/json"' "$HTTP_SINK_HEADERS"
 
 kill "$HTTP_SINK_SERVER_PID" || true
 rm -f "$HTTP_SINK_OUTPUT" "$HTTP_SINK_HEADERS"

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -48,6 +48,22 @@ CREATE SINK s_bad_url FROM t_url WITH (
 statement ok
 DROP TABLE t_url;
 
+# ---- Validation: auto schema change should be rejected ----
+statement ok
+CREATE TABLE t_auto_schema_change (payload varchar primary key);
+
+statement error http sink does not support schema change
+CREATE SINK s_auto_schema_change FROM t_auto_schema_change WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    primary_key = 'payload',
+    auto.schema.change = 'true'
+);
+
+statement ok
+DROP TABLE t_auto_schema_change;
+
 # ---- Success: varchar payload ----
 statement ok
 CREATE TABLE t_varchar (payload varchar);

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -1,0 +1,108 @@
+statement ok
+set sink_decouple = false;
+
+# ---- Validation: multiple columns should be rejected ----
+# force_append_only bypasses the planner-level retract-stream check so our
+# connector validate() is actually reached.
+statement ok
+CREATE TABLE t_multi_col (a varchar, b varchar);
+
+statement error HTTP sink requires exactly 1 column
+CREATE SINK s_multi_col FROM t_multi_col WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_multi_col;
+
+# ---- Validation: wrong column type should be rejected ----
+statement ok
+CREATE TABLE t_int_col (payload int);
+
+statement error HTTP sink column must be varchar or jsonb
+CREATE SINK s_int_col FROM t_int_col WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_int_col;
+
+# ---- Validation: invalid URL should be rejected ----
+statement ok
+CREATE TABLE t_url (payload varchar);
+
+statement error invalid URL
+CREATE SINK s_bad_url FROM t_url WITH (
+    connector = 'http',
+    url = 'not a valid url !!',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+DROP TABLE t_url;
+
+# ---- Success: varchar payload ----
+statement ok
+CREATE TABLE t_varchar (payload varchar);
+
+statement ok
+CREATE SINK s_varchar FROM t_varchar WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true',
+    header.x_test = 'rw-http-sink'
+);
+
+statement ok
+INSERT INTO t_varchar VALUES ('hello world');
+
+statement ok
+INSERT INTO t_varchar VALUES ('{"key":"value"}');
+
+statement ok
+FLUSH;
+
+# NULL values should be silently skipped (no POST sent)
+statement ok
+INSERT INTO t_varchar VALUES (NULL);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_varchar;
+
+statement ok
+DROP TABLE t_varchar;
+
+# ---- Success: jsonb payload ----
+statement ok
+CREATE TABLE t_jsonb (payload jsonb);
+
+statement ok
+CREATE SINK s_jsonb FROM t_jsonb WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+statement ok
+INSERT INTO t_jsonb VALUES ('{"event":"test","v":42}'::jsonb);
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_jsonb;
+
+statement ok
+DROP TABLE t_jsonb;

--- a/e2e_test/sink/http_sink.slt
+++ b/e2e_test/sink/http_sink.slt
@@ -57,12 +57,43 @@ CREATE SINK s_auto_schema_change FROM t_auto_schema_change WITH (
     connector = 'http',
     url = 'http://localhost:18081',
     type = 'append-only',
+    ignore_delete = 'true',
     primary_key = 'payload',
     auto.schema.change = 'true'
 );
 
 statement ok
 DROP TABLE t_auto_schema_change;
+
+# ---- Success: ignore_delete allows non-append-only input ----
+statement ok
+CREATE TABLE t_ignore_delete_src (payload varchar);
+
+statement ok
+CREATE SINK s_ignore_delete FROM t_ignore_delete_src WITH (
+    connector = 'http',
+    url = 'http://localhost:18081',
+    type = 'append-only',
+    ignore_delete = 'true'
+);
+
+statement ok
+INSERT INTO t_ignore_delete_src VALUES ('before update');
+
+statement ok
+UPDATE t_ignore_delete_src SET payload = 'after update' WHERE payload = 'before update';
+
+statement ok
+DELETE FROM t_ignore_delete_src WHERE payload = 'after update';
+
+statement ok
+FLUSH;
+
+statement ok
+DROP SINK s_ignore_delete;
+
+statement ok
+DROP TABLE t_ignore_delete_src;
 
 # ---- Success: varchar payload ----
 statement ok

--- a/e2e_test/sink/http_sink_mock_server.py
+++ b/e2e_test/sink/http_sink_mock_server.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# Copyright 2026 RisingWave Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Mock HTTP server for testing the RisingWave HTTP sink.
 

--- a/e2e_test/sink/http_sink_mock_server.py
+++ b/e2e_test/sink/http_sink_mock_server.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Mock HTTP server for testing the RisingWave HTTP sink.
+
+Usage:
+    python3 http_sink_mock_server.py <body_output_file> <port> [<header_output_file>]
+
+Each POST request body is appended as a line to the body output file.
+If a header output file is given, received headers are appended as a JSON line per request.
+Responds 200 OK to every POST, 400 to anything else.
+"""
+
+import json
+import signal
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def main():
+    body_output_file = sys.argv[1] if len(sys.argv) > 1 else "/tmp/http_sink_test_body.txt"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 18081
+    header_output_file = sys.argv[3] if len(sys.argv) > 3 else None
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length).decode("utf-8")
+            with open(body_output_file, "a") as f:
+                f.write(body + "\n")
+            if header_output_file is not None:
+                headers = {k.lower(): v for k, v in self.headers.items()}
+                with open(header_output_file, "a") as f:
+                    f.write(json.dumps(headers) + "\n")
+            self.send_response(200)
+            self.end_headers()
+
+        def do_GET(self):
+            # Health check endpoint
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass  # suppress request logs
+
+    server = HTTPServer(("", port), Handler)
+
+    def handle_sigterm(signum, frame):
+        server.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
@@ -108,7 +108,8 @@ fn validate_http_sink(
 
     let parsed_url = url
         .parse()
-        .map_err(|e| SinkError::Config(anyhow!("invalid URL: {}", e)))?;
+        .context("invalid URL")
+        .map_err(SinkError::Config)?;
 
     Ok((col_type, parsed_url))
 }
@@ -176,22 +177,26 @@ impl HttpSinkWriter {
             config
                 .content_type
                 .parse()
-                .map_err(|e| SinkError::Http(anyhow!("invalid content_type: {}", e)))?,
+                .context("invalid content_type")
+                .map_err(SinkError::Http)?,
         );
         for (k, v) in &headers {
             let name: reqwest::header::HeaderName = k
                 .parse()
-                .map_err(|e| SinkError::Http(anyhow!("invalid header name '{}': {}", k, e)))?;
+                .with_context(|| format!("invalid header name '{k}'"))
+                .map_err(SinkError::Http)?;
             let value: reqwest::header::HeaderValue = v
                 .parse()
-                .map_err(|e| SinkError::Http(anyhow!("invalid header value for '{}': {}", k, e)))?;
+                .with_context(|| format!("invalid header value for '{k}'"))
+                .map_err(SinkError::Http)?;
             header_map.insert(name, value);
         }
 
         let client = reqwest::Client::builder()
             .default_headers(header_map)
             .build()
-            .map_err(|e| SinkError::Http(anyhow!("failed to build HTTP client: {}", e)))?;
+            .context("failed to build HTTP client")
+            .map_err(SinkError::Http)?;
 
         Ok(Self {
             client,
@@ -228,7 +233,8 @@ impl AsyncTruncateSinkWriter for HttpSinkWriter {
                 .body(payload)
                 .send()
                 .await
-                .map_err(|e| SinkError::Http(anyhow!("HTTP request failed: {}", e)))?;
+                .context("HTTP request failed")
+                .map_err(SinkError::Http)?;
 
             if !resp.status().is_success() {
                 let status = resp.status();

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -1,0 +1,246 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use anyhow::anyhow;
+use risingwave_common::array::{Op, StreamChunk};
+use risingwave_common::catalog::Schema;
+use risingwave_common::row::Row;
+use risingwave_common::types::{DataType, ScalarRefImpl};
+use serde::Deserialize;
+use with_options::WithOptions;
+
+use crate::enforce_secret::EnforceSecret;
+use crate::sink::log_store::DeliveryFutureManagerAddFuture;
+use crate::sink::writer::{
+    AsyncTruncateLogSinkerOf, AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt,
+};
+use crate::sink::{Result, SINK_TYPE_APPEND_ONLY, Sink, SinkError, SinkParam, SinkWriterParam};
+
+pub const HTTP_SINK: &str = "http";
+
+fn default_content_type() -> String {
+    "application/json".to_owned()
+}
+
+#[derive(Clone, Debug, Deserialize, WithOptions)]
+pub struct HttpConfig {
+    /// The endpoint URL to POST data to.
+    pub url: String,
+
+    /// Content-Type header value. Defaults to "application/json".
+    #[serde(default = "default_content_type")]
+    pub content_type: String,
+
+    /// Sink type, must be "append-only".
+    pub r#type: String,
+}
+
+impl EnforceSecret for HttpConfig {}
+
+impl HttpConfig {
+    pub fn from_btreemap(
+        values: BTreeMap<String, String>,
+    ) -> Result<(Self, BTreeMap<String, String>)> {
+        // Extract header.* keys before serde parsing
+        let mut headers = BTreeMap::new();
+        let mut rest = BTreeMap::new();
+        for (k, v) in &values {
+            if let Some(header_name) = k.strip_prefix("header.") {
+                headers.insert(header_name.to_owned(), v.clone());
+            } else {
+                rest.insert(k.clone(), v.clone());
+            }
+        }
+
+        let config = serde_json::from_value::<HttpConfig>(serde_json::to_value(rest).unwrap())
+            .map_err(|e| SinkError::Config(anyhow!(e)))?;
+
+        if config.r#type != SINK_TYPE_APPEND_ONLY {
+            return Err(SinkError::Config(anyhow!(
+                "HTTP sink only supports append-only mode"
+            )));
+        }
+
+        Ok((config, headers))
+    }
+}
+
+/// Validates the HTTP sink parameters and returns the extracted column type and parsed URL
+/// so callers can use them directly without re-parsing.
+fn validate_http_sink(
+    is_append_only: bool,
+    schema: &Schema,
+    url: &str,
+) -> Result<(DataType, reqwest::Url)> {
+    if !is_append_only {
+        return Err(SinkError::Config(anyhow!(
+            "HTTP sink only supports append-only mode"
+        )));
+    }
+
+    if schema.fields().len() != 1 {
+        return Err(SinkError::Config(anyhow!(
+            "HTTP sink requires exactly 1 column, got {}",
+            schema.fields().len()
+        )));
+    }
+
+    let col_type = schema.fields()[0].data_type.clone();
+    if col_type != DataType::Varchar && col_type != DataType::Jsonb {
+        return Err(SinkError::Config(anyhow!(
+            "HTTP sink column must be varchar or jsonb, got {:?}",
+            col_type
+        )));
+    }
+
+    let parsed_url = url
+        .parse()
+        .map_err(|e| SinkError::Config(anyhow!("invalid URL: {}", e)))?;
+
+    Ok((col_type, parsed_url))
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpSink {
+    pub config: HttpConfig,
+    headers: BTreeMap<String, String>,
+}
+
+impl EnforceSecret for HttpSink {
+    fn enforce_secret<'a>(
+        prop_iter: impl Iterator<Item = &'a str>,
+    ) -> crate::error::ConnectorResult<()> {
+        for prop in prop_iter {
+            HttpConfig::enforce_one(prop)?;
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<SinkParam> for HttpSink {
+    type Error = SinkError;
+
+    fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
+        let schema = param.schema();
+        let url = param
+            .properties
+            .get("url")
+            .ok_or_else(|| SinkError::Config(anyhow!("missing 'url' in WITH")))?;
+        validate_http_sink(param.sink_type.is_append_only(), &schema, url)?;
+
+        let (config, headers) = HttpConfig::from_btreemap(param.properties)?;
+        Ok(Self { config, headers })
+    }
+}
+
+impl Sink for HttpSink {
+    type LogSinker = AsyncTruncateLogSinkerOf<HttpSinkWriter>;
+
+    const SINK_NAME: &'static str = HTTP_SINK;
+
+    async fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
+        Ok(
+            HttpSinkWriter::new(self.config.clone(), self.headers.clone())?
+                .into_log_sinker(usize::MAX),
+        )
+    }
+}
+
+pub struct HttpSinkWriter {
+    client: reqwest::Client,
+    endpoint: String,
+}
+
+impl HttpSinkWriter {
+    pub fn new(config: HttpConfig, headers: BTreeMap<String, String>) -> Result<Self> {
+        let mut header_map = reqwest::header::HeaderMap::new();
+        header_map.insert(
+            reqwest::header::CONTENT_TYPE,
+            config
+                .content_type
+                .parse()
+                .map_err(|e| SinkError::Http(anyhow!("invalid content_type: {}", e)))?,
+        );
+        for (k, v) in &headers {
+            let name: reqwest::header::HeaderName = k
+                .parse()
+                .map_err(|e| SinkError::Http(anyhow!("invalid header name '{}': {}", k, e)))?;
+            let value: reqwest::header::HeaderValue = v
+                .parse()
+                .map_err(|e| SinkError::Http(anyhow!("invalid header value for '{}': {}", k, e)))?;
+            header_map.insert(name, value);
+        }
+
+        let client = reqwest::Client::builder()
+            .default_headers(header_map)
+            .build()
+            .map_err(|e| SinkError::Http(anyhow!("failed to build HTTP client: {}", e)))?;
+
+        Ok(Self {
+            client,
+            endpoint: config.url,
+        })
+    }
+}
+
+impl AsyncTruncateSinkWriter for HttpSinkWriter {
+    async fn write_chunk<'a>(
+        &'a mut self,
+        chunk: StreamChunk,
+        _add_future: DeliveryFutureManagerAddFuture<'a, Self::DeliveryFuture>,
+    ) -> Result<()> {
+        for (op, row) in chunk.rows() {
+            if op != Op::Insert {
+                continue;
+            }
+
+            let payload = match row.datum_at(0) {
+                Some(ScalarRefImpl::Utf8(s)) => s.to_owned(),
+                Some(ScalarRefImpl::Jsonb(j)) => j.to_string(),
+                Some(_) => {
+                    return Err(SinkError::Http(anyhow!(
+                        "unexpected column type, expected varchar or jsonb"
+                    )));
+                }
+                None => continue, // skip NULL rows
+            };
+
+            let resp = self
+                .client
+                .post(&self.endpoint)
+                .body(payload)
+                .send()
+                .await
+                .map_err(|e| SinkError::Http(anyhow!("HTTP request failed: {}", e)))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(SinkError::Http(anyhow!(
+                    "HTTP sink received non-success response: {} {}",
+                    status,
+                    body
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, anyhow};
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::Row;
@@ -74,14 +75,17 @@ impl HttpConfig {
     }
 }
 
-/// Validates the HTTP sink parameters and returns the extracted column type and parsed URL
-/// so callers can use them directly without re-parsing.
+/// Validates the HTTP sink parameters and returns the parsed URL and default headers so callers
+/// can use them directly without re-parsing.
 fn validate_http_sink(
     is_append_only: bool,
+    ignore_delete: bool,
     schema: &Schema,
     url: &str,
-) -> Result<(DataType, reqwest::Url)> {
-    if !is_append_only {
+    content_type: Option<&str>,
+    headers: &BTreeMap<String, String>,
+) -> Result<(reqwest::Url, HeaderMap)> {
+    if !is_append_only && !ignore_delete {
         return Err(SinkError::Config(anyhow!(
             "HTTP sink only supports append-only mode"
         )));
@@ -107,22 +111,38 @@ fn validate_http_sink(
         .context("invalid URL")
         .map_err(SinkError::Config)?;
 
-    Ok((col_type, parsed_url))
-}
-
-fn default_content_type(col_type: &DataType) -> &'static str {
-    match col_type {
-        DataType::Varchar => "text/plain",
-        DataType::Jsonb => "application/json",
-        _ => unreachable!("validated HTTP sink column type"),
+    let mut header_map = HeaderMap::new();
+    header_map.insert(
+        CONTENT_TYPE,
+        content_type
+            .unwrap_or(match col_type {
+                DataType::Varchar => "text/plain",
+                DataType::Jsonb => "application/json",
+                _ => unreachable!("validated HTTP sink column type"),
+            })
+            .parse()
+            .context("invalid content_type")
+            .map_err(SinkError::Config)?,
+    );
+    for (k, v) in headers {
+        let name: HeaderName = k
+            .parse()
+            .with_context(|| format!("invalid header name '{k}'"))
+            .map_err(SinkError::Config)?;
+        let value: HeaderValue = v
+            .parse()
+            .with_context(|| format!("invalid header value for '{k}'"))
+            .map_err(SinkError::Config)?;
+        header_map.insert(name, value);
     }
+
+    Ok((parsed_url, header_map))
 }
 
 #[derive(Clone, Debug)]
 pub struct HttpSink {
-    pub config: HttpConfig,
-    col_type: DataType,
-    headers: BTreeMap<String, String>,
+    endpoint: String,
+    header_map: HeaderMap,
 }
 
 impl EnforceSecret for HttpSink {
@@ -141,17 +161,18 @@ impl TryFrom<SinkParam> for HttpSink {
 
     fn try_from(param: SinkParam) -> std::result::Result<Self, Self::Error> {
         let schema = param.schema();
-        let url = param
-            .properties
-            .get("url")
-            .ok_or_else(|| SinkError::Config(anyhow!("missing 'url' in WITH")))?;
-        let (col_type, _) = validate_http_sink(param.sink_type.is_append_only(), &schema, url)?;
-
         let (config, headers) = HttpConfig::from_btreemap(param.properties)?;
+        let (_parsed_url, header_map) = validate_http_sink(
+            param.sink_type.is_append_only(),
+            param.ignore_delete,
+            &schema,
+            &config.url,
+            config.content_type.as_deref(),
+            &headers,
+        )?;
         Ok(Self {
-            config,
-            col_type,
-            headers,
+            endpoint: config.url,
+            header_map,
         })
     }
 }
@@ -166,13 +187,8 @@ impl Sink for HttpSink {
     }
 
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
-        let content_type = self
-            .config
-            .content_type
-            .as_deref()
-            .unwrap_or_else(|| default_content_type(&self.col_type));
         Ok(
-            HttpSinkWriter::new(self.config.clone(), self.headers.clone(), content_type)?
+            HttpSinkWriter::new(self.endpoint.clone(), self.header_map.clone())?
                 .into_log_sinker(usize::MAX),
         )
     }
@@ -184,41 +200,14 @@ pub struct HttpSinkWriter {
 }
 
 impl HttpSinkWriter {
-    pub fn new(
-        config: HttpConfig,
-        headers: BTreeMap<String, String>,
-        content_type: &str,
-    ) -> Result<Self> {
-        let mut header_map = reqwest::header::HeaderMap::new();
-        header_map.insert(
-            reqwest::header::CONTENT_TYPE,
-            content_type
-                .parse()
-                .context("invalid content_type")
-                .map_err(SinkError::Http)?,
-        );
-        for (k, v) in &headers {
-            let name: reqwest::header::HeaderName = k
-                .parse()
-                .with_context(|| format!("invalid header name '{k}'"))
-                .map_err(SinkError::Http)?;
-            let value: reqwest::header::HeaderValue = v
-                .parse()
-                .with_context(|| format!("invalid header value for '{k}'"))
-                .map_err(SinkError::Http)?;
-            header_map.insert(name, value);
-        }
-
+    pub fn new(endpoint: String, header_map: HeaderMap) -> Result<Self> {
         let client = reqwest::Client::builder()
             .default_headers(header_map)
             .build()
             .context("failed to build HTTP client")
             .map_err(SinkError::Http)?;
 
-        Ok(Self {
-            client,
-            endpoint: config.url,
-        })
+        Ok(Self { client, endpoint })
     }
 }
 

--- a/src/connector/src/sink/http.rs
+++ b/src/connector/src/sink/http.rs
@@ -31,18 +31,14 @@ use crate::sink::{Result, SINK_TYPE_APPEND_ONLY, Sink, SinkError, SinkParam, Sin
 
 pub const HTTP_SINK: &str = "http";
 
-fn default_content_type() -> String {
-    "application/json".to_owned()
-}
-
 #[derive(Clone, Debug, Deserialize, WithOptions)]
 pub struct HttpConfig {
     /// The endpoint URL to POST data to.
     pub url: String,
 
-    /// Content-Type header value. Defaults to "application/json".
-    #[serde(default = "default_content_type")]
-    pub content_type: String,
+    /// Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
+    /// for `jsonb`.
+    pub content_type: Option<String>,
 
     /// Sink type, must be "append-only".
     pub r#type: String,
@@ -114,9 +110,18 @@ fn validate_http_sink(
     Ok((col_type, parsed_url))
 }
 
+fn default_content_type(col_type: &DataType) -> &'static str {
+    match col_type {
+        DataType::Varchar => "text/plain",
+        DataType::Jsonb => "application/json",
+        _ => unreachable!("validated HTTP sink column type"),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct HttpSink {
     pub config: HttpConfig,
+    col_type: DataType,
     headers: BTreeMap<String, String>,
 }
 
@@ -140,10 +145,14 @@ impl TryFrom<SinkParam> for HttpSink {
             .properties
             .get("url")
             .ok_or_else(|| SinkError::Config(anyhow!("missing 'url' in WITH")))?;
-        validate_http_sink(param.sink_type.is_append_only(), &schema, url)?;
+        let (col_type, _) = validate_http_sink(param.sink_type.is_append_only(), &schema, url)?;
 
         let (config, headers) = HttpConfig::from_btreemap(param.properties)?;
-        Ok(Self { config, headers })
+        Ok(Self {
+            config,
+            col_type,
+            headers,
+        })
     }
 }
 
@@ -157,8 +166,13 @@ impl Sink for HttpSink {
     }
 
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
+        let content_type = self
+            .config
+            .content_type
+            .as_deref()
+            .unwrap_or_else(|| default_content_type(&self.col_type));
         Ok(
-            HttpSinkWriter::new(self.config.clone(), self.headers.clone())?
+            HttpSinkWriter::new(self.config.clone(), self.headers.clone(), content_type)?
                 .into_log_sinker(usize::MAX),
         )
     }
@@ -170,12 +184,15 @@ pub struct HttpSinkWriter {
 }
 
 impl HttpSinkWriter {
-    pub fn new(config: HttpConfig, headers: BTreeMap<String, String>) -> Result<Self> {
+    pub fn new(
+        config: HttpConfig,
+        headers: BTreeMap<String, String>,
+        content_type: &str,
+    ) -> Result<Self> {
         let mut header_map = reqwest::header::HeaderMap::new();
         header_map.insert(
             reqwest::header::CONTENT_TYPE,
-            config
-                .content_type
+            content_type
                 .parse()
                 .context("invalid content_type")
                 .map_err(SinkError::Http)?,

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -28,6 +28,7 @@ pub mod encoder;
 pub mod file_sink;
 pub mod formatter;
 feature_gated_sink_mod!(google_pubsub, GooglePubSub, "google_pubsub");
+pub mod http;
 pub mod iceberg;
 pub mod kafka;
 pub mod kinesis;
@@ -125,6 +126,7 @@ macro_rules! for_all_sinks {
                 { Kafka, $crate::sink::kafka::KafkaSink, $crate::sink::kafka::KafkaConfig },
                 { Pulsar, $crate::sink::pulsar::PulsarSink, $crate::sink::pulsar::PulsarConfig },
                 { BlackHole, $crate::sink::trivial::BlackHoleSink, () },
+                { Http, $crate::sink::http::HttpSink, $crate::sink::http::HttpConfig },
                 { Kinesis, $crate::sink::kinesis::KinesisSink, $crate::sink::kinesis::KinesisSinkConfig },
                 { ClickHouse, $crate::sink::clickhouse::ClickHouseSink, $crate::sink::clickhouse::ClickHouseConfig },
                 { Iceberg, $crate::sink::iceberg::IcebergSink, $crate::sink::iceberg::IcebergConfig },
@@ -993,6 +995,12 @@ pub enum SinkError {
     ClickHouse(String),
     #[error("Redis error: {0}")]
     Redis(String),
+    #[error("Http error: {0}")]
+    Http(
+        #[source]
+        #[backtrace]
+        anyhow::Error,
+    ),
     #[error("Mqtt error: {0}")]
     Mqtt(
         #[source]

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -442,9 +442,10 @@ HttpConfig:
     required: true
   - name: content_type
     field_type: String
-    comments: Content-Type header value. Defaults to "application/json".
+    comments: |-
+      Content-Type header value. Defaults to `text/plain` for `varchar` and `application/json`
+      for `jsonb`.
     required: false
-    default: '"application/json" . to_owned ()'
   - name: r#type
     field_type: String
     comments: Sink type, must be "append-only".

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -434,6 +434,21 @@ GooglePubSubConfig:
       The provided account credential must have the
       `pubsub.publisher` [role](https://cloud.google.com/pubsub/docs/access-control#roles)
     required: false
+HttpConfig:
+  fields:
+  - name: url
+    field_type: String
+    comments: The endpoint URL to POST data to.
+    required: true
+  - name: content_type
+    field_type: String
+    comments: Content-Type header value. Defaults to "application/json".
+    required: false
+    default: '"application/json" . to_owned ()'
+  - name: r#type
+    field_type: String
+    comments: Sink type, must be "append-only".
+    required: true
 IcebergConfig:
   fields:
   - name: r#type


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds a new HTTP sink connector that sends append-only rows to an HTTP endpoint with `POST` requests.

### Main changes
- Adds a new `http` sink implementation in `src/connector/src/sink/http.rs`.
- Registers the new sink in `src/connector/src/sink/mod.rs`.
- Adds e2e coverage for the HTTP sink in `e2e_test/sink/http_sink.slt`.
- Adds a lightweight mock HTTP server for e2e verification in `e2e_test/sink/http_sink_mock_server.py`.
- Extends `ci/scripts/e2e-sink-test.sh` to run the HTTP sink e2e test.

### Behavior
- Supports append-only HTTP sink writes.
- Supports single-column payloads with:
  - `varchar` -> request body sent as plain text, default `Content-Type: text/plain`
  - `jsonb` -> request body sent as JSON string, default `Content-Type: application/json`
- Supports custom request headers through `header.*` sink properties.
- Validates unsupported configurations early, including:
  - non-append-only usage
  - multi-column input
  - unsupported column types
  - invalid URL
  - `auto.schema.change = 'true'`

### Why
This provides a simple sink option for pushing RisingWave output to generic HTTP services and webhooks, while keeping the initial scope small and well-validated.

### Tests
- Added e2e test cases for:
  - invalid schema and URL validation
  - auto schema change rejection
  - successful `varchar` and `jsonb` delivery
  - inferred default `Content-Type` behavior
  - custom header propagation

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
