### PR TITLE
perf(optimizer): skip order enforcement for singleton batch plans

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/functional_dependency.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/functional_dependency.yaml
@@ -26,6 +26,8 @@
     - logical_plan
     - stream_plan
     - batch_plan
+    - batch_local_plan
+    - batch_distributed_plan
 # Order key should not be pruned for index,
 # since it uses it as distribution key as well.
 - name: test functional dependency for order key pruning (index)

--- a/src/frontend/planner_test/tests/testdata/output/functional_dependency.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/functional_dependency.yaml
@@ -50,9 +50,14 @@
     LogicalProject { exprs: [v.cnt] }
     └─LogicalScan { table: v, columns: [v.cnt, v._rw_timestamp], cardinality: 0..=1 }
   batch_plan: |-
-    BatchExchange { order: [v.cnt ASC], dist: Single }
-    └─BatchSort { order: [v.cnt ASC] }
-      └─BatchScan { table: v, columns: [v.cnt], distribution: Single }
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: v, columns: [v.cnt], distribution: Single }
+  batch_local_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: v, columns: [v.cnt], distribution: SomeShard }
+  batch_distributed_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: v, columns: [v.cnt], distribution: Single }
   stream_plan: |-
     StreamMaterialize { columns: [cnt], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamTableScan { table: v, columns: [v.cnt], stream_scan_type: SnapshotBackfill, stream_key: [], pk: [], dist: Single }

--- a/src/frontend/planner_test/tests/testdata/output/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/order_by.yaml
@@ -281,12 +281,11 @@
         t_0.v1 asc;
   batch_plan: |-
     BatchProject { exprs: [1:Int32] }
-    └─BatchExchange { order: [t1.v1 ASC], dist: Single }
+    └─BatchExchange { order: [], dist: Single }
       └─BatchProject { exprs: [1:Int32, t1.v1] }
-        └─BatchSort { order: [t1.v1 ASC] }
-          └─BatchHashAgg { group_key: [t1.v1], aggs: [] }
-            └─BatchExchange { order: [], dist: HashShard(t1.v1) }
-              └─BatchValues { rows: [] }
+        └─BatchHashAgg { group_key: [t1.v1], aggs: [] }
+          └─BatchExchange { order: [], dist: HashShard(t1.v1) }
+            └─BatchValues { rows: [] }
 - name: distinct on order by
   sql: |
     create table t (x int, y int);

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -322,7 +322,7 @@ impl LogicalPlanRoot {
 
 impl BatchOptimizedLogicalPlanRoot {
     /// Optimize and generate a singleton batch physical plan without exchange nodes.
-    pub fn gen_batch_plan(self) -> Result<BatchPlanRoot> {
+    pub fn gen_batch_plan(mut self) -> Result<BatchPlanRoot> {
         if TemporalJoinValidator::exist_dangling_temporal_scan(self.plan.clone()) {
             return Err(ErrorCode::NotSupported(
                 "do not support temporal join for batch queries".to_owned(),
@@ -341,6 +341,11 @@ impl BatchOptimizedLogicalPlanRoot {
         if ctx.is_explain_trace() {
             ctx.trace("Const eval exprs:");
             ctx.trace(plan.explain_to_string());
+        }
+
+        // A singleton result does not need a physical order guarantee.
+        if CardinalityVisitor.visit(plan.clone()).is_at_most(1) {
+            self.required_order = Order::any();
         }
 
         // Convert to physical plan node


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR skips batch required-order enforcement when the optimized batch plan is guaranteed to return at most one row.

Before this change, `BatchOptimizedLogicalPlanRoot::gen_batch_plan` always kept `required_order` intact, so later order enforcement could still insert a redundant `BatchSort` even when `CardinalityVisitor` had already proven the batch plan is a singleton. This shows up in cases such as point lookups with `ORDER BY`, or predicates that are statically false but still carry `ORDER BY`.

This PR clears `required_order` to `Order::any()` after constant evaluation if the batch plan cardinality is at most one. That lets the existing order-enforcement path short-circuit naturally without changing non-singleton behavior.

Planner regressions are added to cover:
- singleton `ORDER BY` planning in `functional_dependency`
- always-false predicate + `ORDER BY` in `order_by`

Validated with:
- `./risedev run-planner-test functional_dependency`
- `./risedev run-planner-test order_by`

- No issue

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Avoid redundant `BatchSort` operators for batch queries that are guaranteed to produce at most one row.

</details>
