### PR TITLE
fix(connector): drain kafka enumerator events during meta split discovery (#25405)

### DIFF
--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -182,6 +182,26 @@ impl SplitEnumerator for KafkaSplitEnumerator {
     }
 
     async fn list_splits(&mut self) -> ConnectorResult<Vec<KafkaSplit>> {
+        // `KafkaSplitEnumerator` uses `BaseConsumer`, which does not have a background polling
+        // thread. Poll once per `list_splits` invocation so meta's periodic source-manager tick
+        // can serve queued callbacks like librdkafka statistics events.
+        if let Some(Err(poll_err)) = {
+            #[cfg(not(madsim))]
+            {
+                self.client.poll(Duration::ZERO)
+            }
+            #[cfg(madsim)]
+            {
+                self.client.poll(Duration::ZERO).await
+            }
+        } {
+            tracing::warn!(
+                 error = %poll_err,
+                topic = self.topic,
+                broker_address = self.broker_address,
+                "failed to poll kafka client");
+        }
+
         let topic_partitions = self.fetch_topic_partition().await.with_context(|| {
             format!(
                 "failed to fetch metadata from kafka ({})",

--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -28,6 +28,7 @@ use rdkafka::{ClientConfig, Offset, TopicPartitionList};
 use risingwave_common::bail;
 use risingwave_common::id::FragmentId;
 use risingwave_common::metrics::LabelGuardedIntGauge;
+use thiserror_ext::AsReport;
 
 use crate::connector_common::read_kafka_log_level;
 use crate::error::{ConnectorError, ConnectorResult};
@@ -196,7 +197,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
             }
         } {
             tracing::warn!(
-                 error = %poll_err,
+                error = %poll_err.as_report(),
                 topic = self.topic,
                 broker_address = self.broker_address,
                 "failed to poll kafka client");


### PR DESCRIPTION
## Summary
Backport the meta-side Kafka enumerator polling fix to `release-2.8`.

This keeps the `KafkaSplitEnumerator`'s `BaseConsumer` from leaving queued librdkafka callbacks unserved during meta's periodic split discovery when `statistics.interval.ms` is enabled.

## What changed
- poll the Kafka enumerator client once at the start of `list_splits()`
- only log `tracing::warn!` when that poll returns `Some(Err(_))`
- keep split discovery behavior unchanged otherwise

## Why backport
Meta on the release branch uses the same long-lived Kafka split enumerator path in source manager, so the same callback-queue pressure applies there.

## Validation
- `rustfmt --edition 2024 src/connector/src/source/kafka/enumerator.rs`
- `cargo check -p risingwave_connector --lib --quiet`
