### PR TITLE
chore(ci): improve backward compat test

### DIFF
--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -40,6 +40,10 @@ source e2e_test/backwards-compat-tests/scripts/utils.sh
 configure_rw() {
 VERSION="$1"
 ENABLE_BUILD="$2"
+# Whether to build the Java connector-node from source during `risedev d`.
+# Defaults to true for backwards compatibility; callers that have already
+# provided a pre-built connector (via download) should pass "false".
+BUILD_CONNECTOR="${3:-true}"
 
 echo "--- Setting up cluster config"
   if version_le "$VERSION" "1.8.9"; then
@@ -80,14 +84,39 @@ ENABLE_BUILD_RUST=$ENABLE_BUILD
 # Use target/debug for simplicity.
 ENABLE_RELEASE_PROFILE=false
 ENABLE_UDF=true
-
-ENABLE_BUILD_RW_CONNECTOR=true
 EOF
+
+# cargo-make's `env_set` predicate only checks that the variable is defined,
+# regardless of value — so we must omit ENABLE_BUILD_RW_CONNECTOR entirely when
+# we want `build-connector-node` to be skipped.
+if [[ "$BUILD_CONNECTOR" == "true" ]]; then
+  echo "ENABLE_BUILD_RW_CONNECTOR=true" >> risedev-components.user.env
+fi
 
 # See https://github.com/risingwavelabs/risingwave/pull/15448
 if version_le "${VERSION:-}" "1.8.0" ; then
   echo "ENABLE_ALL_IN_ONE=true" >> risedev-components.user.env
 fi
+}
+
+# Try to download the pre-built Java connector-node tarball for a specific
+# release from GitHub. Returns 0 on success (connector extracted and
+# CONNECTOR_LIBS_PATH exported), non-zero if the release asset is unavailable.
+download_old_connector_artifact() {
+  local version="$1"
+  local tarball="risingwave-connector-v${version}.tar.gz"
+  local url="https://github.com/risingwavelabs/risingwave/releases/download/v${version}/${tarball}"
+  echo "--- Try downloading pre-built Java connector for $version"
+  rm -f "$tarball"
+  if ! wget --no-verbose "$url" -O "$tarball"; then
+    rm -f "$tarball"
+    return 1
+  fi
+  rm -rf ./connector-node
+  mkdir -p ./connector-node
+  tar xf "$tarball" -C ./connector-node
+  export CONNECTOR_LIBS_PATH="$(pwd)/connector-node/libs"
+  return 0
 }
 
 setup_old_cluster() {
@@ -97,31 +126,44 @@ setup_old_cluster() {
   cargo build -p risedev
   echo "--- Get RisingWave binary for $OLD_VERSION"
   OLD_URL=https://github.com/risingwavelabs/risingwave/releases/download/v${OLD_VERSION}/risingwave-v${OLD_VERSION}-x86_64-unknown-linux.tar.gz
+  local enable_build_rust="false"
   set +e
   wget --no-verbose "$OLD_URL"
-  if [[ "$?" -ne 0 ]]; then
-    set -e
+  wget_rc=$?
+  set -e
+  if [[ "$wget_rc" -ne 0 ]]; then
     echo "Failed to download ${OLD_VERSION} from github releases, build from source later during \`risedev d\`"
-    configure_rw "$OLD_VERSION" true
+    enable_build_rust="true"
   elif [[ $OLD_VERSION = '1.10.0' || $OLD_VERSION = '1.10.1' || $OLD_VERSION = '1.10.2' || $OLD_VERSION = '2.0.0' ]]; then
-    set -e
     echo "1.10.x, 2.0.0 have dynamically linked openssl, build from source later during \`risedev d\`"
-    configure_rw "$OLD_VERSION" true
+    enable_build_rust="true"
   else
-    set -e
     tar -xvf risingwave-v"${OLD_VERSION}"-x86_64-unknown-linux.tar.gz
     mv risingwave target/debug/risingwave
 
     echo "--- Start cluster on tag $OLD_VERSION"
     git config --global --add safe.directory /risingwave
-    configure_rw "$OLD_VERSION" false
   fi
+
+  # Try to reuse the pre-built Java connector from the old release. Falls back
+  # to building from source (inside `risedev d`) when the asset is unavailable.
+  local build_connector="true"
+  if download_old_connector_artifact "$OLD_VERSION"; then
+    build_connector="false"
+  else
+    echo "Pre-built Java connector for $OLD_VERSION not found, build from source later during \`risedev d\`"
+  fi
+
+  configure_rw "$OLD_VERSION" "$enable_build_rust" "$build_connector"
 }
 
 setup_new_cluster() {
   echo "--- Setup Risingwave @ $RW_COMMIT"
   git checkout "$RW_COMMIT"
   download_and_prepare_rw "$profile" common
+  # Reuse the Java connector artifact produced by the `build-other` step
+  # instead of rebuilding it from source during `risedev d`.
+  download_connector_node_artifact
   # Make sure we always start w/o old config
   rm -r .risingwave/config
 }
@@ -139,7 +181,7 @@ main() {
   # Assume we use the latest version, so we just set to some large number.
   # The current $NEW_VERSION as of this change is 1.7.0, so we can't use that.
   # See: https://github.com/risingwavelabs/risingwave/pull/15448
-  configure_rw "99.99.99" false
+  configure_rw "99.99.99" false false
   validate_new_cluster "$NEW_VERSION"
 }
 

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -812,6 +812,7 @@ steps:
       || build.env("CI_STEPS") =~ /(^|,)backwards?-compat-tests?(,|$$)/
     depends_on:
       - "build"
+      - "build-other"
     plugins:
       - docker-compose#v5.5.0:
           <<: *docker-compose

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -828,6 +828,7 @@ steps:
         build.env("CI_STEPS") =~ /(^|,)backwards?-compat-tests?(,|$$)/
     depends_on:
       - "build"
+      - "build-other"
     plugins:
       - docker-compose#v5.5.0:
           <<: *docker-compose


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Avoid rebuilding the Java connector-node from source inside the `Backwards compatibility tests` step.

Before: `configure_rw` always wrote `ENABLE_BUILD_RW_CONNECTOR=true`, so every matrix job ran Maven twice (once for old cluster, once for new cluster) — up to 8 Maven builds per run.

After:
- New cluster reuses the `risingwave-connector.tar.gz` artifact produced by the `build-other` step (same as every other e2e job).
- Old cluster downloads `risingwave-connector-v${OLD_VERSION}.tar.gz` from the matching GitHub Release, and falls back to building from source only if the asset is missing.
- `ENABLE_BUILD_RW_CONNECTOR` is omitted from `risedev-components.user.env` when we have a pre-built connector, so `build-connector-node` is skipped by cargo-make.
- Added `build-other` to `depends_on` for backwards-compat in both `pull-request.yml` and `main-cron.yml`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>