### PR TITLE
refactor(storage): normalize compact task table ids

### DIFF
--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -46,9 +46,16 @@ ENABLE_BUILD="$2"
 BUILD_CONNECTOR="${3:-true}"
 
 echo "--- Setting up cluster config"
+local hummock_stale_table_ids_config=""
+if ! version_lt "$VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
+  write_hummock_stale_table_ids_config
+  hummock_stale_table_ids_config="  config-path: $HUMMOCK_STALE_TABLE_IDS_CONFIG"
+fi
+
   if version_le "$VERSION" "1.8.9"; then
     cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
+${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: sqlite
@@ -62,14 +69,15 @@ EOF
      # so we need to specify the meta-backend: sqlite
      cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
- steps:
-   - use: minio
-   - use: sqlite
-   - use: meta-node
-     meta-backend: sqlite
-   - use: compute-node
-   - use: frontend
-   - use: compactor
+${hummock_stale_table_ids_config}
+  steps:
+    - use: minio
+    - use: sqlite
+    - use: meta-node
+      meta-backend: sqlite
+    - use: compute-node
+    - use: frontend
+    - use: compactor
 EOF
   fi
 

--- a/ci/scripts/backwards-compat-test.sh
+++ b/ci/scripts/backwards-compat-test.sh
@@ -46,16 +46,9 @@ ENABLE_BUILD="$2"
 BUILD_CONNECTOR="${3:-true}"
 
 echo "--- Setting up cluster config"
-local hummock_stale_table_ids_config=""
-if ! version_lt "$VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
-  write_hummock_stale_table_ids_config
-  hummock_stale_table_ids_config="  config-path: $HUMMOCK_STALE_TABLE_IDS_CONFIG"
-fi
-
   if version_le "$VERSION" "1.8.9"; then
     cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
-${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: sqlite
@@ -69,7 +62,6 @@ EOF
      # so we need to specify the meta-backend: sqlite
      cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
-${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: sqlite

--- a/e2e_test/backwards-compat-tests/README.md
+++ b/e2e_test/backwards-compat-tests/README.md
@@ -19,3 +19,4 @@ We currently cover the following:
 5. TPC-H
 6. Kafka Source
 7. AsOf join
+8. Hummock stale SST table ids after dropping one table from a mixed-table SST (old version >= 2.8.0)

--- a/e2e_test/backwards-compat-tests/scripts/run_local.sh
+++ b/e2e_test/backwards-compat-tests/scripts/run_local.sh
@@ -16,9 +16,16 @@ configure_rw() {
   VERSION="$1"
 
   echo "--- Setting up cluster config"
+  local hummock_stale_table_ids_config=""
+  if ! version_lt "$VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
+    write_hummock_stale_table_ids_config
+    hummock_stale_table_ids_config="  config-path: $HUMMOCK_STALE_TABLE_IDS_CONFIG"
+  fi
+
   if version_le "$VERSION" "1.9.0"; then
     cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
+${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: etcd
@@ -31,21 +38,39 @@ full-without-monitoring:
       address: message_queue
       port: 29092
 EOF
+  elif version_lt "$VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
+    cat <<EOF > risedev-profiles.user.yml
+full-without-monitoring:
+${hummock_stale_table_ids_config}
+  steps:
+    - use: minio
+    - use: etcd
+    - use: meta-node
+      meta-backend: etcd
+    - use: compute-node
+    - use: frontend
+    - use: compactor
+    - use: kafka
+      user-managed: true
+      address: message_queue
+      port: 29092
+EOF
   else
     cat <<EOF > risedev-profiles.user.yml
- full-without-monitoring:
-   steps:
-     - use: minio
-     - use: etcd
-     - use: meta-node
-       meta-backend: etcd
-     - use: compute-node
-     - use: frontend
-     - use: compactor
-     - use: kafka
-       user-managed: true
-       address: message_queue
-       port: 29092
+full-without-monitoring:
+${hummock_stale_table_ids_config}
+  steps:
+    - use: minio
+    - use: sqlite
+    - use: meta-node
+      meta-backend: sqlite
+    - use: compute-node
+    - use: frontend
+    - use: compactor
+    - use: kafka
+      user-managed: true
+      address: message_queue
+      port: 29092
 EOF
   fi
 

--- a/e2e_test/backwards-compat-tests/scripts/run_local.sh
+++ b/e2e_test/backwards-compat-tests/scripts/run_local.sh
@@ -16,16 +16,9 @@ configure_rw() {
   VERSION="$1"
 
   echo "--- Setting up cluster config"
-  local hummock_stale_table_ids_config=""
-  if ! version_lt "$VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
-    write_hummock_stale_table_ids_config
-    hummock_stale_table_ids_config="  config-path: $HUMMOCK_STALE_TABLE_IDS_CONFIG"
-  fi
-
   if version_le "$VERSION" "1.9.0"; then
     cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
-${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: etcd
@@ -41,7 +34,6 @@ EOF
   elif version_lt "$VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
     cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
-${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: etcd
@@ -58,7 +50,6 @@ EOF
   else
     cat <<EOF > risedev-profiles.user.yml
 full-without-monitoring:
-${hummock_stale_table_ids_config}
   steps:
     - use: minio
     - use: sqlite

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -20,10 +20,8 @@ RECOVERY_DURATION=20
 # Setup test directory
 TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
 # Keep this case on recently verified releases. It relies on Hummock system tables and
-# background compaction group merge/compaction to build a mixed-table SST.
+# risectl commands to build a mixed-table SST deterministically.
 HUMMOCK_STALE_TABLE_IDS_MIN_VERSION=2.8.0
-HUMMOCK_STALE_TABLE_IDS_AUTO_MERGE_TIMEOUT_SEC=180
-HUMMOCK_STALE_TABLE_IDS_CONFIG="$TEST_DIR/hummock-stale-table-ids/config.toml"
 mkdir -p $TEST_DIR
 cp -r e2e_test/backwards-compat-tests/slt/* $TEST_DIR
 
@@ -74,6 +72,14 @@ run_sql_scalar() {
   psql -h localhost -p 4566 -d dev -U root -At -c "$@" | tr -d '[:space:]'
 }
 
+run_risectl() (
+  set -euo pipefail
+  set -a
+  source .risingwave/config/risedev-env
+  set +a
+  .risingwave/bin/risingwave/risectl "$@"
+)
+
 check_version() {
   local VERSION=$1
   local raw_version=$(run_sql "SELECT version();")
@@ -111,19 +117,6 @@ seed_json_kafka() {
   insert_json_kafka '{"user_id": 9},{"timestamp": "2023-07-28 06:54:00", "user_id": 9, "page_id": 4, "action": "yjtyjtyyy"}'
 }
 
-write_hummock_stale_table_ids_config() {
-  mkdir -p "$(dirname "$HUMMOCK_STALE_TABLE_IDS_CONFIG")"
-  cat <<EOF > "$HUMMOCK_STALE_TABLE_IDS_CONFIG"
-[meta]
-# Merge often so the two test tables join quickly, but keep compaction less
-# frequent. Once the mixed SST is observed, this leaves enough time to drop the
-# table and shut down the old cluster before the next compaction can rewrite it.
-periodic_scheduling_compaction_group_merge_interval_sec = 1
-periodic_scheduling_compaction_group_split_interval_sec = 0
-periodic_compaction_interval_sec = 60
-EOF
-}
-
 seed_hummock_stale_table_ids() {
   rm -f "$TEST_DIR/hummock-stale-table-ids/enabled" \
     "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
@@ -145,8 +138,27 @@ seed_hummock_stale_table_ids() {
     exit 1
   fi
 
-  local mixed_sst_count=0
-  for _ in $(seq 1 "$HUMMOCK_STALE_TABLE_IDS_AUTO_MERGE_TIMEOUT_SEC"); do
+  local live_compaction_group_id
+  live_compaction_group_id=$(run_sql_scalar "SELECT compaction_group_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb LIMIT 1;")
+  local dropped_compaction_group_id
+  dropped_compaction_group_id=$(run_sql_scalar "SELECT compaction_group_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb LIMIT 1;")
+  if [[ -z "$live_compaction_group_id" || -z "$dropped_compaction_group_id" ]]; then
+    echo "Failed to capture hummock compaction groups: live=${live_compaction_group_id}, dropped=${dropped_compaction_group_id}"
+    exit 1
+  fi
+
+  if [[ "$live_compaction_group_id" != "$dropped_compaction_group_id" ]]; then
+    run_risectl hummock merge-compaction-group \
+      --left-group-id "$live_compaction_group_id" \
+      --right-group-id "$dropped_compaction_group_id"
+  fi
+
+  run_risectl hummock trigger-manual-compaction \
+    --compaction-group-id "$live_compaction_group_id" \
+    --level 0
+
+  local mixed_sst_count
+  for _ in $(seq 1 60); do
     mixed_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb AND table_ids @> '[${dropped_table_id}]'::jsonb;")
     if [[ "$mixed_sst_count" != "0" ]]; then
       break

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -22,7 +22,7 @@ TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
 # Keep this case on recently verified releases. It relies on Hummock system tables and
 # background compaction group merge/compaction to build a mixed-table SST.
 HUMMOCK_STALE_TABLE_IDS_MIN_VERSION=2.8.0
-HUMMOCK_STALE_TABLE_IDS_AUTO_MERGE_TIMEOUT_SEC=120
+HUMMOCK_STALE_TABLE_IDS_AUTO_MERGE_TIMEOUT_SEC=180
 HUMMOCK_STALE_TABLE_IDS_CONFIG="$TEST_DIR/hummock-stale-table-ids/config.toml"
 mkdir -p $TEST_DIR
 cp -r e2e_test/backwards-compat-tests/slt/* $TEST_DIR
@@ -115,9 +115,12 @@ write_hummock_stale_table_ids_config() {
   mkdir -p "$(dirname "$HUMMOCK_STALE_TABLE_IDS_CONFIG")"
   cat <<EOF > "$HUMMOCK_STALE_TABLE_IDS_CONFIG"
 [meta]
+# Merge often so the two test tables join quickly, but keep compaction less
+# frequent. Once the mixed SST is observed, this leaves enough time to drop the
+# table and shut down the old cluster before the next compaction can rewrite it.
 periodic_scheduling_compaction_group_merge_interval_sec = 1
 periodic_scheduling_compaction_group_split_interval_sec = 0
-periodic_compaction_interval_sec = 10
+periodic_compaction_interval_sec = 60
 EOF
 }
 

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -147,16 +147,41 @@ seed_hummock_stale_table_ids() {
     exit 1
   fi
 
+  # Put both tables into one compaction group so a manual L0 compaction can
+  # rewrite their SST metadata into one mixed-table SST.
   if [[ "$live_compaction_group_id" != "$dropped_compaction_group_id" ]]; then
     run_risectl hummock merge-compaction-group \
       --left-group-id "$live_compaction_group_id" \
       --right-group-id "$dropped_compaction_group_id"
   fi
 
+  # Target the exact L0 SSTs that contain either table id. This avoids depending
+  # on the default manual selector deciding that there is enough data to compact.
+  local target_sst_ids
+  target_sst_ids=$(run_sql_scalar "
+    SELECT string_agg(sstable_id::varchar, ',' ORDER BY sub_level_id, sstable_id)
+    FROM rw_catalog.rw_hummock_sstables
+    WHERE compaction_group_id = ${live_compaction_group_id}
+      AND level_id = 0
+      AND (
+        table_ids @> '[${live_table_id}]'::jsonb
+        OR table_ids @> '[${dropped_table_id}]'::jsonb
+      );
+  ")
+  if [[ -z "$target_sst_ids" ]]; then
+    echo "Failed to find L0 SSTs for hummock stale table ids test: live_table_id=${live_table_id}, dropped_table_id=${dropped_table_id}, compaction_group_id=${live_compaction_group_id}"
+    exit 1
+  fi
+
+  # `risectl` does not expose a reliable shell exit status for "no task picked",
+  # so the test verifies success by observing the resulting SST metadata below.
   run_risectl hummock trigger-manual-compaction \
     --compaction-group-id "$live_compaction_group_id" \
-    --level 0
+    --level 0 \
+    --sst-ids "$target_sst_ids"
 
+  # Fail closed unless the current Hummock version really contains an SST whose
+  # metadata references both the live table and the table that will be dropped.
   local mixed_sst_count
   for _ in $(seq 1 60); do
     mixed_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb AND table_ids @> '[${dropped_table_id}]'::jsonb;")
@@ -172,6 +197,8 @@ seed_hummock_stale_table_ids() {
 
   echo "$dropped_table_id" > "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
 
+  # Simulate the old-version upgrade state: the dropped table is unregistered
+  # from compaction group configs, while old SST metadata can still contain it.
   run_sql "DROP TABLE hummock_stale_dropped;"
   run_sql "FLUSH;"
 

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -19,9 +19,11 @@ RECOVERY_DURATION=20
 
 # Setup test directory
 TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
-# Keep this case on recently verified releases. It relies on Hummock system tables and ctl
-# commands to build a mixed-table SST deterministically.
+# Keep this case on recently verified releases. It relies on Hummock system tables and
+# background compaction group merge/compaction to build a mixed-table SST.
 HUMMOCK_STALE_TABLE_IDS_MIN_VERSION=2.8.0
+HUMMOCK_STALE_TABLE_IDS_AUTO_MERGE_TIMEOUT_SEC=120
+HUMMOCK_STALE_TABLE_IDS_CONFIG="$TEST_DIR/hummock-stale-table-ids/config.toml"
 mkdir -p $TEST_DIR
 cp -r e2e_test/backwards-compat-tests/slt/* $TEST_DIR
 
@@ -109,11 +111,19 @@ seed_json_kafka() {
   insert_json_kafka '{"user_id": 9},{"timestamp": "2023-07-28 06:54:00", "user_id": 9, "page_id": 4, "action": "yjtyjtyyy"}'
 }
 
+write_hummock_stale_table_ids_config() {
+  mkdir -p "$(dirname "$HUMMOCK_STALE_TABLE_IDS_CONFIG")"
+  cat <<EOF > "$HUMMOCK_STALE_TABLE_IDS_CONFIG"
+[meta]
+periodic_scheduling_compaction_group_merge_interval_sec = 1
+periodic_scheduling_compaction_group_split_interval_sec = 0
+periodic_compaction_interval_sec = 10
+EOF
+}
+
 seed_hummock_stale_table_ids() {
   rm -f "$TEST_DIR/hummock-stale-table-ids/enabled" \
-    "$TEST_DIR/hummock-stale-table-ids/live_table_id" \
-    "$TEST_DIR/hummock-stale-table-ids/dropped_table_id" \
-    "$TEST_DIR/hummock-stale-table-ids/compaction_group_id"
+    "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
 
   if version_lt "$OLD_VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
     echo "--- HUMMOCK STALE TABLE IDS TEST: Skipped for old version ${OLD_VERSION}"
@@ -121,11 +131,6 @@ seed_hummock_stale_table_ids() {
   fi
 
   echo "--- HUMMOCK STALE TABLE IDS TEST: Seeding old cluster with mixed-table SST"
-  # Build ctl before creating the target tables. Otherwise the first `risedev ctl` invocation can
-  # spend minutes compiling after we capture compaction group ids, during which the old cluster may
-  # compact and purge those groups.
-  cargo build -p risingwave_ctl
-
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hummock-stale-table-ids/seed.slt"
 
   local live_table_id
@@ -137,31 +142,8 @@ seed_hummock_stale_table_ids() {
     exit 1
   fi
 
-  echo "$live_table_id" > "$TEST_DIR/hummock-stale-table-ids/live_table_id"
-  echo "$dropped_table_id" > "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
-
-  local live_compaction_group_id
-  live_compaction_group_id=$(run_sql_scalar "SELECT compaction_group_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb LIMIT 1;")
-  local dropped_compaction_group_id
-  dropped_compaction_group_id=$(run_sql_scalar "SELECT compaction_group_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb LIMIT 1;")
-  if [[ -z "$live_compaction_group_id" || -z "$dropped_compaction_group_id" ]]; then
-    echo "Failed to capture hummock compaction groups: live=${live_compaction_group_id}, dropped=${dropped_compaction_group_id}"
-    exit 1
-  fi
-  echo "$live_compaction_group_id" > "$TEST_DIR/hummock-stale-table-ids/compaction_group_id"
-
-  if [[ "$live_compaction_group_id" != "$dropped_compaction_group_id" ]]; then
-    ./risedev ctl hummock merge-compaction-group \
-      --left-group-id "$live_compaction_group_id" \
-      --right-group-id "$dropped_compaction_group_id"
-  fi
-
-  ./risedev ctl hummock trigger-manual-compaction \
-    --compaction-group-id "$live_compaction_group_id" \
-    --level 0
-
-  local mixed_sst_count
-  for _ in $(seq 1 30); do
+  local mixed_sst_count=0
+  for _ in $(seq 1 "$HUMMOCK_STALE_TABLE_IDS_AUTO_MERGE_TIMEOUT_SEC"); do
     mixed_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb AND table_ids @> '[${dropped_table_id}]'::jsonb;")
     if [[ "$mixed_sst_count" != "0" ]]; then
       break
@@ -173,8 +155,17 @@ seed_hummock_stale_table_ids() {
     exit 1
   fi
 
+  echo "$dropped_table_id" > "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
+
   run_sql "DROP TABLE hummock_stale_dropped;"
   run_sql "FLUSH;"
+
+  local registered_stale_table_count
+  registered_stale_table_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_compaction_group_configs WHERE member_tables @> '[${dropped_table_id}]'::jsonb;")
+  if [[ "$registered_stale_table_count" != "0" ]]; then
+    echo "Old cluster did not unregister dropped table id ${dropped_table_id}"
+    exit 1
+  fi
 
   local stale_sst_count
   stale_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb;")
@@ -197,50 +188,10 @@ validate_hummock_stale_table_ids() {
   echo "--- HUMMOCK STALE TABLE IDS TEST: Validating new cluster before compaction"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hummock-stale-table-ids/validate_restart.slt"
 
-  local live_table_id
-  live_table_id=$(cat "$TEST_DIR/hummock-stale-table-ids/live_table_id")
   local dropped_table_id
   dropped_table_id=$(cat "$TEST_DIR/hummock-stale-table-ids/dropped_table_id")
   local stale_sst_count
   stale_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb;")
-  if [[ "$stale_sst_count" != "0" ]]; then
-    local compaction_group_id
-    compaction_group_id=$(cat "$TEST_DIR/hummock-stale-table-ids/compaction_group_id")
-    if [[ -z "$compaction_group_id" ]]; then
-      echo "Failed to locate compaction group for live table id ${live_table_id}"
-      exit 1
-    fi
-
-    local stale_level
-    stale_level=$(run_sql_scalar "SELECT level_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb LIMIT 1;")
-    if [[ -z "$stale_level" ]]; then
-      echo "Failed to locate stale SST level for dropped table id ${dropped_table_id}"
-      exit 1
-    fi
-    local stale_sst_ids
-    stale_sst_ids=$(run_sql_scalar "SELECT string_agg(sstable_id::varchar, ',') FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb AND level_id = ${stale_level};")
-    if [[ -z "$stale_sst_ids" ]]; then
-      echo "Failed to locate stale SSTs for dropped table id ${dropped_table_id}: level=${stale_level}, ssts=${stale_sst_ids}"
-      exit 1
-    fi
-
-    echo "--- HUMMOCK STALE TABLE IDS TEST: Triggering compaction after upgrade, compaction_group_id=${compaction_group_id}, level=${stale_level}, sst_ids=${stale_sst_ids}, dropped_table_id=${dropped_table_id}"
-    ./risedev ctl hummock trigger-manual-compaction \
-      --compaction-group-id "$compaction_group_id" \
-      --level "$stale_level" \
-      --sst-ids "$stale_sst_ids" \
-      --exclusive \
-      --retry-interval-ms 1000
-    sleep 5
-
-    for _ in $(seq 1 30); do
-      stale_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb;")
-      if [[ "$stale_sst_count" == "0" ]]; then
-        break
-      fi
-      sleep 1
-    done
-  fi
   if [[ "$stale_sst_count" != "0" ]]; then
     echo "Recovered new cluster still has SST metadata containing dropped table id ${dropped_table_id}"
     exit 1

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -19,6 +19,9 @@ RECOVERY_DURATION=20
 
 # Setup test directory
 TEST_DIR=.risingwave/e2e_test/backwards-compat-tests/
+# Keep this case on recently verified releases. It relies on Hummock system tables and ctl
+# commands to build a mixed-table SST deterministically.
+HUMMOCK_STALE_TABLE_IDS_MIN_VERSION=2.8.0
 mkdir -p $TEST_DIR
 cp -r e2e_test/backwards-compat-tests/slt/* $TEST_DIR
 
@@ -65,6 +68,10 @@ run_sql() {
   psql -h localhost -p 4566 -d dev -U root -c "$@"
 }
 
+run_sql_scalar() {
+  psql -h localhost -p 4566 -d dev -U root -At -c "$@" | tr -d '[:space:]'
+}
+
 check_version() {
   local VERSION=$1
   local raw_version=$(run_sql "SELECT version();")
@@ -102,6 +109,139 @@ seed_json_kafka() {
   insert_json_kafka '{"user_id": 9},{"timestamp": "2023-07-28 06:54:00", "user_id": 9, "page_id": 4, "action": "yjtyjtyyy"}'
 }
 
+seed_hummock_stale_table_ids() {
+  rm -f "$TEST_DIR/hummock-stale-table-ids/enabled" \
+    "$TEST_DIR/hummock-stale-table-ids/live_table_id" \
+    "$TEST_DIR/hummock-stale-table-ids/dropped_table_id" \
+    "$TEST_DIR/hummock-stale-table-ids/compaction_group_id"
+
+  if version_lt "$OLD_VERSION" "$HUMMOCK_STALE_TABLE_IDS_MIN_VERSION"; then
+    echo "--- HUMMOCK STALE TABLE IDS TEST: Skipped for old version ${OLD_VERSION}"
+    return
+  fi
+
+  echo "--- HUMMOCK STALE TABLE IDS TEST: Seeding old cluster with mixed-table SST"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hummock-stale-table-ids/seed.slt"
+
+  local live_table_id
+  live_table_id=$(run_sql_scalar "SELECT id FROM rw_catalog.rw_tables WHERE name = 'hummock_stale_live';")
+  local dropped_table_id
+  dropped_table_id=$(run_sql_scalar "SELECT id FROM rw_catalog.rw_tables WHERE name = 'hummock_stale_dropped';")
+  if [[ -z "$live_table_id" || -z "$dropped_table_id" ]]; then
+    echo "Failed to capture hummock stale table ids: live=${live_table_id}, dropped=${dropped_table_id}"
+    exit 1
+  fi
+
+  echo "$live_table_id" > "$TEST_DIR/hummock-stale-table-ids/live_table_id"
+  echo "$dropped_table_id" > "$TEST_DIR/hummock-stale-table-ids/dropped_table_id"
+
+  local live_compaction_group_id
+  live_compaction_group_id=$(run_sql_scalar "SELECT compaction_group_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb LIMIT 1;")
+  local dropped_compaction_group_id
+  dropped_compaction_group_id=$(run_sql_scalar "SELECT compaction_group_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb LIMIT 1;")
+  if [[ -z "$live_compaction_group_id" || -z "$dropped_compaction_group_id" ]]; then
+    echo "Failed to capture hummock compaction groups: live=${live_compaction_group_id}, dropped=${dropped_compaction_group_id}"
+    exit 1
+  fi
+  echo "$live_compaction_group_id" > "$TEST_DIR/hummock-stale-table-ids/compaction_group_id"
+
+  if [[ "$live_compaction_group_id" != "$dropped_compaction_group_id" ]]; then
+    ./risedev ctl hummock merge-compaction-group \
+      --left-group-id "$live_compaction_group_id" \
+      --right-group-id "$dropped_compaction_group_id"
+  fi
+
+  ./risedev ctl hummock trigger-manual-compaction \
+    --compaction-group-id "$live_compaction_group_id" \
+    --level 0
+
+  local mixed_sst_count
+  for _ in $(seq 1 30); do
+    mixed_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${live_table_id}]'::jsonb AND table_ids @> '[${dropped_table_id}]'::jsonb;")
+    if [[ "$mixed_sst_count" != "0" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$mixed_sst_count" == "0" ]]; then
+    echo "Failed to build mixed-table SST for hummock stale table ids test"
+    exit 1
+  fi
+
+  run_sql "DROP TABLE hummock_stale_dropped;"
+  run_sql "FLUSH;"
+
+  local stale_sst_count
+  stale_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb;")
+  if [[ "$stale_sst_count" == "0" ]]; then
+    echo "Old cluster did not retain stale SST table id ${dropped_table_id}; the backwards compatibility test would be ineffective"
+    exit 1
+  fi
+
+  echo "--- HUMMOCK STALE TABLE IDS TEST: Validating old cluster"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hummock-stale-table-ids/validate_original.slt"
+  touch "$TEST_DIR/hummock-stale-table-ids/enabled"
+}
+
+validate_hummock_stale_table_ids() {
+  if [[ ! -f "$TEST_DIR/hummock-stale-table-ids/enabled" ]]; then
+    echo "--- HUMMOCK STALE TABLE IDS TEST: Skipped"
+    return
+  fi
+
+  echo "--- HUMMOCK STALE TABLE IDS TEST: Validating new cluster before compaction"
+  sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hummock-stale-table-ids/validate_restart.slt"
+
+  local live_table_id
+  live_table_id=$(cat "$TEST_DIR/hummock-stale-table-ids/live_table_id")
+  local dropped_table_id
+  dropped_table_id=$(cat "$TEST_DIR/hummock-stale-table-ids/dropped_table_id")
+  local stale_sst_count
+  stale_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb;")
+  if [[ "$stale_sst_count" != "0" ]]; then
+    local compaction_group_id
+    compaction_group_id=$(cat "$TEST_DIR/hummock-stale-table-ids/compaction_group_id")
+    if [[ -z "$compaction_group_id" ]]; then
+      echo "Failed to locate compaction group for live table id ${live_table_id}"
+      exit 1
+    fi
+
+    local stale_level
+    stale_level=$(run_sql_scalar "SELECT level_id FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb LIMIT 1;")
+    if [[ -z "$stale_level" ]]; then
+      echo "Failed to locate stale SST level for dropped table id ${dropped_table_id}"
+      exit 1
+    fi
+    local stale_sst_ids
+    stale_sst_ids=$(run_sql_scalar "SELECT string_agg(sstable_id::varchar, ',') FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb AND level_id = ${stale_level};")
+    if [[ -z "$stale_sst_ids" ]]; then
+      echo "Failed to locate stale SSTs for dropped table id ${dropped_table_id}: level=${stale_level}, ssts=${stale_sst_ids}"
+      exit 1
+    fi
+
+    echo "--- HUMMOCK STALE TABLE IDS TEST: Triggering compaction after upgrade, compaction_group_id=${compaction_group_id}, level=${stale_level}, sst_ids=${stale_sst_ids}, dropped_table_id=${dropped_table_id}"
+    ./risedev ctl hummock trigger-manual-compaction \
+      --compaction-group-id "$compaction_group_id" \
+      --level "$stale_level" \
+      --sst-ids "$stale_sst_ids" \
+      --exclusive \
+      --retry-interval-ms 1000
+    sleep 5
+
+    for _ in $(seq 1 30); do
+      stale_sst_count=$(run_sql_scalar "SELECT count(*) FROM rw_catalog.rw_hummock_sstables WHERE table_ids @> '[${dropped_table_id}]'::jsonb;")
+      if [[ "$stale_sst_count" == "0" ]]; then
+        break
+      fi
+      sleep 1
+    done
+  fi
+  if [[ "$stale_sst_count" != "0" ]]; then
+    echo "Recovered new cluster still has SST metadata containing dropped table id ${dropped_table_id}"
+    exit 1
+  fi
+}
+
 # https://stackoverflow.com/a/4024263
 version_le() {
   printf '%s\n' "$1" "$2" | sort -C -V
@@ -117,7 +257,7 @@ get_old_version() {
   # For backwards compat test we assume we are testing the latest version of RW (i.e. latest main commit)
   # against the Nth latest release candidate, where N > 1. N can be larger,
   # in case some old cluster did not upgrade.
-  if [[ -z $VERSION_OFFSET ]]; then
+  if [[ -z ${VERSION_OFFSET:-} ]]; then
     local VERSION_OFFSET=1
   fi
 
@@ -299,6 +439,8 @@ seed_old_cluster() {
   echo "--- wait for a version checkpoint"
   sleep 60
 
+  seed_hummock_stale_table_ids
+
   echo "--- Killing cluster"
   kill_cluster
   echo "--- Killed cluster"
@@ -354,6 +496,8 @@ validate_new_cluster() {
 
   echo "--- CDC TEST: Validating new cluster"
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/cdc/validate_restart.slt"
+
+  validate_hummock_stale_table_ids
 
   kill_cluster
 }

--- a/e2e_test/backwards-compat-tests/scripts/utils.sh
+++ b/e2e_test/backwards-compat-tests/scripts/utils.sh
@@ -121,6 +121,11 @@ seed_hummock_stale_table_ids() {
   fi
 
   echo "--- HUMMOCK STALE TABLE IDS TEST: Seeding old cluster with mixed-table SST"
+  # Build ctl before creating the target tables. Otherwise the first `risedev ctl` invocation can
+  # spend minutes compiling after we capture compaction group ids, during which the old cluster may
+  # compact and purge those groups.
+  cargo build -p risingwave_ctl
+
   sqllogictest -d dev -h localhost -p 4566 "$TEST_DIR/hummock-stale-table-ids/seed.slt"
 
   local live_table_id

--- a/e2e_test/backwards-compat-tests/slt/hummock-stale-table-ids/seed.slt
+++ b/e2e_test/backwards-compat-tests/slt/hummock-stale-table-ids/seed.slt
@@ -1,0 +1,23 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO false;
+
+statement ok
+DROP TABLE IF EXISTS hummock_stale_live;
+
+statement ok
+DROP TABLE IF EXISTS hummock_stale_dropped;
+
+statement ok
+CREATE TABLE hummock_stale_live(k int primary key, v int);
+
+statement ok
+CREATE TABLE hummock_stale_dropped(k int primary key, v int);
+
+statement ok
+INSERT INTO hummock_stale_live SELECT a AS k, a * 10 AS v FROM generate_series(1, 1000) AS s(a);
+
+statement ok
+INSERT INTO hummock_stale_dropped SELECT a AS k, a * 100 AS v FROM generate_series(1, 1000) AS s(a);
+
+statement ok
+FLUSH;

--- a/e2e_test/backwards-compat-tests/slt/hummock-stale-table-ids/validate_original.slt
+++ b/e2e_test/backwards-compat-tests/slt/hummock-stale-table-ids/validate_original.slt
@@ -1,0 +1,9 @@
+query II
+SELECT count(*), sum(v) FROM hummock_stale_live;
+----
+1000 5005000
+
+query I
+SELECT count(*) FROM rw_catalog.rw_tables WHERE name = 'hummock_stale_dropped';
+----
+0

--- a/e2e_test/backwards-compat-tests/slt/hummock-stale-table-ids/validate_restart.slt
+++ b/e2e_test/backwards-compat-tests/slt/hummock-stale-table-ids/validate_restart.slt
@@ -1,0 +1,9 @@
+query II
+SELECT count(*), sum(v) FROM hummock_stale_live;
+----
+1000 5005000
+
+query I
+SELECT count(*) FROM rw_catalog.rw_tables WHERE name = 'hummock_stale_dropped';
+----
+0

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_compact_task_assignment.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_compact_task_assignment.rs
@@ -14,6 +14,7 @@
 
 use risingwave_common::types::{Fields, JsonbVal};
 use risingwave_frontend_macro::system_catalog;
+use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_pb::id::CompactionGroupId;
 use serde_json::json;
 
@@ -35,6 +36,7 @@ struct RwHummockCompactTaskAssignment {
     target_sub_level_id: i64,
     compression_algorithm: i32,
     table_ids: JsonbVal,
+    existing_table_ids: JsonbVal,
 }
 
 #[system_catalog(table, "rw_catalog.rw_hummock_compact_task_assignment")]
@@ -44,9 +46,18 @@ async fn read(reader: &SysCatalogReaderImpl) -> Result<Vec<RwHummockCompactTaskA
 
     let mut rows = vec![];
     for compact_task_assignment in compact_task_assignments {
-        let compact_task = compact_task_assignment.compact_task.unwrap();
+        let compact_task = CompactTask::from(compact_task_assignment.compact_task.unwrap());
 
         let select_level = compact_task.input_ssts[0].level_idx;
+        let table_ids = compact_task
+            .get_table_ids_from_input_ssts()
+            .map(|table_id| table_id.as_raw_id())
+            .collect::<Vec<_>>();
+        let existing_table_ids = compact_task
+            .existing_table_ids
+            .iter()
+            .map(|table_id| table_id.as_raw_id())
+            .collect::<Vec<_>>();
 
         rows.push(RwHummockCompactTaskAssignment {
             compaction_group_id: compact_task.compaction_group_id,
@@ -60,7 +71,8 @@ async fn read(reader: &SysCatalogReaderImpl) -> Result<Vec<RwHummockCompactTaskA
             target_file_size: compact_task.target_file_size as _,
             target_sub_level_id: compact_task.target_sub_level_id as _,
             compression_algorithm: compact_task.compression_algorithm as _,
-            table_ids: json!(compact_task.existing_table_ids).into(),
+            table_ids: json!(table_ids).into(),
+            existing_table_ids: json!(existing_table_ids).into(),
         });
     }
 

--- a/src/meta/src/hummock/manager/compaction/compact_task_builder.rs
+++ b/src/meta/src/hummock/manager/compaction/compact_task_builder.rs
@@ -1,0 +1,240 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+
+use itertools::Itertools;
+use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::compact_task::CompactTask;
+use risingwave_hummock_sdk::key_range::KeyRange;
+use risingwave_hummock_sdk::level::InputLevel;
+use risingwave_hummock_sdk::table_watermark::{TableWatermarks, WatermarkSerdeType};
+use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId};
+use risingwave_pb::hummock::compact_task::TaskStatus;
+use risingwave_pb::hummock::{CompactionConfig, TableOption, TableSchema};
+
+use crate::hummock::compaction::CompactionTask as PickedCompactionTask;
+
+pub(super) struct CompactTaskBuildContext {
+    pub(super) task_id: HummockCompactionTaskId,
+    pub(super) compaction_group_id: CompactionGroupId,
+    pub(super) compaction_group_version_id: u64,
+    pub(super) existing_table_ids: Vec<TableId>,
+    pub(super) table_options: BTreeMap<TableId, TableOption>,
+    pub(super) is_target_level_last: bool,
+    pub(super) compaction_config: Arc<CompactionConfig>,
+    pub(super) current_epoch_time: u64,
+}
+
+pub(super) fn build_base_compact_task(
+    picked_task: PickedCompactionTask,
+    context: CompactTaskBuildContext,
+) -> (CompactTask, Vec<TableId>) {
+    let target_level_id = picked_task.input.target_level as u32;
+    let mut input_ssts = picked_task.input.input_levels;
+    let existing_table_id_set: HashSet<_> = context.existing_table_ids.iter().copied().collect();
+    retain_table_ids_in_input_ssts(&mut input_ssts, &existing_table_id_set);
+    let compact_table_ids = collect_table_ids_from_input_ssts(&input_ssts);
+    let compact_table_id_set: HashSet<_> = compact_table_ids.iter().copied().collect();
+    let mut table_options = context.table_options;
+    retain_table_options(&mut table_options, &compact_table_id_set);
+    let compression_algorithm = match picked_task.compression_algorithm.as_str() {
+        "Lz4" => 1,
+        "Zstd" => 2,
+        _ => 0,
+    };
+    let compaction_config = context.compaction_config.as_ref();
+
+    (
+        CompactTask {
+            input_ssts,
+            splits: vec![KeyRange::inf()],
+            sorted_output_ssts: vec![],
+            task_id: context.task_id,
+            target_level: target_level_id,
+            // Only gc delete keys in last level because there may be older versions in lower levels.
+            gc_delete_keys: context.is_target_level_last,
+            base_level: picked_task.base_level as u32,
+            task_status: TaskStatus::Pending,
+            compaction_group_id: context.compaction_group_id,
+            compaction_group_version_id: context.compaction_group_version_id,
+            existing_table_ids: context.existing_table_ids,
+            compression_algorithm,
+            target_file_size: picked_task.target_file_size,
+            table_options,
+            current_epoch_time: context.current_epoch_time,
+            compaction_filter_mask: compaction_config.compaction_filter_mask,
+            target_sub_level_id: picked_task.input.target_sub_level_id,
+            task_type: picked_task.compaction_task_type,
+            split_weight_by_vnode: picked_task.input.vnode_partition_count,
+            max_sub_compaction: compaction_config.max_sub_compaction,
+            max_kv_count_for_xor16: compaction_config.max_kv_count_for_xor16,
+            max_vnode_key_range_bytes: compaction_config.max_vnode_key_range_bytes,
+            ..Default::default()
+        },
+        compact_table_ids,
+    )
+}
+
+pub(super) fn attach_compact_task_table_metadata(
+    compact_task: &mut CompactTask,
+    compact_table_ids: &[TableId],
+    table_watermarks: BTreeMap<TableId, TableWatermarks>,
+    all_versioned_table_schemas: &HashMap<TableId, Vec<i32>>,
+) {
+    let mut pk_prefix_table_watermarks = BTreeMap::default();
+    let mut non_pk_prefix_table_watermarks = BTreeMap::default();
+    let mut value_table_watermarks = BTreeMap::default();
+    for (table_id, watermark) in table_watermarks {
+        match watermark.watermark_type {
+            WatermarkSerdeType::PkPrefix => {
+                pk_prefix_table_watermarks.insert(table_id, watermark);
+            }
+            WatermarkSerdeType::NonPkPrefix => {
+                non_pk_prefix_table_watermarks.insert(table_id, watermark);
+            }
+            WatermarkSerdeType::Value => {
+                value_table_watermarks.insert(table_id, watermark);
+            }
+        }
+    }
+
+    compact_task.pk_prefix_table_watermarks = pk_prefix_table_watermarks;
+    compact_task.non_pk_prefix_table_watermarks = non_pk_prefix_table_watermarks;
+    compact_task.value_table_watermarks = value_table_watermarks;
+    compact_task.table_schemas = compact_table_ids
+        .iter()
+        .filter_map(|table_id| {
+            all_versioned_table_schemas.get(table_id).map(|column_ids| {
+                (
+                    *table_id,
+                    TableSchema {
+                        column_ids: column_ids.clone(),
+                    },
+                )
+            })
+        })
+        .collect();
+}
+
+fn retain_table_options(
+    table_options: &mut BTreeMap<TableId, TableOption>,
+    table_id_set: &HashSet<TableId>,
+) {
+    table_options.retain(|table_id, _| table_id_set.contains(table_id));
+}
+
+fn retain_table_ids_in_input_ssts(input_ssts: &mut [InputLevel], table_id_set: &HashSet<TableId>) {
+    for input_level in &mut *input_ssts {
+        for sst in &mut input_level.table_infos {
+            let mut inner = sst.get_inner();
+            inner
+                .table_ids
+                .retain(|table_id| table_id_set.contains(table_id));
+            sst.set_inner(inner);
+        }
+    }
+}
+
+fn collect_table_ids_from_input_ssts(input_ssts: &[InputLevel]) -> Vec<TableId> {
+    input_ssts
+        .iter()
+        .flat_map(|level| level.table_infos.iter())
+        .flat_map(|sst| sst.table_ids.iter().copied())
+        .sorted()
+        .dedup()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+
+    use super::*;
+
+    fn test_sstable(table_ids: Vec<TableId>) -> SstableInfo {
+        SstableInfo::from(SstableInfoInner {
+            table_ids,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_retain_table_ids_in_input_ssts() {
+        let mut input_ssts = vec![InputLevel {
+            table_infos: vec![
+                test_sstable(vec![TableId::new(3), TableId::new(1), TableId::new(2)]),
+                test_sstable(vec![TableId::new(2)]),
+                test_sstable(vec![TableId::new(3), TableId::new(1)]),
+            ],
+            ..Default::default()
+        }];
+        let existing_table_id_set = HashSet::from_iter([TableId::new(1), TableId::new(3)]);
+        retain_table_ids_in_input_ssts(&mut input_ssts, &existing_table_id_set);
+
+        let table_infos = &input_ssts[0].table_infos;
+        assert_eq!(
+            table_infos[0].table_ids,
+            vec![TableId::new(3), TableId::new(1)]
+        );
+        assert!(table_infos[1].table_ids.is_empty());
+        assert_eq!(
+            table_infos[2].table_ids,
+            vec![TableId::new(3), TableId::new(1)]
+        );
+
+        let compact_table_ids = collect_table_ids_from_input_ssts(&input_ssts);
+        assert_eq!(compact_table_ids, vec![TableId::new(1), TableId::new(3)]);
+    }
+
+    #[test]
+    fn test_retain_table_ids_keeps_dropped_only_ssts_for_trivial_reclaim() {
+        let mut input_ssts = vec![InputLevel {
+            table_infos: vec![test_sstable(vec![TableId::new(2)])],
+            ..Default::default()
+        }];
+        let existing_table_id_set = HashSet::from_iter([TableId::new(1)]);
+        retain_table_ids_in_input_ssts(&mut input_ssts, &existing_table_id_set);
+
+        assert_eq!(input_ssts[0].table_infos.len(), 1);
+        assert!(input_ssts[0].table_infos[0].table_ids.is_empty());
+
+        let compact_table_ids = collect_table_ids_from_input_ssts(&input_ssts);
+        assert!(compact_table_ids.is_empty());
+
+        let compact_task = CompactTask {
+            input_ssts,
+            ..Default::default()
+        };
+        assert!(compact_task.is_trivial_reclaim());
+    }
+
+    #[test]
+    fn test_retain_table_options() {
+        let mut table_options = BTreeMap::from([
+            (TableId::new(1), TableOption::default()),
+            (TableId::new(2), TableOption::default()),
+            (TableId::new(3), TableOption::default()),
+        ]);
+        let compact_table_id_set = HashSet::from_iter([TableId::new(1), TableId::new(3)]);
+
+        retain_table_options(&mut table_options, &compact_table_id_set);
+
+        assert_eq!(
+            table_options.keys().copied().collect::<Vec<_>>(),
+            vec![TableId::new(1), TableId::new(3)]
+        );
+    }
+}

--- a/src/meta/src/hummock/manager/compaction/compact_task_builder.rs
+++ b/src/meta/src/hummock/manager/compaction/compact_task_builder.rs
@@ -19,7 +19,6 @@ use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::key_range::KeyRange;
-use risingwave_hummock_sdk::level::InputLevel;
 use risingwave_hummock_sdk::table_watermark::{TableWatermarks, WatermarkSerdeType};
 use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId};
 use risingwave_pb::hummock::compact_task::TaskStatus;
@@ -43,10 +42,14 @@ pub(super) fn build_base_compact_task(
     context: CompactTaskBuildContext,
 ) -> (CompactTask, Vec<TableId>) {
     let target_level_id = picked_task.input.target_level as u32;
-    let mut input_ssts = picked_task.input.input_levels;
-    let existing_table_id_set: HashSet<_> = context.existing_table_ids.iter().copied().collect();
-    retain_table_ids_in_input_ssts(&mut input_ssts, &existing_table_id_set);
-    let compact_table_ids = collect_table_ids_from_input_ssts(&input_ssts);
+    let input_ssts = picked_task.input.input_levels;
+    let compact_table_ids = input_ssts
+        .iter()
+        .flat_map(|level| level.table_infos.iter())
+        .flat_map(|sst| sst.table_ids.iter().copied())
+        .sorted()
+        .dedup()
+        .collect_vec();
     let compact_table_id_set: HashSet<_> = compact_table_ids.iter().copied().collect();
     let mut table_options = context.table_options;
     retain_table_options(&mut table_options, &compact_table_id_set);
@@ -136,90 +139,9 @@ fn retain_table_options(
     table_options.retain(|table_id, _| table_id_set.contains(table_id));
 }
 
-fn retain_table_ids_in_input_ssts(input_ssts: &mut [InputLevel], table_id_set: &HashSet<TableId>) {
-    for input_level in &mut *input_ssts {
-        for sst in &mut input_level.table_infos {
-            let mut inner = sst.get_inner();
-            inner
-                .table_ids
-                .retain(|table_id| table_id_set.contains(table_id));
-            sst.set_inner(inner);
-        }
-    }
-}
-
-fn collect_table_ids_from_input_ssts(input_ssts: &[InputLevel]) -> Vec<TableId> {
-    input_ssts
-        .iter()
-        .flat_map(|level| level.table_infos.iter())
-        .flat_map(|sst| sst.table_ids.iter().copied())
-        .sorted()
-        .dedup()
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
-    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
-
     use super::*;
-
-    fn test_sstable(table_ids: Vec<TableId>) -> SstableInfo {
-        SstableInfo::from(SstableInfoInner {
-            table_ids,
-            ..Default::default()
-        })
-    }
-
-    #[test]
-    fn test_retain_table_ids_in_input_ssts() {
-        let mut input_ssts = vec![InputLevel {
-            table_infos: vec![
-                test_sstable(vec![TableId::new(3), TableId::new(1), TableId::new(2)]),
-                test_sstable(vec![TableId::new(2)]),
-                test_sstable(vec![TableId::new(3), TableId::new(1)]),
-            ],
-            ..Default::default()
-        }];
-        let existing_table_id_set = HashSet::from_iter([TableId::new(1), TableId::new(3)]);
-        retain_table_ids_in_input_ssts(&mut input_ssts, &existing_table_id_set);
-
-        let table_infos = &input_ssts[0].table_infos;
-        assert_eq!(
-            table_infos[0].table_ids,
-            vec![TableId::new(3), TableId::new(1)]
-        );
-        assert!(table_infos[1].table_ids.is_empty());
-        assert_eq!(
-            table_infos[2].table_ids,
-            vec![TableId::new(3), TableId::new(1)]
-        );
-
-        let compact_table_ids = collect_table_ids_from_input_ssts(&input_ssts);
-        assert_eq!(compact_table_ids, vec![TableId::new(1), TableId::new(3)]);
-    }
-
-    #[test]
-    fn test_retain_table_ids_keeps_dropped_only_ssts_for_trivial_reclaim() {
-        let mut input_ssts = vec![InputLevel {
-            table_infos: vec![test_sstable(vec![TableId::new(2)])],
-            ..Default::default()
-        }];
-        let existing_table_id_set = HashSet::from_iter([TableId::new(1)]);
-        retain_table_ids_in_input_ssts(&mut input_ssts, &existing_table_id_set);
-
-        assert_eq!(input_ssts[0].table_infos.len(), 1);
-        assert!(input_ssts[0].table_infos[0].table_ids.is_empty());
-
-        let compact_table_ids = collect_table_ids_from_input_ssts(&input_ssts);
-        assert!(compact_table_ids.is_empty());
-
-        let compact_task = CompactTask {
-            input_ssts,
-            ..Default::default()
-        };
-        assert!(compact_task.is_trivial_reclaim());
-    }
 
     #[test]
     fn test_retain_table_options() {

--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -298,61 +298,63 @@ impl HummockManager {
             &self.env.opts,
         );
         let mut new_version_delta = version.new_delta();
-        let mut modified_groups: HashMap<CompactionGroupId, /* #member table */ u64> =
-            HashMap::new();
+        struct UnregisterGroupChange {
+            remaining_member_count: usize,
+            removed_table_ids: HashSet<TableId>,
+        }
+        let mut group_changes: HashMap<CompactionGroupId, UnregisterGroupChange> = HashMap::new();
         // Remove member tables
         for table_id in table_ids.into_iter().unique() {
             let version = new_version_delta.latest_version();
             let Some(info) = version.state_table_info.info().get(&table_id) else {
                 continue;
             };
+            let compaction_group_id = info.compaction_group_id;
 
-            modified_groups
-                .entry(info.compaction_group_id)
-                .and_modify(|count| *count -= 1)
-                .or_insert(
-                    version
-                        .state_table_info
-                        .compaction_group_member_tables()
-                        .get(&info.compaction_group_id)
-                        .expect("should exist")
-                        .len() as u64
-                        - 1,
-                );
+            let group_change =
+                group_changes
+                    .entry(compaction_group_id)
+                    .or_insert_with(|| UnregisterGroupChange {
+                        remaining_member_count: version
+                            .state_table_info
+                            .compaction_group_member_tables()
+                            .get(&compaction_group_id)
+                            .expect("should exist")
+                            .len(),
+                        removed_table_ids: HashSet::new(),
+                    });
+            group_change.remaining_member_count = group_change
+                .remaining_member_count
+                .checked_sub(1)
+                .expect("member table count should be positive");
+            assert!(group_change.removed_table_ids.insert(table_id));
             new_version_delta.removed_table_ids.insert(table_id);
         }
 
-        let groups_to_remove = modified_groups
-            .into_iter()
-            .filter_map(|(group_id, member_count)| {
-                if member_count == 0 && group_id > StaticCompactionGroupId::End {
-                    return Some((
-                        group_id,
-                        new_version_delta
-                            .latest_version()
-                            .get_compaction_group_levels(group_id)
-                            .levels
-                            .len(),
-                    ));
-                }
-                None
-            })
-            .collect_vec();
-        for (group_id, _) in &groups_to_remove {
-            let group_deltas = &mut new_version_delta
-                .group_deltas
-                .entry(*group_id)
-                .or_default()
-                .group_deltas;
-
-            let group_delta = GroupDelta::GroupDestroy(PbGroupDestroy {});
-            group_deltas.push(group_delta);
-        }
-
-        for (group_id, max_level) in groups_to_remove {
-            remove_compaction_group_in_sst_stat(&self.metrics, group_id, max_level);
-            // clean up compaction schedule state for the removed group
-            self.compaction_state.remove_compaction_group(group_id);
+        for (group_id, change) in group_changes {
+            if change.remaining_member_count == 0 && group_id > StaticCompactionGroupId::End {
+                let max_level = new_version_delta
+                    .latest_version()
+                    .get_compaction_group_levels(group_id)
+                    .levels
+                    .len();
+                new_version_delta
+                    .group_deltas
+                    .entry(group_id)
+                    .or_default()
+                    .group_deltas
+                    .push(GroupDelta::GroupDestroy(PbGroupDestroy {}));
+                remove_compaction_group_in_sst_stat(&self.metrics, group_id, max_level);
+                // clean up compaction schedule state for the removed group
+                self.compaction_state.remove_compaction_group(group_id);
+            } else {
+                new_version_delta
+                    .group_deltas
+                    .entry(group_id)
+                    .or_default()
+                    .group_deltas
+                    .push(GroupDelta::PruneTableIdsFromSsts(change.removed_table_ids));
+            }
         }
 
         new_version_delta.pre_apply();

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -31,13 +31,13 @@ use risingwave_common::config::meta::default::compaction_config;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compact_task::{CompactTask, ReportTask};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
-use risingwave_hummock_sdk::key_range::KeyRange;
+use risingwave_hummock_sdk::compaction_group::hummock_version_ext::safe_epoch_table_watermarks_impl;
 use risingwave_hummock_sdk::level::Levels;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_stats::{
     PbTableStatsMap, add_prost_table_stats_map, purge_prost_table_stats,
 };
-use risingwave_hummock_sdk::table_watermark::WatermarkSerdeType;
+use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::version::{GroupDelta, IntraLevelDelta};
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockCompactionTaskId, HummockContextId, HummockSstableId,
@@ -48,7 +48,7 @@ use risingwave_pb::hummock::compact_task::{TaskStatus, TaskType};
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
 use risingwave_pb::hummock::{
     CompactTaskAssignment, CompactionConfig, PbCompactStatus, PbCompactTaskAssignment,
-    SubscribeCompactionEventRequest, TableOption, TableSchema, compact_task,
+    SubscribeCompactionEventRequest, TableOption, compact_task,
 };
 use thiserror_ext::AsReport;
 use tokio::sync::RwLockWriteGuard;
@@ -64,9 +64,15 @@ use crate::hummock::compaction::selector::{
     ManualCompactionSelector, SpaceReclaimCompactionSelector, TombstoneCompactionSelector,
     TtlCompactionSelector, VnodeWatermarkCompactionSelector,
 };
-use crate::hummock::compaction::{CompactStatus, CompactionDeveloperConfig, CompactionSelector};
+use crate::hummock::compaction::{
+    CompactStatus, CompactionDeveloperConfig, CompactionSelector,
+    CompactionTask as PickedCompactionTask,
+};
 use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::CompactionTaskReportResult;
+use crate::hummock::manager::compaction::compact_task_builder::{
+    CompactTaskBuildContext, attach_compact_task_table_metadata, build_base_compact_task,
+};
 use crate::hummock::manager::transaction::{
     HummockVersionStatsTransaction, HummockVersionTransaction,
 };
@@ -86,6 +92,7 @@ pub enum ManualCompactionTriggerResult {
     Retry,
 }
 
+mod compact_task_builder;
 pub mod compaction_event_loop;
 pub mod compaction_group_manager;
 pub mod compaction_group_schedule;
@@ -129,6 +136,11 @@ fn init_selectors() -> HashMap<compact_task::TaskType, Box<dyn CompactionSelecto
         Box::<VnodeWatermarkCompactionSelector>::default(),
     );
     compaction_selectors
+}
+
+enum BuiltCompactTask {
+    MetaFinished(CompactTask),
+    PendingAssignment(CompactTask),
 }
 
 impl HummockVersionTransaction<'_> {
@@ -404,9 +416,6 @@ impl HummockManager {
             }
             let mut compact_status = compaction_statuses.get_mut(compaction_group_id).unwrap();
 
-            let can_trivial_move = matches!(selector.task_type(), TaskType::Dynamic)
-                || matches!(selector.task_type(), TaskType::Emergency);
-
             let mut stats = LocalSelectorStatistic::default();
             let member_table_ids: Vec<_> = version
                 .latest_version()
@@ -427,7 +436,7 @@ impl HummockManager {
                 }
             }
 
-            while let Some(compact_task) = compact_status.get_compact_task(
+            while let Some(picked_task) = compact_status.get_compact_task(
                 version
                     .latest_version()
                     .get_compaction_group_levels(compaction_group_id),
@@ -444,156 +453,76 @@ impl HummockManager {
                 &version.latest_version().table_watermarks,
                 &version.latest_version().state_table_info,
             ) {
-                let target_level_id = compact_task.input.target_level as u32;
-                let compaction_group_version_id = version
+                let compaction_group_levels = version
                     .latest_version()
-                    .get_compaction_group_levels(compaction_group_id)
-                    .compaction_group_version_id;
-                let compression_algorithm = match compact_task.compression_algorithm.as_str() {
-                    "Lz4" => 1,
-                    "Zstd" => 2,
-                    _ => 0,
-                };
-                let vnode_partition_count = compact_task.input.vnode_partition_count;
-                let mut compact_task = CompactTask {
-                    input_ssts: compact_task.input.input_levels,
-                    splits: vec![KeyRange::inf()],
-                    sorted_output_ssts: vec![],
-                    task_id,
-                    target_level: target_level_id,
-                    // only gc delete keys in last level because there may be older version in more bottom
-                    // level.
-                    gc_delete_keys: version
-                        .latest_version()
-                        .get_compaction_group_levels(compaction_group_id)
-                        .is_last_level(target_level_id),
-                    base_level: compact_task.base_level as u32,
-                    task_status: TaskStatus::Pending,
-                    compaction_group_id: group_config.group_id,
-                    compaction_group_version_id,
-                    existing_table_ids: member_table_ids.clone(),
-                    compression_algorithm,
-                    target_file_size: compact_task.target_file_size,
-                    table_options: table_id_to_option
-                        .iter()
-                        .map(|(table_id, table_option)| {
-                            (*table_id, TableOption::from(table_option))
-                        })
-                        .collect(),
-                    current_epoch_time: Epoch::now().0,
-                    compaction_filter_mask: group_config.compaction_config.compaction_filter_mask,
-                    target_sub_level_id: compact_task.input.target_sub_level_id,
-                    task_type: compact_task.compaction_task_type,
-                    split_weight_by_vnode: vnode_partition_count,
-                    max_sub_compaction: group_config.compaction_config.max_sub_compaction,
-                    max_kv_count_for_xor16: group_config.compaction_config.max_kv_count_for_xor16,
-                    max_vnode_key_range_bytes: group_config
-                        .compaction_config
-                        .max_vnode_key_range_bytes,
-                    ..Default::default()
-                };
+                    .get_compaction_group_levels(compaction_group_id);
+                let target_level_id = picked_task.input.target_level as u32;
+                let is_target_level_last = compaction_group_levels.is_last_level(target_level_id);
+                let table_options = table_id_to_option
+                    .iter()
+                    .map(|(table_id, table_option)| (*table_id, TableOption::from(table_option)))
+                    .collect();
+                let built_compact_task = self.build_ready_compact_task(
+                    picked_task,
+                    CompactTaskBuildContext {
+                        task_id,
+                        compaction_group_id: group_config.group_id,
+                        compaction_group_version_id: compaction_group_levels
+                            .compaction_group_version_id,
+                        existing_table_ids: member_table_ids.clone(),
+                        table_options,
+                        is_target_level_last,
+                        compaction_config: group_config.compaction_config.clone(),
+                        current_epoch_time: Epoch::now().0,
+                    },
+                    &version.latest_version().table_watermarks,
+                    &all_versioned_table_schemas,
+                );
 
-                let is_trivial_reclaim = compact_task.is_trivial_reclaim();
-                let is_trivial_move = compact_task.is_trivial_move_task();
-                if is_trivial_reclaim || (is_trivial_move && can_trivial_move) {
-                    let log_label = if is_trivial_reclaim {
-                        "TrivialReclaim"
-                    } else {
-                        "TrivialMove"
-                    };
-                    let label = if is_trivial_reclaim {
-                        "trivial-space-reclaim"
-                    } else {
-                        "trivial-move"
-                    };
-
-                    tracing::debug!(
-                        "{} for compaction group {}: input: {:?}, cost time: {:?}",
-                        log_label,
-                        compact_task.compaction_group_id,
-                        compact_task.input_ssts,
-                        start_time.elapsed()
-                    );
-                    compact_task.task_status = TaskStatus::Success;
-                    compact_status.report_compact_task(&compact_task);
-                    if !is_trivial_reclaim {
-                        compact_task
-                            .sorted_output_ssts
-                            .clone_from(&compact_task.input_ssts[0].table_infos);
-                    }
-                    update_table_stats_for_vnode_watermark_trivial_reclaim(
-                        &mut version_stats.table_stats,
-                        &compact_task,
-                    );
-                    self.metrics
-                        .compact_frequency
-                        .with_label_values(&[
+                match built_compact_task {
+                    BuiltCompactTask::MetaFinished(compact_task) => {
+                        let label = compact_task.task_label();
+                        tracing::debug!(
+                            "{} for compaction group {}: input: {:?}, cost time: {:?}",
                             label,
-                            &compact_task.compaction_group_id.to_string(),
-                            selector.task_type().as_str_name(),
-                            "SUCCESS",
-                        ])
-                        .inc();
+                            compact_task.compaction_group_id,
+                            compact_task.input_ssts,
+                            start_time.elapsed()
+                        );
+                        compact_status.report_compact_task(&compact_task);
+                        update_table_stats_for_vnode_watermark_trivial_reclaim(
+                            &mut version_stats.table_stats,
+                            &compact_task,
+                        );
+                        self.metrics
+                            .compact_frequency
+                            .with_label_values(&[
+                                label,
+                                &compact_task.compaction_group_id.to_string(),
+                                selector.task_type().as_str_name(),
+                                "SUCCESS",
+                            ])
+                            .inc();
 
-                    version.apply_compact_task(&compact_task);
-                    trivial_tasks.push(compact_task);
-                    if trivial_tasks.len() >= self.env.opts.max_trivial_move_task_count_per_loop {
-                        break 'outside;
-                    }
-                } else {
-                    self.calculate_vnode_partition(
-                        &mut compact_task,
-                        group_config.compaction_config.as_ref(),
-                    );
-
-                    let mut pk_prefix_table_watermarks = BTreeMap::default();
-                    let mut non_pk_prefix_table_watermarks = BTreeMap::default();
-                    let mut value_table_watermarks = BTreeMap::default();
-                    for (table_id, watermark) in version
-                        .latest_version()
-                        .safe_epoch_table_watermarks(&compact_task.build_compact_table_ids())
-                    {
-                        match watermark.watermark_type {
-                            WatermarkSerdeType::PkPrefix => {
-                                pk_prefix_table_watermarks.insert(table_id, watermark);
-                            }
-                            WatermarkSerdeType::NonPkPrefix => {
-                                non_pk_prefix_table_watermarks.insert(table_id, watermark);
-                            }
-                            WatermarkSerdeType::Value => {
-                                value_table_watermarks.insert(table_id, watermark);
-                            }
+                        version.apply_compact_task(&compact_task);
+                        trivial_tasks.push(compact_task);
+                        if trivial_tasks.len() >= self.env.opts.max_trivial_move_task_count_per_loop
+                        {
+                            break 'outside;
                         }
                     }
-                    compact_task.pk_prefix_table_watermarks = pk_prefix_table_watermarks;
-                    compact_task.non_pk_prefix_table_watermarks = non_pk_prefix_table_watermarks;
-                    compact_task.value_table_watermarks = value_table_watermarks;
+                    BuiltCompactTask::PendingAssignment(compact_task) => {
+                        compact_task_assignment.insert(
+                            compact_task.task_id,
+                            CompactTaskAssignment {
+                                compact_task: Some(compact_task.clone().into()),
+                                context_id: META_NODE_ID, // deprecated
+                            },
+                        );
 
-                    compact_task.table_schemas = compact_task
-                        .existing_table_ids
-                        .iter()
-                        .filter_map(|table_id| {
-                            all_versioned_table_schemas.get(table_id).map(|column_ids| {
-                                (
-                                    *table_id,
-                                    TableSchema {
-                                        column_ids: column_ids.clone(),
-                                    },
-                                )
-                            })
-                        })
-                        .collect();
-
-                    compact_task_assignment.insert(
-                        compact_task.task_id,
-                        CompactTaskAssignment {
-                            compact_task: Some(compact_task.clone().into()),
-                            context_id: META_NODE_ID, // deprecated
-                        },
-                    );
-
-                    pick_tasks.push(compact_task);
-                    break;
+                        pick_tasks.push(compact_task);
+                        break;
+                    }
                 }
 
                 stats.report_to_metrics(compaction_group_id, self.metrics.as_ref());
@@ -1218,9 +1147,10 @@ impl HummockManager {
         &self,
         compact_task: &mut CompactTask,
         compaction_config: &CompactionConfig,
+        compact_table_ids: &[TableId],
     ) {
         if compaction_config.split_weight_by_vnode > 0 {
-            for table_id in &compact_task.existing_table_ids {
+            for table_id in compact_table_ids {
                 compact_task
                     .table_vnode_partition
                     .insert(*table_id, compact_task.split_weight_by_vnode);
@@ -1229,21 +1159,16 @@ impl HummockManager {
             return;
         }
 
-        // Calculate per-table size from input SSTs
+        // Calculate per-table size from normalized input SSTs.
         let mut table_size_info: HashMap<TableId, u64> = HashMap::default();
-        let mut existing_table_ids: HashSet<TableId> = HashSet::default();
         for input_ssts in &compact_task.input_ssts {
             for sst in &input_ssts.table_infos {
-                existing_table_ids.extend(sst.table_ids.iter());
                 for table_id in &sst.table_ids {
                     *table_size_info.entry(*table_id).or_default() +=
                         sst.sst_size / (sst.table_ids.len() as u64);
                 }
             }
         }
-        compact_task
-            .existing_table_ids
-            .retain(|table_id| existing_table_ids.contains(table_id));
 
         let hybrid_vnode_count = self.env.opts.hybrid_partition_node_count;
         let default_partition_count = self.env.opts.partition_vnode_count;
@@ -1290,13 +1215,14 @@ impl HummockManager {
 
         compact_task
             .table_vnode_partition
-            .retain(|table_id, _| compact_task.existing_table_ids.contains(table_id));
+            .retain(|table_id, _| compact_table_ids.contains(table_id));
     }
 
     pub(crate) fn calculate_vnode_partition(
         &self,
         compact_task: &mut CompactTask,
         compaction_config: &CompactionConfig,
+        compact_table_ids: &[TableId],
     ) {
         // Do not split sst by vnode partition when target_level > base_level
         // The purpose of data alignment is mainly to improve the parallelism of base level compaction
@@ -1307,7 +1233,64 @@ impl HummockManager {
         }
 
         // Apply split_weight_by_vnode based partition strategy
-        self.apply_split_weight_by_vnode_partition(compact_task, compaction_config);
+        self.apply_split_weight_by_vnode_partition(
+            compact_task,
+            compaction_config,
+            compact_table_ids,
+        );
+    }
+
+    fn build_ready_compact_task(
+        &self,
+        picked_task: PickedCompactionTask,
+        context: CompactTaskBuildContext,
+        table_watermarks: &HashMap<TableId, Arc<TableWatermarks>>,
+        all_versioned_table_schemas: &HashMap<TableId, Vec<i32>>,
+    ) -> BuiltCompactTask {
+        let compaction_config = context.compaction_config.clone();
+        let (mut compact_task, compact_table_ids) = build_base_compact_task(picked_task, context);
+
+        if compact_task.is_trivial_reclaim() {
+            compact_task.task_status = TaskStatus::Success;
+            compact_task.sorted_output_ssts.clear();
+            return BuiltCompactTask::MetaFinished(compact_task);
+        }
+
+        if compact_task.is_trivial_move_task() {
+            compact_task.task_status = TaskStatus::Success;
+            compact_task.sorted_output_ssts = compact_task.input_ssts[0]
+                .read_sstable_infos()
+                .cloned()
+                .collect();
+            return BuiltCompactTask::MetaFinished(compact_task);
+        }
+
+        self.prepare_compact_task_for_assignment(
+            &mut compact_task,
+            compaction_config.as_ref(),
+            &compact_table_ids,
+            safe_epoch_table_watermarks_impl(table_watermarks, &compact_table_ids),
+            all_versioned_table_schemas,
+        );
+
+        BuiltCompactTask::PendingAssignment(compact_task)
+    }
+
+    fn prepare_compact_task_for_assignment(
+        &self,
+        compact_task: &mut CompactTask,
+        compaction_config: &CompactionConfig,
+        compact_table_ids: &[TableId],
+        table_watermarks: BTreeMap<TableId, TableWatermarks>,
+        all_versioned_table_schemas: &HashMap<TableId, Vec<i32>>,
+    ) {
+        self.calculate_vnode_partition(compact_task, compaction_config, compact_table_ids);
+        attach_compact_task_table_metadata(
+            compact_task,
+            compact_table_ids,
+            table_watermarks,
+            all_versioned_table_schemas,
+        );
     }
 
     pub fn compactor_manager_ref(&self) -> crate::hummock::CompactorManagerRef {

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -546,14 +546,12 @@ impl HummockManager {
                         group_config.compaction_config.as_ref(),
                     );
 
-                    let table_ids_to_be_compacted = compact_task.build_compact_table_ids();
-
                     let mut pk_prefix_table_watermarks = BTreeMap::default();
                     let mut non_pk_prefix_table_watermarks = BTreeMap::default();
                     let mut value_table_watermarks = BTreeMap::default();
                     for (table_id, watermark) in version
                         .latest_version()
-                        .safe_epoch_table_watermarks(&table_ids_to_be_compacted)
+                        .safe_epoch_table_watermarks(&compact_task.build_compact_table_ids())
                     {
                         match watermark.watermark_type {
                             WatermarkSerdeType::PkPrefix => {

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -513,6 +513,14 @@ impl HummockManager {
             }
         }
         tracing::info!("Finish redo Hummock version.");
+        let pruned_stale_table_id_count = redo_state.prune_stale_table_ids_from_ssts();
+        if pruned_stale_table_id_count > 0 {
+            tracing::warn!(
+                pruned_stale_table_id_count,
+                version_id = ?redo_state.id,
+                "Pruned stale table ids from recovered Hummock SST metadata."
+            );
+        }
         versioning_guard.version_stats = hummock_version_stats::Entity::find()
             .one(&meta_store.conn)
             .await

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -2446,6 +2446,63 @@ async fn test_partition_level() {
 }
 
 #[tokio::test]
+async fn test_unregister_table_prunes_sst_table_ids() {
+    let (_env, hummock_manager, _, worker_id) = setup_compute_env(80).await;
+    let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
+        hummock_manager.clone(),
+        worker_id as _,
+    ));
+    let compaction_group_id = StaticCompactionGroupId::StateDefault;
+    hummock_manager
+        .register_table_ids_for_test(&[(100, compaction_group_id), (101, compaction_group_id)])
+        .await
+        .unwrap();
+    hummock_meta_client
+        .commit_epoch(
+            test_epoch(30),
+            SyncResult {
+                uncommitted_ssts: vec![
+                    gen_local_sstable_info(10, vec![100, 101], test_epoch(20)),
+                    gen_local_sstable_info(11, vec![101], test_epoch(20)),
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    hummock_manager
+        .unregister_table_ids([TableId::new(101)])
+        .await
+        .unwrap();
+
+    let current_version = hummock_manager.get_current_version().await;
+    assert_eq!(
+        current_version
+            .state_table_info
+            .compaction_group_member_table_ids(compaction_group_id)
+            .iter()
+            .copied()
+            .collect_vec(),
+        vec![TableId::new(100)]
+    );
+    assert_eq!(
+        get_compaction_group_object_ids(&current_version, compaction_group_id),
+        vec![10]
+    );
+    let levels = current_version.get_compaction_group_levels(compaction_group_id);
+    let table_ids = levels
+        .l0
+        .sub_levels
+        .iter()
+        .chain(levels.levels.iter())
+        .flat_map(|level| level.table_infos.iter())
+        .map(|sst| sst.table_ids.clone())
+        .collect_vec();
+    assert_eq!(table_ids, vec![vec![TableId::new(100)]]);
+}
+
+#[tokio::test]
 async fn test_unregister_moved_table() {
     let (_env, hummock_manager, _, worker_id) = setup_compute_env(80).await;
     let hummock_meta_client = Arc::new(MockHummockMetaClient::new(

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -30,18 +30,21 @@ use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::get_compaction_group_ssts;
 use risingwave_hummock_sdk::key::{FullKey, gen_key_from_str};
 use risingwave_hummock_sdk::key_range::KeyRange;
+use risingwave_hummock_sdk::level::Level;
 use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
 use risingwave_hummock_sdk::table_stats::{TableStats, TableStatsMap, to_prost_table_stats_map};
-use risingwave_hummock_sdk::version::{HummockVersion, MAX_HUMMOCK_VERSION_ID};
+use risingwave_hummock_sdk::version::{
+    HummockVersion, HummockVersionStateTableInfo, MAX_HUMMOCK_VERSION_ID,
+};
 use risingwave_hummock_sdk::{
     CompactionGroupId, FIRST_VERSION_ID, HummockEpoch, HummockObjectId, HummockSstableId,
     HummockSstableObjectId, LocalSstableInfo, SyncResult,
 };
 use risingwave_pb::common::worker_node::Property;
 use risingwave_pb::common::{HostAddress, WorkerType};
-use risingwave_pb::hummock::HummockPinnedVersion;
 use risingwave_pb::hummock::compact_task::TaskStatus;
 use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
+use risingwave_pb::hummock::{HummockPinnedVersion, PbLevelType, StateTableInfo};
 use risingwave_rpc_client::HummockMetaClient;
 use thiserror_ext::AsReport;
 
@@ -50,6 +53,7 @@ use crate::controller::cluster::ClusterController;
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
 use crate::hummock::compaction::selector::{ManualCompactionOption, default_compaction_selector};
 use crate::hummock::error::Error;
+use crate::hummock::manager::checkpoint::HummockVersionCheckpoint;
 use crate::hummock::table_write_throughput_statistic::TableWriteThroughputStatisticManager;
 use crate::hummock::test_utils::*;
 use crate::hummock::{CompactorManager, HummockManager, HummockManagerRef, MockHummockMetaClient};
@@ -195,6 +199,34 @@ async fn setup_compute_env_with_meta_opts(
         .await
         .unwrap();
     (env, hummock_manager, cluster_ctl, worker_id)
+}
+
+async fn build_hummock_manager_for_test_env(env: MetaSrvEnv) -> HummockManagerRef {
+    let config = CompactionConfigBuilder::new()
+        .level0_tier_compact_file_number(1)
+        .level0_max_compact_file_number(130)
+        .level0_sub_level_compact_level_count(2)
+        .level0_overlapping_sub_level_compact_level_count(1)
+        .build();
+    let cluster_ctl = Arc::new(
+        ClusterController::new(env.clone(), Duration::from_secs(1))
+            .await
+            .unwrap(),
+    );
+    let catalog_ctl = Arc::new(CatalogController::new(env.clone()).await.unwrap());
+    let compactor_manager = Arc::new(CompactorManager::for_test());
+    let (compactor_streams_change_tx, _compactor_streams_change_rx) =
+        tokio::sync::mpsc::unbounded_channel();
+    HummockManager::with_config(
+        env,
+        cluster_ctl,
+        catalog_ctl,
+        Arc::new(MetaMetrics::default()),
+        compactor_manager,
+        config,
+        compactor_streams_change_tx,
+    )
+    .await
 }
 
 fn compaction_group_ranges(version: &HummockVersion) -> Vec<(u32, u32)> {
@@ -2820,6 +2852,138 @@ async fn test_vacuum() {
         .await
         .unwrap();
     assert_eq!(deleted, 3);
+}
+
+#[tokio::test]
+async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() {
+    let data_directory = format!(
+        "hummock_recover_prune_stale_table_ids_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let env = MetaSrvEnv::for_test_opts(MetaOpts::test(false), |params| {
+        // Use shared memory so the second manager can read the dirty checkpoint written by the
+        // first manager, while a unique data directory keeps this test isolated.
+        params.state_store = Some("hummock+memory".to_owned());
+        params.data_directory = Some(data_directory);
+    })
+    .await;
+    let initial_manager = build_hummock_manager_for_test_env(env.clone()).await;
+
+    let compaction_group_id = StaticCompactionGroupId::StateDefault;
+    let live_table_id = TableId::new(100);
+    let stale_table_id = TableId::new(200);
+
+    let mut dirty_version = HummockVersion::create_init_version(Arc::new(
+        CompactionConfigBuilder::new()
+            .level0_sub_level_compact_level_count(2)
+            .build(),
+    ));
+    dirty_version.state_table_info =
+        HummockVersionStateTableInfo::from_protobuf_owned(HashMap::from_iter([(
+            live_table_id,
+            StateTableInfo {
+                committed_epoch: test_epoch(1),
+                compaction_group_id,
+            },
+        )]));
+
+    let live_and_stale_sst = gen_sstable_info(
+        10,
+        vec![live_table_id.as_raw_id(), stale_table_id.as_raw_id()],
+        test_epoch(1),
+    );
+    let stale_only_sst = gen_sstable_info(11, vec![stale_table_id.as_raw_id()], test_epoch(1));
+    let live_only_sst = gen_sstable_info(12, vec![live_table_id.as_raw_id()], test_epoch(1));
+    let another_live_only_sst =
+        gen_sstable_info(13, vec![live_table_id.as_raw_id()], test_epoch(1));
+    let dirty_l0_sub_levels = vec![
+        live_and_stale_sst,
+        stale_only_sst,
+        live_only_sst,
+        another_live_only_sst,
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(idx, sst)| Level {
+        level_idx: 0,
+        level_type: PbLevelType::Nonoverlapping,
+        total_file_size: sst.sst_size,
+        uncompressed_file_size: sst.uncompressed_file_size,
+        sub_level_id: idx as u64,
+        table_infos: vec![sst],
+        vnode_partition_count: 0,
+    })
+    .collect_vec();
+    let group = dirty_version.levels.get_mut(&compaction_group_id).unwrap();
+    group.l0.total_file_size = dirty_l0_sub_levels
+        .iter()
+        .map(|level| level.total_file_size)
+        .sum();
+    group.l0.uncompressed_file_size = dirty_l0_sub_levels
+        .iter()
+        .map(|level| level.uncompressed_file_size)
+        .sum();
+    group.l0.sub_levels = dirty_l0_sub_levels;
+
+    // Simulate the upgrade path:
+    // 1. an old version wrote SST metadata containing table ids [live, dropped];
+    // 2. the old version dropped one table, but the checkpoint still had stale SST table ids;
+    // 3. the new version recovers this checkpoint and picks a compaction task.
+    //
+    // After checkpoint and delta replay, recovery should normalize the recovered current version
+    // before publishing it. The normalization should retain only live `state_table_info` table ids
+    // in SST metadata and remove SSTs whose `table_ids` become empty. Otherwise the new compactor
+    // will pass the stale read set to catalog acquire and fail before compaction can run.
+    initial_manager
+        .write_checkpoint(&HummockVersionCheckpoint {
+            version: dirty_version,
+            stale_objects: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    let recovered_manager = build_hummock_manager_for_test_env(env).await;
+    let compact_task = recovered_manager
+        .get_compact_task(compaction_group_id, &mut *default_compaction_selector())
+        .await
+        .unwrap()
+        .expect("dirty old-version SST should be picked for compaction");
+    let compact_table_ids = compact_task.get_table_ids_from_input_ssts().collect_vec();
+
+    assert!(
+        !compact_table_ids.contains(&stale_table_id),
+        "new-version compaction task must not read dropped table id; otherwise compactor catalog acquire will fail. read_table_ids: {:?}, task: {}",
+        compact_table_ids,
+        compact_task_to_string(&compact_task),
+    );
+    let recovered_version = recovered_manager.get_current_version().await;
+    let recovered_group_levels = recovered_version.get_compaction_group_levels(compaction_group_id);
+    let recovered_ssts = recovered_group_levels
+        .l0
+        .sub_levels
+        .iter()
+        .chain(recovered_group_levels.levels.iter())
+        .flat_map(|level| level.table_infos.iter())
+        .collect_vec();
+    let stale_table_sst_ids = recovered_ssts
+        .iter()
+        .filter(|sst| sst.table_ids.contains(&stale_table_id))
+        .map(|sst| sst.sst_id)
+        .collect_vec();
+    assert!(
+        stale_table_sst_ids.is_empty(),
+        "recovered version should prune stale table ids from SST metadata: {:?}",
+        stale_table_sst_ids
+    );
+    let recovered_sst_ids = recovered_ssts.iter().map(|sst| sst.sst_id).collect_vec();
+    assert!(
+        !recovered_sst_ids.contains(&HummockSstableId::new(11)),
+        "SSTs whose table_ids become empty after pruning should be removed from the recovered version: {:?}",
+        recovered_sst_ids
+    );
 }
 
 /// Regression test: `try_merge_compaction_group` must return `Err` for groups

--- a/src/meta/src/hummock/manager/transaction.rs
+++ b/src/meta/src/hummock/manager/transaction.rs
@@ -197,7 +197,9 @@ impl<'a> HummockVersionTransaction<'a> {
                 .or_default()
                 .group_deltas;
 
-            group_deltas.push(GroupDelta::TruncateTables(table_ids.into_iter().collect()));
+            group_deltas.push(GroupDelta::PruneTableIdsFromSsts(
+                table_ids.into_iter().collect(),
+            ));
         }
 
         // update state table info

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -373,7 +373,6 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| {
             let sub_iters = vec![
                 ConcatSstableIterator::new(
-                    vec![0.into()],
                     level1.clone(),
                     KeyRange::inf(),
                     sstable_store.clone(),
@@ -381,7 +380,6 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
                     0,
                 ),
                 ConcatSstableIterator::new(
-                    vec![0.into()],
                     level2.clone(),
                     KeyRange::inf(),
                     sstable_store.clone(),
@@ -504,7 +502,6 @@ fn bench_drop_column_compaction_impl(c: &mut Criterion, column_num: usize) {
     let get_iter = || {
         let sub_iters = vec![
             ConcatSstableIterator::new(
-                vec![10.into(), 11.into()],
                 level1.clone(),
                 KeyRange::inf(),
                 sstable_store.clone(),
@@ -512,7 +509,6 @@ fn bench_drop_column_compaction_impl(c: &mut Criterion, column_num: usize) {
                 0,
             ),
             ConcatSstableIterator::new(
-                vec![10.into(), 11.into()],
                 level2.clone(),
                 KeyRange::inf(),
                 sstable_store.clone(),

--- a/src/storage/hummock_sdk/src/compact.rs
+++ b/src/storage/hummock_sdk/src/compact.rs
@@ -61,21 +61,17 @@ pub fn compact_task_to_string(compact_task: &CompactTask) -> String {
     )
     .unwrap();
     s.push_str("Input: \n");
-    let existing_table_ids: HashSet<TableId> =
-        compact_task.existing_table_ids.iter().copied().collect();
     let mut input_sst_table_ids: HashSet<TableId> = HashSet::new();
-    let mut dropped_table_ids = HashSet::new();
+    let mut dropped_only_sst_count = 0;
     for level_entry in &compact_task.input_ssts {
         let tables: Vec<String> = level_entry
             .table_infos
             .iter()
             .map(|table| {
-                for tid in &table.table_ids {
-                    if !existing_table_ids.contains(tid) {
-                        dropped_table_ids.insert(tid);
-                    } else {
-                        input_sst_table_ids.insert(*tid);
-                    }
+                if table.table_ids.is_empty() {
+                    dropped_only_sst_count += 1;
+                } else {
+                    input_sst_table_ids.extend(table.table_ids.iter().copied());
                 }
                 if table.total_key_count != 0 {
                     format!(
@@ -110,8 +106,13 @@ pub fn compact_task_to_string(compact_task: &CompactTask) -> String {
             });
     }
 
-    if !dropped_table_ids.is_empty() {
-        writeln!(s, "Dropped table_ids: {:?} ", dropped_table_ids).unwrap();
+    if dropped_only_sst_count > 0 {
+        writeln!(
+            s,
+            "Dropped-only input SST count: {:?} ",
+            dropped_only_sst_count
+        )
+        .unwrap();
     }
     s
 }
@@ -156,14 +157,11 @@ pub fn statistics_compact_task(task: &CompactTask) -> CompactTaskStatistics {
     let mut total_file_size = 0;
     let mut total_uncompressed_file_size = 0;
 
-    for level in &task.input_ssts {
-        total_file_count += level.table_infos.len() as u64;
-
-        level.table_infos.iter().for_each(|sst| {
-            total_file_size += sst.file_size;
-            total_uncompressed_file_size += sst.uncompressed_file_size;
-            total_key_count += sst.total_key_count;
-        });
+    for sst in task.read_input_ssts() {
+        total_file_count += 1;
+        total_file_size += sst.file_size;
+        total_uncompressed_file_size += sst.uncompressed_file_size;
+        total_key_count += sst.total_key_count;
     }
 
     CompactTaskStatistics {
@@ -204,15 +202,17 @@ pub fn estimate_memory_for_compact_task(
     for level in &task.input_ssts {
         if level.level_type == LevelType::Nonoverlapping {
             let mut cur_level_max_sst_meta_size = 0;
-            for sst in &level.table_infos {
+            for sst in level.read_sstable_infos() {
                 let meta_size = sst.file_size - sst.meta_offset;
                 task_max_sst_meta_ratio =
                     std::cmp::max(task_max_sst_meta_ratio, meta_size * 100 / sst.file_size);
                 cur_level_max_sst_meta_size = std::cmp::max(meta_size, cur_level_max_sst_meta_size);
             }
-            result += max_input_stream_estimated_memory + cur_level_max_sst_meta_size;
+            if cur_level_max_sst_meta_size > 0 {
+                result += max_input_stream_estimated_memory + cur_level_max_sst_meta_size;
+            }
         } else {
-            for sst in &level.table_infos {
+            for sst in level.read_sstable_infos() {
                 let meta_size = sst.file_size - sst.meta_offset;
                 result += max_input_stream_estimated_memory + meta_size;
                 task_max_sst_meta_ratio =

--- a/src/storage/hummock_sdk/src/compact_task.rs
+++ b/src/storage/hummock_sdk/src/compact_task.rs
@@ -171,15 +171,7 @@ impl CompactTask {
         if self.task_type == TaskType::VnodeWatermark {
             return true;
         }
-        let exist_table_ids =
-            HashSet::<TableId>::from_iter(self.existing_table_ids.iter().copied());
-        self.input_ssts.iter().all(|level| {
-            level.table_infos.iter().all(|sst| {
-                sst.table_ids
-                    .iter()
-                    .all(|table_id| !exist_table_ids.contains(table_id))
-            })
-        })
+        self.build_compact_table_ids().is_empty()
     }
 }
 
@@ -617,5 +609,32 @@ impl From<ReportTask> for PbReportTask {
                 .collect_vec(),
             object_timestamps: value.object_timestamps,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::TableId;
+
+    use super::CompactTask;
+    use crate::level::InputLevel;
+    use crate::sstable_info::{SstableInfo, SstableInfoInner};
+
+    #[test]
+    fn test_empty_sstable_table_ids_is_trivial_reclaim() {
+        let task = CompactTask {
+            input_ssts: vec![InputLevel {
+                table_infos: vec![SstableInfo::from(SstableInfoInner {
+                    table_ids: vec![],
+                    ..Default::default()
+                })],
+                ..Default::default()
+            }],
+            existing_table_ids: vec![TableId::new(1)],
+            ..Default::default()
+        };
+
+        assert!(task.build_compact_table_ids().is_empty());
+        assert!(task.is_trivial_reclaim());
     }
 }

--- a/src/storage/hummock_sdk/src/compact_task.rs
+++ b/src/storage/hummock_sdk/src/compact_task.rs
@@ -36,9 +36,8 @@ use crate::{CompactionGroupId, HummockSstableObjectId};
 pub struct CompactTask {
     /// SSTs selected by meta, which will be removed from LSM after compaction succeeds.
     ///
-    /// After meta-side task construction, each SST's `table_ids` is normalized to the live table
-    /// ids this task should read. An SST with empty `table_ids` is a dropped-only input kept here so
-    /// meta can remove it from the version without sending it through the compactor read path.
+    /// Each SST's `table_ids` comes from version metadata, where truncate/drop table deltas prune
+    /// table ids before later compaction tasks are picked.
     pub input_ssts: Vec<InputLevel>,
     /// In ideal case, the compaction will generate `splits.len()` tables which have key range
     /// corresponding to that in `splits`, respectively
@@ -59,8 +58,8 @@ pub struct CompactTask {
     pub compaction_group_version_id: u64,
     /// Table ids that still exist in the version when the compaction task is picked.
     ///
-    /// This may be broader than the table ids touched by this task's input SSTs. After meta-side
-    /// task construction, `input_ssts[*].table_ids` contains the task-local live table ids.
+    /// This may be broader than the table ids touched by this task's input SSTs. Task-local table
+    /// ids should be read from `input_ssts[*].table_ids`.
     pub existing_table_ids: Vec<TableId>,
     pub compression_algorithm: u32,
     pub target_file_size: u64,
@@ -255,9 +254,8 @@ impl CompactTask {
 
     /// Returns input SSTs that should be read by the compactor.
     ///
-    /// Dropped-only SST entries have empty `table_ids` after meta-side task construction. They are
-    /// still part of `input_ssts` so meta can remove them from the version, but they are not read by
-    /// the compactor.
+    /// SST entries with empty `table_ids` are ignored defensively and should not be read by the
+    /// compactor.
     pub fn read_input_ssts(&self) -> impl Iterator<Item = &SstableInfo> {
         self.input_ssts
             .iter()

--- a/src/storage/hummock_sdk/src/compact_task.rs
+++ b/src/storage/hummock_sdk/src/compact_task.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::mem::size_of;
 
 use itertools::Itertools;
@@ -34,7 +34,11 @@ use crate::{CompactionGroupId, HummockSstableObjectId};
 
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct CompactTask {
-    /// SSTs to be compacted, which will be removed from LSM after compaction
+    /// SSTs selected by meta, which will be removed from LSM after compaction succeeds.
+    ///
+    /// After meta-side task construction, each SST's `table_ids` is normalized to the live table
+    /// ids this task should read. An SST with empty `table_ids` is a dropped-only input kept here so
+    /// meta can remove it from the version without sending it through the compactor read path.
     pub input_ssts: Vec<InputLevel>,
     /// In ideal case, the compaction will generate `splits.len()` tables which have key range
     /// corresponding to that in `splits`, respectively
@@ -53,7 +57,10 @@ pub struct CompactTask {
     pub compaction_group_id: CompactionGroupId,
     /// compaction group id when the compaction task is created
     pub compaction_group_version_id: u64,
-    /// `existing_table_ids` for compaction drop key
+    /// Table ids that still exist in the version when the compaction task is picked.
+    ///
+    /// This may be broader than the table ids touched by this task's input SSTs. After meta-side
+    /// task construction, `input_ssts[*].table_ids` contains the task-local live table ids.
     pub existing_table_ids: Vec<TableId>,
     pub compression_algorithm: u32,
     pub target_file_size: u64,
@@ -166,12 +173,27 @@ impl CompactTask {
         false
     }
 
+    pub fn task_label(&self) -> &'static str {
+        if self.is_trivial_reclaim() {
+            return "trivial-space-reclaim";
+        }
+
+        if self.is_trivial_move_task() {
+            return "trivial-move";
+        }
+
+        "normal"
+    }
+
     pub fn is_trivial_reclaim(&self) -> bool {
         // Currently all VnodeWatermark tasks are trivial reclaim.
         if self.task_type == TaskType::VnodeWatermark {
             return true;
         }
-        self.build_compact_table_ids().is_empty()
+        self.input_ssts
+            .iter()
+            .flat_map(|level| level.table_infos.iter())
+            .all(|sst| sst.table_ids.is_empty())
     }
 }
 
@@ -185,36 +207,24 @@ impl CompactTask {
 
     // The compact task may need to reclaim key with range tombstone
     pub fn contains_range_tombstone(&self) -> bool {
-        self.input_ssts
-            .iter()
-            .flat_map(|level| level.table_infos.iter())
+        self.read_input_ssts()
             .any(|sst| sst.range_tombstone_count > 0)
     }
 
     // The compact task may need to reclaim key with split sst
     pub fn contains_split_sst(&self) -> bool {
-        self.input_ssts
-            .iter()
-            .flat_map(|level| level.table_infos.iter())
+        self.read_input_ssts()
             .any(|sst| sst.sst_id.as_raw_id() != sst.object_id.as_raw_id())
     }
 
+    /// Returns sorted and deduplicated table ids from this task's normalized input SST metadata.
     pub fn get_table_ids_from_input_ssts(&self) -> impl Iterator<Item = StateTableId> + use<> {
         self.input_ssts
             .iter()
             .flat_map(|level| level.table_infos.iter())
-            .flat_map(|sst| sst.table_ids.clone())
+            .flat_map(|sst| sst.table_ids.iter().copied())
             .sorted()
             .dedup()
-    }
-
-    // filter the table-id that in existing_table_ids with the table-id in compact-task
-    pub fn build_compact_table_ids(&self) -> Vec<StateTableId> {
-        let existing_table_ids: HashSet<TableId> =
-            HashSet::from_iter(self.existing_table_ids.clone());
-        self.get_table_ids_from_input_ssts()
-            .filter(|table_id| existing_table_ids.contains(table_id))
-            .collect()
     }
 
     pub fn is_expired(&self, compaction_group_version_id_expected: u64) -> bool {
@@ -228,9 +238,7 @@ impl CompactTask {
     /// Returns true if the total key count exceeds the configured threshold.
     pub fn should_use_block_based_filter(&self) -> bool {
         let kv_count = self
-            .input_ssts
-            .iter()
-            .flat_map(|level| level.table_infos.iter())
+            .read_input_ssts()
             .map(|sst| sst.total_key_count)
             .sum::<u64>();
 
@@ -242,7 +250,18 @@ impl CompactTask {
     /// The hint is only meaningful when all input SSTs belong to a single table.
     pub fn effective_max_vnode_key_range_bytes(&self) -> Option<usize> {
         let limit = self.max_vnode_key_range_bytes.filter(|&v| v > 0)? as usize;
-        (self.build_compact_table_ids().len() == 1).then_some(limit)
+        (self.get_table_ids_from_input_ssts().count() == 1).then_some(limit)
+    }
+
+    /// Returns input SSTs that should be read by the compactor.
+    ///
+    /// Dropped-only SST entries have empty `table_ids` after meta-side task construction. They are
+    /// still part of `input_ssts` so meta can remove them from the version, but they are not read by
+    /// the compactor.
+    pub fn read_input_ssts(&self) -> impl Iterator<Item = &SstableInfo> {
+        self.input_ssts
+            .iter()
+            .flat_map(|level| level.read_sstable_infos())
     }
 }
 
@@ -615,26 +634,132 @@ impl From<ReportTask> for PbReportTask {
 #[cfg(test)]
 mod tests {
     use risingwave_common::catalog::TableId;
+    use risingwave_pb::hummock::PbLevelType;
+    use risingwave_pb::hummock::compact_task::TaskType;
 
     use super::CompactTask;
     use crate::level::InputLevel;
     use crate::sstable_info::{SstableInfo, SstableInfoInner};
 
+    fn test_sstable(sst_id: u64, table_ids: Vec<TableId>) -> SstableInfo {
+        SstableInfo::from(SstableInfoInner {
+            object_id: sst_id.into(),
+            sst_id: sst_id.into(),
+            table_ids,
+            ..Default::default()
+        })
+    }
+
+    fn test_read_property_sstable(table_ids: Vec<TableId>) -> SstableInfo {
+        SstableInfo::from(SstableInfoInner {
+            object_id: 1.into(),
+            sst_id: 2.into(),
+            table_ids,
+            range_tombstone_count: 1,
+            total_key_count: 100,
+            ..Default::default()
+        })
+    }
+
     #[test]
-    fn test_empty_sstable_table_ids_is_trivial_reclaim() {
+    fn test_empty_table_ids_are_reclaim_and_have_no_input_table_ids() {
         let task = CompactTask {
             input_ssts: vec![InputLevel {
-                table_infos: vec![SstableInfo::from(SstableInfoInner {
-                    table_ids: vec![],
-                    ..Default::default()
-                })],
+                table_infos: vec![test_sstable(1, vec![])],
                 ..Default::default()
             }],
             existing_table_ids: vec![TableId::new(1)],
             ..Default::default()
         };
 
-        assert!(task.build_compact_table_ids().is_empty());
+        assert!(task.get_table_ids_from_input_ssts().next().is_none());
         assert!(task.is_trivial_reclaim());
+    }
+
+    #[test]
+    fn test_read_properties_ignore_empty_table_ids() {
+        let task = CompactTask {
+            input_ssts: vec![InputLevel {
+                table_infos: vec![
+                    test_read_property_sstable(vec![]),
+                    SstableInfo::from(SstableInfoInner {
+                        object_id: 3.into(),
+                        sst_id: 3.into(),
+                        table_ids: vec![TableId::new(1)],
+                        total_key_count: 1,
+                        ..Default::default()
+                    }),
+                ],
+                ..Default::default()
+            }],
+            max_kv_count_for_xor16: Some(10),
+            ..Default::default()
+        };
+
+        assert!(!task.contains_range_tombstone());
+        assert!(!task.contains_split_sst());
+        assert!(!task.should_use_block_based_filter());
+
+        let task = CompactTask {
+            input_ssts: vec![InputLevel {
+                table_infos: vec![test_read_property_sstable(vec![TableId::new(1)])],
+                ..Default::default()
+            }],
+            max_kv_count_for_xor16: Some(10),
+            ..Default::default()
+        };
+
+        assert!(task.contains_range_tombstone());
+        assert!(task.contains_split_sst());
+        assert!(task.should_use_block_based_filter());
+    }
+
+    #[test]
+    fn test_task_label_for_trivial_move_and_reclaim() {
+        let trivial_move_task = CompactTask {
+            input_ssts: vec![
+                InputLevel {
+                    level_idx: 1,
+                    level_type: PbLevelType::Nonoverlapping,
+                    table_infos: vec![
+                        test_sstable(10, vec![TableId::new(1)]),
+                        test_sstable(11, vec![]),
+                    ],
+                },
+                InputLevel {
+                    level_idx: 2,
+                    level_type: PbLevelType::Nonoverlapping,
+                    table_infos: vec![],
+                },
+            ],
+            target_level: 2,
+            task_type: TaskType::Dynamic,
+            ..Default::default()
+        };
+
+        assert!(!trivial_move_task.is_trivial_reclaim());
+        assert_eq!(trivial_move_task.task_label(), "trivial-move");
+
+        let trivial_reclaim_task = CompactTask {
+            input_ssts: vec![
+                InputLevel {
+                    level_idx: 1,
+                    level_type: PbLevelType::Nonoverlapping,
+                    table_infos: vec![test_sstable(10, vec![])],
+                },
+                InputLevel {
+                    level_idx: 2,
+                    level_type: PbLevelType::Nonoverlapping,
+                    table_infos: vec![],
+                },
+            ],
+            target_level: 2,
+            task_type: TaskType::Dynamic,
+            ..Default::default()
+        };
+
+        assert!(trivial_reclaim_task.is_trivial_reclaim());
+        assert!(trivial_reclaim_task.is_trivial_move_task());
+        assert_eq!(trivial_reclaim_task.task_label(), "trivial-space-reclaim");
     }
 }

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -412,7 +412,7 @@ impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
                     GroupDeltaCommon::GroupConstruct(_)
                     | GroupDeltaCommon::GroupDestroy(_)
                     | GroupDeltaCommon::GroupMerge(_)
-                    | GroupDeltaCommon::TruncateTables(_) => {}
+                    | GroupDeltaCommon::PruneTableIdsFromSsts(_) => {}
                 }
             }
 
@@ -617,13 +617,13 @@ impl<L: Clone> HummockVersionCommon<SstableInfo, L> {
                         self.levels.remove(compaction_group_id);
                     }
 
-                    GroupDeltaCommon::TruncateTables(table_ids) => {
+                    GroupDeltaCommon::PruneTableIdsFromSsts(table_ids) => {
                         self.levels
                             .get_mut(compaction_group_id)
                             .unwrap_or_else(|| {
                                 panic!("compaction group {} does not exist", compaction_group_id)
                             })
-                            .truncate_tables(table_ids);
+                            .prune_table_ids_from_ssts(table_ids);
                     }
                 }
             }
@@ -1079,11 +1079,11 @@ impl Levels {
         }
     }
 
-    /// Truncate specified table ids from all levels, remove emptied SSTs and sub-levels,
+    /// Prune specified table ids from all SST metadata, remove emptied SSTs and sub-levels,
     /// then bump `compaction_group_version_id`.
-    pub(crate) fn truncate_tables(&mut self, table_ids: &HashSet<TableId>) {
+    pub(crate) fn prune_table_ids_from_ssts(&mut self, table_ids: &HashSet<TableId>) {
         for level in self.l0.sub_levels.iter_mut().chain(self.levels.iter_mut()) {
-            level.truncate_tables(table_ids);
+            level.prune_table_ids_from_ssts(table_ids);
         }
         self.l0.normalize();
         self.compaction_group_version_id += 1;
@@ -1339,10 +1339,18 @@ impl Level {
         original_len != self.table_infos.len()
     }
 
-    /// Truncate specified `table_ids` from each SST's metadata,
+    /// Prune specified `table_ids` from each SST's metadata,
     /// remove SSTs that become empty, then recompute sizes.
-    fn truncate_tables(&mut self, table_ids: &HashSet<TableId>) {
+    fn prune_table_ids_from_ssts(&mut self, table_ids: &HashSet<TableId>) {
         for sstable_info in &mut self.table_infos {
+            if !sstable_info
+                .table_ids
+                .iter()
+                .any(|table_id| table_ids.contains(table_id))
+            {
+                continue;
+            }
+
             let mut inner = sstable_info.get_inner();
             inner.table_ids.retain(|id| !table_ids.contains(id));
             sstable_info.set_inner(inner);
@@ -2752,7 +2760,7 @@ mod tests {
     }
 
     #[test]
-    fn test_level_truncate_tables() {
+    fn test_level_prune_table_ids_from_ssts() {
         let mut level = Level {
             level_idx: 1,
             level_type: LevelType::Nonoverlapping,
@@ -2766,8 +2774,8 @@ mod tests {
             ..Default::default()
         };
 
-        let truncate_ids = HashSet::from([TableId::new(2)]);
-        level.truncate_tables(&truncate_ids);
+        let pruned_table_ids = HashSet::from([TableId::new(2)]);
+        level.prune_table_ids_from_ssts(&pruned_table_ids);
 
         // SST 3 should be removed (was only table_id=2)
         assert_eq!(level.table_infos.len(), 2);
@@ -2776,9 +2784,9 @@ mod tests {
         assert_eq!(level.total_file_size, 100 + 200);
         assert_eq!(level.uncompressed_file_size, 200 + 400);
 
-        // Truncate remaining tables → all SSTs removed.
-        let truncate_ids = HashSet::from([TableId::new(1), TableId::new(3)]);
-        level.truncate_tables(&truncate_ids);
+        // Prune remaining tables, so all SSTs are removed.
+        let pruned_table_ids = HashSet::from([TableId::new(1), TableId::new(3)]);
+        level.prune_table_ids_from_ssts(&pruned_table_ids);
         assert!(level.table_infos.is_empty());
         assert_eq!(level.total_file_size, 0);
         assert_eq!(level.uncompressed_file_size, 0);
@@ -2838,7 +2846,7 @@ mod tests {
     }
 
     #[test]
-    fn test_levels_truncate_tables() {
+    fn test_levels_prune_table_ids_from_ssts() {
         #[expect(deprecated)]
         let mut levels = Levels {
             l0: OverlappingLevel {
@@ -2885,8 +2893,8 @@ mod tests {
             compaction_group_version_id: 0,
         };
 
-        // Truncate table 10
-        levels.truncate_tables(&HashSet::from([TableId::new(10)]));
+        // Prune table 10 from SST metadata.
+        levels.prune_table_ids_from_ssts(&HashSet::from([TableId::new(10)]));
 
         assert_eq!(levels.l0.sub_levels.len(), 1);
         assert_eq!(levels.l0.sub_levels[0].sub_level_id, 1);
@@ -2911,7 +2919,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_version_delta_truncate_tables() {
+    fn test_apply_version_delta_prune_table_ids_from_ssts() {
         let mut version = HummockVersion {
             id: HummockVersionId::new(0),
             levels: HashMap::from_iter([(1.into(), {
@@ -2972,9 +2980,9 @@ mod tests {
             group_deltas: HashMap::from_iter([(
                 1.into(),
                 GroupDeltas {
-                    group_deltas: vec![GroupDelta::TruncateTables(HashSet::from([TableId::new(
-                        100,
-                    )]))],
+                    group_deltas: vec![GroupDelta::PruneTableIdsFromSsts(HashSet::from([
+                        TableId::new(100),
+                    ]))],
                 },
             )]),
             ..Default::default()
@@ -2992,15 +3000,10 @@ mod tests {
         assert_eq!(cg.l0.sub_levels[0].sub_level_id, 1);
         assert_eq!(cg.l0.sub_levels[0].table_infos.len(), 1);
         assert_eq!(2, cg.l0.sub_levels[0].table_infos[0].sst_id);
-        for sub_level in &cg.l0.sub_levels {
-            for sst in &sub_level.table_infos {
-                assert!(
-                    !sst.table_ids.is_empty(),
-                    "SST {} should not have empty table_ids",
-                    sst.sst_id
-                );
-            }
-        }
+        assert_eq!(
+            cg.l0.sub_levels[0].table_infos[0].table_ids,
+            vec![TableId::new(200)]
+        );
 
         assert_eq!(cg.l0.total_file_size, 60);
         assert_eq!(cg.l0.uncompressed_file_size, 120);

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -91,6 +91,49 @@ impl<L> HummockVersionCommon<SstableInfo, L> {
             .map(|s| s.sst_id)
     }
 
+    /// Prune stale table ids that no longer exist in `state_table_info` from SST metadata.
+    ///
+    /// This is used to normalize recovered versions from old clusters where dropped table ids
+    /// may still exist in persisted SST metadata.
+    pub fn prune_stale_table_ids_from_ssts(&mut self) -> usize {
+        let live_table_ids: HashSet<_> = self.state_table_info.info().keys().copied().collect();
+        // Older checkpoints may rely on deprecated `member_table_ids` before `state_table_info`
+        // is backfilled.
+        if live_table_ids.is_empty()
+            && self.levels.values().any(|levels| {
+                #[expect(deprecated)]
+                {
+                    !levels.member_table_ids.is_empty()
+                }
+            })
+        {
+            return 0;
+        }
+
+        let mut pruned_table_ids = HashSet::new();
+
+        for levels in self.levels.values_mut() {
+            let stale_table_ids = levels
+                .l0
+                .sub_levels
+                .iter()
+                .chain(levels.levels.iter())
+                .flat_map(|level| level.table_infos.iter())
+                .flat_map(|sst| sst.table_ids.iter().copied())
+                .filter(|table_id| !live_table_ids.contains(table_id))
+                .collect::<HashSet<_>>();
+
+            if stale_table_ids.is_empty() {
+                continue;
+            }
+
+            pruned_table_ids.extend(stale_table_ids.iter().copied());
+            levels.prune_table_ids_from_ssts(&stale_table_ids);
+        }
+
+        pruned_table_ids.len()
+    }
+
     pub fn level_iter<F: FnMut(&Level) -> bool>(
         &self,
         compaction_group_id: CompactionGroupId,
@@ -1579,7 +1622,9 @@ mod tests {
     use risingwave_common::catalog::TableId;
     use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::test_epoch;
-    use risingwave_pb::hummock::{CompactionConfig, GroupConstruct, GroupDestroy, LevelType};
+    use risingwave_pb::hummock::{
+        CompactionConfig, GroupConstruct, GroupDestroy, LevelType, StateTableInfo,
+    };
 
     use super::group_split;
     use crate::HummockVersionId;
@@ -1590,7 +1635,8 @@ mod tests {
     use crate::level::{Level, Levels, OverlappingLevel};
     use crate::sstable_info::{SstableInfo, SstableInfoInner};
     use crate::version::{
-        GroupDelta, GroupDeltas, HummockVersion, HummockVersionDelta, IntraLevelDelta,
+        GroupDelta, GroupDeltas, HummockVersion, HummockVersionDelta, HummockVersionStateTableInfo,
+        IntraLevelDelta,
     };
 
     fn gen_sstable_info(sst_id: u64, table_ids: Vec<u32>, epoch: u64) -> SstableInfo {
@@ -3018,6 +3064,114 @@ mod tests {
         assert_eq!(cg.levels[0].uncompressed_file_size, 160);
 
         assert_eq!(cg.compaction_group_version_id, 1);
+    }
+
+    #[test]
+    fn test_prune_stale_table_ids_from_ssts() {
+        let live_table_id = TableId::new(100);
+        let stale_table_id = TableId::new(200);
+        let mut version = HummockVersion {
+            id: HummockVersionId::new(0),
+            levels: HashMap::from_iter([(1.into(), {
+                #[expect(deprecated)]
+                let levels = Levels {
+                    l0: OverlappingLevel {
+                        sub_levels: vec![Level {
+                            level_idx: 0,
+                            level_type: LevelType::Overlapping,
+                            table_infos: vec![make_sst(
+                                1,
+                                vec![live_table_id.as_raw_id(), stale_table_id.as_raw_id()],
+                                50,
+                            )],
+                            total_file_size: 50,
+                            uncompressed_file_size: 100,
+                            sub_level_id: 1,
+                            ..Default::default()
+                        }],
+                        total_file_size: 50,
+                        uncompressed_file_size: 100,
+                    },
+                    levels: vec![Level {
+                        level_idx: 1,
+                        level_type: LevelType::Nonoverlapping,
+                        table_infos: vec![make_sst(2, vec![stale_table_id.as_raw_id()], 60)],
+                        total_file_size: 60,
+                        uncompressed_file_size: 120,
+                        ..Default::default()
+                    }],
+                    group_id: 1.into(),
+                    parent_group_id: 0.into(),
+                    member_table_ids: vec![],
+                    compaction_group_version_id: 0,
+                };
+                levels
+            })]),
+            state_table_info: HummockVersionStateTableInfo::from_protobuf_owned(
+                HashMap::from_iter([(
+                    live_table_id,
+                    StateTableInfo {
+                        committed_epoch: 1,
+                        compaction_group_id: 1.into(),
+                    },
+                )]),
+            ),
+            ..Default::default()
+        };
+
+        assert_eq!(version.prune_stale_table_ids_from_ssts(), 1);
+
+        let cg = version.get_compaction_group_levels(1.into());
+        assert_eq!(cg.l0.sub_levels.len(), 1);
+        assert_eq!(cg.l0.sub_levels[0].table_infos.len(), 1);
+        assert_eq!(cg.l0.sub_levels[0].table_infos[0].sst_id, 1);
+        assert_eq!(
+            cg.l0.sub_levels[0].table_infos[0].table_ids,
+            vec![live_table_id]
+        );
+        assert!(cg.levels[0].table_infos.is_empty());
+        assert_eq!(cg.compaction_group_version_id, 1);
+    }
+
+    #[test]
+    fn test_prune_stale_table_ids_from_ssts_skips_legacy_member_table_ids() {
+        let mut version = HummockVersion {
+            id: HummockVersionId::new(0),
+            levels: HashMap::from_iter([(1.into(), {
+                #[expect(deprecated)]
+                let levels = Levels {
+                    l0: OverlappingLevel {
+                        sub_levels: vec![Level {
+                            level_idx: 0,
+                            level_type: LevelType::Overlapping,
+                            table_infos: vec![make_sst(1, vec![100, 200], 50)],
+                            total_file_size: 50,
+                            uncompressed_file_size: 100,
+                            sub_level_id: 1,
+                            ..Default::default()
+                        }],
+                        total_file_size: 50,
+                        uncompressed_file_size: 100,
+                    },
+                    group_id: 1.into(),
+                    parent_group_id: 0.into(),
+                    member_table_ids: vec![100, 200],
+                    compaction_group_version_id: 0,
+                    ..Default::default()
+                };
+                levels
+            })]),
+            ..Default::default()
+        };
+
+        assert_eq!(version.prune_stale_table_ids_from_ssts(), 0);
+
+        let cg = version.get_compaction_group_levels(1.into());
+        assert_eq!(
+            cg.l0.sub_levels[0].table_infos[0].table_ids,
+            vec![TableId::new(100), TableId::new(200)]
+        );
+        assert_eq!(cg.compaction_group_version_id, 0);
     }
 
     #[test]

--- a/src/storage/hummock_sdk/src/level.rs
+++ b/src/storage/hummock_sdk/src/level.rs
@@ -379,6 +379,16 @@ impl InputLevel {
                 .map(|sst| sst.estimated_encode_len())
                 .sum::<usize>()
     }
+
+    /// Returns SSTs that should be read by a compact task.
+    ///
+    /// Empty `table_ids` marks a dropped-only SST that is kept in the task input only for version
+    /// removal.
+    pub fn read_sstable_infos(&self) -> impl Iterator<Item = &SstableInfo> {
+        self.table_infos
+            .iter()
+            .filter(|sst| !sst.table_ids.is_empty())
+    }
 }
 
 impl From<PbInputLevel> for InputLevel {

--- a/src/storage/hummock_sdk/src/level.rs
+++ b/src/storage/hummock_sdk/src/level.rs
@@ -382,8 +382,8 @@ impl InputLevel {
 
     /// Returns SSTs that should be read by a compact task.
     ///
-    /// Empty `table_ids` marks a dropped-only SST that is kept in the task input only for version
-    /// removal.
+    /// SST entries with empty `table_ids` are ignored defensively and should not be read by the
+    /// compactor.
     pub fn read_sstable_infos(&self) -> impl Iterator<Item = &SstableInfo> {
         self.table_infos
             .iter()

--- a/src/storage/hummock_sdk/src/version.rs
+++ b/src/storage/hummock_sdk/src/version.rs
@@ -686,7 +686,7 @@ impl<T> HummockVersionDeltaCommon<T> {
                         GroupDeltaCommon::GroupConstruct(_)
                         | GroupDeltaCommon::GroupDestroy(_)
                         | GroupDeltaCommon::GroupMerge(_)
-                        | GroupDeltaCommon::TruncateTables(_) => None,
+                        | GroupDeltaCommon::PruneTableIdsFromSsts(_) => None,
                     };
                     sst_slice.into_iter().flatten()
                 })
@@ -1014,7 +1014,10 @@ pub enum GroupDeltaCommon<T> {
     GroupConstruct(Box<PbGroupConstruct>),
     GroupDestroy(PbGroupDestroy),
     GroupMerge(PbGroupMerge),
-    TruncateTables(HashSet<TableId>),
+    /// Prunes table ids from SST metadata.
+    ///
+    /// Serialized as protobuf `truncate_tables` for compatibility.
+    PruneTableIdsFromSsts(HashSet<TableId>),
 }
 
 pub type GroupDelta = GroupDeltaCommon<SstableInfo>;
@@ -1045,7 +1048,9 @@ where
                     .collect(),
             ),
             Some(PbDeltaType::TruncateTables(pb_truncate_tables)) => {
-                GroupDeltaCommon::TruncateTables(pb_truncate_tables.table_ids.into_iter().collect())
+                GroupDeltaCommon::PruneTableIdsFromSsts(
+                    pb_truncate_tables.table_ids.into_iter().collect(),
+                )
             }
 
             None => panic!("delta_type is not set"),
@@ -1079,7 +1084,7 @@ where
                         .collect(),
                 })),
             },
-            GroupDeltaCommon::TruncateTables(table_ids) => PbGroupDelta {
+            GroupDeltaCommon::PruneTableIdsFromSsts(table_ids) => PbGroupDelta {
                 delta_type: Some(PbDeltaType::TruncateTables(PbTruncateTables {
                     table_ids: table_ids.iter().copied().collect(),
                 })),
@@ -1111,7 +1116,7 @@ where
                     inserted_table_infos: new_sub_level.iter().map(PbSstableInfo::from).collect(),
                 })),
             },
-            GroupDeltaCommon::TruncateTables(table_ids) => PbGroupDelta {
+            GroupDeltaCommon::PruneTableIdsFromSsts(table_ids) => PbGroupDelta {
                 delta_type: Some(PbDeltaType::TruncateTables(PbTruncateTables {
                     table_ids: table_ids.iter().copied().collect(),
                 })),
@@ -1146,7 +1151,7 @@ where
                     .collect(),
             ),
             Some(PbDeltaType::TruncateTables(pb_truncate_tables)) => {
-                GroupDeltaCommon::TruncateTables(
+                GroupDeltaCommon::PruneTableIdsFromSsts(
                     pb_truncate_tables.table_ids.iter().copied().collect(),
                 )
             }

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -584,15 +584,18 @@ pub(crate) mod tests {
         let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
 
-        // assert compact_task
-        assert_eq!(
-            compact_task
-                .input_ssts
+        // The dropped table has already been pruned from version SST metadata before task picking.
+        let compact_input_ssts = compact_task
+            .input_ssts
+            .iter()
+            .filter(|level| level.level_idx != compact_task.target_level)
+            .flat_map(|level| level.table_infos.iter())
+            .collect_vec();
+        assert_eq!(compact_input_ssts.len(), kv_count / 2);
+        assert!(
+            compact_input_ssts
                 .iter()
-                .filter(|level| level.level_idx != compact_task.target_level)
-                .map(|level| level.table_infos.len())
-                .sum::<usize>(),
-            kv_count
+                .all(|sst| sst.table_ids == vec![existing_table_id])
         );
 
         // 4. compact

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -1368,6 +1368,13 @@ pub(crate) mod tests {
         output.sst_info.sst_info
     }
 
+    fn with_table_ids(mut sst: SstableInfo, table_ids: Vec<TableId>) -> SstableInfo {
+        let mut inner = sst.get_inner();
+        inner.table_ids = table_ids;
+        sst.set_inner(inner);
+        sst
+    }
+
     async fn test_fast_compact_impl(data: Vec<Vec<KeyValue>>) {
         let (env, hummock_manager_ref, cluster_ctl_ref, worker_id) = setup_compute_env(8080).await;
         let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
@@ -2400,15 +2407,15 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_fast_compactor_existing_table_ids_filter_in_rest_stage() {
+    async fn test_fast_compactor_input_table_ids_filter_in_rest_stage() {
         let (env, hummock_manager_ref, cluster_ctl_ref, worker_id) = setup_compute_env(8080).await;
         let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
             hummock_manager_ref.clone(),
             worker_id,
         ));
 
-        let existing_table_id = TableId::new(1);
-        let filtered_table_id = TableId::new(2);
+        let read_table_id = TableId::new(1);
+        let dropped_table_id = TableId::new(2);
 
         let storage = get_hummock_storage(
             hummock_meta_client.clone(),
@@ -2420,14 +2427,15 @@ pub(crate) mod tests {
             )
             .await,
             &hummock_manager_ref,
-            &[existing_table_id, filtered_table_id],
+            &[read_table_id, dropped_table_id],
         )
         .await;
 
         hummock_manager_ref.get_new_object_ids(10).await.unwrap();
         let compact_ctx = get_compactor_context(&storage);
-        let compaction_catalog_agent_ref =
-            CompactionCatalogAgent::for_test(vec![existing_table_id, filtered_table_id]);
+        let build_catalog_agent_ref =
+            CompactionCatalogAgent::for_test(vec![read_table_id, dropped_table_id]);
+        let compaction_catalog_agent_ref = CompactionCatalogAgent::for_test(vec![read_table_id]);
 
         let sstable_store = compact_ctx.sstable_store.clone();
         let options = SstableBuilderOptions {
@@ -2445,25 +2453,17 @@ pub(crate) mod tests {
             vec![
                 vec![
                     (
-                        FullKey::new(
-                            existing_table_id,
-                            TableKey(b"a-left".to_vec()),
-                            test_epoch(100),
-                        ),
+                        FullKey::new(read_table_id, TableKey(b"a-left".to_vec()), test_epoch(100)),
                         HummockValue::put(b"a-left-value".to_vec()),
                     ),
                     (
-                        FullKey::new(
-                            existing_table_id,
-                            TableKey(b"c-left".to_vec()),
-                            test_epoch(100),
-                        ),
+                        FullKey::new(read_table_id, TableKey(b"c-left".to_vec()), test_epoch(100)),
                         HummockValue::put(b"c-left-value".to_vec()),
                     ),
                 ],
                 vec![(
                     FullKey::new(
-                        filtered_table_id,
+                        dropped_table_id,
                         TableKey(b"skip-me".to_vec()),
                         test_epoch(100),
                     ),
@@ -2472,14 +2472,17 @@ pub(crate) mod tests {
             ],
             options.clone(),
             sstable_store.clone(),
-            compaction_catalog_agent_ref.clone(),
+            build_catalog_agent_ref.clone(),
         )
         .await;
+        // Simulate meta-side task normalization: physical blocks still include the dropped table,
+        // while task input metadata exposes only readable table ids.
+        let sst = with_table_ids(sst, vec![read_table_id]);
         let right_sst = build_test_sstable_with_blocks(
             2,
             vec![vec![(
                 FullKey::new(
-                    existing_table_id,
+                    read_table_id,
                     TableKey(b"b-right".to_vec()),
                     test_epoch(100),
                 ),
@@ -2487,7 +2490,7 @@ pub(crate) mod tests {
             )]],
             options,
             sstable_store.clone(),
-            compaction_catalog_agent_ref.clone(),
+            build_catalog_agent_ref.clone(),
         )
         .await;
 
@@ -2504,7 +2507,7 @@ pub(crate) mod tests {
                     table_infos: vec![right_sst],
                 },
             ],
-            existing_table_ids: vec![existing_table_id],
+            existing_table_ids: vec![read_table_id],
             task_id: 1,
             splits: vec![KeyRange::inf()],
             target_level: 6,
@@ -2521,15 +2524,15 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_fast_compactor_existing_table_ids_filter_in_merge_raw_copy_stage() {
+    async fn test_fast_compactor_input_table_ids_filter_in_merge_raw_copy_stage() {
         let (env, hummock_manager_ref, cluster_ctl_ref, worker_id) = setup_compute_env(8080).await;
         let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
             hummock_manager_ref.clone(),
             worker_id,
         ));
 
-        let filtered_table_id = TableId::new(1);
-        let existing_table_id = TableId::new(2);
+        let dropped_table_id = TableId::new(1);
+        let read_table_id = TableId::new(2);
         let storage = get_hummock_storage(
             hummock_meta_client.clone(),
             get_notification_client_for_test(
@@ -2540,14 +2543,15 @@ pub(crate) mod tests {
             )
             .await,
             &hummock_manager_ref,
-            &[filtered_table_id, existing_table_id],
+            &[dropped_table_id, read_table_id],
         )
         .await;
 
         hummock_manager_ref.get_new_object_ids(10).await.unwrap();
         let compact_ctx = get_compactor_context(&storage);
-        let compaction_catalog_agent_ref =
-            CompactionCatalogAgent::for_test(vec![filtered_table_id, existing_table_id]);
+        let build_catalog_agent_ref =
+            CompactionCatalogAgent::for_test(vec![dropped_table_id, read_table_id]);
+        let compaction_catalog_agent_ref = CompactionCatalogAgent::for_test(vec![read_table_id]);
 
         let sstable_store = compact_ctx.sstable_store.clone();
         let options = SstableBuilderOptions {
@@ -2565,39 +2569,34 @@ pub(crate) mod tests {
             vec![
                 vec![(
                     FullKey::new(
-                        filtered_table_id,
+                        dropped_table_id,
                         TableKey(b"filtered".to_vec()),
                         test_epoch(200),
                     ),
                     HummockValue::put(b"filtered-value".to_vec()),
                 )],
                 vec![(
-                    FullKey::new(
-                        existing_table_id,
-                        TableKey(b"left".to_vec()),
-                        test_epoch(200),
-                    ),
+                    FullKey::new(read_table_id, TableKey(b"left".to_vec()), test_epoch(200)),
                     HummockValue::put(b"left-value".to_vec()),
                 )],
             ],
             options.clone(),
             sstable_store.clone(),
-            compaction_catalog_agent_ref.clone(),
+            build_catalog_agent_ref.clone(),
         )
         .await;
+        // Simulate meta-side task normalization: physical blocks still include the dropped table,
+        // while task input metadata exposes only readable table ids.
+        let left_sst = with_table_ids(left_sst, vec![read_table_id]);
         let right_sst = build_test_sstable_with_blocks(
             2,
             vec![vec![(
-                FullKey::new(
-                    existing_table_id,
-                    TableKey(b"right".to_vec()),
-                    test_epoch(100),
-                ),
+                FullKey::new(read_table_id, TableKey(b"right".to_vec()), test_epoch(100)),
                 HummockValue::put(b"right-value".to_vec()),
             )]],
             options,
             sstable_store.clone(),
-            compaction_catalog_agent_ref.clone(),
+            build_catalog_agent_ref.clone(),
         )
         .await;
 
@@ -2614,7 +2613,7 @@ pub(crate) mod tests {
                     table_infos: vec![right_sst],
                 },
             ],
-            existing_table_ids: vec![existing_table_id],
+            existing_table_ids: vec![read_table_id],
             task_id: 1,
             splits: vec![KeyRange::inf()],
             target_level: 6,

--- a/src/storage/src/hummock/compactor/compaction_filter.rs
+++ b/src/storage/src/hummock/compactor/compaction_filter.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use dyn_clone::DynClone;
 use risingwave_common::catalog::TableId;
@@ -30,35 +30,6 @@ dyn_clone::clone_trait_object!(CompactionFilter);
 pub struct DummyCompactionFilter;
 
 impl CompactionFilter for DummyCompactionFilter {}
-
-#[derive(Clone)]
-pub struct StateCleanUpCompactionFilter {
-    existing_table_ids: HashSet<TableId>,
-    last_table: Option<(TableId, bool)>,
-}
-
-impl StateCleanUpCompactionFilter {
-    pub fn new(table_id_set: HashSet<TableId>) -> Self {
-        StateCleanUpCompactionFilter {
-            existing_table_ids: table_id_set,
-            last_table: None,
-        }
-    }
-}
-
-impl CompactionFilter for StateCleanUpCompactionFilter {
-    fn should_delete(&mut self, key: FullKey<&[u8]>) -> bool {
-        let table_id = key.user_key.table_id;
-        if let Some((last_table_id, removed)) = self.last_table.as_ref()
-            && *last_table_id == table_id
-        {
-            return *removed;
-        }
-        let removed = !self.existing_table_ids.contains(&table_id);
-        self.last_table = Some((table_id, removed));
-        removed
-    }
-}
 
 #[derive(Clone)]
 pub struct TtlCompactionFilter {

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use std::ops::Bound;
 use std::sync::Arc;
@@ -23,7 +23,6 @@ use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::constants::hummock::CompactionFilterFlag;
 use risingwave_hummock_sdk::compact_task::CompactTask;
-use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
@@ -36,8 +35,7 @@ use tokio::time::Instant;
 pub use super::context::CompactorContext;
 use crate::compaction_catalog_manager::CompactionCatalogAgentRef;
 use crate::hummock::compactor::{
-    ConcatSstableIterator, MultiCompactionFilter, StateCleanUpCompactionFilter, TaskProgress,
-    TtlCompactionFilter,
+    ConcatSstableIterator, MultiCompactionFilter, TaskProgress, TtlCompactionFilter,
 };
 use crate::hummock::iterator::{
     Forward, HummockIterator, MergeIterator, NonPkPrefixSkipWatermarkIterator,
@@ -125,10 +123,6 @@ pub struct TaskConfig {
     pub(crate) cache_policy: CachePolicy,
     pub(crate) gc_delete_keys: bool,
     pub(crate) retain_multiple_version: bool,
-    /// `stats_target_table_ids` decides whether a dropped key should be counted as table stats
-    /// change. For an divided SST as input, a dropped key shouldn't be counted if its table id
-    /// doesn't belong to this divided SST. See `Compactor::compact_and_build_sst`.
-    pub(crate) stats_target_table_ids: Option<HashSet<TableId>>,
     pub(crate) use_block_based_filter: bool,
 
     pub(crate) table_vnode_partition: BTreeMap<TableId, u32>,
@@ -154,7 +148,6 @@ impl TaskConfig {
             cache_policy,
             gc_delete_keys,
             retain_multiple_version: false,
-            stats_target_table_ids: None,
             use_block_based_filter,
             table_vnode_partition: BTreeMap::default(),
             table_schemas,
@@ -173,13 +166,8 @@ pub fn build_multi_compaction_filter(compact_task: &CompactTask) -> MultiCompact
     let mut multi_filter = MultiCompactionFilter::default();
     let compaction_filter_flag =
         CompactionFilterFlag::from_bits(compact_task.compaction_filter_mask).unwrap_or_default();
-    if compaction_filter_flag.contains(CompactionFilterFlag::STATE_CLEAN) {
-        let state_clean_up_filter = Box::new(StateCleanUpCompactionFilter::new(
-            HashSet::from_iter(compact_task.existing_table_ids.clone()),
-        ));
-
-        multi_filter.register(state_clean_up_filter);
-    }
+    // STATE_CLEAN is handled by compact-task table-id normalization and iterator-level block
+    // pruning. Keep the flag as a no-op here for compatibility with existing task configs.
 
     if compaction_filter_flag.contains(CompactionFilterFlag::TTL) {
         let id_to_ttl = compact_task
@@ -203,7 +191,7 @@ pub fn build_multi_compaction_filter(compact_task: &CompactTask) -> MultiCompact
 }
 
 fn generate_splits_fast(
-    sstable_infos: &Vec<SstableInfo>,
+    sstable_infos: &[&SstableInfo],
     compaction_size: u64,
     context: &CompactorContext,
     max_sub_compaction: u32,
@@ -258,7 +246,7 @@ fn generate_splits_fast(
 }
 
 pub async fn generate_splits(
-    sstable_infos: &Vec<SstableInfo>,
+    sstable_infos: &[&SstableInfo],
     compaction_size: u64,
     context: &CompactorContext,
     max_sub_compaction: u32,
@@ -276,25 +264,19 @@ pub async fn generate_splits(
         let mut indexes = vec![];
         // preload the meta and get the smallest key to split sub_compaction
         for sstable_info in sstable_infos {
-            indexes.extend(
-                context
-                    .sstable_store
-                    .sstable(sstable_info, &mut StoreLocalStatistic::default())
-                    .await?
-                    .meta
-                    .block_metas
-                    .iter()
-                    .map(|block| {
-                        let data_size = block.len;
-                        let full_key = FullKey {
-                            user_key: FullKey::decode(&block.smallest_key).user_key,
-                            epoch_with_gap: EpochWithGap::new_max_epoch(),
-                        }
-                        .encode();
-                        (data_size as u64, full_key)
-                    })
-                    .collect_vec(),
-            );
+            let sstable = context
+                .sstable_store
+                .sstable(sstable_info, &mut StoreLocalStatistic::default())
+                .await?;
+            indexes.extend(sstable.meta.block_metas.iter().map(|block| {
+                let data_size = block.len;
+                let full_key = FullKey {
+                    user_key: FullKey::decode(&block.smallest_key).user_key,
+                    epoch_with_gap: EpochWithGap::new_max_epoch(),
+                }
+                .encode();
+                (data_size as u64, full_key)
+            }));
         }
         // sort by key, as for every data block has the same size;
         indexes.sort_by(|a, b| KeyComparator::compare_encoded_full_key(a.1.as_ref(), b.1.as_ref()));
@@ -339,9 +321,7 @@ pub async fn generate_splits(
 pub fn estimate_task_output_capacity(context: CompactorContext, task: &CompactTask) -> usize {
     let max_target_file_size = context.storage_opts.sstable_size_mb as usize * (1 << 20);
     let total_input_uncompressed_file_size = task
-        .input_ssts
-        .iter()
-        .flat_map(|level| level.table_infos.iter())
+        .read_input_ssts()
         .map(|table| table.uncompressed_file_size)
         .sum::<u64>();
 
@@ -355,40 +335,32 @@ pub async fn check_compaction_result(
     context: CompactorContext,
     compaction_catalog_agent_ref: CompactionCatalogAgentRef,
 ) -> HummockResult<bool> {
-    let mut table_ids_from_input_ssts = compact_task.get_table_ids_from_input_ssts();
-    let need_clean_state_table = table_ids_from_input_ssts
-        .any(|table_id| !compact_task.existing_table_ids.contains(&table_id));
     // This check method does not consider dropped keys by compaction filter.
-    if compact_task.contains_ttl() || need_clean_state_table {
+    if compact_task.contains_ttl() {
         return Ok(true);
     }
 
     let mut table_iters = Vec::new();
 
-    let compact_table_ids = compact_task.build_compact_table_ids();
-
     for level in &compact_task.input_ssts {
-        if level.table_infos.is_empty() {
-            continue;
-        }
-
-        // Do not need to filter the table because manager has done it.
         if level.level_type == PbLevelType::Nonoverlapping {
-            debug_assert!(can_concat(&level.table_infos));
+            let tables = level.read_sstable_infos().cloned().collect_vec();
+            if tables.is_empty() {
+                continue;
+            }
+            debug_assert!(can_concat(&tables));
 
             table_iters.push(ConcatSstableIterator::new(
-                compact_table_ids.clone(),
-                level.table_infos.clone(),
+                tables,
                 KeyRange::inf(),
                 context.sstable_store.clone(),
                 Arc::new(TaskProgress::default()),
                 context.storage_opts.compactor_iter_max_io_retry_times,
             ));
         } else {
-            for table_info in &level.table_infos {
+            for table_info in level.read_sstable_infos().cloned() {
                 table_iters.push(ConcatSstableIterator::new(
-                    compact_table_ids.clone(),
-                    vec![table_info.clone()],
+                    vec![table_info],
                     KeyRange::inf(),
                     context.sstable_store.clone(),
                     Arc::new(TaskProgress::default()),
@@ -424,7 +396,6 @@ pub async fn check_compaction_result(
         )
     };
     let iter = ConcatSstableIterator::new(
-        compact_table_ids.clone(),
         compact_task.sorted_output_ssts.clone(),
         KeyRange::inf(),
         context.sstable_store.clone(),
@@ -461,13 +432,11 @@ pub async fn check_compaction_result(
 
 pub async fn check_flush_result<I: HummockIterator<Direction = Forward>>(
     left_iter: UserIterator<I>,
-    existing_table_ids: Vec<StateTableId>,
     sort_ssts: Vec<SstableInfo>,
     context: CompactorContext,
 ) -> HummockResult<bool> {
     let iter = ConcatSstableIterator::new(
-        existing_table_ids.clone(),
-        sort_ssts.clone(),
+        sort_ssts,
         KeyRange::inf(),
         context.sstable_store.clone(),
         Arc::new(TaskProgress::default()),
@@ -537,43 +506,31 @@ async fn check_result<
 }
 
 pub fn optimize_by_copy_block(compact_task: &CompactTask, context: &CompactorContext) -> bool {
-    let task_input = build_compact_task_input_ssts(compact_task);
-    optimize_by_copy_block_with_input(compact_task, context, &task_input)
-}
-
-struct CompactTaskInputSsts {
-    sstable_infos: Vec<SstableInfo>,
-    compaction_size: u64,
+    let input_ssts = compact_task.read_input_ssts().collect_vec();
+    let compaction_size = input_ssts_size(&input_ssts);
+    optimize_by_copy_block_with_input(compact_task, context, &input_ssts, compaction_size)
 }
 
 fn optimize_by_copy_block_with_input(
     compact_task: &CompactTask,
     context: &CompactorContext,
-    task_input: &CompactTaskInputSsts,
+    input_ssts: &[&SstableInfo],
+    compaction_size: u64,
 ) -> bool {
-    let all_ssts_are_blocked_filter = task_input
-        .sstable_infos
+    let all_ssts_are_blocked_filter = input_ssts
         .iter()
         .all(|table_info| table_info.bloom_filter_kind == BloomFilterType::Blocked);
 
-    let delete_key_count = task_input
-        .sstable_infos
+    let delete_key_count = input_ssts
         .iter()
         .map(|table_info| table_info.stale_key_count + table_info.range_tombstone_count)
         .sum::<u64>();
-    let total_key_count = task_input
-        .sstable_infos
+    let total_key_count = input_ssts
         .iter()
         .map(|table_info| table_info.total_key_count)
         .sum::<u64>();
 
-    let input_table_ids: HashSet<TableId> = HashSet::from_iter(
-        task_input
-            .sstable_infos
-            .iter()
-            .flat_map(|sst| sst.table_ids.clone()),
-    );
-    let single_table = input_table_ids.len() == 1;
+    let single_table = compact_task.get_table_ids_from_input_ssts().count() == 1;
     context.storage_opts.enable_fast_compaction
         && all_ssts_are_blocked_filter
         && !compact_task.contains_range_tombstone()
@@ -582,7 +539,7 @@ fn optimize_by_copy_block_with_input(
         && single_table
         && compact_task.target_level > 0
         && compact_task.input_ssts.len() == 2
-        && task_input.compaction_size < context.storage_opts.compactor_fast_max_compact_task_size
+        && compaction_size < context.storage_opts.compactor_fast_max_compact_task_size
         && delete_key_count * 100
             < context.storage_opts.compactor_fast_max_compact_delete_ratio as u64 * total_key_count
         && compact_task.task_type == PbTaskType::Dynamic
@@ -593,12 +550,13 @@ pub async fn generate_splits_for_task(
     context: &CompactorContext,
     optimize_by_copy_block: bool,
 ) -> HummockResult<()> {
-    let task_input = build_compact_task_input_ssts(compact_task);
+    let input_ssts = compact_task.read_input_ssts().collect_vec();
+    let compaction_size = input_ssts_size(&input_ssts);
 
     if !optimize_by_copy_block {
         let splits = generate_splits(
-            &task_input.sstable_infos,
-            task_input.compaction_size,
+            &input_ssts,
+            compaction_size,
             context,
             compact_task.max_sub_compaction,
         )
@@ -615,22 +573,22 @@ pub async fn generate_splits_for_task(
 pub fn metrics_report_for_task(compact_task: &CompactTask, context: &CompactorContext) {
     let group_label = compact_task.compaction_group_id.to_string();
     let cur_level_label = compact_task.input_ssts[0].level_idx.to_string();
-    let select_table_infos = compact_task
-        .input_ssts
-        .iter()
-        .filter(|level| level.level_idx != compact_task.target_level)
-        .flat_map(|level| level.table_infos.iter())
-        .collect_vec();
-    let target_table_infos = compact_task
-        .input_ssts
-        .iter()
-        .filter(|level| level.level_idx == compact_task.target_level)
-        .flat_map(|level| level.table_infos.iter())
-        .collect_vec();
-    let select_size = select_table_infos
-        .iter()
-        .map(|table| table.sst_size)
-        .sum::<u64>();
+
+    let (select_size, select_count) = read_sstable_size_and_count(
+        compact_task
+            .input_ssts
+            .iter()
+            .filter(|level| level.level_idx != compact_task.target_level)
+            .flat_map(|level| level.read_sstable_infos()),
+    );
+    let (target_level_read_bytes, target_count) = read_sstable_size_and_count(
+        compact_task
+            .input_ssts
+            .iter()
+            .filter(|level| level.level_idx == compact_task.target_level)
+            .flat_map(|level| level.read_sstable_infos()),
+    );
+
     context
         .compactor_metrics
         .compact_read_current_level
@@ -640,9 +598,8 @@ pub fn metrics_report_for_task(compact_task: &CompactTask, context: &CompactorCo
         .compactor_metrics
         .compact_read_sstn_current_level
         .with_label_values(&[&group_label, &cur_level_label])
-        .inc_by(select_table_infos.len() as u64);
+        .inc_by(select_count as u64);
 
-    let target_level_read_bytes = target_table_infos.iter().map(|t| t.sst_size).sum::<u64>();
     let next_level_label = compact_task.target_level.to_string();
     context
         .compactor_metrics
@@ -653,13 +610,24 @@ pub fn metrics_report_for_task(compact_task: &CompactTask, context: &CompactorCo
         .compactor_metrics
         .compact_read_sstn_next_level
         .with_label_values(&[&group_label, &next_level_label])
-        .inc_by(target_table_infos.len() as u64);
+        .inc_by(target_count as u64);
+}
+
+fn read_sstable_size_and_count<'a>(
+    sstable_infos: impl IntoIterator<Item = &'a SstableInfo>,
+) -> (u64, usize) {
+    sstable_infos
+        .into_iter()
+        .fold((0, 0), |(size, count), table_info| {
+            (size + table_info.sst_size, count + 1)
+        })
 }
 
 pub fn calculate_task_parallelism(compact_task: &CompactTask, context: &CompactorContext) -> usize {
-    let task_input = build_compact_task_input_ssts(compact_task);
+    let input_ssts = compact_task.read_input_ssts().collect_vec();
+    let compaction_size = input_ssts_size(&input_ssts);
     let optimize_by_copy_block =
-        optimize_by_copy_block_with_input(compact_task, context, &task_input);
+        optimize_by_copy_block_with_input(compact_task, context, &input_ssts, compaction_size);
 
     if optimize_by_copy_block {
         return 1;
@@ -669,34 +637,16 @@ pub fn calculate_task_parallelism(compact_task: &CompactTask, context: &Compacto
     calculate_task_parallelism_impl(
         context.compaction_executor.worker_num(),
         parallel_compact_size,
-        task_input.compaction_size,
+        compaction_size,
         compact_task.max_sub_compaction,
     )
 }
 
-fn build_compact_task_input_ssts(compact_task: &CompactTask) -> CompactTaskInputSsts {
-    let compact_table_ids = compact_task.build_compact_table_ids();
-    let compact_table_id_set: HashSet<_> = compact_table_ids.iter().copied().collect();
-    let sstable_infos = compact_task
-        .input_ssts
-        .iter()
-        .flat_map(|level| level.table_infos.iter())
-        .filter(|table_info| {
-            table_info
-                .table_ids
-                .iter()
-                .any(|table_id| compact_table_id_set.contains(table_id))
-        })
-        .cloned()
-        .collect_vec();
-    let compaction_size = sstable_infos
+fn input_ssts_size(input_ssts: &[&SstableInfo]) -> u64 {
+    input_ssts
         .iter()
         .map(|table_info| table_info.sst_size)
-        .sum();
-    CompactTaskInputSsts {
-        sstable_infos,
-        compaction_size,
-    }
+        .sum()
 }
 
 pub fn calculate_task_parallelism_impl(

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -97,7 +97,6 @@ impl CompactorRunner {
             right: task.splits[split_index].right.clone(),
             right_exclusive: true,
         };
-
         let compactor = Compactor::new(
             context.clone(),
             options,
@@ -106,7 +105,6 @@ impl CompactorRunner {
                 cache_policy: CachePolicy::NotFill,
                 gc_delete_keys: task.gc_delete_keys,
                 retain_multiple_version: false,
-                stats_target_table_ids: Some(HashSet::from_iter(task.existing_table_ids.clone())),
                 use_block_based_filter,
                 table_vnode_partition: task.table_vnode_partition.clone(),
                 table_schemas: task
@@ -162,31 +160,20 @@ impl CompactorRunner {
             .storage_opts
             .compactor_iter_max_io_retry_times;
         let mut table_iters = Vec::new();
-        let compact_table_ids = self.compact_task.build_compact_table_ids();
 
         for level in &self.compact_task.input_ssts {
-            if level.table_infos.is_empty() {
+            let tables = level
+                .read_sstable_infos()
+                .filter(|table_info| self.key_range.full_key_overlap(&table_info.key_range))
+                .cloned()
+                .collect_vec();
+            if tables.is_empty() {
                 continue;
             }
 
-            let tables = level
-                .table_infos
-                .iter()
-                .filter(|table_info| {
-                    let table_ids = &table_info.table_ids;
-                    let exist_table = table_ids
-                        .iter()
-                        .any(|table_id| compact_table_ids.contains(table_id));
-
-                    self.key_range.full_key_overlap(&table_info.key_range) && exist_table
-                })
-                .cloned()
-                .collect_vec();
-            // Do not need to filter the table because manager has done it.
             if level.level_type == LevelType::Nonoverlapping {
-                debug_assert!(can_concat(&level.table_infos));
+                debug_assert!(can_concat(&tables));
                 table_iters.push(ConcatSstableIterator::new(
-                    compact_table_ids.clone(),
                     tables,
                     self.compactor.task_config.key_range.clone(),
                     self.sstable_store.clone(),
@@ -203,7 +190,7 @@ impl CompactorRunner {
                 let sst_groups = partition_overlapping_sstable_infos(tables);
                 tracing::warn!(
                     "COMPACT A LARGE OVERLAPPING LEVEL: try to partition {} ssts with {} groups",
-                    level.table_infos.len(),
+                    sst_groups.iter().map(Vec::len).sum::<usize>(),
                     sst_groups.len()
                 );
                 for (idx, table_infos) in sst_groups.into_iter().enumerate() {
@@ -215,7 +202,6 @@ impl CompactorRunner {
                         table_infos
                     );
                     table_iters.push(ConcatSstableIterator::new(
-                        compact_table_ids.clone(),
                         table_infos,
                         self.compactor.task_config.key_range.clone(),
                         self.sstable_store.clone(),
@@ -226,7 +212,6 @@ impl CompactorRunner {
             } else {
                 for table_info in tables {
                     table_iters.push(ConcatSstableIterator::new(
-                        compact_table_ids.clone(),
                         vec![table_info],
                         self.compactor.task_config.key_range.clone(),
                         self.sstable_store.clone(),
@@ -588,7 +573,7 @@ pub async fn compact_with_agent(
 /// Always return `Ok` and let hummock manager handle errors.
 pub async fn compact(
     compactor_context: CompactorContext,
-    mut compact_task: CompactTask,
+    compact_task: CompactTask,
     shutdown_rx: Receiver<()>,
     object_id_getter: Arc<dyn GetObjectId>,
     compaction_catalog_manager_ref: CompactionCatalogManagerRef,
@@ -600,16 +585,16 @@ pub async fn compact(
     ),
     Option<MemoryTracker>,
 ) {
-    let table_ids_to_be_compacted = compact_task.build_compact_table_ids();
+    let read_table_ids = compact_task.get_table_ids_from_input_ssts().collect_vec();
     let compaction_catalog_agent_ref = match compaction_catalog_manager_ref
-        .acquire(table_ids_to_be_compacted.clone())
+        .acquire(read_table_ids.clone())
         .await
     {
         Ok(compaction_catalog_agent_ref) => {
             let acquire_table_ids: HashSet<StateTableId> =
                 compaction_catalog_agent_ref.table_ids().collect();
-            if acquire_table_ids.len() != table_ids_to_be_compacted.len() {
-                let diff = table_ids_to_be_compacted
+            if acquire_table_ids.len() != read_table_ids.len() {
+                let diff = read_table_ids
                     .into_iter()
                     .collect::<HashSet<_>>()
                     .symmetric_difference(&acquire_table_ids)
@@ -648,17 +633,6 @@ pub async fn compact(
             );
         }
     };
-
-    // rewrite compact_task watermarks
-    {
-        compact_task
-            .pk_prefix_table_watermarks
-            .retain(|table_id, _| table_ids_to_be_compacted.contains(table_id));
-
-        compact_task
-            .non_pk_prefix_table_watermarks
-            .retain(|table_id, _| table_ids_to_be_compacted.contains(table_id));
-    }
 
     compact_with_agent(
         compactor_context,
@@ -703,6 +677,7 @@ pub(crate) fn compact_done(
             compact_task.sorted_output_ssts.push(sst_info.sst_info);
         }
     }
+    assert_output_table_ids_subset_of_read_input(&compact_task);
 
     let group_label = compact_task.compaction_group_id.to_string();
     let level_label = compact_task.target_level.to_string();
@@ -718,6 +693,27 @@ pub(crate) fn compact_done(
         .inc_by(compact_task.sorted_output_ssts.len() as u64);
 
     (compact_task, table_stats_map, object_timestamps)
+}
+
+/// Compactor output must only contain table ids that are readable in the normalized task input.
+fn assert_output_table_ids_subset_of_read_input(compact_task: &CompactTask) {
+    let read_table_ids = compact_task
+        .get_table_ids_from_input_ssts()
+        .collect::<HashSet<_>>();
+
+    for output_sst in &compact_task.sorted_output_ssts {
+        assert!(
+            output_sst
+                .table_ids
+                .iter()
+                .all(|table_id| read_table_ids.contains(table_id)),
+            "compaction output contains table ids outside task read input: task_id={}, output_sst_id={}, read_table_ids={:?}, output_table_ids={:?}",
+            compact_task.task_id,
+            output_sst.sst_id,
+            read_table_ids,
+            output_sst.table_ids,
+        );
+    }
 }
 
 pub async fn compact_and_build_sst<F>(
@@ -811,15 +807,9 @@ where
         if drop {
             compaction_statistics.iter_drop_key_counts += 1;
 
-            let should_count = match task_config.stats_target_table_ids.as_ref() {
-                Some(target_table_ids) => target_table_ids.contains(&iter_key.user_key.table_id),
-                None => true,
-            };
-            if should_count {
-                last_table_stats.total_key_count -= 1;
-                last_table_stats.total_key_size -= iter_key.encoded_len() as i64;
-                last_table_stats.total_value_size -= iter.value().encoded_len() as i64;
-            }
+            last_table_stats.total_key_count -= 1;
+            last_table_stats.total_key_size -= iter_key.encoded_len() as i64;
+            last_table_stats.total_value_size -= iter.value().encoded_len() as i64;
             iter.next()
                 .instrument_await("iter_next_in_drop".verbose())
                 .await?;

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -110,8 +110,8 @@ impl BlockStreamIterator {
     }
 
     async fn create_stream(&mut self) -> HummockResult<()> {
-        // Fast compact only support the single table compaction.(not split sst)
-        // So we don't need to filter the block_metas with table_id and key_range
+        // Fast compaction streams the physical SST blocks directly. Table-id pruning is handled
+        // later by `CompactTaskExecutor` before raw block copy or decoded block compaction.
         let block_stream = self
             .sstable_store
             .get_stream_for_blocks(
@@ -379,13 +379,13 @@ impl<C: CompactionFilter> CompactorRunner<C> {
         let get_id_time = Arc::new(AtomicU64::new(0));
 
         let key_range = KeyRange::inf();
+        let read_table_ids = HashSet::from_iter(task.get_table_ids_from_input_ssts());
 
         let task_config = TaskConfig {
             key_range,
             cache_policy: CachePolicy::NotFill,
             gc_delete_keys: task.gc_delete_keys,
             retain_multiple_version: false,
-            stats_target_table_ids: Some(HashSet::from_iter(task.existing_table_ids.clone())),
             table_vnode_partition: task.table_vnode_partition.clone(),
             use_block_based_filter: true,
             table_schemas: Default::default(),
@@ -422,13 +422,19 @@ impl<C: CompactionFilter> CompactorRunner<C> {
             compact_task_to_string(&task)
         );
         let left = Box::new(ConcatSstableIterator::new(
-            task.input_ssts[0].table_infos.clone(),
+            task.input_ssts[0]
+                .read_sstable_infos()
+                .cloned()
+                .collect_vec(),
             context.sstable_store.clone(),
             task_progress.clone(),
             context.storage_opts.compactor_iter_max_io_retry_times,
         ));
         let right = Box::new(ConcatSstableIterator::new(
-            task.input_ssts[1].table_infos.clone(),
+            task.input_ssts[1]
+                .read_sstable_infos()
+                .cloned()
+                .collect_vec(),
             context.sstable_store,
             task_progress.clone(),
             context.storage_opts.compactor_iter_max_io_retry_times,
@@ -447,8 +453,6 @@ impl<C: CompactionFilter> CompactorRunner<C> {
             compaction_catalog_agent_ref,
         );
 
-        let compact_table_ids = HashSet::from_iter(task.build_compact_table_ids());
-
         Self {
             executor: CompactTaskExecutor::new(
                 sst_builder,
@@ -458,7 +462,7 @@ impl<C: CompactionFilter> CompactorRunner<C> {
                 non_pk_prefix_state,
                 value_skip_watermark_state,
                 compaction_filter,
-                compact_table_ids,
+                read_table_ids,
             ),
             left,
             right,
@@ -659,7 +663,7 @@ pub struct CompactTaskExecutor<F: TableBuilderFactory, C: CompactionFilter> {
     non_pk_prefix_skip_watermark_state: NonPkPrefixSkipWatermarkState,
     value_skip_watermark_state: ValueSkipWatermarkState,
     compaction_filter: C,
-    compact_table_ids: HashSet<TableId>,
+    read_table_ids: HashSet<TableId>,
 }
 
 impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
@@ -671,7 +675,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
         non_pk_prefix_skip_watermark_state: NonPkPrefixSkipWatermarkState,
         value_skip_watermark_state: ValueSkipWatermarkState,
         compaction_filter: C,
-        compact_table_ids: HashSet<TableId>,
+        read_table_ids: HashSet<TableId>,
     ) -> Self {
         Self {
             builder,
@@ -687,7 +691,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
             non_pk_prefix_skip_watermark_state,
             value_skip_watermark_state,
             compaction_filter,
-            compact_table_ids,
+            read_table_ids,
         }
     }
 
@@ -715,7 +719,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
 
     #[inline(always)]
     fn should_skip_block(&self, table_id: TableId) -> bool {
-        !self.compact_table_ids.contains(&table_id)
+        !self.read_table_ids.contains(&table_id)
     }
 
     #[inline(always)]
@@ -785,17 +789,9 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
             if drop {
                 self.compaction_statistics.iter_drop_key_counts += 1;
 
-                let should_count = match self.task_config.stats_target_table_ids.as_ref() {
-                    Some(target_table_ids) => {
-                        target_table_ids.contains(&self.last_key.user_key.table_id)
-                    }
-                    None => true,
-                };
-                if should_count {
-                    self.last_table_stats.total_key_count -= 1;
-                    self.last_table_stats.total_key_size -= self.last_key.encoded_len() as i64;
-                    self.last_table_stats.total_value_size -= value.encoded_len() as i64;
-                }
+                self.last_table_stats.total_key_count -= 1;
+                self.last_table_stats.total_key_size -= self.last_key.encoded_len() as i64;
+                self.last_table_stats.total_value_size -= value.encoded_len() as i64;
                 iter.next();
                 continue;
             }
@@ -809,7 +805,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
 
     pub fn shall_copy_raw_block(&mut self, smallest_key: &FullKey<&[u8]>) -> bool {
         if self.should_skip_block(smallest_key.user_key.table_id) {
-            // If the table id of smallest key is not in compact_table_ids, we can not copy the raw block.
+            // If the table id of smallest key is not in read_table_ids, we can not copy the raw block.
             return false;
         }
 

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -30,6 +30,7 @@ use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_stats::TableStats;
 use risingwave_hummock_sdk::{EpochWithGap, LocalSstableInfo, can_concat, compact_task_to_string};
+use risingwave_pb::hummock::BloomFilterType;
 
 use crate::compaction_catalog_manager::CompactionCatalogAgentRef;
 use crate::hummock::block_stream::BlockDataStream;
@@ -421,20 +422,30 @@ impl<C: CompactionFilter> CompactorRunner<C> {
             task.target_level,
             compact_task_to_string(&task)
         );
+        let left_ssts = task.input_ssts[0]
+            .read_sstable_infos()
+            .cloned()
+            .collect_vec();
+        let right_ssts = task.input_ssts[1]
+            .read_sstable_infos()
+            .cloned()
+            .collect_vec();
+        assert!(
+            left_ssts
+                .iter()
+                .chain(right_ssts.iter())
+                .all(|sst| sst.bloom_filter_kind == BloomFilterType::Blocked),
+            "fast compaction requires blocked-filter SSTs: {}",
+            compact_task_to_string(&task)
+        );
         let left = Box::new(ConcatSstableIterator::new(
-            task.input_ssts[0]
-                .read_sstable_infos()
-                .cloned()
-                .collect_vec(),
+            left_ssts,
             context.sstable_store.clone(),
             task_progress.clone(),
             context.storage_opts.compactor_iter_max_io_retry_times,
         ));
         let right = Box::new(ConcatSstableIterator::new(
-            task.input_ssts[1]
-                .read_sstable_infos()
-                .cloned()
-                .collect_vec(),
+            right_ssts,
             context.sstable_store,
             task_progress.clone(),
             context.storage_opts.compactor_iter_max_io_retry_times,
@@ -865,5 +876,132 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
                     .should_delete(key, value))
             || (self.value_skip_watermark_state.has_watermark()
                 && self.value_skip_watermark_state.should_delete(key, value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Arc;
+
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::compact_task::CompactTask;
+    use risingwave_hummock_sdk::key::FullKey;
+    use risingwave_hummock_sdk::level::InputLevel;
+    use risingwave_pb::hummock::compact_task::TaskType;
+    use risingwave_pb::hummock::{BloomFilterType, LevelType};
+
+    use super::CompactorRunner;
+    use crate::compaction_catalog_manager::CompactionCatalogAgent;
+    use crate::hummock::compactor::compaction_utils::optimize_by_copy_block;
+    use crate::hummock::compactor::task_progress::TaskProgress;
+    use crate::hummock::compactor::{CompactorContext, MultiCompactionFilter};
+    use crate::hummock::iterator::test_utils::mock_sstable_store;
+    use crate::hummock::test_utils::{
+        default_builder_opt_for_test, default_opts_for_test, gen_test_sstable_impl, test_value_of,
+    };
+    use crate::hummock::value::HummockValue;
+    use crate::hummock::{
+        BlockedXor16FilterBuilder, CachePolicy, SharedComapctorObjectIdManager, Xor16FilterBuilder,
+    };
+    use crate::monitor::CompactorMetrics;
+
+    fn test_key(table_id: u32, idx: usize) -> FullKey<Vec<u8>> {
+        let mut table_key = VirtualNode::ZERO.to_be_bytes().to_vec();
+        table_key.extend_from_slice(format!("key_test_{idx:05}").as_bytes());
+        FullKey::for_test(TableId::new(table_id), table_key, test_epoch(1))
+    }
+
+    #[tokio::test]
+    async fn test_fast_compact_skips_empty_table_id_sst() {
+        let sstable_store = mock_sstable_store().await;
+        let table_id_to_vnode = HashMap::from([
+            (1, VirtualNode::COUNT_FOR_TEST),
+            (2, VirtualNode::COUNT_FOR_TEST),
+        ]);
+        let table_id_to_watermark_serde = HashMap::from([(1, None), (2, None)]);
+
+        let mut dropped_only_sst = gen_test_sstable_impl::<_, Xor16FilterBuilder>(
+            default_builder_opt_for_test(),
+            1,
+            (0..2).map(|idx| (test_key(1, idx), HummockValue::put(test_value_of(idx)))),
+            sstable_store.clone(),
+            CachePolicy::NotFill,
+            table_id_to_vnode.clone(),
+            table_id_to_watermark_serde.clone(),
+        )
+        .await;
+        assert_eq!(dropped_only_sst.bloom_filter_kind, BloomFilterType::Sstable);
+        let mut inner = dropped_only_sst.get_inner();
+        inner.table_ids.clear();
+        dropped_only_sst.set_inner(inner);
+
+        let live_left_sst = gen_test_sstable_impl::<_, BlockedXor16FilterBuilder>(
+            default_builder_opt_for_test(),
+            2,
+            (0..2).map(|idx| (test_key(2, idx), HummockValue::put(test_value_of(idx)))),
+            sstable_store.clone(),
+            CachePolicy::NotFill,
+            table_id_to_vnode.clone(),
+            table_id_to_watermark_serde.clone(),
+        )
+        .await;
+        let live_right_sst = gen_test_sstable_impl::<_, BlockedXor16FilterBuilder>(
+            default_builder_opt_for_test(),
+            3,
+            (2..4).map(|idx| (test_key(2, idx), HummockValue::put(test_value_of(idx)))),
+            sstable_store.clone(),
+            CachePolicy::NotFill,
+            table_id_to_vnode,
+            table_id_to_watermark_serde,
+        )
+        .await;
+
+        let mut storage_opts = default_opts_for_test();
+        storage_opts.enable_fast_compaction = true;
+        storage_opts.compactor_fast_max_compact_task_size = u64::MAX;
+        storage_opts.compactor_fast_max_compact_delete_ratio = 100;
+        let context = CompactorContext::new_local_compact_context(
+            Arc::new(storage_opts),
+            sstable_store,
+            Arc::new(CompactorMetrics::unused()),
+            None,
+        );
+
+        let task = CompactTask {
+            input_ssts: vec![
+                InputLevel {
+                    level_idx: 1,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: vec![dropped_only_sst, live_left_sst],
+                },
+                InputLevel {
+                    level_idx: 2,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: vec![live_right_sst],
+                },
+            ],
+            task_id: 42,
+            target_level: 2,
+            existing_table_ids: vec![TableId::new(2)],
+            target_file_size: 1 << 20,
+            task_type: TaskType::Dynamic,
+            ..Default::default()
+        };
+
+        assert_eq!(task.input_ssts[0].read_sstable_infos().count(), 1);
+        assert!(optimize_by_copy_block(&task, &context));
+
+        let runner = CompactorRunner::new(
+            context,
+            task,
+            CompactionCatalogAgent::for_test(vec![1, 2]),
+            SharedComapctorObjectIdManager::for_test(VecDeque::from([100])),
+            Arc::new(TaskProgress::default()),
+            MultiCompactionFilter::default(),
+        );
+        runner.run().await.unwrap();
     }
 }

--- a/src/storage/src/hummock/compactor/iterator.rs
+++ b/src/storage/src/hummock/compactor/iterator.rs
@@ -23,7 +23,6 @@ use await_tree::{InstrumentAwait, SpanExt};
 use fail::fail_point;
 use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::KeyComparator;
-use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
@@ -61,8 +60,8 @@ pub struct SstableStreamIterator {
     /// For key sanity check of divided SST and debugging
     sstable_info: SstableInfo,
 
-    /// To Filter out the blocks
-    compact_table_ids: HashSet<StateTableId>,
+    /// Table ids used to decide which blocks should be read from this SST.
+    read_table_ids: HashSet<TableId>,
     task_progress: Arc<TaskProgress>,
     io_retry_times: usize,
     max_io_retry_times: usize,
@@ -96,17 +95,14 @@ impl SstableStreamIterator {
         task_progress: Arc<TaskProgress>,
         sstable_store: SstableStoreRef,
         max_io_retry_times: usize,
-        compact_table_ids: HashSet<StateTableId>,
     ) -> Self {
+        let read_table_ids = HashSet::from_iter(sstable_info.table_ids.iter().copied());
         // Further filter the block_metas_range with sstable_info.key_range
         // This is necessary when the SST is split into multiple SstableInfo with different key ranges
         let block_metas_range = {
             let block_metas = &sstable.meta.block_metas[block_metas_range.clone()];
-            let inner_range = filter_block_metas(
-                block_metas,
-                &compact_table_ids,
-                sstable_info.key_range.clone(),
-            );
+            let inner_range =
+                filter_block_metas(block_metas, &read_table_ids, sstable_info.key_range.clone());
             // Adjust the range to be relative to the original block_metas
             (block_metas_range.start + inner_range.start)
                 ..(block_metas_range.start + inner_range.end)
@@ -123,7 +119,7 @@ impl SstableStreamIterator {
             block_metas_range,
             block_idx: 0,
             stats_ptr: stats.remote_io_time.clone(),
-            compact_table_ids,
+            read_table_ids,
             sstable_info,
             sstable_store,
             task_progress,
@@ -162,7 +158,7 @@ impl SstableStreamIterator {
 
     async fn prune_from_valid_block_iter(&mut self) -> HummockResult<()> {
         while let Some(block_iter) = self.block_iter.as_mut() {
-            if self.compact_table_ids.contains(&block_iter.table_id()) {
+            if self.read_table_ids.contains(&block_iter.table_id()) {
                 return Ok(());
             } else {
                 self.next_block().await?;
@@ -384,8 +380,6 @@ pub struct ConcatSstableIterator {
     /// All non-overlapping tables.
     sstables: Vec<SstableInfo>,
 
-    compact_table_ids: HashSet<StateTableId>,
-
     sstable_store: SstableStoreRef,
 
     stats: StoreLocalStatistic,
@@ -398,7 +392,6 @@ impl ConcatSstableIterator {
     /// arranged in ascending order when it serves as a forward iterator,
     /// and arranged in descending order when it serves as a backward iterator.
     pub fn new(
-        compact_table_ids: Vec<StateTableId>,
         sst_infos: Vec<SstableInfo>,
         key_range: KeyRange,
         sstable_store: SstableStoreRef,
@@ -410,7 +403,6 @@ impl ConcatSstableIterator {
             sstable_iter: None,
             cur_idx: 0,
             sstables: sst_infos,
-            compact_table_ids: HashSet::from_iter(compact_table_ids),
             sstable_store,
             task_progress,
             stats: StoreLocalStatistic::default(),
@@ -420,13 +412,11 @@ impl ConcatSstableIterator {
 
     #[cfg(test)]
     pub fn for_test(
-        existing_table_ids: Vec<impl Into<StateTableId>>,
         sst_infos: Vec<SstableInfo>,
         key_range: KeyRange,
         sstable_store: SstableStoreRef,
     ) -> Self {
         Self::new(
-            existing_table_ids.into_iter().map(Into::into).collect(),
             sst_infos,
             key_range,
             sstable_store,
@@ -456,11 +446,8 @@ impl ConcatSstableIterator {
         self.cur_idx = idx;
         while self.cur_idx < self.sstables.len() {
             let table_info = &self.sstables[self.cur_idx];
-            let mut found = table_info
-                .table_ids
-                .iter()
-                .any(|table_id| self.compact_table_ids.contains(table_id));
-            if !found {
+            let read_table_ids = HashSet::from_iter(table_info.table_ids.iter().copied());
+            if read_table_ids.is_empty() {
                 self.cur_idx += 1;
                 seek_key = None;
                 continue;
@@ -478,21 +465,10 @@ impl ConcatSstableIterator {
                 None => self.key_range.clone(),
             };
 
-            let compact_sstable_table_ids = {
-                // unite table_ids between sstable and compact_table_ids
-                let sstable_table_ids = HashSet::from_iter(table_info.table_ids.iter().cloned());
-                sstable_table_ids
-                    .intersection(&self.compact_table_ids)
-                    .cloned()
-                    .collect()
-            };
+            let block_metas_range =
+                filter_block_metas(&sstable.meta.block_metas, &read_table_ids, filter_key_range);
 
-            let block_metas_range = filter_block_metas(
-                &sstable.meta.block_metas,
-                &compact_sstable_table_ids,
-                filter_key_range,
-            );
-
+            let mut found = true;
             if block_metas_range.is_empty() {
                 found = false;
             } else {
@@ -505,7 +481,6 @@ impl ConcatSstableIterator {
                     self.task_progress.clone(),
                     self.sstable_store.clone(),
                     self.max_io_retry_times,
-                    compact_sstable_table_ids,
                 );
                 sstable_iter.seek(seek_key).await?;
 
@@ -669,7 +644,7 @@ impl<I: HummockIterator<Direction = Forward>> HummockIterator for MonitoredCompa
 
 pub(crate) fn filter_block_metas(
     block_metas: &[BlockMeta],
-    compact_table_ids: &HashSet<TableId>,
+    read_table_ids: &HashSet<TableId>,
     key_range: KeyRange,
 ) -> Range<usize> {
     if block_metas.is_empty() {
@@ -705,10 +680,10 @@ pub(crate) fn filter_block_metas(
     }
     .saturating_sub(1);
 
-    // skip blocks that are not in existing_table_ids
+    // Skip blocks that are not in the SST read table ids.
     while start_index <= end_index {
         let start_block_table_id = block_metas[start_index].table_id();
-        if compact_table_ids.contains(&start_block_table_id) {
+        if read_table_ids.contains(&start_block_table_id) {
             break;
         }
 
@@ -727,7 +702,7 @@ pub(crate) fn filter_block_metas(
 
     while start_index <= end_index {
         let end_block_table_id = block_metas[end_index].table_id();
-        if compact_table_ids.contains(&end_block_table_id) {
+        if read_table_ids.contains(&end_block_table_id) {
             break;
         }
 
@@ -797,12 +772,8 @@ mod tests {
             test_key_of(start_index).encode().into(),
             test_key_of(end_index).encode().into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         iter.seek(FullKey::decode(&kr.left)).await.unwrap();
 
         for idx in start_index..end_index {
@@ -821,24 +792,16 @@ mod tests {
             test_key_of(30000).encode().into(),
             test_key_of(40000).encode().into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         iter.seek(FullKey::decode(&kr.left)).await.unwrap();
         assert!(!iter.is_valid());
         let kr = KeyRange::new(
             test_key_of(start_index).encode().into(),
             test_key_of(40000).encode().into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         iter.seek(FullKey::decode(&kr.left)).await.unwrap();
         for idx in start_index..30000 {
             let key = iter.key();
@@ -857,12 +820,8 @@ mod tests {
             test_key_of(0).encode().into(),
             test_key_of(40000).encode().into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         iter.seek(test_key_of(10000).to_ref()).await.unwrap();
         assert!(iter.is_valid() && iter.cur_idx == 1 && iter.key() == test_key_of(10000).to_ref());
         iter.seek(test_key_of(10001).to_ref()).await.unwrap();
@@ -881,12 +840,8 @@ mod tests {
             test_key_of(6000).encode().into(),
             test_key_of(16000).encode().into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         iter.seek(test_key_of(17000).to_ref()).await.unwrap();
         assert!(!iter.is_valid());
         iter.seek(test_key_of(1).to_ref()).await.unwrap();
@@ -916,12 +871,8 @@ mod tests {
             test_key_of(0).encode().into(),
             test_key_of(40000).encode().into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         let sst = sstable_store
             .sstable(&iter.sstables[0], &mut iter.stats)
             .await
@@ -956,12 +907,8 @@ mod tests {
             next_full_key(&block_1_smallest_key).into(),
             prev_full_key(&block_2_smallest_key).into(),
         );
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![0],
-            table_infos.clone(),
-            kr.clone(),
-            sstable_store.clone(),
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(table_infos.clone(), kr.clone(), sstable_store.clone());
         // Use block_2_smallest_key as seek key and result in invalid iterator.
         let seek_key = FullKey::decode(&block_2_smallest_key);
         assert!(seek_key.cmp(&FullKey::decode(&kr.right)) == Ordering::Greater);
@@ -1314,7 +1261,6 @@ mod tests {
             let mut full_key_tracker = FullKeyTracker::<Vec<u8>>::new(FullKey::default());
 
             let mut iter = ConcatSstableIterator::for_test(
-                vec![0],
                 vec![sst_1.clone(), sst_2.clone()],
                 KeyRange::default(),
                 sstable_store.clone(),
@@ -1336,14 +1282,12 @@ mod tests {
         {
             let mut full_key_tracker = FullKeyTracker::<Vec<u8>>::new(FullKey::default());
             let concat_1 = ConcatSstableIterator::for_test(
-                vec![0],
                 vec![sst_1.clone()],
                 KeyRange::default(),
                 sstable_store.clone(),
             );
 
             let concat_2 = ConcatSstableIterator::for_test(
-                vec![0],
                 vec![sst_2.clone()],
                 KeyRange::default(),
                 sstable_store.clone(),
@@ -1390,7 +1334,6 @@ mod tests {
         .into();
 
         let mut iter = ConcatSstableIterator::for_test(
-            vec![1, 3],
             vec![table_info.clone()],
             KeyRange::default(),
             sstable_store.clone(),
@@ -1406,12 +1349,8 @@ mod tests {
         iter.next().await.unwrap();
         assert!(!iter.is_valid());
 
-        let mut iter = ConcatSstableIterator::for_test(
-            vec![1, 3],
-            vec![table_info],
-            KeyRange::default(),
-            sstable_store,
-        );
+        let mut iter =
+            ConcatSstableIterator::for_test(vec![table_info], KeyRange::default(), sstable_store);
         iter.seek(key_2.to_ref()).await.unwrap();
         assert!(iter.is_valid());
         assert_eq!(iter.key(), key_3.to_ref());

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -963,6 +963,28 @@ pub fn start_compactor(
                         match event {
                             ResponseEvent::CompactTask(compact_task) => {
                                 let compact_task = CompactTask::from(compact_task);
+                                if compact_task.build_compact_table_ids().is_empty() {
+                                    tracing::info!(
+                                        task_id = compact_task.task_id,
+                                        "Skip compaction task because no existing table ids remain in input SSTs"
+                                    );
+                                    let (compact_task, table_stats, object_timestamps) =
+                                        compact_done(
+                                            compact_task,
+                                            context.clone(),
+                                            vec![],
+                                            TaskStatus::Success,
+                                        );
+
+                                    send_report_task_event(
+                                        &compact_task,
+                                        table_stats,
+                                        object_timestamps,
+                                        &request_sender,
+                                    );
+
+                                    continue 'consume_stream;
+                                }
                                 let parallelism =
                                     calculate_task_parallelism(&compact_task, &context);
 

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -49,8 +49,7 @@ use std::time::{Duration, SystemTime};
 use await_tree::{InstrumentAwait, SpanExt};
 pub use compaction_executor::CompactionExecutor;
 pub use compaction_filter::{
-    CompactionFilter, DummyCompactionFilter, MultiCompactionFilter, StateCleanUpCompactionFilter,
-    TtlCompactionFilter,
+    CompactionFilter, DummyCompactionFilter, MultiCompactionFilter, TtlCompactionFilter,
 };
 pub use context::{
     CompactionAwaitTreeRegRef, CompactorContext, await_tree_key, new_compaction_await_tree_reg_ref,
@@ -963,28 +962,6 @@ pub fn start_compactor(
                         match event {
                             ResponseEvent::CompactTask(compact_task) => {
                                 let compact_task = CompactTask::from(compact_task);
-                                if compact_task.build_compact_table_ids().is_empty() {
-                                    tracing::info!(
-                                        task_id = compact_task.task_id,
-                                        "Skip compaction task because no existing table ids remain in input SSTs"
-                                    );
-                                    let (compact_task, table_stats, object_timestamps) =
-                                        compact_done(
-                                            compact_task,
-                                            context.clone(),
-                                            vec![],
-                                            TaskStatus::Success,
-                                        );
-
-                                    send_report_task_event(
-                                        &compact_task,
-                                        table_stats,
-                                        object_timestamps,
-                                        &request_sender,
-                                    );
-
-                                    continue 'consume_stream;
-                                }
                                 let parallelism =
                                     calculate_task_parallelism(&compact_task, &context);
 
@@ -1050,8 +1027,10 @@ pub fn start_compactor(
                                     let need_check_task = !compact_task.sorted_output_ssts.is_empty() && compact_task.task_status == TaskStatus::Success;
 
                                     if enable_check_compaction_result && need_check_task {
-                                        let compact_table_ids = compact_task.build_compact_table_ids();
-                                        match compaction_catalog_manager_ref.acquire(compact_table_ids.into_iter().collect()).await {
+                                        let read_table_ids = compact_task
+                                            .get_table_ids_from_input_ssts()
+                                            .collect::<Vec<_>>();
+                                        match compaction_catalog_manager_ref.acquire(read_table_ids.into_iter().collect()).await {
                                             Ok(compaction_catalog_agent_ref) =>  {
                                                 match check_compaction_result(&compact_task, context.clone(), compaction_catalog_agent_ref).await
                                                 {

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -296,7 +296,6 @@ async fn compact_shared_buffer<const IS_NEW_VALUE: bool>(
             compaction_executor.spawn(async move {
                 match check_flush_result(
                     left_iter,
-                    Vec::from_iter(existing_table_ids.iter().cloned()),
                     sst_infos,
                     context,
                 )
@@ -563,7 +562,6 @@ impl SharedBufferCompactRunner {
                 cache_policy: CachePolicy::Fill(Hint::Normal),
                 gc_delete_keys: GC_DELETE_KEYS_FOR_FLUSH,
                 retain_multiple_version: true,
-                stats_target_table_ids: None,
                 table_vnode_partition,
                 use_block_based_filter,
                 table_schemas: Default::default(),

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -416,9 +416,6 @@ async fn test_failpoints_compactor_iterator_recreate() {
         Arc::new(TaskProgress::default()),
         sstable_store,
         100,
-        vec![risingwave_common::catalog::TableId::new(table_id as u32)]
-            .into_iter()
-            .collect(),
     );
     let mut cnt = 0;
     sstable_iter.seek(None).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Closes #N/A
- Move stale table-id cleanup to Hummock version-delta apply, so later compact tasks are picked from already-pruned SST metadata instead of rewriting `CompactTask.input_ssts` during task construction.
- Rename the Rust-side delta to `PruneTableIdsFromSsts` while keeping the existing protobuf `truncate_tables` wire format for compatibility. Truncate table and drop/unregister table both use this pruning path; full dynamic-group removal still uses `GroupDestroy`.
- Keep `CompactTask::existing_table_ids` as version live/member table ids. Task-local readable table ids now come from `input_ssts[*].table_ids`, and `CompactTask::build_compact_table_ids()` is removed.
- Simplify compactor-side handling around this invariant: do not register `StateCleanUpCompactionFilter` on the main path, read only SSTs with non-empty table ids, and keep block-level table-id pruning as the physical-SST safety guard.
- Add/update tests for version SST metadata pruning, truncate/drop apply paths, unregister table pruning, compact-task read semantics, and drop-table compaction behavior.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

N/A

</details>
