### PR TITLE
fix(sink): ensure barrier progress must be truncated on log store

### DIFF
--- a/src/connector/src/sink/log_store.rs
+++ b/src/connector/src/sink/log_store.rs
@@ -217,6 +217,31 @@ pub struct TransformChunkLogReader<F: Fn(StreamChunk) -> StreamChunk, R: LogRead
     inner: R,
 }
 
+pub struct TruncateBarrierLogReader<R: LogReader> {
+    inner: R,
+    pending_barriers: VecDeque<TruncateOffset>,
+}
+
+impl<R: LogReader> TruncateBarrierLogReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            pending_barriers: VecDeque::new(),
+        }
+    }
+
+    fn truncate_pending_barriers_before(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+        while let Some(barrier_offset) = self.pending_barriers.front().copied() {
+            if barrier_offset >= offset {
+                break;
+            }
+            self.inner.truncate(barrier_offset)?;
+            self.pending_barriers.pop_front();
+        }
+        Ok(())
+    }
+}
+
 impl<F: Fn(StreamChunk) -> StreamChunk + Send + 'static, R: LogReader> LogReader
     for TransformChunkLogReader<F, R>
 {
@@ -249,6 +274,42 @@ impl<F: Fn(StreamChunk) -> StreamChunk + Send + 'static, R: LogReader> LogReader
         start_offset: Option<u64>,
     ) -> impl Future<Output = LogStoreResult<()>> + Send + '_ {
         self.inner.start_from(start_offset)
+    }
+}
+
+impl<R: LogReader> LogReader for TruncateBarrierLogReader<R> {
+    async fn init(&mut self) -> LogStoreResult<()> {
+        self.pending_barriers.clear();
+        self.inner.init().await
+    }
+
+    async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
+        let (epoch, item) = self.inner.next_item().await?;
+        if matches!(item, LogStoreReadItem::Barrier { .. }) {
+            self.pending_barriers
+                .push_back(TruncateOffset::Barrier { epoch });
+        }
+        Ok((epoch, item))
+    }
+
+    fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+        self.truncate_pending_barriers_before(offset)?;
+        let should_pop_current_barrier = self.pending_barriers.front().copied() == Some(offset);
+        self.inner.truncate(offset)?;
+        if should_pop_current_barrier {
+            self.pending_barriers.pop_front();
+        }
+        Ok(())
+    }
+
+    async fn rewind(&mut self) -> LogStoreResult<()> {
+        self.pending_barriers.clear();
+        self.inner.rewind().await
+    }
+
+    async fn start_from(&mut self, start_offset: Option<u64>) -> LogStoreResult<()> {
+        self.pending_barriers.clear();
+        self.inner.start_from(start_offset).await
     }
 }
 
@@ -886,17 +947,58 @@ impl<F: TryFuture<Ok = ()> + Unpin + 'static> DeliveryFutureManager<F> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::future::{Future, poll_fn};
     use std::pin::pin;
     use std::task::Poll;
 
     use futures::{FutureExt, TryFuture};
+    use risingwave_common::array::StreamChunk;
     use risingwave_common::util::epoch::test_epoch;
     use tokio::sync::oneshot;
     use tokio::sync::oneshot::Receiver;
 
-    use super::LogStoreResult;
+    use super::{LogReader, LogStoreReadItem, LogStoreResult, TruncateBarrierLogReader};
     use crate::sink::log_store::{DeliveryFutureManager, TruncateOffset};
+
+    struct MockLogReader {
+        items: VecDeque<(u64, LogStoreReadItem)>,
+        truncate_calls: Vec<TruncateOffset>,
+    }
+
+    impl MockLogReader {
+        fn new(items: impl IntoIterator<Item = (u64, LogStoreReadItem)>) -> Self {
+            Self {
+                items: items.into_iter().collect(),
+                truncate_calls: Vec::new(),
+            }
+        }
+    }
+
+    impl LogReader for MockLogReader {
+        async fn init(&mut self) -> LogStoreResult<()> {
+            Ok(())
+        }
+
+        async fn start_from(&mut self, _start_offset: Option<u64>) -> LogStoreResult<()> {
+            Ok(())
+        }
+
+        async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
+            self.items
+                .pop_front()
+                .ok_or_else(|| anyhow::anyhow!("no item"))
+        }
+
+        fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
+            self.truncate_calls.push(offset);
+            Ok(())
+        }
+
+        async fn rewind(&mut self) -> LogStoreResult<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn test_truncate_offset_cmp() {
@@ -1188,5 +1290,116 @@ mod tests {
         }
 
         assert_eq!(0, manager.future_count);
+    }
+
+    #[tokio::test]
+    async fn test_truncate_barrier_reader_truncates_previous_barriers_first() {
+        let inner = MockLogReader::new([
+            (
+                1,
+                LogStoreReadItem::Barrier {
+                    is_checkpoint: false,
+                    new_vnode_bitmap: None,
+                    is_stop: false,
+                    schema_change: None,
+                },
+            ),
+            (
+                2,
+                LogStoreReadItem::Barrier {
+                    is_checkpoint: false,
+                    new_vnode_bitmap: None,
+                    is_stop: false,
+                    schema_change: None,
+                },
+            ),
+        ]);
+        let mut reader = TruncateBarrierLogReader::new(inner);
+
+        reader.init().await.unwrap();
+        reader.start_from(None).await.unwrap();
+        reader.next_item().await.unwrap();
+        reader.next_item().await.unwrap();
+        reader
+            .truncate(TruncateOffset::Barrier { epoch: 2 })
+            .unwrap();
+
+        assert_eq!(
+            reader.inner.truncate_calls,
+            vec![
+                TruncateOffset::Barrier { epoch: 1 },
+                TruncateOffset::Barrier { epoch: 2 },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_truncate_barrier_reader_keeps_later_barrier_pending() {
+        let inner = MockLogReader::new([
+            (
+                1,
+                LogStoreReadItem::Barrier {
+                    is_checkpoint: false,
+                    new_vnode_bitmap: None,
+                    is_stop: false,
+                    schema_change: None,
+                },
+            ),
+            (
+                2,
+                LogStoreReadItem::StreamChunk {
+                    chunk: StreamChunk::default(),
+                    chunk_id: 0,
+                },
+            ),
+            (
+                2,
+                LogStoreReadItem::Barrier {
+                    is_checkpoint: false,
+                    new_vnode_bitmap: None,
+                    is_stop: false,
+                    schema_change: None,
+                },
+            ),
+        ]);
+        let mut reader = TruncateBarrierLogReader::new(inner);
+
+        reader.init().await.unwrap();
+        reader.start_from(None).await.unwrap();
+        reader.next_item().await.unwrap();
+        reader.next_item().await.unwrap();
+        reader.next_item().await.unwrap();
+        reader
+            .truncate(TruncateOffset::Chunk {
+                epoch: 2,
+                chunk_id: 0,
+            })
+            .unwrap();
+
+        assert_eq!(
+            reader.inner.truncate_calls,
+            vec![
+                TruncateOffset::Barrier { epoch: 1 },
+                TruncateOffset::Chunk {
+                    epoch: 2,
+                    chunk_id: 0,
+                },
+            ]
+        );
+
+        reader
+            .truncate(TruncateOffset::Barrier { epoch: 2 })
+            .unwrap();
+        assert_eq!(
+            reader.inner.truncate_calls,
+            vec![
+                TruncateOffset::Barrier { epoch: 1 },
+                TruncateOffset::Chunk {
+                    epoch: 2,
+                    chunk_id: 0,
+                },
+                TruncateOffset::Barrier { epoch: 2 },
+            ]
+        );
     }
 }

--- a/src/connector/src/sink/log_store.rs
+++ b/src/connector/src/sink/log_store.rs
@@ -38,21 +38,25 @@ use tokio::sync::mpsc::UnboundedReceiver;
 pub type LogStoreResult<T> = Result<T, anyhow::Error>;
 pub type ChunkId = usize;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum TruncateOffset {
     Chunk { epoch: u64, chunk_id: ChunkId },
     Barrier { epoch: u64 },
 }
 
-impl PartialOrd for TruncateOffset {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+impl Ord for TruncateOffset {
+    fn cmp(&self, other: &Self) -> Ordering {
         let extract = |offset: &TruncateOffset| match offset {
             TruncateOffset::Chunk { epoch, chunk_id } => (*epoch, *chunk_id),
             TruncateOffset::Barrier { epoch } => (*epoch, usize::MAX),
         };
-        let this = extract(self);
-        let other = extract(other);
-        this.partial_cmp(&other)
+        extract(self).cmp(&extract(other))
+    }
+}
+
+impl PartialOrd for TruncateOffset {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -219,7 +223,7 @@ pub struct TransformChunkLogReader<F: Fn(StreamChunk) -> StreamChunk, R: LogRead
 
 pub struct TruncateBarrierLogReader<R: LogReader> {
     inner: R,
-    pending_barriers: VecDeque<TruncateOffset>,
+    pending_barriers: VecDeque<u64>,
 }
 
 impl<R: LogReader> TruncateBarrierLogReader<R> {
@@ -228,17 +232,6 @@ impl<R: LogReader> TruncateBarrierLogReader<R> {
             inner,
             pending_barriers: VecDeque::new(),
         }
-    }
-
-    fn truncate_pending_barriers_before(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        while let Some(barrier_offset) = self.pending_barriers.front().copied() {
-            if barrier_offset >= offset {
-                break;
-            }
-            self.inner.truncate(barrier_offset)?;
-            self.pending_barriers.pop_front();
-        }
-        Ok(())
     }
 }
 
@@ -286,19 +279,31 @@ impl<R: LogReader> LogReader for TruncateBarrierLogReader<R> {
     async fn next_item(&mut self) -> LogStoreResult<(u64, LogStoreReadItem)> {
         let (epoch, item) = self.inner.next_item().await?;
         if matches!(item, LogStoreReadItem::Barrier { .. }) {
-            self.pending_barriers
-                .push_back(TruncateOffset::Barrier { epoch });
+            self.pending_barriers.push_back(epoch);
         }
         Ok((epoch, item))
     }
 
     fn truncate(&mut self, offset: TruncateOffset) -> LogStoreResult<()> {
-        self.truncate_pending_barriers_before(offset)?;
-        let should_pop_current_barrier = self.pending_barriers.front().copied() == Some(offset);
-        self.inner.truncate(offset)?;
-        if should_pop_current_barrier {
-            self.pending_barriers.pop_front();
+        while let Some(front_epoch) = self.pending_barriers.front().copied() {
+            match (TruncateOffset::Barrier { epoch: front_epoch }).cmp(&offset) {
+                Ordering::Less => {
+                    self.inner
+                        .truncate(TruncateOffset::Barrier { epoch: front_epoch })?;
+                    self.pending_barriers.pop_front();
+                }
+                Ordering::Equal => {
+                    self.inner.truncate(offset)?;
+                    self.pending_barriers.pop_front();
+                    return Ok(());
+                }
+                Ordering::Greater => {
+                    self.inner.truncate(offset)?;
+                    return Ok(());
+                }
+            }
         }
+        self.inner.truncate(offset)?;
         Ok(())
     }
 

--- a/src/stream/src/common/log_store_impl/in_mem.rs
+++ b/src/stream/src/common/log_store_impl/in_mem.rs
@@ -20,7 +20,7 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::util::epoch::{EpochExt, EpochPair, INVALID_EPOCH};
 use risingwave_connector::sink::log_store::{
     FlushCurrentEpochOptions, LogReader, LogStoreFactory, LogStoreReadItem, LogStoreResult,
-    LogWriter, LogWriterPostFlushCurrentEpoch, TruncateOffset,
+    LogWriter, LogWriterPostFlushCurrentEpoch, TruncateBarrierLogReader, TruncateOffset,
 };
 use tokio::sync::mpsc::{
     Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel,
@@ -121,7 +121,7 @@ impl BoundedInMemLogStoreFactory {
 }
 
 impl LogStoreFactory for BoundedInMemLogStoreFactory {
-    type Reader = BoundedInMemLogStoreReader;
+    type Reader = TruncateBarrierLogReader<BoundedInMemLogStoreReader>;
     type Writer = BoundedInMemLogStoreWriter;
 
     const ALLOW_REWIND: bool = false;
@@ -146,7 +146,7 @@ impl LogStoreFactory for BoundedInMemLogStoreFactory {
             truncated_epoch_rx,
             wait_init_epoch: Some(self.wait_init_epoch),
         };
-        (reader, writer)
+        (TruncateBarrierLogReader::new(reader), writer)
     }
 }
 

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -23,7 +23,7 @@ use risingwave_common::metrics::{
     LabelGuardedHistogram, LabelGuardedIntCounter, LabelGuardedIntGauge,
 };
 use risingwave_connector::sink::SinkParam;
-use risingwave_connector::sink::log_store::LogStoreFactory;
+use risingwave_connector::sink::log_store::{LogStoreFactory, TruncateBarrierLogReader};
 use risingwave_pb::catalog::Table;
 use risingwave_storage::StateStore;
 use risingwave_storage::store::{LocalStateStore, NewLocalOptions, OpConsistencyLevel};
@@ -553,7 +553,9 @@ impl<S: StateStore> KvLogStoreFactory<S> {
 }
 
 impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
-    type Reader = KvLogStoreReader<<S::Local as LocalStateStore>::FlushedSnapshotReader>;
+    type Reader = TruncateBarrierLogReader<
+        KvLogStoreReader<<S::Local as LocalStateStore>::FlushedSnapshotReader>,
+    >;
     type Writer = KvLogStoreWriter<S::Local>;
 
     const ALLOW_REWIND: bool = true;
@@ -611,7 +613,7 @@ impl<S: StateStore> LogStoreFactory for KvLogStoreFactory<S> {
             self.identity,
         );
 
-        (reader, writer)
+        (TruncateBarrierLogReader::new(reader), writer)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes sink log reader truncation progress when barriers are yielded but not explicitly truncated before a later truncate offset arrives.

Previously, a log reader could yield multiple barriers and then receive a truncate call on a later chunk or barrier offset. In that case, earlier yielded barriers could be skipped instead of being truncated in order. That breaks the expectation that all yielded barrier progress is reflected in log store truncation.

This PR introduces a generic `TruncateBarrierLogReader` wrapper in `src/connector/src/sink/log_store.rs` that:

- records yielded barrier offsets,
- buffers pending untruncated barriers,
- truncates all earlier pending barriers before applying the requested truncate offset,
- clears its pending state on `init`, `start_from`, and `rewind`.

The wrapper is then applied to both current log store factories:

- `BoundedInMemLogStoreFactory`
- `KvLogStoreFactory`

This keeps the behavior generic and avoids duplicating barrier-truncation bookkeeping inside individual reader implementations.

The PR also adds unit tests for:
- truncating earlier barriers before a later barrier truncate,
- preserving later barriers when truncating a chunk offset first.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
