### PR TITLE
fix(dml): wait for persistence before completing fast insert in dml executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11735,7 +11735,6 @@ dependencies = [
  "risingwave_connector",
  "risingwave_dml",
  "risingwave_expr",
- "risingwave_hummock_sdk",
  "risingwave_pb",
  "risingwave_rpc_client",
  "risingwave_storage",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -31,7 +31,6 @@ risingwave_common = { workspace = true }
 risingwave_connector = { workspace = true }
 risingwave_dml = { workspace = true }
 risingwave_expr = { workspace = true }
-risingwave_hummock_sdk = { workspace = true }
 risingwave_pb = { workspace = true }
 risingwave_rpc_client = { workspace = true }
 risingwave_storage = { workspace = true }
@@ -51,7 +50,6 @@ workspace-hack = { path = "../workspace-hack" }
 
 [dev-dependencies]
 rand = { workspace = true }
-risingwave_hummock_sdk = { workspace = true }
 tempfile = "3"
 
 [lints]

--- a/src/batch/src/executor/fast_insert.rs
+++ b/src/batch/src/executor/fast_insert.rs
@@ -22,7 +22,7 @@ use risingwave_common::types::DataType;
 use risingwave_dml::dml_manager::DmlManagerRef;
 use risingwave_pb::task_service::FastInsertRequest;
 
-use crate::error::Result;
+use crate::error::{BatchError, Result};
 
 /// A fast insert executor spacially designed for non-pgwire inserts such as websockets and webhooks.
 pub struct FastInsertExecutor {
@@ -142,8 +142,9 @@ impl FastInsertExecutor {
         if wait_for_persistence {
             write_handle
                 .end_wait_persistence()
+                .map_err(BatchError::from)?
                 .await
-                .map_err(Into::into)
+                .map_err(BatchError::from)
         } else {
             write_handle.end().await.map_err(Into::into)
         }

--- a/src/batch/src/executor/fast_insert.rs
+++ b/src/batch/src/executor/fast_insert.rs
@@ -19,7 +19,6 @@ use risingwave_common::array::{DataChunk, Op, SerialArray, StreamChunk};
 use risingwave_common::catalog::{Field, Schema, TableId, TableVersionId};
 use risingwave_common::transaction::transaction_id::TxnId;
 use risingwave_common::types::DataType;
-use risingwave_common::util::epoch::{Epoch, INVALID_EPOCH};
 use risingwave_dml::dml_manager::DmlManagerRef;
 use risingwave_pb::task_service::FastInsertRequest;
 
@@ -94,8 +93,8 @@ impl FastInsertExecutor {
     pub async fn do_execute(
         self,
         data_chunk_to_insert: DataChunk,
-        returning_epoch: bool,
-    ) -> Result<Epoch> {
+        wait_for_persistence: bool,
+    ) -> Result<()> {
         let table_dml_handle = self
             .dml_manager
             .table_dml_handle(self.table_id, self.table_version_id)?;
@@ -140,12 +139,13 @@ impl FastInsertExecutor {
             Result::Ok(())
         };
         write_txn_data(data_chunk_to_insert).await?;
-        if returning_epoch {
-            write_handle.end_returning_epoch().await.map_err(Into::into)
+        if wait_for_persistence {
+            write_handle
+                .end_wait_persistence()
+                .await
+                .map_err(Into::into)
         } else {
-            write_handle.end().await?;
-            // the returned epoch is invalid and should not be used.
-            Ok(Epoch(INVALID_EPOCH))
+            write_handle.end().await.map_err(Into::into)
         }
     }
 }
@@ -153,7 +153,6 @@ impl FastInsertExecutor {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::ops::Bound;
 
     use assert_matches::assert_matches;
     use futures::StreamExt;
@@ -162,8 +161,6 @@ mod tests {
     use risingwave_common::transaction::transaction_message::TxnMsg;
     use risingwave_common::types::JsonbVal;
     use risingwave_dml::dml_manager::DmlManager;
-    use risingwave_storage::hummock::test_utils::{ReadOptions, StateStoreReadTestExt};
-    use risingwave_storage::memory::MemoryStateStore;
     use serde_json::json;
 
     use super::*;
@@ -173,9 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fast_insert() -> Result<()> {
-        let epoch = Epoch::now();
         let dml_manager = Arc::new(DmlManager::for_test());
-        let store = MemoryStateStore::new();
         // Schema of the table
         let mut schema = Schema::new(vec![Field::unnamed(DataType::Jsonb)]);
         schema.fields.push(Field::unnamed(DataType::Serial)); // row_id column
@@ -221,28 +216,22 @@ mod tests {
             0,
         ));
         let handle = tokio::spawn(async move {
-            let epoch_received = insert_executor.do_execute(data_chunk, true).await.unwrap();
-            assert_eq!(epoch, epoch_received);
+            insert_executor.do_execute(data_chunk, true).await.unwrap();
         });
 
         // Read
         assert_matches!(reader.next().await.unwrap()?, TxnMsg::Begin(_));
 
         assert_matches!(reader.next().await.unwrap()?, TxnMsg::Data(_, chunk) => {
-            assert_eq!(chunk.columns().len(),2);
+            assert_eq!(chunk.columns().len(), 2);
             let array = chunk.columns()[0].as_jsonb().iter().collect::<Vec<_>>();
             assert_eq!(JsonbVal::from(array[0].unwrap()), jsonb_val);
         });
 
-        assert_matches!(reader.next().await.unwrap()?, TxnMsg::End(_, Some(epoch_notifier)) => {
-            epoch_notifier.send(epoch).unwrap();
+        // Simulate the DmlExecutor: fire the persistence notifier after try_wait_epoch succeeds.
+        assert_matches!(reader.next().await.unwrap()?, TxnMsg::End(_, Some(persistence_notifier)) => {
+            persistence_notifier.send(()).unwrap();
         });
-        let epoch = u64::MAX;
-        let full_range = (Bound::Unbounded, Bound::Unbounded);
-        let store_content = store
-            .scan(full_range, epoch, None, ReadOptions::default())
-            .await?;
-        assert!(store_content.is_empty());
 
         handle.await.unwrap();
 

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -21,7 +21,6 @@ use risingwave_pb::task_service::{
     CancelTaskRequest, CancelTaskResponse, CreateTaskRequest, ExecuteRequest, FastInsertRequest,
     FastInsertResponse, GetDataResponse, TaskInfoResponse, fast_insert_response,
 };
-use risingwave_storage::dispatch_state_store;
 use thiserror_ext::AsReport;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
@@ -204,28 +203,12 @@ impl BatchServiceImpl {
     }
 
     async fn do_fast_insert(&self, insert_req: FastInsertRequest) -> Result<(), BatchError> {
-        let table_id = insert_req.table_id;
         let wait_for_persistence = insert_req.wait_for_persistence;
         let (executor, data_chunk) =
             FastInsertExecutor::build(self.env.dml_manager_ref(), insert_req)?;
-        let epoch = executor
+        executor
             .do_execute(data_chunk, wait_for_persistence)
             .await?;
-        if wait_for_persistence {
-            dispatch_state_store!(self.env.state_store(), store, {
-                use risingwave_hummock_sdk::HummockReadEpoch;
-                use risingwave_storage::StateStore;
-                use risingwave_storage::store::TryWaitEpochOptions;
-
-                store
-                    .try_wait_epoch(
-                        HummockReadEpoch::Committed(epoch.0),
-                        TryWaitEpochOptions { table_id },
-                    )
-                    .await
-                    .map_err(BatchError::from)?;
-            });
-        }
         Ok(())
     }
 }

--- a/src/common/src/transaction/transaction_message.rs
+++ b/src/common/src/transaction/transaction_message.rs
@@ -18,13 +18,13 @@ use tokio::sync::oneshot;
 use crate::array::StreamChunk;
 use crate::transaction::transaction_id::TxnId;
 use crate::transaction::transaction_message::TxnMsg::{Begin, Data, End, Rollback};
-use crate::util::epoch::Epoch;
 
 #[derive(Debug, EnumAsInner)]
 pub enum TxnMsg {
     Begin(TxnId),
     Data(TxnId, StreamChunk),
-    End(TxnId, Option<oneshot::Sender<Epoch>>),
+    /// The optional sender is fired after the data has been durably persisted.
+    End(TxnId, Option<oneshot::Sender<()>>),
     Rollback(TxnId),
 }
 

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -185,6 +185,7 @@ async fn test_table_materialize() -> StreamResult<()> {
             column_descs.clone(),
             1024,
             RateLimit::Disabled,
+            memory_state_store.clone(),
         )
         .boxed(),
     );

--- a/src/dml/src/table.rs
+++ b/src/dml/src/table.rs
@@ -14,13 +14,13 @@
 
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use futures_async_stream::try_stream;
 use parking_lot::RwLock;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::transaction::transaction_id::TxnId;
 use risingwave_common::transaction::transaction_message::TxnMsg;
-use risingwave_common::util::epoch::Epoch;
 use tokio::sync::oneshot;
 
 use crate::error::{DmlError, Result};
@@ -195,20 +195,25 @@ impl WriteHandle {
         Ok(())
     }
 
-    pub async fn end_returning_epoch(mut self) -> Result<Epoch> {
+    /// Like `end`, but waits until the data has been durably persisted before returning.
+    /// The `DmlExecutor` fires the persistence signal after `try_wait_epoch` succeeds.
+    pub async fn end_wait_persistence(self) -> Result<()> {
+        self.end_wait_persistence_future()?.await
+    }
+
+    /// Like `end`, but returns a future so the caller can await the persistence ack separately
+    /// from issuing the end message.
+    pub fn end_wait_persistence_future(mut self) -> Result<BoxFuture<'static, Result<()>>> {
         assert_eq!(self.txn_state, TxnState::Begin);
         self.txn_state = TxnState::Committed;
-        // Await the notifier.
-        let (epoch_notifier_tx, epoch_notifier_rx) = oneshot::channel();
-        let notifier = self.write_txn_control_msg_returning_epoch(TxnMsg::End(
-            self.txn_id,
-            Some(epoch_notifier_tx),
-        ))?;
-        notifier.await.map_err(|_| DmlError::ReaderClosed)?;
-        let epoch = epoch_notifier_rx
-            .await
-            .map_err(|_| DmlError::ReaderClosed)?;
-        Ok(epoch)
+        let (persistence_tx, persistence_rx) = oneshot::channel();
+        let notifier =
+            self.write_txn_control_msg(TxnMsg::End(self.txn_id, Some(persistence_tx)))?;
+        Ok(Box::pin(async move {
+            notifier.await.map_err(|_| DmlError::ReaderClosed)?;
+            persistence_rx.await.map_err(|_| DmlError::ReaderClosed)?;
+            Ok(())
+        }))
     }
 
     pub fn rollback(mut self) -> Result<oneshot::Receiver<usize>> {
@@ -241,21 +246,6 @@ impl WriteHandle {
     /// Same as the `write_txn_data_msg`, but it is not an async function and send control message
     /// without permit acquiring.
     fn write_txn_control_msg(&self, txn_msg: TxnMsg) -> Result<oneshot::Receiver<usize>> {
-        assert_eq!(self.txn_id, txn_msg.txn_id());
-        let (notifier_tx, notifier_rx) = oneshot::channel();
-        match self.tx.send_immediate(txn_msg, notifier_tx) {
-            Ok(_) => Ok(notifier_rx),
-
-            // It's possible that the source executor is scaled in or migrated, so the channel
-            // is closed. To guarantee the transactional atomicity, bail out.
-            Err(_) => Err(DmlError::ReaderClosed),
-        }
-    }
-
-    fn write_txn_control_msg_returning_epoch(
-        &self,
-        txn_msg: TxnMsg,
-    ) -> Result<oneshot::Receiver<usize>> {
         assert_eq!(self.txn_id, txn_msg.txn_id());
         let (notifier_tx, notifier_rx) = oneshot::channel();
         match self.tx.send_immediate(txn_msg, notifier_tx) {
@@ -402,6 +392,30 @@ mod tests {
         // Rollback on drop
         drop(write_handle);
         assert_matches!(reader.next().await.unwrap()?, TxnMsg::Rollback(_));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_end_wait_persistence() -> Result<()> {
+        let table_dml_handle = Arc::new(new_table_dml_handle());
+        let mut reader = table_dml_handle.stream_reader().into_stream();
+        let mut write_handle = table_dml_handle
+            .write_handle(TEST_SESSION_ID, TEST_TRANSACTION_ID)
+            .unwrap();
+        write_handle.begin().unwrap();
+
+        assert_matches!(reader.next().await.unwrap()?, TxnMsg::Begin(_));
+
+        let handle = tokio::spawn(async move {
+            write_handle.end_wait_persistence().await.unwrap();
+        });
+
+        assert_matches!(reader.next().await.unwrap()?, TxnMsg::End(_, Some(persistence_notifier)) => {
+            persistence_notifier.send(()).unwrap();
+        });
+
+        handle.await.unwrap();
 
         Ok(())
     }

--- a/src/dml/src/table.rs
+++ b/src/dml/src/table.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
 use futures_async_stream::try_stream;
 use parking_lot::RwLock;
 use risingwave_common::array::StreamChunk;
@@ -197,23 +197,17 @@ impl WriteHandle {
 
     /// Like `end`, but waits until the data has been durably persisted before returning.
     /// The `DmlExecutor` fires the persistence signal after `try_wait_epoch` succeeds.
-    pub async fn end_wait_persistence(self) -> Result<()> {
-        self.end_wait_persistence_future()?.await
-    }
-
-    /// Like `end`, but returns a future so the caller can await the persistence ack separately
-    /// from issuing the end message.
-    pub fn end_wait_persistence_future(mut self) -> Result<BoxFuture<'static, Result<()>>> {
+    pub fn end_wait_persistence(mut self) -> Result<impl Future<Output = Result<()>> + 'static> {
         assert_eq!(self.txn_state, TxnState::Begin);
         self.txn_state = TxnState::Committed;
         let (persistence_tx, persistence_rx) = oneshot::channel();
         let notifier =
             self.write_txn_control_msg(TxnMsg::End(self.txn_id, Some(persistence_tx)))?;
-        Ok(Box::pin(async move {
+        Ok(async move {
             notifier.await.map_err(|_| DmlError::ReaderClosed)?;
             persistence_rx.await.map_err(|_| DmlError::ReaderClosed)?;
             Ok(())
-        }))
+        })
     }
 
     pub fn rollback(mut self) -> Result<oneshot::Receiver<usize>> {
@@ -408,7 +402,7 @@ mod tests {
         assert_matches!(reader.next().await.unwrap()?, TxnMsg::Begin(_));
 
         let handle = tokio::spawn(async move {
-            write_handle.end_wait_persistence().await.unwrap();
+            write_handle.end_wait_persistence().unwrap().await.unwrap();
         });
 
         assert_matches!(reader.next().await.unwrap()?, TxnMsg::End(_, Some(persistence_notifier)) => {

--- a/src/stream/src/executor/dml.rs
+++ b/src/stream/src/executor/dml.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::mem;
 
 use either::Either;
-use futures::future::{BoxFuture, Either as FutureEither, select};
+use futures::future::{Either as FutureEither, select};
 use futures::stream::FuturesOrdered;
 use futures::{StreamExt, TryStreamExt};
 use risingwave_common::catalog::{ColumnDesc, TableId, TableVersionId};
@@ -76,7 +77,7 @@ struct TxnBuffer {
     overflow: bool,
 }
 
-impl<S: StateStore + Clone> DmlExecutor<S> {
+impl<S: StateStore> DmlExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         actor_ctx: ActorContextRef,
@@ -162,8 +163,7 @@ impl<S: StateStore + Clone> DmlExecutor<S> {
 
         // In-flight persistence waits, one future per closed epoch that had pending notifiers.
         // Polled concurrently with the input stream via next_input_driving_persistence.
-        let mut persistence_futures: FuturesOrdered<BoxFuture<'static, StreamExecutorResult<()>>> =
-            FuturesOrdered::new();
+        let mut persistence_futures = FuturesOrdered::new();
 
         while let Some(input_msg) =
             next_input_driving_persistence(&mut stream, &mut persistence_futures).await?
@@ -178,7 +178,7 @@ impl<S: StateStore + Clone> DmlExecutor<S> {
                             let closing_epoch = barrier.epoch.prev;
                             let store = self.state_store.clone();
                             let table_id = self.table_id;
-                            persistence_futures.push_back(Box::pin(async move {
+                            persistence_futures.push_back(async move {
                                 store
                                     .try_wait_epoch(
                                         HummockReadEpoch::Committed(closing_epoch),
@@ -190,7 +190,7 @@ impl<S: StateStore + Clone> DmlExecutor<S> {
                                     let _ = tx.send(());
                                 }
                                 Ok(())
-                            }));
+                            });
                         }
 
                         // We should handle barrier messages here to pause or resume the data from
@@ -354,7 +354,7 @@ impl<S: StateStore + Clone> DmlExecutor<S> {
     }
 }
 
-impl<S: StateStore + Clone> Execute for DmlExecutor<S> {
+impl<S: StateStore> Execute for DmlExecutor<S> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner().boxed()
     }
@@ -365,7 +365,7 @@ impl<S: StateStore + Clone> Execute for DmlExecutor<S> {
 /// (and thus the actor) to fail and trigger recovery.
 async fn next_input_driving_persistence(
     stream: &mut StreamReaderWithPause<false, TxnMsg>,
-    persistence_futures: &mut FuturesOrdered<BoxFuture<'static, StreamExecutorResult<()>>>,
+    persistence_futures: &mut FuturesOrdered<impl Future<Output = StreamExecutorResult<()>>>,
 ) -> StreamExecutorResult<Option<Either<Message, TxnMsg>>> {
     loop {
         if persistence_futures.is_empty() {
@@ -445,17 +445,16 @@ async fn apply_dml_rate_limit(
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use futures::FutureExt;
     use risingwave_common::catalog::{ColumnId, Field, INITIAL_TABLE_VERSION_ID};
     use risingwave_common::test_prelude::StreamChunkTestExt;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_dml::dml_manager::DmlManager;
-    use risingwave_hummock_sdk::HummockReadEpoch;
     use risingwave_hummock_sdk::key::TableKeyRange;
     use risingwave_storage::error::StorageResult;
     use risingwave_storage::memory::MemoryStateStore;
     use risingwave_storage::panic_store::{PanicStateStore, PanicStateStoreIter};
     use risingwave_storage::store::*;
-    use tokio::sync::oneshot;
 
     use super::*;
     use crate::executor::test_utils::MockSource;
@@ -695,12 +694,6 @@ mod tests {
         let msg = dml_executor.next().await.unwrap().unwrap();
         assert!(matches!(msg, Message::Barrier(_)));
 
-        let drain_handle = tokio::spawn(async move {
-            while let Some(msg) = dml_executor.next().await {
-                let _ = msg.unwrap();
-            }
-        });
-
         let table_dml_handle = dml_manager
             .table_dml_handle(table_id, INITIAL_TABLE_VERSION_ID)
             .unwrap();
@@ -716,8 +709,16 @@ mod tests {
             .await
             .unwrap();
 
-        let persist_handle = tokio::spawn(async move {
-            write_handle.end_wait_persistence().await.unwrap();
+        let mut persistence_future = Box::pin(write_handle.end_wait_persistence().unwrap());
+
+        // Drive the executor until all queued DML messages are consumed. The transaction is smaller
+        // than `chunk_size`, so it is buffered and no output is produced before the next barrier.
+        assert!(dml_executor.next().now_or_never().is_none());
+
+        let drain_handle = tokio::spawn(async move {
+            while let Some(msg) = dml_executor.next().await {
+                let _ = msg.unwrap();
+            }
         });
 
         tx.push_barrier_with_prev_epoch_for_test(test_epoch(11), test_epoch(10), false);
@@ -728,10 +729,10 @@ mod tests {
             HummockReadEpoch::Committed(epoch) if epoch == test_epoch(10)
         ));
         assert_eq!(options.table_id, table_id);
-        assert!(!persist_handle.is_finished());
+        assert!(persistence_future.as_mut().now_or_never().is_none());
 
         wait_epoch_release_tx.send(()).unwrap();
-        persist_handle.await.unwrap();
+        persistence_future.await.unwrap();
 
         drain_handle.abort();
     }

--- a/src/stream/src/executor/dml.rs
+++ b/src/stream/src/executor/dml.rs
@@ -16,21 +16,27 @@ use std::collections::BTreeMap;
 use std::mem;
 
 use either::Either;
-use futures::TryStreamExt;
+use futures::future::{BoxFuture, Either as FutureEither, select};
+use futures::stream::FuturesOrdered;
+use futures::{StreamExt, TryStreamExt};
 use risingwave_common::catalog::{ColumnDesc, TableId, TableVersionId};
 use risingwave_common::transaction::transaction_id::TxnId;
 use risingwave_common::transaction::transaction_message::TxnMsg;
 use risingwave_common_rate_limit::{MonitoredRateLimiter, RateLimit, RateLimiter};
 use risingwave_dml::dml_manager::DmlManagerRef;
 use risingwave_expr::codegen::BoxStream;
+use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_pb::common::ThrottleType;
+use risingwave_storage::StateStore;
+use risingwave_storage::store::TryWaitEpochOptions;
+use tokio::sync::oneshot;
 
 use crate::executor::prelude::*;
 use crate::executor::stream_reader::StreamReaderWithPause;
 
 /// [`DmlExecutor`] accepts both stream data and batch data for data manipulation on a specific
 /// table. The two streams will be merged into one and then sent to downstream.
-pub struct DmlExecutor {
+pub struct DmlExecutor<S: StateStore> {
     actor_ctx: ActorContextRef,
 
     upstream: Executor,
@@ -50,6 +56,8 @@ pub struct DmlExecutor {
     chunk_size: usize,
 
     rate_limiter: Arc<MonitoredRateLimiter>,
+
+    state_store: S,
 }
 
 /// If a transaction's data is less than `MAX_CHUNK_FOR_ATOMICITY` * `CHUNK_SIZE`, we can provide
@@ -68,7 +76,7 @@ struct TxnBuffer {
     overflow: bool,
 }
 
-impl DmlExecutor {
+impl<S: StateStore + Clone> DmlExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         actor_ctx: ActorContextRef,
@@ -79,6 +87,7 @@ impl DmlExecutor {
         column_descs: Vec<ColumnDesc>,
         chunk_size: usize,
         rate_limit: RateLimit,
+        state_store: S,
     ) -> Self {
         let rate_limiter = Arc::new(RateLimiter::new(rate_limit).monitored(table_id));
         Self {
@@ -90,6 +99,7 @@ impl DmlExecutor {
             column_descs,
             chunk_size,
             rate_limiter,
+            state_store,
         }
     }
 
@@ -131,8 +141,6 @@ impl DmlExecutor {
             stream.pause_stream();
         }
 
-        let mut epoch = barrier.get_curr_epoch();
-
         yield Message::Barrier(barrier);
 
         // Active transactions: txn_id -> TxnBuffer with transaction chunks.
@@ -148,12 +156,43 @@ impl DmlExecutor {
                 .collect(),
         );
 
-        while let Some(input_msg) = stream.next().await {
-            match input_msg? {
+        // Notifiers from end_wait_persistence() calls in the current open epoch.
+        // Drained into a try_wait_epoch future on each barrier.
+        let mut pending_persistence_notifiers: Vec<oneshot::Sender<()>> = Vec::new();
+
+        // In-flight persistence waits, one future per closed epoch that had pending notifiers.
+        // Polled concurrently with the input stream via next_input_driving_persistence.
+        let mut persistence_futures: FuturesOrdered<BoxFuture<'static, StreamExecutorResult<()>>> =
+            FuturesOrdered::new();
+
+        while let Some(input_msg) =
+            next_input_driving_persistence(&mut stream, &mut persistence_futures).await?
+        {
+            match input_msg {
                 Either::Left(msg) => {
                     // Stream messages.
                     if let Message::Barrier(barrier) = &msg {
-                        epoch = barrier.get_curr_epoch();
+                        // Flush any pending persistence notifiers for the epoch that is closing.
+                        if !pending_persistence_notifiers.is_empty() {
+                            let notifiers = mem::take(&mut pending_persistence_notifiers);
+                            let closing_epoch = barrier.epoch.prev;
+                            let store = self.state_store.clone();
+                            let table_id = self.table_id;
+                            persistence_futures.push_back(Box::pin(async move {
+                                store
+                                    .try_wait_epoch(
+                                        HummockReadEpoch::Committed(closing_epoch),
+                                        TryWaitEpochOptions { table_id },
+                                    )
+                                    .await
+                                    .map_err(StreamExecutorError::from)?;
+                                for tx in notifiers {
+                                    let _ = tx.send(());
+                                }
+                                Ok(())
+                            }));
+                        }
+
                         // We should handle barrier messages here to pause or resume the data from
                         // DML.
                         if let Some(mutation) = barrier.mutation.as_deref() {
@@ -210,9 +249,9 @@ impl DmlExecutor {
                                     panic!("Transaction id collision txn_id = {}.", txn_id)
                                 });
                         }
-                        TxnMsg::End(txn_id, epoch_notifier) => {
-                            if let Some(sender) = epoch_notifier {
-                                let _ = sender.send(epoch);
+                        TxnMsg::End(txn_id, persistence_notifier) => {
+                            if let Some(tx) = persistence_notifier {
+                                pending_persistence_notifiers.push(tx);
                             }
                             let mut txn_buffer = active_txn_map.remove(&txn_id)
                                 .unwrap_or_else(|| panic!("Receive an unexpected transaction end message. Active transaction map doesn't contain this transaction txn_id = {}.", txn_id));
@@ -315,9 +354,32 @@ impl DmlExecutor {
     }
 }
 
-impl Execute for DmlExecutor {
+impl<S: StateStore + Clone> Execute for DmlExecutor<S> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner().boxed()
+    }
+}
+
+/// Poll `stream` for the next input message while concurrently driving `persistence_futures`.
+/// Any error from a completed persistence future is propagated immediately, causing the executor
+/// (and thus the actor) to fail and trigger recovery.
+async fn next_input_driving_persistence(
+    stream: &mut StreamReaderWithPause<false, TxnMsg>,
+    persistence_futures: &mut FuturesOrdered<BoxFuture<'static, StreamExecutorResult<()>>>,
+) -> StreamExecutorResult<Option<Either<Message, TxnMsg>>> {
+    loop {
+        if persistence_futures.is_empty() {
+            return stream.next().await.transpose();
+        }
+
+        match select(persistence_futures.next(), stream.next()).await {
+            FutureEither::Left((Some(Ok(())), _)) => continue,
+            FutureEither::Left((Some(Err(err)), _)) => return Err(err),
+            FutureEither::Left((None, _)) => {
+                unreachable!("persistence_futures is known to be non-empty")
+            }
+            FutureEither::Right((stream_item, _)) => return stream_item.transpose(),
+        }
     }
 }
 
@@ -333,8 +395,8 @@ async fn apply_dml_rate_limit(
             TxnMsg::Begin(txn_id) => {
                 yield TxnMsg::Begin(txn_id);
             }
-            TxnMsg::End(txn_id, epoch_notifier) => {
-                yield TxnMsg::End(txn_id, epoch_notifier);
+            TxnMsg::End(txn_id, persistence_notifier) => {
+                yield TxnMsg::End(txn_id, persistence_notifier);
             }
             TxnMsg::Rollback(txn_id) => {
                 yield TxnMsg::Rollback(txn_id);
@@ -381,17 +443,85 @@ async fn apply_dml_rate_limit(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
 
     use risingwave_common::catalog::{ColumnId, Field, INITIAL_TABLE_VERSION_ID};
     use risingwave_common::test_prelude::StreamChunkTestExt;
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_dml::dml_manager::DmlManager;
+    use risingwave_hummock_sdk::HummockReadEpoch;
+    use risingwave_hummock_sdk::key::TableKeyRange;
+    use risingwave_storage::error::StorageResult;
+    use risingwave_storage::memory::MemoryStateStore;
+    use risingwave_storage::panic_store::{PanicStateStore, PanicStateStoreIter};
+    use risingwave_storage::store::*;
+    use tokio::sync::oneshot;
 
     use super::*;
     use crate::executor::test_utils::MockSource;
 
     const TEST_TRANSACTION_ID: TxnId = 0;
     const TEST_SESSION_ID: u32 = 0;
+
+    type WaitEpochCallSender = oneshot::Sender<(HummockReadEpoch, TryWaitEpochOptions)>;
+
+    #[derive(Clone)]
+    struct MockWaitEpochStateStore {
+        wait_epoch_called_tx: Arc<Mutex<Option<WaitEpochCallSender>>>,
+        wait_epoch_release_rx: Arc<tokio::sync::Mutex<Option<oneshot::Receiver<()>>>>,
+    }
+
+    impl StateStoreReadLog for MockWaitEpochStateStore {
+        type ChangeLogIter = PanicStateStoreIter<StateStoreReadLogItem>;
+
+        async fn next_epoch(&self, _epoch: u64, _options: NextEpochOptions) -> StorageResult<u64> {
+            panic!("should not read changelog from MockWaitEpochStateStore")
+        }
+
+        async fn iter_log(
+            &self,
+            _epoch_range: (u64, u64),
+            _key_range: TableKeyRange,
+            _options: ReadLogOptions,
+        ) -> StorageResult<Self::ChangeLogIter> {
+            panic!("should not read changelog from MockWaitEpochStateStore")
+        }
+    }
+
+    impl StateStore for MockWaitEpochStateStore {
+        type Local = PanicStateStore;
+        type ReadSnapshot = PanicStateStore;
+        type VectorWriter = PanicStateStore;
+
+        async fn try_wait_epoch(
+            &self,
+            epoch: HummockReadEpoch,
+            options: TryWaitEpochOptions,
+        ) -> StorageResult<()> {
+            if let Some(tx) = self.wait_epoch_called_tx.lock().unwrap().take() {
+                assert!(tx.send((epoch, options)).is_ok());
+            }
+            let rx = self.wait_epoch_release_rx.lock().await.take().unwrap();
+            rx.await.unwrap();
+            Ok(())
+        }
+
+        async fn new_local(&self, _option: NewLocalOptions) -> Self::Local {
+            panic!("should not create local state from MockWaitEpochStateStore")
+        }
+
+        async fn new_read_snapshot(
+            &self,
+            _epoch: HummockReadEpoch,
+            _options: NewReadSnapshotOptions,
+        ) -> StorageResult<Self::ReadSnapshot> {
+            panic!("should not read snapshot from MockWaitEpochStateStore")
+        }
+
+        async fn new_vector_writer(&self, _options: NewVectorWriterOptions) -> Self::VectorWriter {
+            panic!("should not create vector writer from MockWaitEpochStateStore")
+        }
+    }
 
     #[tokio::test]
     async fn test_dml_executor() {
@@ -419,6 +549,7 @@ mod tests {
             column_descs,
             1024,
             RateLimit::Disabled,
+            MemoryStateStore::new(),
         );
         let mut dml_executor = dml_executor.boxed().execute();
 
@@ -528,5 +659,80 @@ mod tests {
 
         let msg = dml_executor.next().await.unwrap().unwrap();
         assert!(matches!(msg, Message::Barrier(_)));
+    }
+
+    #[tokio::test]
+    async fn test_dml_executor_waits_for_barrier_prev_epoch_persistence() {
+        let table_id = TableId::new(233);
+        let schema = Schema::new(vec![Field::unnamed(DataType::Int64)]);
+        let column_descs = vec![ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64)];
+        let stream_key = vec![0];
+        let dml_manager = Arc::new(DmlManager::for_test());
+        let (wait_epoch_called_tx, wait_epoch_called_rx) = oneshot::channel();
+        let (wait_epoch_release_tx, wait_epoch_release_rx) = oneshot::channel();
+
+        let (mut tx, source) = MockSource::channel();
+        let source = source.into_executor(schema, stream_key);
+        let dml_executor = DmlExecutor::new(
+            ActorContext::for_test(0),
+            source,
+            dml_manager.clone(),
+            table_id,
+            INITIAL_TABLE_VERSION_ID,
+            column_descs,
+            1024,
+            RateLimit::Disabled,
+            MockWaitEpochStateStore {
+                wait_epoch_called_tx: Arc::new(Mutex::new(Some(wait_epoch_called_tx))),
+                wait_epoch_release_rx: Arc::new(tokio::sync::Mutex::new(Some(
+                    wait_epoch_release_rx,
+                ))),
+            },
+        );
+        let mut dml_executor = dml_executor.boxed().execute();
+
+        tx.push_barrier_with_prev_epoch_for_test(test_epoch(10), test_epoch(9), false);
+        let msg = dml_executor.next().await.unwrap().unwrap();
+        assert!(matches!(msg, Message::Barrier(_)));
+
+        let drain_handle = tokio::spawn(async move {
+            while let Some(msg) = dml_executor.next().await {
+                let _ = msg.unwrap();
+            }
+        });
+
+        let table_dml_handle = dml_manager
+            .table_dml_handle(table_id, INITIAL_TABLE_VERSION_ID)
+            .unwrap();
+        let mut write_handle = table_dml_handle
+            .write_handle(TEST_SESSION_ID, TEST_TRANSACTION_ID)
+            .unwrap();
+        write_handle.begin().unwrap();
+        write_handle
+            .write_chunk(StreamChunk::from_pretty(
+                " I
+                + 7",
+            ))
+            .await
+            .unwrap();
+
+        let persist_handle = tokio::spawn(async move {
+            write_handle.end_wait_persistence().await.unwrap();
+        });
+
+        tx.push_barrier_with_prev_epoch_for_test(test_epoch(11), test_epoch(10), false);
+
+        let (wait_epoch, options) = wait_epoch_called_rx.await.unwrap();
+        assert!(matches!(
+            wait_epoch,
+            HummockReadEpoch::Committed(epoch) if epoch == test_epoch(10)
+        ));
+        assert_eq!(options.table_id, table_id);
+        assert!(!persist_handle.is_finished());
+
+        wait_epoch_release_tx.send(()).unwrap();
+        persist_handle.await.unwrap();
+
+        drain_handle.abort();
     }
 }

--- a/src/stream/src/from_proto/dml.rs
+++ b/src/stream/src/from_proto/dml.rs
@@ -30,7 +30,7 @@ impl ExecutorBuilder for DmlExecutorBuilder {
     async fn new_boxed_executor(
         params: ExecutorParams,
         node: &Self::Node,
-        _store: impl StateStore,
+        store: impl StateStore,
     ) -> StreamResult<Executor> {
         let [upstream]: [_; 1] = params.input.try_into().unwrap();
         let table_id = node.table_id;
@@ -45,6 +45,7 @@ impl ExecutorBuilder for DmlExecutorBuilder {
             column_descs,
             params.config.developer.chunk_size,
             node.rate_limit.into(),
+            store,
         );
         Ok((params.info, exec).into())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- This PR extracts the DML executor and webhook persistence-waiting part from `yiming/test-tapdata`.
- Fast insert no longer waits for persistence in the batch RPC layer by returning an epoch and then calling `try_wait_epoch` outside the DML path.
- Instead, `WriteHandle` now supports waiting for durable persistence directly, and `DmlExecutor` holds persistence notifiers until the closing barrier's previous epoch has passed `try_wait_epoch`.
- This keeps the persistence waiting mechanism inside the normal DML execution flow and makes webhook-triggered fast inserts complete only after their data is durably persisted.
- The executor builder and related tests are updated to pass the state store into `DmlExecutor` and verify the new persistence behavior.
- This PR intentionally excludes the new websocket ingest implementation and the new RPC method introduced in the original branch.


## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
