### PR TITLE
fix(sink): update kv log store value indices after schema change

### DIFF
--- a/src/connector/src/sink/test_sink.rs
+++ b/src/connector/src/sink/test_sink.rs
@@ -59,6 +59,10 @@ impl Sink for TestSink {
 
     const SINK_NAME: &'static str = "test";
 
+    fn support_schema_change() -> bool {
+        true
+    }
+
     async fn validate(&self) -> crate::sink::Result<()> {
         Ok(())
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -1822,11 +1822,12 @@ impl CatalogController {
                         ObjectModel(sink, sink_obj.unwrap(), sink_streaming_job.clone()).into(),
                     )),
                 });
-                if let Some((log_store_table_id, new_log_store_table_columns)) =
-                    finish_sink_context.new_log_store_table
-                {
+                if let Some(new_log_store_table) = finish_sink_context.new_log_store_table {
+                    let log_store_table_id = new_log_store_table.id;
                     let new_log_store_table_columns: ColumnCatalogArray =
-                        new_log_store_table_columns.into();
+                        new_log_store_table.columns.clone().into();
+                    let new_log_store_table_value_indices =
+                        new_log_store_table.value_indices.clone();
                     let (mut table, table_obj) = Table::find_by_id(log_store_table_id)
                         .find_also_related(Object)
                         .one(txn)
@@ -1835,11 +1836,13 @@ impl CatalogController {
                     Table::update(table::ActiveModel {
                         table_id: Set(log_store_table_id),
                         columns: Set(new_log_store_table_columns.clone()),
+                        value_indices: Set(new_log_store_table_value_indices.clone().into()),
                         ..Default::default()
                     })
                     .exec(txn)
                     .await?;
                     table.columns = new_log_store_table_columns;
+                    table.value_indices = new_log_store_table_value_indices.into();
                     objects.push(PbObject {
                         object_info: Some(PbObjectInfo::Table(
                             ObjectModel(table, table_obj.unwrap(), sink_streaming_job.clone())
@@ -3399,7 +3402,7 @@ pub struct FinishAutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink_id: SinkId,
     pub columns: Vec<PbColumnCatalog>,
-    pub new_log_store_table: Option<(TableId, Vec<PbColumnCatalog>)>,
+    pub new_log_store_table: Option<PbTable>,
 }
 
 async fn update_connector_props_fragments<F>(

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -3402,7 +3402,7 @@ pub struct FinishAutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink_id: SinkId,
     pub columns: Vec<PbColumnCatalog>,
-    pub new_log_store_table: Option<PbTable>,
+    pub new_log_store_table: Option<Box<PbTable>>,
 }
 
 async fn update_connector_props_fragments<F>(

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1589,10 +1589,7 @@ impl DdlController {
                             tmp_sink_id: sink.tmp_sink_id,
                             original_sink_id: sink.original_sink.id,
                             columns: sink.new_schema.clone(),
-                            new_log_store_table: sink
-                                .new_log_store_table
-                                .as_ref()
-                                .map(|table| (table.id, table.columns.clone())),
+                            new_log_store_table: sink.new_log_store_table.clone(),
                         })
                         .collect()
                 });

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1534,7 +1534,7 @@ impl DdlController {
                             .map(|col| col.name.clone())
                             .collect(),
                         new_fragment: new_sink_fragment,
-                        new_log_store_table,
+                        new_log_store_table: new_log_store_table.map(Box::new),
                         ctx: sink_ctx,
                     });
                 }

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -509,6 +509,7 @@ fn rewrite_log_store_table(
     extend_sink_columns(&mut log_store_table.columns, newly_added_columns, |name| {
         format!("{}_{}", upstream_table_name, name)
     });
+    log_store_table.value_indices = (0..log_store_table.columns.len() as i32).collect();
 }
 
 /// Rewrite `StreamScan` + Merge to match the new upstream schema.

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -2604,9 +2604,17 @@ mod tests {
         );
 
         let new_log_store_table = new_log_store_table.expect("log store table should be updated");
+        assert!(
+            new_log_store_table.columns.iter().all(|col| !col
+                .column_desc
+                .as_ref()
+                .unwrap()
+                .name
+                .contains("tmp"))
+        );
         assert_eq!(
             new_log_store_table.value_indices,
-            (0..columns.len()).map(|i| i as i32).collect::<Vec<_>>()
+            (0..new_log_store_table.columns.len() as i32).collect::<Vec<_>>()
         );
     }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -192,7 +192,7 @@ pub struct AutoRefreshSchemaSinkContext {
     pub newly_add_fields: Vec<Field>,
     pub removed_column_names: Vec<String>,
     pub new_fragment: Fragment,
-    pub new_log_store_table: Option<PbTable>,
+    pub new_log_store_table: Option<Box<PbTable>>,
     /// The sink's own stream context (timezone, `config_override`).
     pub ctx: StreamContext,
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/mod.rs
@@ -627,22 +627,28 @@ mod tests {
     use std::task::Poll;
     use std::time::Duration;
 
+    use futures::StreamExt;
     use itertools::Itertools;
-    use risingwave_common::array::StreamChunk;
+    use risingwave_common::array::{Op, StreamChunk};
     use risingwave_common::bitmap::{Bitmap, BitmapBuilder};
+    use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ColumnId};
     use risingwave_common::hash::VirtualNode;
-    use risingwave_common::types::DataType;
+    use risingwave_common::row::{OwnedRow, Row};
+    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
     use risingwave_common::util::epoch::{EpochExt, EpochPair};
     use risingwave_connector::sink::log_store::{
         ChunkId, FlushCurrentEpochOptions, LogReader, LogStoreFactory, LogStoreReadItem, LogWriter,
         TruncateOffset,
     };
+    use risingwave_hummock_sdk::HummockReadEpoch;
     use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
     use risingwave_pb::plan_common::PbField;
     use risingwave_pb::stream_plan::{PbSinkAddColumnsOp, PbSinkSchemaChange};
+    use risingwave_storage::table::batch_table::BatchTable;
 
     use crate::common::log_store_impl::kv_log_store::test_utils::{
-        LogWriterTestExt, TEST_DATA_SIZE, calculate_vnode_bitmap, check_rows_eq,
+        LogWriterTestExt, TEST_DATA_SIZE, TEST_TABLE_ID, calculate_vnode_bitmap, check_rows_eq,
         check_stream_chunk_eq, gen_multi_vnode_stream_chunks, gen_stream_chunk_with_info,
         gen_test_log_store_table,
     };
@@ -2300,5 +2306,232 @@ mod tests {
 
         // Writer should be able to continue with the next epoch after reader truncation.
         writer.write_chunk(gen_stream_chunk(10)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_schema_change_batch_scan_skips_old_schema_rows() {
+        let pk_info: &'static KvLogStorePkInfo = &KV_LOG_STORE_V2_INFO;
+        let test_env = prepare_hummock_test_env().await;
+
+        let old_table = gen_test_log_store_table(pk_info);
+        test_env.register_table(old_table.clone()).await;
+
+        let old_chunk = gen_stream_chunk_with_info(0, pk_info);
+        let old_bitmap = Arc::new(calculate_vnode_bitmap(old_chunk.rows()));
+        let factory = KvLogStoreFactory::new(
+            test_env.storage.clone(),
+            old_table.clone(),
+            Some(old_bitmap),
+            1024,
+            1024,
+            KvLogStoreMetrics::for_test(),
+            "test",
+            None,
+            pk_info,
+        );
+        let (mut reader, mut writer) = factory.build().await;
+
+        let epoch1 = test_env
+            .storage
+            .get_pinned_version()
+            .table_committed_epoch(old_table.id)
+            .unwrap()
+            .next_epoch();
+        test_env
+            .storage
+            .start_epoch(epoch1, HashSet::from_iter([TEST_TABLE_ID]));
+        writer
+            .init(EpochPair::new_test_epoch(epoch1), false)
+            .await
+            .unwrap();
+        writer.write_chunk(old_chunk).await.unwrap();
+
+        let epoch2 = epoch1.next_epoch();
+        test_env
+            .storage
+            .start_epoch(epoch2, HashSet::from_iter([TEST_TABLE_ID]));
+        let schema_change = PbSinkSchemaChange {
+            original_schema: old_table
+                .columns
+                .iter()
+                .map(|col| PbField {
+                    data_type: Some(
+                        col.column_desc
+                            .as_ref()
+                            .unwrap()
+                            .column_type
+                            .as_ref()
+                            .unwrap()
+                            .clone(),
+                    ),
+                    name: col.column_desc.as_ref().unwrap().name.clone(),
+                })
+                .collect(),
+            op: Some(
+                risingwave_pb::stream_plan::sink_schema_change::PbOp::AddColumns(
+                    PbSinkAddColumnsOp {
+                        fields: vec![PbField {
+                            data_type: Some(DataType::Int32.to_protobuf()),
+                            name: "age".to_owned(),
+                        }],
+                    },
+                ),
+            ),
+        };
+        let flush_future = writer.flush_current_epoch(
+            epoch2,
+            FlushCurrentEpochOptions {
+                is_checkpoint: true,
+                new_vnode_bitmap: None,
+                is_stop: false,
+                schema_change: Some(schema_change),
+            },
+        );
+        let mut flush_future = Box::pin(flush_future);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), flush_future.as_mut())
+                .await
+                .is_err()
+        );
+
+        reader.init().await.unwrap();
+        reader.start_from(None).await.unwrap();
+        let _ = reader.next_item().await.unwrap();
+        let _ = reader.next_item().await.unwrap();
+        reader
+            .truncate(TruncateOffset::Barrier { epoch: epoch1 })
+            .unwrap();
+        {
+            let post_flush = tokio::time::timeout(Duration::from_secs(10), flush_future)
+                .await
+                .expect("schema-change flush should finish after reader truncates barrier")
+                .unwrap();
+            post_flush.post_yield_barrier().await.unwrap();
+        }
+        tokio::time::timeout(Duration::from_secs(10), test_env.commit_epoch(epoch1))
+            .await
+            .expect("committing the schema-change epoch should not hang");
+
+        drop(reader);
+        drop(writer);
+        test_env.storage.clear_shared_buffer().await;
+
+        let mut new_table = old_table.clone();
+        new_table.columns.push(
+            ColumnCatalog::visible(ColumnDesc::named(
+                "age",
+                ColumnId::new(new_table.columns.len() as i32),
+                DataType::Int32,
+            ))
+            .to_protobuf(),
+        );
+        new_table.value_indices = (0..new_table.columns.len() as i32).collect();
+        let mut builder = DataChunkBuilder::new(
+            vec![DataType::Int64, DataType::Varchar, DataType::Int32],
+            1024,
+        );
+        let vnode_zero_ids = (0_i64..)
+            .filter(|id| {
+                let row = OwnedRow::new(vec![
+                    Some(ScalarImpl::Int64(*id)),
+                    Some(ScalarImpl::Utf8("probe".into())),
+                    Some(ScalarImpl::Int32(0)),
+                ]);
+                VirtualNode::compute_row_for_test(&row, &[0]).to_index() == 0
+            })
+            .take(2)
+            .collect_vec();
+        for row in [
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(vnode_zero_ids[0])),
+                Some(ScalarImpl::Utf8("alice".into())),
+                Some(ScalarImpl::Int32(40)),
+            ]),
+            OwnedRow::new(vec![
+                Some(ScalarImpl::Int64(vnode_zero_ids[1])),
+                Some(ScalarImpl::Utf8("bob".into())),
+                Some(ScalarImpl::Int32(50)),
+            ]),
+        ] {
+            assert!(builder.append_one_row(row).is_none());
+        }
+        let new_chunk =
+            StreamChunk::from_parts(vec![Op::Insert, Op::Insert], builder.consume_all().unwrap());
+
+        let new_bitmap = Arc::new(calculate_vnode_bitmap(new_chunk.rows()));
+        let factory = KvLogStoreFactory::new(
+            test_env.storage.clone(),
+            new_table.clone(),
+            Some(new_bitmap.clone()),
+            1024,
+            1024,
+            KvLogStoreMetrics::for_test(),
+            "test",
+            None,
+            pk_info,
+        );
+        let (_, mut writer) = factory.build().await;
+        test_env
+            .storage
+            .start_epoch(epoch2, HashSet::from_iter([TEST_TABLE_ID]));
+        writer
+            .init(EpochPair::new_test_epoch(epoch2), false)
+            .await
+            .unwrap();
+        writer.write_chunk(new_chunk).await.unwrap();
+        let epoch3 = epoch2.next_epoch();
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            writer.flush_current_epoch_for_test(epoch3, true),
+        )
+        .await
+        .expect("flushing the rebuilt writer should not hang")
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(10), test_env.commit_epoch(epoch2))
+            .await
+            .expect("committing the rebuilt-writer epoch should not hang");
+
+        let batch_table = BatchTable::for_test(
+            test_env.storage.clone(),
+            TEST_TABLE_ID,
+            new_table
+                .columns
+                .iter()
+                .map(|col| col.column_desc.as_ref().unwrap().into())
+                .collect_vec(),
+            pk_info.pk_orderings.to_vec(),
+            (0..pk_info.pk_len()).collect_vec(),
+            new_table
+                .value_indices
+                .iter()
+                .map(|&idx| idx as usize)
+                .collect_vec(),
+        );
+        let age_column_idx = pk_info.predefined_column_len() + 2;
+        let mut iter = pin!(
+            batch_table
+                .batch_iter(
+                    HummockReadEpoch::Committed(epoch2),
+                    false,
+                    Default::default(),
+                )
+                .await
+                .unwrap()
+        );
+
+        let mut ages = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut ages = vec![];
+            while let Some(row) = iter.next().await {
+                let row = row.unwrap();
+                if let Some(age) = row.datum_at(age_column_idx) {
+                    ages.push(age.into_int32());
+                }
+            }
+            ages
+        })
+        .await
+        .expect("batch scan after schema change should not hang");
+        ages.sort_unstable();
+        assert_eq!(ages, vec![40, 50]);
     }
 }

--- a/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
@@ -162,17 +162,6 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
         }
         flush_info.report(&self.metrics);
 
-        if let Some(truncate_offset) = self.tx.pop_truncation(epoch) {
-            self.last_truncate_offset = Some(truncate_offset);
-        }
-        let post_seal_epoch = self.state.seal_current_epoch(
-            next_epoch,
-            self.last_truncate_offset
-                .map(|(epoch, seq_id)| {
-                    LogStoreVnodeProgress::Aligned(self.state.vnodes().clone(), epoch, seq_id)
-                })
-                .unwrap_or(LogStoreVnodeProgress::None),
-        );
         let has_schema_change = options.schema_change.is_some();
         // Barrier's new_vnode_bitmap field does not need to be passed to log-reader, because when sink is decoupled, we
         // always rebuild sink when update vnode bitmap.
@@ -188,6 +177,17 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
             assert_eq!(truncate_offset, (epoch, None));
             self.last_truncate_offset = Some(truncate_offset);
         }
+        if let Some(truncate_offset) = self.tx.pop_truncation(epoch) {
+            self.last_truncate_offset = Some(truncate_offset);
+        }
+        let post_seal_epoch = self.state.seal_current_epoch(
+            next_epoch,
+            self.last_truncate_offset
+                .map(|(epoch, seq_id)| {
+                    LogStoreVnodeProgress::Aligned(self.state.vnodes().clone(), epoch, seq_id)
+                })
+                .unwrap_or(LogStoreVnodeProgress::None),
+        );
         let update_vnode_bitmap_tx = &mut self.update_vnode_bitmap_tx;
         let tx = &mut self.tx;
         self.seq_id = FIRST_SEQ_ID;

--- a/src/tests/simulation/tests/integration_tests/sink/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/mod.rs
@@ -23,6 +23,8 @@ mod recovery;
 #[cfg(madsim)]
 mod scale;
 #[cfg(madsim)]
+mod schema_change;
+#[cfg(madsim)]
 mod utils;
 
 #[cfg(madsim)]

--- a/src/tests/simulation/tests/integration_tests/sink/schema_change.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/schema_change.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tests/simulation/tests/integration_tests/sink/schema_change.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/schema_change.rs
@@ -1,0 +1,211 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::Result;
+use risingwave_simulation::cluster::{Cluster, ConfigPath, Configuration, Session};
+use tokio::time::sleep;
+
+use crate::sink::utils::*;
+
+async fn start_schema_change_test_cluster() -> Result<Cluster> {
+    let config_path = {
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp config file");
+        file.write_all(include_bytes!("../../../../../config/ci-sim.toml"))
+            .expect("failed to write config file");
+        file.into_temp_path()
+    };
+
+    Cluster::start(Configuration {
+        config_path: ConfigPath::Temp(config_path.into()),
+        frontend_nodes: 1,
+        compute_nodes: 1,
+        meta_nodes: 1,
+        compactor_nodes: 1,
+        compute_node_cores: 2,
+        ..Default::default()
+    })
+    .await
+}
+
+async fn find_log_store_table_name(session: &mut Session, sink_name: &str) -> Result<String> {
+    let table_name_prefix = format!("public.__internal_{}_", sink_name);
+    let internal_tables = session.run("show internal tables").await?;
+    internal_tables
+        .lines()
+        .find(|line| {
+            line.contains(&table_name_prefix)
+                && line
+                    .strip_prefix(&table_name_prefix)
+                    .map(|rest| rest.to_ascii_lowercase().contains("sink"))
+                    .unwrap_or(false)
+        })
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "failed to find log store internal table for {sink_name}. tables: {}",
+                internal_tables
+            )
+        })
+}
+
+/// Test that value_indices is properly updated after auto schema change on the kv log store table.
+///
+/// Bug: On `main`, when ALTER TABLE adds a column, the kv log store internal table gets the new
+/// column added to its `columns` list, but `value_indices` is NOT updated in the catalog.
+/// This means the state table's serialization/deserialization is broken:
+/// - Writes after schema change silently drop the new column's data
+/// - Reads hit type mismatch panics because stale value_indices cause column misalignment
+///
+/// This test:
+/// 1. Creates a table and a decoupled sink with auto.schema.change enabled
+/// 2. Inserts initial data
+/// 3. ALTER TABLE ADD COLUMN to trigger schema change
+/// 4. Waits for schema change to propagate (new column visible in describe)
+/// 5. Inserts data with the new column populated
+/// 6. Flushes the new epoch so the retained log rows become queryable
+/// 7. Queries the retained kv log store internal table directly
+///
+/// On main (buggy): the query fails with a type mismatch panic because value_indices is stale.
+/// After fix: the query succeeds and returns the actual inserted age values.
+#[tokio::test]
+async fn test_schema_change_kv_log_store_value_indices() -> Result<()> {
+    let mut cluster = start_schema_change_test_cluster().await?;
+    let test_sink = SimulationTestSink::register_new(TestSinkType::RetainLog);
+
+    let mut session = cluster.start_session();
+
+    // Use decoupled mode to ensure kv log store is used
+    session.run("set streaming_parallelism = 1").await?;
+    session.run("set sink_decouple = true").await?;
+
+    session
+        .run("create table test_table (id int primary key, name varchar)")
+        .await?;
+
+    session
+        .run(
+            "create sink test_schema_change_sink from test_table \
+             with (connector = 'test', type = 'upsert', auto.schema.change = 'true')",
+        )
+        .await?;
+
+    // Insert initial data (2 columns: id, name)
+    session
+        .run("insert into test_table values (1, 'alice'), (2, 'bob'), (3, 'charlie')")
+        .await?;
+    test_sink.store.wait_for_count(3).await?;
+    session.run("flush").await?;
+
+    // Find the log store internal table
+    let log_store_table =
+        find_log_store_table_name(&mut session, "test_schema_change_sink").await?;
+
+    // ALTER TABLE to add a new column — triggers auto-refresh schema change
+    session
+        .run("alter table test_table add column age int")
+        .await?;
+
+    // Wait for schema change to propagate to the log store table
+    for i in 0..60 {
+        match session.run(format!("describe {}", log_store_table)).await {
+            Ok(desc) => {
+                if desc.to_ascii_lowercase().contains("age") {
+                    break;
+                }
+            }
+            Err(_) => {}
+        }
+        if i == 59 {
+            return Err(anyhow::anyhow!(
+                "Timed out waiting for schema change to propagate to log store table"
+            ));
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    // Re-find the log store table (could have been replaced during schema change)
+    let log_store_table =
+        find_log_store_table_name(&mut session, "test_schema_change_sink").await?;
+
+    // Insert data WITH the new column populated.
+    session
+        .run("insert into test_table values (4, 'dave', 40), (5, 'eve', 50), (6, 'frank', 60)")
+        .await?;
+    test_sink.store.wait_for_count(6).await?;
+    session.run("flush").await?;
+
+    // Find the age column name in the log store table (prefixed with upstream table name)
+    let describe_final = session.run(format!("describe {}", log_store_table)).await?;
+    let age_column_name = describe_final
+        .lines()
+        .find(|line| line.to_ascii_lowercase().contains("age"))
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Could not find age column in log store table after schema change:\n{}",
+                describe_final
+            )
+        })?;
+
+    // Query the log store table for the new column.
+    let query = format!(
+        "select {age_col}, count(*) from {table} where {age_col} is not null group by {age_col} order by {age_col}",
+        age_col = age_column_name,
+        table = log_store_table,
+    );
+    let mut last_error = None;
+    let mut last_rows = String::new();
+    for attempt in 0..60 {
+        match session.run(&query).await {
+            Ok(rows) => {
+                let non_null_count = rows.trim().lines().count();
+                if non_null_count > 0 {
+                    last_rows = rows;
+                    last_error = None;
+                    break;
+                }
+                last_rows = rows;
+            }
+            Err(e) => {
+                last_error = Some(e);
+            }
+        }
+        if attempt % 5 == 4 {
+            session.run("flush").await?;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    if let Some(e) = last_error {
+        return Err(anyhow::anyhow!(
+            "Query on log store internal table failed after schema change \
+             (likely stale value_indices causing column misalignment): {}",
+            e
+        ));
+    }
+    let non_null_count = last_rows.trim().lines().count();
+    if non_null_count == 0 {
+        return Err(anyhow::anyhow!(
+            "After schema change, the kv log store internal table has NULL for the age column. \
+             value_indices was not updated during schema change."
+        ));
+    }
+
+    session.run("drop sink test_schema_change_sink").await?;
+    session.run("drop table test_table").await?;
+
+    Ok(())
+}

--- a/src/tests/simulation/tests/integration_tests/sink/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/utils.rs
@@ -35,8 +35,11 @@ use risingwave_common::catalog::Field;
 use risingwave_common::row::Row;
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
+use risingwave_connector::sink::boxed::{BoxLogSinker, DynLogReader};
 use risingwave_connector::sink::coordinate::CoordinatedLogSinker;
-use risingwave_connector::sink::log_store::DeliveryFutureManagerAddFuture;
+use risingwave_connector::sink::log_store::{
+    DeliveryFutureManagerAddFuture, LogStoreReadItem, TruncateOffset,
+};
 use risingwave_connector::sink::test_sink::{
     TestSinkRegistryGuard, register_build_coordinated_sink, register_build_sink,
 };
@@ -44,8 +47,8 @@ use risingwave_connector::sink::writer::{
     AsyncTruncateSinkWriter, AsyncTruncateSinkWriterExt, SinkWriter,
 };
 use risingwave_connector::sink::{
-    SinglePhaseCommitCoordinator, SinkCommitCoordinator, SinkCommittedEpochSubscriber, SinkError,
-    TwoPhaseCommitCoordinator,
+    LogSinker, SinglePhaseCommitCoordinator, SinkCommitCoordinator, SinkCommittedEpochSubscriber,
+    SinkError, SinkLogReader, TwoPhaseCommitCoordinator,
 };
 use risingwave_connector::source::test_source::{
     BoxSource, TestSourceRegistryGuard, TestSourceSplit, register_test_source,
@@ -495,6 +498,7 @@ pub enum TestSinkType {
     SinglePhaseCoordinatedSink,
     TwoPhaseCoordinatedSink,
     AsyncTruncate,
+    RetainLog,
 }
 
 #[macro_export]
@@ -655,6 +659,64 @@ impl SimulationTestSink {
                         }
                         .into_log_sinker(10),
                     );
+                    async move { Ok(log_sinker) }.boxed()
+                }
+            }),
+            TestSinkType::RetainLog => register_build_sink({
+                let parallelism_counter = parallelism_counter.clone();
+                let store = store.clone();
+                move |_, _| {
+                    parallelism_counter.fetch_add(1, Relaxed);
+                    let store = store.clone();
+                    let parallelism_counter = parallelism_counter.clone();
+                    let log_sinker: BoxLogSinker =
+                        Box::new(move |mut log_reader: &mut dyn DynLogReader| {
+                            async move {
+                                struct ParallelismGuard(Arc<AtomicUsize>);
+
+                                impl Drop for ParallelismGuard {
+                                    fn drop(&mut self) {
+                                        self.0.fetch_sub(1, Relaxed);
+                                    }
+                                }
+
+                                let _parallelism_guard = ParallelismGuard(parallelism_counter);
+
+                                log_reader.start_from(None).await?;
+                                loop {
+                                    let (epoch, item) = log_reader.next_item().await?;
+                                    match item {
+                                        LogStoreReadItem::StreamChunk { chunk, .. } => {
+                                            for (op, row) in chunk.rows() {
+                                                assert_eq!(op, Op::Insert);
+                                                assert!(row.len() >= 2);
+                                                let id = row.datum_at(0).unwrap().into_int32();
+                                                let name = row
+                                                    .datum_at(1)
+                                                    .unwrap()
+                                                    .into_utf8()
+                                                    .to_string();
+                                                store.insert(id, name);
+                                            }
+                                        }
+                                        LogStoreReadItem::Barrier {
+                                            is_checkpoint,
+                                            schema_change,
+                                            ..
+                                        } => {
+                                            if is_checkpoint {
+                                                store.inc_checkpoint();
+                                            }
+                                            if schema_change.is_some() {
+                                                log_reader
+                                                    .truncate(TruncateOffset::Barrier { epoch })?;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            .boxed()
+                        });
                     async move { Ok(log_sinker) }.boxed()
                 }
             }),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes auto schema change for decoupled sinks backed by the kv log store.

Previously, when `ALTER TABLE ... ADD COLUMN` triggered sink schema change, the internal log store table schema was updated with the new `columns`, but its `value_indices` could remain stale in the rewritten table metadata and in the catalog update path. That led to incorrect serialization/deserialization for rows written after the schema change:
- newly added column values could be dropped from retained log rows
- scans on the internal log store table could fail with type mismatches because columns were read with misaligned indices

This PR fixes that by:
- rebuilding the log store table `value_indices` after extending the schema during sink schema change
- carrying the full rewritten `PbTable` through the auto-refresh schema flow instead of only forwarding the new columns
- persisting both `columns` and `value_indices` when finishing the streaming job replacement in meta
- adding regression coverage in both the kv log store test and the madsim sink schema change test

The new tests cover:
- batch scan behavior after schema change, ensuring old-schema rows are skipped and new-schema rows remain readable
- an end-to-end decoupled sink schema change flow that verifies retained log rows expose the newly added column correctly after `ALTER TABLE ADD COLUMN`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
