### PR TITLE
chore(deps): bump openssl to 0.10.78 to fix high-severity advisories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ risedev-components.user.env
 risedev-compose.yml
 risedev-profiles.user.yml
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Test Generated Files & Outputs
 ft.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "libloading 0.8.9",
  "toml 0.9.12+spec-1.1.0",
  "windows-registry 0.6.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2260,7 +2260,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4924,7 +4924,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7467,7 +7467,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8986,7 +8986,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.11",
  "http 1.4.0",
@@ -9225,9 +9225,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -9266,9 +9266,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -10521,8 +10521,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -10540,8 +10540,8 @@ name = "prost-build"
 version = "0.14.3"
 source = "git+https://github.com/risingwavelabs/prost.git?rev=040a192409e45069158300baec4f402ad1fe101a#040a192409e45069158300baec4f402ad1fe101a"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -10562,7 +10562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10574,7 +10574,7 @@ version = "0.14.3"
 source = "git+https://github.com/risingwavelabs/prost.git?rev=040a192409e45069158300baec4f402ad1fe101a#040a192409e45069158300baec4f402ad1fe101a"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13637,7 +13637,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15489,7 +15489,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ mysql_async = { version = "0.36", features = [
     "rust_decimal",
 ] }
 opendal = "0.55"
+openssl = "0.10.78"
 opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = "0.31"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -113,7 +113,7 @@ opendal = { workspace = true, features = [
     "services-webhdfs",
 ] }
 opensearch = { version = "2.3.0", features = ["rustls-tls"] }
-openssl = "0.10.72"
+openssl = { workspace = true }
 parking_lot = { workspace = true }
 parquet = { version = "58", features = ["async"] }
 paste = "1"

--- a/src/expr/impl/Cargo.toml
+++ b/src/expr/impl/Cargo.toml
@@ -46,7 +46,7 @@ linkme = { workspace = true }
 md5 = { package = "md-5", version = "0.10.6" }
 moka = { version = "0.12.0", features = ["sync"] }
 num-traits = "0.2"
-openssl = "0.10.72"
+openssl = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 risingwave_common = { workspace = true }

--- a/src/expr/impl/src/scalar/encrypt.rs
+++ b/src/expr/impl/src/scalar/encrypt.rs
@@ -143,7 +143,15 @@ impl CipherConfig {
         input: &[u8],
         operation: CipherMode,
     ) -> std::result::Result<Box<[u8]>, ErrorStack> {
-        let mut decrypter = Crypter::new(self.cipher, operation, self.crypt_key.as_ref(), None)?;
+        // Default the IV to all-zeros when the cipher requires one, to match pgcrypto:
+        // https://github.com/postgres/postgres/blob/REL_18_3/contrib/pgcrypto/pgcrypto.c#L325
+        let iv = self.cipher.iv_len().map(|len| vec![0u8; len]);
+        let mut decrypter = Crypter::new(
+            self.cipher,
+            operation,
+            self.crypt_key.as_ref(),
+            iv.as_deref(),
+        )?;
         let enable_padding = match self.padding {
             Padding::Pkcs => true,
             Padding::None => false,
@@ -203,6 +211,13 @@ mod test {
         )
         .unwrap();
         let encrypted = encrypt(data, &config).unwrap();
+
+        // Pin the zero-IV default: AES-128-CBC / PKCS, key 00..0F, IV all-zero.
+        let expected: &[u8] = &[
+            0x92, 0x76, 0xfd, 0xf3, 0x84, 0xf3, 0x85, 0x18, 0xfa, 0x6c, 0x83, 0x10, 0xf1, 0x91,
+            0x67, 0x8d,
+        ];
+        assert_eq!(encrypted.as_ref(), expected);
 
         let decrypted = decrypt(&encrypted, &config).unwrap();
         assert_eq!(decrypted, (*data).into());

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -16,7 +16,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = { workspace = true }
 jsonwebtoken = { workspace = true }
 ldap3 = { version = "0.12.1", default-features = false, features = ["tls-rustls-aws-lc-rs"] }
-openssl = "0.10.72"
+openssl = { workspace = true }
 panic-message = "0.3"
 parking_lot = { workspace = true }
 peekable = { version = "0.4", features = ["tokio"] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

resolve https://github.com/risingwavelabs/risingwave/security/dependabot/401
resolve https://github.com/risingwavelabs/risingwave/security/dependabot/405
resolve https://github.com/risingwavelabs/risingwave/security/dependabot/403

Bump `openssl` from `0.10.72` → `0.10.78` to fix four high-severity Dependabot advisories:

- [GHSA-pqf5-4pqq-29f5](https://github.com/advisories/GHSA-pqf5-4pqq-29f5) — `Deriver::derive` buffer overflow on OpenSSL 1.1.1
- [GHSA-8c75-8mhr-p7r9](https://github.com/advisories/GHSA-8c75-8mhr-p7r9) — AES key wrap out-of-bounds write
- [GHSA-hppc-g8h3-xhp3](https://github.com/advisories/GHSA-hppc-g8h3-xhp3) — PSK/cookie trampolines leak adjacent memory
- [GHSA-ghm9-cr32-g9qj](https://github.com/advisories/GHSA-ghm9-cr32-g9qj) — `MdCtxRef::digest_final` writes past caller buffer

Side effects:
- `openssl` promoted to a workspace dep.
- `0.10.78` now **panics** in `Crypter::new` when a cipher requires an IV but `None` is supplied. Our `encrypt`/`decrypt` SQL functions relied on this path for AES-CBC (previously silently used a zero IV). Explicitly pass a zero IV to match [pgcrypto's behavior](https://github.com/postgres/postgres/blob/REL_18_3/contrib/pgcrypto/pgcrypto.c#L325), preserving round-trip compatibility with existing ciphertexts. `test_decrypt` now pins the zero-IV default with a known-answer check.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Bumped `openssl` to `0.10.78` to address four high-severity RustSec advisories. No user-facing behavior changes.

</details>