### PR TITLE
chore(meta): promote create streaming job lifecycle logs to info

### DIFF
--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1064,7 +1064,7 @@ impl DdlController {
             }
         };
         let job_id = streaming_job.id();
-        tracing::debug!(
+        tracing::info!(
             id = %job_id,
             definition = streaming_job.definition(),
             create_type = streaming_job.create_type().as_str_name(),

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1064,7 +1064,8 @@ impl DdlController {
             }
         };
         let job_id = streaming_job.id();
-        tracing::info!(
+        tracing::info!(id = %job_id, "starting streaming job");
+        tracing::debug!(
             id = %job_id,
             definition = streaming_job.definition(),
             create_type = streaming_job.create_type().as_str_name(),

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -348,7 +348,8 @@ impl GlobalStreamManager {
                 CreateType::Unspecified => unreachable!(),
             };
 
-            tracing::info!(?streaming_job, "stream job finish");
+            tracing::info!(id = %streaming_job.id(), "stream job finish");
+            tracing::debug!(?streaming_job, "stream job finish");
             Ok(version)
         }
         .in_current_span();
@@ -543,7 +544,8 @@ impl GlobalStreamManager {
             .run_command(streaming_job.database_id(), command)
             .await?;
 
-        tracing::info!(?streaming_job, "first barrier collected for stream job");
+        tracing::info!(id = %streaming_job.id(), "first barrier collected for stream job");
+        tracing::debug!(?streaming_job, "first barrier collected for stream job");
 
         Ok(streaming_job)
     }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -348,7 +348,7 @@ impl GlobalStreamManager {
                 CreateType::Unspecified => unreachable!(),
             };
 
-            tracing::debug!(?streaming_job, "stream job finish");
+            tracing::info!(?streaming_job, "stream job finish");
             Ok(version)
         }
         .in_current_span();
@@ -543,7 +543,7 @@ impl GlobalStreamManager {
             .run_command(streaming_job.database_id(), command)
             .await?;
 
-        tracing::debug!(?streaming_job, "first barrier collected for stream job");
+        tracing::info!(?streaming_job, "first barrier collected for stream job");
 
         Ok(streaming_job)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Today, when a user runs `CREATE MATERIALIZED VIEW` (or any other streaming-job DDL), the default meta log at `INFO` is essentially silent on success — every lifecycle message inside the DDL controller / stream manager is at `DEBUG`. Operators have no way to tell from the log whether meta received the job, whether actors were built, or whether the first barrier was collected, unless they flip the whole meta to `DEBUG`.

This PR promotes three per-DDL log sites from `debug!` to `info!`, chosen to bracket the three externally observable phases of job creation:

- `ddl_controller.rs` — `starting streaming job` (meta accepted the DDL and began processing)
- `stream_manager.rs` — `first barrier collected for stream job` (job is actually running downstream)
- `stream_manager.rs` — `stream job finish` (creation completed)

Intermediate implementation-detail logs (`building streaming job`, `built actors finished`, `sending Command::CreateStreamingJob`) are intentionally left at `debug!` — they fire on the same code path as the three above and would only add noise at `INFO`.

Each of these logs fires at most once per streaming job, so the extra volume at `INFO` is negligible, while the debuggability win for "job stuck in creation" investigations is significant.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Meta now logs the start, first-barrier, and finish of streaming-job creation at `INFO` level instead of `DEBUG`, so operators can see per-DDL progress in the default meta log.

</details>