### PR TITLE
fix(meta): clean dropped streaming jobs outside post collect

### DIFF
--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -527,7 +527,9 @@ pub async fn start_service_as_election_leader(
             env.clone(),
             metadata_manager.clone(),
             barrier_scheduler.clone(),
+            hummock_manager.clone(),
             source_manager.clone(),
+            refresh_manager.clone(),
             scale_controller.clone(),
         )
         .unwrap(),

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -799,9 +799,9 @@ impl DatabaseCheckpointControl {
 
             Some(Command::DropStreamingJobs {
                 streaming_job_ids,
-                unregistered_state_table_ids,
                 unregistered_fragment_ids,
                 dropped_sink_fragment_by_targets,
+                ..
             }) => {
                 let actors = self
                     .database_info
@@ -835,10 +835,7 @@ impl DatabaseCheckpointControl {
                     table_ids,
                     None,
                     node_actors,
-                    PostCollectCommand::DropStreamingJobs {
-                        streaming_job_ids,
-                        unregistered_state_table_ids,
-                    },
+                    PostCollectCommand::DropStreamingJobs,
                 )
             }
 

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -448,6 +448,7 @@ pub enum Command {
     /// drop actors, and then delete the job fragments info from meta store.
     DropStreamingJobs {
         streaming_job_ids: HashSet<JobId>,
+        /// Used by recovery quick path when draining buffered drop/cancel commands.
         unregistered_state_table_ids: HashSet<TableId>,
         unregistered_fragment_ids: HashSet<FragmentId>,
         // target_fragment -> [sink_fragments]
@@ -678,10 +679,7 @@ impl Command {
 #[derive(Debug)]
 pub enum PostCollectCommand {
     Command(String),
-    DropStreamingJobs {
-        streaming_job_ids: HashSet<JobId>,
-        unregistered_state_table_ids: HashSet<TableId>,
-    },
+    DropStreamingJobs,
     CreateStreamingJob {
         info: CreateStreamingJobCommandInfo,
         job_type: CreateStreamingJobType,
@@ -714,7 +712,7 @@ impl PostCollectCommand {
 
     pub fn should_checkpoint(&self) -> bool {
         match self {
-            PostCollectCommand::DropStreamingJobs { .. }
+            PostCollectCommand::DropStreamingJobs
             | PostCollectCommand::CreateStreamingJob { .. }
             | PostCollectCommand::Reschedule { .. }
             | PostCollectCommand::ReplaceStreamJob { .. }
@@ -729,7 +727,7 @@ impl PostCollectCommand {
     pub fn command_name(&self) -> &str {
         match self {
             PostCollectCommand::Command(name) => name.as_str(),
-            PostCollectCommand::DropStreamingJobs { .. } => "DropStreamingJobs",
+            PostCollectCommand::DropStreamingJobs => "DropStreamingJobs",
             PostCollectCommand::CreateStreamingJob { .. } => "CreateStreamingJob",
             PostCollectCommand::Reschedule { .. } => "Reschedule",
             PostCollectCommand::ReplaceStreamJob { .. } => "ReplaceStreamJob",

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -42,7 +42,7 @@ use crate::barrier::{
 use crate::hummock::CommitEpochInfo;
 use crate::manager::LocalNotification;
 use crate::model::FragmentDownstreamRelation;
-use crate::stream::SourceChange;
+use crate::stream::{SourceChange, cleanup_dropped_streaming_jobs};
 use crate::{MetaError, MetaResult};
 
 impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
@@ -300,26 +300,7 @@ impl PostCollectCommand {
                     .await?;
             }
 
-            PostCollectCommand::DropStreamingJobs {
-                streaming_job_ids,
-                unregistered_state_table_ids,
-            } => {
-                for job_id in streaming_job_ids {
-                    barrier_manager_context
-                        .refresh_manager
-                        .remove_progress_tracker(job_id.as_mv_table_id(), "drop_streaming_jobs");
-                }
-
-                barrier_manager_context
-                    .hummock_manager
-                    .unregister_table_ids(unregistered_state_table_ids.iter().cloned())
-                    .await?;
-                barrier_manager_context
-                    .metadata_manager
-                    .catalog_controller
-                    .complete_dropped_tables(unregistered_state_table_ids.iter().copied())
-                    .await;
-            }
+            PostCollectCommand::DropStreamingJobs => {}
             PostCollectCommand::ConnectorPropsChange(obj_id_map_props) => {
                 // todo: we dont know the type of the object id, it can be a source or a sink. Should carry more info in the barrier command.
                 barrier_manager_context
@@ -532,10 +513,15 @@ impl PostCollectCommand {
                         &replace_plan,
                     )
                     .await;
-                barrier_manager_context
-                    .hummock_manager
-                    .unregister_table_ids(to_drop_state_table_ids.iter().cloned())
-                    .await?;
+                cleanup_dropped_streaming_jobs(
+                    &barrier_manager_context.refresh_manager,
+                    &barrier_manager_context.hummock_manager,
+                    &barrier_manager_context.metadata_manager,
+                    [],
+                    to_drop_state_table_ids.clone(),
+                    "replace_streaming_job",
+                )
+                .await?;
             }
 
             PostCollectCommand::CreateSubscription { subscription_id } => {

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -47,7 +47,9 @@ use crate::manager::ActiveStreamingWorkerNodes;
 use crate::model::{ActorId, FragmentDownstreamRelation, FragmentId, StreamActor};
 use crate::rpc::ddl_controller::refill_upstream_sink_union_in_table;
 use crate::stream::cdc::reload_cdc_table_snapshot_splits;
-use crate::stream::{SourceChange, StreamFragmentGraph, UpstreamSinkInfo};
+use crate::stream::{
+    SourceChange, StreamFragmentGraph, UpstreamSinkInfo, cleanup_dropped_streaming_jobs,
+};
 
 #[derive(Debug)]
 pub(crate) struct UpstreamSinkRecoveryInfo {
@@ -214,6 +216,24 @@ fn build_stream_actors(
 }
 
 impl GlobalBarrierWorkerContextImpl {
+    async fn apply_pre_applied_drop_cancel(
+        &self,
+        database_id: Option<DatabaseId>,
+    ) -> MetaResult<bool> {
+        let drop_cancel = self.scheduled_barriers.pre_apply_drop_cancel(database_id);
+        let has_drop_streaming_jobs = !drop_cancel.streaming_job_ids.is_empty();
+        cleanup_dropped_streaming_jobs(
+            &self.refresh_manager,
+            &self.hummock_manager,
+            &self.metadata_manager,
+            drop_cancel.streaming_job_ids,
+            drop_cancel.dropped_state_table_ids,
+            "drop_streaming_jobs",
+        )
+        .await?;
+        Ok(has_drop_streaming_jobs)
+    }
+
     /// Clean catalogs for creating streaming jobs that are in foreground mode or table fragments not persisted.
     async fn clean_dirty_streaming_jobs(&self, database_id: Option<DatabaseId>) -> MetaResult<()> {
         self.metadata_manager
@@ -595,7 +615,7 @@ impl GlobalBarrierWorkerContextImpl {
                     tracing::info!("recovered background job progress");
 
                     // This is a quick path to accelerate the process of dropping and canceling streaming jobs.
-                    let _ = self.scheduled_barriers.pre_apply_drop_cancel(None);
+                    let _ = self.apply_pre_applied_drop_cancel(None).await?;
                     self.metadata_manager
                         .catalog_controller
                         .cleanup_dropped_tables()
@@ -653,12 +673,7 @@ impl GlobalBarrierWorkerContextImpl {
                     }
 
                     let mut recovery_context = self.load_recovery_context(None).await?;
-                    let dropped_table_ids = self.scheduled_barriers.pre_apply_drop_cancel(None);
-                    if !dropped_table_ids.is_empty() {
-                        self.metadata_manager
-                            .catalog_controller
-                            .complete_dropped_tables(dropped_table_ids)
-                            .await;
+                    if self.apply_pre_applied_drop_cancel(None).await? {
                         recovery_context = self.load_recovery_context(None).await?;
                     }
 
@@ -768,13 +783,9 @@ impl GlobalBarrierWorkerContextImpl {
         tracing::info!(?database_id, "recovered background job progress");
 
         // This is a quick path to accelerate the process of dropping and canceling streaming jobs.
-        let dropped_table_ids = self
-            .scheduled_barriers
-            .pre_apply_drop_cancel(Some(database_id));
-        self.metadata_manager
-            .catalog_controller
-            .complete_dropped_tables(dropped_table_ids)
-            .await;
+        let _ = self
+            .apply_pre_applied_drop_cancel(Some(database_id))
+            .await?;
 
         let recovery_context = self.load_recovery_context(Some(database_id)).await?;
 

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -606,9 +606,17 @@ pub(super) enum MarkReadyOptions {
     },
 }
 
+pub(super) struct PreApplyDropCancel {
+    pub streaming_job_ids: Vec<JobId>,
+    pub dropped_state_table_ids: Vec<TableId>,
+}
+
 impl ScheduledBarriers {
     /// Pre buffered drop and cancel command, return all dropped state tables if any.
-    pub(super) fn pre_apply_drop_cancel(&self, database_id: Option<DatabaseId>) -> Vec<TableId> {
+    pub(super) fn pre_apply_drop_cancel(
+        &self,
+        database_id: Option<DatabaseId>,
+    ) -> PreApplyDropCancel {
         self.pre_apply_drop_cancel_scheduled(database_id)
     }
 
@@ -749,9 +757,12 @@ impl ScheduledBarriers {
     pub(super) fn pre_apply_drop_cancel_scheduled(
         &self,
         database_id: Option<DatabaseId>,
-    ) -> Vec<TableId> {
+    ) -> PreApplyDropCancel {
         let mut queue = self.inner.queue.lock();
-        let mut dropped_tables = vec![];
+        let mut drop_cancel = PreApplyDropCancel {
+            streaming_job_ids: vec![],
+            dropped_state_table_ids: vec![],
+        };
 
         let mut pre_apply_drop_cancel = |queue: &mut DatabaseScheduledQueue| {
             while let Some(ScheduledQueueItem {
@@ -760,10 +771,14 @@ impl ScheduledBarriers {
             {
                 match command {
                     Command::DropStreamingJobs {
+                        streaming_job_ids,
                         unregistered_state_table_ids,
                         ..
                     } => {
-                        dropped_tables.extend(unregistered_state_table_ids);
+                        drop_cancel.streaming_job_ids.extend(streaming_job_ids);
+                        drop_cancel
+                            .dropped_state_table_ids
+                            .extend(unregistered_state_table_ids);
                     }
                     Command::DropSubscription { .. } => {}
                     _ => {
@@ -789,7 +804,7 @@ impl ScheduledBarriers {
             }
         }
 
-        dropped_tables
+        drop_cancel
     }
 }
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -34,7 +34,8 @@ use tokio::sync::{Mutex, OwnedSemaphorePermit, oneshot};
 use tracing::Instrument;
 
 use super::{
-    ReschedulePolicy, ScaleControllerRef, StreamFragmentGraph, UserDefinedFragmentBackfillOrder,
+    GlobalRefreshManagerRef, ReschedulePolicy, ScaleControllerRef, StreamFragmentGraph,
+    UserDefinedFragmentBackfillOrder,
 };
 use crate::barrier::{
     BarrierScheduler, Command, CreateStreamingJobCommandInfo, CreateStreamingJobType,
@@ -43,6 +44,7 @@ use crate::barrier::{
 use crate::controller::catalog::DropTableConnectorContext;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::error::bail_invalid_parameter;
+use crate::hummock::HummockManagerRef;
 use crate::manager::{
     MetaSrvEnv, MetadataManager, NotificationVersion, StreamingJob, StreamingJobType,
 };
@@ -55,6 +57,32 @@ use crate::stream::{ReplaceJobSplitPlan, SourceManagerRef};
 use crate::{MetaError, MetaResult};
 
 pub type GlobalStreamManagerRef = Arc<GlobalStreamManager>;
+
+pub(crate) async fn cleanup_dropped_streaming_jobs(
+    refresh_manager: &GlobalRefreshManagerRef,
+    hummock_manager: &HummockManagerRef,
+    metadata_manager: &MetadataManager,
+    streaming_job_ids: impl IntoIterator<Item = JobId>,
+    state_table_ids: Vec<TableId>,
+    progress_status: &str,
+) -> MetaResult<()> {
+    for job_id in streaming_job_ids {
+        refresh_manager.remove_progress_tracker(job_id.as_mv_table_id(), progress_status);
+    }
+
+    if state_table_ids.is_empty() {
+        return Ok(());
+    }
+
+    hummock_manager
+        .unregister_table_ids(state_table_ids.clone())
+        .await?;
+    metadata_manager
+        .catalog_controller
+        .complete_dropped_tables(state_table_ids)
+        .await;
+    Ok(())
+}
 
 #[derive(Default)]
 pub struct CreateStreamingJobOption {
@@ -267,8 +295,12 @@ pub struct GlobalStreamManager {
     /// Broadcasts and collect barriers
     pub barrier_scheduler: BarrierScheduler,
 
+    pub hummock_manager: HummockManagerRef,
+
     /// Maintains streaming sources from external system like kafka
     pub source_manager: SourceManagerRef,
+
+    pub refresh_manager: GlobalRefreshManagerRef,
 
     /// Creating streaming job info.
     creating_job_info: CreatingStreamingJobInfoRef,
@@ -281,14 +313,18 @@ impl GlobalStreamManager {
         env: MetaSrvEnv,
         metadata_manager: MetadataManager,
         barrier_scheduler: BarrierScheduler,
+        hummock_manager: HummockManagerRef,
         source_manager: SourceManagerRef,
+        refresh_manager: GlobalRefreshManagerRef,
         scale_controller: ScaleControllerRef,
     ) -> MetaResult<Self> {
         Ok(Self {
             env,
             metadata_manager,
             barrier_scheduler,
+            hummock_manager,
             source_manager,
+            refresh_manager,
             creating_job_info: Arc::new(CreatingStreamingJobInfo::default()),
             scale_controller,
         })
@@ -395,6 +431,8 @@ impl GlobalStreamManager {
                                 let cancel_command = self.metadata_manager.catalog_controller
                                     .build_cancel_command(&job_fragments)
                                     .await?;
+                                let cleanup_state_table_ids =
+                                    job_fragments.all_table_ids().collect_vec();
                                 self.metadata_manager.catalog_controller
                                     .try_abort_creating_streaming_job(job_id, true)
                                     .await?;
@@ -402,6 +440,15 @@ impl GlobalStreamManager {
                                 self.barrier_scheduler
                                     .run_command(database_id, cancel_command)
                                     .await?;
+                                cleanup_dropped_streaming_jobs(
+                                    &self.refresh_manager,
+                                    &self.hummock_manager,
+                                    &self.metadata_manager,
+                                    [job_id],
+                                    cleanup_state_table_ids,
+                                    "cancel_streaming_job",
+                                )
+                                .await?;
                                 Ok(())
                             }
                             .await;
@@ -623,7 +670,9 @@ impl GlobalStreamManager {
         dropped_sink_fragment_by_targets: HashMap<FragmentId, Vec<FragmentId>>,
     ) {
         if !streaming_job_ids.is_empty() || !state_table_ids.is_empty() {
-            let _ = self
+            let cleanup_streaming_job_ids = streaming_job_ids.clone();
+            let cleanup_state_table_ids = state_table_ids.clone();
+            let run_result = self
                 .barrier_scheduler
                 .run_command(
                     database_id,
@@ -634,10 +683,24 @@ impl GlobalStreamManager {
                         dropped_sink_fragment_by_targets,
                     },
                 )
-                .await
-                .inspect_err(|err| {
-                    tracing::error!(error = ?err.as_report(), "failed to run drop command");
-                });
+                .await;
+            let result = match run_result {
+                Ok(()) => {
+                    cleanup_dropped_streaming_jobs(
+                        &self.refresh_manager,
+                        &self.hummock_manager,
+                        &self.metadata_manager,
+                        cleanup_streaming_job_ids,
+                        cleanup_state_table_ids,
+                        "drop_streaming_jobs",
+                    )
+                    .await
+                }
+                Err(err) => Err(err),
+            };
+            let _ = result.inspect_err(|err| {
+                tracing::error!(error = ?err.as_report(), "failed to run drop command");
+            });
         }
     }
 
@@ -645,8 +708,7 @@ impl GlobalStreamManager {
     /// 1. Send cancel message to stream jobs (via `cancel_jobs`).
     /// 2. Send cancel message to recovered stream jobs (via `barrier_scheduler`).
     ///
-    /// Cleanup of their state will be cleaned up after the `CancelStreamJob` command succeeds,
-    /// by the barrier manager for both of them.
+    /// Cleanup of their state is handled by the caller after the drop command is collected.
     pub async fn cancel_streaming_jobs(&self, job_ids: Vec<JobId>) -> MetaResult<Vec<JobId>> {
         if job_ids.is_empty() {
             return Ok(vec![]);
@@ -695,6 +757,7 @@ impl GlobalStreamManager {
                 .catalog_controller
                 .build_cancel_command(&fragment)
                 .await?;
+            let cleanup_state_table_ids = fragment.all_table_ids().collect_vec();
 
             let (_, database_id) = self
                 .metadata_manager
@@ -706,6 +769,15 @@ impl GlobalStreamManager {
                 self.barrier_scheduler
                     .run_command(database_id, cancel_command)
                     .await?;
+                cleanup_dropped_streaming_jobs(
+                    &self.refresh_manager,
+                    &self.hummock_manager,
+                    &self.metadata_manager,
+                    [id],
+                    cleanup_state_table_ids,
+                    "cancel_streaming_job",
+                )
+                .await?;
             }
 
             tracing::info!(?id, "cancelled background streaming job");

--- a/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
+use risingwave_common::catalog::TableId;
 use risingwave_common::error::AsReport;
+use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_simulation::cluster::{Cluster, Configuration, Session};
 use tokio::time::sleep;
 
 use crate::utils::{
     kill_cn_and_meta_and_wait_recover, kill_cn_and_wait_recover,
-    kill_cn_meta_and_wait_full_recovery, kill_random_and_wait_recover,
+    kill_cn_meta_and_wait_full_recovery, kill_random_and_wait_recover, member_table_ids,
+    wait_all_database_recovered, wait_for_jobs_cleared, wait_jobs_running, wait_member_table_ids,
 };
 
 const CREATE_TABLE: &str = "CREATE TABLE t(v1 int);";
@@ -36,6 +41,9 @@ const RESET_RATE_LIMIT: &str = "SET BACKFILL_RATE_LIMIT=DEFAULT;";
 const CREATE_MV1: &str = "CREATE MATERIALIZED VIEW mv1 as SELECT * FROM t;";
 const DROP_MV1: &str = "DROP MATERIALIZED VIEW mv1;";
 const WAIT: &str = "WAIT;";
+const DATABASE_RECOVERY_START: &str = "DATABASE_RECOVERY_START";
+const DATABASE_RECOVERY_SUCCESS: &str = "DATABASE_RECOVERY_SUCCESS";
+const MAX_HEARTBEAT_INTERVAL_SEC: u64 = 10;
 
 async fn cancel_stream_jobs(session: &mut Session) -> Result<Vec<u32>> {
     tracing::info!("finding streaming jobs to cancel");
@@ -57,6 +65,164 @@ async fn cancel_stream_jobs(session: &mut Session) -> Result<Vec<u32>> {
     Ok(ids)
 }
 
+async fn database_id_mapping(session: &mut Session) -> Result<HashMap<String, u32>> {
+    let rows = session.run("select name, id from rw_databases").await?;
+    Ok(rows
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let (name, id) = line.rsplit_once(' ').unwrap();
+            (name.to_owned(), u32::from_str(id.trim()).unwrap())
+        })
+        .collect())
+}
+
+async fn database_recovery_events(session: &mut Session) -> Result<HashMap<u32, Vec<String>>> {
+    let rows = session
+        .run(
+            "select event_type,
+       case event_type
+           when 'DATABASE_RECOVERY_START' then info -> 'recovery' -> 'databaseStart' ->> 'databaseId'
+           when 'DATABASE_RECOVERY_SUCCESS' then info -> 'recovery' -> 'databaseSuccess' ->> 'databaseId'
+           when 'DATABASE_RECOVERY_FAILURE' then info -> 'recovery' -> 'databaseFailure' ->> 'databaseId'
+           end as database_id
+from rw_catalog.rw_event_logs
+where event_type like '%DATABASE_RECOVERY%'
+order by timestamp;",
+        )
+        .await?;
+    let mut result = HashMap::new();
+    for line in rows.lines().filter(|line| !line.trim().is_empty()) {
+        let (event_type, id) = line.rsplit_once(' ').unwrap();
+        result
+            .entry(u32::from_str(id.trim())?)
+            .or_insert_with(Vec::new)
+            .push(event_type.to_owned());
+    }
+    Ok(result)
+}
+
+async fn wait_until(session: &mut Session, sql: &str, target: &str) -> Result<()> {
+    tokio::time::timeout(Duration::from_secs(100), async {
+        loop {
+            if session.run(sql).await.unwrap() == target {
+                return;
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await?;
+    Ok(())
+}
+
+async fn wait_for_database_recovery_state(
+    session: &mut Session,
+    database_id: u32,
+    target: &str,
+) -> Result<()> {
+    wait_until(
+        session,
+        &format!(
+            "select recovery_state from rw_catalog.rw_recovery_info where database_id = {};",
+            database_id
+        ),
+        target,
+    )
+    .await
+}
+
+async fn wait_for_stream_job_and_member_tables(
+    session: &mut Session,
+    baseline_member_tables: &HashSet<u32>,
+) -> Result<HashSet<u32>> {
+    for _ in 0..60 {
+        let jobs = session.run("show jobs;").await?;
+        if !jobs.trim().is_empty() {
+            let current_member_tables = member_table_ids(session).await?;
+            let created_member_tables = current_member_tables
+                .difference(baseline_member_tables)
+                .copied()
+                .collect::<HashSet<_>>();
+            if !created_member_tables.is_empty() {
+                return Ok(created_member_tables);
+            }
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    Err(anyhow!(
+        "failed to observe a creating stream job with new member tables"
+    ))
+}
+
+async fn compaction_group_id_by_table_id(
+    session: &mut Session,
+    table_id: u32,
+) -> Result<CompactionGroupId> {
+    Ok(session
+        .run(format!(
+            "SELECT id FROM rw_hummock_compaction_group_configs WHERE member_tables @> '[{table_id}]'::jsonb;"
+        ))
+        .await?
+        .parse::<CompactionGroupId>()?)
+}
+
+async fn sstable_ids_by_table_id(session: &mut Session, table_id: u32) -> Result<Vec<u64>> {
+    let rows = session
+        .run(format!(
+            "SELECT sstable_id FROM rw_hummock_sstables WHERE table_ids @> '[{table_id}]'::jsonb ORDER BY sstable_id;"
+        ))
+        .await?;
+    rows.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| Ok(u64::from_str(line.trim())?))
+        .collect()
+}
+
+async fn wait_for_sstable_ids_by_table_id(
+    session: &mut Session,
+    table_id: u32,
+) -> Result<Vec<u64>> {
+    for _ in 0..60 {
+        let sstable_ids = sstable_ids_by_table_id(session, table_id).await?;
+        if !sstable_ids.is_empty() {
+            return Ok(sstable_ids);
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    Err(anyhow!("failed to observe sstables for table {}", table_id))
+}
+
+async fn wait_for_compaction_group_sstable_count(
+    session: &mut Session,
+    compaction_group_id: CompactionGroupId,
+    expected_at_least: usize,
+) -> Result<usize> {
+    for _ in 0..60 {
+        let count = session
+            .run(format!(
+                "SELECT COUNT(*) FROM rw_hummock_sstables WHERE compaction_group_id = {compaction_group_id};"
+            ))
+            .await?
+            .parse::<usize>()?;
+        if count >= expected_at_least {
+            return Ok(count);
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    Err(anyhow!(
+        "failed to observe at least {} sstables in compaction group {}",
+        expected_at_least,
+        compaction_group_id
+    ))
+}
+
+async fn compactor_worker_count(session: &mut Session) -> Result<usize> {
+    Ok(session
+        .run("SELECT COUNT(*) FROM rw_catalog.rw_worker_nodes WHERE \"type\" = 'Compactor';")
+        .await?
+        .parse::<usize>()?)
+}
+
 fn init_logger() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -68,6 +234,250 @@ async fn create_mv(session: &mut Session) -> Result<()> {
     session.run(CREATE_MV1).await?;
     sleep(Duration::from_secs(2)).await;
     Ok(())
+}
+
+#[tokio::test]
+async fn test_snapshot_backfill_cancel_database_recovery_manual_compaction_attempt() {
+    init_logger();
+    let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
+    config.compute_nodes = 3;
+    config.compute_node_cores = 2;
+    config.compactor_nodes = 2;
+    config.compute_resource_groups = HashMap::from([
+        (1, "group1".to_owned()),
+        (2, "group2".to_owned()),
+        (3, "group3".to_owned()),
+    ]);
+    let mut cluster = Cluster::start(config).await.unwrap();
+    let mut session = cluster.start_session();
+
+    session
+        .run("create database group1 with resource_group='group1'")
+        .await
+        .unwrap();
+    session
+        .run("create database group2 with resource_group='group2'")
+        .await
+        .unwrap();
+    session.run("set rw_implicit_flush = true;").await.unwrap();
+
+    let database_id_mapping = database_id_mapping(&mut session).await.unwrap();
+    let group1_database_id = database_id_mapping["group1"];
+
+    session.run("use group1;").await.unwrap();
+    session.run("set background_ddl = false;").await.unwrap();
+    session
+        .run("set streaming_use_snapshot_backfill = true;")
+        .await
+        .unwrap();
+    session.run("set backfill_rate_limit = 1;").await.unwrap();
+    session
+        .run("create table t (k int primary key, v int);")
+        .await
+        .unwrap();
+    session
+        .run("insert into t select i, i from generate_series(1, 10000) as i;")
+        .await
+        .unwrap();
+    session.run("flush;").await.unwrap();
+    session
+        .run("create table recovery_probe (v int);")
+        .await
+        .unwrap();
+    session
+        .run("insert into recovery_probe select * from generate_series(1, 10);")
+        .await
+        .unwrap();
+    session.run("flush;").await.unwrap();
+
+    let baseline_member_tables = member_table_ids(&mut session).await.unwrap();
+
+    let mut create_session = cluster.start_session();
+    tokio::spawn(async move {
+        create_session.run("use group1;").await.unwrap();
+        create_session
+            .run("set background_ddl = false;")
+            .await
+            .unwrap();
+        create_session
+            .run("set streaming_use_snapshot_backfill = true;")
+            .await
+            .unwrap();
+        create_session
+            .run("set backfill_rate_limit = 1;")
+            .await
+            .unwrap();
+        let _ = create_session
+            .run("create materialized view mv1 as select * from t;")
+            .await;
+    });
+
+    let created_member_tables =
+        wait_for_stream_job_and_member_tables(&mut session, &baseline_member_tables)
+            .await
+            .unwrap();
+    let candidate_table_id = *created_member_tables.iter().min().unwrap();
+    let candidate_sstable_ids = wait_for_sstable_ids_by_table_id(&mut session, candidate_table_id)
+        .await
+        .unwrap();
+    let original_compaction_group_id =
+        compaction_group_id_by_table_id(&mut session, candidate_table_id)
+            .await
+            .unwrap();
+    cluster
+        .split_compaction_group(
+            original_compaction_group_id,
+            TableId::new(candidate_table_id),
+        )
+        .await
+        .unwrap();
+    let candidate_compaction_group_id =
+        compaction_group_id_by_table_id(&mut session, candidate_table_id)
+            .await
+            .unwrap();
+    wait_for_compaction_group_sstable_count(&mut session, candidate_compaction_group_id, 1)
+        .await
+        .unwrap();
+    tracing::info!(
+        ?created_member_tables,
+        candidate_table_id,
+        ?candidate_sstable_ids,
+        ?original_compaction_group_id,
+        ?candidate_compaction_group_id,
+        "observed creating snapshot-backfill state tables"
+    );
+
+    let mut monitor_session = cluster.start_session();
+    monitor_session.run("use group2;").await.unwrap();
+
+    cluster.simple_kill_nodes(["compute-1"]).await;
+    wait_until(
+        &mut monitor_session,
+        "select count(*) from rw_catalog.rw_worker_nodes where host = '192.168.3.1';",
+        "0",
+    )
+    .await
+    .unwrap();
+
+    wait_for_database_recovery_state(&mut monitor_session, group1_database_id, "RECOVERING")
+        .await
+        .unwrap();
+
+    let mut cancel_session = cluster.start_session();
+    let cancel_handle = tokio::spawn(async move { cancel_stream_jobs(&mut cancel_session).await });
+
+    sleep(Duration::from_millis(100)).await;
+    cluster.simple_restart_nodes(["compute-1"]).await;
+    wait_all_database_recovered(&mut cluster).await;
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC)).await;
+
+    let cancel_result = cancel_handle.await.unwrap();
+    tracing::info!(
+        ?cancel_result,
+        "cancel result after concurrent database recovery"
+    );
+
+    let database_recovery_events = database_recovery_events(&mut monitor_session)
+        .await
+        .unwrap();
+    let group1_events = database_recovery_events
+        .get(&group1_database_id)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        group1_events.ends_with(&[
+            DATABASE_RECOVERY_START.to_owned(),
+            DATABASE_RECOVERY_SUCCESS.to_owned(),
+        ]),
+        "failed to observe database recovery for group1, got events: {group1_events:?}"
+    );
+
+    session.run("use group1;").await.unwrap();
+    wait_for_jobs_cleared(&mut session).await.unwrap();
+    let member_tables_after_recovery = member_table_ids(&mut session).await.unwrap();
+    let dangling_member_tables = created_member_tables
+        .intersection(&member_tables_after_recovery)
+        .copied()
+        .collect::<HashSet<_>>();
+    tracing::info!(
+        ?created_member_tables,
+        ?member_tables_after_recovery,
+        ?dangling_member_tables,
+        "member tables after concurrent cancel and database recovery"
+    );
+    assert!(
+        !dangling_member_tables.is_empty(),
+        "failed to keep created state tables in hummock member tables after recovery"
+    );
+    assert!(
+        dangling_member_tables.contains(&candidate_table_id),
+        "failed to keep candidate table {} in hummock member tables after recovery; dangling tables: {:?}",
+        candidate_table_id,
+        dangling_member_tables
+    );
+
+    let compactor_count_before = compactor_worker_count(&mut session).await.unwrap();
+    let sstable_count_before =
+        wait_for_compaction_group_sstable_count(&mut session, candidate_compaction_group_id, 1)
+            .await
+            .unwrap();
+    cluster
+        .simple_kill_nodes(["compactor-1", "compactor-2"])
+        .await;
+    wait_until(
+        &mut session,
+        "SELECT COUNT(*) FROM rw_catalog.rw_worker_nodes WHERE \"type\" = 'Compactor';",
+        "0",
+    )
+    .await
+    .unwrap();
+    cluster
+        .simple_restart_nodes(["compactor-1", "compactor-2"])
+        .await;
+    wait_until(
+        &mut session,
+        "SELECT COUNT(*) FROM rw_catalog.rw_worker_nodes WHERE \"type\" = 'Compactor';",
+        &compactor_count_before.to_string(),
+    )
+    .await
+    .unwrap();
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC)).await;
+    tracing::info!(
+        candidate_table_id,
+        ?candidate_compaction_group_id,
+        compactor_count_before,
+        sstable_count_before,
+        "triggering manual compaction on stale table compaction group after compactor restart"
+    );
+
+    cluster
+        .trigger_manual_compaction(candidate_compaction_group_id, 0)
+        .await
+        .unwrap();
+    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC)).await;
+
+    let compactor_count_after = compactor_worker_count(&mut session).await.unwrap();
+    let sstable_count_after =
+        wait_for_compaction_group_sstable_count(&mut session, candidate_compaction_group_id, 1)
+            .await
+            .unwrap();
+    let candidate_sstable_ids_after = sstable_ids_by_table_id(&mut session, candidate_table_id)
+        .await
+        .unwrap();
+    tracing::info!(
+        candidate_table_id,
+        ?candidate_compaction_group_id,
+        compactor_count_before,
+        compactor_count_after,
+        sstable_count_before,
+        sstable_count_after,
+        ?candidate_sstable_ids_after,
+        "manual compaction result for stale table compaction group"
+    );
+    assert_eq!(
+        compactor_count_after, compactor_count_before,
+        "manual compaction crashed a compactor worker"
+    );
 }
 
 #[tokio::test]
@@ -251,6 +661,83 @@ async fn test_ddl_cancel() -> Result<()> {
     session.run("DROP MATERIALIZED VIEW mv1").await?;
     session.run("DROP TABLE t").await?;
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cancel_snapshot_backfill_unregisters_table_ids() -> Result<()> {
+    init_logger();
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = cluster.start_session();
+
+    session.run("set streaming_parallelism = 1;").await?;
+    session.run("set backfill_rate_limit = 1;").await?;
+    session
+        .run("set streaming_use_snapshot_backfill = true;")
+        .await?;
+    session.run("set background_ddl = true;").await?;
+
+    session
+        .run("create table t (k int primary key, v int);")
+        .await?;
+    session
+        .run("insert into t select i, i from generate_series(1, 10000) as i;")
+        .await?;
+    session.flush().await?;
+
+    let baseline_member_tables = member_table_ids(&mut session).await?;
+
+    let mut create_session = cluster.start_session();
+    let create_handle = tokio::spawn(async move {
+        create_session.run("set streaming_parallelism = 1;").await?;
+        create_session.run("set backfill_rate_limit = 1;").await?;
+        create_session
+            .run("set streaming_use_snapshot_backfill = true;")
+            .await?;
+        create_session.run("set background_ddl = true;").await?;
+        create_session
+            .run("create materialized view mv as select * from t;")
+            .await
+    });
+
+    let running_jobs = wait_jobs_running(&mut session).await?;
+    tracing::info!("running jobs before cancel: {running_jobs}");
+    sleep(Duration::from_secs(2)).await;
+
+    let member_tables_before_cancel = member_table_ids(&mut session).await?;
+    assert!(
+        member_tables_before_cancel.len() > baseline_member_tables.len(),
+        "snapshot backfill did not create extra member tables before cancel: baseline={baseline_member_tables:?}, current={member_tables_before_cancel:?}"
+    );
+
+    let job_id = running_jobs
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| anyhow!("failed to parse job id from show jobs output: {running_jobs}"))?;
+    let cancel_result = session.run(format!("cancel job {job_id};")).await?;
+    assert!(
+        cancel_result.contains(job_id),
+        "unexpected cancel result: {cancel_result}"
+    );
+
+    wait_for_jobs_cleared(&mut session).await?;
+    wait_member_table_ids(&mut session, &baseline_member_tables).await?;
+
+    let member_tables_after_cancel = member_table_ids(&mut session).await?;
+    assert_eq!(member_tables_after_cancel, baseline_member_tables);
+
+    let create_result = create_handle.await.unwrap();
+    if let Err(err) = create_result {
+        assert!(
+            err.to_string().contains("cancel")
+                || err.to_string().contains("drop")
+                || err.to_string().contains("not found"),
+            "unexpected create mv result after cancel: {err}"
+        );
+    }
+
+    session.run("drop table t;").await?;
     Ok(())
 }
 

--- a/src/tests/simulation/tests/integration_tests/utils.rs
+++ b/src/tests/simulation/tests/integration_tests/utils.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
-use anyhow::Result;
-use risingwave_simulation::cluster::{Cluster, KillOpts};
+use anyhow::{Result, anyhow};
+use risingwave_simulation::cluster::{Cluster, KillOpts, Session};
 use serde::Deserialize;
 use tokio::time::{Instant, sleep};
 
@@ -47,6 +48,55 @@ pub(crate) async fn kill_cn_meta_and_wait_full_recovery(cluster: &mut Cluster) {
         .kill_nodes(["compute-1", "compute-2", "compute-3", "meta-1"], 0)
         .await;
     wait_all_database_recovered(cluster).await;
+}
+
+pub(crate) async fn member_table_ids(session: &mut Session) -> Result<HashSet<u32>> {
+    let rows = session
+        .run("select member_tables from rw_catalog.rw_hummock_compaction_group_configs;")
+        .await?;
+    let mut ids = HashSet::new();
+    for line in rows.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        let member_tables: Vec<u32> = serde_json::from_str(line)?;
+        ids.extend(member_tables);
+    }
+    Ok(ids)
+}
+
+pub(crate) async fn wait_jobs_running(session: &mut Session) -> Result<String> {
+    for _ in 0..60 {
+        let jobs = session.run("show jobs;").await?;
+        if !jobs.trim().is_empty() {
+            return Ok(jobs);
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    Err(anyhow!("jobs are still not running after waiting"))
+}
+
+pub(crate) async fn wait_for_jobs_cleared(session: &mut Session) -> Result<()> {
+    for _ in 0..30 {
+        if session.run("show jobs;").await?.trim().is_empty() {
+            return Ok(());
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    Err(anyhow!("failed to observe empty show jobs"))
+}
+
+pub(crate) async fn wait_member_table_ids(
+    session: &mut Session,
+    expected: &HashSet<u32>,
+) -> Result<()> {
+    for _ in 0..60 {
+        let current = member_table_ids(session).await?;
+        if &current == expected {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    Err(anyhow!(
+        "member tables do not match expected set after waiting"
+    ))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR fixes the dropped-state-table cleanup path for streaming job drop/cancel flows, especially the snapshot backfill cancel and recovery cases from #25466.

Previously, `unregister_table_ids` and `complete_dropped_tables` were tied to barrier-manager post-collect handling, while some cancel paths could bypass the expected cleanup sequence. That could leave state table IDs in Hummock version metadata after the catalog state had already been removed, which later caused compactor failures when resolving table info.

This PR changes the flow as follows:

- Moves dropped streaming job cleanup into the issuing side / recovery side, instead of relying on `PostCollectCommand::DropStreamingJobs`.
- Introduces a shared cleanup helper to consistently perform:
  - refresh progress tracker removal
  - `unregister_table_ids`
  - `complete_dropped_tables`
- Applies the shared cleanup logic to:
  - normal drop streaming job flow
  - background snapshot backfill cancel flow
  - recovery pre-apply drop/cancel flow
  - replace-stream cleanup path for dropped state tables
- Keeps `PostCollectCommand::DropStreamingJobs` only as a checkpoint marker and removes the redundant cleanup from post-collect.
- Adds / updates simulation integration tests to cover:
  - snapshot backfill cancel unregistering table IDs
  - snapshot backfill cancel + database recovery + manual compaction repro path

This makes the cleanup behavior consistent even when snapshot backfill cancel goes through a separate path, and prevents stale table IDs from remaining in Hummock version metadata after the corresponding tables are already dropped from catalog state.

- Closes #25466

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed a meta cleanup issue that could leave stale state table IDs after snapshot backfill job cancel / recovery, which could later cause compactor failures during table info resolution.

</details>
