### PR TITLE
feat(log): prefix trace_id in stdout log lines when tracing is on

### DIFF
--- a/src/utils/runtime/src/logger.rs
+++ b/src/utils/runtime/src/logger.rs
@@ -38,6 +38,51 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, filter, reload};
 
+/// A [`FormatEvent`] wrapper that prepends `trace_id=<16-hex> ` to each log
+/// line when the event occurs inside a span that carries `OpenTelemetry`
+/// context. Only the top 8 bytes of the 16-byte `trace_id` are rendered to
+/// keep log lines short; the full id is still what the `OTel` exporter sends.
+///
+/// No-op when tracing is disabled or no `OTel` context is attached — nothing is
+/// written and the inner formatter output is unchanged.
+#[cfg(not(madsim))]
+struct WithTraceId<E> {
+    inner: E,
+}
+
+#[cfg(not(madsim))]
+impl<S, N, E> tracing_subscriber::fmt::FormatEvent<S, N> for WithTraceId<E>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+    E: tracing_subscriber::fmt::FormatEvent<S, N>,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        use opentelemetry::TraceId;
+        use tracing_opentelemetry::OtelData;
+
+        if let Some(scope) = ctx.event_scope() {
+            let trace_id = scope.from_root().find_map(|span| {
+                span.extensions()
+                    .get::<OtelData>()
+                    .and_then(OtelData::trace_id)
+                    .filter(|id| *id != TraceId::INVALID)
+            });
+            if let Some(trace_id) = trace_id {
+                let bytes = trace_id.to_bytes();
+                let short = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+                write!(writer, "trace_id={short:016x} ")?;
+            }
+        }
+        self.inner.format_event(ctx, writer, event)
+    }
+}
+
 /// Parse a comma-separated list of `key=value` pairs into `OpenTelemetry` `KeyValue` attributes.
 ///
 /// - Splits by comma to get pairs.
@@ -335,17 +380,30 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
                 }
             });
 
+        // Non-JSON formatters: prepend `trace_id=<hex>` via [`WithTraceId`] when an OTel
+        // context is present. JSON path keeps its native formatting (trace_id is already
+        // carried via spans in the JSON output and breaking the JSON structure with a
+        // prefix would be worse than missing the field).
+        #[cfg(not(madsim))]
+        fn wrap_trace_id<E>(e: E) -> WithTraceId<E> {
+            WithTraceId { inner: e }
+        }
+        #[cfg(madsim)]
+        fn wrap_trace_id<E>(e: E) -> E {
+            e
+        }
+
         let fmt_layer = match deployment {
-            Deployment::Ci => fmt_layer.compact().boxed(),
+            Deployment::Ci => fmt_layer.compact().map_event_format(wrap_trace_id).boxed(),
             Deployment::Cloud => fmt_layer
                 .json()
                 .map_event_format(|e| e.with_current_span(false)) // avoid duplication as there's a span list field
                 .boxed(),
             Deployment::Other => {
                 if env_var_is_true("ENABLE_PRETTY_LOG") {
-                    fmt_layer.pretty().boxed()
+                    fmt_layer.pretty().map_event_format(wrap_trace_id).boxed()
                 } else {
-                    fmt_layer.boxed()
+                    fmt_layer.map_event_format(wrap_trace_id).boxed()
                 }
             }
         };


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

When \`enable_tracing\` is on, we already propagate a W3C trace context across frontend → meta → compute via \`WrappedChannel\` / \`TracingExtractLayer\`, so every span on every service shares the same \`trace_id\`. The problem: the trace id lives inside \`tracing-opentelemetry\`'s private \`OtelData\` extension, and the default \`tracing-subscriber\` fmt layer has no visibility into it. Without a Jaeger/Tempo UI, there's no way to correlate a single DDL or query across log files.

This PR adds a tiny \`FormatEvent\` adapter (\`WithTraceId\`) that, when an event fires inside a span carrying an OTel context, prepends \`trace_id=<16-hex> \` to the line. Only the top 8 bytes of the 16-byte trace id are rendered to keep log lines compact (25 chars of prefix); the full id is still what the OTLP exporter sends.

### Design notes

- **Gated \`#[cfg(not(madsim))]\`**: \`opentelemetry\` and friends aren't in the madsim dep set. Under madsim the wrapper degrades to an identity function and no prefix is printed.
- **No-op when tracing is off**: if no OTel layer is installed, or the reload filter has disabled it, no \`OtelData\` ends up on spans, the scope walk finds nothing, and nothing is written. So toggling \`enable_tracing\` on/off at runtime also flips the prefix on/off.
- **JSON deployment (Cloud) is skipped**: prepending \`trace_id=...\` to a JSON line would corrupt the document. The JSON formatter already renders the span tree; trace id can be surfaced as a proper JSON field in a follow-up if needed.
- **Three \`map_event_format\` call sites** (\`compact\` / \`pretty\` / default full) are structurally required because each picks a different concrete event format type, and the wrap has to happen after the type is chosen but before \`.boxed()\` erases it.

### Verified locally

With \`ALTER SYSTEM SET enable_tracing = true\` and a \`CREATE MATERIALIZED VIEW\`, the same trace id shows up in both frontend and meta logs:

\`\`\`
# frontend-4566.log
trace_id=c285634d57e6fe2d ...  handle_query{... sql=CREATE TABLE ...;CREATE MV ... user=root}: pgwire_query_log: status="started"

# meta-node-5690.log
trace_id=c285634d57e6fe2d ...  grpc_serve{/CreateTable}: starting streaming job id=6 definition="CREATE TABLE ..."
trace_id=c285634d57e6fe2d ...  grpc_serve{/CreateTable}:grpc_serve{/CreateMaterializedView}: starting streaming job id=7 definition="CREATE MATERIALIZED VIEW ..."
\`\`\`

With tracing off, no prefix is printed (zero-overhead default).

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

When \`enable_tracing\` is on, meta / frontend / compute log lines emitted inside a traced span now carry a \`trace_id=<16-hex>\` prefix, making it possible to correlate a single DDL or query across service logs via \`grep\` alone — no OTLP collector required.

</details>