### PR TITLE
feat: 2/10 add RBAC role membership storage contract

### DIFF
--- a/proto/user.proto
+++ b/proto/user.proto
@@ -35,6 +35,7 @@ message UserInfo {
   repeated GrantPrivilege grant_privileges = 8;
 
   bool is_admin = 9;
+  optional bool can_inherit = 10;
 }
 
 enum Action {
@@ -100,6 +101,7 @@ message UpdateUserRequest {
     RENAME = 5;
     CREATE_USER = 6;
     ADMIN = 7;
+    INHERIT = 8;
   }
   UserInfo user = 1;
   repeated UpdateField update_fields = 2;
@@ -134,6 +136,27 @@ message RevokePrivilegeRequest {
 message RevokePrivilegeResponse {
   common.Status status = 1;
   uint64 version = 2;
+}
+
+message RoleMembership {
+  uint32 role_id = 1;
+  uint32 member_id = 2;
+  uint32 granted_by = 3;
+  bool admin_option = 4;
+  bool inherit_option = 5;
+  bool set_option = 6;
+  uint32 id = 7;
+}
+
+message ListRoleMembershipsRequest {
+  // When false, an empty member_ids list returns no memberships.
+  // Set this explicitly for callers that need the full membership graph.
+  repeated uint32 member_ids = 1;
+  bool include_all = 2;
+}
+
+message ListRoleMembershipsResponse {
+  repeated RoleMembership memberships = 1;
 }
 
 message AlterDefaultPrivilegeRequest {
@@ -175,4 +198,6 @@ service UserService {
   rpc RevokePrivilege(RevokePrivilegeRequest) returns (RevokePrivilegeResponse);
   // AlterDefaultPrivilege alters the default privileges.
   rpc AlterDefaultPrivilege(AlterDefaultPrivilegeRequest) returns (AlterDefaultPrivilegeResponse);
+  // ListRoleMemberships lists direct role memberships for the requested members.
+  rpc ListRoleMemberships(ListRoleMembershipsRequest) returns (ListRoleMembershipsResponse);
 }

--- a/src/frontend/src/handler/create_user.rs
+++ b/src/frontend/src/handler/create_user.rs
@@ -45,6 +45,7 @@ pub async fn handle_create_user(
         name: user_name.clone(),
         // the LOGIN option is implied if it is not explicitly specified.
         can_login: true,
+        can_inherit: Some(true),
         ..Default::default()
     };
     let mut notices = vec![];

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -15,7 +15,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::Context;
-use risingwave_common::id::{ConnectionId, JobId, SourceId, TableId, WorkerId};
+use risingwave_common::id::{ConnectionId, JobId, SourceId, TableId, UserId, WorkerId};
 use risingwave_common::session_config::SessionConfig;
 use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::util::cluster_limit::ClusterLimit;
@@ -47,6 +47,7 @@ use risingwave_pb::meta::{
     RefreshRequest, RefreshResponse, list_sink_log_store_tables_response,
 };
 use risingwave_pb::secret::PbSecretRef;
+use risingwave_pb::user::RoleMembership as PbRoleMembership;
 use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
 
@@ -210,6 +211,13 @@ pub trait FrontendMetaClient: Send + Sync {
     ) -> Result<()>;
 
     async fn list_hosted_iceberg_tables(&self) -> Result<Vec<IcebergTable>>;
+
+    async fn list_role_memberships(
+        &self,
+        member_ids: Vec<UserId>,
+    ) -> Result<Vec<PbRoleMembership>>;
+
+    async fn list_all_role_memberships(&self) -> Result<Vec<PbRoleMembership>>;
 
     async fn get_fragment_by_id(
         &self,
@@ -548,6 +556,17 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn list_hosted_iceberg_tables(&self) -> Result<Vec<IcebergTable>> {
         self.0.list_hosted_iceberg_tables().await
+    }
+
+    async fn list_role_memberships(
+        &self,
+        member_ids: Vec<UserId>,
+    ) -> Result<Vec<PbRoleMembership>> {
+        self.0.list_role_memberships(member_ids).await
+    }
+
+    async fn list_all_role_memberships(&self) -> Result<Vec<PbRoleMembership>> {
+        self.0.list_all_role_memberships().await
     }
 
     async fn get_fragment_by_id(

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -77,7 +77,7 @@ use risingwave_pb::secret::PbSecretRef;
 use risingwave_pb::stream_plan::StreamFragmentGraph;
 use risingwave_pb::user::alter_default_privilege_request::Operation as AlterDefaultPrivilegeOperation;
 use risingwave_pb::user::update_user_request::UpdateField;
-use risingwave_pb::user::{GrantPrivilege, UserInfo};
+use risingwave_pb::user::{GrantPrivilege, RoleMembership, UserInfo};
 use risingwave_rpc_client::error::Result as RpcResult;
 use tempfile::{Builder, NamedTempFile};
 
@@ -1056,6 +1056,7 @@ impl UserInfoWriter for MockUserInfoWriter {
             UpdateField::AuthInfo => user_info.auth_info.clone_from(&update_user.auth_info),
             UpdateField::Rename => user_info.name.clone_from(&update_user.name),
             UpdateField::Admin => user_info.is_admin = update_user.is_admin,
+            UpdateField::Inherit => user_info.can_inherit = update_user.can_inherit,
             UpdateField::Unspecified => unreachable!(),
         });
         lock.update_user(update_user);
@@ -1128,6 +1129,7 @@ impl MockUserInfoWriter {
             can_create_db: true,
             can_create_user: true,
             can_login: true,
+            can_inherit: Some(true),
             ..Default::default()
         });
         user_info.write().create_user(UserInfo {
@@ -1138,6 +1140,7 @@ impl MockUserInfoWriter {
             can_create_user: true,
             can_login: true,
             is_admin: true,
+            can_inherit: Some(true),
             ..Default::default()
         });
         Self {
@@ -1387,6 +1390,17 @@ impl FrontendMetaClient for MockFrontendMetaClient {
 
     async fn list_hosted_iceberg_tables(&self) -> RpcResult<Vec<IcebergTable>> {
         unimplemented!()
+    }
+
+    async fn list_role_memberships(
+        &self,
+        _member_ids: Vec<UserId>,
+    ) -> RpcResult<Vec<RoleMembership>> {
+        Ok(vec![])
+    }
+
+    async fn list_all_role_memberships(&self) -> RpcResult<Vec<RoleMembership>> {
+        Ok(vec![])
     }
 
     async fn list_iceberg_compaction_status(&self) -> RpcResult<Vec<IcebergCompactionStatus>> {

--- a/src/frontend/src/user/user_catalog.rs
+++ b/src/frontend/src/user/user_catalog.rs
@@ -31,6 +31,7 @@ pub struct UserCatalog {
     pub can_create_user: bool,
     pub can_login: bool,
     pub is_admin: bool,
+    pub can_inherit: bool,
     pub auth_info: Option<PbAuthInfo>,
     pub grant_privileges: Vec<PbGrantPrivilege>,
 
@@ -51,6 +52,7 @@ impl From<PbUserInfo> for UserCatalog {
             can_create_user: user.can_create_user,
             can_login: user.can_login,
             is_admin: user.is_admin,
+            can_inherit: user.can_inherit.unwrap_or(true),
             auth_info: user.auth_info,
             grant_privileges: user.grant_privileges,
             database_acls: Default::default(),
@@ -73,6 +75,7 @@ impl UserCatalog {
             can_create_user: self.can_create_user,
             can_login: self.can_login,
             is_admin: self.is_admin,
+            can_inherit: Some(self.can_inherit),
             auth_info: self.auth_info.clone(),
             grant_privileges: self.grant_privileges.clone(),
         }

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -70,6 +70,8 @@ mod m20260119_153927_streaming_job_is_serverless_backfill;
 mod m20260120_120000_streaming_job_backfill_orders;
 mod m20260311_000000_legacy_streaming_parallelism_session_params;
 mod m20260312_000000_streaming_job_backfill_parallelism_strategy;
+mod m20260422_000001_role_membership;
+mod m20260422_000002_user_inherit_flag;
 mod m20260518_000000_disable_unused_read_prefix_hints;
 mod m20260519_000000_streaming_job_batch_refresh_seconds;
 mod utils;
@@ -180,6 +182,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260120_120000_streaming_job_backfill_orders::Migration),
             Box::new(m20260311_000000_legacy_streaming_parallelism_session_params::Migration),
             Box::new(m20260312_000000_streaming_job_backfill_parallelism_strategy::Migration),
+            Box::new(m20260422_000001_role_membership::Migration),
+            Box::new(m20260422_000002_user_inherit_flag::Migration),
             Box::new(m20260518_000000_disable_unused_read_prefix_hints::Migration),
             Box::new(m20260519_000000_streaming_job_batch_refresh_seconds::Migration),
         ]

--- a/src/meta/model/migration/src/m20260422_000001_role_membership.rs
+++ b/src/meta/model/migration/src/m20260422_000001_role_membership.rs
@@ -1,0 +1,151 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(UserRoleMembership::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(UserRoleMembership::Id)
+                            .integer()
+                            .primary_key()
+                            .auto_increment(),
+                    )
+                    .col(
+                        ColumnDef::new(UserRoleMembership::RoleId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(UserRoleMembership::MemberId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(UserRoleMembership::GrantedBy)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(UserRoleMembership::AdminOption)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(UserRoleMembership::InheritOption)
+                            .boolean()
+                            .not_null()
+                            .default(true),
+                    )
+                    .col(
+                        ColumnDef::new(UserRoleMembership::SetOption)
+                            .boolean()
+                            .not_null()
+                            .default(true),
+                    )
+                    .foreign_key(
+                        &mut ForeignKey::create()
+                            .name("FK_user_role_membership_role_id")
+                            .from(UserRoleMembership::Table, UserRoleMembership::RoleId)
+                            .to(User::Table, User::UserId)
+                            .on_delete(ForeignKeyAction::Cascade)
+                            .to_owned(),
+                    )
+                    .foreign_key(
+                        &mut ForeignKey::create()
+                            .name("FK_user_role_membership_member_id")
+                            .from(UserRoleMembership::Table, UserRoleMembership::MemberId)
+                            .to(User::Table, User::UserId)
+                            .on_delete(ForeignKeyAction::Cascade)
+                            .to_owned(),
+                    )
+                    .foreign_key(
+                        &mut ForeignKey::create()
+                            .name("FK_user_role_membership_granted_by")
+                            .from(UserRoleMembership::Table, UserRoleMembership::GrantedBy)
+                            .to(User::Table, User::UserId)
+                            .on_delete(ForeignKeyAction::Restrict)
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_user_role_membership_item")
+                    .table(UserRoleMembership::Table)
+                    .unique()
+                    .col(UserRoleMembership::RoleId)
+                    .col(UserRoleMembership::MemberId)
+                    .col(UserRoleMembership::GrantedBy)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_user_role_membership_member")
+                    .table(UserRoleMembership::Table)
+                    .col(UserRoleMembership::MemberId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_user_role_membership_member")
+                    .table(UserRoleMembership::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_user_role_membership_item")
+                    .table(UserRoleMembership::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(UserRoleMembership::Table).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum UserRoleMembership {
+    Table,
+    Id,
+    RoleId,
+    MemberId,
+    GrantedBy,
+    AdminOption,
+    InheritOption,
+    SetOption,
+}
+
+#[derive(DeriveIden)]
+enum User {
+    #[sea_orm(iden = "user")]
+    Table,
+    UserId,
+}

--- a/src/meta/model/migration/src/m20260422_000002_user_inherit_flag.rs
+++ b/src/meta/model/migration/src/m20260422_000002_user_inherit_flag.rs
@@ -1,0 +1,41 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(User::Table)
+                    .add_column(
+                        ColumnDef::new(User::CanInherit)
+                            .boolean()
+                            .not_null()
+                            .default(true),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(User::Table)
+                    .drop_column(User::CanInherit)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum User {
+    #[sea_orm(iden = "user")]
+    Table,
+    CanInherit,
+}

--- a/src/meta/model/src/lib.rs
+++ b/src/meta/model/src/lib.rs
@@ -69,6 +69,7 @@ pub mod table;
 pub mod user;
 pub mod user_default_privilege;
 pub mod user_privilege;
+pub mod user_role_membership;
 pub mod view;
 pub mod worker;
 pub mod worker_property;
@@ -77,6 +78,7 @@ pub type TransactionId = i32;
 
 pub type PrivilegeId = i32;
 pub type DefaultPrivilegeId = i32;
+pub type RoleMembershipId = i32;
 
 pub use risingwave_pb::id::{CompactionGroupId, HummockSstableObjectId, HummockVersionId};
 pub type Epoch = i64;

--- a/src/meta/model/src/prelude.rs
+++ b/src/meta/model/src/prelude.rs
@@ -47,6 +47,7 @@ pub use super::table::Entity as Table;
 pub use super::user::Entity as User;
 pub use super::user_default_privilege::Entity as UserDefaultPrivilege;
 pub use super::user_privilege::Entity as UserPrivilege;
+pub use super::user_role_membership::Entity as UserRoleMembership;
 pub use super::view::Entity as View;
 pub use super::worker::Entity as Worker;
 pub use super::worker_property::Entity as WorkerProperty;

--- a/src/meta/model/src/user.rs
+++ b/src/meta/model/src/user.rs
@@ -32,6 +32,7 @@ pub struct Model {
     pub can_create_user: bool,
     pub can_login: bool,
     pub is_admin: bool,
+    pub can_inherit: bool,
     pub auth_info: Option<AuthInfo>,
 }
 
@@ -60,6 +61,7 @@ impl From<PbUserInfo> for ActiveModel {
             can_create_user: Set(user.can_create_user),
             can_login: Set(user.can_login),
             is_admin: Set(user.is_admin),
+            can_inherit: Set(user.can_inherit.unwrap_or(true)),
             auth_info: Set(user.auth_info.as_ref().map(AuthInfo::from)),
         }
     }
@@ -75,6 +77,7 @@ impl From<Model> for PbUserInfo {
             can_create_user: val.can_create_user,
             can_login: val.can_login,
             is_admin: val.is_admin,
+            can_inherit: Some(val.can_inherit),
             auth_info: val.auth_info.map(|x| x.to_protobuf()),
             grant_privileges: vec![], // fill in later
         }

--- a/src/meta/model/src/user_role_membership.rs
+++ b/src/meta/model/src/user_role_membership.rs
@@ -1,0 +1,76 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::user::PbRoleMembership;
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{RoleMembershipId, UserId};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[sea_orm(table_name = "user_role_membership")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: RoleMembershipId,
+    pub role_id: UserId,
+    pub member_id: UserId,
+    pub granted_by: UserId,
+    pub admin_option: bool,
+    pub inherit_option: bool,
+    pub set_option: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::RoleId",
+        to = "super::user::Column::UserId",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Role,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::MemberId",
+        to = "super::user::Column::UserId",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Member,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::GrantedBy",
+        to = "super::user::Column::UserId",
+        on_update = "NoAction",
+        on_delete = "Restrict"
+    )]
+    Grantor,
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl From<Model> for PbRoleMembership {
+    fn from(value: Model) -> Self {
+        Self {
+            id: value.id as _,
+            role_id: value.role_id,
+            member_id: value.member_id,
+            granted_by: value.granted_by,
+            admin_option: value.admin_option,
+            inherit_option: value.inherit_option,
+            set_option: value.set_option,
+        }
+    }
+}

--- a/src/meta/service/src/user_service.rs
+++ b/src/meta/service/src/user_service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use itertools::Itertools;
 use risingwave_meta::manager::MetadataManager;
 use risingwave_meta_model::UserId;
 use risingwave_pb::user::alter_default_privilege_request::Operation;
@@ -21,8 +20,8 @@ use risingwave_pb::user::user_service_server::UserService;
 use risingwave_pb::user::{
     AlterDefaultPrivilegeRequest, AlterDefaultPrivilegeResponse, CreateUserRequest,
     CreateUserResponse, DropUserRequest, DropUserResponse, GrantPrivilegeRequest,
-    GrantPrivilegeResponse, RevokePrivilegeRequest, RevokePrivilegeResponse, UpdateUserRequest,
-    UpdateUserResponse,
+    GrantPrivilegeResponse, ListRoleMembershipsRequest, ListRoleMembershipsResponse,
+    RevokePrivilegeRequest, RevokePrivilegeResponse, UpdateUserRequest, UpdateUserResponse,
 };
 use tonic::{Request, Response, Status};
 
@@ -142,6 +141,21 @@ impl UserService for UserServiceImpl {
             status: None,
             version,
         }))
+    }
+
+    async fn list_role_memberships(
+        &self,
+        request: Request<ListRoleMembershipsRequest>,
+    ) -> Result<Response<ListRoleMembershipsResponse>, Status> {
+        let req = request.into_inner();
+        let member_ids = req.member_ids;
+        let memberships = self
+            .metadata_manager
+            .catalog_controller
+            .list_role_memberships(&member_ids, req.include_all)
+            .await?;
+
+        Ok(Response::new(ListRoleMembershipsResponse { memberships }))
     }
 
     async fn alter_default_privilege(

--- a/src/meta/src/backup_restore/restore_impl/v2.rs
+++ b/src/meta/src/backup_restore/restore_impl/v2.rs
@@ -109,6 +109,15 @@ impl Writer<MetadataV2> for WriterModelV2ToMetaStoreV2 {
         insert_models(metadata.workers.clone(), db).await?;
         insert_models(metadata.worker_properties.clone(), db).await?;
         insert_models(metadata.users.clone(), db).await?;
+        insert_models(
+            metadata
+                .user_role_memberships
+                .iter()
+                .sorted_by_key(|m| m.id)
+                .cloned(),
+            db,
+        )
+        .await?;
         // The sort is required to pass table's foreign key check.
         use risingwave_meta_model::object::ObjectType;
         insert_models(
@@ -214,6 +223,7 @@ macro_rules! for_all_auto_increment {
             {"worker", workers, worker_id},
             {"object", objects, oid},
             {"user", users, user_id},
+            {"user_role_membership", user_role_memberships, id},
             {"user_privilege", user_privileges, id},
             {"fragment", fragments, fragment_id},
             {"object_dependency", object_dependencies, id}

--- a/src/meta/src/controller/user.rs
+++ b/src/meta/src/controller/user.rs
@@ -17,18 +17,20 @@ use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use risingwave_common::catalog::{DEFAULT_SUPER_USER, DEFAULT_SUPER_USER_FOR_PG};
 use risingwave_meta_model::object::ObjectType;
-use risingwave_meta_model::prelude::{Object, User, UserDefaultPrivilege, UserPrivilege};
+use risingwave_meta_model::prelude::{
+    Object, User, UserDefaultPrivilege, UserPrivilege, UserRoleMembership,
+};
 use risingwave_meta_model::user_privilege::Action;
 use risingwave_meta_model::{
     AuthInfo, DatabaseId, DefaultPrivilegeId, PrivilegeId, SchemaId, UserId, object, user,
-    user_default_privilege, user_privilege,
+    user_default_privilege, user_privilege, user_role_membership,
 };
 use risingwave_pb::common::PbObjectType;
 use risingwave_pb::meta::subscribe_response::{
     Info as NotificationInfo, Operation as NotificationOperation,
 };
 use risingwave_pb::user::update_user_request::PbUpdateField;
-use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
+use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbRoleMembership, PbUserInfo};
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::{OnConflict, SimpleExpr, Value};
 use sea_orm::{
@@ -127,6 +129,11 @@ impl CatalogController {
             }
             PbUpdateField::Rename => user.name = Set(update_user.name.clone()),
             PbUpdateField::Admin => user.is_admin = Set(update_user.is_admin),
+            PbUpdateField::Inherit => {
+                if let Some(can_inherit) = update_user.can_inherit {
+                    user.can_inherit = Set(can_inherit);
+                }
+            }
         });
 
         let user = user.update(&inner.db).await?;
@@ -140,6 +147,29 @@ impl CatalogController {
             .await;
 
         Ok(version)
+    }
+
+    pub async fn list_role_memberships(
+        &self,
+        member_ids: &[UserId],
+        include_all: bool,
+    ) -> MetaResult<Vec<PbRoleMembership>> {
+        debug_assert!(
+            !include_all || member_ids.is_empty(),
+            "member_ids must be empty when include_all is true"
+        );
+        let inner = self.inner.read().await;
+        let memberships = if include_all {
+            UserRoleMembership::find().all(&inner.db).await?
+        } else if member_ids.is_empty() {
+            vec![]
+        } else {
+            UserRoleMembership::find()
+                .filter(user_role_membership::Column::MemberId.is_in(member_ids.iter().copied()))
+                .all(&inner.db)
+                .await?
+        };
+        Ok(memberships.into_iter().map(Into::into).collect())
     }
 
     #[cfg(test)]
@@ -803,6 +833,36 @@ mod tests {
         mgr.create_user(make_test_user("test_user_2")).await?;
         let user_1 = mgr.get_user_by_name("test_user_1").await?;
         let user_2 = mgr.get_user_by_name("test_user_2").await?;
+        assert!(user_1.can_inherit);
+        assert!(user_2.can_inherit);
+
+        mgr.create_user(make_test_user("test_user_inherit_regression"))
+            .await?;
+        let inherit_regression_user = mgr.get_user_by_name("test_user_inherit_regression").await?;
+        mgr.update_user(
+            PbUserInfo {
+                id: inherit_regression_user.user_id as _,
+                can_inherit: Some(false),
+                ..Default::default()
+            },
+            &[PbUpdateField::Inherit],
+        )
+        .await?;
+        let inherit_regression_user = mgr.get_user(inherit_regression_user.user_id).await?;
+        assert!(!inherit_regression_user.can_inherit);
+
+        mgr.update_user(
+            PbUserInfo {
+                id: inherit_regression_user.user_id as _,
+                can_create_db: true,
+                ..Default::default()
+            },
+            &[PbUpdateField::CreateDb],
+        )
+        .await?;
+        let inherit_regression_user = mgr.get_user(inherit_regression_user.user_id).await?;
+        assert!(!inherit_regression_user.can_inherit);
+        assert!(inherit_regression_user.can_create_db);
 
         assert!(
             mgr.create_user(make_test_user("test_user_1"))
@@ -849,13 +909,17 @@ mod tests {
             true,
         )
         .await?;
-        mgr.grant_privilege(
-            vec![user_2.user_id],
-            std::slice::from_ref(&create_without_option),
-            user_1.user_id,
-            false,
-        )
-        .await?;
+        assert!(
+            mgr.grant_privilege(
+                vec![user_2.user_id],
+                std::slice::from_ref(&create_without_option),
+                user_1.user_id,
+                false,
+            )
+            .await
+            .is_err(),
+            "user_1 does not have grant option for CREATE"
+        );
 
         assert!(
             mgr.drop_user(user_1.user_id).await.is_err(),
@@ -992,6 +1056,55 @@ mod tests {
 
         mgr.drop_user(user_1.user_id).await?;
         mgr.drop_user(user_2.user_id).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_role_memberships_filters_and_requires_explicit_full_scan() -> MetaResult<()>
+    {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+        mgr.create_user(make_test_user("role_a")).await?;
+        mgr.create_user(make_test_user("member_a")).await?;
+        mgr.create_user(make_test_user("grantor_a")).await?;
+        let role = mgr.get_user_by_name("role_a").await?;
+        let member = mgr.get_user_by_name("member_a").await?;
+        let grantor = mgr.get_user_by_name("grantor_a").await?;
+
+        {
+            let inner = mgr.inner.read().await;
+            user_role_membership::ActiveModel {
+                role_id: Set(role.user_id),
+                member_id: Set(member.user_id),
+                granted_by: Set(grantor.user_id),
+                admin_option: Set(false),
+                inherit_option: Set(true),
+                set_option: Set(true),
+                ..Default::default()
+            }
+            .insert(&inner.db)
+            .await?;
+        }
+
+        assert!(
+            mgr.list_role_memberships(&[], false).await?.is_empty(),
+            "filtered list should not treat an empty filter as a full scan"
+        );
+
+        let member_memberships = mgr.list_role_memberships(&[member.user_id], false).await?;
+        assert_eq!(member_memberships.len(), 1);
+        assert_eq!(member_memberships[0].role_id, role.user_id);
+        assert_eq!(member_memberships[0].member_id, member.user_id);
+        assert_eq!(member_memberships[0].granted_by, grantor.user_id);
+
+        assert!(
+            mgr.list_role_memberships(&[role.user_id], false)
+                .await?
+                .is_empty(),
+            "the filter should match member_id only"
+        );
+
+        let all_memberships = mgr.list_role_memberships(&[], true).await?;
+        assert_eq!(all_memberships.len(), 1);
         Ok(())
     }
 }

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -1013,10 +1013,18 @@ for_all_wrapped_id_fields! (
             user_ids: UserId,
             granted_by: UserId,
         }
+        ListRoleMembershipsRequest {
+            member_ids: UserId,
+        }
         RevokePrivilegeRequest {
             user_ids: UserId,
             granted_by: UserId,
             revoke_by: UserId,
+        }
+        RoleMembership {
+            role_id: UserId,
+            member_id: UserId,
+            granted_by: UserId,
         }
         UserInfo {
             id: UserId,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1036,6 +1036,27 @@ impl MetaClient {
         Ok(resp.version)
     }
 
+    pub async fn list_role_memberships(
+        &self,
+        member_ids: Vec<UserId>,
+    ) -> Result<Vec<RoleMembership>> {
+        let request = ListRoleMembershipsRequest {
+            member_ids,
+            include_all: false,
+        };
+        let resp = self.inner.list_role_memberships(request).await?;
+        Ok(resp.memberships)
+    }
+
+    pub async fn list_all_role_memberships(&self) -> Result<Vec<RoleMembership>> {
+        let request = ListRoleMembershipsRequest {
+            member_ids: vec![],
+            include_all: true,
+        };
+        let resp = self.inner.list_role_memberships(request).await?;
+        Ok(resp.memberships)
+    }
+
     pub async fn alter_default_privilege(
         &self,
         user_ids: Vec<UserId>,
@@ -2760,6 +2781,7 @@ macro_rules! for_all_meta_rpc {
             ,{ user_client, drop_user, DropUserRequest, DropUserResponse }
             ,{ user_client, grant_privilege, GrantPrivilegeRequest, GrantPrivilegeResponse }
             ,{ user_client, revoke_privilege, RevokePrivilegeRequest, RevokePrivilegeResponse }
+            ,{ user_client, list_role_memberships, ListRoleMembershipsRequest, ListRoleMembershipsResponse }
             ,{ user_client, alter_default_privilege, AlterDefaultPrivilegeRequest, AlterDefaultPrivilegeResponse }
             ,{ scale_client, get_cluster_info, GetClusterInfoRequest, GetClusterInfoResponse }
             ,{ scale_client, reschedule, RescheduleRequest, RescheduleResponse }

--- a/src/storage/backup/src/meta_snapshot_v2.rs
+++ b/src/storage/backup/src/meta_snapshot_v2.rs
@@ -74,7 +74,8 @@ macro_rules! for_all_metadata_models_v2 {
             {pending_sink_state, risingwave_meta_model::pending_sink_state},
             {refresh_jobs, risingwave_meta_model::refresh_job},
             {cdc_table_snapshot_splits, risingwave_meta_model::cdc_table_snapshot_split},
-            {hummock_table_change_logs, risingwave_meta_model::hummock_table_change_log}
+            {hummock_table_change_logs, risingwave_meta_model::hummock_table_change_log},
+            {user_role_memberships, risingwave_meta_model::user_role_membership}
         }
     };
 }


### PR DESCRIPTION
Part of the re-cut RBAC stack. This stack was split so each PR is an independently reviewable functional slice around ~1k changed lines, with e2e coverage added where the SQL runtime becomes available.

Review-only fixes included in this recut:
- keep #25521 as parser/fallback-only instead of carrying the full runtime;
- move meta revoke/drop tests out of the production-code PR;
- replace stale `role options are not supported yet` frontend tests with positive CREATEROLE/INHERIT coverage once frontend support lands;
- restore role membership ddl e2e coverage in the frontend runtime test slice.

Local verification run for the recut:
- `git diff --check origin/main ralph/rbac-v2-10-pg-catalog-compat`

No compile/build/e2e run in this recut pass.
