### PR TITLE
feat: 10/10 align RBAC pg_catalog compatibility

### DIFF
--- a/e2e_test/batch/catalog/has_privilege.slt.part
+++ b/e2e_test/batch/catalog/has_privilege.slt.part
@@ -33,28 +33,28 @@ statement ok
 GRANT ALL PRIVILEGES ON DATABASE test_db TO test_user;
 
 statement ok
-GRANT ALL PRIVILEGES ON foo TO test_user GRANTED BY root;
+GRANT ALL PRIVILEGES ON foo TO test_user GRANTED BY current_user;
 
 statement ok
-GRANT INSERT ON bar TO test_user WITH GRANT OPTION GRANTED BY root;
+GRANT INSERT ON bar TO test_user WITH GRANT OPTION GRANTED BY current_user;
 
 statement ok
-GRANT INSERT ON foo_view TO test_user WITH GRANT OPTION GRANTED BY root;
+GRANT INSERT ON foo_view TO test_user WITH GRANT OPTION GRANTED BY current_user;
 
 statement ok
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO test_user WITH GRANT OPTION GRANTED BY root;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO test_user WITH GRANT OPTION GRANTED BY current_user;
 
 statement ok
-GRANT SELECT ON ALL MATERIALIZED VIEWS IN SCHEMA public TO test_user WITH GRANT OPTION GRANTED BY root;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN SCHEMA public TO test_user WITH GRANT OPTION GRANTED BY current_user;
 
 statement ok
-GRANT SELECT ON ALL SOURCES IN SCHEMA public TO test_user WITH GRANT OPTION GRANTED BY root;
+GRANT SELECT ON ALL SOURCES IN SCHEMA public TO test_user WITH GRANT OPTION GRANTED BY current_user;
 
 statement ok
 GRANT CREATE ON SCHEMA test_schema TO test_user;
 
 query error table not found: bar_err
-GRANT INSERT ON bar_err TO test_user WITH GRANT OPTION GRANTED BY root;
+GRANT INSERT ON bar_err TO test_user WITH GRANT OPTION GRANTED BY current_user;
 
 query error database not found: test_db_err
 SELECT has_database_privilege('test_user', 'test_db_err', 'CONNECT');
@@ -71,8 +71,10 @@ SELECT has_table_privilege('test_user', 'foo', 'SELE CT');
 query error Invalid parameter privilege: unrecognized privilege type: "SELECT INSERT"
 SELECT has_table_privilege('test_user', 'foo', 'SELECT INSERT');
 
-query error Invalid parameter privilege
+query I
 SELECT has_table_privilege('test_user', 'foo', 'SELECT, INSERT  WITH GRANT OPTION');
+----
+t
 
 query error Invalid parameter user: User test_user_err not found
 SELECT has_schema_privilege('test_user_err', 'test_schema', 'CREATE');
@@ -102,6 +104,11 @@ SELECT has_table_privilege('test_user', 'foo', 'SELECT WITH GRANT OPTION');
 t
 
 query I
+SELECT has_table_privilege('test_user', 'foo', 'select with grant option');
+----
+t
+
+query I
 SELECT has_table_privilege('test_user', 'foo', 'INSERT WITH GRANT OPTION');
 ----
 f
@@ -119,7 +126,7 @@ t
 query I
 SELECT has_table_privilege('test_user', 'foo', 'DELETE WITH GRANT OPTION, INSERT, SELECT WITH GRANT OPTION');
 ----
-f
+t
 
 query I
 SELECT has_table_privilege('test_user', 'foo_view', 'SELECT');
@@ -236,7 +243,7 @@ SELECT has_database_privilege('test_user', 'test_db', 'CONNECT');
 f
 
 statement ok
-REVOKE SELECT ON ALL TABLES IN SCHEMA public FROM test_user GRANTED BY root;
+REVOKE SELECT ON ALL TABLES IN SCHEMA public FROM test_user GRANTED BY current_user;
 
 query I
 SELECT has_table_privilege('test_user', 'bar'::regclass, 'SELECT');
@@ -254,7 +261,7 @@ SELECT has_table_privilege('test_user', 'foo_view', 'INSERT');
 t
 
 statement ok
-REVOKE INSERT ON foo_view FROM test_user GRANTED BY root;
+REVOKE INSERT ON foo_view FROM test_user GRANTED BY current_user;
 
 query I
 SELECT has_table_privilege('test_user', 'foo_view', 'INSERT');

--- a/e2e_test/batch/catalog/pg_auth_members.slt.part
+++ b/e2e_test/batch/catalog/pg_auth_members.slt.part
@@ -1,0 +1,113 @@
+statement ok
+DROP SCHEMA IF EXISTS rw_role_owned_schema CASCADE;
+
+statement ok
+DROP ROLE IF EXISTS rw_role_member_test;
+
+statement ok
+DROP ROLE IF EXISTS rw_role_option_test;
+
+statement ok
+DROP ROLE IF EXISTS rw_role_catalog_test;
+
+statement ok
+CREATE ROLE rw_role_catalog_test;
+
+statement ok
+CREATE ROLE rw_role_option_test;
+
+statement ok
+CREATE ROLE rw_role_member_test;
+
+statement ok
+GRANT rw_role_catalog_test TO rw_role_member_test WITH ADMIN OPTION;
+
+statement ok
+GRANT rw_role_option_test TO rw_role_member_test WITH INHERIT FALSE, SET FALSE;
+
+query TTTTTTT
+SELECT (auth.oid > 0)::text AS oid_present,
+       role_role.rolname,
+       member_role.rolname,
+       grantor_role.rolname,
+       auth.admin_option::text,
+       auth.inherit_option::text,
+       auth.set_option::text
+FROM pg_catalog.pg_auth_members auth
+JOIN pg_catalog.pg_roles role_role ON role_role.oid = auth.roleid
+JOIN pg_catalog.pg_roles member_role ON member_role.oid = auth.member
+JOIN pg_catalog.pg_roles grantor_role ON grantor_role.oid = auth.grantor
+WHERE role_role.rolname IN ('rw_role_catalog_test', 'rw_role_option_test')
+  AND member_role.rolname = 'rw_role_member_test'
+ORDER BY role_role.rolname;
+----
+true rw_role_catalog_test rw_role_member_test root true true true
+true rw_role_option_test rw_role_member_test root false false false
+
+query TTT
+SELECT count(*)::text,
+       count(DISTINCT auth.oid)::text,
+       (min(auth.oid) > 0)::text
+FROM pg_catalog.pg_auth_members auth
+JOIN pg_catalog.pg_roles role_role ON role_role.oid = auth.roleid
+JOIN pg_catalog.pg_roles member_role ON member_role.oid = auth.member
+WHERE role_role.rolname IN ('rw_role_catalog_test', 'rw_role_option_test')
+  AND member_role.rolname = 'rw_role_member_test';
+----
+2 2 true
+
+statement ok
+CREATE SCHEMA rw_role_owned_schema;
+
+statement ok
+ALTER SCHEMA rw_role_owned_schema OWNER TO rw_role_catalog_test;
+
+statement ok
+SET ROLE rw_role_catalog_test;
+
+query TTT
+SELECT session_user, current_user, current_role;
+----
+postgres rw_role_catalog_test rw_role_catalog_test
+
+statement ok
+CREATE TABLE rw_role_owned_schema.owned_by_active_role(v int);
+
+statement ok
+RESET ROLE;
+
+query T
+SELECT owner_role.rolname
+FROM pg_catalog.pg_class cls
+JOIN pg_catalog.pg_roles owner_role ON owner_role.oid = cls.relowner
+WHERE cls.relname = 'owned_by_active_role';
+----
+rw_role_catalog_test
+
+statement ok
+REVOKE rw_role_catalog_test FROM rw_role_member_test;
+
+statement ok
+REVOKE rw_role_option_test FROM rw_role_member_test;
+
+query I
+SELECT count(*)
+FROM pg_catalog.pg_auth_members auth
+JOIN pg_catalog.pg_roles role_role ON role_role.oid = auth.roleid
+JOIN pg_catalog.pg_roles member_role ON member_role.oid = auth.member
+WHERE role_role.rolname IN ('rw_role_catalog_test', 'rw_role_option_test')
+  AND member_role.rolname = 'rw_role_member_test';
+----
+0
+
+statement ok
+DROP SCHEMA rw_role_owned_schema CASCADE;
+
+statement ok
+DROP ROLE rw_role_member_test;
+
+statement ok
+DROP ROLE rw_role_option_test;
+
+statement ok
+DROP ROLE rw_role_catalog_test;

--- a/e2e_test/batch/catalog/pg_class.slt.part
+++ b/e2e_test/batch/catalog/pg_class.slt.part
@@ -10,7 +10,7 @@ SELECT oid,relname,relowner,relkind FROM pg_catalog.pg_class ORDER BY oid limit 
 2147478653 pg_am 1 v
 2147478654 pg_attrdef 1 v
 2147478655 pg_attribute 1 v
-2147478656 pg_auth_members 1 v
+2147478656 pg_auth_members 1 r
 2147478657 pg_cast 1 r
 2147478658 pg_class 1 r
 2147478659 pg_collation 1 v

--- a/e2e_test/batch/catalog/pg_roles.slt.part
+++ b/e2e_test/batch/catalog/pg_roles.slt.part
@@ -8,4 +8,27 @@ FROM pg_catalog.pg_roles r
 WHERE r.rolname = 'root'
 ORDER BY 1;
 ----
-root t t t t t -1 NULL t t
+root t t t t t -1 NULL f f
+
+statement ok
+CREATE ROLE role_inherit_catalog_test WITH NOINHERIT;
+
+query TT
+SELECT rolname, rolinherit::text
+FROM pg_catalog.pg_roles
+WHERE rolname = 'role_inherit_catalog_test';
+----
+role_inherit_catalog_test false
+
+statement ok
+ALTER ROLE role_inherit_catalog_test WITH INHERIT;
+
+query TT
+SELECT rolname, rolinherit::text
+FROM pg_catalog.pg_roles
+WHERE rolname = 'role_inherit_catalog_test';
+----
+role_inherit_catalog_test true
+
+statement ok
+DROP ROLE role_inherit_catalog_test;

--- a/e2e_test/batch/catalog/pg_shadow.slt.part
+++ b/e2e_test/batch/catalog/pg_shadow.slt.part
@@ -2,3 +2,16 @@ query ITTTTTTT
 select * from pg_shadow where usename = 'root';
 ----
 root 1 t t f f NULL NULL NULL
+
+statement ok
+CREATE ROLE pg_shadow_nologin_probe NOLOGIN;
+
+query I
+SELECT count(*)
+FROM pg_catalog.pg_shadow
+WHERE usename = 'pg_shadow_nologin_probe';
+----
+0
+
+statement ok
+DROP ROLE pg_shadow_nologin_probe;

--- a/e2e_test/batch/catalog/pg_user.slt.part
+++ b/e2e_test/batch/catalog/pg_user.slt.part
@@ -1,6 +1,19 @@
-query ITTT
+query TITTTTTTT
 SELECT * FROM pg_catalog.pg_user order by usesysid;
 ----
-1 root t t ********
-2 postgres t t ********
-3 rwadmin t t ********
+root 1 t t f f ******** NULL NULL
+postgres 2 t t f f ******** NULL NULL
+rwadmin 3 t t f f ******** NULL NULL
+
+statement ok
+CREATE ROLE pg_user_nologin_probe NOLOGIN;
+
+query I
+SELECT count(*)
+FROM pg_catalog.pg_user
+WHERE usename = 'pg_user_nologin_probe';
+----
+0
+
+statement ok
+DROP ROLE pg_user_nologin_probe;

--- a/e2e_test/batch/types/pg_catalog.slt.part
+++ b/e2e_test/batch/types/pg_catalog.slt.part
@@ -45,3 +45,112 @@ val	NULL
 
 statement ok
 drop table myy_table;
+
+statement ok
+create schema rw_visible_s1;
+
+statement ok
+create schema rw_visible_s2;
+
+statement ok
+create table rw_visible_s1.t(v int);
+
+statement ok
+create table rw_visible_s2.t(v int);
+
+statement ok
+set search_path = rw_visible_s1, rw_visible_s2;
+
+query TB
+select n.nspname, pg_table_is_visible(c.oid)
+from pg_class c
+join pg_namespace n on c.relnamespace = n.oid
+where n.nspname in ('rw_visible_s1', 'rw_visible_s2')
+  and c.relname = 't'
+order by n.nspname;
+----
+rw_visible_s1 t
+rw_visible_s2 f
+
+statement ok
+set search_path = rw_visible_s1;
+
+query TB
+select n.nspname, pg_table_is_visible(c.oid)
+from pg_class c
+join pg_namespace n on c.relnamespace = n.oid
+where n.nspname = 'rw_visible_s2'
+  and c.relname = 't';
+----
+rw_visible_s2 f
+
+statement ok
+set search_path to default;
+
+statement ok
+create schema rw_visible_private;
+
+statement ok
+create schema rw_visible_accessible;
+
+statement ok
+create table rw_visible_private.usage_shadow(v int);
+
+statement ok
+create table rw_visible_accessible.usage_shadow(v int);
+
+statement ok
+create user rw_visible_user with password '';
+
+statement ok
+grant usage on schema rw_visible_accessible to rw_visible_user;
+
+statement ok
+set search_path = rw_visible_private, rw_visible_accessible;
+
+statement ok
+set role rw_visible_user;
+
+query TB
+select n.nspname, pg_table_is_visible(c.oid)
+from pg_class c
+join pg_namespace n on c.relnamespace = n.oid
+where n.nspname in ('rw_visible_private', 'rw_visible_accessible')
+  and c.relname = 'usage_shadow'
+order by n.nspname;
+----
+rw_visible_accessible t
+rw_visible_private f
+
+statement ok
+reset role;
+
+statement ok
+set search_path to default;
+
+statement ok
+drop table rw_visible_private.usage_shadow;
+
+statement ok
+drop table rw_visible_accessible.usage_shadow;
+
+statement ok
+drop schema rw_visible_private;
+
+statement ok
+drop schema rw_visible_accessible;
+
+statement ok
+drop user rw_visible_user;
+
+statement ok
+drop table rw_visible_s1.t;
+
+statement ok
+drop table rw_visible_s2.t;
+
+statement ok
+drop schema rw_visible_s1;
+
+statement ok
+drop schema rw_visible_s2;

--- a/e2e_test/ddl/privilege.slt
+++ b/e2e_test/ddl/privilege.slt
@@ -11,28 +11,32 @@ statement ok
 CREATE SCHEMA schema1;
 
 # Grant privilege on schema for user1.
-statement ok
+statement error
 GRANT CREATE ON SCHEMA schema1 TO user1 WITH GRANT OPTION GRANTED BY user;
+
+# The GRANTED BY role for object privileges must be the current user.
+statement ok
+GRANT CREATE ON SCHEMA schema1 TO user1 WITH GRANT OPTION GRANTED BY current_user;
 
 # Grant privilege on all sources in schema for user1.
 statement ok
-GRANT ALL PRIVILEGES ON ALL SOURCES IN SCHEMA schema1 TO user1 GRANTED BY user;
+GRANT ALL PRIVILEGES ON ALL SOURCES IN SCHEMA schema1 TO user1 GRANTED BY current_user;
 
 # Grant invalid privilege on source.
 statement error
-GRANT INSERT ON ALL SOURCES IN SCHEMA schema1 TO user1 GRANTED BY user;
+GRANT INSERT ON ALL SOURCES IN SCHEMA schema1 TO user1 GRANTED BY current_user;
 
 # Grant insert privilege on table.
 statement ok
-GRANT INSERT ON ALL TABLES IN SCHEMA schema1 TO user1 GRANTED BY user;
+GRANT INSERT ON ALL TABLES IN SCHEMA schema1 TO user1 GRANTED BY current_user;
 
 # Grant privilege on table.
 statement ok
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA schema1 TO user1 GRANTED BY user;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA schema1 TO user1 GRANTED BY current_user;
 
 # Grant privilege on all mviews in schema for user1.
 statement ok
-GRANT ALL PRIVILEGES ON ALL MATERIALIZED VIEWS IN SCHEMA schema1 TO user1 GRANTED BY user;
+GRANT ALL PRIVILEGES ON ALL MATERIALIZED VIEWS IN SCHEMA schema1 TO user1 GRANTED BY current_user;
 
 # Revoke privilege on all mviews in schema for user1.
 statement ok
@@ -59,23 +63,23 @@ CREATE DATABASE db1;
 
 # Grant privilege for user1.
 statement ok
-GRANT ALL ON DATABASE db1 TO user1 WITH GRANT OPTION GRANTED BY user;
+GRANT ALL ON DATABASE db1 TO user1 WITH GRANT OPTION GRANTED BY current_user;
 
 # Grant invalid privilege on database for user1.
 statement error
-GRANT INSERT ON DATABASE db1 TO user1 WITH GRANT OPTION GRANTED BY user;
+GRANT INSERT ON DATABASE db1 TO user1 WITH GRANT OPTION GRANTED BY current_user;
 
 # Grant privilege on invalid database for user1.
 statement error
-GRANT ALL ON DATABASE db_invalid TO user1 WITH GRANT OPTION GRANTED BY user;
+GRANT ALL ON DATABASE db_invalid TO user1 WITH GRANT OPTION GRANTED BY current_user;
 
 # Grant privilege on database for invalid user.
 statement error
-GRANT ALL ON DATABASE db_invalid TO user_invalid WITH GRANT OPTION GRANTED BY user;
+GRANT ALL ON DATABASE db_invalid TO user_invalid WITH GRANT OPTION GRANTED BY current_user;
 
 # Revoke GRANT OPTION FOR from database for user1.
 statement ok
-REVOKE GRANT OPTION FOR ALL ON DATABASE db1 from user1 GRANTED BY user;
+REVOKE GRANT OPTION FOR ALL ON DATABASE db1 from user1 GRANTED BY current_user;
 
 # Revoke privilege on database for user1.
 statement ok

--- a/e2e_test/ddl/schema_qualified_name.slt
+++ b/e2e_test/ddl/schema_qualified_name.slt
@@ -17,10 +17,10 @@ statement ok
 CREATE USER user1;
 
 statement error
-GRANT ALL PRIVILEGES ON ALL SOURCES IN SCHEMA dev.qualified_name TO user1 GRANTED BY user;
+GRANT ALL PRIVILEGES ON ALL SOURCES IN SCHEMA dev.qualified_name TO user1 GRANTED BY current_user;
 
 statement ok
-GRANT ALL PRIVILEGES ON ALL SOURCES IN SCHEMA qualified_name TO user1 GRANTED BY user;
+GRANT ALL PRIVILEGES ON ALL SOURCES IN SCHEMA qualified_name TO user1 GRANTED BY current_user;
 
 statement ok
 drop table qualified_name.test;

--- a/src/frontend/planner_test/tests/testdata/input/sysinfo_funcs.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/sysinfo_funcs.yaml
@@ -11,6 +11,14 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    select current_user;
+  expected_outputs:
+  - batch_plan
+- sql: |
+    select current_role;
+  expected_outputs:
+  - batch_plan
+- sql: |
     select current_schemas(true);
   expected_outputs:
   - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -1044,32 +1044,25 @@
     ORDER BY 1;
   batch_plan: |-
     BatchExchange { order: [rw_users.name ASC], dist: Single }
-    └─BatchProject { exprs: [rw_users.name, rw_users.is_super, true:Boolean, rw_users.create_user, rw_users.create_db, rw_users.can_login, -1:Int32, null:Timestamptz, $expr1, true:Boolean, true:Boolean] }
+    └─BatchProject { exprs: [rw_users.name, rw_users.is_super, rw_users.can_inherit, rw_users.create_user, rw_users.create_db, rw_users.can_login, -1:Int32, null:Timestamptz, $expr1, false:Boolean, false:Boolean] }
       └─BatchSort { order: [rw_users.name ASC] }
         └─BatchHashJoin { type: LeftOuter, predicate: rw_users.id IS NOT DISTINCT FROM rw_users.id, output: all }
           ├─BatchExchange { order: [], dist: HashShard(rw_users.id) }
           │ └─BatchFilter { predicate: Not(RegexpEq(rw_users.name, '^pg_':Varchar)) }
-          │   └─BatchSysScan { table: rw_users, columns: [rw_users.id, rw_users.name, rw_users.is_super, rw_users.create_db, rw_users.create_user, rw_users.can_login], distribution: Single }
+          │   └─BatchSysScan { table: rw_users, columns: [rw_users.id, rw_users.name, rw_users.is_super, rw_users.create_db, rw_users.create_user, rw_users.can_login, rw_users.can_inherit], distribution: Single }
           └─BatchProject { exprs: [rw_users.id, Coalesce(array_agg(rw_users.name) filter(IsNotNull(1:Int32)), ARRAY[]:List(Varchar)) as $expr1] }
             └─BatchHashAgg { group_key: [rw_users.id], aggs: [array_agg(rw_users.name) filter(IsNotNull(1:Int32))] }
-              └─BatchHashJoin { type: LeftOuter, predicate: rw_users.id IS NOT DISTINCT FROM rw_users.id, output: [rw_users.id, rw_users.name, 1:Int32] }
+              └─BatchHashJoin { type: LeftOuter, predicate: rw_users.id IS NOT DISTINCT FROM pg_auth_members.member, output: [rw_users.id, rw_users.name, 1:Int32] }
                 ├─BatchHashAgg { group_key: [rw_users.id], aggs: [] }
                 │ └─BatchExchange { order: [], dist: HashShard(rw_users.id) }
                 │   └─BatchFilter { predicate: Not(RegexpEq(rw_users.name, '^pg_':Varchar)) }
                 │     └─BatchSysScan { table: rw_users, columns: [rw_users.id, rw_users.name], distribution: Single }
-                └─BatchExchange { order: [], dist: HashShard(rw_users.id) }
-                  └─BatchProject { exprs: [rw_users.id, rw_users.name, 1:Int32] }
-                    └─BatchHashJoin { type: Inner, predicate: null:Int32 = rw_users.id, output: [rw_users.id, rw_users.name] }
-                      ├─BatchExchange { order: [], dist: HashShard(null:Int32) }
-                      │ └─BatchProject { exprs: [rw_users.id, null:Int32] }
-                      │   └─BatchNestedLoopJoin { type: Inner, predicate: true, output: all }
-                      │     ├─BatchExchange { order: [], dist: Single }
-                      │     │ └─BatchHashAgg { group_key: [rw_users.id], aggs: [] }
-                      │     │   └─BatchExchange { order: [], dist: HashShard(rw_users.id) }
-                      │     │     └─BatchFilter { predicate: false:Boolean }
-                      │     │       └─BatchSysScan { table: rw_users, columns: [rw_users.id], distribution: Single }
-                      │     └─BatchFilter { predicate: false:Boolean }
-                      │       └─BatchValues { rows: [] }
+                └─BatchExchange { order: [], dist: HashShard(pg_auth_members.member) }
+                  └─BatchProject { exprs: [pg_auth_members.member, rw_users.name, 1:Int32] }
+                    └─BatchHashJoin { type: Inner, predicate: pg_auth_members.roleid = rw_users.id, output: [pg_auth_members.member, rw_users.name] }
+                      ├─BatchExchange { order: [], dist: HashShard(pg_auth_members.roleid) }
+                      │ └─BatchFilter { predicate: IsNotNull(pg_auth_members.member) }
+                      │   └─BatchSysScan { table: pg_auth_members, columns: [pg_auth_members.roleid, pg_auth_members.member], distribution: Single }
                       └─BatchExchange { order: [], dist: HashShard(rw_users.id) }
                         └─BatchSysScan { table: rw_users, columns: [rw_users.id, rw_users.name], distribution: Single }
 - name: correlated array subquery (issue 14423)

--- a/src/frontend/planner_test/tests/testdata/output/sysinfo_funcs.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/sysinfo_funcs.yaml
@@ -9,6 +9,12 @@
     select session_user;
   batch_plan: 'BatchValues { rows: [[''root'':Varchar]] }'
 - sql: |
+    select current_user;
+  batch_plan: 'BatchValues { rows: [[''root'':Varchar]] }'
+- sql: |
+    select current_role;
+  batch_plan: 'BatchValues { rows: [[''root'':Varchar]] }'
+- sql: |
     select current_schemas(true);
   batch_plan: 'BatchValues { rows: [[ARRAY[pg_catalog, rw_catalog, public]:List(Varchar)]] }'
 - sql: |

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -109,18 +109,19 @@ impl Binder {
         fn session_user() -> Handle {
             guard_by_len(|binder, []| {
                 Ok(ExprImpl::literal_varchar(
-                    binder.auth_context.user_name.clone(),
+                    binder.auth_context.session_user_name().to_owned(),
                 ))
             })
         }
 
-        // `CURRENT_USER` is the user name of the user that is executing the command,
-        // `CURRENT_ROLE`, `USER` are synonyms for `CURRENT_USER`. Since we don't support
-        // `SET ROLE xxx` for now, they will all returns session user name.
+        // `CURRENT_USER` is the user name of the user that is executing the command and
+        // `CURRENT_ROLE`, `USER` are synonyms for `CURRENT_USER`. We still default the current
+        // user to the session user until `SET ROLE` support lands, but keep the identities
+        // separate in `AuthContext` so the binder is ready for effective-role semantics.
         fn current_user() -> Handle {
             guard_by_len(|binder, []| {
                 Ok(ExprImpl::literal_varchar(
-                    binder.auth_context.user_name.clone(),
+                    binder.auth_context.current_user_name().to_owned(),
                 ))
             })
         }
@@ -535,9 +536,9 @@ impl Binder {
 
                     let mut schema_names = vec![];
                     for path in paths {
-                        let mut schema_name = path;
+                        let mut schema_name: &str = path;
                         if schema_name == USER_NAME_WILD_CARD {
-                            schema_name = &binder.auth_context.user_name;
+                            schema_name = binder.auth_context.current_user_name();
                         }
 
                         if binder
@@ -545,7 +546,7 @@ impl Binder {
                             .get_schema_by_name(&binder.db_name, schema_name)
                             .is_ok()
                         {
-                            schema_names.push(schema_name.as_str());
+                            schema_names.push(schema_name);
                         }
                     }
 
@@ -663,7 +664,12 @@ impl Binder {
                 ("pg_encoding_to_char", raw_literal(ExprImpl::literal_varchar("UTF8".into()))),
                 ("has_database_privilege", raw(|binder, mut inputs| {
                     if inputs.len() == 2 {
-                        inputs.insert(0, ExprImpl::literal_varchar(binder.auth_context.user_name.clone()));
+                        inputs.insert(
+                            0,
+                            ExprImpl::literal_varchar(
+                                binder.auth_context.current_user_name().to_owned(),
+                            ),
+                        );
                     }
                     if inputs.len() == 3 {
                         Ok(FunctionCall::new(ExprType::HasDatabasePrivilege, inputs)?.into())
@@ -676,7 +682,12 @@ impl Binder {
                 })),
                 ("has_table_privilege", raw(|binder, mut inputs| {
                     if inputs.len() == 2 {
-                        inputs.insert(0, ExprImpl::literal_varchar(binder.auth_context.user_name.clone()));
+                        inputs.insert(
+                            0,
+                            ExprImpl::literal_varchar(
+                                binder.auth_context.current_user_name().to_owned(),
+                            ),
+                        );
                     }
                     if inputs.len() == 3 {
                         if inputs[1].return_type() == DataType::Varchar {
@@ -692,7 +703,12 @@ impl Binder {
                 })),
                 ("has_any_column_privilege", raw(|binder, mut inputs| {
                     if inputs.len() == 2 {
-                        inputs.insert(0, ExprImpl::literal_varchar(binder.auth_context.user_name.clone()));
+                        inputs.insert(
+                            0,
+                            ExprImpl::literal_varchar(
+                                binder.auth_context.current_user_name().to_owned(),
+                            ),
+                        );
                     }
                     if inputs.len() == 3 {
                         if inputs[1].return_type() == DataType::Varchar {
@@ -708,7 +724,12 @@ impl Binder {
                 })),
                 ("has_schema_privilege", raw(|binder, mut inputs| {
                     if inputs.len() == 2 {
-                        inputs.insert(0, ExprImpl::literal_varchar(binder.auth_context.user_name.clone()));
+                        inputs.insert(
+                            0,
+                            ExprImpl::literal_varchar(
+                                binder.auth_context.current_user_name().to_owned(),
+                            ),
+                        );
                     }
                     if inputs.len() == 3 {
                         Ok(FunctionCall::new(ExprType::HasSchemaPrivilege, inputs)?.into())
@@ -721,7 +742,12 @@ impl Binder {
                 })),
                 ("has_function_privilege", raw(|binder, mut inputs| {
                     if inputs.len() == 2 {
-                        inputs.insert(0, ExprImpl::literal_varchar(binder.auth_context.user_name.clone()));
+                        inputs.insert(
+                            0,
+                            ExprImpl::literal_varchar(
+                                binder.auth_context.current_user_name().to_owned(),
+                            ),
+                        );
                     }
                     if inputs.len() == 3 {
                         Ok(FunctionCall::new(ExprType::HasFunctionPrivilege, inputs)?.into())

--- a/src/frontend/src/binder/for_system.rs
+++ b/src/frontend/src/binder/for_system.rs
@@ -39,7 +39,7 @@ impl Binder {
         let search_path = SchemaPath::new(
             schema_name.as_deref(),
             &self.search_path,
-            &self.auth_context.user_name,
+            self.auth_context.current_user_name(),
         );
         let (sink_catalog, _) =
             self.catalog
@@ -56,7 +56,7 @@ impl Binder {
         let search_path = SchemaPath::new(
             schema_name.as_deref(),
             &self.search_path,
-            &self.auth_context.user_name,
+            self.auth_context.current_user_name(),
         );
         let (view_catalog, _) =
             self.catalog

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -450,12 +450,16 @@ impl Binder {
         self.catalog.first_valid_schema(
             &self.db_name,
             &self.search_path,
-            &self.auth_context.user_name,
+            self.auth_context.current_user_name(),
         )
     }
 
     fn bind_schema_path<'a>(&'a self, schema_name: Option<&'a str>) -> SchemaPath<'a> {
-        SchemaPath::new(schema_name, &self.search_path, &self.auth_context.user_name)
+        SchemaPath::new(
+            schema_name,
+            &self.search_path,
+            self.auth_context.current_user_name(),
+        )
     }
 
     pub fn set_clause(&mut self, clause: Option<Clause>) {

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -195,7 +195,7 @@ impl Binder {
                     // So we should always use current database here.
                     assert!(db_name.is_none());
                     let db_name = self.db_name.clone();
-                    let user_name = self.auth_context.user_name.clone();
+                    let user_name = self.auth_context.current_user_name().to_owned();
 
                     for path in self.search_path.path() {
                         if is_system_schema(path)
@@ -299,7 +299,10 @@ impl Binder {
                     ))
                     .into());
                 }
-                if let Some(user) = self.user.get_user_by_name(&self.auth_context.user_name) {
+                if let Some(user) = self
+                    .user
+                    .get_user_by_name(self.auth_context.current_user_name())
+                {
                     if !catalog_user_has_privilege(
                         &self.user,
                         user,

--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -47,7 +47,7 @@ use crate::session::AuthContext;
 use crate::user::UserId;
 use crate::user::user_catalog::UserCatalog;
 use crate::user::user_privilege::available_prost_privilege;
-use crate::user::user_service::UserInfoReader;
+use crate::user::user_service::{RoleMembershipInfoReader, UserInfoReader};
 
 #[derive(Clone, Debug, PartialEq, Hash)]
 pub struct SystemTableCatalog {
@@ -95,6 +95,8 @@ pub struct SysCatalogReaderImpl {
     catalog_reader: CatalogReader,
     // Read user info.
     user_info_reader: UserInfoReader,
+    // Read role membership info.
+    role_membership_info_reader: RoleMembershipInfoReader,
     // Read from meta.
     meta_client: Arc<dyn FrontendMetaClient>,
     // Read auth context.
@@ -111,6 +113,7 @@ impl SysCatalogReaderImpl {
     pub fn new(
         catalog_reader: CatalogReader,
         user_info_reader: UserInfoReader,
+        role_membership_info_reader: RoleMembershipInfoReader,
         meta_client: Arc<dyn FrontendMetaClient>,
         auth_context: Arc<AuthContext>,
         config: Arc<RwLock<SessionConfig>>,
@@ -120,6 +123,7 @@ impl SysCatalogReaderImpl {
         Self {
             catalog_reader,
             user_info_reader,
+            role_membership_info_reader,
             meta_client,
             auth_context,
             config,
@@ -424,6 +428,33 @@ mod tests {
         assert_eq!(
             extract_parallelism_from_table_state(&fallback_state),
             "adaptive"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_identity_and_role_catalog_queries() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+
+        let identity_rows = frontend
+            .query_formatted_result("SELECT session_user, current_user, current_role")
+            .await;
+        assert_eq!(
+            identity_rows,
+            vec!["Row([Some(b\"root\"), Some(b\"root\"), Some(b\"root\")])".to_owned()]
+        );
+
+        let role_rows = frontend
+            .query_formatted_result(
+                "SELECT rolname, rolcanlogin, rolsuper, rolcreatedb, rolcreaterole \
+                 FROM pg_catalog.pg_roles WHERE rolname = 'root'",
+            )
+            .await;
+        assert_eq!(
+            role_rows,
+            vec![
+                "Row([Some(b\"root\"), Some(b\"t\"), Some(b\"t\"), Some(b\"t\"), Some(b\"t\")])"
+                    .to_owned()
+            ]
         );
     }
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_auth_members.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_auth_members.rs
@@ -15,11 +15,15 @@
 use risingwave_common::types::Fields;
 use risingwave_frontend_macro::system_catalog;
 
-/// The catalog `pg_auth_members` shows the membership relations between roles. Any non-circular set of relationships is allowed.
+use crate::catalog::system_catalog::SysCatalogReaderImpl;
+use crate::error::Result;
+
+/// The catalog `pg_auth_members` shows the membership relations between roles. Any non-circular
+/// set of relationships is allowed.
 /// Ref: `https://www.postgresql.org/docs/current/catalog-pg-auth-members.html`
-#[system_catalog(view, "pg_catalog.pg_auth_members")]
 #[derive(Fields)]
 struct PgAuthMember {
+    #[primary_key]
     oid: i32,
     roleid: i32,
     member: i32,
@@ -27,4 +31,29 @@ struct PgAuthMember {
     admin_option: bool,
     inherit_option: bool,
     set_option: bool,
+}
+
+#[system_catalog(table, "pg_catalog.pg_auth_members")]
+fn read_pg_auth_members(reader: &SysCatalogReaderImpl) -> Result<Vec<PgAuthMember>> {
+    let mut memberships = reader.role_membership_info_reader.read_guard().clone();
+    memberships.sort_by_key(|membership| {
+        (
+            membership.role_id,
+            membership.member_id,
+            membership.granted_by,
+        )
+    });
+
+    Ok(memberships
+        .into_iter()
+        .map(|membership| PgAuthMember {
+            oid: membership.id as i32,
+            roleid: membership.role_id.as_raw_id() as i32,
+            member: membership.member_id.as_raw_id() as i32,
+            grantor: membership.granted_by.as_raw_id() as i32,
+            admin_option: membership.admin_option,
+            inherit_option: membership.inherit_option,
+            set_option: membership.set_option,
+        })
+        .collect())
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_roles.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_roles.rs
@@ -17,27 +17,30 @@ use risingwave_frontend_macro::system_catalog;
 
 /// The catalog `pg_roles` provides access to information about database roles. This is simply a
 /// publicly readable view of `pg_authid` that blanks out the password field.
+///
+/// Today this is a compatibility shim over `rw_catalog.rw_users`; membership-derived role state
+/// will be layered in as the unified principal model lands.
 /// Ref: `https://www.postgresql.org/docs/current/view-pg-roles.html`
 #[system_catalog(
     view,
     "pg_catalog.pg_roles",
-    "SELECT id AS oid,
-        name AS rolname,
+    "SELECT name AS rolname,
         is_super AS rolsuper,
-        true AS rolinherit,
+        can_inherit AS rolinherit,
         create_user AS rolcreaterole,
         create_db AS rolcreatedb,
         can_login AS rolcanlogin,
-        true AS rolreplication,
+        false AS rolreplication,
         -1 AS rolconnlimit,
+        '********' AS rolpassword,
         NULL::timestamptz AS rolvaliduntil,
-        true AS rolbypassrls,
-        '********' AS rolpassword
+        false AS rolbypassrls,
+        NULL::text[] AS rolconfig,
+        id AS oid
     FROM rw_catalog.rw_users"
 )]
 #[derive(Fields)]
 struct PgRule {
-    oid: i32,
     rolname: String,
     rolsuper: bool,
     rolinherit: bool,
@@ -46,7 +49,9 @@ struct PgRule {
     rolcanlogin: bool,
     rolreplication: bool,
     rolconnlimit: i32,
+    rolpassword: String,
     rolvaliduntil: Timestamptz,
     rolbypassrls: bool,
-    rolpassword: String,
+    rolconfig: Vec<String>,
+    oid: i32,
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_shadow.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_shadow.rs
@@ -31,7 +31,8 @@ use risingwave_frontend_macro::system_catalog;
             NULL::text[] AS useconfig
         FROM rw_catalog.rw_users u
         JOIN rw_catalog.rw_user_secrets s
-            ON u.id = s.id"
+            ON u.id = s.id
+        WHERE u.can_login"
 )]
 #[derive(Fields)]
 struct PgShadow {

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_user.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_user.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::types::Fields;
+use risingwave_common::types::{Fields, Timestamptz};
 use risingwave_frontend_macro::system_catalog;
 
 /// The catalog `pg_user` provides access to information about database users.
@@ -20,18 +20,27 @@ use risingwave_frontend_macro::system_catalog;
 #[system_catalog(
     view,
     "pg_catalog.pg_user",
-    "SELECT id AS usesysid,
-        name,
+    "SELECT name AS usename,
+        id AS usesysid,
         create_db AS usecreatedb,
         is_super AS usesuper,
-        '********' AS passwd
-    FROM rw_catalog.rw_users"
+        false AS userepl,
+        false AS usebypassrls,
+        '********' AS passwd,
+        NULL::timestamptz AS valuntil,
+        NULL::text[] AS useconfig
+    FROM rw_catalog.rw_users
+    WHERE can_login"
 )]
 #[derive(Fields)]
 struct PgUser {
-    usesysid: i32,
     usename: String,
+    usesysid: i32,
     usecreatedb: bool,
     usesuper: bool,
+    userepl: bool,
+    usebypassrls: bool,
     passwd: String,
+    valuntil: Timestamptz,
+    useconfig: Vec<String>,
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/iceberg_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/iceberg_tables.rs
@@ -44,7 +44,7 @@ async fn read(reader: &SysCatalogReaderImpl) -> Result<Vec<IcebergTables>> {
     let catalog_reader = reader.catalog_reader.read_guard();
     let user_reader = reader.user_info_reader.read_guard();
     let user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .ok_or_else(|| anyhow!("User not found"))?;
 
     let mut res = Vec::new();

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_columns.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_columns.rs
@@ -48,7 +48,7 @@ fn read_rw_columns(reader: &SysCatalogReaderImpl) -> Result<Vec<RwColumn>> {
     let catalog_reader = reader.catalog_reader.read_guard();
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_connections.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_connections.rs
@@ -40,7 +40,7 @@ fn read_rw_connections(reader: &SysCatalogReaderImpl) -> Result<Vec<RwConnection
     let user_reader = reader.user_info_reader.read_guard();
     let users = user_reader.get_all_users();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let username_map = user_reader.get_user_name_map();
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_functions.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_functions.rs
@@ -44,7 +44,7 @@ fn read(reader: &SysCatalogReaderImpl) -> Result<Vec<RwFunction>> {
     let user_reader = reader.user_info_reader.read_guard();
     let users = user_reader.get_all_users();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let username_map = user_reader.get_user_name_map();
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
@@ -46,7 +46,7 @@ fn read_rw_indexes(reader: &SysCatalogReaderImpl) -> Result<Vec<RwIndex>> {
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
 
     Ok(schemas

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_internal_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_internal_tables.rs
@@ -41,7 +41,7 @@ fn read_rw_internal_tables(reader: &SysCatalogReaderImpl) -> Result<Vec<RwIntern
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let users = user_reader.get_all_users();
     let username_map = user_reader.get_user_name_map();

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_materialized_views.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_materialized_views.rs
@@ -46,7 +46,7 @@ fn read_rw_materialized_views(reader: &SysCatalogReaderImpl) -> Result<Vec<RwMat
     let user_reader = reader.user_info_reader.read_guard();
     let users = user_reader.get_all_users();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let username_map = user_reader.get_user_name_map();
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -49,7 +49,7 @@ async fn read_relation_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwRelat
         let schemas = catalog_reader.get_all_schema_names(&reader.auth_context.database)?;
         let user_reader = reader.user_info_reader.read_guard();
         let current_user = user_reader
-            .get_user_by_name(&reader.auth_context.user_name)
+            .get_user_by_name(reader.auth_context.current_user_name())
             .expect("user not found");
         for schema in &schemas {
             let schema_catalog =
@@ -94,7 +94,7 @@ async fn read_relation_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwRelat
     let schemas = catalog_reader.get_all_schema_names(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     for schema in &schemas {
         let schema_catalog =

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_secrets.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_secrets.rs
@@ -36,7 +36,7 @@ fn read_rw_secret_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSecret>> {
     let user_reader = reader.user_info_reader.read_guard();
     let users = user_reader.get_all_users();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let username_map = user_reader.get_user_name_map();
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
@@ -54,7 +54,7 @@ fn read_rw_sinks_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSink>> {
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let users = user_reader.get_all_users();
     let username_map = user_reader.get_user_name_map();

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_subscriptions.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_subscriptions.rs
@@ -42,7 +42,7 @@ fn read_rw_subscriptions_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwSub
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let users = user_reader.get_all_users();
     let username_map = user_reader.get_user_name_map();

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
@@ -43,7 +43,7 @@ fn read_rw_table_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwTable>> {
     let user_reader = reader.user_info_reader.read_guard();
     let users = user_reader.get_all_users();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let username_map = user_reader.get_user_name_map();
 

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_user_secrets.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_user_secrets.rs
@@ -33,10 +33,10 @@ struct RwUserSecret {
 fn read_rw_user_secrets_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwUserSecret>> {
     let user_info_reader = reader.user_info_reader.read_guard();
     // Since this catalog contains passwords, it must not be publicly readable.
-    match user_info_reader.get_user_by_name(&reader.auth_context.user_name) {
+    match user_info_reader.get_user_by_name(reader.auth_context.current_user_name()) {
         None => {
             return Err(ErrorCode::CatalogError(
-                format!("user {} not found", reader.auth_context.user_name).into(),
+                format!("user {} not found", reader.auth_context.current_user_name()).into(),
             )
             .into());
         }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_users.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_users.rs
@@ -29,6 +29,7 @@ struct RwUser {
     create_user: bool,
     can_login: bool,
     is_admin: bool,
+    can_inherit: bool,
 }
 
 #[system_catalog(table, "rw_catalog.rw_users")]
@@ -46,6 +47,7 @@ fn read_rw_user_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwUser>> {
             create_user: user.can_create_user,
             can_login: user.can_login,
             is_admin: user.is_admin,
+            can_inherit: user.can_inherit,
         })
         .collect())
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_views.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_views.rs
@@ -38,7 +38,7 @@ fn read_rw_view_info(reader: &SysCatalogReaderImpl) -> Result<Vec<RwView>> {
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
     let user_reader = reader.user_info_reader.read_guard();
     let current_user = user_reader
-        .get_user_by_name(&reader.auth_context.user_name)
+        .get_user_by_name(reader.auth_context.current_user_name())
         .expect("user not found");
     let users = user_reader.get_all_users();
     let username_map = user_reader.get_user_name_map();

--- a/src/frontend/src/expr/function_impl/cast_regclass.rs
+++ b/src/frontend/src/expr/function_impl/cast_regclass.rs
@@ -78,7 +78,11 @@ fn resolve_regclass_inner(
     let obj = Parser::parse_object_name_str(class_name)?;
 
     let (schema_name, class_name) = Binder::resolve_schema_qualified_name(db_name, &obj)?;
-    let schema_path = SchemaPath::new(schema_name.as_deref(), search_path, &auth_context.user_name);
+    let schema_path = SchemaPath::new(
+        schema_name.as_deref(),
+        search_path,
+        auth_context.current_user_name(),
+    );
     Ok(catalog
         .read_guard()
         .get_id_by_class_name(db_name, schema_path, &class_name)?)

--- a/src/frontend/src/expr/function_impl/context.rs
+++ b/src/frontend/src/expr/function_impl/context.rs
@@ -23,6 +23,7 @@ use crate::session::AuthContext;
 define_context! {
     pub(super) CATALOG_READER: crate::catalog::CatalogReader,
     pub(super) USER_INFO_READER: crate::user::user_service::UserInfoReader,
+    pub(super) ROLE_MEMBERSHIP_INFO_READER: crate::user::user_service::RoleMembershipInfoReader,
     pub(super) AUTH_CONTEXT: Arc<AuthContext>,
     pub(super) DB_NAME: String,
     pub(super) SEARCH_PATH: SearchPath,

--- a/src/frontend/src/expr/function_impl/has_privilege.rs
+++ b/src/frontend/src/expr/function_impl/has_privilege.rs
@@ -22,12 +22,18 @@ use risingwave_pb::user::Action;
 use risingwave_sqlparser::parser::Parser;
 use thiserror_ext::AsReport;
 
-use super::context::{AUTH_CONTEXT, CATALOG_READER, DB_NAME, SEARCH_PATH, USER_INFO_READER};
+use super::context::{
+    AUTH_CONTEXT, CATALOG_READER, DB_NAME, ROLE_MEMBERSHIP_INFO_READER, SEARCH_PATH,
+    USER_INFO_READER,
+};
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::system_catalog::is_system_catalog;
 use crate::catalog::{CatalogReader, DatabaseId, OwnedGrantObject, SchemaId};
 use crate::session::AuthContext;
-use crate::user::user_service::UserInfoReader;
+use crate::user::effective_privilege::{
+    principal_has_privilege, principal_has_privilege_with_grant_option, role_memberships_snapshot,
+};
+use crate::user::user_service::{RoleMembershipInfoReader, UserInfoReader};
 use crate::{Binder, bind_data_type};
 
 #[inline(always)]
@@ -212,9 +218,10 @@ fn has_function_privilege_3(user_id: i32, function_name: &str, privileges: &str)
     has_function_privilege_impl(user_name.as_str(), function_oid, privileges)
 }
 
-#[capture_context(USER_INFO_READER)]
+#[capture_context(USER_INFO_READER, ROLE_MEMBERSHIP_INFO_READER)]
 fn has_privilege_impl(
     user_info_reader: &UserInfoReader,
+    role_membership_info_reader: &RoleMembershipInfoReader,
     user_name: &str,
     object: &OwnedGrantObject,
     actions: &Vec<(Action, bool)>,
@@ -225,11 +232,28 @@ fn has_privilege_impl(
         .ok_or(user_not_found_err(
             format!("User {} not found", user_name).as_str(),
         ))?;
-    if user_catalog.id == object.owner {
-        // if the user is the owner of the object, they have all privileges
-        return Ok(true);
-    }
-    Ok(user_catalog.check_privilege_with_grant_option(&object.object, actions))
+    let memberships = role_memberships_snapshot(role_membership_info_reader);
+    Ok(actions.iter().any(|(action, require_grant_option)| {
+        if *require_grant_option {
+            principal_has_privilege_with_grant_option(
+                user_info_reader,
+                &memberships,
+                user_catalog,
+                object.owner,
+                object.object,
+                *action,
+            )
+        } else {
+            principal_has_privilege(
+                user_info_reader,
+                &memberships,
+                user_catalog,
+                object.owner,
+                object.object,
+                (*action).into(),
+            )
+        }
+    }))
 }
 
 #[capture_context(USER_INFO_READER)]
@@ -262,7 +286,7 @@ fn get_grant_object_by_oid(
         .get_grant_object_by_oid(oid)
         .ok_or(ExprError::InvalidParam {
             name: "oid",
-            reason: format!("Table {} not found", oid).as_str().into(),
+            reason: "object not found".into(),
         })
 }
 
@@ -364,7 +388,11 @@ fn get_function_id_by_name(
                 reason: e.to_report_string().into(),
             }
         })?;
-    let schema_path = SchemaPath::new(schema.as_deref(), search_path, &auth_context.user_name);
+    let schema_path = SchemaPath::new(
+        schema.as_deref(),
+        search_path,
+        auth_context.current_user_name(),
+    );
 
     let reader = &catalog_reader.read_guard();
     Ok(reader
@@ -383,10 +411,17 @@ fn parse_privilege(
 ) -> Result<Vec<(Action, bool)>> {
     let mut privileges = Vec::new();
     for part in privilege_string.split(',').map(str::trim) {
-        let (privilege_type, grant_option) = match part.rsplit_once(" WITH GRANT OPTION") {
-            Some((p, _)) => (p, true),
-            None => (part, false),
+        let tokens = part.split_whitespace().collect::<Vec<_>>();
+        let (privilege_tokens, grant_option) = if tokens.len() >= 4
+            && tokens[tokens.len() - 3].eq_ignore_ascii_case("WITH")
+            && tokens[tokens.len() - 2].eq_ignore_ascii_case("GRANT")
+            && tokens[tokens.len() - 1].eq_ignore_ascii_case("OPTION")
+        {
+            (&tokens[..tokens.len() - 3], true)
+        } else {
+            (&tokens[..], false)
         };
+        let privilege_type = privilege_tokens.join(" ");
         match Action::from_str_name(privilege_type.to_uppercase().as_str()) {
             Some(Action::Unspecified) | None => {
                 return Err(ExprError::InvalidParam {

--- a/src/frontend/src/expr/function_impl/pg_table_is_visible.rs
+++ b/src/frontend/src/expr/function_impl/pg_table_is_visible.rs
@@ -12,30 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::acl::AclMode;
 use risingwave_common::id::ObjectId;
-use risingwave_common::session_config::SearchPath;
+use risingwave_common::session_config::{SearchPath, USER_NAME_WILD_CARD};
 use risingwave_expr::{Result, capture_context, function};
 
-use super::context::{AUTH_CONTEXT, CATALOG_READER, DB_NAME, SEARCH_PATH, USER_INFO_READER};
-use crate::catalog::CatalogReader;
+use super::context::{
+    AUTH_CONTEXT, CATALOG_READER, DB_NAME, ROLE_MEMBERSHIP_INFO_READER, SEARCH_PATH,
+    USER_INFO_READER,
+};
+use crate::catalog::schema_catalog::SchemaCatalog;
 use crate::catalog::system_catalog::is_system_catalog;
-use crate::expr::function_impl::has_privilege::user_not_found_err;
+use crate::catalog::{CatalogReader, OwnedByUserCatalog};
 use crate::session::AuthContext;
-use crate::user::has_schema_usage_privilege;
-use crate::user::user_service::UserInfoReader;
+use crate::user::effective_privilege::{role_memberships_snapshot, session_has_privilege};
+use crate::user::user_service::{RoleMembershipInfoReader, UserInfoReader};
 
 #[function("pg_table_is_visible(int4) -> boolean")]
 fn pg_table_is_visible(oid: i32) -> Result<Option<bool>> {
     pg_table_is_visible_impl_captured(ObjectId::new(oid as _))
 }
 
-#[capture_context(CATALOG_READER, USER_INFO_READER, AUTH_CONTEXT, SEARCH_PATH, DB_NAME)]
+#[capture_context(
+    CATALOG_READER,
+    SEARCH_PATH,
+    DB_NAME,
+    AUTH_CONTEXT,
+    USER_INFO_READER,
+    ROLE_MEMBERSHIP_INFO_READER
+)]
 fn pg_table_is_visible_impl(
     catalog: &CatalogReader,
-    user_info: &UserInfoReader,
-    auth_context: &AuthContext,
     search_path: &SearchPath,
     db_name: &str,
+    auth_context: &AuthContext,
+    user_info_reader: &UserInfoReader,
+    role_membership_reader: &RoleMembershipInfoReader,
     oid: ObjectId,
 ) -> Result<Option<bool>> {
     // To maintain consistency with PostgreSQL, we ensure that system catalogs are always visible.
@@ -44,26 +56,78 @@ fn pg_table_is_visible_impl(
     }
 
     let catalog_reader = catalog.read_guard();
-    let user_reader = user_info.read_guard();
-    let user_info = user_reader
-        .get_user_by_name(&auth_context.user_name)
-        .ok_or(user_not_found_err(
-            format!("User {} not found", auth_context.user_name).as_str(),
-        ))?;
-    // Return true only if:
-    // 1. The schema of the object exists in the search path.
-    // 2. User have `USAGE` privilege on the schema.
-    for schema in search_path.path() {
-        if let Ok(schema) = catalog_reader.get_schema_by_name(db_name, schema)
-            && schema.contains_object(oid)
-        {
-            return if has_schema_usage_privilege(user_info, schema.id(), schema.owner) {
-                Ok(Some(true))
-            } else {
-                Ok(Some(false))
+    let Some(target_name) = catalog_reader
+        .iter_schemas(db_name)
+        .ok()
+        .and_then(|mut schemas| schemas.find_map(|schema| relation_name_by_oid(schema, oid)))
+    else {
+        return Ok(None);
+    };
+
+    let current_user_name = user_info_reader
+        .read_guard()
+        .get_user_by_id(&auth_context.current_user_id())
+        .map(|user| user.name.clone());
+    let memberships = role_memberships_snapshot(role_membership_reader);
+    for schema_name in search_path.path() {
+        let schema_name = if schema_name == USER_NAME_WILD_CARD {
+            let Some(user_name) = current_user_name.as_deref() else {
+                continue;
             };
+            user_name
+        } else {
+            schema_name
+        };
+        if let Ok(schema) = catalog_reader.get_schema_by_name(db_name, schema_name)
+            && session_has_privilege(
+                user_info_reader,
+                auth_context,
+                &memberships,
+                schema.owner(),
+                schema.id(),
+                AclMode::Usage,
+            )
+            && let Some(found_oid) = relation_oid_by_name(schema, &target_name)
+        {
+            return Ok(Some(found_oid == oid));
         }
     }
 
-    Ok(None)
+    Ok(Some(false))
+}
+
+fn relation_name_by_oid(schema: &SchemaCatalog, oid: ObjectId) -> Option<String> {
+    if let Some(table) = schema.get_created_table_by_id(oid.as_table_id()) {
+        Some(table.name.clone())
+    } else if let Some(view) = schema.get_view_by_id(oid.as_view_id()) {
+        Some(view.name.clone())
+    } else if let Some(source) = schema.get_source_by_id(oid.as_source_id()) {
+        Some(source.name.clone())
+    } else if let Some(sink) = schema.get_sink_by_id(oid.as_sink_id()) {
+        Some(sink.name.clone())
+    } else if let Some(index) = schema.get_index_by_id(oid.as_index_id()) {
+        Some(index.name.clone())
+    } else {
+        schema
+            .get_subscription_by_id(oid.as_subscription_id())
+            .map(|subscription| subscription.name.clone())
+    }
+}
+
+fn relation_oid_by_name(schema: &SchemaCatalog, name: &str) -> Option<ObjectId> {
+    if let Some(table) = schema.get_created_table_by_name(name) {
+        Some(table.id.as_object_id())
+    } else if let Some(view) = schema.get_view_by_name(name) {
+        Some(view.id.into())
+    } else if let Some(source) = schema.get_source_by_name(name) {
+        Some(source.id.into())
+    } else if let Some(sink) = schema.get_created_sink_by_name(name) {
+        Some(sink.id.into())
+    } else if let Some(index) = schema.get_created_index_by_name(name) {
+        Some(index.id.as_object_id())
+    } else {
+        schema
+            .get_subscription_by_name(name)
+            .map(|subscription| subscription.id.into())
+    }
 }

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -139,6 +139,7 @@ impl LocalQueryExecution {
         let meta_client = self.front_env.meta_client_ref();
 
         let sender1 = sender.clone();
+        let role_membership_info_reader = self.front_env.role_membership_info_reader().clone();
         let exec = async move {
             let mut data_stream = self.run().map(|r| r.map_err(|e| Box::new(e) as BoxedError));
             while let Some(mut r) = data_stream.next().await {
@@ -158,12 +159,17 @@ impl LocalQueryExecution {
         use risingwave_expr::expr_context::*;
 
         use crate::expr::function_impl::context::{
-            AUTH_CONTEXT, CATALOG_READER, DB_NAME, META_CLIENT, SEARCH_PATH, USER_INFO_READER,
+            AUTH_CONTEXT, CATALOG_READER, DB_NAME, META_CLIENT, ROLE_MEMBERSHIP_INFO_READER,
+            SEARCH_PATH, USER_INFO_READER,
         };
 
         // box is necessary, otherwise the size of `exec` will double each time it is nested.
         let exec = async move { CATALOG_READER::scope(catalog_reader, exec).await }.boxed();
         let exec = async move { USER_INFO_READER::scope(user_info_reader, exec).await }.boxed();
+        let exec = async move {
+            ROLE_MEMBERSHIP_INFO_READER::scope(role_membership_info_reader, exec).await
+        }
+        .boxed();
         let exec = async move { DB_NAME::scope(db_name, exec).await }.boxed();
         let exec = async move { SEARCH_PATH::scope(search_path, exec).await }.boxed();
         let exec = async move { AUTH_CONTEXT::scope(auth_context, exec).await }.boxed();

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -60,6 +60,7 @@ impl BatchTaskContext for FrontendBatchTaskContext {
         Arc::new(SysCatalogReaderImpl::new(
             self.session.env().catalog_reader().clone(),
             self.session.env().user_info_reader().clone(),
+            self.session.env().role_membership_info_reader().clone(),
             self.session.env().meta_client_ref(),
             self.session.auth_context(),
             self.session.shared_config(),

--- a/src/frontend/src/user/effective_privilege.rs
+++ b/src/frontend/src/user/effective_privilege.rs
@@ -15,7 +15,8 @@
 use std::collections::{HashSet, VecDeque};
 
 use risingwave_common::acl::AclMode;
-use risingwave_pb::user::RoleMembership;
+use risingwave_pb::user::grant_privilege::Object as GrantObject;
+use risingwave_pb::user::{Action as PbAction, RoleMembership};
 
 use crate::session::AuthContext;
 use crate::user::UserId;
@@ -102,6 +103,25 @@ pub fn principal_has_privilege(
     catalog_user_has_privilege(&reader, principal, memberships, owner, object, mode)
 }
 
+pub fn principal_has_privilege_with_grant_option(
+    user_info_reader: &UserInfoReader,
+    memberships: &[RoleMembership],
+    principal: &UserCatalog,
+    owner: UserId,
+    object: impl Copy + Into<GrantObject>,
+    action: PbAction,
+) -> bool {
+    let reader = user_info_reader.read_guard();
+    catalog_user_has_privilege_with_grant_option(
+        &reader,
+        principal,
+        memberships,
+        owner,
+        object,
+        action,
+    )
+}
+
 pub fn catalog_user_has_privilege(
     user_info: &UserInfoManager,
     principal: &UserCatalog,
@@ -128,6 +148,33 @@ pub fn catalog_user_has_privilege(
     false
 }
 
+pub fn catalog_user_has_privilege_with_grant_option(
+    user_info: &UserInfoManager,
+    principal: &UserCatalog,
+    memberships: &[RoleMembership],
+    owner: UserId,
+    object: impl Copy + Into<GrantObject>,
+    action: PbAction,
+) -> bool {
+    let object = object.into();
+    if has_grant_option_or_owner(principal, owner, &object, action) {
+        return true;
+    }
+
+    for role_id in reachable_role_ids([principal.id], memberships, |membership| {
+        membership.inherit_option
+    }) {
+        let Some(role) = user_info.get_user_by_id(&role_id) else {
+            continue;
+        };
+        if has_grant_option_or_owner(role, owner, &object, action) {
+            return true;
+        }
+    }
+
+    false
+}
+
 fn has_direct_privilege_for_catalog_user(
     user: &UserCatalog,
     owner: UserId,
@@ -135,6 +182,17 @@ fn has_direct_privilege_for_catalog_user(
     mode: AclMode,
 ) -> bool {
     user.is_super || has_inherited_privilege_for_catalog_user(user, owner, object, mode)
+}
+
+fn has_grant_option_or_owner(
+    user: &UserCatalog,
+    owner: UserId,
+    object: &GrantObject,
+    action: PbAction,
+) -> bool {
+    user.is_super
+        || user.id == owner
+        || user.check_privilege_with_grant_option(object, &vec![(action, true)])
 }
 
 fn has_inherited_privilege_for_catalog_user(

--- a/src/meta/src/controller/utils.rs
+++ b/src/meta/src/controller/utils.rs
@@ -38,7 +38,7 @@ use risingwave_meta_model::{
     JobStatus, ObjectId, PrivilegeId, SchemaId, SinkId, SourceId, StreamNode, StreamSourceInfo,
     TableId, TableIdArray, UserId, WorkerId, connection, database, fragment, fragment_relation,
     function, index, object, object_dependency, schema, secret, sink, source, streaming_job,
-    subscription, table, user, user_default_privilege, user_privilege, view,
+    subscription, table, user, user_default_privilege, user_privilege, user_role_membership, view,
 };
 use risingwave_meta_model_migration::WithQuery;
 use risingwave_pb::catalog::{
@@ -56,7 +56,7 @@ use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
 use risingwave_pb::plan_common::{ColumnCatalog, DefaultColumnDesc};
 use risingwave_pb::stream_plan::{PbDispatchOutputMapping, PbDispatcher, PbDispatcherType};
 use risingwave_pb::user::grant_privilege::{PbActionWithGrantOption, PbObject as PbGrantObject};
-use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbUserInfo};
+use risingwave_pb::user::{PbAction, PbGrantPrivilege, PbRoleMembership, PbUserInfo};
 use risingwave_sqlparser::ast::Statement as SqlStatement;
 use risingwave_sqlparser::parser::Parser;
 use sea_orm::sea_query::{
@@ -995,6 +995,27 @@ where
         user_infos.push(user_info);
     }
     Ok(user_infos)
+}
+
+pub async fn list_role_memberships<C>(
+    member_ids: impl IntoIterator<Item = UserId>,
+    db: &C,
+) -> MetaResult<Vec<PbRoleMembership>>
+where
+    C: ConnectionTrait,
+{
+    let member_ids = member_ids.into_iter().collect_vec();
+    if member_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    Ok(UserRoleMembership::find()
+        .filter(user_role_membership::Column::MemberId.is_in(member_ids))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect())
 }
 
 /// `get_object_owner` returns the owner of the given object.


### PR DESCRIPTION
Part of the re-cut RBAC stack. This stack was split so each PR is an independently reviewable functional slice around ~1k changed lines, with e2e coverage added where the SQL runtime becomes available.

Review-only fixes included in this recut:
- keep #25521 as parser/fallback-only instead of carrying the full runtime;
- move meta revoke/drop tests out of the production-code PR;
- replace stale `role options are not supported yet` frontend tests with positive CREATEROLE/INHERIT coverage once frontend support lands;
- restore role membership ddl e2e coverage in the frontend runtime test slice.

Local verification run for the recut:
- `git diff --check origin/main ralph/rbac-v2-10-pg-catalog-compat`

No compile/build/e2e run in this recut pass.
