### PR TITLE
sqlparser: pilot winnow-rule integration for expr_cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "path-slash",
  "regex",
  "toml 1.1.2+spec-1.1.0",
- "windows-registry 0.6.1",
+ "windows-registry",
  "windows-sys 0.61.2",
 ]
 
@@ -10060,6 +10060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "pratt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bbc12f7936a7b195790dd6d9b982b66c54f45ff6766decf25c44cac302dce"
+
+[[package]]
 name = "predicates"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13004,6 +13010,7 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "winnow 1.0.1",
+ "winnow-rule",
  "workspace-hack",
 ]
 
@@ -17902,6 +17909,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winnow-rule"
+version = "0.1.1"
+source = "git+https://github.com/TennyZhuang/winnow-rule.git?rev=13814e8#13814e8a8528d418e5d3b24f21ed16890a362449"
+dependencies = [
+ "pratt",
+ "proc-macro-error 1.0.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "winnow 1.0.1",
 ]
 
 [[package]]

--- a/src/sqlparser/Cargo.toml
+++ b/src/sqlparser/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 winnow = "1.0.1"
+winnow-rule = { git = "https://github.com/TennyZhuang/winnow-rule.git", rev = "13814e8" }
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }

--- a/src/sqlparser/src/parser_v2/expr.rs
+++ b/src/sqlparser/src/parser_v2/expr.rs
@@ -12,6 +12,7 @@
 use winnow::combinator::{alt, cut_err, opt, preceded, repeat, seq, trace};
 use winnow::error::ContextError;
 use winnow::{ModalParser, ModalResult, Parser};
+use winnow_rule::rule;
 
 use super::{ParserExt, TokenStream, data_type, token};
 use crate::ast::Expr;
@@ -77,13 +78,11 @@ pub fn expr_cast<S>(input: &mut S) -> ModalResult<Expr>
 where
     S: TokenStream,
 {
-    let parse = cut_err(seq! {Expr::Cast {
-        _: Token::LParen,
-        expr: expr_parse.map(Box::new),
-        _: Keyword::AS,
-        data_type: data_type,
-        _: Token::RParen,
-    }});
+    let parse = rule!(^(#Token::LParen ~ #expr_parse ~ #Keyword::AS ~ #data_type ~ #Token::RParen))
+        .map(|(_, expr, _, data_type, _)| Expr::Cast {
+            expr: Box::new(expr),
+            data_type,
+        });
 
     trace("expr_cast", parse).parse_next(input)
 }


### PR DESCRIPTION
## Summary

Proof-of-concept integration of [winnow-rule](https://github.com/TennyZhuang/winnow-rule) into RisingWave's SQL parser. Rewrites `expr_cast` in `parser_v2/expr.rs` using the `rule!` macro to validate that winnow-rule's DSL works with RisingWave's custom token-stream parser.

## Changes

- Added `winnow-rule` (git dependency, winnow 1.0 compatible) to `risingwave_sqlparser`
- Rewrote `expr_cast` from `seq!` struct-construction style to `rule!` tuple-skeleton + `.map()` style

## What was tested

- `cargo check -p risingwave_sqlparser` — clean compile
- `cargo test -p risingwave_sqlparser` — 32/32 unit tests pass
- `cargo test -p risingwave_sqlparser --test parser_test` — 26/26 snapshot tests pass

## Context

This is part of a regression exercise evaluating winnow-rule for RisingWave's parser. The pilot validates:
1. `rule!` works with custom token streams (not just `&str`/`&[u8]`)
2. Enum-variant parser paths (`#Token::LParen`, `#Keyword::AS`) work in the `rule!` DSL
3. No adapter code is needed

The broader question of whether `rule!` is preferable to `seq!` for struct-building patterns is a style decision for maintainers — this PR provides a concrete comparison point.

Not intended for merge into main — opened for review and CI validation only.