### PR TITLE
chore(release): bump version to v2.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "delta_btree_map"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "educe",
  "enum-as-inner",
@@ -8634,7 +8634,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openai_embedding_service"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "async-openai",
  "axum 0.7.4",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "auto_enums",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "risedev"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "risedev-config"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -10995,7 +10995,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave-fields-derive"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "expect-test",
  "indoc",
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_backup"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11028,7 +11028,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11073,7 +11073,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch_executors"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11117,7 +11117,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_bench"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "clap",
  "madsim-tokio",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd_all"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "clap",
  "console",
@@ -11191,7 +11191,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -11313,7 +11313,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_estimate_size"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "bytes",
  "educe",
@@ -11327,7 +11327,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_heap_profiling"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -11346,7 +11346,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_log"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "governor",
  "madsim-tokio",
@@ -11356,7 +11356,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_metrics"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "auto_impl",
  "bytes",
@@ -11392,7 +11392,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_proc_macro"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "bae",
  "itertools 0.14.0",
@@ -11404,7 +11404,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_rate_limit"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "arc-swap",
  "madsim-tokio",
@@ -11418,7 +11418,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_secret"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -11442,7 +11442,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_service"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "async-trait",
  "axum 0.7.4",
@@ -11466,7 +11466,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compaction_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11487,7 +11487,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compactor"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -11511,7 +11511,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compute"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11557,7 +11557,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "adbc_core",
  "adbc_snowflake",
@@ -11697,7 +11697,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector_codec"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "apache-avro 0.16.0",
@@ -11732,7 +11732,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_ctl"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11772,7 +11772,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_dml"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "assert_matches",
  "futures",
@@ -11790,7 +11790,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_e2e_extended_mode_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11805,7 +11805,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_error"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11859,7 +11859,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr_impl"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11927,7 +11927,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12025,7 +12025,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend_macro"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_sdk"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "bytes",
  "hex",
@@ -12050,7 +12050,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12082,7 +12082,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_trace"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -12154,7 +12154,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_license"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "auto_enums",
  "expect-test",
@@ -12173,7 +12173,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mem_table_spill_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "madsim-tokio",
  "risingwave_common",
@@ -12184,7 +12184,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12261,7 +12261,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_dashboard"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
@@ -12282,7 +12282,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "prost 0.13.4",
  "risingwave_common",
@@ -12294,7 +12294,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model_migration"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "easy-ext",
  "madsim-tokio",
@@ -12307,7 +12307,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_node"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "clap",
  "educe",
@@ -12334,7 +12334,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_service"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12363,7 +12363,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mysql_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "futures",
  "madsim-tokio",
@@ -12372,7 +12372,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_object_store"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -12405,7 +12405,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_pb"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "enum-as-inner",
  "fs-err",
@@ -12431,7 +12431,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_planner_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -12453,7 +12453,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_regress_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -12467,7 +12467,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rpc_client"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12498,7 +12498,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rt"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "await-tree",
  "console",
@@ -12581,7 +12581,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlparser"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "console",
@@ -12602,7 +12602,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlsmith"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12633,7 +12633,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_state_cleaning_test"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -12652,7 +12652,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_storage"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_stream"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12798,7 +12798,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_telemetry_event"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "jsonbb",
  "madsim-tokio",
@@ -12812,7 +12812,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_test_runner"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "fail",
  "sync-point",
@@ -12821,7 +12821,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_variables"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "chrono",
  "workspace-hack",
@@ -17461,7 +17461,7 @@ dependencies = [
 
 [[package]]
 name = "with_options"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -17481,7 +17481,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-config"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "aws-lc-rs",
  "libz-sys",
@@ -17495,7 +17495,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-hack"
-version = "2.8.2"
+version = "2.8.3"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.2"
+version = "2.8.3"
 edition = "2024"
 homepage = "https://github.com/risingwavelabs/risingwave"
 keywords = ["sql", "database", "streaming"]

--- a/docker/docker-compose-distributed.yml
+++ b/docker/docker-compose-distributed.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   compactor-0:
     <<: *image

--- a/docker/docker-compose-with-azblob.yml
+++ b/docker/docker-compose-with-azblob.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-gcs.yml
+++ b/docker/docker-compose-with-gcs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-lakekeeper.yml
+++ b/docker/docker-compose-with-lakekeeper.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 
 x-lakekeeper-image: &lakekeeper-image
   image: ${LAKEKEEPER__SERVER_IMAGE:-quay.io/lakekeeper/catalog:latest-main}

--- a/docker/docker-compose-with-local-fs.yml
+++ b/docker/docker-compose-with-local-fs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-obs.yml
+++ b/docker/docker-compose-with-obs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-oss.yml
+++ b/docker/docker-compose-with-oss.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-s3.yml
+++ b/docker/docker-compose-with-s3.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-sqlite.yml
+++ b/docker/docker-compose-with-sqlite.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.2}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v2.8.3}
 services:
   risingwave-standalone:
     <<: *image


### PR DESCRIPTION
This PR bumps the version from v2.8.2 to v2.8.3 for the release.

## Changes

- Update Cargo.toml version to 2.8.3
- Update Docker image tags to v2.8.3
- Run cargo update -vv -w to update workspace dependencies

## Checklist

- [x] Version bumped in Cargo.toml
- [x] Docker image tags updated
- [x] Cargo.lock updated via cargo update

## Release Notes

See [CHANGELOG](https://github.com/risingwavelabs/risingwave/blob/release-2.8/CHANGELOG.md) for detailed changes in this release.

## Related

Release version: v2.8.3
Base branch: release-2.8