### PR TITLE
fix(stream): restore committed watermark by natural value

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -40,7 +40,7 @@ use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::row_serde::OrderedRowSerde;
-use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::util::sort_util::{OrderType, cmp_datum};
 use risingwave_common::util::value_encoding::BasicSerde;
 use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_hummock_sdk::key::{
@@ -942,26 +942,26 @@ where
         });
 
         // Restore persisted table watermark.
-        let max_watermark_of_vnodes = distribution
-            .vnodes()
-            .iter_vnodes()
-            .filter_map(|vnode| local_state_store.get_table_watermark(vnode))
-            .max();
-        let committed_watermark = if let Some((deser, _)) = watermark_serde.as_ref()
-            && let Some(max_watermark) = max_watermark_of_vnodes
-        {
-            let deserialized = deser.deserialize(&max_watermark).ok().and_then(|row| {
-                assert!(row.len() == 1);
-                row[0].clone()
-            });
-            if deserialized.is_none() {
-                tracing::error!(
-                    vnodes = ?distribution.vnodes(),
-                    watermark = ?max_watermark,
-                    "Failed to deserialize persisted watermark from state store.",
-                );
-            }
-            deserialized
+        let committed_watermark = if let Some((deser, _)) = watermark_serde.as_ref() {
+            distribution
+                .vnodes()
+                .iter_vnodes()
+                .filter_map(|vnode| {
+                    let bytes = local_state_store.get_table_watermark(vnode)?;
+                    let datum = deser.deserialize(&bytes).ok().and_then(|row| {
+                        assert!(row.len() == 1);
+                        row[0].clone()
+                    });
+                    if datum.is_none() {
+                        tracing::error!(
+                            ?vnode,
+                            watermark = ?bytes,
+                            "Failed to deserialize persisted watermark from state store.",
+                        );
+                    }
+                    datum
+                })
+                .max_by(|a, b| cmp_datum(Some(a), Some(b), OrderType::ascending()))
         } else {
             None
         };

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -33,7 +33,9 @@ use risingwave_storage::store::PrefetchOptions;
 use risingwave_storage::table::SINGLETON_VNODE;
 
 use crate::common::table::state_table::{ReplicatedStateTable, StateTable};
-use crate::common::table::test_utils::{gen_pbtable, gen_pbtable_with_value_indices};
+use crate::common::table::test_utils::{
+    gen_pbtable, gen_pbtable_with_dist_key, gen_pbtable_with_value_indices,
+};
 
 #[tokio::test]
 async fn test_state_table_update_insert() {
@@ -1826,6 +1828,77 @@ async fn test_non_pk_prefix_watermark_read() {
             .unwrap();
         assert_eq!(r3, item_3);
     }
+}
+
+#[tokio::test]
+async fn test_committed_watermark_descending_direction() {
+    const TEST_TABLE_ID: TableId = TableId::new(233);
+    let mut table = gen_pbtable_with_dist_key(
+        TEST_TABLE_ID,
+        vec![
+            ColumnDesc::unnamed(ColumnId::from(0), DataType::Int32),
+            ColumnDesc::unnamed(ColumnId::from(1), DataType::Int32),
+        ],
+        vec![OrderType::descending()],
+        vec![0],
+        1,
+        vec![0],
+    );
+    table.watermark_indices = vec![0];
+    table.clean_watermark_indices = vec![0];
+
+    let test_env = prepare_hummock_test_env().await;
+    test_env.register_table(table.clone()).await;
+
+    let vnode_count = VirtualNode::COUNT_FOR_TEST;
+    let half = vnode_count / 2;
+    let bitmap_of = |range: std::ops::Range<usize>| {
+        let mut b = BitmapBuilder::zeroed(vnode_count);
+        range.for_each(|i| b.set(i, true));
+        Arc::new(b.finish())
+    };
+
+    let mut state_table_low = StateTable::from_table_catalog_inconsistent_op(
+        &table,
+        test_env.storage.clone(),
+        Some(bitmap_of(0..half)),
+    )
+    .await;
+    let mut state_table_high = StateTable::from_table_catalog_inconsistent_op(
+        &table,
+        test_env.storage.clone(),
+        Some(bitmap_of(half..vnode_count)),
+    )
+    .await;
+
+    let mut epoch = EpochPair::new_test_epoch(test_epoch(1));
+    test_env
+        .storage
+        .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
+    state_table_low.init_epoch(epoch).await.unwrap();
+    state_table_high.init_epoch(epoch).await.unwrap();
+
+    state_table_low.update_watermark(ScalarImpl::Int32(100));
+    state_table_high.update_watermark(ScalarImpl::Int32(200));
+
+    epoch.inc_for_test();
+    test_env
+        .storage
+        .start_epoch(epoch.curr, HashSet::from_iter([TEST_TABLE_ID]));
+    state_table_low.commit_for_test(epoch).await.unwrap();
+    state_table_high.commit_for_test(epoch).await.unwrap();
+    test_env.commit_epoch(epoch.prev).await;
+
+    let state_table = StateTable::from_table_catalog_inconsistent_op(
+        &table,
+        test_env.storage.clone(),
+        Some(bitmap_of(0..vnode_count)),
+    )
+    .await;
+    assert_eq!(
+        state_table.get_committed_watermark(),
+        Some(&ScalarImpl::Int32(200)),
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

When initializing a `StateTable`, the committed watermark is restored by picking the most-progressed value across vnodes. Previously this used `.max()` on the raw serialized bytes:

```rust
let max_watermark_of_vnodes = distribution
    .vnodes()
    .iter_vnodes()
    .filter_map(|vnode| local_state_store.get_table_watermark(vnode))
    .max();
```

This is only correct for `WatermarkDirection::Ascending`. For descending columns (i.e. `PkPrefix` / `NonPkPrefix` watermark whose column is sorted DESC), memcomparable encoding inverts byte order, so byte-level `.max()` actually returns the **least**-progressed watermark in natural value space. After recovery the state table would resume from a watermark behind where cleanup actually happened.

This PR deserializes each vnode's watermark and picks the largest by natural value via `cmp_datum(_, _, OrderType::ascending())`. The comparison is direction-agnostic: a watermark always progresses upward in natural value space; `WatermarkDirection` only flips the byte encoding.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
