### PR TITLE
fix(meta): clean up compaction group metrics

### DIFF
--- a/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_manager.rs
@@ -40,7 +40,7 @@ use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::transaction::HummockVersionTransaction;
 use crate::hummock::manager::versioning::Versioning;
 use crate::hummock::manager::{HummockManager, commit_multi_var};
-use crate::hummock::metrics_utils::remove_compaction_group_in_sst_stat;
+use crate::hummock::metrics_utils::remove_compaction_group_metrics;
 use crate::hummock::model::CompactionGroup;
 use crate::hummock::sequence::next_compaction_group_id;
 use crate::manager::MetaSrvEnv;
@@ -344,7 +344,7 @@ impl HummockManager {
                     .or_default()
                     .group_deltas
                     .push(GroupDelta::GroupDestroy(PbGroupDestroy {}));
-                remove_compaction_group_in_sst_stat(&self.metrics, group_id, max_level);
+                remove_compaction_group_metrics(&self.metrics, group_id, max_level);
                 // clean up compaction schedule state for the removed group
                 self.compaction_state.remove_compaction_group(group_id);
             } else {

--- a/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
+++ b/src/meta/src/hummock/manager/compaction/compaction_group_schedule.rs
@@ -40,7 +40,7 @@ use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::transaction::HummockVersionTransaction;
 use crate::hummock::manager::versioning::Versioning;
 use crate::hummock::manager::{HummockManager, commit_multi_var};
-use crate::hummock::metrics_utils::remove_compaction_group_in_sst_stat;
+use crate::hummock::metrics_utils::remove_compaction_group_metrics;
 use crate::hummock::sequence::{next_compaction_group_id, next_sstable_id};
 use crate::hummock::table_write_throughput_statistic::{
     TableWriteThroughputStatistic, TableWriteThroughputStatisticManager,
@@ -425,7 +425,7 @@ impl HummockManager {
                     .levels
                     .len();
 
-                remove_compaction_group_in_sst_stat(
+                remove_compaction_group_metrics(
                     &self.metrics,
                     right_group_id,
                     right_group_max_level,

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -21,6 +21,8 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use prometheus::Registry;
+use prometheus::core::Collector;
+use prometheus::proto::MetricFamily;
 use risingwave_common::catalog::TableId;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::util::epoch::{EpochExt, test_epoch};
@@ -86,6 +88,21 @@ fn pin_versions_sum(pin_versions: &[HummockPinnedVersion]) -> usize {
 
 fn gen_sstable_info(sst_id: u64, table_ids: Vec<u32>, epoch: u64) -> SstableInfo {
     gen_sstable_info_impl(sst_id, table_ids, epoch).into()
+}
+
+fn metric_has_label_value(
+    metric_families: &[MetricFamily],
+    label_name: &str,
+    label_value: &str,
+) -> bool {
+    metric_families.iter().any(|metric_family| {
+        metric_family.get_metric().iter().any(|metric| {
+            metric
+                .get_label()
+                .iter()
+                .any(|label| label.name() == label_name && label.value() == label_value)
+        })
+    })
 }
 
 fn gen_sstable_info_impl(sst_id: u64, table_ids: Vec<u32>, epoch: u64) -> SstableInfoInner {
@@ -1742,6 +1759,102 @@ async fn test_move_state_tables_to_dedicated_compaction_group_on_demand_basic() 
             .collect_vec(),
         vec![100, 101]
     );
+}
+
+#[tokio::test]
+async fn test_merge_compaction_group_removes_split_group_metrics() {
+    let (_env, hummock_manager, _, worker_id) = setup_compute_env(80).await;
+    let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
+        hummock_manager.clone(),
+        worker_id as _,
+    ));
+
+    let compaction_group_id = StaticCompactionGroupId::StateDefault;
+    hummock_manager
+        .register_table_ids_for_test(&[
+            (100, compaction_group_id),
+            (101, compaction_group_id),
+            (102, compaction_group_id),
+        ])
+        .await
+        .unwrap();
+
+    let epoch = test_epoch(30);
+    let ssts = [100, 101, 102]
+        .into_iter()
+        .enumerate()
+        .map(|(idx, table_id)| gen_local_sstable_info(10 + idx as u64, vec![table_id], epoch))
+        .collect_vec();
+    hummock_meta_client
+        .commit_epoch(
+            epoch,
+            SyncResult {
+                uncommitted_ssts: ssts,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let (right_group_id, _) = hummock_manager
+        .move_state_tables_to_dedicated_compaction_group(
+            compaction_group_id,
+            &[101.into(), 102.into()],
+            None,
+        )
+        .await
+        .unwrap();
+    let left_group_id = get_compaction_group_id_by_table_id(hummock_manager.clone(), 100).await;
+    assert_ne!(left_group_id, right_group_id);
+
+    // Exercise production metric paths before merging: checkpoint updates split stats, and compact
+    // task picking records compact task metrics for the split group.
+    hummock_manager.create_version_checkpoint(0).await.unwrap();
+    let compact_task = hummock_manager
+        .get_compact_task(right_group_id, &mut *default_compaction_selector())
+        .await
+        .unwrap();
+    assert!(compact_task.is_some());
+
+    let right_group_label = right_group_id.to_string();
+    let collect_group_metrics = || {
+        [
+            (
+                "state_table_count",
+                hummock_manager.metrics.state_table_count.collect(),
+            ),
+            (
+                "compact_task_size",
+                hummock_manager.metrics.compact_task_size.collect(),
+            ),
+            (
+                "compact_task_file_count",
+                hummock_manager.metrics.compact_task_file_count.collect(),
+            ),
+        ]
+    };
+    for (metric_name, metric_families) in collect_group_metrics() {
+        assert!(
+            metric_has_label_value(&metric_families, "group", &right_group_label),
+            "{metric_name} should have right group metric before merge"
+        );
+    }
+
+    hummock_manager
+        .merge_compaction_group_for_test(
+            left_group_id,
+            right_group_id,
+            HashSet::from_iter([100.into(), 101.into(), 102.into()]),
+        )
+        .await
+        .unwrap();
+
+    for (metric_name, metric_families) in collect_group_metrics() {
+        assert!(
+            !metric_has_label_value(&metric_families, "group", &right_group_label),
+            "{metric_name} should not have right group metric after merge"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -19,7 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use itertools::{Itertools, enumerate};
 use prometheus::IntGauge;
-use prometheus::core::{AtomicU64, GenericCounter};
+use prometheus::core::{AtomicU64, Collector, GenericCounter, MetricVec, MetricVecBuilder};
 use risingwave_common::id::{JobId, TableId};
 use risingwave_hummock_sdk::change_log::TableChangeLog;
 use risingwave_hummock_sdk::compact_task::CompactTask;
@@ -52,6 +52,7 @@ pub struct LocalTableMetrics {
 
 const MIN_FLUSH_COUNT: usize = 16;
 const MIN_FLUSH_DATA_SIZE: u64 = 128 * 1024 * 1024;
+const COMPACTION_GROUP_LABEL_NAME: &str = "group";
 
 impl LocalTableMetrics {
     pub fn inc_write_throughput(&mut self, val: u64) {
@@ -219,12 +220,10 @@ pub fn trigger_sst_stat(
 
     {
         // sub level stat
-        let overlapping_level_label =
-            build_compact_task_l0_stat_metrics_label(compaction_group_id, true, false);
+        let overlapping_level_label = L0SubLevelMetricKind::Overlapping.label(compaction_group_id);
         let non_overlap_level_label =
-            build_compact_task_l0_stat_metrics_label(compaction_group_id, false, false);
-        let partition_level_label =
-            build_compact_task_l0_stat_metrics_label(compaction_group_id, true, true);
+            L0SubLevelMetricKind::NonOverlapping.label(compaction_group_id);
+        let partition_level_label = L0SubLevelMetricKind::VnodePartition.label(compaction_group_id);
 
         let overlapping_sst_num = current_version
             .levels
@@ -336,11 +335,12 @@ pub fn trigger_epoch_stat(metrics: &MetaMetrics, version: &HummockVersion) {
     );
 }
 
-pub fn remove_compaction_group_in_sst_stat(
+pub fn remove_compaction_group_metrics(
     metrics: &MetaMetrics,
     compaction_group_id: CompactionGroupId,
     max_level: usize,
 ) {
+    let group_label = compaction_group_id.to_string();
     let mut idx = 0;
     loop {
         let level_label = build_level_metrics_label(compaction_group_id, idx);
@@ -348,12 +348,10 @@ pub fn remove_compaction_group_in_sst_stat(
             .level_sst_num
             .remove_label_values(&[&level_label])
             .is_ok();
-
         metrics
             .level_file_size
             .remove_label_values(&[&level_label])
             .ok();
-
         metrics
             .level_compact_cnt
             .remove_label_values(&[&level_label])
@@ -364,21 +362,92 @@ pub fn remove_compaction_group_in_sst_stat(
         idx += 1;
     }
 
-    let overlapping_level_label = build_level_l0_metrics_label(compaction_group_id, true);
-    let non_overlap_level_label = build_level_l0_metrics_label(compaction_group_id, false);
-    metrics
-        .level_sst_num
-        .remove_label_values(&[&overlapping_level_label])
-        .ok();
-    metrics
-        .level_sst_num
-        .remove_label_values(&[&non_overlap_level_label])
-        .ok();
+    for kind in L0SubLevelMetricKind::ALL {
+        let level_label = kind.label(compaction_group_id);
+        metrics
+            .level_sst_num
+            .remove_label_values(&[&level_label])
+            .ok();
+    }
 
     remove_compacting_task_stat(metrics, compaction_group_id, max_level);
+    remove_compact_skip_frequency(metrics, compaction_group_id, max_level);
+    remove_lsm_stat(metrics, &group_label);
     remove_split_stat(metrics, compaction_group_id);
-    remove_compact_task_metrics(metrics, compaction_group_id, max_level);
+    remove_compact_task_metrics(metrics, &group_label);
     remove_compaction_group_stat(metrics, compaction_group_id);
+}
+
+fn remove_metric_series_with_label<T>(
+    metric_vec: &MetricVec<T>,
+    target_label_name: &str,
+    target_label_value: &str,
+) where
+    T: MetricVecBuilder,
+{
+    for metric_family in metric_vec.collect() {
+        for metric in metric_family.get_metric() {
+            let labels = metric.get_label();
+            if labels.iter().any(|label| {
+                label.name() == target_label_name && label.value() == target_label_value
+            }) {
+                let labels: HashMap<_, _> = labels
+                    .iter()
+                    .map(|label| (label.name(), label.value()))
+                    .collect();
+                metric_vec.remove(&labels).ok();
+            }
+        }
+    }
+}
+
+fn remove_lsm_stat(metrics: &MetaMetrics, group_label: &str) {
+    metrics
+        .write_stop_compaction_groups
+        .remove_label_values(&[group_label])
+        .ok();
+    metrics
+        .compact_pending_bytes
+        .remove_label_values(&[group_label])
+        .ok();
+
+    remove_metric_series_with_label(
+        &metrics.compact_frequency,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.compact_level_compression_ratio,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+}
+
+fn remove_compact_skip_frequency(
+    metrics: &MetaMetrics,
+    compaction_group_id: CompactionGroupId,
+    max_level: usize,
+) {
+    for start_level in 0..=max_level {
+        for target_level in 0..=max_level {
+            let level_label = format!(
+                "cg{}-{}-to-{}",
+                compaction_group_id, start_level, target_level
+            );
+            for skip_type in [
+                "write-amp",
+                "count",
+                "pending-files",
+                "overlapping",
+                "picker",
+            ] {
+                metrics
+                    .compact_skip_frequency
+                    .remove_label_values(&[level_label.as_str(), skip_type])
+                    .ok();
+            }
+        }
+    }
 }
 
 pub fn remove_compacting_task_stat(
@@ -637,25 +706,11 @@ pub fn trigger_split_stat(metrics: &MetaMetrics, version: &HummockVersion) {
     }
 }
 
-pub fn build_level_metrics_label(
-    compaction_group_id: CompactionGroupId,
-    level_idx: usize,
-) -> String {
+fn build_level_metrics_label(compaction_group_id: CompactionGroupId, level_idx: usize) -> String {
     format!("cg{}_L{}", compaction_group_id, level_idx)
 }
 
-pub fn build_level_l0_metrics_label(
-    compaction_group_id: CompactionGroupId,
-    overlapping: bool,
-) -> String {
-    if overlapping {
-        format!("cg{}_l0_sub_overlapping", compaction_group_id)
-    } else {
-        format!("cg{}_l0_sub_non_overlap", compaction_group_id)
-    }
-}
-
-pub fn build_compact_task_stat_metrics_label(
+fn build_compact_task_stat_metrics_label(
     compaction_group_id: CompactionGroupId,
     select_level: usize,
     target_level: usize,
@@ -666,17 +721,27 @@ pub fn build_compact_task_stat_metrics_label(
     )
 }
 
-pub fn build_compact_task_l0_stat_metrics_label(
-    compaction_group_id: CompactionGroupId,
-    overlapping: bool,
-    partition: bool,
-) -> String {
-    if partition {
-        format!("cg{}_l0_sub_partition", compaction_group_id)
-    } else if overlapping {
-        format!("cg{}_l0_sub_overlapping", compaction_group_id)
-    } else {
-        format!("cg{}_l0_sub_non_overlap", compaction_group_id)
+#[derive(Clone, Copy)]
+enum L0SubLevelMetricKind {
+    Overlapping,
+    NonOverlapping,
+    VnodePartition,
+}
+
+impl L0SubLevelMetricKind {
+    const ALL: [Self; 3] = [
+        Self::Overlapping,
+        Self::NonOverlapping,
+        Self::VnodePartition,
+    ];
+
+    fn label(self, compaction_group_id: CompactionGroupId) -> String {
+        let suffix = match self {
+            Self::Overlapping => "l0_sub_overlapping",
+            Self::NonOverlapping => "l0_sub_non_overlap",
+            Self::VnodePartition => "l0_sub_partition",
+        };
+        format!("cg{}_{}", compaction_group_id, suffix)
     }
 }
 
@@ -687,37 +752,27 @@ pub fn build_compact_task_level_type_metrics_label(
     format!("L{}->L{}", select_level, target_level)
 }
 
-pub fn remove_compact_task_metrics(
-    metrics: &MetaMetrics,
-    compaction_group_id: CompactionGroupId,
-    max_level: usize,
-) {
-    for select_level in 0..=max_level {
-        for target_level in 0..=max_level {
-            let level_type_label =
-                build_compact_task_level_type_metrics_label(select_level, target_level);
-            let should_continue = metrics
-                .l0_compact_level_count
-                .remove_label_values(&[&compaction_group_id.to_string(), &level_type_label])
-                .is_ok();
-
-            metrics
-                .compact_task_size
-                .remove_label_values(&[&compaction_group_id.to_string(), &level_type_label])
-                .ok();
-
-            metrics
-                .compact_task_size
-                .remove_label_values(&[
-                    &compaction_group_id.to_string(),
-                    &format!("{} uncompressed", level_type_label),
-                ])
-                .ok();
-            if !should_continue {
-                break;
-            }
-        }
-    }
+fn remove_compact_task_metrics(metrics: &MetaMetrics, group_label: &str) {
+    remove_metric_series_with_label(
+        &metrics.l0_compact_level_count,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.compact_task_size,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.compact_task_file_count,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.compact_task_trivial_move_sst_count,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
 }
 
 pub fn trigger_compact_tasks_stat(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Clean up compaction-group-scoped metrics when a compaction group is destroyed or merged, so stale series such as `storage_compact_pending_bytes{group="..."}` do not remain in the meta metrics exporter after the group disappears from the current Hummock version.

This PR keeps existing metric names and label schemas unchanged. It only extends the existing compaction group cleanup path to remove additional existing label values, including:

- LSM pending bytes and compression ratio metrics.
- Write-stop and compact-frequency group labels.
- Compact task histogram labels.
- L0 partition sub-level labels and compact skip labels.

The cleanup function is also renamed from `remove_compaction_group_in_sst_stat` to `remove_compaction_group_metrics` to match the broader responsibility.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change. This fixes stale internal metrics series for removed or merged compaction groups.

</details>
