### PR TITLE
feat(session): allow unitless `statement_timeout` to mean `ms`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "path-slash",
  "regex",
  "toml 1.1.2+spec-1.1.0",
- "windows-registry 0.6.1",
+ "windows-registry",
  "windows-sys 0.61.2",
 ]
 

--- a/e2e_test/batch/config.slt
+++ b/e2e_test/batch/config.slt
@@ -18,8 +18,14 @@ set synchronize_seqscans to f;
 statement ok
 set synchronize_seqscans to default;
 
-statement error time unit is required
+# This means 2ms since v3.0, aligned with PostgreSQL
+# In v2.7 and prior versions, it was 2s
+statement ok
 set statement_timeout = 2;
+
+skipif madsim
+statement error timeout
+select pg_sleep(1);
 
 statement ok
 set statement_timeout = '2s';

--- a/src/common/src/session_config/statement_timeout.rs
+++ b/src/common/src/session_config/statement_timeout.rs
@@ -27,7 +27,7 @@ impl std::str::FromStr for StatementTimeout {
         let (val_str, unit) = s
             .find(|c: char| !c.is_numeric())
             .map(|i| s.split_at(i))
-            .ok_or_else(|| "time unit is required: ms s min h d".to_owned())?;
+            .unwrap_or((s, "ms"));
 
         let val = val_str
             .parse::<u32>()
@@ -95,9 +95,9 @@ mod tests {
             StatementTimeout(100)
         );
 
-        assert!(
-            "100".parse::<StatementTimeout>().is_err(),
-            "should fail without unit"
+        assert_eq!(
+            "100".parse::<StatementTimeout>().unwrap(),
+            StatementTimeout(100)
         );
         assert!(
             "100x".parse::<StatementTimeout>().is_err(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Follow-up of #24633, making v3.0 compatible with PostgreSQL in this behavior.

This shall NOT be cherry-picked to v2.7 or v2.8 as it would be BREAKING CHANGE from v2.7

Resolves #25556

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
