### PR TITLE
fix(meta): sync inflight stream node rate_limit on Throttle command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ You may need to learn how to build and test RisingWave when implementing feature
 - Use `./risedev d` to run a RisingWave instance in the background via tmux.
   - It builds RisingWave binaries if necessary. The build process can take up to 10 minutes, depending on the incremental build results. Use a large timeout for this step, and be patient.
   - It kills the previous instance, if exists.
-  - Optionally pass a profile name (see `risedev.yml`) to choose external services or components. By default it uses `default`.
+  - Optionally pass a profile name (see `risedev.yml` and for local profile see `risedev-profiles.user.yml`) to choose external services or components. By default it uses `default`.
   - This runs in the background so you do not need a separate terminal.
   - You can connect right after the command finishes.
   - Logs are written to files in `.risingwave/log` folder.

--- a/e2e_test/background_ddl/alter_rate_limit_inflight_sync.slt
+++ b/e2e_test/background_ddl/alter_rate_limit_inflight_sync.slt
@@ -1,0 +1,67 @@
+# Regression for the Throttle / inflight-nodes desync fixed alongside this test:
+# ALTER ... rate_limit only updated DB + actor mutation, not `database_info.fragment.nodes`,
+# so a later ALTER PARALLELISM would materialize fresh actors from the stale snapshot and
+# resume backfill at rate_limit = 0. Mirrors the source-side test at
+# `e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial`.
+
+# Use ArrangementBackfill so the creating MV is online-reschedulable.
+statement ok
+set streaming_use_snapshot_backfill = false;
+
+statement ok
+set streaming_parallelism = 1;
+
+statement ok
+create table t (v int);
+
+statement ok
+insert into t select * from generate_series(1, 1000);
+
+statement ok
+flush;
+
+statement ok
+set background_ddl = true;
+
+statement ok
+create materialized view mv with (backfill_rate_limit = 0) as select * from t;
+
+# Backfill must really be paused before we exercise the ALTER path.
+sleep 2s
+
+query I
+select count(*) from rw_catalog.rw_ddl_progress;
+----
+1
+
+statement ok
+alter materialized view mv set backfill_rate_limit to 10;
+
+statement ok
+alter materialized view mv set parallelism = 16;
+
+statement ok
+set background_ddl = false;
+
+# Without the fix, fresh actors come up at rate_limit=0 and the count stays at 1 forever.
+query I retry 60 backoff 1s
+select count(*) from rw_catalog.rw_ddl_progress;
+----
+0
+
+query I
+select count(*) from mv;
+----
+1000
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t;
+
+statement ok
+set streaming_parallelism = default;
+
+statement ok
+set streaming_use_snapshot_backfill = default;

--- a/e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial
@@ -1,0 +1,137 @@
+# Regression: `ALTER SOURCE source_rate_limit` updates DB and notifies running actors via
+# `Mutation::Throttle`, but historically did not refresh `database_info.fragment(..).nodes`.
+# A subsequent reschedule (e.g. `ALTER SOURCE SET PARALLELISM`) materialized fresh source
+# actors from stale inflight nodes, so they started with the *original* `rate_limit = Some(0)`
+# and stayed paused -- their splits never produced data.
+#
+# Repro:
+#   1. CREATE SOURCE with `source_rate_limit = 0` (parallelism=1).
+#      All actors + inflight nodes start at rate_limit = Some(0).
+#   2. ALTER SOURCE ... source_rate_limit TO DEFAULT.
+#      DB → null, the running actor resumes via Throttle mutation.
+#      Without the fix, inflight `info.nodes.source_inner.rate_limit` is still Some(0).
+#   3. ALTER SOURCE SET PARALLELISM = 4.
+#      Reschedule materializes 3 fresh actors from inflight. Without the fix, those actors
+#      start with `rate_limit_rps = Some(0)` and the 3 partitions assigned to them never
+#      drain.
+#   4. Produce 100 more rows, distributed round-robin across 4 partitions. Verify the MV
+#      sees all 200. With the bug, only the 1 partition on the kept actor advances and the
+#      MV stalls below 200.
+
+control substitution on
+
+system ok
+rpk topic delete test_rl_inflight_sync || true
+
+system ok
+rpk topic create test_rl_inflight_sync --partitions 4 --replicas 1
+
+############## Seed 100 rows into kafka
+
+statement ok
+create table seed (v1 int);
+
+statement ok
+insert into seed select * from generate_series(1, 100);
+
+statement ok
+create sink seed_sink from seed with (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'test_rl_inflight_sync',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+sleep 5s
+
+############## Step 1: CREATE SOURCE with rate_limit = 0, parallelism = 1.
+# Inflight `info.nodes.source_inner.rate_limit` is set to Some(0) here.
+
+statement ok
+SET STREAMING_PARALLELISM = 1;
+
+statement ok
+create source rl_src (v1 int) with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test_rl_inflight_sync',
+  source_rate_limit = 0
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+SET STREAMING_PARALLELISM = DEFAULT;
+
+statement ok
+flush;
+
+query T
+select rate_limit from rw_rate_limit join rw_relations on table_id = id where name = 'rl_src';
+----
+0
+
+query I
+select parallelism from rw_fragments join rw_relations on rw_fragments.table_id = rw_relations.id
+where name = 'rl_src';
+----
+1
+
+############## Step 2: ALTER source rate_limit TO DEFAULT.
+# DB cleared, the existing 1 actor is resumed by the Throttle mutation.
+# Without the fix, inflight `info.nodes.source_inner.rate_limit` stays at Some(0).
+
+statement ok
+alter source rl_src set source_rate_limit to default;
+
+# rw_rate_limit only lists fragments with a non-null rate_limit; should now be empty.
+query T
+select rate_limit from rw_rate_limit join rw_relations on table_id = id where name = 'rl_src';
+----
+
+############## Step 3: Scale parallelism 1 → 4.
+# This adds 3 brand-new source actors. Without the fix they read stale inflight nodes
+# and come up paused.
+
+statement ok
+alter source rl_src set parallelism = 4;
+
+query I
+select parallelism from rw_fragments join rw_relations on rw_fragments.table_id = rw_relations.id
+where name = 'rl_src';
+----
+4
+
+############## Step 4: Verify the upstream source is not stuck on any partition.
+# We attach an MV after the reschedule. SourceBackfill backfills directly from kafka (it
+# gets the seed 100 regardless), but data produced *after* backfill must flow through the
+# upstream Source actors -- which is exactly what the bug breaks for the 3 new actors.
+
+statement ok
+create materialized view rl_mv as select count(*) as c from rl_src;
+
+query I retry 30 backoff 1s
+select c from rl_mv;
+----
+100
+
+statement ok
+insert into seed select * from generate_series(101, 200);
+
+# With the bug, ~75 of the 100 new rows land on partitions owned by the freshly-created
+# (paused) actors and never reach the MV. With the fix all 100 flow through.
+query I retry 60 backoff 1s
+select c from rl_mv;
+----
+200
+
+############## Cleanup
+
+statement ok
+drop source rl_src cascade;
+
+statement ok
+drop sink seed_sink;
+
+statement ok
+drop table seed;
+
+system ok
+rpk topic delete test_rl_inflight_sync || true

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -793,6 +793,10 @@ impl DatabaseCheckpointControl {
 
             Some(Command::Throttle { jobs, config }) => {
                 let mutation = Some(Command::throttle_to_mutation(&config));
+                for (fragment_id, throttle_config) in &config {
+                    self.database_info
+                        .pre_apply_throttle(*fragment_id, throttle_config);
+                }
                 throttle_for_creating_jobs = Some((jobs, config));
                 self.apply_simple_command(mutation, "Throttle")
             }

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -28,6 +28,7 @@ use risingwave_common::util::stream_graph_visitor::visit_stream_node_mut;
 use risingwave_connector::source::{SplitImpl, SplitMetaData};
 use risingwave_meta_model::WorkerId;
 use risingwave_meta_model::fragment::DistributionType;
+use risingwave_pb::common::ThrottleType;
 use risingwave_pb::ddl_service::PbBackfillType;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::SubscriberId;
@@ -36,6 +37,7 @@ use risingwave_pb::meta::subscribe_response::Operation;
 use risingwave_pb::source::PbCdcTableSnapshotSplits;
 use risingwave_pb::stream_plan::PbUpstreamSinkInfo;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::throttle_mutation::ThrottleConfig;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use tracing::{info, warn};
 
@@ -1137,6 +1139,51 @@ impl InflightDatabaseInfo {
                 }
             }
         }
+    }
+
+    /// Sync inflight `nodes.rate_limit` so a later reschedule won't materialize new actors
+    /// from stale data. Mirrors `controller/streaming_job.rs::update_*_rate_limit_by_*`.
+    pub(crate) fn pre_apply_throttle(&mut self, fragment_id: FragmentId, config: &ThrottleConfig) {
+        // Snapshot-backfill creating jobs live outside main inflight; their throttles
+        // flow through `on_new_upstream_barrier`.
+        if !self.fragment_location.contains_key(&fragment_id) {
+            return;
+        }
+        let throttle_type = config.throttle_type();
+        let rate_limit = config.rate_limit;
+        let (info, _) = self.fragment_mut(fragment_id);
+
+        visit_stream_node_mut(&mut info.nodes, |node| match throttle_type {
+            ThrottleType::Source => {
+                if let NodeBody::Source(node) = node
+                    && let Some(node_inner) = &mut node.source_inner
+                {
+                    node_inner.rate_limit = rate_limit;
+                }
+                if let NodeBody::StreamFsFetch(node) = node
+                    && let Some(node_inner) = &mut node.node_inner
+                {
+                    node_inner.rate_limit = rate_limit;
+                }
+            }
+            ThrottleType::Backfill => match node {
+                NodeBody::StreamCdcScan(node) => node.rate_limit = rate_limit,
+                NodeBody::StreamScan(node) => node.rate_limit = rate_limit,
+                NodeBody::SourceBackfill(node) => node.rate_limit = rate_limit,
+                _ => {}
+            },
+            ThrottleType::Sink => {
+                if let NodeBody::Sink(node) = node {
+                    node.rate_limit = rate_limit;
+                }
+            }
+            ThrottleType::Dml => {
+                if let NodeBody::Dml(node) = node {
+                    node.rate_limit = rate_limit;
+                }
+            }
+            ThrottleType::Unspecified => {}
+        });
     }
 
     /// Update split assignments for actors in fragments.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`Command::Throttle` updates `Source.rate_limit` on the catalog row and rewrites the matching
`rate_limit` field on `Fragment.stream_node`, then notifies running actors via
`Mutation::Throttle`. It does **not**, however, refresh
`InflightDatabaseInfo.fragment(..).nodes` — the meta barrier scheduler's in-memory snapshot of
each fragment's `StreamNode`. Every other DB-mutating command in `apply_command`
(`CreateStreamingJob`, `ReplaceStreamJob`, `RescheduleIntent`, `SourceChangeSplit`, …) has a
matching `pre_apply_*` that keeps inflight in sync; only `Throttle` skipped this and went
straight to `apply_simple_command`.

The fallout: `RescheduleIntent`'s `reschedule_actors_to_create` materializes new actors from
`database_info.fragment(fragment_id).nodes.clone()` (`command.rs:1531`). When ALTER had
flipped DB / runtime to a new rate_limit but inflight was stale, any later layout change
would spawn fresh actors that revert to the **previous** value persisted at job creation /
last recovery. The most painful symptom is "ALTER ... source_rate_limit TO 0; ALTER ...
TO DEFAULT (works); some unrelated reschedule (e.g. `serverless_backfill` provisioning a new
worker, ALTER PARALLELISM, scaling) → source pauses again, with `rate_limit_rps = Some(0)`."

This is also exactly the mechanism behind the family of bugs reported in #20554 and the
sibling `update_fragment_rate_limit_by_fragment_id` issue tracked in #25561.

### Fix

Add `InflightDatabaseInfo::pre_apply_throttle` mirroring the per-target DB writers
(`update_{source,backfill,sink,dml}_rate_limit_by_*`). It dispatches on `ThrottleType` and
rewrites the matching `rate_limit` field:

| `ThrottleType` | nodes updated |
| --- | --- |
| `Source`     | `Source.source_inner.rate_limit`, `StreamFsFetch.node_inner.rate_limit` |
| `Backfill`   | `StreamCdcScan.rate_limit`, `StreamScan.rate_limit`, `SourceBackfill.rate_limit` |
| `Sink`       | `Sink.rate_limit` |
| `Dml`        | `Dml.rate_limit` |
| `Unspecified`| no-op |

Snapshot-backfill creating jobs maintain their own fragment view in
`independent_checkpoint_job_controls`, so `pre_apply_throttle` skips fragments that are not
in the main inflight rather than panic through `fragment_mut`.

`apply_command`'s `Throttle` arm now calls `pre_apply_throttle` for each
`(fragment_id, ThrottleConfig)` before producing the mutation.

### Reproducer

`e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial`:

1. `CREATE SOURCE` with `source_rate_limit = 0` and `STREAMING_PARALLELISM = 1`.
2. `ALTER SOURCE ... source_rate_limit TO DEFAULT`.
3. `ALTER SOURCE SET PARALLELISM = 4` to force a reschedule that materializes 3+ fresh
   actors.
4. Insert 100 more rows and assert the counting MV reaches 200.

Locally verified:
- **With this fix**: passes (~18s, a few backoff retries waiting on the kafka pipeline).
- **Without this fix**: stalls at `100/200`, `query ... retry 60` exhausts and the test fails.

- Closes nothing (no tracking issue was filed for this); cross-references #25561 (sibling).

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixes a bug where `ALTER SOURCE ... source_rate_limit` (and the analogous backfill / sink /
dml rate-limit alters) would silently revert after any subsequent reschedule of the affected
fragment. Most visibly, a paused source that the user un-paused via
`ALTER ... source_rate_limit TO DEFAULT` could re-pause itself when a downstream MV / sink
change provoked a reschedule (for example, when `serverless_backfill` provisioning brought up
a new compute worker and triggered auto-parallelism rescheduling).

</details>
