### PR TITLE
feat: expose Hasura column requiredness flags

### DIFF
--- a/e2e_test/batch/catalog/pg_attribute_hasura.slt
+++ b/e2e_test/batch/catalog/pg_attribute_hasura.slt
@@ -16,6 +16,7 @@ statement ok
 create table hasura_defaults (
     id int primary key,
     required_v int not null,
+    nullable_v int,
     optional_v int default 42,
     required_default_v int not null default 7,
     gen_v int as id + 1
@@ -25,10 +26,11 @@ query TTT rowsort
 select attname, attnotnull, atthasdef
 from pg_catalog.pg_attribute
 where attrelid = 'hasura_defaults'::regclass
-  and attname in ('id', 'required_v', 'optional_v', 'required_default_v')
+  and attname in ('id', 'required_v', 'nullable_v', 'optional_v', 'required_default_v')
 order by attname;
 ----
 id t f
+nullable_v f f
 optional_v f t
 required_default_v t t
 required_v t f

--- a/e2e_test/batch/catalog/pg_attribute_hasura.slt
+++ b/e2e_test/batch/catalog/pg_attribute_hasura.slt
@@ -1,0 +1,54 @@
+# Copyright 2026 RisingWave Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+statement ok
+create table hasura_defaults (
+    id int primary key,
+    required_v int not null,
+    optional_v int default 42,
+    required_default_v int not null default 7,
+    gen_v int as id + 1
+);
+
+query TTT rowsort
+select attname, attnotnull, atthasdef
+from pg_catalog.pg_attribute
+where attrelid = 'hasura_defaults'::regclass
+  and attname in ('id', 'required_v', 'optional_v', 'required_default_v')
+order by attname;
+----
+id t f
+optional_v f t
+required_default_v t t
+required_v t f
+
+query TT rowsort
+select attname, atthasdef
+from pg_catalog.pg_attribute
+where attrelid = 'hasura_defaults'::regclass
+  and attname = 'gen_v'
+order by attname;
+----
+gen_v t
+
+query TT
+select attname, attgenerated
+from pg_catalog.pg_attribute
+where attrelid = 'hasura_defaults'::regclass
+  and attname = 'gen_v';
+----
+gen_v s
+
+statement ok
+drop table hasura_defaults;

--- a/e2e_test/batch/catalog/pg_type_category.slt
+++ b/e2e_test/batch/catalog/pg_type_category.slt
@@ -1,0 +1,27 @@
+# Copyright 2026 RisingWave Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+query TT rowsort
+select typname, typcategory
+from pg_catalog.pg_type
+where typname in ('int4', '_int4', 'varchar', 'bool', 'timestamp', 'interval', 'jsonb')
+order by typname;
+----
+_int4 A
+bool B
+int4 N
+interval T
+jsonb U
+timestamp D
+varchar S

--- a/src/frontend/planner_test/tests/testdata/input/hasura_compatibility.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/hasura_compatibility.yaml
@@ -18,3 +18,24 @@
     select pg_catalog.pg_relation_is_updatable('hasura_s'::regclass, true);
   expected_outputs:
   - batch_plan
+- sql: |
+    create table hasura_defaults (
+      id int primary key,
+      required_v int not null,
+      optional_v int default 42,
+      required_default_v int not null default 7
+    );
+    select attname, attnotnull, atthasdef
+    from pg_catalog.pg_attribute
+    where attrelid = 'hasura_defaults'::regclass
+      and attname in ('id', 'required_v', 'optional_v', 'required_default_v')
+    order by attnum;
+  expected_outputs:
+  - batch_plan
+- sql: |
+    select typname, typcategory
+    from pg_catalog.pg_type
+    where typname in ('int4', '_int4', 'varchar', 'interval')
+    order by typname;
+  expected_outputs:
+  - batch_plan

--- a/src/frontend/planner_test/tests/testdata/input/hasura_compatibility.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/hasura_compatibility.yaml
@@ -35,7 +35,7 @@
 - sql: |
     select typname, typcategory
     from pg_catalog.pg_type
-    where typname in ('int4', '_int4', 'varchar', 'interval')
+    where typname in ('int4', '_int4', 'varchar', 'bool', 'timestamp', 'interval', 'jsonb')
     order by typname;
   expected_outputs:
   - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/hasura_compatibility.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/hasura_compatibility.yaml
@@ -22,3 +22,30 @@
   batch_plan: |-
     BatchProject { exprs: [PgRelationIsUpdatable(CastRegclass('hasura_s':Varchar), true:Boolean) as $expr1] }
     └─BatchValues { rows: [[]] }
+- sql: |
+    create table hasura_defaults (
+      id int primary key,
+      required_v int not null,
+      optional_v int default 42,
+      required_default_v int not null default 7
+    );
+    select attname, attnotnull, atthasdef
+    from pg_catalog.pg_attribute
+    where attrelid = 'hasura_defaults'::regclass
+      and attname in ('id', 'required_v', 'optional_v', 'required_default_v')
+    order by attnum;
+  batch_plan: |-
+    BatchProject { exprs: [rw_columns.name, $expr1, rw_columns.has_default] }
+    └─BatchSort { order: [$expr2 ASC] }
+      └─BatchProject { exprs: [rw_columns.name, Not(rw_columns.is_nullable) as $expr1, rw_columns.has_default, rw_columns.position::Int16 as $expr2] }
+        └─BatchFilter { predicate: (rw_columns.relation_id = CastRegclass('hasura_defaults':Varchar)) AND In(rw_columns.name, 'id':Varchar, 'required_v':Varchar, 'optional_v':Varchar, 'required_default_v':Varchar) AND (rw_columns.is_hidden = false:Boolean) }
+          └─BatchSysScan { table: rw_columns, columns: [rw_columns.relation_id, rw_columns.name, rw_columns.position, rw_columns.is_hidden, rw_columns.is_nullable, rw_columns.has_default], distribution: Single }
+- sql: |
+    select typname, typcategory
+    from pg_catalog.pg_type
+    where typname in ('int4', '_int4', 'varchar', 'interval')
+    order by typname;
+  batch_plan: |-
+    BatchSort { order: [pg_type.typname ASC] }
+    └─BatchFilter { predicate: In(pg_type.typname, 'int4':Varchar, '_int4':Varchar, 'varchar':Varchar, 'interval':Varchar) }
+      └─BatchSysScan { table: pg_type, columns: [pg_type.typname, pg_type.typcategory], distribution: Single }

--- a/src/frontend/planner_test/tests/testdata/output/hasura_compatibility.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/hasura_compatibility.yaml
@@ -37,15 +37,15 @@
   batch_plan: |-
     BatchProject { exprs: [rw_columns.name, $expr1, rw_columns.has_default] }
     └─BatchSort { order: [$expr2 ASC] }
-      └─BatchProject { exprs: [rw_columns.name, Not(rw_columns.is_nullable) as $expr1, rw_columns.has_default, rw_columns.position::Int16 as $expr2] }
+      └─BatchProject { exprs: [rw_columns.name, (Not(rw_columns.is_nullable) OR rw_columns.is_primary_key) as $expr1, rw_columns.has_default, rw_columns.position::Int16 as $expr2] }
         └─BatchFilter { predicate: (rw_columns.relation_id = CastRegclass('hasura_defaults':Varchar)) AND In(rw_columns.name, 'id':Varchar, 'required_v':Varchar, 'optional_v':Varchar, 'required_default_v':Varchar) AND (rw_columns.is_hidden = false:Boolean) }
-          └─BatchSysScan { table: rw_columns, columns: [rw_columns.relation_id, rw_columns.name, rw_columns.position, rw_columns.is_hidden, rw_columns.is_nullable, rw_columns.has_default], distribution: Single }
+          └─BatchSysScan { table: rw_columns, columns: [rw_columns.relation_id, rw_columns.name, rw_columns.position, rw_columns.is_hidden, rw_columns.is_primary_key, rw_columns.is_nullable, rw_columns.has_default], distribution: Single }
 - sql: |
     select typname, typcategory
     from pg_catalog.pg_type
-    where typname in ('int4', '_int4', 'varchar', 'interval')
+    where typname in ('int4', '_int4', 'varchar', 'bool', 'timestamp', 'interval', 'jsonb')
     order by typname;
   batch_plan: |-
     BatchSort { order: [pg_type.typname ASC] }
-    └─BatchFilter { predicate: In(pg_type.typname, 'int4':Varchar, '_int4':Varchar, 'varchar':Varchar, 'interval':Varchar) }
+    └─BatchFilter { predicate: In(pg_type.typname, 'int4':Varchar, '_int4':Varchar, 'varchar':Varchar, 'bool':Varchar, 'timestamp':Varchar, 'interval':Varchar, 'jsonb':Varchar) }
       └─BatchSysScan { table: pg_type, columns: [pg_type.typname, pg_type.typcategory], distribution: Single }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
@@ -34,7 +34,7 @@ use risingwave_frontend_macro::system_catalog;
             END AS attndims,
             c.type_len AS attlen,
             c.position::smallint AS attnum,
-            NOT c.is_nullable AS attnotnull,
+            (NOT c.is_nullable OR c.is_primary_key) AS attnotnull,
             c.has_default AS atthasdef,
             false AS attisdropped,
             ''::varchar AS attidentity,

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
@@ -34,8 +34,8 @@ use risingwave_frontend_macro::system_catalog;
             END AS attndims,
             c.type_len AS attlen,
             c.position::smallint AS attnum,
-            false AS attnotnull,
-            false AS atthasdef,
+            NOT c.is_nullable AS attnotnull,
+            c.has_default AS atthasdef,
             false AS attisdropped,
             ''::varchar AS attidentity,
             CASE

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_type.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_type.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::types::Fields;
+use risingwave_common::types::{DataType, Fields};
 use risingwave_frontend_macro::system_catalog;
 use risingwave_pb::id::SchemaId;
 
@@ -100,9 +100,43 @@ fn read_pg_type(reader: &SysCatalogReaderImpl) -> Result<Vec<PgType>> {
             typdelim: ',',
             typrelid: 0,
             typdefault: None,
-            typcategory: None,
+            typcategory: infer_pg_type_category(rw_type.id, rw_type.typelem),
             typreceive: None,
         });
     }
     Ok(rows)
+}
+
+fn infer_pg_type_category(oid: i32, typelem: i32) -> Option<String> {
+    if typelem != 0 {
+        return Some("A".into());
+    }
+
+    let category = match DataType::from_oid(oid) {
+        Ok(DataType::Boolean) => "B",
+        Ok(
+            DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Decimal
+            | DataType::Serial
+            | DataType::Int256,
+        ) => "N",
+        Ok(DataType::Varchar) => "S",
+        Ok(DataType::Date | DataType::Time | DataType::Timestamp | DataType::Timestamptz) => "D",
+        Ok(DataType::Interval) => "T",
+        Ok(
+            DataType::Bytea
+            | DataType::Jsonb
+            | DataType::List(_)
+            | DataType::Map(_)
+            | DataType::Struct(_)
+            | DataType::Vector(_),
+        )
+        | Err(_) => "U",
+    };
+
+    Some(category.into())
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_columns.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_columns.rs
@@ -16,7 +16,6 @@ use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::types::Fields;
 use risingwave_frontend_macro::system_catalog;
 use risingwave_pb::id::RelationId;
-use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
 
 use crate::catalog::schema_catalog::SchemaCatalog;
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
@@ -198,8 +197,5 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
 }
 
 fn has_default(column: &ColumnCatalog) -> bool {
-    matches!(
-        &column.column_desc.generated_or_default_column,
-        Some(GeneratedOrDefaultColumn::DefaultColumn(_))
-    )
+    column.column_desc.generated_or_default_column.is_some()
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_columns.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_columns.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::types::Fields;
 use risingwave_frontend_macro::system_catalog;
 use risingwave_pb::id::RelationId;
+use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
 
 use crate::catalog::schema_catalog::SchemaCatalog;
 use crate::catalog::system_catalog::SysCatalogReaderImpl;
@@ -36,6 +38,7 @@ struct RwColumn {
     is_distribution_key: bool,
     is_generated: bool,
     is_nullable: bool,
+    has_default: bool,
     generation_expression: Option<String>,
     data_type: String,
     type_oid: i32,
@@ -71,6 +74,7 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
                 is_distribution_key: false,
                 is_generated: false,
                 is_nullable: true,
+                has_default: false,
                 generation_expression: None,
                 data_type: column.data_type().to_string(),
                 type_oid: column.data_type().to_oid(),
@@ -94,6 +98,7 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
                 is_distribution_key: sink.distribution_key.contains(&index),
                 is_generated: false,
                 is_nullable: column.nullable(),
+                has_default: has_default(column),
                 generation_expression: None,
                 data_type: column.data_type().to_string(),
                 type_oid: column.data_type().to_oid(),
@@ -116,6 +121,7 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
                 is_distribution_key: false,
                 is_generated: false,
                 is_nullable: column.nullable(),
+                has_default: has_default(column),
                 generation_expression: None,
                 data_type: column.data_type().to_string(),
                 type_oid: column.data_type().to_oid(),
@@ -141,6 +147,7 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
                     is_distribution_key: table.distribution_key.contains(&index),
                     is_generated: column.is_generated(),
                     is_nullable: column.nullable(),
+                    has_default: has_default(column),
                     generation_expression: column.generated_expr().map(|expr_node| {
                         let expr = ExprImpl::from_expr_proto(expr_node).unwrap();
                         let expr_display = ExprDisplay {
@@ -173,6 +180,7 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
                     is_distribution_key: false,
                     is_generated: false,
                     is_nullable: column.nullable(),
+                    has_default: has_default(column),
                     generation_expression: None,
                     data_type: column.data_type().to_string(),
                     type_oid: column.data_type().to_oid(),
@@ -187,4 +195,11 @@ fn read_rw_columns_in_schema(current_user: &UserCatalog, schema: &SchemaCatalog)
         .chain(table_rows)
         .chain(schema_rows)
         .collect()
+}
+
+fn has_default(column: &ColumnCatalog) -> bool {
+    matches!(
+        &column.column_desc.generated_or_default_column,
+        Some(GeneratedOrDefaultColumn::DefaultColumn(_))
+    )
 }


### PR DESCRIPTION
## Summary
- expose PostgreSQL-style column requiredness signals that Hasura relies on during schema introspection
- report primary-key columns as effectively not-null in `pg_attribute.attnotnull`
- expose default/generated-column presence through `pg_attribute.atthasdef`
- add runtime e2e coverage for `pg_attribute` and `pg_type.typcategory`

## Why
Hasura's PostgreSQL source path uses these catalog fields to decide:
- which insert input fields are required (`attnotnull`)
- which columns may be omitted because the database can supply a value (`atthasdef`)
- whether a type should be treated as an array or a scalar family (`typcategory`)

Without this PR, Hasura still mis-classifies some RisingWave columns even after PR1.

## Stacking
Base: #25565

## Tests
- `UPDATE_EXPECT=1 ./risedev run-planner-test hasura_compatibility`
- `./risedev slt './e2e_test/batch/catalog/pg_attribute_hasura.slt' './e2e_test/batch/catalog/pg_type_category.slt'`
