### PR TITLE
feat: expose Hasura foreign key metadata in pg_constraint

### DIFF
--- a/e2e_test/batch/catalog/pg_constraint_hasura_fk.slt
+++ b/e2e_test/batch/catalog/pg_constraint_hasura_fk.slt
@@ -35,6 +35,12 @@ create table hasura_child (
         on delete restrict on update no action
 );
 
+statement ok
+create table hasura_default_fk_child (
+    id int primary key,
+    parent_id int references hasura_parent(id)
+);
+
 query TTTTTTTT
 select
     conname,
@@ -65,8 +71,26 @@ where conname = 'hasura_child_composite_fkey';
 ----
 hasura_child_composite_fkey f t t {3,4} {1,2} r a
 
+query TTTTTTTT
+select
+    conname,
+    contype,
+    conrelid = 'hasura_default_fk_child'::regclass,
+    confrelid = 'hasura_parent'::regclass,
+    conkey,
+    confkey,
+    confdeltype,
+    confupdtype
+from pg_catalog.pg_constraint
+where conname = 'hasura_default_fk_child_parent_id_fkey';
+----
+hasura_default_fk_child_parent_id_fkey f t t {2} {1} a a
+
 statement ok
 drop table hasura_child;
+
+statement ok
+drop table hasura_default_fk_child;
 
 statement ok
 drop table hasura_parent_composite;

--- a/e2e_test/batch/catalog/pg_constraint_hasura_fk.slt
+++ b/e2e_test/batch/catalog/pg_constraint_hasura_fk.slt
@@ -1,0 +1,75 @@
+# Copyright 2026 RisingWave Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+statement ok
+create table hasura_parent (
+    id int primary key
+);
+
+statement ok
+create table hasura_parent_composite (
+    tenant_id int,
+    parent_id int,
+    primary key (tenant_id, parent_id)
+);
+
+statement ok
+create table hasura_child (
+    id int primary key,
+    parent_id int references hasura_parent on delete cascade on update set null,
+    tenant_id int,
+    composite_parent_id int,
+    constraint hasura_child_composite_fkey foreign key (tenant_id, composite_parent_id)
+        references hasura_parent_composite (tenant_id, parent_id)
+        on delete restrict on update no action
+);
+
+query TTTTTTTT
+select
+    conname,
+    contype,
+    conrelid = 'hasura_child'::regclass,
+    confrelid = 'hasura_parent'::regclass,
+    conkey,
+    confkey,
+    confdeltype,
+    confupdtype
+from pg_catalog.pg_constraint
+where conname = 'hasura_child_parent_id_fkey';
+----
+hasura_child_parent_id_fkey f t t {2} {1} c n
+
+query TTTTTTTT
+select
+    conname,
+    contype,
+    conrelid = 'hasura_child'::regclass,
+    confrelid = 'hasura_parent_composite'::regclass,
+    conkey,
+    confkey,
+    confdeltype,
+    confupdtype
+from pg_catalog.pg_constraint
+where conname = 'hasura_child_composite_fkey';
+----
+hasura_child_composite_fkey f t t {3,4} {1,2} r a
+
+statement ok
+drop table hasura_child;
+
+statement ok
+drop table hasura_parent_composite;
+
+statement ok
+drop table hasura_parent;

--- a/src/frontend/planner_test/tests/testdata/input/hasura_compatibility.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/hasura_compatibility.yaml
@@ -39,3 +39,15 @@
     order by typname;
   expected_outputs:
   - batch_plan
+- sql: |
+    create table hasura_parent (id int primary key);
+    create table hasura_child (
+      id int primary key,
+      parent_id int references hasura_parent(id) on delete cascade on update set null
+    );
+    select conname, contype, confdeltype, confupdtype
+    from pg_catalog.pg_constraint
+    where conrelid = 'hasura_child'::regclass
+      and contype = 'f';
+  expected_outputs:
+  - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/hasura_compatibility.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/hasura_compatibility.yaml
@@ -49,3 +49,17 @@
     BatchSort { order: [pg_type.typname ASC] }
     └─BatchFilter { predicate: In(pg_type.typname, 'int4':Varchar, '_int4':Varchar, 'varchar':Varchar, 'bool':Varchar, 'timestamp':Varchar, 'interval':Varchar, 'jsonb':Varchar) }
       └─BatchSysScan { table: pg_type, columns: [pg_type.typname, pg_type.typcategory], distribution: Single }
+- sql: |
+    create table hasura_parent (id int primary key);
+    create table hasura_child (
+      id int primary key,
+      parent_id int references hasura_parent(id) on delete cascade on update set null
+    );
+    select conname, contype, confdeltype, confupdtype
+    from pg_catalog.pg_constraint
+    where conrelid = 'hasura_child'::regclass
+      and contype = 'f';
+  batch_plan: |-
+    BatchProject { exprs: [pg_constraint.conname, pg_constraint.contype, pg_constraint.confdeltype, pg_constraint.confupdtype] }
+    └─BatchFilter { predicate: (pg_constraint.conrelid = CastRegclass('hasura_child':Varchar)) AND (pg_constraint.contype = 'f':Varchar) }
+      └─BatchSysScan { table: pg_constraint, columns: [pg_constraint.conname, pg_constraint.contype, pg_constraint.conrelid, pg_constraint.confupdtype, pg_constraint.confdeltype], distribution: Single }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_constraint.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_constraint.rs
@@ -15,10 +15,14 @@
 use risingwave_common::types::Fields;
 use risingwave_frontend_macro::system_catalog;
 use risingwave_pb::id::{ObjectId, RelationId, SchemaId};
+use risingwave_sqlparser::ast::{
+    ColumnOption, ObjectName, ReferentialAction, Statement, TableConstraint,
+};
 
 use crate::TableCatalog;
 use crate::catalog::schema_catalog::SchemaCatalog;
 use crate::catalog::system_catalog::{SysCatalogReaderImpl, SystemTableCatalog};
+use crate::catalog::table_catalog::TableType;
 use crate::error::Result;
 
 /// The catalog `pg_constraint` records information about table and index inheritance hierarchies.
@@ -131,10 +135,18 @@ fn read_pg_constraint(reader: &SysCatalogReaderImpl) -> Result<Vec<PgConstraint>
     let catalog_reader = reader.catalog_reader.read_guard();
     let schemas = catalog_reader.iter_schemas(&reader.auth_context.database)?;
 
-    Ok(schemas.flat_map(read_pg_constraint_in_schema).collect())
+    Ok(schemas
+        .flat_map(|schema| {
+            read_pg_constraint_in_schema(&catalog_reader, &reader.auth_context.database, schema)
+        })
+        .collect())
 }
 
-fn read_pg_constraint_in_schema(schema: &SchemaCatalog) -> Vec<PgConstraint> {
+fn read_pg_constraint_in_schema(
+    catalog_reader: &crate::catalog::root_catalog::Catalog,
+    database: &str,
+    schema: &SchemaCatalog,
+) -> Vec<PgConstraint> {
     // Note: We only support primary key constraints now.
     let system_table_rows = schema
         .iter_system_tables()
@@ -144,5 +156,335 @@ fn read_pg_constraint_in_schema(schema: &SchemaCatalog) -> Vec<PgConstraint> {
         .iter_table_mv_indices()
         .map(|table| PgConstraint::from_table(schema, table.as_ref()));
 
-    system_table_rows.chain(table_rows).collect()
+    let foreign_key_rows = schema.iter_table_mv_indices().flat_map(|table| {
+        foreign_key_constraints_from_definition(catalog_reader, database, schema, table.as_ref())
+    });
+
+    system_table_rows
+        .chain(table_rows)
+        .chain(foreign_key_rows)
+        .collect()
+}
+
+fn foreign_key_constraints_from_definition(
+    catalog_reader: &crate::catalog::root_catalog::Catalog,
+    database: &str,
+    current_schema: &SchemaCatalog,
+    table: &TableCatalog,
+) -> Vec<PgConstraint> {
+    if !matches!(table.table_type(), TableType::Table) {
+        return vec![];
+    }
+
+    let Ok(Statement::CreateTable {
+        columns,
+        constraints,
+        ..
+    }) = table.create_sql_ast()
+    else {
+        return vec![];
+    };
+
+    let mut rows = Vec::new();
+    let mut ordinal = 0u32;
+
+    for constraint in constraints {
+        if let TableConstraint::ForeignKey {
+            name,
+            columns,
+            foreign_table,
+            referred_columns,
+            on_delete,
+            on_update,
+        } = constraint
+            && let Some(row) = build_foreign_key_constraint(
+                catalog_reader,
+                database,
+                current_schema,
+                table,
+                name,
+                columns,
+                foreign_table,
+                referred_columns,
+                on_delete,
+                on_update,
+                ordinal,
+            )
+        {
+            rows.push(row);
+            ordinal += 1;
+        }
+    }
+
+    for column in columns {
+        for option in column.options {
+            if let ColumnOption::ForeignKey {
+                foreign_table,
+                referred_columns,
+                on_delete,
+                on_update,
+            } = option.option
+                && let Some(row) = build_foreign_key_constraint(
+                    catalog_reader,
+                    database,
+                    current_schema,
+                    table,
+                    option.name,
+                    vec![column.name.clone()],
+                    foreign_table,
+                    referred_columns,
+                    on_delete,
+                    on_update,
+                    ordinal,
+                )
+            {
+                rows.push(row);
+                ordinal += 1;
+            }
+        }
+    }
+
+    rows
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_foreign_key_constraint(
+    catalog_reader: &crate::catalog::root_catalog::Catalog,
+    database: &str,
+    current_schema: &SchemaCatalog,
+    table: &TableCatalog,
+    name: Option<risingwave_sqlparser::ast::Ident>,
+    columns: Vec<risingwave_sqlparser::ast::Ident>,
+    foreign_table: ObjectName,
+    referred_columns: Vec<risingwave_sqlparser::ast::Ident>,
+    on_delete: Option<ReferentialAction>,
+    on_update: Option<ReferentialAction>,
+    ordinal: u32,
+) -> Option<PgConstraint> {
+    let foreign_table =
+        resolve_referenced_table(catalog_reader, database, current_schema, &foreign_table)?;
+    let conkey = column_positions(table, &columns)?;
+    let confkey = if referred_columns.is_empty() {
+        Some(
+            foreign_table
+                .pk
+                .iter()
+                .map(|order| (order.column_index + 1) as i16)
+                .collect(),
+        )
+    } else {
+        column_positions(foreign_table, &referred_columns)
+    }?;
+
+    let constraint_name = name
+        .map(|ident| ident.real_value())
+        .unwrap_or_else(|| default_foreign_key_name(&table.name, &columns));
+
+    Some(make_foreign_key_constraint_row(
+        current_schema.id(),
+        table,
+        foreign_table,
+        constraint_name,
+        conkey,
+        confkey,
+        on_delete,
+        on_update,
+        ordinal,
+    ))
+}
+
+fn resolve_referenced_table<'a>(
+    catalog_reader: &'a crate::catalog::root_catalog::Catalog,
+    database: &str,
+    current_schema: &'a SchemaCatalog,
+    object_name: &ObjectName,
+) -> Option<&'a std::sync::Arc<TableCatalog>> {
+    match object_name.0.as_slice() {
+        [table] => current_schema.get_created_table_by_name(&table.real_value()),
+        [schema, table] => catalog_reader
+            .get_schema_by_name(database, &schema.real_value())
+            .ok()?
+            .get_created_table_by_name(&table.real_value()),
+        [db, schema, table] if db.real_value() == database => catalog_reader
+            .get_schema_by_name(database, &schema.real_value())
+            .ok()?
+            .get_created_table_by_name(&table.real_value()),
+        _ => None,
+    }
+}
+
+fn column_positions(
+    table: &TableCatalog,
+    columns: &[risingwave_sqlparser::ast::Ident],
+) -> Option<Vec<i16>> {
+    columns
+        .iter()
+        .map(|ident| {
+            table
+                .columns
+                .iter()
+                .position(|column| column.name() == ident.real_value())
+                .map(|index| (index + 1) as i16)
+        })
+        .collect()
+}
+
+fn default_foreign_key_name(
+    table_name: &str,
+    columns: &[risingwave_sqlparser::ast::Ident],
+) -> String {
+    let joined = columns
+        .iter()
+        .map(|ident| ident.real_value())
+        .collect::<Vec<_>>()
+        .join("_");
+    format!("{table_name}_{joined}_fkey")
+}
+
+fn foreign_key_action_code(action: Option<ReferentialAction>) -> &'static str {
+    match action.unwrap_or(ReferentialAction::NoAction) {
+        ReferentialAction::NoAction => "a",
+        ReferentialAction::Restrict => "r",
+        ReferentialAction::Cascade => "c",
+        ReferentialAction::SetNull => "n",
+        ReferentialAction::SetDefault => "d",
+    }
+}
+
+fn synthetic_constraint_oid(table: &TableCatalog, ordinal: u32) -> ObjectId {
+    let raw = table.id.as_object_id().as_raw_id();
+    ObjectId::new(raw.wrapping_mul(131).wrapping_add(ordinal + 1))
+}
+
+fn make_foreign_key_constraint_row(
+    schema_id: SchemaId,
+    table: &TableCatalog,
+    foreign_table: &TableCatalog,
+    constraint_name: String,
+    conkey: Vec<i16>,
+    confkey: Vec<i16>,
+    on_delete: Option<ReferentialAction>,
+    on_update: Option<ReferentialAction>,
+    ordinal: u32,
+) -> PgConstraint {
+    PgConstraint {
+        oid: synthetic_constraint_oid(table, ordinal),
+        conname: constraint_name,
+        connamespace: schema_id,
+        contype: "f".to_owned(),
+        condeferrable: false,
+        convalidated: true,
+        conrelid: table.id.as_relation_id(),
+        contypid: 0,
+        conindid: RelationId::new(0),
+        conparentid: 0,
+        confrelid: foreign_table.id.as_relation_id().as_raw_id() as i32,
+        confupdtype: foreign_key_action_code(on_update).to_owned(),
+        confdeltype: foreign_key_action_code(on_delete).to_owned(),
+        confmatchtype: "s".to_owned(),
+        conislocal: true,
+        coninhcount: 0,
+        connoinherit: true,
+        conkey: Some(conkey),
+        confkey: Some(confkey),
+        conpfeqop: None,
+        conppeqop: None,
+        conffeqop: None,
+        confdelsetcols: None,
+        conexclop: None,
+        conbin: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::catalog::{
+        ColumnCatalog, ColumnDesc, ColumnId, DatabaseId, SchemaId, StreamJobStatus, TableId,
+    };
+    use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
+
+    use super::*;
+
+    fn visible_column(name: &str, id: i32) -> ColumnCatalog {
+        ColumnCatalog::visible(ColumnDesc::named(
+            name,
+            ColumnId::new(id),
+            risingwave_common::types::DataType::Int32,
+        ))
+    }
+
+    fn test_table(
+        id: u32,
+        name: &str,
+        definition: &str,
+        columns: Vec<ColumnCatalog>,
+        pk_indices: Vec<usize>,
+    ) -> TableCatalog {
+        TableCatalog {
+            id: TableId::new(id),
+            schema_id: SchemaId::new(1),
+            database_id: DatabaseId::new(1),
+            name: name.to_owned(),
+            columns,
+            pk: pk_indices
+                .into_iter()
+                .map(|column_index| ColumnOrder::new(column_index, OrderType::ascending()))
+                .collect(),
+            table_type: TableType::Table,
+            stream_job_status: StreamJobStatus::Created,
+            definition: definition.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_make_foreign_key_constraint_row() {
+        let parent = test_table(
+            10,
+            "parent",
+            "create table parent (id int primary key);",
+            vec![visible_column("id", 1)],
+            vec![0],
+        );
+        let child = test_table(
+            20,
+            "child",
+            "create table child (id int primary key, parent_id int references parent(id));",
+            vec![visible_column("id", 1), visible_column("parent_id", 2)],
+            vec![0],
+        );
+
+        let row = make_foreign_key_constraint_row(
+            SchemaId::new(1),
+            &child,
+            &parent,
+            "child_parent_id_fkey".to_owned(),
+            vec![2],
+            vec![1],
+            Some(ReferentialAction::Cascade),
+            Some(ReferentialAction::SetNull),
+            0,
+        );
+
+        assert_eq!(row.contype, "f");
+        assert_eq!(row.conname, "child_parent_id_fkey");
+        assert_eq!(row.conrelid, child.id.as_relation_id());
+        assert_eq!(row.confrelid, parent.id.as_relation_id().as_raw_id() as i32);
+        assert_eq!(row.conkey, Some(vec![2]));
+        assert_eq!(row.confkey, Some(vec![1]));
+        assert_eq!(row.confdeltype, "c");
+        assert_eq!(row.confupdtype, "n");
+    }
+
+    #[test]
+    fn test_default_foreign_key_name() {
+        let name = default_foreign_key_name(
+            "child",
+            &[
+                risingwave_sqlparser::ast::Ident::from("parent_id"),
+                risingwave_sqlparser::ast::Ident::from("tenant_id"),
+            ],
+        );
+        assert_eq!(name, "child_parent_id_tenant_id_fkey");
+    }
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_constraint.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_constraint.rs
@@ -147,7 +147,7 @@ fn read_pg_constraint_in_schema(
     database: &str,
     schema: &SchemaCatalog,
 ) -> Vec<PgConstraint> {
-    // Note: We only support primary key constraints now.
+    // We expose primary-key and foreign-key metadata for PostgreSQL compatibility.
     let system_table_rows = schema
         .iter_system_tables()
         .map(|table| PgConstraint::from_system_table(schema, table.as_ref()));

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -129,6 +129,20 @@ fn ensure_column_options_supported(c: &ColumnDef) -> Result<()> {
     Ok(())
 }
 
+fn contains_foreign_key_constraints(
+    column_defs: &[ColumnDef],
+    table_constraints: &[TableConstraint],
+) -> bool {
+    column_defs.iter().any(|column| {
+        column
+            .options
+            .iter()
+            .any(|option| matches!(option.option, ColumnOption::ForeignKey { .. }))
+    }) || table_constraints
+        .iter()
+        .any(|constraint| matches!(constraint, TableConstraint::ForeignKey { .. }))
+}
+
 /// Binds the column schemas declared in CREATE statement into `ColumnDesc`.
 /// If a column is marked as `primary key`, its `ColumnId` is also returned.
 /// This primary key is not combined with table constraints yet.
@@ -1471,6 +1485,12 @@ pub async fn handle_create_table(
 
     if append_only {
         session.notice_to_user("APPEND ONLY TABLE is currently an experimental feature.");
+    }
+
+    if contains_foreign_key_constraints(&column_defs, &constraints) {
+        session.notice_to_user(
+            "FOREIGN KEY constraints are accepted for compatibility but not enforced at runtime.",
+        );
     }
 
     session.check_cluster_limits().await?;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -120,6 +120,7 @@ fn ensure_column_options_supported(c: &ColumnDef) -> Result<()> {
             ColumnOption::DefaultValue(_) => {}
             ColumnOption::DefaultValueInternal { .. } => {}
             ColumnOption::Unique { is_primary: true } => {}
+            ColumnOption::ForeignKey { .. } => {}
             ColumnOption::Null => {}
             ColumnOption::NotNull => {}
             _ => bail_not_implemented!("column constraints \"{}\"", option_def),
@@ -381,6 +382,7 @@ pub fn bind_table_constraints(table_constraints: &[TableConstraint]) -> Result<V
                 }
                 pk_column_names = columns.iter().map(|c| c.real_value()).collect_vec();
             }
+            TableConstraint::ForeignKey { .. } => {}
             _ => bail_not_implemented!("table constraint \"{}\"", constraint),
         }
     }


### PR DESCRIPTION
## Summary
- expose `contype = 'f'` rows in `pg_constraint` from RisingWave table definitions
- populate the PostgreSQL fields Hasura needs for relationship discovery: `conrelid`, `confrelid`, `conkey`, `confkey`, `confdeltype`, and `confupdtype`
- accept table-level foreign key syntax for compatibility and emit a notice that foreign keys are not enforced at runtime
- add runtime e2e coverage for foreign-key metadata exposure

## Why
PR1 made Hasura understand relation-level mutability.
PR2 made Hasura understand column requiredness and type categories.

PR3 is the next metadata layer: it lets Hasura auto-discover table relationships from `pg_constraint` instead of requiring manual relationship configuration.

This PR is intentionally **metadata compatibility only**. It does **not** implement foreign-key enforcement or cascade execution semantics in RisingWave.

## Stacking
Base: #25569

## Tests
- `./risedev run-planner-test hasura_compatibility`
- `./risedev slt '/tmp/rw-pr3/e2e_test/batch/catalog/pg_constraint_hasura_fk.slt'`
- manual notice check via `psql`:
  - `create table notice_parent (id int primary key);`
  - `create table notice_child (id int primary key, parent_id int references notice_parent(id));`
  - verified notice: `FOREIGN KEY constraints are accepted for compatibility but not enforced at runtime.`
