### PR TITLE
fix(meta): sync source secret deps on alter connection

### DIFF
--- a/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
+++ b/e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt
@@ -148,13 +148,19 @@ statement ok
 create secret s_broker_conn with ( backend = 'meta' ) as 'message_queue_sasl_1:19092';
 
 statement ok
+create secret s_password_conn_old with ( backend = 'meta' ) as 'rw';
+
+statement ok
+create secret s_password_conn_new with ( backend = 'meta' ) as 'rw';
+
+statement ok
 create connection kafka_conn_non_shared with (
     type = 'kafka',
     properties.bootstrap.server = secret s_broker_conn,
     properties.security.protocol = 'SASL_PLAINTEXT',
     properties.sasl.mechanism = 'PLAIN',
     properties.sasl.username = 'dev',
-    properties.sasl.password = 'rw'
+    properties.sasl.password = secret s_password_conn_old
 );
 
 statement ok
@@ -181,7 +187,15 @@ alter secret s_broker_conn with ( backend = 'meta' ) as 'message_queue_sasl_2:19
 # Changing the broker is done by altering the underlying secret, and `ALTER CONNECTION` triggers
 # re-applying secrets and broadcasting updated props to dependent sources.
 statement ok
-alter connection kafka_conn_non_shared connector with (properties.sasl.username = 'dev1');
+alter connection kafka_conn_non_shared connector with (
+    properties.sasl.username = 'dev1',
+    properties.sasl.password = secret s_password_conn_new
+);
+
+# The old password secret should no longer be referenced by either the connection
+# or its dependent source after ALTER CONNECTION propagates the new secret.
+statement ok
+drop secret s_password_conn_old;
 
 system ok
 cat << EOF | rpk topic produce test_alter_non_shared_source_conn -X brokers=message_queue_sasl_2:19093 -X sasl.mechanism=PLAIN -X user=dev1 -X pass=rw
@@ -229,6 +243,9 @@ drop connection kafka_conn_non_shared;
 
 statement ok
 drop secret s_broker_conn;
+
+statement ok
+drop secret s_password_conn_new;
 
 system ok
 rpk topic delete test_alter_non_shared_source -X brokers=message_queue_sasl_1:19092 -X sasl.mechanism=PLAIN -X user=dev -X pass=rw

--- a/src/connector/src/with_options.rs
+++ b/src/connector/src/with_options.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -268,8 +268,11 @@ impl WithOptionsSecResolved {
         update_alter_props: BTreeMap<String, String>,
         update_alter_secret_refs: BTreeMap<String, PbSecretRef>,
     ) -> ConnectorResult<(Vec<SecretId>, Vec<SecretId>)> {
-        let mut to_add_secret_dep: Vec<SecretId> = vec![];
-        let mut to_remove_secret_dep: Vec<SecretId> = vec![];
+        let old_secret_ids = self
+            .secret_ref
+            .values()
+            .map(|secret_ref| secret_ref.secret_id)
+            .collect::<BTreeSet<_>>();
 
         // make sure the key in update_alter_props and update_alter_secret_refs not collide
         for key in update_alter_props.keys() {
@@ -283,31 +286,31 @@ impl WithOptionsSecResolved {
         // remove legacy key if it's set in both plaintext and secret
         // When a property changes from secret to plaintext, remove the old secret dependency
         for k in update_alter_props.keys() {
-            if let Some(removed_secret) = self.secret_ref.remove(k) {
-                to_remove_secret_dep.push(removed_secret.secret_id);
-            }
+            self.secret_ref.remove(k);
         }
 
         // Handle secret ref updates
-        for (k, v) in &update_alter_secret_refs {
+        for k in update_alter_secret_refs.keys() {
             // Remove any plaintext value for this key
             self.inner.remove(k);
-
-            if let Some(old_secret_ref) = self.secret_ref.get(k) {
-                if old_secret_ref.secret_id != v.secret_id {
-                    // Secret is being changed to a different secret
-                    to_remove_secret_dep.push(old_secret_ref.secret_id);
-                    to_add_secret_dep.push(v.secret_id);
-                }
-                // If the secret ref is the same, we don't need to update dependencies
-            } else {
-                // New secret dependency being added
-                to_add_secret_dep.push(v.secret_id);
-            }
         }
 
         self.inner.extend(update_alter_props);
         self.secret_ref.extend(update_alter_secret_refs);
+
+        let new_secret_ids = self
+            .secret_ref
+            .values()
+            .map(|secret_ref| secret_ref.secret_id)
+            .collect::<BTreeSet<_>>();
+        let to_add_secret_dep = new_secret_ids
+            .difference(&old_secret_ids)
+            .copied()
+            .collect();
+        let to_remove_secret_dep = old_secret_ids
+            .difference(&new_secret_ids)
+            .copied()
+            .collect();
 
         Ok((to_add_secret_dep, to_remove_secret_dep))
     }

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2900,12 +2900,40 @@ impl CatalogController {
                         .map(|secret_ref| secret_ref.to_protobuf())
                         .unwrap_or_default(),
                 );
-                let (_source_to_add_secret_dep, _source_to_remove_secret_dep) =
+                let (source_to_add_secret_dep, source_to_remove_secret_dep) =
                     source_options_with_secret
                         .handle_update(alter_props.clone(), alter_secret_refs.clone())?;
 
                 // Validate the updated source properties
                 let _ = ConnectorProperties::extract(source_options_with_secret.clone(), true)?;
+
+                // Keep source-level secret dependencies in sync with the source properties that
+                // are rewritten from the altered connection.
+                let source_used_by_id = source
+                    .optional_associated_table_id
+                    .map(|table_id| table_id.as_object_id())
+                    .unwrap_or_else(|| source_id.as_object_id());
+                if !source_to_add_secret_dep.is_empty() {
+                    ObjectDependency::insert_many(source_to_add_secret_dep.into_iter().map(
+                        |secret_id| object_dependency::ActiveModel {
+                            oid: Set(secret_id.into()),
+                            used_by: Set(source_used_by_id),
+                            ..Default::default()
+                        },
+                    ))
+                    .exec(&txn)
+                    .await?;
+                }
+                if !source_to_remove_secret_dep.is_empty() {
+                    let _ = ObjectDependency::delete_many()
+                        .filter(
+                            object_dependency::Column::Oid
+                                .is_in(source_to_remove_secret_dep)
+                                .and(object_dependency::Column::UsedBy.eq(source_used_by_id)),
+                        )
+                        .exec(&txn)
+                        .await?;
+                }
 
                 // Prepare source update
                 let active_source = source::ActiveModel {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes a stale secret dependency left behind when `ALTER CONNECTION ... CONNECTOR WITH (...)` propagates a new secret reference to dependent sources.

Previously, the dependent-source update path computed the source-level secret dependency delta from `WithOptionsSecResolved::handle_update(...)`, but discarded it. As a result, the source catalog properties and fragments could be rewritten from an old secret to a new secret, while `object_dependency` still recorded the source as depending on the old secret. This made `DROP SECRET old_secret` fail after successful connection secret rotation.

This PR applies the computed source dependency add/remove sets in the same transaction as the dependent source catalog and fragment updates. For table-associated sources, it uses the associated table object id as the dependency owner, matching the existing direct source alter path.

The regression test extends the Kafka non-shared-source-with-connection SLT case to rotate a SASL password secret through `ALTER CONNECTION` and then immediately drop the old secret.

- Closes #25581

## Checklist

- [x] No rustdoc comments are necessary for this bug fix.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- Fuzzing tests: not applicable; this is metadata dependency bookkeeping for an existing ALTER CONNECTION path.
- Breaking changes: none.
- Benchmarks: not applicable; this updates metadata dependency rows during DDL.
- Release branches: not applicable unless maintainers request a backport.


## Documentation

- Documentation updates: not needed; this fixes internal dependency tracking semantics without changing SQL syntax or documented behavior.

<details>
<summary><b>Release note</b></summary>

Fixes secret cleanup after rotating a secret-backed Kafka connection property used by dependent sources. After `ALTER CONNECTION` switches the connection/source from an old secret to a new secret, the old secret can now be dropped as expected.

</details>

## Verification

- `cargo fmt --check`
- `git diff --check -- src/meta/src/controller/streaming_job.rs e2e_test/source_inline/kafka/alter/alter_connector_props_non_shared_source.slt`
- `cargo check -p risingwave_meta --lib`
- `cargo build -p risingwave_cmd_all --bin risingwave`
- Local Redpanda/Kafka repro against the patched binary: `DROP SECRET s_dep_repro_1` succeeds after `ALTER CONNECTION` rotates `properties.sasl.password` to `SECRET s_dep_repro_2`, and `rw_catalog.rw_sources.connector_props` points to `s_dep_repro_2`.
