### PR TITLE
fix(meta): cleanup dirty recovery hummock tables

### DIFF
--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -240,11 +240,25 @@ impl GlobalBarrierWorkerContextImpl {
             .catalog_controller
             .clean_dirty_subscription(database_id)
             .await?;
-        let dirty_associated_source_ids = self
+
+        let cleaned_dirty_jobs = self
             .metadata_manager
             .catalog_controller
             .clean_dirty_creating_jobs(database_id)
             .await?;
+        if database_id.is_some() {
+            // Per-database recovery does not run the global Hummock purge below. Unregister the
+            // dirty jobs cleaned in this database through the normal dropped-table cleanup path.
+            cleanup_dropped_streaming_jobs(
+                &self.refresh_manager,
+                &self.hummock_manager,
+                &self.metadata_manager,
+                cleaned_dirty_jobs.streaming_job_ids,
+                cleaned_dirty_jobs.dropped_table_ids,
+                "clean_dirty_creating_jobs",
+            )
+            .await?;
+        }
         self.metadata_manager
             .reset_all_refresh_jobs_to_idle()
             .await?;
@@ -252,7 +266,7 @@ impl GlobalBarrierWorkerContextImpl {
         // unregister cleaned sources.
         self.source_manager
             .apply_source_change(SourceChange::DropSource {
-                dropped_source_ids: dirty_associated_source_ids,
+                dropped_source_ids: cleaned_dirty_jobs.source_ids,
             })
             .await;
 

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -144,6 +144,14 @@ pub struct ReleaseContext {
     pub(crate) removed_iceberg_table_sinks: Vec<PbSink>,
 }
 
+#[derive(Default)]
+pub(crate) struct CleanedDirtyStreamingJobs {
+    pub(crate) streaming_job_ids: Vec<JobId>,
+    /// Only populated for per-database recovery.
+    pub(crate) dropped_table_ids: Vec<TableId>,
+    pub(crate) source_ids: Vec<SourceId>,
+}
+
 impl CatalogController {
     pub async fn new(env: MetaSrvEnv) -> MetaResult<Self> {
         let meta_store = env.meta_store();
@@ -447,11 +455,11 @@ impl CatalogController {
     }
 
     /// `clean_dirty_creating_jobs` cleans up creating jobs that are creating in Foreground mode or in Initial status.
-    pub async fn clean_dirty_creating_jobs(
+    pub(crate) async fn clean_dirty_creating_jobs(
         &self,
         database_id: Option<DatabaseId>,
-    ) -> MetaResult<Vec<SourceId>> {
-        let inner = self.inner.write().await;
+    ) -> MetaResult<CleanedDirtyStreamingJobs> {
+        let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
         let filter_condition = streaming_job::Column::JobStatus.eq(JobStatus::Initial).or(
@@ -468,7 +476,6 @@ impl CatalogController {
 
         let mut dirty_job_objs: Vec<PartialObject> = streaming_job::Entity::find()
             .select_only()
-            .column(streaming_job::Column::JobId)
             .columns([
                 object::Column::Oid,
                 object::Column::ObjType,
@@ -490,12 +497,19 @@ impl CatalogController {
         Self::clean_dirty_sink_downstreams(&txn).await?;
 
         if dirty_job_objs.is_empty() {
-            return Ok(vec![]);
+            return Ok(CleanedDirtyStreamingJobs::default());
         }
 
         self.log_cleaned_dirty_jobs(&dirty_job_objs, &txn).await?;
 
-        let dirty_job_ids = dirty_job_objs.iter().map(|obj| obj.oid).collect::<Vec<_>>();
+        let dirty_job_ids = dirty_job_objs
+            .iter()
+            .map(|obj| obj.oid.as_job_id())
+            .collect_vec();
+        let dirty_job_table_ids = dirty_job_ids
+            .iter()
+            .map(|job_id| job_id.as_mv_table_id())
+            .collect_vec();
 
         // Filter out dummy objs for replacement.
         // todo: we'd better introduce a new dummy object type for replacement.
@@ -515,12 +529,12 @@ impl CatalogController {
             .into_iter()
             .collect();
 
-        let dirty_background_jobs: HashSet<ObjectId> = streaming_job::Entity::find()
+        let dirty_background_jobs: HashSet<JobId> = streaming_job::Entity::find()
             .select_only()
             .column(streaming_job::Column::JobId)
             .filter(
                 streaming_job::Column::JobId
-                    .is_in(dirty_job_ids.clone())
+                    .is_in(dirty_job_ids.iter().copied())
                     .and(streaming_job::Column::CreateType.eq(CreateType::Background)),
             )
             .into_tuple()
@@ -531,13 +545,14 @@ impl CatalogController {
 
         // notify delete for failed materialized views and background jobs.
         let to_notify_objs = dirty_job_objs
-            .into_iter()
+            .iter()
             .filter(|obj| {
                 matches!(
                     dirty_table_type_map.get(&obj.oid),
                     Some(TableType::MaterializedView)
-                ) || dirty_background_jobs.contains(&obj.oid)
+                ) || dirty_background_jobs.contains(&obj.oid.as_job_id())
             })
+            .cloned()
             .collect_vec();
 
         // The source ids for dirty tables with connector.
@@ -547,20 +562,25 @@ impl CatalogController {
             .column(table::Column::OptionalAssociatedSourceId)
             .filter(
                 table::Column::TableId
-                    .is_in(dirty_job_ids.clone())
+                    .is_in(dirty_job_table_ids)
                     .and(table::Column::OptionalAssociatedSourceId.is_not_null()),
             )
             .into_tuple()
             .all(&txn)
             .await?;
 
-        let dirty_state_table_ids: Vec<TableId> = Table::find()
+        let dirty_internal_state_table_ids: Vec<TableId> = Table::find()
             .select_only()
             .column(table::Column::TableId)
-            .filter(table::Column::BelongsToJobId.is_in(dirty_job_ids.clone()))
+            .filter(table::Column::BelongsToJobId.is_in(dirty_job_ids.iter().copied()))
             .into_tuple()
             .all(&txn)
             .await?;
+        let dirty_state_table_ids = dirty_job_ids
+            .iter()
+            .map(|job_id| job_id.as_mv_table_id())
+            .chain(dirty_internal_state_table_ids.iter().copied())
+            .collect_vec();
 
         let dirty_internal_table_objs = Object::find()
             .select_only()
@@ -577,11 +597,12 @@ impl CatalogController {
             .await?;
 
         let to_delete_objs: HashSet<ObjectId> = dirty_job_ids
-            .clone()
-            .into_iter()
+            .iter()
+            .map(|job_id| job_id.as_object_id())
             .chain(
                 dirty_state_table_ids
-                    .into_iter()
+                    .iter()
+                    .copied()
                     .map(|table_id| table_id.as_object_id()),
             )
             .chain(
@@ -591,6 +612,22 @@ impl CatalogController {
             )
             .collect();
 
+        // Per-database recovery does not run the global Hummock purge. Keep table catalogs so the
+        // caller can reuse the normal dropped-table cleanup path after the catalog rows are deleted.
+        let dropped_tables = if database_id.is_some() {
+            Table::find()
+                .find_also_related(Object)
+                .filter(table::Column::TableId.is_in(dirty_state_table_ids.iter().copied()))
+                .all(&txn)
+                .await?
+                .into_iter()
+                .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)))
+                .collect_vec()
+        } else {
+            vec![]
+        };
+        let dropped_table_ids = dropped_tables.iter().map(|table| table.id).collect_vec();
+
         let res = Object::delete_many()
             .filter(object::Column::Oid.is_in(to_delete_objs))
             .exec(&txn)
@@ -598,6 +635,9 @@ impl CatalogController {
         assert!(res.rows_affected > 0);
 
         txn.commit().await?;
+        inner
+            .dropped_tables
+            .extend(dropped_tables.into_iter().map(|t| (t.id, t)));
 
         let object_group = build_object_group_for_delete(
             to_notify_objs
@@ -610,7 +650,11 @@ impl CatalogController {
             .notify_frontend(NotificationOperation::Delete, object_group)
             .await;
 
-        Ok(dirty_associated_source_ids)
+        Ok(CleanedDirtyStreamingJobs {
+            streaming_job_ids: dirty_job_ids,
+            dropped_table_ids,
+            source_ids: dirty_associated_source_ids,
+        })
     }
 
     pub async fn comment_on(&self, comment: PbComment) -> MetaResult<NotificationVersion> {

--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -25,6 +25,56 @@ mod tests {
     const TEST_SCHEMA_ID: SchemaId = SchemaId::new(2);
     const TEST_OWNER_ID: UserId = UserId::new(1);
 
+    async fn insert_test_table(
+        txn: &DatabaseTransaction,
+        table_id: TableId,
+        name: &str,
+        table_type: TableType,
+        belongs_to_job_id: Option<JobId>,
+        definition: &str,
+    ) -> MetaResult<()> {
+        table::ActiveModel {
+            table_id: Set(table_id),
+            name: Set(name.to_owned()),
+            optional_associated_source_id: Set(None),
+            table_type: Set(table_type),
+            belongs_to_job_id: Set(belongs_to_job_id),
+            columns: Set(vec![].into()),
+            pk: Set(vec![].into()),
+            distribution_key: Set(Vec::<i32>::new().into()),
+            stream_key: Set(Vec::<i32>::new().into()),
+            append_only: Set(false),
+            fragment_id: Set(None),
+            vnode_col_index: Set(None),
+            row_id_index: Set(None),
+            value_indices: Set(Vec::<i32>::new().into()),
+            definition: Set(definition.to_owned()),
+            handle_pk_conflict_behavior: Set(HandleConflictBehavior::NoCheck),
+            version_column_indices: Set(None),
+            read_prefix_len_hint: Set(0),
+            watermark_indices: Set(Vec::<i32>::new().into()),
+            dist_key_in_pk: Set(Vec::<i32>::new().into()),
+            dml_fragment_id: Set(None),
+            cardinality: Set(None),
+            cleaned_by_watermark: Set(false),
+            description: Set(None),
+            version: Set(None),
+            retention_seconds: Set(None),
+            cdc_table_id: Set(None),
+            vnode_count: Set(1),
+            webhook_info: Set(None),
+            engine: Set(None),
+            clean_watermark_index_in_pk: Set(None),
+            clean_watermark_indices: Set(None),
+            refreshable: Set(false),
+            vector_index_info: Set(None),
+            cdc_table_type: Set(None),
+        }
+        .insert(txn)
+        .await?;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_database_func() -> MetaResult<()> {
         let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
@@ -354,6 +404,106 @@ mod tests {
         assert!(
             Table::find_by_id(job_id.as_mv_table_id())
                 .one(db)
+                .await?
+                .is_none()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_clean_dirty_creating_jobs_records_dropped_tables_for_per_db_recovery()
+    -> MetaResult<()> {
+        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+
+        let inner = mgr.inner.write().await;
+        let txn = inner.db.begin().await?;
+        let mv_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        let job_id = mv_obj.oid.as_job_id();
+        let mv_table_id = job_id.as_mv_table_id();
+        insert_test_table(
+            &txn,
+            mv_table_id,
+            "mv_dirty",
+            TableType::MaterializedView,
+            None,
+            "CREATE MATERIALIZED VIEW mv_dirty AS SELECT 1",
+        )
+        .await?;
+
+        let internal_obj = CatalogController::create_object(
+            &txn,
+            ObjectType::Table,
+            TEST_OWNER_ID,
+            Some(TEST_DATABASE_ID),
+            Some(TEST_SCHEMA_ID),
+        )
+        .await?;
+        let internal_table_id = internal_obj.oid.as_table_id();
+        insert_test_table(
+            &txn,
+            internal_table_id,
+            "__internal_mv_dirty",
+            TableType::Internal,
+            Some(job_id),
+            "",
+        )
+        .await?;
+
+        streaming_job::ActiveModel {
+            job_id: Set(job_id),
+            job_status: Set(JobStatus::Creating),
+            create_type: Set(CreateType::Foreground),
+            timezone: Set(None),
+            config_override: Set(None),
+            adaptive_parallelism_strategy: Set(None),
+            parallelism: Set(StreamingParallelism::Adaptive),
+            backfill_parallelism: Set(None),
+            backfill_orders: Set(None),
+            max_parallelism: Set(1),
+            specific_resource_group: Set(None),
+            is_serverless_backfill: Set(false),
+        }
+        .insert(&txn)
+        .await?;
+        txn.commit().await?;
+        drop(inner);
+
+        let cleaned = mgr
+            .clean_dirty_creating_jobs(Some(TEST_DATABASE_ID))
+            .await?;
+        assert_eq!(cleaned.streaming_job_ids, vec![job_id]);
+        assert!(cleaned.source_ids.is_empty());
+        let mut dropped_table_ids = cleaned.dropped_table_ids;
+        dropped_table_ids.sort_unstable();
+        assert_eq!(dropped_table_ids, vec![mv_table_id, internal_table_id]);
+
+        let inner = mgr.inner.read().await;
+        assert!(inner.dropped_tables.contains_key(&mv_table_id));
+        assert!(inner.dropped_tables.contains_key(&internal_table_id));
+        assert!(Object::find_by_id(job_id).one(&inner.db).await?.is_none());
+        assert!(
+            StreamingJob::find_by_id(job_id)
+                .one(&inner.db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            Table::find_by_id(mv_table_id)
+                .one(&inner.db)
+                .await?
+                .is_none()
+        );
+        assert!(
+            Table::find_by_id(internal_table_id)
+                .one(&inner.db)
                 .await?
                 .is_none()
         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Related to #25466

This PR is scoped to **per-database recovery dirty-job cleanup**. It does not change DDL abort handling.

Bug:

- Global recovery can clean dirty creating-job catalogs and then run a full-catalog Hummock purge.
- Per-database recovery can also clean dirty creating-job catalogs through `clean_dirty_creating_jobs(Some(database_id))`, but it does not run the global Hummock purge.
- Therefore, if per-database recovery removes dirty creating-job catalog rows, the corresponding Hummock table ids can remain as stale member/SST table ids.

Fix:

- Make `clean_dirty_creating_jobs` return the cleaned streaming job ids, table ids, and source ids instead of only source ids.
- In per-database recovery only, cache the table catalogs before deleting catalog rows, then reuse `cleanup_dropped_streaming_jobs` to unregister Hummock table ids and notify Hummock/compactor.
- Leave global recovery unchanged; it still relies on the existing full-catalog Hummock purge.

Not covered by this PR:

- DDL abort after create failure or `DROP/CANCEL` of `Initial` jobs. That path is fixed separately in #25604.
- The SQL/simulation repro that forces a foreground create failure belongs to #25604, because the stale ids are cleaned through the DDL abort path after the create fails.

### Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p risingwave_meta --lib`
- `cargo test -p risingwave_meta test_clean_dirty_creating_jobs_records_dropped_tables_for_per_db_recovery --lib -- --nocapture`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed stale Hummock table ids left by dirty creating jobs during per-database recovery.

</details>
