### PR TITLE
fix(sqlserver-cdc): tolerate ill-formed UTF-16 in nvarchar/ntext payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15483,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.12.2"
-source = "git+https://github.com/risingwavelabs/tiberius.git?rev=59350b92775a61611cf1fc3a5d0ff38bf264e6ac#59350b92775a61611cf1fc3a5d0ff38bf264e6ac"
+source = "git+https://github.com/risingwavelabs/tiberius.git?rev=3133b49dc22915266ae22bb83a32e10b4cdfb988#3133b49dc22915266ae22bb83a32e10b4cdfb988"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15483,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.12.2"
-source = "git+https://github.com/risingwavelabs/tiberius.git?rev=3133b49dc22915266ae22bb83a32e10b4cdfb988#3133b49dc22915266ae22bb83a32e10b4cdfb988"
+source = "git+https://github.com/risingwavelabs/tiberius.git?rev=cd69774fb1a4e08c0a3ea3b2041de7cc09662464#cd69774fb1a4e08c0a3ea3b2041de7cc09662464"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -180,7 +180,7 @@ thiserror = { workspace = true }
 thiserror-ext = { workspace = true }
 # To easiy get the type_name and impl IntoSql for rust_decimal, we fork the crate.
 # Another reason is that we are planning to refactor their IntoSql trait to allow specifying the type to convert.
-tiberius = { git = "https://github.com/risingwavelabs/tiberius.git", rev = "59350b92775a61611cf1fc3a5d0ff38bf264e6ac", default-features = false, features = [
+tiberius = { git = "https://github.com/risingwavelabs/tiberius.git", rev = "3133b49dc22915266ae22bb83a32e10b4cdfb988", default-features = false, features = [
     "chrono",
     "sql-browser-tokio",
     "rustls",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -180,7 +180,7 @@ thiserror = { workspace = true }
 thiserror-ext = { workspace = true }
 # To easiy get the type_name and impl IntoSql for rust_decimal, we fork the crate.
 # Another reason is that we are planning to refactor their IntoSql trait to allow specifying the type to convert.
-tiberius = { git = "https://github.com/risingwavelabs/tiberius.git", rev = "3133b49dc22915266ae22bb83a32e10b4cdfb988", default-features = false, features = [
+tiberius = { git = "https://github.com/risingwavelabs/tiberius.git", rev = "cd69774fb1a4e08c0a3ea3b2041de7cc09662464", default-features = false, features = [
     "chrono",
     "sql-browser-tokio",
     "rustls",


### PR DESCRIPTION
## Summary

Bump `tiberius` to `risingwavelabs/tiberius@3133b49d`, which switches `nvarchar` / `ntext` column-data decoding from `String::from_utf16` (strict) to `from_utf16_lossy`.

## Why

SQL Server does not enforce well-formed UTF-16 in `nvarchar` storage. A row containing a **lone surrogate** (e.g. `NCHAR(0xD83D)` written without its low-surrogate partner — common via legacy ETL / MERGE replication / buggy clients) currently causes `tiberius` to reject the entire snapshot chunk with `FromUtf16Error`.

Failure mode in CDC backfill is bad: the bad chunk wipes the in-flight result stream, the consumer re-issues from the last persisted LSN / PK, and immediately re-hits the same chunk → **infinite retry loop with zero forward progress**. Observed in production stalled at ~210k rows (chunk #211 at the default `snapshot.batch_size = 1000` contained a lone surrogate).

After this bump, lone surrogates decode to `U+FFFD` and backfill survives. Protocol-level UTF-16 paths in `tiberius` (env-change tokens, login, identifiers) remain strict on purpose — those are server-controlled metadata where a malformed value indicates a real TDS protocol violation.

Upstream `tiberius` PR: https://github.com/risingwavelabs/tiberius/pull/2

## Test plan

- [x] `./risedev c` clean.
- [x] Local repro (`wcy-tools/mssql-cdc/repro_utf16.sh`): a 101-row table with one row containing `NCHAR(0xD83D)` finishes backfill at 101/101; the bad row lands as `'lone�'`.
- [x] Pre-fix on the same setup: backfill stalls with `FromUtf16Error` from `tiberius` in the connector log.