### PR TITLE
feat(expr): support array overlap predicates

### DIFF
--- a/e2e_test/batch/functions/array_predicates.slt.part
+++ b/e2e_test/batch/functions/array_predicates.slt.part
@@ -1,0 +1,54 @@
+query T
+select array[1,2,3] @> array[2,3];
+----
+t
+
+query T
+select array[1,2,3] @> array[3,4];
+----
+f
+
+query T
+select array[2,3] <@ array[1,2,3];
+----
+t
+
+query T
+select array[2,4] <@ array[1,2,3];
+----
+f
+
+query T
+select array[1,2,3] && array[3,4];
+----
+t
+
+query T
+select array[1,2,3] && array[4,5];
+----
+f
+
+query T
+select array_overlaps(array['a','b'], array['b','c']);
+----
+t
+
+query T
+select array_is_overlap(array['a','b'], array['c','d']);
+----
+f
+
+query T
+select array_is_intersect(array['a','b'], array['b','c']);
+----
+t
+
+query T
+select array[1,null] && array[null,2];
+----
+f
+
+query T
+select array[null]::int[] && array[null]::int[];
+----
+f

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -257,6 +257,7 @@ message ExprNode {
     ARRAY_CONTAINED = 551;
     ARRAY_FLATTEN = 552;
     ARRAY_REVERSE = 553;
+    ARRAY_OVERLAPS = 554;
 
     // Int256 functions
     HEX_TO_INT256 = 560;

--- a/src/expr/impl/src/scalar/array_contain.rs
+++ b/src/expr/impl/src/scalar/array_contain.rs
@@ -89,8 +89,7 @@ use risingwave_expr::function;
 /// ----
 /// NULL
 /// ```
-#[function("array_contains(anyarray, anyarray) -> boolean")]
-fn array_contains(left: ListRef<'_>, right: ListRef<'_>) -> bool {
+fn array_contains_impl(left: ListRef<'_>, right: ListRef<'_>) -> bool {
     let flatten = left.flatten();
     let set: HashSet<_> = flatten.iter().collect();
     right
@@ -99,26 +98,73 @@ fn array_contains(left: ListRef<'_>, right: ListRef<'_>) -> bool {
         .all(|item| item.is_some_and(|v| set.contains(&Some(v))))
 }
 
+#[function("array_contains(anyarray, anyarray) -> boolean")]
+fn array_contains(left: ListRef<'_>, right: ListRef<'_>) -> bool {
+    array_contains_impl(left, right)
+}
+
 #[function("array_contained(anyarray, anyarray) -> boolean")]
 fn array_contained(left: ListRef<'_>, right: ListRef<'_>) -> bool {
-    array_contains(right, left)
+    array_contains_impl(right, left)
+}
+
+fn array_overlaps_impl(left: ListRef<'_>, right: ListRef<'_>) -> bool {
+    let flatten = left.flatten();
+    let set: HashSet<_> = flatten.iter().flatten().collect();
+    right
+        .flatten()
+        .iter()
+        .any(|item| item.is_some_and(|v| set.contains(&v)))
+}
+
+#[function("array_overlaps(anyarray, anyarray) -> boolean")]
+fn array_overlaps(left: ListRef<'_>, right: ListRef<'_>) -> bool {
+    array_overlaps_impl(left, right)
 }
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::types::{ListValue, Scalar};
+    use risingwave_common::types::{DataType, ListValue, Scalar, ScalarImpl};
 
     use super::*;
 
     #[test]
     fn test_contains() {
-        assert!(array_contains(
+        assert!(array_contains_impl(
             ListValue::from_iter([2, 3]).as_scalar_ref(),
             ListValue::from_iter([2]).as_scalar_ref(),
         ));
-        assert!(!array_contains(
+        assert!(!array_contains_impl(
             ListValue::from_iter([2, 3]).as_scalar_ref(),
             ListValue::from_iter([5]).as_scalar_ref(),
+        ));
+    }
+
+    #[test]
+    fn test_overlaps() {
+        assert!(array_overlaps_impl(
+            ListValue::from_iter([2, 3]).as_scalar_ref(),
+            ListValue::from_iter([3, 5]).as_scalar_ref(),
+        ));
+        assert!(!array_overlaps_impl(
+            ListValue::from_iter([2, 3]).as_scalar_ref(),
+            ListValue::from_iter([4, 5]).as_scalar_ref(),
+        ));
+        assert!(!array_overlaps_impl(
+            ListValue::from_datum_iter(
+                &DataType::Int32,
+                [Some(ScalarImpl::Int32(1)), None::<ScalarImpl>],
+            )
+            .as_scalar_ref(),
+            ListValue::from_datum_iter(
+                &DataType::Int32,
+                [None::<ScalarImpl>, Some(ScalarImpl::Int32(2))],
+            )
+            .as_scalar_ref(),
+        ));
+        assert!(!array_overlaps_impl(
+            ListValue::from_datum_iter(&DataType::Int32, [None::<ScalarImpl>]).as_scalar_ref(),
+            ListValue::from_datum_iter(&DataType::Int32, [None::<ScalarImpl>]).as_scalar_ref(),
         ));
     }
 }

--- a/src/frontend/planner_test/tests/testdata/output/array.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/array.yaml
@@ -205,14 +205,14 @@
     Failed to bind expression: ARRAY[2, 3] @> ARRAY['1']
 
     Caused by:
-      Bind error: Cannot array_contains unnested type integer to unnested type character varying
+      Bind error: Cannot compare array predicate unnested type integer to unnested type character varying
 - name: array_contains(int[][], varchar[][]) -> bool
   sql: select array[array[1,2]] @> array[array['2','3']];
   binder_error: |
     Failed to bind expression: ARRAY[ARRAY[1, 2]] @> ARRAY[ARRAY['2', '3']]
 
     Caused by:
-      Bind error: Cannot array_contains unnested type integer to unnested type character varying
+      Bind error: Cannot compare array predicate unnested type integer to unnested type character varying
 - name: any contains(null, null) -> bool
   sql: select '{}' @> '{}';
   binder_error: |

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -137,6 +137,23 @@ impl Binder {
                     }
                 }
             }
+            BinaryOperator::Custom(name) if name == "&&" => {
+                let left_type = (!bound_left.is_untyped()).then(|| bound_left.return_type());
+                let right_type = (!bound_right.is_untyped()).then(|| bound_right.return_type());
+                match (left_type, right_type) {
+                    (Some(DataType::List { .. }), Some(DataType::List { .. }))
+                    | (Some(DataType::List { .. }), None)
+                    | (None, Some(DataType::List { .. })) => ExprType::ArrayOverlaps,
+                    (left, right) => {
+                        return Err(ErrorCode::BindError(format!(
+                            "operator does not exist: {} && {}",
+                            left.map_or_else(|| String::from("unknown"), |x| x.to_string()),
+                            right.map_or_else(|| String::from("unknown"), |x| x.to_string()),
+                        ))
+                        .into());
+                    }
+                }
+            }
             BinaryOperator::Custom(name) if name == "||" => {
                 let left_type = (!bound_left.is_untyped()).then(|| bound_left.return_type());
                 let right_type = (!bound_right.is_untyped()).then(|| bound_right.return_type());

--- a/src/frontend/src/binder/expr/function/builtin_scalar.rs
+++ b/src/frontend/src/binder/expr/function/builtin_scalar.rs
@@ -344,6 +344,9 @@ impl Binder {
                 ("arraycontains", raw_call(ExprType::ArrayContains)),
                 ("array_contained", raw_call(ExprType::ArrayContained)),
                 ("arraycontained", raw_call(ExprType::ArrayContained)),
+                ("array_overlaps", raw_call(ExprType::ArrayOverlaps)),
+                ("array_is_overlap", raw_call(ExprType::ArrayOverlaps)),
+                ("array_is_intersect", raw_call(ExprType::ArrayOverlaps)),
                 ("array_flatten", guard_by_len(|_binder, [input]| {
                     input.ensure_array_type().map_err(|_| ErrorCode::BindError("array_flatten expects `any[][]` input".into()))?;
                     let return_type = input.return_type().into_list_elem();

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -82,6 +82,7 @@ impl std::fmt::Debug for FunctionCall {
                 ExprType::BitwiseXor => debug_binary_op(f, "#", &self.inputs),
                 ExprType::ArrayContains => debug_binary_op(f, "@>", &self.inputs),
                 ExprType::ArrayContained => debug_binary_op(f, "<@", &self.inputs),
+                ExprType::ArrayOverlaps => debug_binary_op(f, "&&", &self.inputs),
                 _ => {
                     let func_name = format!("{:?}", self.func_type);
                     let mut builder = f.debug_tuple(&func_name);
@@ -379,6 +380,9 @@ impl std::fmt::Debug for FunctionCallDisplay<'_> {
             }
             ExprType::ArrayContained => {
                 explain_verbose_binary_op(f, "<@", &that.inputs, self.input_schema)
+            }
+            ExprType::ArrayOverlaps => {
+                explain_verbose_binary_op(f, "&&", &that.inputs, self.input_schema)
             }
             ExprType::Proctime => {
                 write!(f, "{:?}", that.func_type)

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -255,6 +255,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | Type::ArrayPosition
             | Type::ArrayContains
             | Type::ArrayContained
+            | Type::ArrayOverlaps
             | Type::ArrayFlatten
             | Type::HexToInt256
             | Type::JsonbConcat

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -585,8 +585,8 @@ fn infer_type_for_special(
             }
             Ok(Some(DataType::Varchar))
         }
-        ExprType::ArrayContains | ExprType::ArrayContained => {
-            ensure_arity!("array_contains/array_contained", | inputs | == 2);
+        ExprType::ArrayContains | ExprType::ArrayContained | ExprType::ArrayOverlaps => {
+            ensure_arity!("array_contains/array_contained/array_overlaps", | inputs | == 2);
             let left_type = (!inputs[0].is_untyped()).then(|| inputs[0].return_type());
             let right_type = (!inputs[1].is_untyped()).then(|| inputs[1].return_type());
             match (left_type, right_type) {
@@ -602,7 +602,7 @@ fn infer_type_for_special(
                         Ok(Some(DataType::Boolean))
                     } else {
                         Err(ErrorCode::BindError(format!(
-                            "Cannot array_contains unnested type {} to unnested type {}",
+                            "Cannot compare array predicate unnested type {} to unnested type {}",
                             left, right
                         ))
                         .into())

--- a/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
+++ b/src/frontend/src/optimizer/plan_expr_visitor/strong.rs
@@ -285,6 +285,7 @@ impl Strong {
             | ExprType::ArrayReverse
             | ExprType::ArrayContains
             | ExprType::ArrayContained
+            | ExprType::ArrayOverlaps
             | ExprType::ArrayFlatten
             | ExprType::HexToInt256
             | ExprType::JsonbAccess


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

- This PR adds support for array overlap predicates in SQL.
- It binds the PostgreSQL-style `&&` operator for array inputs and renders the new expression type in debug and verbose explain output.
- It registers `array_overlaps(anyarray, anyarray)` together with the `array_is_overlap` and `array_is_intersect` aliases.
- It wires the new expression type through type inference, purity analysis, and strong-expression analysis.
- It implements the scalar function in `array_contain.rs` and keeps null handling aligned with PostgreSQL by not treating `NULL` elements as overlapping matches.
- It adds unit coverage and SQLLogicTest coverage for `@>`, `<@`, `&&`, the aliases, and null-overlap edge cases.
- No linked issue.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

RisingWave now supports PostgreSQL-style array overlap predicates through the `&&` operator and the `array_overlaps`, `array_is_overlap`, and `array_is_intersect` helper functions.

</details>
