### PR TITLE
fix(sqlparser): correctly parse escaped double-quoted identifiers

### DIFF
--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -21,8 +21,7 @@ mod statement;
 mod value;
 
 use std::collections::HashSet;
-use std::fmt;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -178,7 +177,7 @@ impl Ident {
         let needs_quotes = QuoteIdent::needs_quotes(value);
 
         if needs_quotes {
-            Self::with_quote_unchecked('"', value.replace('"', "\"\""))
+            Self::with_quote_unchecked('"', value)
         } else {
             Self::new_unchecked(value)
         }
@@ -204,7 +203,8 @@ impl ParseTo for Ident {
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.quote_style {
-            Some(q) if q == '"' || q == '\'' || q == '`' => write!(f, "{}{}{}", q, self.value, q),
+            Some(q) if q == '\'' || q == '`' => write!(f, "{}{}{}", q, self.value, q),
+            Some('"') => write!(f, "\"{}\"", self.value.replace('"', "\"\"")),
             Some('[') => write!(f, "[{}]", self.value),
             None => f.write_str(&self.value),
             _ => panic!("unexpected quote style"),

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -161,9 +161,11 @@ impl Ident {
         })
     }
 
-    /// Value after considering quote style
-    /// In certain places, double quotes can force case-sensitive, but not always
-    /// e.g. session variables.
+    /// Returns the identifier value used for name lookup and comparison.
+    ///
+    /// Unquoted identifiers are folded to lowercase, while double-quoted identifiers preserve
+    /// their case and unescaped contents. For example, `Foo` becomes `foo`, while `"Foo"` remains
+    /// `Foo` and `"a""b"` becomes `a"b`.
     pub fn real_value(&self) -> String {
         match self.quote_style {
             Some('"') => self.value.clone(),
@@ -171,8 +173,11 @@ impl Ident {
         }
     }
 
-    /// Convert a real value back to Ident. Behaves the same as SQL function `quote_ident` or
-    /// [`QuoteIdent`] wrapper.
+    /// Creates an identifier from a name used internally by the database.
+    ///
+    /// The input is stored as its unescaped value. Double quotes are selected when needed to
+    /// preserve the name in SQL; escaping embedded quotes is left to the [`Display`] implementation.
+    /// This behaves like the SQL `quote_ident` function and the [`QuoteIdent`] wrapper.
     pub fn from_real_value(value: &str) -> Self {
         let needs_quotes = QuoteIdent::needs_quotes(value);
 

--- a/src/sqlparser/src/tokenizer.rs
+++ b/src/sqlparser/src/tokenizer.rs
@@ -484,17 +484,8 @@ impl<'a> Tokenizer<'a> {
                 }
                 // delimited (quoted) identifier
                 quote_start if is_delimited_identifier_start(quote_start) => {
-                    self.next(); // consume the opening quote
-                    let quote_end = Word::matching_end_quote(quote_start);
-                    let s = self.peeking_take_while(|ch| ch != quote_end);
-                    if self.next() == Some(quote_end) {
-                        Ok(Some(Token::make_word(&s, Some(quote_start))))
-                    } else {
-                        self.error(format!(
-                            "Expected close delimiter '{}' before EOF.",
-                            quote_end
-                        ))
-                    }
+                    let s = self.tokenize_delimited_identifier(quote_start)?;
+                    Ok(Some(Token::make_word(&s, Some(quote_start))))
                 }
                 // numbers and period
                 '0'..='9' | '.' => {
@@ -653,6 +644,36 @@ impl<'a> Tokenizer<'a> {
             },
             None => Ok(None),
         }
+    }
+
+    fn tokenize_delimited_identifier(
+        &mut self,
+        quote_start: char,
+    ) -> Result<String, TokenizerError> {
+        let quote_end = Word::matching_end_quote(quote_start);
+        let mut s = String::new();
+
+        self.next(); // consume opening quote
+
+        while let Some(ch) = self.peek() {
+            self.next(); // consume ch
+
+            if ch == quote_end {
+                if self.peek() == Some(quote_end) {
+                    self.next(); // consume escaped quote
+                    s.push(quote_end);
+                } else {
+                    return Ok(s);
+                }
+            } else {
+                s.push(ch);
+            }
+        }
+
+        self.error(format!(
+            "Expected close delimiter '{}' before EOF.",
+            quote_end
+        ))
     }
 
     /// Tokenize dollar preceded value (i.e: a string/placeholder)

--- a/src/sqlparser/src/tokenizer.rs
+++ b/src/sqlparser/src/tokenizer.rs
@@ -192,9 +192,10 @@ pub struct Word {
 impl fmt::Display for Word {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.quote_style {
-            Some(s) if s == '"' || s == '[' || s == '`' => {
+            Some(s) if s == '[' || s == '`' => {
                 write!(f, "{}{}{}", s, self.value, Word::matching_end_quote(s))
             }
+            Some('"') => write!(f, "\"{}\"", self.value.replace('"', "\"\"")),
             None => f.write_str(&self.value),
             _ => panic!("Unexpected quote_style!"),
         }
@@ -1161,6 +1162,18 @@ mod tests {
         ];
 
         compare(expected, tokens);
+    }
+
+    #[test]
+    fn display_escaped_double_quote_in_delimited_identifier() {
+        let sql = String::from(r###"SELECT "a""b", "x""""y""###);
+        let mut tokenizer = Tokenizer::new(&sql);
+        let tokens = tokenizer.tokenize_with_whitespace().unwrap();
+
+        assert_eq!(
+            tokens.iter().map(ToString::to_string).collect::<String>(),
+            sql
+        );
     }
 
     #[test]

--- a/src/sqlparser/src/tokenizer.rs
+++ b/src/sqlparser/src/tokenizer.rs
@@ -1146,6 +1146,24 @@ mod tests {
     }
 
     #[test]
+    fn tokenize_escaped_double_quote_in_delimited_identifier() {
+        let sql = String::from(r###"SELECT "a""b", "x""""y""###);
+        let mut tokenizer = Tokenizer::new(&sql);
+        let tokens = tokenizer.tokenize_with_whitespace().unwrap();
+
+        let expected = vec![
+            Token::make_keyword("SELECT"),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word("a\"b", Some('"')),
+            Token::Comma,
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word("x\"\"y", Some('"')),
+        ];
+
+        compare(expected, tokens);
+    }
+
+    #[test]
     fn tokenize_bitwise_op() {
         let sql = String::from("SELECT one | two ^ three");
         let mut tokenizer = Tokenizer::new(&sql);

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -2318,6 +2318,32 @@ fn parse_literal_string_with_dollar_quoted_string() {
 }
 
 #[test]
+fn parse_escaped_double_quote_in_delimited_identifier() {
+    {
+        let select = verified_only_select(r#"SELECT 'STRI"NG' AS "'STRI""NG""#);
+
+        match only(&select.projection) {
+            SelectItem::ExprWithAlias { expr, alias } => {
+                assert_eq!(
+                    &Expr::Value(Value::SingleQuotedString("STRI\"NG".to_owned())),
+                    expr
+                );
+                assert_eq!(&Ident::with_quote_unchecked('"', "'STRI\"NG"), alias);
+            }
+            _ => panic!("expected ExprWithAlias"),
+        }
+    }
+
+    {
+        let select = verified_only_select(r#"SELECT "'STRI""NG""#);
+        assert_eq!(
+            &Expr::Identifier(Ident::with_quote_unchecked('"', "'STRI\"NG")),
+            expr_from_projection(only(&select.projection)),
+        );
+    }
+}
+
+#[test]
 fn parse_literal_time() {
     let sql = "SELECT TIME '01:23:34'";
     let select = verified_only_select(sql);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Closes #14731.

Fixes parsing of escaped double quotes inside quoted identifiers.
Previously, Parser stopped parsing a quoted identifier at the first double quote, so PostgreSQL-compatible identifiers containing `""` could be split into multiple tokens.

For example, the following SQL failed to parse:

```sql
SELECT 'STRI"NG' AS "'STRI""NG'";
```

This PR:

- Adds dedicated parsing for delimited identifiers.
- Treats `""` inside a double-quoted identifier as one literal `"`.
- Stores the unescaped identifier value in Ident.
- Escapes embedded double quotes in Ident::Display to preserve SQL round trips.
- Adds tokenizer and parser regression tests for identifiers containing escaped double quotes.

### Verification
```
cargo test -p risingwave_sqlparser tokenize_escaped_double_quote_in_delimited_identifier
cargo test -p risingwave_sqlparser parse_escaped_double_quote_in_delimited_identifier
```

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
