### PR TITLE
fix(meta): unregister aborted initial job tables

### DIFF
--- a/src/meta/src/controller/catalog/test.rs
+++ b/src/meta/src/controller/catalog/test.rs
@@ -14,12 +14,23 @@
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_meta_model::table::HandleConflictBehavior;
     use risingwave_pb::catalog::StreamSourceInfo;
     use risingwave_pb::catalog::subscription::SubscriptionState;
     use tokio::sync::oneshot;
 
+    use crate::barrier::BarrierScheduler;
     use crate::controller::catalog::*;
+    use crate::controller::streaming_job::AbortCreatingStreamingJobReason;
+    use crate::hummock::HummockManagerRef;
+    use crate::hummock::test_utils::{register_table_ids_to_compaction_group, setup_compute_env};
+    use crate::manager::MetadataManager;
+    use crate::rpc::ddl_controller::try_abort_creating_streaming_job_and_cleanup;
+    use crate::stream::{GlobalRefreshManager, GlobalRefreshManagerRef};
 
     const TEST_DATABASE_ID: DatabaseId = DatabaseId::new(1);
     const TEST_SCHEMA_ID: SchemaId = SchemaId::new(2);
@@ -261,9 +272,66 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_abort_initial_materialized_view_reports_cancellation() -> MetaResult<()> {
-        let mgr = CatalogController::new(MetaSrvEnv::for_test().await).await?;
+    async fn test_abort_initial_materialized_views_unregister_hummock() -> MetaResult<()> {
+        let (env, hummock_manager, cluster_controller, _) = setup_compute_env(80).await;
+        let mgr = Arc::new(CatalogController::new(env.clone()).await?);
+        let metadata_manager = MetadataManager::new(cluster_controller, mgr.clone());
+        let (barrier_scheduler, _) =
+            BarrierScheduler::new_pair(hummock_manager.clone(), Arc::new(Default::default()));
+        let (refresh_manager, refresh_join_handle, refresh_shutdown_tx) =
+            GlobalRefreshManager::start(
+                metadata_manager.clone(),
+                barrier_scheduler,
+                &env,
+                Duration::from_secs(60),
+            )
+            .await?;
 
+        abort_initial_materialized_view_and_check_hummock_cleanup(
+            &mgr,
+            &metadata_manager,
+            &refresh_manager,
+            &hummock_manager,
+            CreateType::Foreground,
+            AbortCreatingStreamingJobReason::Cancelled,
+            "foreground_cancel",
+        )
+        .await?;
+        abort_initial_materialized_view_and_check_hummock_cleanup(
+            &mgr,
+            &metadata_manager,
+            &refresh_manager,
+            &hummock_manager,
+            CreateType::Background,
+            AbortCreatingStreamingJobReason::Cancelled,
+            "background_cancel",
+        )
+        .await?;
+        abort_initial_materialized_view_and_check_hummock_cleanup(
+            &mgr,
+            &metadata_manager,
+            &refresh_manager,
+            &hummock_manager,
+            CreateType::Foreground,
+            AbortCreatingStreamingJobReason::CreateFailed,
+            "foreground_failure",
+        )
+        .await?;
+
+        let _ = refresh_shutdown_tx.send(());
+        let _ = refresh_join_handle.await;
+        Ok(())
+    }
+
+    async fn abort_initial_materialized_view_and_check_hummock_cleanup(
+        mgr: &Arc<CatalogController>,
+        metadata_manager: &MetadataManager,
+        refresh_manager: &GlobalRefreshManagerRef,
+        hummock_manager: &HummockManagerRef,
+        create_type: CreateType,
+        reason: AbortCreatingStreamingJobReason,
+        name_suffix: &str,
+    ) -> MetaResult<()> {
         let mut inner = mgr.inner.write().await;
         let txn = inner.db.begin().await?;
         let obj = CatalogController::create_object(
@@ -278,7 +346,7 @@ mod tests {
 
         table::ActiveModel {
             table_id: Set(obj.oid.as_table_id()),
-            name: Set("mv_abort_initial".to_owned()),
+            name: Set(format!("mv_abort_initial_{name_suffix}")),
             optional_associated_source_id: Set(None),
             table_type: Set(TableType::MaterializedView),
             belongs_to_job_id: Set(None),
@@ -291,7 +359,9 @@ mod tests {
             vnode_col_index: Set(None),
             row_id_index: Set(None),
             value_indices: Set(Vec::<i32>::new().into()),
-            definition: Set("CREATE MATERIALIZED VIEW mv_abort_initial AS SELECT 1".to_owned()),
+            definition: Set(format!(
+                "CREATE MATERIALIZED VIEW mv_abort_initial_{name_suffix} AS SELECT 1"
+            )),
             handle_pk_conflict_behavior: Set(HandleConflictBehavior::NoCheck),
             version_column_indices: Set(None),
             read_prefix_len_hint: Set(0),
@@ -319,7 +389,7 @@ mod tests {
         streaming_job::ActiveModel {
             job_id: Set(job_id),
             job_status: Set(JobStatus::Initial),
-            create_type: Set(CreateType::Foreground),
+            create_type: Set(create_type),
             timezone: Set(None),
             config_override: Set(None),
             adaptive_parallelism_strategy: Set(None),
@@ -338,15 +408,40 @@ mod tests {
         txn.commit().await?;
         drop(inner);
 
-        let (aborted, database_id) = mgr.try_abort_creating_streaming_job(job_id, true).await?;
+        let state_table_id = job_id.as_mv_table_id();
+        register_table_ids_to_compaction_group(
+            hummock_manager,
+            &[state_table_id],
+            StaticCompactionGroupId::StateDefault,
+        )
+        .await;
+        assert!(
+            hummock_manager
+                .get_current_version()
+                .await
+                .state_table_info
+                .compaction_group_member_table_ids(StaticCompactionGroupId::StateDefault)
+                .contains(&state_table_id)
+        );
+
+        let aborted = try_abort_creating_streaming_job_and_cleanup(
+            metadata_manager,
+            refresh_manager,
+            hummock_manager,
+            job_id,
+            reason,
+        )
+        .await?;
         assert!(aborted);
-        assert_eq!(database_id, Some(TEST_DATABASE_ID));
 
         let err = rx
             .await
             .expect("finish notifier should be notified")
-            .expect_err("initial job drop should cancel the create wait");
-        assert!(err.contains("cancelled"));
+            .expect_err("initial job abort should fail the create wait");
+        match reason {
+            AbortCreatingStreamingJobReason::Cancelled => assert!(err.contains("cancelled")),
+            AbortCreatingStreamingJobReason::CreateFailed => assert!(err.contains("not found")),
+        }
 
         let db = &mgr.inner.read().await.db;
         assert!(Object::find_by_id(job_id).one(db).await?.is_none());
@@ -356,6 +451,14 @@ mod tests {
                 .one(db)
                 .await?
                 .is_none()
+        );
+        assert!(
+            !hummock_manager
+                .get_current_version()
+                .await
+                .state_table_info
+                .compaction_group_member_table_ids(StaticCompactionGroupId::StateDefault)
+                .contains(&state_table_id)
         );
 
         Ok(())

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -99,6 +99,28 @@ use crate::model::{
 use crate::stream::SplitAssignment;
 use crate::{MetaError, MetaResult};
 
+/// Why a creating streaming job is being aborted.
+///
+/// This reason controls whether a live background creating job may be left for recovery and what
+/// error is reported to create waiters. Once the job is decided to be aborted, catalog and Hummock
+/// cleanup are the same for both reasons.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AbortCreatingStreamingJobReason {
+    Cancelled,
+    CreateFailed,
+}
+
+/// Result of trying to abort a creating streaming job.
+///
+/// A background creating job can be left for recovery instead of being aborted.
+pub(crate) enum AbortCreatingStreamingJobResult {
+    Aborted {
+        database_id: Option<DatabaseId>,
+        state_table_ids: Vec<TableId>,
+    },
+    LeftForRecovery,
+}
+
 /// A planned fragment update for dependent sources when a connection's properties change.
 ///
 /// We keep it as a named struct (instead of a tuple) for readability and to avoid clippy
@@ -748,15 +770,18 @@ impl CatalogController {
         })
     }
 
-    /// `try_abort_creating_streaming_job` is used to abort the job that is under initial status or in `FOREGROUND` mode.
-    /// It returns (true, _) if the job is not found or aborted.
-    /// It returns (_, Some(`database_id`)) is the `database_id` of the `job_id` exists
+    /// `try_abort_creating_streaming_job` is used to abort a streaming job that is under
+    /// initial status or in `FOREGROUND` mode.
+    ///
+    /// It returns `LeftForRecovery` only when a background creating job should be left for
+    /// recovery. Otherwise, `Aborted` carries the table ids that must be unregistered after the
+    /// catalog abort.
     #[await_tree::instrument]
-    pub async fn try_abort_creating_streaming_job(
+    pub(crate) async fn try_abort_creating_streaming_job(
         &self,
         mut job_id: JobId,
-        is_cancelled: bool,
-    ) -> MetaResult<(bool, Option<DatabaseId>)> {
+        reason: AbortCreatingStreamingJobReason,
+    ) -> MetaResult<AbortCreatingStreamingJobResult> {
         let mut inner = self.inner.write().await;
         let txn = inner.db.begin().await?;
 
@@ -766,14 +791,19 @@ impl CatalogController {
                 id = %job_id,
                 "streaming job not found when aborting creating, might be cancelled already or cleaned by recovery"
             );
-            return Ok((true, None));
+            return Ok(AbortCreatingStreamingJobResult::Aborted {
+                database_id: None,
+                state_table_ids: vec![],
+            });
         };
         let database_id = obj
             .database_id
             .ok_or_else(|| anyhow!("obj has no database id: {:?}", obj))?;
         let streaming_job = streaming_job::Entity::find_by_id(job_id).one(&txn).await?;
 
-        if !is_cancelled && let Some(streaming_job) = &streaming_job {
+        if reason == AbortCreatingStreamingJobReason::CreateFailed
+            && let Some(streaming_job) = &streaming_job
+        {
             assert_ne!(streaming_job.job_status, JobStatus::Created);
             if streaming_job.create_type == CreateType::Background
                 && streaming_job.job_status == JobStatus::Creating
@@ -788,7 +818,7 @@ impl CatalogController {
                         id = %job_id,
                         "streaming job is created in background and still in creating status"
                     );
-                    return Ok((false, Some(database_id)));
+                    return Ok(AbortCreatingStreamingJobResult::LeftForRecovery);
                 }
             }
         }
@@ -830,25 +860,24 @@ impl CatalogController {
             }
         }
 
-        if is_cancelled {
-            let dropped_tables = Table::find()
-                .find_also_related(Object)
-                .filter(
-                    table::Column::TableId.is_in(
-                        internal_table_ids
-                            .iter()
-                            .cloned()
-                            .chain(table_obj.iter().map(|t| t.table_id as _)),
-                    ),
-                )
-                .all(&txn)
-                .await?
-                .into_iter()
-                .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)));
-            inner
-                .dropped_tables
-                .extend(dropped_tables.map(|t| (t.id, t)));
-        }
+        let state_table_ids = internal_table_ids
+            .iter()
+            .copied()
+            .chain(table_obj.iter().map(|t| t.table_id as _))
+            .unique()
+            .collect_vec();
+        // Keep table catalogs so the caller can notify Hummock and compactor after unregistering
+        // the aborted job table ids.
+        let dropped_tables = Table::find()
+            .find_also_related(Object)
+            .filter(table::Column::TableId.is_in(state_table_ids.clone()))
+            .all(&txn)
+            .await?
+            .into_iter()
+            .map(|(table, obj)| PbTable::from(ObjectModel(table, obj.unwrap(), None)));
+        inner
+            .dropped_tables
+            .extend(dropped_tables.map(|t| (t.id, t)));
 
         if need_notify {
             // Special handling for iceberg sinks: the `job_id` may have been rewritten to the table id.
@@ -922,10 +951,14 @@ impl CatalogController {
             Object::delete_by_id(source_id).exec(&txn).await?;
         }
 
-        let err = if is_cancelled {
-            MetaError::cancelled(format!("streaming job {job_id} is cancelled"))
-        } else {
-            MetaError::catalog_id_not_found("stream job", format!("streaming job {job_id} failed"))
+        let err = match reason {
+            AbortCreatingStreamingJobReason::Cancelled => {
+                MetaError::cancelled(format!("streaming job {job_id} is cancelled"))
+            }
+            AbortCreatingStreamingJobReason::CreateFailed => MetaError::catalog_id_not_found(
+                "stream job",
+                format!("streaming job {job_id} failed"),
+            ),
         };
         let abort_reason = format!("streaming job aborted {}", err.as_report());
         for tx in inner
@@ -953,7 +986,10 @@ impl CatalogController {
             self.notify_frontend(Operation::Delete, build_object_group_for_delete(objs))
                 .await;
         }
-        Ok((true, Some(database_id)))
+        Ok(AbortCreatingStreamingJobResult::Aborted {
+            database_id: Some(database_id),
+            state_table_ids,
+        })
     }
 
     #[await_tree::instrument]

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -73,9 +73,13 @@ use tracing::Instrument;
 use crate::barrier::{BarrierManagerRef, Command};
 use crate::controller::catalog::{DropTableConnectorContext, ReleaseContext};
 use crate::controller::cluster::StreamingClusterInfo;
-use crate::controller::streaming_job::{FinishAutoRefreshSchemaSinkContext, SinkIntoTableContext};
+use crate::controller::streaming_job::{
+    AbortCreatingStreamingJobReason, AbortCreatingStreamingJobResult,
+    FinishAutoRefreshSchemaSinkContext, SinkIntoTableContext,
+};
 use crate::controller::utils::build_select_node_list;
 use crate::error::{MetaErrorInner, bail_invalid_parameter, bail_unavailable};
+use crate::hummock::HummockManagerRef;
 use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{
@@ -92,10 +96,11 @@ use crate::stream::cdc::{
 use crate::stream::{
     ActorGraphBuildResult, ActorGraphBuilder, AutoRefreshSchemaSinkContext,
     CompleteStreamFragmentGraph, CreateStreamingJobContext, CreateStreamingJobOption,
-    FragmentGraphDownstreamContext, FragmentGraphUpstreamContext, GlobalStreamManagerRef,
-    ReplaceStreamJobContext, ReschedulePolicy, SourceChange, SourceManagerRef, StreamFragmentGraph,
-    UpstreamSinkInfo, check_sink_fragments_support_refresh_schema, create_source_worker,
-    rewrite_refresh_schema_sink_fragment, state_match, validate_sink,
+    FragmentGraphDownstreamContext, FragmentGraphUpstreamContext, GlobalRefreshManagerRef,
+    GlobalStreamManagerRef, ReplaceStreamJobContext, ReschedulePolicy, SourceChange,
+    SourceManagerRef, StreamFragmentGraph, UpstreamSinkInfo,
+    check_sink_fragments_support_refresh_schema, cleanup_dropped_streaming_jobs,
+    create_source_worker, rewrite_refresh_schema_sink_fragment, state_match, validate_sink,
 };
 use crate::telemetry::report_event;
 use crate::{MetaError, MetaResult};
@@ -348,6 +353,37 @@ impl CreatingStreamingJobPermit {
         });
 
         Self { semaphore }
+    }
+}
+
+/// Try to abort a creating streaming job and clean up Hummock state only if the abort happens.
+pub(crate) async fn try_abort_creating_streaming_job_and_cleanup(
+    metadata_manager: &MetadataManager,
+    refresh_manager: &GlobalRefreshManagerRef,
+    hummock_manager: &HummockManagerRef,
+    job_id: JobId,
+    reason: AbortCreatingStreamingJobReason,
+) -> MetaResult<bool> {
+    let abort_result = metadata_manager
+        .catalog_controller
+        .try_abort_creating_streaming_job(job_id, reason)
+        .await?;
+    match abort_result {
+        AbortCreatingStreamingJobResult::Aborted {
+            state_table_ids, ..
+        } => {
+            cleanup_dropped_streaming_jobs(
+                refresh_manager,
+                hummock_manager,
+                metadata_manager,
+                [job_id],
+                state_table_ids,
+                "abort_creating_streaming_job",
+            )
+            .await?;
+            Ok(true)
+        }
+        AbortCreatingStreamingJobResult::LeftForRecovery => Ok(false),
     }
 }
 
@@ -1113,14 +1149,16 @@ impl DdlController {
                 self.env.event_log_manager_ref().add_event_logs(vec![
                     risingwave_pb::meta::event_log::Event::CreateStreamJobFail(event),
                 ]);
-                let (aborted, _) = self
-                    .metadata_manager
-                    .catalog_controller
-                    .try_abort_creating_streaming_job(job_id, false)
-                    .await?;
+                let aborted = try_abort_creating_streaming_job_and_cleanup(
+                    &self.metadata_manager,
+                    &self.stream_manager.refresh_manager,
+                    &self.stream_manager.hummock_manager,
+                    job_id,
+                    AbortCreatingStreamingJobReason::CreateFailed,
+                )
+                .await?;
                 if aborted {
                     tracing::warn!(id = %job_id, "aborted streaming job");
-                    // FIXME: might also need other cleanup here
                     if let Some(source_id) = source_id {
                         self.source_manager
                             .apply_source_change(SourceChange::DropSource {
@@ -1705,10 +1743,14 @@ impl DdlController {
             .await?;
         let version = match job_status {
             JobStatus::Initial => {
-                self.metadata_manager
-                    .catalog_controller
-                    .try_abort_creating_streaming_job(job_id.id(), true)
-                    .await?;
+                try_abort_creating_streaming_job_and_cleanup(
+                    &self.metadata_manager,
+                    &self.stream_manager.refresh_manager,
+                    &self.stream_manager.hummock_manager,
+                    job_id.id(),
+                    AbortCreatingStreamingJobReason::Cancelled,
+                )
+                .await?;
                 IGNORED_NOTIFICATION_VERSION
             }
             JobStatus::Creating => {

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -43,6 +43,9 @@ use crate::barrier::{
 };
 use crate::controller::catalog::DropTableConnectorContext;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
+use crate::controller::streaming_job::{
+    AbortCreatingStreamingJobReason, AbortCreatingStreamingJobResult,
+};
 use crate::error::bail_invalid_parameter;
 use crate::hummock::HummockManagerRef;
 use crate::manager::{
@@ -434,7 +437,10 @@ impl GlobalStreamManager {
                                 let cleanup_state_table_ids =
                                     job_fragments.all_table_ids().collect_vec();
                                 self.metadata_manager.catalog_controller
-                                    .try_abort_creating_streaming_job(job_id, true)
+                                    .try_abort_creating_streaming_job(
+                                        job_id,
+                                        AbortCreatingStreamingJobReason::Cancelled,
+                                    )
                                     .await?;
 
                                 self.barrier_scheduler
@@ -759,13 +765,17 @@ impl GlobalStreamManager {
                 .await?;
             let cleanup_state_table_ids = fragment.all_table_ids().collect_vec();
 
-            let (_, database_id) = self
+            let abort_result = self
                 .metadata_manager
                 .catalog_controller
-                .try_abort_creating_streaming_job(id, true)
+                .try_abort_creating_streaming_job(id, AbortCreatingStreamingJobReason::Cancelled)
                 .await?;
 
-            if let Some(database_id) = database_id {
+            if let AbortCreatingStreamingJobResult::Aborted {
+                database_id: Some(database_id),
+                ..
+            } = abort_result
+            {
                 self.barrier_scheduler
                     .run_command(database_id, cancel_command)
                     .await?;

--- a/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/background_ddl.rs
@@ -17,9 +17,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
-use risingwave_common::catalog::TableId;
 use risingwave_common::error::AsReport;
-use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_simulation::cluster::{Cluster, Configuration, Session};
 use tokio::time::sleep;
 
@@ -154,75 +152,6 @@ async fn wait_for_stream_job_and_member_tables(
     ))
 }
 
-async fn compaction_group_id_by_table_id(
-    session: &mut Session,
-    table_id: u32,
-) -> Result<CompactionGroupId> {
-    Ok(session
-        .run(format!(
-            "SELECT id FROM rw_hummock_compaction_group_configs WHERE member_tables @> '[{table_id}]'::jsonb;"
-        ))
-        .await?
-        .parse::<CompactionGroupId>()?)
-}
-
-async fn sstable_ids_by_table_id(session: &mut Session, table_id: u32) -> Result<Vec<u64>> {
-    let rows = session
-        .run(format!(
-            "SELECT sstable_id FROM rw_hummock_sstables WHERE table_ids @> '[{table_id}]'::jsonb ORDER BY sstable_id;"
-        ))
-        .await?;
-    rows.lines()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| Ok(u64::from_str(line.trim())?))
-        .collect()
-}
-
-async fn wait_for_sstable_ids_by_table_id(
-    session: &mut Session,
-    table_id: u32,
-) -> Result<Vec<u64>> {
-    for _ in 0..60 {
-        let sstable_ids = sstable_ids_by_table_id(session, table_id).await?;
-        if !sstable_ids.is_empty() {
-            return Ok(sstable_ids);
-        }
-        sleep(Duration::from_secs(1)).await;
-    }
-    Err(anyhow!("failed to observe sstables for table {}", table_id))
-}
-
-async fn wait_for_compaction_group_sstable_count(
-    session: &mut Session,
-    compaction_group_id: CompactionGroupId,
-    expected_at_least: usize,
-) -> Result<usize> {
-    for _ in 0..60 {
-        let count = session
-            .run(format!(
-                "SELECT COUNT(*) FROM rw_hummock_sstables WHERE compaction_group_id = {compaction_group_id};"
-            ))
-            .await?
-            .parse::<usize>()?;
-        if count >= expected_at_least {
-            return Ok(count);
-        }
-        sleep(Duration::from_secs(1)).await;
-    }
-    Err(anyhow!(
-        "failed to observe at least {} sstables in compaction group {}",
-        expected_at_least,
-        compaction_group_id
-    ))
-}
-
-async fn compactor_worker_count(session: &mut Session) -> Result<usize> {
-    Ok(session
-        .run("SELECT COUNT(*) FROM rw_catalog.rw_worker_nodes WHERE \"type\" = 'Compactor';")
-        .await?
-        .parse::<usize>()?)
-}
-
 fn init_logger() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -237,7 +166,7 @@ async fn create_mv(session: &mut Session) -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_snapshot_backfill_cancel_database_recovery_manual_compaction_attempt() {
+async fn test_snapshot_backfill_failed_foreground_ddl_unregisters_table_ids() {
     init_logger();
     let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
     config.compute_nodes = 3;
@@ -293,7 +222,7 @@ async fn test_snapshot_backfill_cancel_database_recovery_manual_compaction_attem
     let baseline_member_tables = member_table_ids(&mut session).await.unwrap();
 
     let mut create_session = cluster.start_session();
-    tokio::spawn(async move {
+    let create_handle = tokio::spawn(async move {
         create_session.run("use group1;").await.unwrap();
         create_session
             .run("set background_ddl = false;")
@@ -307,43 +236,17 @@ async fn test_snapshot_backfill_cancel_database_recovery_manual_compaction_attem
             .run("set backfill_rate_limit = 1;")
             .await
             .unwrap();
-        let _ = create_session
+        create_session
             .run("create materialized view mv1 as select * from t;")
-            .await;
+            .await
     });
 
     let created_member_tables =
         wait_for_stream_job_and_member_tables(&mut session, &baseline_member_tables)
             .await
             .unwrap();
-    let candidate_table_id = *created_member_tables.iter().min().unwrap();
-    let candidate_sstable_ids = wait_for_sstable_ids_by_table_id(&mut session, candidate_table_id)
-        .await
-        .unwrap();
-    let original_compaction_group_id =
-        compaction_group_id_by_table_id(&mut session, candidate_table_id)
-            .await
-            .unwrap();
-    cluster
-        .split_compaction_group(
-            original_compaction_group_id,
-            TableId::new(candidate_table_id),
-        )
-        .await
-        .unwrap();
-    let candidate_compaction_group_id =
-        compaction_group_id_by_table_id(&mut session, candidate_table_id)
-            .await
-            .unwrap();
-    wait_for_compaction_group_sstable_count(&mut session, candidate_compaction_group_id, 1)
-        .await
-        .unwrap();
     tracing::info!(
         ?created_member_tables,
-        candidate_table_id,
-        ?candidate_sstable_ids,
-        ?original_compaction_group_id,
-        ?candidate_compaction_group_id,
         "observed creating snapshot-backfill state tables"
     );
 
@@ -363,18 +266,15 @@ async fn test_snapshot_backfill_cancel_database_recovery_manual_compaction_attem
         .await
         .unwrap();
 
-    let mut cancel_session = cluster.start_session();
-    let cancel_handle = tokio::spawn(async move { cancel_stream_jobs(&mut cancel_session).await });
-
     sleep(Duration::from_millis(100)).await;
     cluster.simple_restart_nodes(["compute-1"]).await;
     wait_all_database_recovered(&mut cluster).await;
     sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC)).await;
 
-    let cancel_result = cancel_handle.await.unwrap();
-    tracing::info!(
-        ?cancel_result,
-        "cancel result after concurrent database recovery"
+    let create_result = create_handle.await.unwrap();
+    assert!(
+        create_result.is_err(),
+        "foreground DDL should fail when database recovery interrupts it, got {create_result:?}"
     );
 
     let database_recovery_events = database_recovery_events(&mut monitor_session)
@@ -394,89 +294,28 @@ async fn test_snapshot_backfill_cancel_database_recovery_manual_compaction_attem
 
     session.run("use group1;").await.unwrap();
     wait_for_jobs_cleared(&mut session).await.unwrap();
+    wait_member_table_ids(&mut session, &baseline_member_tables)
+        .await
+        .unwrap();
     let member_tables_after_recovery = member_table_ids(&mut session).await.unwrap();
-    let dangling_member_tables = created_member_tables
+    let remaining_created_member_tables = created_member_tables
         .intersection(&member_tables_after_recovery)
         .copied()
         .collect::<HashSet<_>>();
     tracing::info!(
         ?created_member_tables,
         ?member_tables_after_recovery,
-        ?dangling_member_tables,
-        "member tables after concurrent cancel and database recovery"
-    );
-    assert!(
-        !dangling_member_tables.is_empty(),
-        "failed to keep created state tables in hummock member tables after recovery"
-    );
-    assert!(
-        dangling_member_tables.contains(&candidate_table_id),
-        "failed to keep candidate table {} in hummock member tables after recovery; dangling tables: {:?}",
-        candidate_table_id,
-        dangling_member_tables
-    );
-
-    let compactor_count_before = compactor_worker_count(&mut session).await.unwrap();
-    let sstable_count_before =
-        wait_for_compaction_group_sstable_count(&mut session, candidate_compaction_group_id, 1)
-            .await
-            .unwrap();
-    cluster
-        .simple_kill_nodes(["compactor-1", "compactor-2"])
-        .await;
-    wait_until(
-        &mut session,
-        "SELECT COUNT(*) FROM rw_catalog.rw_worker_nodes WHERE \"type\" = 'Compactor';",
-        "0",
-    )
-    .await
-    .unwrap();
-    cluster
-        .simple_restart_nodes(["compactor-1", "compactor-2"])
-        .await;
-    wait_until(
-        &mut session,
-        "SELECT COUNT(*) FROM rw_catalog.rw_worker_nodes WHERE \"type\" = 'Compactor';",
-        &compactor_count_before.to_string(),
-    )
-    .await
-    .unwrap();
-    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC)).await;
-    tracing::info!(
-        candidate_table_id,
-        ?candidate_compaction_group_id,
-        compactor_count_before,
-        sstable_count_before,
-        "triggering manual compaction on stale table compaction group after compactor restart"
-    );
-
-    cluster
-        .trigger_manual_compaction(candidate_compaction_group_id, 0)
-        .await
-        .unwrap();
-    sleep(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SEC)).await;
-
-    let compactor_count_after = compactor_worker_count(&mut session).await.unwrap();
-    let sstable_count_after =
-        wait_for_compaction_group_sstable_count(&mut session, candidate_compaction_group_id, 1)
-            .await
-            .unwrap();
-    let candidate_sstable_ids_after = sstable_ids_by_table_id(&mut session, candidate_table_id)
-        .await
-        .unwrap();
-    tracing::info!(
-        candidate_table_id,
-        ?candidate_compaction_group_id,
-        compactor_count_before,
-        compactor_count_after,
-        sstable_count_before,
-        sstable_count_after,
-        ?candidate_sstable_ids_after,
-        "manual compaction result for stale table compaction group"
+        ?remaining_created_member_tables,
+        "member tables after failed foreground DDL and database recovery"
     );
     assert_eq!(
-        compactor_count_after, compactor_count_before,
-        "manual compaction crashed a compactor worker"
+        member_tables_after_recovery, baseline_member_tables,
+        "failed foreground DDL should clean Hummock member tables back to the baseline"
+    );
+    assert!(
+        remaining_created_member_tables.is_empty(),
+        "failed foreground DDL left created state tables in Hummock member tables: {:?}",
+        remaining_created_member_tables
     );
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Related to #25466
- Split from #25592

This PR is scoped to **DDL abort cleanup for creating streaming jobs**. It does not change per-database dirty-job recovery cleanup; that path is fixed separately in #25592.

Bug:

- When creating a streaming job fails, `create_streaming_job_inner` tries to abort the creating job with `AbortCreatingStreamingJobReason::CreateFailed`.
- `DROP/CANCEL` of an `Initial` job also tries to abort through the same catalog helper with `AbortCreatingStreamingJobReason::Cancelled`.
- Before this PR, these DDL abort callers could delete catalog rows without running the existing dropped-table cleanup path, so Hummock table ids that had already been registered could remain stale.
- The stale-id cleanup responsibility is in the DDL abort path after the create is actually aborted, independent of the mechanism that caused the foreground create to fail.

Fix:

- Split abort input reason from abort outcome:
  - `AbortCreatingStreamingJobReason` records why the abort is requested: `Cancelled` or `CreateFailed`.
  - `AbortCreatingStreamingJobResult` records what happened: `Aborted { state_table_ids, .. }` or `LeftForRecovery`.
- Collect cleanup table ids from the catalog table rows deleted by the abort path: internal table catalogs plus the MV table catalog.
- Route DDL create failure and `DROP/CANCEL` of `Initial` jobs through `try_abort_creating_streaming_job_and_cleanup`, so Hummock unregister and Hummock/compactor notification happen through the existing dropped-table cleanup path only when the catalog abort actually happens.
- Keep replace-job abort handling and live `Background/Creating` recovery unchanged.

Not covered by this PR:

- Dirty creating-job cleanup during per-database recovery. That is #25592.

### Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p risingwave_meta --lib`
- `cargo test -p risingwave_meta test_abort_initial_materialized_views_unregister_hummock --lib -- --nocapture`
- `./risedev sit-test test_snapshot_backfill_failed_foreground_ddl_unregisters_table_ids --no-capture`

The unit test is a focused meta-layer regression test: it uses the real `HummockManager`, `CatalogController`, and `cleanup_dropped_streaming_jobs` path, manually builds the minimal `Initial` MV catalog state, registers the MV table id into Hummock, then verifies abort cleanup unregisters it.

The simulation test updates the existing recovery case to match the intended invariant: when a foreground snapshot-backfill DDL is interrupted by database recovery and aborts, the created state tables are removed from Hummock member tables instead of being kept as dangling table ids.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed stale Hummock table ids that can remain after aborting a creating streaming job in the DDL path.

</details>

