### PR TITLE
fix(meta): sync inflight stream node rate_limit on Throttle command (#25562)

### DIFF
--- a/e2e_test/background_ddl/alter_rate_limit_inflight_sync.slt
+++ b/e2e_test/background_ddl/alter_rate_limit_inflight_sync.slt
@@ -1,0 +1,67 @@
+# Regression for the Throttle / inflight-nodes desync fixed alongside this test:
+# ALTER ... rate_limit only updated DB + actor mutation, not `database_info.fragment.nodes`,
+# so a later ALTER PARALLELISM would materialize fresh actors from the stale snapshot and
+# resume backfill at rate_limit = 0. Mirrors the source-side test at
+# `e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial`.
+
+# Use ArrangementBackfill so the creating MV is online-reschedulable.
+statement ok
+set streaming_use_snapshot_backfill = false;
+
+statement ok
+set streaming_parallelism = 1;
+
+statement ok
+create table t (v int);
+
+statement ok
+insert into t select * from generate_series(1, 1000);
+
+statement ok
+flush;
+
+statement ok
+set background_ddl = true;
+
+statement ok
+create materialized view mv with (backfill_rate_limit = 0) as select * from t;
+
+# Backfill must really be paused before we exercise the ALTER path.
+sleep 2s
+
+query I
+select count(*) from rw_catalog.rw_ddl_progress;
+----
+1
+
+statement ok
+alter materialized view mv set backfill_rate_limit to 10;
+
+statement ok
+alter materialized view mv set parallelism = 16;
+
+statement ok
+set background_ddl = false;
+
+# Without the fix, fresh actors come up at rate_limit=0 and the count stays at 1 forever.
+query I retry 60 backoff 1s
+select count(*) from rw_catalog.rw_ddl_progress;
+----
+0
+
+query I
+select count(*) from mv;
+----
+1000
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t;
+
+statement ok
+set streaming_parallelism = default;
+
+statement ok
+set streaming_use_snapshot_backfill = default;

--- a/e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial
+++ b/e2e_test/source_inline/kafka/alter/source_rate_limit_inflight_sync.slt.serial
@@ -1,0 +1,137 @@
+# Regression: `ALTER SOURCE source_rate_limit` updates DB and notifies running actors via
+# `Mutation::Throttle`, but historically did not refresh `database_info.fragment(..).nodes`.
+# A subsequent reschedule (e.g. `ALTER SOURCE SET PARALLELISM`) materialized fresh source
+# actors from stale inflight nodes, so they started with the *original* `rate_limit = Some(0)`
+# and stayed paused -- their splits never produced data.
+#
+# Repro:
+#   1. CREATE SOURCE with `source_rate_limit = 0` (parallelism=1).
+#      All actors + inflight nodes start at rate_limit = Some(0).
+#   2. ALTER SOURCE ... source_rate_limit TO DEFAULT.
+#      DB → null, the running actor resumes via Throttle mutation.
+#      Without the fix, inflight `info.nodes.source_inner.rate_limit` is still Some(0).
+#   3. ALTER SOURCE SET PARALLELISM = 4.
+#      Reschedule materializes 3 fresh actors from inflight. Without the fix, those actors
+#      start with `rate_limit_rps = Some(0)` and the 3 partitions assigned to them never
+#      drain.
+#   4. Produce 100 more rows, distributed round-robin across 4 partitions. Verify the MV
+#      sees all 200. With the bug, only the 1 partition on the kept actor advances and the
+#      MV stalls below 200.
+
+control substitution on
+
+system ok
+rpk topic delete test_rl_inflight_sync || true
+
+system ok
+rpk topic create test_rl_inflight_sync --partitions 4 --replicas 1
+
+############## Seed 100 rows into kafka
+
+statement ok
+create table seed (v1 int);
+
+statement ok
+insert into seed select * from generate_series(1, 100);
+
+statement ok
+create sink seed_sink from seed with (
+    ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+    topic = 'test_rl_inflight_sync',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+
+sleep 5s
+
+############## Step 1: CREATE SOURCE with rate_limit = 0, parallelism = 1.
+# Inflight `info.nodes.source_inner.rate_limit` is set to Some(0) here.
+
+statement ok
+SET STREAMING_PARALLELISM = 1;
+
+statement ok
+create source rl_src (v1 int) with (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'test_rl_inflight_sync',
+  source_rate_limit = 0
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+SET STREAMING_PARALLELISM = DEFAULT;
+
+statement ok
+flush;
+
+query T
+select rate_limit from rw_rate_limit join rw_relations on table_id = id where name = 'rl_src';
+----
+0
+
+query I
+select parallelism from rw_fragments join rw_relations on rw_fragments.table_id = rw_relations.id
+where name = 'rl_src';
+----
+1
+
+############## Step 2: ALTER source rate_limit TO DEFAULT.
+# DB cleared, the existing 1 actor is resumed by the Throttle mutation.
+# Without the fix, inflight `info.nodes.source_inner.rate_limit` stays at Some(0).
+
+statement ok
+alter source rl_src set source_rate_limit to default;
+
+# rw_rate_limit only lists fragments with a non-null rate_limit; should now be empty.
+query T
+select rate_limit from rw_rate_limit join rw_relations on table_id = id where name = 'rl_src';
+----
+
+############## Step 3: Scale parallelism 1 → 4.
+# This adds 3 brand-new source actors. Without the fix they read stale inflight nodes
+# and come up paused.
+
+statement ok
+alter source rl_src set parallelism = 4;
+
+query I
+select parallelism from rw_fragments join rw_relations on rw_fragments.table_id = rw_relations.id
+where name = 'rl_src';
+----
+4
+
+############## Step 4: Verify the upstream source is not stuck on any partition.
+# We attach an MV after the reschedule. SourceBackfill backfills directly from kafka (it
+# gets the seed 100 regardless), but data produced *after* backfill must flow through the
+# upstream Source actors -- which is exactly what the bug breaks for the 3 new actors.
+
+statement ok
+create materialized view rl_mv as select count(*) as c from rl_src;
+
+query I retry 30 backoff 1s
+select c from rl_mv;
+----
+100
+
+statement ok
+insert into seed select * from generate_series(101, 200);
+
+# With the bug, ~75 of the 100 new rows land on partitions owned by the freshly-created
+# (paused) actors and never reach the MV. With the fix all 100 flow through.
+query I retry 60 backoff 1s
+select c from rl_mv;
+----
+200
+
+############## Cleanup
+
+statement ok
+drop source rl_src cascade;
+
+statement ok
+drop sink seed_sink;
+
+statement ok
+drop table seed;
+
+system ok
+rpk topic delete test_rl_inflight_sync || true

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -259,6 +259,12 @@ impl DatabaseCheckpointControl {
                     );
                 }
             }
+            Some(Command::Throttle { config, .. }) => {
+                for (fragment_id, throttle_config) in config {
+                    self.database_info
+                        .pre_apply_throttle(*fragment_id, throttle_config);
+                }
+            }
             _ => {}
         };
 

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -27,6 +27,7 @@ use risingwave_common::util::stream_graph_visitor::visit_stream_node_mut;
 use risingwave_connector::source::{SplitImpl, SplitMetaData};
 use risingwave_meta_model::WorkerId;
 use risingwave_meta_model::fragment::DistributionType;
+use risingwave_pb::common::ThrottleType;
 use risingwave_pb::ddl_service::PbBackfillType;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::SubscriberId;
@@ -35,6 +36,7 @@ use risingwave_pb::meta::subscribe_response::Operation;
 use risingwave_pb::source::PbCdcTableSnapshotSplits;
 use risingwave_pb::stream_plan::PbUpstreamSinkInfo;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::throttle_mutation::ThrottleConfig;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
 use tracing::{info, warn};
 
@@ -1259,6 +1261,51 @@ impl InflightDatabaseInfo {
             }
         }
         Some(builder.build())
+    }
+
+    /// Sync inflight `nodes.rate_limit` so a later reschedule won't materialize new actors
+    /// from stale data. Mirrors `controller/streaming_job.rs::update_*_rate_limit_by_*`.
+    pub(crate) fn pre_apply_throttle(&mut self, fragment_id: FragmentId, config: &ThrottleConfig) {
+        // Snapshot-backfill creating jobs live outside main inflight; their throttles
+        // flow through `on_new_upstream_barrier`.
+        if !self.fragment_location.contains_key(&fragment_id) {
+            return;
+        }
+        let throttle_type = config.throttle_type();
+        let rate_limit = config.rate_limit;
+        let (info, _) = self.fragment_mut(fragment_id);
+
+        visit_stream_node_mut(&mut info.nodes, |node| match throttle_type {
+            ThrottleType::Source => {
+                if let NodeBody::Source(node) = node
+                    && let Some(node_inner) = &mut node.source_inner
+                {
+                    node_inner.rate_limit = rate_limit;
+                }
+                if let NodeBody::StreamFsFetch(node) = node
+                    && let Some(node_inner) = &mut node.node_inner
+                {
+                    node_inner.rate_limit = rate_limit;
+                }
+            }
+            ThrottleType::Backfill => match node {
+                NodeBody::StreamCdcScan(node) => node.rate_limit = rate_limit,
+                NodeBody::StreamScan(node) => node.rate_limit = rate_limit,
+                NodeBody::SourceBackfill(node) => node.rate_limit = rate_limit,
+                _ => {}
+            },
+            ThrottleType::Sink => {
+                if let NodeBody::Sink(node) = node {
+                    node.rate_limit = rate_limit;
+                }
+            }
+            ThrottleType::Dml => {
+                if let NodeBody::Dml(node) = node {
+                    node.rate_limit = rate_limit;
+                }
+            }
+            ThrottleType::Unspecified => {}
+        });
     }
 
     /// Apply some actor changes after the barrier command is collected, if the command contains any actors that are dropped, we should


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Cherry-pick of #25562 to `release-2.8`.

The original PR fixes a bug where `ALTER ... SET source_rate_limit / backfill_rate_limit / sink_rate_limit / dml_rate_limit` would not be honored after a subsequent reschedule. The meta layer persists the new rate limit to the catalog, but the inflight `nodes.rate_limit` was left stale, so a reschedule that materialized actors from inflight state would resurrect the old value.

The fix adds a `pre_apply_throttle` step on the `Throttle` barrier command that mirrors the catalog update onto the inflight `InflightDatabaseInfo`, keeping the two in sync.

### Adaptation for release-2.8

`apply_command` on `release-2.8` does not have a dedicated `Some(Command::Throttle { .. }) => apply_simple_command(...)` arm — the throttle mutation is generated through the generic `Command::to_mutation` path. The `pre_apply_throttle` call was therefore added inside the existing `match &command { ... }` block in `state.rs::apply_command` (alongside `CreateSubscription` / snapshot-backfill `CreateStreamingJob`).

The `info.rs` addition is identical to the original PR. The doc-only `AGENTS.md` tweak from the original PR was dropped (the file does not exist on `release-2.8`).

## Checklist

- [x] I have added necessary unit tests and integration tests.
- [x] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

