### PR TITLE
fix(optimizer): normalize arithmetic rank predicates for over-window …

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -245,6 +245,62 @@
     - stream_plan
     - optimized_logical_plan_for_batch
     - batch_plan
+- id: TopN by row_number with arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where rank - 1 = 0;
+  expected_outputs:
+    - stream_plan
+- id: TopN by row_number with mirrored arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 0 = rank - 1;
+  expected_outputs:
+    - stream_plan
+- id: TopN by row_number with mirrored arithmetic rank inequality
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 0 < rank - 1 AND rank <= 3;
+  expected_outputs:
+    - stream_plan
+- id: TopN by row_number with mirrored arithmetic rank upper bound
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 3 >= rank + 1;
+  expected_outputs:
+    - stream_plan
+- id: TopN by row_number with mirrored commuted addition rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 2 = 1 + rank;
+  expected_outputs:
+    - stream_plan
+- id: TopN by row_number with nested arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where (rank - 1) - 1 = 0;
+  expected_outputs:
+    - stream_plan
+- id: TopN by row_number with mirrored nested arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 0 = (rank - 1) - 1;
+  expected_outputs:
+    - stream_plan
 - id: TopN by rank without rank output
   sql: |
     create table t(x int, y int);

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -561,6 +561,88 @@
       └─StreamGroupTopN { order: [t.x ASC], limit: 2, offset: 0, group_key: [t.y] }
         └─StreamExchange { dist: HashShard(t.y) }
           └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where rank - 1 = 0;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [y], pk_columns: [y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y] }
+      └─StreamGroupTopN { order: [t.x ASC], limit: 1, offset: 0, group_key: [t.y] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with mirrored arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 0 = rank - 1;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [y], pk_columns: [y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y] }
+      └─StreamGroupTopN { order: [t.x ASC], limit: 1, offset: 0, group_key: [t.y] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with mirrored arithmetic rank inequality
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 0 < rank - 1 AND rank <= 3;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, t._row_id(hidden)], stream_key: [y, t._row_id], pk_columns: [y, t._row_id], pk_conflict: NoCheck }
+    └─StreamGroupTopN { order: [t.x ASC], limit: 2, offset: 1, group_key: [t.y] }
+      └─StreamExchange { dist: HashShard(t.y) }
+        └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with mirrored arithmetic rank upper bound
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 3 >= rank + 1;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, t._row_id(hidden)], stream_key: [y, t._row_id], pk_columns: [y, t._row_id], pk_conflict: NoCheck }
+    └─StreamGroupTopN { order: [t.x ASC], limit: 2, offset: 0, group_key: [t.y] }
+      └─StreamExchange { dist: HashShard(t.y) }
+        └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with mirrored commuted addition rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 2 = 1 + rank;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [y], pk_columns: [y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y] }
+      └─StreamGroupTopN { order: [t.x ASC], limit: 1, offset: 0, group_key: [t.y] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with nested arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where (rank - 1) - 1 = 0;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [y], pk_columns: [y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y] }
+      └─StreamGroupTopN { order: [t.x ASC], limit: 1, offset: 1, group_key: [t.y] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: TopN by row_number with mirrored nested arithmetic rank predicate
+  sql: |
+    create table t(x int, y int);
+    select x, y from
+      (select *, row_number() over(PARTITION BY y ORDER BY x) rank from t)
+    where 0 = (rank - 1) - 1;
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y], stream_key: [y], pk_columns: [y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y] }
+      └─StreamGroupTopN { order: [t.x ASC], limit: 1, offset: 1, group_key: [t.y] }
+        └─StreamExchange { dist: HashShard(t.y) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - id: TopN by rank without rank output
   sql: |
     create table t(x int, y int);

--- a/src/frontend/src/optimizer/rule/over_window_to_topn_rule.rs
+++ b/src/frontend/src/optimizer/rule/over_window_to_topn_rule.rs
@@ -186,18 +186,14 @@ impl ExprRewriter for FilterArithmeticRewriter {
         match func_call.func_type() {
             Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual => {
                 let inputs = func_call.inputs();
-                if inputs.len() == 2 {
-                    // Check if left operand is an arithmetic expression and right operand is a constant
-                    if let ExprImpl::FunctionCall(left_func) = &inputs[0]
-                        && inputs[1].is_const()
-                        && let Some(simplified) = self.simplify_arithmetic_comparison(
-                            left_func,
-                            &inputs[1],
-                            func_call.func_type(),
-                        )
-                    {
-                        return simplified;
-                    }
+                if inputs.len() == 2
+                    && let Some(simplified) = self.simplify_arithmetic_comparison(
+                        &inputs[0],
+                        &inputs[1],
+                        func_call.func_type(),
+                    )
+                {
+                    return self.rewrite_expr(simplified);
                 }
             }
             _ => {}
@@ -215,14 +211,38 @@ impl ExprRewriter for FilterArithmeticRewriter {
 }
 
 impl FilterArithmeticRewriter {
+    fn reverse_comparison(comparison_op: ExprType) -> ExprType {
+        match comparison_op {
+            ExprType::LessThan => ExprType::GreaterThan,
+            ExprType::LessThanOrEqual => ExprType::GreaterThanOrEqual,
+            ExprType::GreaterThan => ExprType::LessThan,
+            ExprType::GreaterThanOrEqual => ExprType::LessThanOrEqual,
+            ExprType::Equal | ExprType::NotEqual => comparison_op,
+            _ => unreachable!(),
+        }
+    }
+
     /// Simplify arithmetic comparison: `(col op const1) comp const2` -> `col comp (const2 reverse_op const1)`
     fn simplify_arithmetic_comparison(
         &self,
-        arithmetic_func: &FunctionCall,
-        comparison_const: &ExprImpl,
+        left: &ExprImpl,
+        right: &ExprImpl,
         comparison_op: ExprType,
     ) -> Option<ExprImpl> {
         use ExprType::{Add, Subtract};
+
+        let (arithmetic_func, comparison_const, comparison_op) =
+            if let ExprImpl::FunctionCall(left_func) = left
+                && right.is_const()
+            {
+                (left_func, right, comparison_op)
+            } else if left.is_const()
+                && let ExprImpl::FunctionCall(right_func) = right
+            {
+                (right_func, left, Self::reverse_comparison(comparison_op))
+            } else {
+                return None;
+            };
 
         // Check arithmetic operation
         match arithmetic_func.func_type() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Closes #25607 

To reiterate what's mentioned in the issue, this PR fixes a missed `OverWindowToTopNRule` application for arithmetic predicates on `row_number()` or `rank()`. Previously, the arithmetic simplifier handled forms like `rank - 1 = 0` by converting to `rank = 1`, but missed predicates where the constant appears on the left side (eg;  `0 = rank - 1`)

With this PR, when the arithmetic expression is on the right side, it swaps operands and reverses the comparison
operator where needed. It also recursively rewrites the simplified output so nested supported arithmetic, such as `(rank - 1) - 1 = 0`, can be simplified.

Also added planner tests for:
  - existing left-side arithmetic predicates
  - mirrored arithmetic predicates
  - mirrored arithmetic inequalities
  - commuted addition
  - nested arithmetic
  - mirrored nested arithmetic

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

