### PR TITLE
fix: use full column subset for distinct agg deduplication check

### DIFF
--- a/e2e_test/streaming/aggregate/count_distinct_row_id_bug.slt
+++ b/e2e_test/streaming/aggregate/count_distinct_row_id_bug.slt
@@ -27,5 +27,12 @@ select count(foo), count(distinct foo), count(distinct bar) from t;
 ----
 3 2 2
 
+-- Test with GROUP BY to exercise group_keys in the deduplication logic
+query IIII rowsort
+select bar, count(foo), count(distinct foo), count(distinct _row_id) from t group by bar;
+----
+1 2 1 2
+2 1 1 1
+
 statement ok
 drop table t;

--- a/e2e_test/streaming/aggregate/count_distinct_row_id_bug.slt
+++ b/e2e_test/streaming/aggregate/count_distinct_row_id_bug.slt
@@ -1,0 +1,31 @@
+-- Test for issue #20187: count(distinct _row_id) causing other count(distinct ...) producing wrong result
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t (foo int, bar int);
+
+statement ok
+insert into t values (1, 1), (2, 2), (1, 1);
+
+-- This should work correctly
+query II
+select count(foo), count(distinct foo) from t;
+----
+3 2
+
+-- This triggers the bug: count(distinct foo) returns 1 instead of 2
+query III
+select count(foo), count(distinct foo), count(distinct _row_id) from t;
+----
+3 2 3
+
+-- This should also work correctly
+query III
+select count(foo), count(distinct foo), count(distinct bar) from t;
+----
+3 2 2
+
+statement ok
+drop table t;

--- a/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
+++ b/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
@@ -149,9 +149,16 @@ impl DistinctAggRule {
             }
         });
 
+        // Use the same deduplication key as column_subsets to determine if Expand is needed.
+        // The key is the full subset: group_keys + agg_call.input_indices().
         let n_different_distinct = distinct_aggs
             .iter()
-            .unique_by(|agg_call| agg_call.input_indices()[0])
+            .map(|agg_call| {
+                let mut subset = group_keys.clone();
+                subset.extend(agg_call.input_indices());
+                subset.to_vec()
+            })
+            .unique()
             .count();
         assert_ne!(n_different_distinct, 0); // since `distinct_aggs` is not empty here
         if n_different_distinct == 1 {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR fixes a bug where `count(distinct _row_id)` appearing in the same query as `count(distinct foo)` caused the latter to produce incorrect results.

The root cause was that `DistinctAggRule::build_expand` decided whether `Expand` was needed using only the first input index of each distinct aggregate (`agg_call.input_indices()[0]`). However, `column_subsets` deduplicates using the full key `group_keys + agg_call.input_indices()`. When two distinct aggregates shared the same first input but required different full deduplication subsets, the rule could skip `Expand`, causing the final aggregation filters/flags to reuse the wrong deduplication state.

The fix aligns `n_different_distinct` with `column_subsets`: both now key on the complete `group_keys + input_indices` subset. This ensures `Expand` is created whenever distinct aggregates need separate deduplication states.

The test (`e2e_test/streaming/aggregate/count_distinct_row_id_bug.slt`) exercises the reported case and adds GROUP BY coverage to verify the fix works correctly with grouped queries.

- Closes #20187

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixes incorrect results from `count(distinct col)` when `count(distinct _row_id)` or other distinct aggregates with overlapping deduplication subsets appear in the same query.

</details>