### PR TITLE
chore(deps): bump openssl to 0.10.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9087,15 +9087,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -9128,9 +9127,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ mysql_async = { version = "0.36", features = [
     "rust_decimal",
 ] }
 opendal = "0.55"
-openssl = "0.10.78"
+openssl = "0.10.79"
 opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = "0.31"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Bumps the workspace `openssl` dependency from `0.10.78` to `0.10.79` (and `openssl-sys` from `0.9.114` to `0.9.115` via `Cargo.lock`) to pick up the fix for **CVE-2026-42327** / **GHSA-xp3w-r5p5-63rr**.

`X509Ref::ocsp_responders` in `rust-openssl` < `0.10.79` returns OCSP responder URLs as `OpensslString`, whose `Deref<Target = str>` wraps the raw bytes via `str::from_utf8_unchecked`. OpenSSL does not enforce that the underlying `IA5String` is ASCII, so a certificate with non-UTF-8 bytes in its OCSP `accessLocation` causes safe Rust to construct a `&str` that violates the UTF-8 invariant — undefined behavior. Fixed upstream in `rust-openssl` 0.10.79.

No source changes required; `./risedev check` passes cleanly.

Resolves Dependabot alert [#409](https://github.com/risingwavelabs/risingwave/security/dependabot/409).

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>
