### PR TITLE
fix(optimizer): fix split now or rule

### DIFF
--- a/e2e_test/batch/basic/boolean.slt.part
+++ b/e2e_test/batch/basic/boolean.slt.part
@@ -76,7 +76,7 @@ SELECT v1 is true,
        v1 is null
 FROM TB1;
 ----
-f	t	f	t	t
+f	s	f	t	t
 f	t	t	f	f
 t	f	f	t	f
 

--- a/e2e_test/batch/basic/boolean.slt.part
+++ b/e2e_test/batch/basic/boolean.slt.part
@@ -76,7 +76,7 @@ SELECT v1 is true,
        v1 is null
 FROM TB1;
 ----
-f	s	f	t	t
+f	t	f	t	t
 f	t	t	f	f
 t	f	f	t	f
 

--- a/src/frontend/planner_test/tests/testdata/input/temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_filter.yaml
@@ -99,6 +99,12 @@
     select * from t1 where ts + interval '1 hour' > now() or ts > ' 2023-12-18 00:00:00+00:00';
   expected_outputs:
     - stream_plan
+- name: Temporal filter with nullable or predicate
+  sql: |
+    create table t1 (ts timestamp with time zone, a int);
+    select * from t1 where ts + interval '1 hour' > now() or a > 0;
+  expected_outputs:
+    - stream_plan
 - name: Temporal filter with or is null
   sql: |
     create table t1 (ts timestamp with time zone);

--- a/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
@@ -357,9 +357,9 @@
       │ └─StreamProject { exprs: [t1.ts, t1._row_id, 0:Int32] }
       │   └─StreamDynamicFilter { predicate: ($expr1 > now), output_watermarks: [[$expr1]], output: [t1.ts, $expr1, t1._row_id], cleaned_by_watermark: true }
       │     ├─StreamProject { exprs: [t1.ts, AddWithTimeZone(t1.ts, '01:00:00':Interval, 'UTC':Varchar) as $expr1, t1._row_id] }
-      │     │ └─StreamFilter { predicate: Not((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) }
+      │     │ └─StreamFilter { predicate: IsNotTrue((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) }
       │     │   └─StreamShare { id: 2 }
-      │     │     └─StreamFilter { predicate: IsNotNull(t1.ts) }
+      │     │     └─StreamFilter { predicate: (IsNotTrue((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) OR (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) }
       │     │       └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
       │     └─StreamExchange { dist: Broadcast }
       │       └─StreamNow { output: [now] }
@@ -367,8 +367,31 @@
         └─StreamProject { exprs: [t1.ts, t1._row_id, 1:Int32] }
           └─StreamFilter { predicate: (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz) }
             └─StreamShare { id: 2 }
-              └─StreamFilter { predicate: IsNotNull(t1.ts) }
+              └─StreamFilter { predicate: (IsNotTrue((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) OR (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) }
                 └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+- name: Temporal filter with nullable or predicate
+  sql: |
+    create table t1 (ts timestamp with time zone, a int);
+    select * from t1 where ts + interval '1 hour' > now() or a > 0;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, a, t1._row_id(hidden), $src(hidden)], stream_key: [t1._row_id, $src], pk_columns: [t1._row_id, $src], pk_conflict: NoCheck }
+    └─StreamUnion { all: true }
+      ├─StreamExchange { dist: HashShard(t1._row_id, 0:Int32) }
+      │ └─StreamProject { exprs: [t1.ts, t1.a, t1._row_id, 0:Int32] }
+      │   └─StreamDynamicFilter { predicate: ($expr1 > now), output_watermarks: [[$expr1]], output: [t1.ts, t1.a, $expr1, t1._row_id], cleaned_by_watermark: true }
+      │     ├─StreamProject { exprs: [t1.ts, t1.a, AddWithTimeZone(t1.ts, '01:00:00':Interval, 'UTC':Varchar) as $expr1, t1._row_id] }
+      │     │ └─StreamFilter { predicate: IsNotTrue((t1.a > 0:Int32)) }
+      │     │   └─StreamShare { id: 2 }
+      │     │     └─StreamFilter { predicate: (IsNotTrue((t1.a > 0:Int32)) OR (t1.a > 0:Int32)) }
+      │     │       └─StreamTableScan { table: t1, columns: [t1.ts, t1.a, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+      │     └─StreamExchange { dist: Broadcast }
+      │       └─StreamNow { output: [now] }
+      └─StreamExchange { dist: HashShard(t1._row_id, 1:Int32) }
+        └─StreamProject { exprs: [t1.ts, t1.a, t1._row_id, 1:Int32] }
+          └─StreamFilter { predicate: (t1.a > 0:Int32) }
+            └─StreamShare { id: 2 }
+              └─StreamFilter { predicate: (IsNotTrue((t1.a > 0:Int32)) OR (t1.a > 0:Int32)) }
+                └─StreamTableScan { table: t1, columns: [t1.ts, t1.a, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
 - name: Temporal filter with or is null
   sql: |
     create table t1 (ts timestamp with time zone);
@@ -380,16 +403,18 @@
       │ └─StreamProject { exprs: [t1.ts, t1._row_id, 0:Int32] }
       │   └─StreamDynamicFilter { predicate: ($expr1 > now), output_watermarks: [[$expr1]], output: [t1.ts, $expr1, t1._row_id], cleaned_by_watermark: true }
       │     ├─StreamProject { exprs: [t1.ts, AddWithTimeZone(t1.ts, '01:00:00':Interval, 'UTC':Varchar) as $expr1, t1._row_id] }
-      │     │ └─StreamFilter { predicate: Not(IsNull(t1.ts)) }
-      │     │   └─StreamShare { id: 1 }
-      │     │     └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+      │     │ └─StreamFilter { predicate: IsNotTrue(IsNull(t1.ts)) }
+      │     │   └─StreamShare { id: 2 }
+      │     │     └─StreamFilter { predicate: (IsNotTrue(IsNull(t1.ts)) OR IsNull(t1.ts)) }
+      │     │       └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
       │     └─StreamExchange { dist: Broadcast }
       │       └─StreamNow { output: [now] }
       └─StreamExchange { dist: HashShard(t1._row_id, 1:Int32) }
         └─StreamProject { exprs: [t1.ts, t1._row_id, 1:Int32] }
           └─StreamFilter { predicate: IsNull(t1.ts) }
-            └─StreamShare { id: 1 }
-              └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+            └─StreamShare { id: 2 }
+              └─StreamFilter { predicate: (IsNotTrue(IsNull(t1.ts)) OR IsNull(t1.ts)) }
+                └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
 - name: Temporal filter with or predicate
   sql: |
     create table t1 (ts timestamp with time zone);
@@ -401,9 +426,9 @@
       │ └─StreamProject { exprs: [t1.ts, t1._row_id, 0:Int32] }
       │   └─StreamDynamicFilter { predicate: ($expr1 > now), output_watermarks: [[$expr1]], output: [t1.ts, $expr1, t1._row_id], cleaned_by_watermark: true }
       │     ├─StreamProject { exprs: [t1.ts, AddWithTimeZone(t1.ts, '01:00:00':Interval, 'UTC':Varchar) as $expr1, t1._row_id] }
-      │     │ └─StreamFilter { predicate: Not((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) AND Not(IsNull(t1.ts)) }
+      │     │ └─StreamFilter { predicate: IsNotTrue(((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz) OR IsNull(t1.ts))) }
       │     │   └─StreamShare { id: 2 }
-      │     │     └─StreamFilter { predicate: (((Not((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) AND Not(IsNull(t1.ts))) OR (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) OR IsNull(t1.ts)) }
+      │     │     └─StreamFilter { predicate: ((IsNotTrue(((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz) OR IsNull(t1.ts))) OR (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) OR IsNull(t1.ts)) }
       │     │       └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
       │     └─StreamExchange { dist: Broadcast }
       │       └─StreamNow { output: [now] }
@@ -411,7 +436,7 @@
         └─StreamProject { exprs: [t1.ts, t1._row_id, 1:Int32] }
           └─StreamFilter { predicate: ((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz) OR IsNull(t1.ts)) }
             └─StreamShare { id: 2 }
-              └─StreamFilter { predicate: (((Not((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) AND Not(IsNull(t1.ts))) OR (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) OR IsNull(t1.ts)) }
+              └─StreamFilter { predicate: ((IsNotTrue(((t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz) OR IsNull(t1.ts))) OR (t1.ts > '2023-12-18 00:00:00+00:00':Timestamptz)) OR IsNull(t1.ts)) }
                 └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
 - name: Many Temporal filter with or predicate
   sql: |
@@ -423,24 +448,24 @@
       ├─StreamExchange { dist: HashShard(t._row_id, $src, 0:Int32) }
       │ └─StreamProject { exprs: [t.t, t.a, t._row_id, $src, 0:Int32] }
       │   └─StreamDynamicFilter { predicate: (t.t < $expr2), output: [t.t, t.a, t._row_id, $src], cleaned_by_watermark: true }
-      │     ├─StreamFilter { predicate: Not((t.a > 1:Int32)) }
+      │     ├─StreamFilter { predicate: IsNotTrue((t.a > 1:Int32)) }
       │     │ └─StreamShare { id: 13 }
       │     │   └─StreamUnion { all: true }
       │     │     ├─StreamExchange { dist: HashShard(t._row_id, 0:Int32) }
       │     │     │ └─StreamProject { exprs: [t.t, t.a, t._row_id, 0:Int32], output_watermarks: [[t.t]] }
       │     │     │   └─StreamDynamicFilter { predicate: (t.t > $expr1), output_watermarks: [[t.t]], output: [t.t, t.a, t._row_id], cleaned_by_watermark: true }
-      │     │     │     ├─StreamFilter { predicate: IsNotNull(t.a) AND Not(IsNull(t.t)) AND Not((t.a < 1:Int32)) }
+      │     │     │     ├─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND IsNotTrue((IsNull(t.t) OR (t.a < 1:Int32))) }
       │     │     │     │ └─StreamShare { id: 2 }
-      │     │     │     │   └─StreamFilter { predicate: IsNotNull(t.a) AND (((Not(IsNull(t.t)) AND Not((t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
+      │     │     │     │   └─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND ((IsNotTrue((IsNull(t.t) OR (t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
       │     │     │     │     └─StreamTableScan { table: t, columns: [t.t, t.a, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
       │     │     │     └─StreamExchange { dist: Broadcast }
       │     │     │       └─StreamProject { exprs: [SubtractWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [[$expr1]], noop_update_hint: true }
       │     │     │         └─StreamNow { output: [now] }
       │     │     └─StreamExchange { dist: HashShard(t._row_id, 1:Int32) }
       │     │       └─StreamProject { exprs: [t.t, t.a, t._row_id, 1:Int32] }
-      │     │         └─StreamFilter { predicate: IsNotNull(t.a) AND (IsNull(t.t) OR (t.a < 1:Int32)) }
+      │     │         └─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND (IsNull(t.t) OR (t.a < 1:Int32)) }
       │     │           └─StreamShare { id: 2 }
-      │     │             └─StreamFilter { predicate: IsNotNull(t.a) AND (((Not(IsNull(t.t)) AND Not((t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
+      │     │             └─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND ((IsNotTrue((IsNull(t.t) OR (t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
       │     │               └─StreamTableScan { table: t, columns: [t.t, t.a, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
       │     └─StreamExchange { dist: Broadcast }
       │       └─StreamProject { exprs: [SubtractWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
@@ -453,18 +478,18 @@
                 ├─StreamExchange { dist: HashShard(t._row_id, 0:Int32) }
                 │ └─StreamProject { exprs: [t.t, t.a, t._row_id, 0:Int32], output_watermarks: [[t.t]] }
                 │   └─StreamDynamicFilter { predicate: (t.t > $expr1), output_watermarks: [[t.t]], output: [t.t, t.a, t._row_id], cleaned_by_watermark: true }
-                │     ├─StreamFilter { predicate: IsNotNull(t.a) AND Not(IsNull(t.t)) AND Not((t.a < 1:Int32)) }
+                │     ├─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND IsNotTrue((IsNull(t.t) OR (t.a < 1:Int32))) }
                 │     │ └─StreamShare { id: 2 }
-                │     │   └─StreamFilter { predicate: IsNotNull(t.a) AND (((Not(IsNull(t.t)) AND Not((t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
+                │     │   └─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND ((IsNotTrue((IsNull(t.t) OR (t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
                 │     │     └─StreamTableScan { table: t, columns: [t.t, t.a, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
                 │     └─StreamExchange { dist: Broadcast }
                 │       └─StreamProject { exprs: [SubtractWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [[$expr1]], noop_update_hint: true }
                 │         └─StreamNow { output: [now] }
                 └─StreamExchange { dist: HashShard(t._row_id, 1:Int32) }
                   └─StreamProject { exprs: [t.t, t.a, t._row_id, 1:Int32] }
-                    └─StreamFilter { predicate: IsNotNull(t.a) AND (IsNull(t.t) OR (t.a < 1:Int32)) }
+                    └─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND (IsNull(t.t) OR (t.a < 1:Int32)) }
                       └─StreamShare { id: 2 }
-                        └─StreamFilter { predicate: IsNotNull(t.a) AND (((Not(IsNull(t.t)) AND Not((t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
+                        └─StreamFilter { predicate: (IsNotTrue((t.a > 1:Int32)) OR (t.a > 1:Int32)) AND ((IsNotTrue((IsNull(t.t) OR (t.a < 1:Int32))) OR IsNull(t.t)) OR (t.a < 1:Int32)) }
                           └─StreamTableScan { table: t, columns: [t.t, t.a, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: Non-trivial now expression
   sql: |
@@ -578,27 +603,29 @@
       │ └─StreamProject { exprs: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id, t1.ta, t2.tb, 0:Int32], output_watermarks: [[t1.ta, t1.ta]] }
       │   └─StreamDynamicFilter { predicate: (t1.ta >= $expr1), output_watermarks: [[t1.ta]], output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id], cleaned_by_watermark: true }
       │     ├─StreamExchange { dist: HashShard(t1.ta, t2.tb, t1._row_id, t2._row_id) }
-      │     │ └─StreamFilter { predicate: Not(IsNull(t1.ta)) }
-      │     │   └─StreamShare { id: 5 }
-      │     │     └─StreamFilter { predicate: ((IsNotNull(t1._row_id) OR IsNotNull(t2._row_id)) OR (IsNotNull(t1.ta) OR IsNotNull(t2.tb))) }
-      │     │       └─StreamHashJoin { type: FullOuter, predicate: t1.ta = t2.tb, output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id] }
-      │     │         ├─StreamExchange { dist: HashShard(t1.ta) }
-      │     │         │ └─StreamTableScan { table: t1, columns: [t1.a, t1.ta, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
-      │     │         └─StreamExchange { dist: HashShard(t2.tb) }
-      │     │           └─StreamTableScan { table: t2, columns: [t2.b, t2.tb, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
+      │     │ └─StreamFilter { predicate: IsNotTrue(IsNull(t1.ta)) }
+      │     │   └─StreamShare { id: 6 }
+      │     │     └─StreamFilter { predicate: (IsNotTrue(IsNull(t1.ta)) OR IsNull(t1.ta)) }
+      │     │       └─StreamFilter { predicate: ((IsNotNull(t1._row_id) OR IsNotNull(t2._row_id)) OR (IsNotNull(t1.ta) OR IsNotNull(t2.tb))) }
+      │     │         └─StreamHashJoin { type: FullOuter, predicate: t1.ta = t2.tb, output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id] }
+      │     │           ├─StreamExchange { dist: HashShard(t1.ta) }
+      │     │           │ └─StreamTableScan { table: t1, columns: [t1.a, t1.ta, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+      │     │           └─StreamExchange { dist: HashShard(t2.tb) }
+      │     │             └─StreamTableScan { table: t2, columns: [t2.b, t2.tb, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
       │     └─StreamExchange { dist: Broadcast }
       │       └─StreamProject { exprs: [SubtractWithTimeZone(now, '02:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [[$expr1]], noop_update_hint: true }
       │         └─StreamNow { output: [now] }
       └─StreamExchange { dist: HashShard(t1._row_id, t2._row_id, t1.ta, t2.tb, 1:Int32) }
         └─StreamProject { exprs: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id, t1.ta, t2.tb, 1:Int32] }
           └─StreamFilter { predicate: IsNull(t1.ta) }
-            └─StreamShare { id: 5 }
-              └─StreamFilter { predicate: ((IsNotNull(t1._row_id) OR IsNotNull(t2._row_id)) OR (IsNotNull(t1.ta) OR IsNotNull(t2.tb))) }
-                └─StreamHashJoin { type: FullOuter, predicate: t1.ta = t2.tb, output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id] }
-                  ├─StreamExchange { dist: HashShard(t1.ta) }
-                  │ └─StreamTableScan { table: t1, columns: [t1.a, t1.ta, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
-                  └─StreamExchange { dist: HashShard(t2.tb) }
-                    └─StreamTableScan { table: t2, columns: [t2.b, t2.tb, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
+            └─StreamShare { id: 6 }
+              └─StreamFilter { predicate: (IsNotTrue(IsNull(t1.ta)) OR IsNull(t1.ta)) }
+                └─StreamFilter { predicate: ((IsNotNull(t1._row_id) OR IsNotNull(t2._row_id)) OR (IsNotNull(t1.ta) OR IsNotNull(t2.tb))) }
+                  └─StreamHashJoin { type: FullOuter, predicate: t1.ta = t2.tb, output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id] }
+                    ├─StreamExchange { dist: HashShard(t1.ta) }
+                    │ └─StreamTableScan { table: t1, columns: [t1.a, t1.ta, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+                    └─StreamExchange { dist: HashShard(t2.tb) }
+                      └─StreamTableScan { table: t2, columns: [t2.b, t2.tb, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [a, ta, b, tb, t1._row_id(hidden), t2._row_id(hidden), t1.ta(hidden), t2.tb(hidden), $src(hidden)], stream_key: [t1._row_id, t2._row_id, t1.ta, t2.tb, $src], pk_columns: [t1._row_id, t2._row_id, t1.ta, t2.tb, $src], pk_conflict: NoCheck }
@@ -613,14 +640,15 @@
         └── StreamExchange Broadcast from 6
 
     Fragment 2
-    StreamFilter { predicate: Not(IsNull(t1.ta)) }
+    StreamFilter { predicate: IsNotTrue(IsNull(t1.ta)) }
     └── StreamExchange NoShuffle from 3
 
     Fragment 3
-    StreamFilter { predicate: ((IsNotNull(t1._row_id) OR IsNotNull(t2._row_id)) OR (IsNotNull(t1.ta) OR IsNotNull(t2.tb))) }
-    └── StreamHashJoin { type: FullOuter, predicate: t1.ta = t2.tb, output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id] } { tables: [ HashJoinLeft: 2, HashJoinDegreeLeft: 3, HashJoinRight: 4, HashJoinDegreeRight: 5 ] }
-        ├── StreamExchange Hash([1]) from 4
-        └── StreamExchange Hash([1]) from 5
+    StreamFilter { predicate: (IsNotTrue(IsNull(t1.ta)) OR IsNull(t1.ta)) }
+    └── StreamFilter { predicate: ((IsNotNull(t1._row_id) OR IsNotNull(t2._row_id)) OR (IsNotNull(t1.ta) OR IsNotNull(t2.tb))) }
+        └── StreamHashJoin { type: FullOuter, predicate: t1.ta = t2.tb, output: [t1.a, t1.ta, t2.b, t2.tb, t1._row_id, t2._row_id] } { tables: [ HashJoinLeft: 2, HashJoinDegreeLeft: 3, HashJoinRight: 4, HashJoinDegreeRight: 5 ] }
+            ├── StreamExchange Hash([1]) from 4
+            └── StreamExchange Hash([1]) from 5
 
     Fragment 4
     StreamTableScan { table: t1, columns: [t1.a, t1.ta, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) } { tables: [ StreamScan: 6 ] }

--- a/src/frontend/src/optimizer/rule/stream/split_now_or_rule.rs
+++ b/src/frontend/src/optimizer/rule/stream/split_now_or_rule.rs
@@ -21,7 +21,7 @@ use crate::optimizer::rule::prelude::{PlanRef, *};
 /// Convert `LogicalFilter` with now or others predicates to a `UNION ALL`
 ///
 /// Before:
-/// ```text
+/// ```
 /// `LogicalFilter`
 ///  now() or others
 ///        |
@@ -33,7 +33,8 @@ use crate::optimizer::rule::prelude::{PlanRef, *};
 ///         `LogicalUnionAll`
 ///         /              \
 /// `LogicalFilter`     `LogicalFilter`
-/// now() & !others        others
+/// now() & others IS      others
+///        NOT TRUE
 ///         |               |
 ///         \              /
 ///         `LogicalShare`
@@ -64,15 +65,23 @@ impl Rule<Logical> for SplitNowOrRule {
             return None;
         }
 
-        // A or B or C ... or Z
+        // A or B or C ... or Z, where A is the now() arm.
         // =>
-        // + A & !B & !C ... &!Z
+        // + A & (B | C ... | Z) IS NOT TRUE
         // + B | C ... | Z
+        //
+        // Do not use `NOT (B | C ... | Z)` here: in SQL three-valued logic,
+        // `NOT NULL` is still `NULL`, while this branch must keep rows where
+        // the non-now arms are not true and the now() arm is true.
 
-        let arm1 = ExprImpl::and(now.into_iter().chain(others.iter().map(|pred| {
-            FunctionCall::new_unchecked(ExprType::Not, vec![pred.clone()], DataType::Boolean).into()
-        })));
         let arm2 = ExprImpl::or(others);
+        let arm1 = ExprImpl::and([
+            now.into_iter()
+                .next()
+                .expect("there should be exactly one now() arm"),
+            FunctionCall::new_unchecked(ExprType::IsNotTrue, vec![arm2.clone()], DataType::Boolean)
+                .into(),
+        ]);
 
         let share = LogicalShare::create(input);
         let filter1 = LogicalFilter::create_with_expr(share.clone(), arm1);

--- a/src/frontend/src/optimizer/rule/stream/split_now_or_rule.rs
+++ b/src/frontend/src/optimizer/rule/stream/split_now_or_rule.rs
@@ -21,7 +21,7 @@ use crate::optimizer::rule::prelude::{PlanRef, *};
 /// Convert `LogicalFilter` with now or others predicates to a `UNION ALL`
 ///
 /// Before:
-/// ```
+/// ```text
 /// `LogicalFilter`
 ///  now() or others
 ///        |


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



- Fix `SplitNowOrRule` to preserve SQL three-valued logic when splitting `now_arm OR others`.

- The previous rewrite used `NOT others` for the `now()` branch, which incorrectly drops rows where `others` evaluates to `NULL` and the `now()` arm is `TRUE`. This changes the split condition to `others IS NOT TRUE`, keeping `UNION ALL` branches disjoint while preserving nullable predicate semantics.



## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
