### PR TITLE
fix(meta): skip missing drop jobs in barrier worker

### DIFF
--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -799,21 +799,9 @@ impl DatabaseCheckpointControl {
 
             Some(Command::DropStreamingJobs {
                 streaming_job_ids,
-                unregistered_fragment_ids,
+                unregistered_state_table_ids: _,
                 dropped_sink_fragment_by_targets,
-                ..
             }) => {
-                let actors = self
-                    .database_info
-                    .fragment_infos()
-                    .filter(|fragment| {
-                        self.database_info
-                            .job_id_by_fragment(fragment.fragment_id)
-                            .is_some_and(|job_id| streaming_job_ids.contains(&job_id))
-                    })
-                    .flat_map(|fragment| fragment.actors.keys().copied())
-                    .collect::<Vec<_>>();
-
                 // pre_apply: drop node upstream for sink targets
                 for (target_fragment, sink_fragments) in &dropped_sink_fragment_by_targets {
                     self.database_info
@@ -822,9 +810,20 @@ impl DatabaseCheckpointControl {
 
                 let (table_ids, node_actors) = self.collect_base_info();
 
-                // post_apply: remove fragments
-                self.database_info
-                    .post_apply_remove_fragments(unregistered_fragment_ids.iter().cloned());
+                let mut actors = Vec::new();
+                for job_id in streaming_job_ids {
+                    let Some(job) = self.database_info.post_apply_remove_job(job_id) else {
+                        warn!(
+                            %job_id,
+                            "skip drop payload for streaming job that has already been removed from barrier worker"
+                        );
+                        continue;
+                    };
+
+                    for fragment in job.fragment_infos.values() {
+                        actors.extend(fragment.actors.keys().copied());
+                    }
+                }
 
                 let mutation = Some(Command::drop_streaming_jobs_to_mutation(
                     &actors,

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -450,7 +450,6 @@ pub enum Command {
         streaming_job_ids: HashSet<JobId>,
         /// Used by recovery quick path when draining buffered drop/cancel commands.
         unregistered_state_table_ids: HashSet<TableId>,
-        unregistered_fragment_ids: HashSet<FragmentId>,
         // target_fragment -> [sink_fragments]
         dropped_sink_fragment_by_targets: HashMap<FragmentId, Vec<FragmentId>>,
     },

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -1101,6 +1101,14 @@ impl InflightDatabaseInfo {
         fragment_id: FragmentId,
         drop_upstream_fragment_ids: &[FragmentId],
     ) {
+        if !self.fragment_location.contains_key(&fragment_id) {
+            warn!(
+                target_fragment_id = %fragment_id,
+                drop_upstream_fragment_ids = ?drop_upstream_fragment_ids,
+                "skip dropping upstream sink fragments for non-existing target fragment"
+            );
+            return;
+        }
         {
             {
                 {
@@ -1352,6 +1360,23 @@ impl InflightDatabaseInfo {
             }
         }
         shared_actor_writer.finish();
+    }
+
+    pub(crate) fn post_apply_remove_job(
+        &mut self,
+        job_id: JobId,
+    ) -> Option<InflightStreamingJobInfo> {
+        let job = self.jobs.remove(&job_id)?;
+        let inner = self.shared_actor_infos.clone();
+        let mut shared_actor_writer = inner.start_writer(self.database_id);
+        for (fragment_id, fragment) in &job.fragment_infos {
+            self.fragment_location
+                .remove(fragment_id)
+                .expect("should exist");
+            shared_actor_writer.remove(fragment);
+        }
+        shared_actor_writer.finish();
+        Some(job)
     }
 }
 

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -740,7 +740,6 @@ impl CatalogController {
         Ok(Command::DropStreamingJobs {
             streaming_job_ids: HashSet::from_iter([table_fragments.stream_job_id()]),
             unregistered_state_table_ids: table_fragments.all_table_ids().collect(),
-            unregistered_fragment_ids: table_fragments.fragment_ids().collect(),
             dropped_sink_fragment_by_targets: dropped_sink_fragment_with_target
                 .into_iter()
                 .map(|(sink, target)| (target as _, vec![sink as _]))

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1316,7 +1316,6 @@ impl DdlController {
                 database_id,
                 removed_streaming_job_ids,
                 removed_state_table_ids,
-                removed_fragments.iter().map(|id| *id as _).collect(),
                 removed_sink_fragment_by_targets
                     .into_iter()
                     .map(|(target, sinks)| {

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use await_tree::span;
@@ -666,7 +666,6 @@ impl GlobalStreamManager {
         database_id: DatabaseId,
         streaming_job_ids: Vec<JobId>,
         state_table_ids: Vec<TableId>,
-        fragment_ids: HashSet<FragmentId>,
         dropped_sink_fragment_by_targets: HashMap<FragmentId, Vec<FragmentId>>,
     ) {
         if !streaming_job_ids.is_empty() || !state_table_ids.is_empty() {
@@ -679,7 +678,6 @@ impl GlobalStreamManager {
                     Command::DropStreamingJobs {
                         streaming_job_ids: streaming_job_ids.into_iter().collect(),
                         unregistered_state_table_ids: state_table_ids.iter().copied().collect(),
-                        unregistered_fragment_ids: fragment_ids,
                         dropped_sink_fragment_by_targets,
                     },
                 )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR fixes the meta-node panic reported in #25516 when the global barrier worker applies a `DropStreamingJobs` command after one of the jobs in that command has already been removed from inflight barrier state.

The change keeps the original drop sequencing in `apply_command`: it first applies upstream sink cleanup, then collects base info, and only then removes inflight jobs. During that post-collect removal loop, the barrier worker now tries to remove each job one by one. If a job is already missing, it logs a warning and continues instead of panicking on the old `should exist` path.

The command payload is also simplified by removing `unregistered_fragment_ids`, since dropped fragments can be derived from the removed inflight job state directly in the barrier worker.

- Closes #25516

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwave-labs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed a meta-node panic that could happen while dropping streaming jobs if the barrier worker had already removed one of the dropped jobs from inflight state.

</details>
