### PR TITLE
fix(sqlserver-cdc): tolerate ill-formed UTF-16 in nvarchar/ntext payloads (#25596)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15096,7 +15096,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.12.2"
-source = "git+https://github.com/risingwavelabs/tiberius.git?rev=59350b92775a61611cf1fc3a5d0ff38bf264e6ac#59350b92775a61611cf1fc3a5d0ff38bf264e6ac"
+source = "git+https://github.com/risingwavelabs/tiberius.git?rev=cd69774fb1a4e08c0a3ea3b2041de7cc09662464#cd69774fb1a4e08c0a3ea3b2041de7cc09662464"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -184,7 +184,7 @@ thiserror = { workspace = true }
 thiserror-ext = { workspace = true }
 # To easiy get the type_name and impl IntoSql for rust_decimal, we fork the crate.
 # Another reason is that we are planning to refactor their IntoSql trait to allow specifying the type to convert.
-tiberius = { git = "https://github.com/risingwavelabs/tiberius.git", rev = "59350b92775a61611cf1fc3a5d0ff38bf264e6ac", default-features = false, features = [
+tiberius = { git = "https://github.com/risingwavelabs/tiberius.git", rev = "cd69774fb1a4e08c0a3ea3b2041de7cc09662464", default-features = false, features = [
     "chrono",
     "sql-browser-tokio",
     "rustls",


### PR DESCRIPTION
Cherry-pick of #25596 onto `release-2.8`.

> **Backport urgency: high — customer-blocking.** A production SQL Server CDC pipeline is stalled on this exact bug; backfill makes zero forward progress until the fix ships on 2.8.

## Summary

Bump `tiberius` to `risingwavelabs/tiberius@cd69774f`, which switches `nvarchar` / `ntext` column-data decoding from `String::from_utf16` (strict) to `from_utf16_lossy`.

## Why this matters

SQL Server does not enforce well-formed UTF-16 in `nvarchar` storage. A row containing a **lone surrogate** (e.g. `NCHAR(0xD83D)` without its low-surrogate partner — produced in practice by legacy ETL, MERGE replication, and buggy clients) causes `tiberius` to reject the entire snapshot chunk with `FromUtf16Error`.

In CDC backfill the bad chunk wipes the in-flight result stream, the consumer re-issues from the last persisted LSN / PK, and immediately re-hits the same chunk → **infinite retry loop, zero forward progress**. Observed in the affected customer's pipeline stalled at ~210k rows (chunk #211 at the default `snapshot.batch_size = 1000`).

After this bump, lone surrogates decode to `U+FFFD` and backfill survives. Protocol-level UTF-16 paths in `tiberius` (env-change tokens, login, identifiers) remain strict on purpose — those decode server-controlled metadata where a malformed value indicates a real TDS protocol violation.

Upstream tiberius PR: https://github.com/risingwavelabs/tiberius/pull/2
Main PR: https://github.com/risingwavelabs/risingwave/pull/25596

## Test plan — red / green confirmed

Reproduction script: `wcy-tools/mssql-cdc/repro_utf16.sh` — 100 normal rows + 1 row containing `NCHAR(0xD83D)` + 1 tail row (101 total).

- **Pre-fix (rev `59350b92`)**: `RED` — backfill stalls, `FromUtf16Error` from `<ConnectorError as From<tiberius::error::Error>>::from` in the connector log.
- **Post-fix (rev `cd69774f`, this PR)**: `GREEN` — backfill completes 101/101. The bad row lands in RW as:

  ```
   k  |   v
  ----+-------
   50 | lone�
  ```

  (`�` = `U+FFFD`, replacement codepoint).