### PR TITLE
feat(optimizer): support column pruning for expand

### DIFF
--- a/e2e_test/batch/grouping_sets/grouping_sets.slt
+++ b/e2e_test/batch/grouping_sets/grouping_sets.slt
@@ -16,5 +16,11 @@ NULL L 15 1 0 2 2
 NULL M 35 1 0 2 2
 NULL NULL 50 1 1 3 4
 
+query I rowsort
+SELECT count(*) FROM items_sold GROUP BY GROUPING SETS ((), ());
+----
+4
+4
+
 statement ok
 drop table items_sold;

--- a/e2e_test/streaming/aggregate/distinct_agg_with_row_id.slt
+++ b/e2e_test/streaming/aggregate/distinct_agg_with_row_id.slt
@@ -1,4 +1,4 @@
-# Test for issue #20187: count(distinct _row_id) causing other count(distinct ...) producing wrong result
+# Regression coverage for split distinct aggregation when one distinct argument is `_row_id`.
 
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
@@ -9,19 +9,27 @@ create table t (foo int, bar int);
 statement ok
 insert into t values (1, 1), (2, 2), (1, 1);
 
-# This should work correctly
+# Baseline without `_row_id`.
 query II
 select count(foo), count(distinct foo) from t;
 ----
 3 2
 
-# This triggers the bug: count(distinct foo) returns 1 instead of 2
+# `_row_id` must not affect deduplication for the other distinct aggregate.
 query III
 select count(foo), count(distinct foo), count(distinct _row_id) from t;
 ----
 3 2 3
 
-# This should also work correctly
+statement ok
+create materialized view mv_distinct_agg_with_row_id as select count(foo) as c1, count(distinct foo) as c2, count(distinct _row_id) as c3 from t;
+
+query III
+select * from mv_distinct_agg_with_row_id;
+----
+3 2 3
+
+# Another distinct aggregate on a user column should still work correctly.
 query III
 select count(foo), count(distinct foo), count(distinct bar) from t;
 ----
@@ -33,6 +41,9 @@ select bar, count(foo), count(distinct foo), count(distinct _row_id) from t grou
 ----
 1 2 1 2
 2 1 1 1
+
+statement ok
+drop materialized view mv_distinct_agg_with_row_id;
 
 statement ok
 drop table t;

--- a/e2e_test/streaming/grouping_sets/grouping_sets.slt
+++ b/e2e_test/streaming/grouping_sets/grouping_sets.slt
@@ -20,6 +20,18 @@ NULL M 35 1 0 2 2
 NULL NULL 50 1 1 3 4
 
 statement ok
+create materialized view v_flag_only as SELECT count(*) FROM items_sold GROUP BY GROUPING SETS ((), ());
+
+query I rowsort
+select * from v_flag_only;
+----
+4
+4
+
+statement ok
+drop materialized view v_flag_only;
+
+statement ok
 drop materialized view v;
 
 statement ok

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -575,6 +575,13 @@
   - optimized_logical_plan_for_stream
   with_config_map:
     RW_FORCE_SPLIT_DISTINCT_AGG: 'true'
+- name: grouping sets can require only expand flag
+  sql: |
+    create table t(a int);
+    select count(*) from t group by grouping sets ((), ());
+  expected_outputs:
+  - optimized_logical_plan_for_batch
+  - optimized_logical_plan_for_stream
 - name: split distinct agg with row id prunes hidden columns
   sql: |
     create table t(foo int, bar int);

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -575,6 +575,12 @@
   - optimized_logical_plan_for_stream
   with_config_map:
     RW_FORCE_SPLIT_DISTINCT_AGG: 'true'
+- name: split distinct agg with row id prunes hidden columns
+  sql: |
+    create table t(foo int, bar int);
+    explain (verbose) create materialized view mv_distinct_agg_with_row_id as select count(foo) as c1, count(distinct foo) as c2, count(distinct _row_id) as c3 from t;
+  expected_outputs:
+  - explain_output
 - name: remove unnecessary distinct for max and min
   sql: |
     create table t(x int, y int);

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1083,9 +1083,24 @@
     LogicalAgg { aggs: [count(t.x_expanded) filter((flag = 0:Int64)), sum(t.y_expanded) filter((flag = 1:Int64))] }
     └─LogicalAgg { group_key: [t.x_expanded, t.y_expanded, flag], aggs: [] }
       └─LogicalExpand { column_subsets: [[t.x], [t.y]] }
-        └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id, t._rw_timestamp] }
+        └─LogicalScan { table: t, columns: [t.x, t.y] }
   with_config_map:
     RW_FORCE_SPLIT_DISTINCT_AGG: 'true'
+- name: split distinct agg with row id prunes hidden columns
+  sql: |
+    create table t(foo int, bar int);
+    explain (verbose) create materialized view mv_distinct_agg_with_row_id as select count(foo) as c1, count(distinct foo) as c2, count(distinct _row_id) as c3 from t;
+  explain_output: |
+    StreamMaterialize { columns: [c1, c2, c3], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [sum0(sum0(count(t.foo_expanded)) filter((flag = 0:Int64))), sum0(count(t.foo_expanded) filter((flag = 0:Int64))), sum0(count(t._row_id_expanded) filter((flag = 1:Int64)))] }
+      └─StreamSimpleAgg [append_only] { aggs: [sum0(sum0(count(t.foo_expanded)) filter((flag = 0:Int64))), sum0(count(t.foo_expanded) filter((flag = 0:Int64))), sum0(count(t._row_id_expanded) filter((flag = 1:Int64))), count] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessSimpleAgg { aggs: [sum0(count(t.foo_expanded)) filter((flag = 0:Int64)), count(t.foo_expanded) filter((flag = 0:Int64)), count(t._row_id_expanded) filter((flag = 1:Int64))] }
+            └─StreamProject { exprs: [t.foo_expanded, t._row_id_expanded, flag, count(t.foo_expanded)] }
+              └─StreamHashAgg { group_key: [t.foo_expanded, t._row_id_expanded, flag], aggs: [count(t.foo_expanded), count] }
+                └─StreamExchange { dist: HashShard(t.foo_expanded, t._row_id_expanded, flag) }
+                  └─StreamExpand { column_subsets: [[t.foo], [t._row_id]] }
+                    └─StreamTableScan { table: t, columns: [t.foo, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: remove unnecessary distinct for max and min
   sql: |
     create table t(x int, y int);

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -1086,6 +1086,20 @@
         └─LogicalScan { table: t, columns: [t.x, t.y] }
   with_config_map:
     RW_FORCE_SPLIT_DISTINCT_AGG: 'true'
+- name: grouping sets can require only expand flag
+  sql: |
+    create table t(a int);
+    select count(*) from t group by grouping sets ((), ());
+  optimized_logical_plan_for_batch: |-
+    LogicalProject { exprs: [count] }
+    └─LogicalAgg { group_key: [flag], aggs: [count] }
+      └─LogicalExpand { column_subsets: [[], []] }
+        └─LogicalScan { table: t, columns: [] }
+  optimized_logical_plan_for_stream: |-
+    LogicalProject { exprs: [count] }
+    └─LogicalAgg { group_key: [flag], aggs: [count] }
+      └─LogicalExpand { column_subsets: [[], []] }
+        └─LogicalScan { table: t, columns: [] }
 - name: split distinct agg with row id prunes hidden columns
   sql: |
     create table t(foo int, bar int);

--- a/src/frontend/planner_test/tests/testdata/output/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery.yaml
@@ -739,12 +739,12 @@
             └─BatchHashAgg { group_key: [integers.correlated_col_expanded, rows.k_expanded, rows.v_expanded, flag], aggs: [] }
               └─BatchExchange { order: [], dist: HashShard(integers.correlated_col_expanded, rows.k_expanded, rows.v_expanded, flag) }
                 └─BatchExpand { column_subsets: [[integers.correlated_col, rows.k], [integers.correlated_col, rows.v]] }
-                  └─BatchHashJoin { type: LeftOuter, predicate: integers.correlated_col IS NOT DISTINCT FROM rows.correlated_col, output: [integers.correlated_col, rows.k, rows.v, 1:Int32] }
+                  └─BatchHashJoin { type: LeftOuter, predicate: integers.correlated_col IS NOT DISTINCT FROM rows.correlated_col, output: [integers.correlated_col, rows.k, rows.v] }
                     ├─BatchHashAgg { group_key: [integers.correlated_col], aggs: [] }
                     │ └─BatchExchange { order: [], dist: HashShard(integers.correlated_col) }
                     │   └─BatchScan { table: integers, columns: [integers.correlated_col], distribution: SomeShard }
                     └─BatchExchange { order: [], dist: HashShard(rows.correlated_col) }
-                      └─BatchProject { exprs: [rows.correlated_col, rows.k, rows.v, 1:Int32] }
+                      └─BatchProject { exprs: [rows.correlated_col, rows.k, rows.v] }
                         └─BatchFilter { predicate: IsNotNull(rows.correlated_col) }
                           └─BatchScan { table: rows, columns: [rows.k, rows.v, rows.correlated_col], distribution: SomeShard }
   stream_plan: |-

--- a/src/frontend/src/optimizer/plan_node/logical_expand.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_expand.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 
 use super::generic::GenericPlanRef;
@@ -131,14 +132,31 @@ impl_distill_by_unit!(LogicalExpand, core, "LogicalExpand");
 
 impl ColPrunable for LogicalExpand {
     fn prune_col(&self, required_cols: &[usize], ctx: &mut ColumnPruningContext) -> PlanRef {
-        // No pruning.
-        let input_required_cols = (0..self.input().schema().len()).collect_vec();
-        LogicalProject::with_out_col_idx(
-            self.clone_with_input(self.input().prune_col(&input_required_cols, ctx))
-                .into(),
-            required_cols.iter().cloned(),
-        )
-        .into()
+        let input_len = self.input().schema().len();
+        let mut input_required_cols = FixedBitSet::with_capacity(input_len);
+        for &idx in required_cols {
+            if idx < input_len {
+                input_required_cols.insert(idx);
+            } else if idx < input_len * 2 {
+                input_required_cols.insert(idx - input_len);
+            } else {
+                assert_eq!(idx, input_len * 2);
+            }
+        }
+        let input_required_cols = input_required_cols.ones().collect_vec();
+        let input_col_change =
+            ColIndexMapping::with_remaining_columns(&input_required_cols, input_len);
+        let input = self.input().prune_col(&input_required_cols, ctx);
+        let (expand, out_col_change) = self.rewrite_with_input(input, input_col_change);
+        let output_required_cols = required_cols
+            .iter()
+            .map(|idx| {
+                out_col_change
+                    .try_map(*idx)
+                    .expect("required column should be kept")
+            })
+            .collect_vec();
+        LogicalProject::with_out_col_idx(expand.into(), output_required_cols.into_iter()).into()
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Column pruning is now supported for the expand operator. Previously, column pooling was not supported for the expand operator, which caused an issue: when a system column was selected, it could not be verified. For example, the rw_timestamp could not be pruned causing failure of creating mv.

- Closes #[ISSUE_NUMBER]

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
