### PR TITLE
refactor: clarify create source binding flow

### DIFF
--- a/src/frontend/src/handler/alter_source_with_sr.rs
+++ b/src/frontend/src/handler/alter_source_with_sr.rs
@@ -35,7 +35,9 @@ use super::{HandlerArgs, RwPgResponse};
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::error::{ErrorCode, Result};
-use crate::handler::create_source::{CreateSourceType, bind_columns_from_source};
+use crate::handler::create_source::{
+    CreateSourceType, SourceCatalogPurpose, bind_columns_from_source,
+};
 use crate::session::SessionImpl;
 use crate::utils::resolve_secret_ref_in_with_options;
 use crate::{Binder, WithOptions};
@@ -166,7 +168,7 @@ pub async fn refresh_sr_and_get_columns_diff(
         session,
         format_encode,
         Either::Right(&with_properties),
-        CreateSourceType::for_replace(original_source),
+        SourceCatalogPurpose::CreateSource(CreateSourceType::for_replace(original_source)),
     )
     .await?
     else {

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -176,8 +176,47 @@ pub enum CreateSourceType {
     /// e.g., shared Kafka source
     SharedNonCdc,
     NonShared,
-    /// create table with connector
-    Table,
+}
+
+/// Why we are creating a source catalog.
+///
+/// This keeps the standalone `CREATE SOURCE` behavior separate from the
+/// associated source catalog created for `CREATE TABLE ... WITH connector`.
+/// The two paths share most binding code, but differ in DDL policy, hidden
+/// source columns, nested type id handling, watermark checks, and whether the
+/// resulting source has an associated table id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceCatalogPurpose {
+    CreateSource(CreateSourceType),
+    CreateTableWithConnector,
+}
+
+impl SourceCatalogPurpose {
+    fn is_create_source(self) -> bool {
+        matches!(self, SourceCatalogPurpose::CreateSource(_))
+    }
+
+    fn create_source_type(self) -> Option<CreateSourceType> {
+        match self {
+            SourceCatalogPurpose::CreateSource(create_source_type) => Some(create_source_type),
+            SourceCatalogPurpose::CreateTableWithConnector => None,
+        }
+    }
+
+    fn is_shared_non_cdc_source(self) -> bool {
+        matches!(
+            self,
+            SourceCatalogPurpose::CreateSource(CreateSourceType::SharedNonCdc)
+        )
+    }
+
+    fn associated_table_id(self) -> Option<TableId> {
+        if self.is_create_source() {
+            None
+        } else {
+            Some(TableId::placeholder())
+        }
+    }
 }
 
 impl CreateSourceType {
@@ -736,75 +775,118 @@ pub(super) fn check_format_encode(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectorPropsPurpose {
+    CreateSource,
+    CreateTableWithConnector,
+}
+
+impl ConnectorPropsPurpose {
+    fn is_create_source(self) -> bool {
+        matches!(self, ConnectorPropsPurpose::CreateSource)
+    }
+}
+
 pub fn bind_connector_props(
     handler_args: &HandlerArgs,
     format_encode: &FormatEncodeOptions,
-    is_create_source: bool,
+    purpose: ConnectorPropsPurpose,
 ) -> Result<(WithOptions, SourceRefreshMode)> {
     let mut with_properties = handler_args.with_options.clone().into_connector_props();
+
+    // Keep this order explicit: compatibility validation may normalize connector
+    // options before later checks read/remove/insert individual fields.
     validate_compatibility(format_encode, &mut with_properties)?;
-    let refresh_mode = {
-        let refresh_mode = resolve_source_refresh_mode_in_with_option(&mut with_properties)?;
-        if is_create_source && refresh_mode.is_some() {
-            return Err(RwError::from(ProtocolError(
-                "`refresh_mode` only supported for CREATE TABLE".to_owned(),
-            )));
-        }
 
-        refresh_mode.unwrap_or(SourceRefreshMode {
-            refresh_mode: Some(RefreshMode::Streaming(SourceRefreshModeStreaming {})),
-        })
-    };
-
+    let refresh_mode = resolve_refresh_mode_for_connector_props(&mut with_properties, purpose)?;
     let create_cdc_source_job = with_properties.is_shareable_cdc_connector();
 
-    if !is_create_source && with_properties.is_shareable_only_cdc_connector() {
+    reject_unsupported_table_connector(&with_properties, purpose)?;
+    if purpose.is_create_source() && create_cdc_source_job {
+        apply_shared_cdc_source_job_defaults(&mut with_properties, handler_args)?;
+    }
+    ensure_mysql_cdc_server_id(&mut with_properties);
+
+    Ok((with_properties, refresh_mode))
+}
+
+fn resolve_refresh_mode_for_connector_props(
+    with_properties: &mut WithOptions,
+    purpose: ConnectorPropsPurpose,
+) -> Result<SourceRefreshMode> {
+    // Resolve and remove `refresh_mode` before connector-purpose defaults are
+    // injected, so only the original user option controls the DDL policy.
+    let refresh_mode = resolve_source_refresh_mode_in_with_option(with_properties)?;
+    if purpose.is_create_source() && refresh_mode.is_some() {
+        return Err(RwError::from(ProtocolError(
+            "`refresh_mode` only supported for CREATE TABLE".to_owned(),
+        )));
+    }
+
+    Ok(refresh_mode.unwrap_or(SourceRefreshMode {
+        refresh_mode: Some(RefreshMode::Streaming(SourceRefreshModeStreaming {})),
+    }))
+}
+
+fn reject_unsupported_table_connector(
+    with_properties: &WithOptions,
+    purpose: ConnectorPropsPurpose,
+) -> Result<()> {
+    if !purpose.is_create_source() && with_properties.is_shareable_only_cdc_connector() {
         return Err(RwError::from(ProtocolError(format!(
             "connector {} does not support `CREATE TABLE`, please use `CREATE SOURCE` instead",
             with_properties.get_connector().unwrap(),
         ))));
     }
-    if is_create_source && create_cdc_source_job {
-        if let Some(value) = with_properties.get(AUTO_SCHEMA_CHANGE_KEY)
-            && value.parse::<bool>().map_err(|_| {
-                ErrorCode::InvalidInputSyntax(format!(
-                    "invalid value of '{}' option",
-                    AUTO_SCHEMA_CHANGE_KEY
-                ))
-            })?
-        {
-            Feature::CdcAutoSchemaChange.check_available()?;
-        }
+    Ok(())
+}
 
-        // set connector to backfill mode
-        with_properties.insert(CDC_SNAPSHOT_MODE_KEY.into(), CDC_SNAPSHOT_BACKFILL.into());
-        // enable cdc sharing mode, which will capture all tables in the given `database.name`
-        with_properties.insert(CDC_SHARING_MODE_KEY.into(), "true".into());
-        // enable transactional cdc
-        if with_properties.enable_transaction_metadata() {
-            with_properties.insert(CDC_TRANSACTIONAL_KEY.into(), "true".into());
-        }
-        // Only set CDC_WAIT_FOR_STREAMING_START_TIMEOUT if not already specified by user.
-        if !with_properties.contains_key(CDC_WAIT_FOR_STREAMING_START_TIMEOUT) {
-            with_properties.insert(
-                CDC_WAIT_FOR_STREAMING_START_TIMEOUT.into(),
-                handler_args
-                    .session
-                    .config()
-                    .cdc_source_wait_streaming_start_timeout()
-                    .to_string(),
-            );
-        }
+fn apply_shared_cdc_source_job_defaults(
+    with_properties: &mut WithOptions,
+    handler_args: &HandlerArgs,
+) -> Result<()> {
+    if let Some(value) = with_properties.get(AUTO_SCHEMA_CHANGE_KEY)
+        && value.parse::<bool>().map_err(|_| {
+            ErrorCode::InvalidInputSyntax(format!(
+                "invalid value of '{}' option",
+                AUTO_SCHEMA_CHANGE_KEY
+            ))
+        })?
+    {
+        Feature::CdcAutoSchemaChange.check_available()?;
     }
+
+    // Set connector to backfill mode.
+    with_properties.insert(CDC_SNAPSHOT_MODE_KEY.into(), CDC_SNAPSHOT_BACKFILL.into());
+    // Enable cdc sharing mode, which will capture all tables in the given `database.name`.
+    with_properties.insert(CDC_SHARING_MODE_KEY.into(), "true".into());
+    // Enable transactional cdc.
+    if with_properties.enable_transaction_metadata() {
+        with_properties.insert(CDC_TRANSACTIONAL_KEY.into(), "true".into());
+    }
+    // Only set CDC_WAIT_FOR_STREAMING_START_TIMEOUT if not already specified by user.
+    if !with_properties.contains_key(CDC_WAIT_FOR_STREAMING_START_TIMEOUT) {
+        with_properties.insert(
+            CDC_WAIT_FOR_STREAMING_START_TIMEOUT.into(),
+            handler_args
+                .session
+                .config()
+                .cdc_source_wait_streaming_start_timeout()
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn ensure_mysql_cdc_server_id(with_properties: &mut WithOptions) {
     if with_properties.is_mysql_cdc_connector() {
-        // Generate a random server id for mysql cdc source if needed
-        // `server.id` (in the range from 1 to 2^32 - 1). This value MUST be unique across whole replication
-        // group (that is, different from any other server id being used by any master or slave)
+        // Generate a random server id for mysql cdc source if needed.
+        // `server.id` (in the range from 1 to 2^32 - 1) must be unique across the whole replication
+        // group (that is, different from any other server id being used by any master or slave).
         with_properties
             .entry("server.id".to_owned())
             .or_insert(rand::rng().random_range(1..u32::MAX).to_string());
     }
-    Ok((with_properties, refresh_mode))
 }
 
 /// When the schema can be inferred from external system (like schema registry),
@@ -847,7 +929,7 @@ pub async fn bind_create_source_or_table_with_connector(
     source_info: StreamSourceInfo,
     include_column_options: IncludeOption,
     col_id_gen: &mut ColumnIdGenerator,
-    create_source_type: CreateSourceType,
+    source_catalog_purpose: SourceCatalogPurpose,
     source_rate_limit: Option<u32>,
     sql_column_strategy: SqlColumnStrategy,
     refresh_mode: SourceRefreshMode,
@@ -858,7 +940,7 @@ pub async fn bind_create_source_or_table_with_connector(
     let (database_id, schema_id) =
         session.get_database_and_schema_id_for_create(schema_name.clone())?;
 
-    let is_create_source = create_source_type != CreateSourceType::Table;
+    let is_create_source = source_catalog_purpose.is_create_source();
 
     if is_create_source {
         // reject refreshable batch source
@@ -962,7 +1044,7 @@ HINT: use `CREATE TABLE <name> WITH (...)` instead of `CREATE TABLE <name> (<col
 
         // For shared sources, we will include partition and offset cols in the SourceExecutor's *output*, to be used by the SourceBackfillExecutor.
         // For shared CDC source, the schema is different. See ColumnCatalog::debezium_cdc_source_cols(), CDC_BACKFILL_TABLE_ADDITIONAL_COLUMNS
-        if create_source_type == CreateSourceType::SharedNonCdc {
+        if source_catalog_purpose.is_shared_non_cdc_source() {
             let (columns_exist, additional_columns) = source_add_partition_offset_cols(
                 &columns,
                 &with_properties.get_connector().unwrap(),
@@ -1081,11 +1163,7 @@ HINT: use `CREATE TABLE <name> WITH (...)` instead of `CREATE TABLE <name> (<col
 
     let definition = handler_args.normalized_sql.clone();
 
-    let associated_table_id = if is_create_source {
-        None
-    } else {
-        Some(TableId::placeholder())
-    };
+    let associated_table_id = source_catalog_purpose.associated_table_id();
     let source = SourceCatalog {
         id: SourceId::placeholder(),
         name: source_name,
@@ -1146,15 +1224,18 @@ pub async fn handle_create_source(
     }
 
     let format_encode = stmt.format_encode.into_v2_with_warning();
-    let (with_properties, refresh_mode) =
-        bind_connector_props(&handler_args, &format_encode, true)?;
+    let (with_properties, refresh_mode) = bind_connector_props(
+        &handler_args,
+        &format_encode,
+        ConnectorPropsPurpose::CreateSource,
+    )?;
 
     let create_source_type = CreateSourceType::for_newly_created(&session, &*with_properties);
     let (columns_from_resolve_source, source_info) = bind_columns_from_source(
         &session,
         &format_encode,
         Either::Left(&with_properties),
-        create_source_type,
+        SourceCatalogPurpose::CreateSource(create_source_type),
     )
     .await?;
     let mut col_id_gen = ColumnIdGenerator::new_initial();
@@ -1182,7 +1263,7 @@ pub async fn handle_create_source(
         source_info,
         stmt.include_column_options,
         &mut col_id_gen,
-        create_source_type,
+        SourceCatalogPurpose::CreateSource(create_source_type),
         overwrite_options.source_rate_limit,
         SqlColumnStrategy::FollowChecked,
         refresh_mode,

--- a/src/frontend/src/handler/create_source/external_schema.rs
+++ b/src/frontend/src/handler/create_source/external_schema.rs
@@ -73,15 +73,18 @@ pub async fn bind_columns_from_source(
     session: &SessionImpl,
     format_encode: &FormatEncodeOptions,
     with_properties: Either<&WithOptions, &WithOptionsSecResolved>,
-    create_source_type: CreateSourceType,
+    source_catalog_purpose: SourceCatalogPurpose,
 ) -> Result<(Option<Vec<ColumnCatalog>>, StreamSourceInfo)> {
+    let create_source_type = source_catalog_purpose.create_source_type();
     let (columns_from_resolve_source, mut source_info) =
-        if create_source_type == CreateSourceType::SharedCdc {
+        if create_source_type == Some(CreateSourceType::SharedCdc) {
             bind_columns_from_source_for_cdc(session, format_encode)?
         } else {
             bind_columns_from_source_for_non_cdc(session, format_encode, with_properties).await?
         };
-    if create_source_type.is_shared() {
+    if let Some(create_source_type) = create_source_type
+        && create_source_type.is_shared()
+    {
         // Note: this field should be called is_shared. Check field doc for more details.
         source_info.cdc_source_job = true;
         source_info.is_distributed = create_source_type == CreateSourceType::SharedNonCdc;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -65,7 +65,10 @@ use risingwave_sqlparser::parser::IncludeOption;
 use thiserror_ext::AsReport;
 
 use super::RwPgResponse;
-use super::create_source::{CreateSourceType, SqlColumnStrategy, bind_columns_from_source};
+use super::create_source::{
+    ConnectorPropsPurpose, CreateSourceType, SourceCatalogPurpose, SqlColumnStrategy,
+    bind_columns_from_source,
+};
 use crate::binder::{Clause, SecureCompareContext, WEBHOOK_PAYLOAD_FIELD_NAME, bind_data_type};
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::source_catalog::SourceCatalog;
@@ -487,8 +490,11 @@ pub(crate) async fn gen_create_table_plan_with_source(
     }
 
     let session = &handler_args.session;
-    let (with_properties, refresh_mode) =
-        bind_connector_props(&handler_args, &format_encode, false)?;
+    let (with_properties, refresh_mode) = bind_connector_props(
+        &handler_args,
+        &format_encode,
+        ConnectorPropsPurpose::CreateTableWithConnector,
+    )?;
     if with_properties.is_shareable_cdc_connector() {
         generated_columns_check_for_cdc_table(&column_defs)?;
         not_null_check_for_cdc_table(&wildcard_idx, &column_defs)?;
@@ -511,7 +517,7 @@ pub(crate) async fn gen_create_table_plan_with_source(
         session,
         &format_encode,
         Either::Left(&with_properties),
-        CreateSourceType::Table,
+        SourceCatalogPurpose::CreateTableWithConnector,
     )
     .await?;
 
@@ -530,7 +536,7 @@ pub(crate) async fn gen_create_table_plan_with_source(
         source_info,
         include_column_options,
         &mut col_id_gen,
-        CreateSourceType::Table,
+        SourceCatalogPurpose::CreateTableWithConnector,
         rate_limit,
         sql_column_strategy,
         refresh_mode,
@@ -2342,8 +2348,11 @@ pub async fn create_iceberg_engine_table(
 
     let overwrite_options = OverwriteOptions::new(&mut source_handler_args);
     let format_encode = create_source_stmt.format_encode.into_v2_with_warning();
-    let (with_properties, refresh_mode) =
-        bind_connector_props(&source_handler_args, &format_encode, true)?;
+    let (with_properties, refresh_mode) = bind_connector_props(
+        &source_handler_args,
+        &format_encode,
+        ConnectorPropsPurpose::CreateSource,
+    )?;
 
     // Create iceberg sink table, used for iceberg source column binding. See `bind_columns_from_source_for_non_cdc` for more details.
     // TODO: We can derive the columns directly from table definition in the future, so that we don't need to pre-create the table catalog.
@@ -2362,7 +2371,7 @@ pub async fn create_iceberg_engine_table(
         &session,
         &format_encode,
         Either::Left(&with_properties),
-        create_source_type,
+        SourceCatalogPurpose::CreateSource(create_source_type),
     )
     .await?;
     let mut col_id_gen = ColumnIdGenerator::new_initial();
@@ -2380,7 +2389,7 @@ pub async fn create_iceberg_engine_table(
         source_info,
         create_source_stmt.include_column_options,
         &mut col_id_gen,
-        create_source_type,
+        SourceCatalogPurpose::CreateSource(create_source_type),
         overwrite_options.source_rate_limit,
         SqlColumnStrategy::FollowChecked,
         refresh_mode,


### PR DESCRIPTION
## What's changed

This PR refactors the frontend source/table connector binding flow without adding new behavior.

- Split the actual standalone source kind (`CreateSourceType`) from why a `SourceCatalog` is being bound (`SourceCatalogPurpose`).
- Replaced boolean `bind_connector_props(..., true/false)` call sites with `ConnectorPropsPurpose`.
- Kept the connector props mutation order explicit by extracting named phases for refresh-mode resolution, table-connector rejection, shared CDC source-job defaults, and MySQL CDC `server.id` defaults.
- Updated `CREATE TABLE ... WITH connector`, Iceberg engine internal source creation, and ALTER SOURCE schema-refresh call sites to pass the explicit purpose.

## Why

`handle_create_source` and adjacent table-with-connector flows previously relied on scattered boolean and sentinel-state checks such as `CreateSourceType::Table`. This made it hard to reason about the order of connector-property reads/removes/inserts and about the subtle differences between standalone sources, table-associated sources, and CDC-table paths.

The refactor keeps the existing ordering and behavior, but makes each purpose and props phase explicit.

## Behavior notes

- No SQL surface or connector behavior is intended to change.
- `CREATE TABLE ... WITH connector` remains a table-associated source path.
- CDC tables from shared CDC sources remain on their separate path and do not go through the source connector binder.
- Iceberg engine internal source creation continues to use CREATE SOURCE-style binding, but does not go through `handle_create_source`.

## Validation

- `./risedev c`