### PR TITLE
fix: propagate table refill policy via hummock notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12925,6 +12925,7 @@ dependencies = [
  "madsim",
  "madsim-rdkafka",
  "madsim-tokio",
+ "madsim-tonic",
  "maplit",
  "paste",
  "pin-project",

--- a/e2e_test/refill/table_refill.slt
+++ b/e2e_test/refill/table_refill.slt
@@ -24,6 +24,9 @@ select name, key, value from rw_streaming_job_config;
 ----
 s3  streaming.developer.cache_refill_policy "both"
 
+statement ok
+recover;
+
 skipif parallel
 system ok
 psql_refill_validate.py --job-name s3 --job-type sink --mode streaming --expect-policy both

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -634,6 +634,8 @@ message MetaSnapshot {
   repeated FragmentWorkerSlotMapping streaming_worker_slot_mappings = 21;
   repeated FragmentWorkerSlotMapping serving_worker_slot_mappings = 22;
   repeated ObjectDependency object_dependencies = 26;
+  TableCacheRefillPolicies table_cache_refill_policies = 27;
+  ServingTableVnodeMappings serving_table_vnode_mappings = 28;
 
   SnapshotVersion version = 13;
 }

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -696,7 +696,7 @@ message SubscribeResponse {
     FragmentWorkerSlotMappings serving_worker_slot_mappings = 28;
     catalog.Secret secret = 29;
     common.ClusterResource cluster_resource = 31;
-    TableRefillRuntimeConfig table_refill_runtime_config = 34;
+    TableRefillRuntimeConfig table_refill_runtime_config = 32;
   }
   reserved 12;
   reserved "parallel_unit_mapping";
@@ -704,8 +704,6 @@ message SubscribeResponse {
   reserved "serving_parallel_unit_mappings";
   reserved 30;
   reserved "compute_node_total_cpu_count";
-  reserved 32, 33;
-  reserved "table_cache_refill_policies", "serving_table_vnode_mappings";
 }
 
 message TableRefillRuntimeConfig {

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -634,10 +634,11 @@ message MetaSnapshot {
   repeated FragmentWorkerSlotMapping streaming_worker_slot_mappings = 21;
   repeated FragmentWorkerSlotMapping serving_worker_slot_mappings = 22;
   repeated ObjectDependency object_dependencies = 26;
-  TableCacheRefillPolicies table_cache_refill_policies = 27;
-  ServingTableVnodeMappings serving_table_vnode_mappings = 28;
+  TableRefillRuntimeConfig table_refill_runtime_config = 27;
 
   SnapshotVersion version = 13;
+  reserved 28;
+  reserved "serving_table_vnode_mappings";
 }
 
 message Object {
@@ -699,6 +700,7 @@ message SubscribeResponse {
     common.ClusterResource cluster_resource = 31;
     TableCacheRefillPolicies table_cache_refill_policies = 32;
     ServingTableVnodeMappings serving_table_vnode_mappings = 33;
+    TableRefillRuntimeConfig table_refill_runtime_config = 34;
   }
   reserved 12;
   reserved "parallel_unit_mapping";
@@ -706,6 +708,12 @@ message SubscribeResponse {
   reserved "serving_parallel_unit_mappings";
   reserved 30;
   reserved "compute_node_total_cpu_count";
+}
+
+message TableRefillRuntimeConfig {
+  TableCacheRefillPolicies table_cache_refill_policies = 1;
+  ServingTableVnodeMappings serving_table_vnode_mappings = 2;
+  uint64 version = 3;
 }
 
 message ServingTableVnodeMappings {

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -637,8 +637,6 @@ message MetaSnapshot {
   TableRefillRuntimeConfig table_refill_runtime_config = 27;
 
   SnapshotVersion version = 13;
-  reserved 28;
-  reserved "serving_table_vnode_mappings";
 }
 
 message Object {
@@ -698,8 +696,6 @@ message SubscribeResponse {
     FragmentWorkerSlotMappings serving_worker_slot_mappings = 28;
     catalog.Secret secret = 29;
     common.ClusterResource cluster_resource = 31;
-    TableCacheRefillPolicies table_cache_refill_policies = 32;
-    ServingTableVnodeMappings serving_table_vnode_mappings = 33;
     TableRefillRuntimeConfig table_refill_runtime_config = 34;
   }
   reserved 12;

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -704,6 +704,8 @@ message SubscribeResponse {
   reserved "serving_parallel_unit_mappings";
   reserved 30;
   reserved "compute_node_total_cpu_count";
+  reserved 32, 33;
+  reserved "table_cache_refill_policies", "serving_table_vnode_mappings";
 }
 
 message TableRefillRuntimeConfig {

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -303,7 +303,8 @@ mod tests {
     #[derive(Default)]
     struct TestObserverState {
         initialized: bool,
-        notifications: Vec<&'static str>,
+        table_refill_runtime_config_versions: Vec<u64>,
+        database_notifications: usize,
     }
 
     impl ObserverState for TestObserverState {
@@ -314,9 +315,9 @@ mod tests {
         fn handle_notification(&mut self, resp: SubscribeResponse) {
             match resp.info.unwrap() {
                 Info::TableRefillRuntimeConfig(_) => {
-                    self.notifications.push("table_refill_runtime_config")
+                    self.table_refill_runtime_config_versions.push(resp.version)
                 }
-                Info::Database(_) => self.notifications.push("database"),
+                Info::Database(_) => self.database_notifications += 1,
                 info => panic!("unexpected notification: {info:?}"),
             }
         }
@@ -382,8 +383,11 @@ mod tests {
 
         assert!(observer_manager.observer_states.initialized);
         assert_eq!(
-            observer_manager.observer_states.notifications,
-            vec!["table_refill_runtime_config"]
+            observer_manager
+                .observer_states
+                .table_refill_runtime_config_versions,
+            vec![11]
         );
+        assert_eq!(observer_manager.observer_states.database_notifications, 0);
     }
 }

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -134,8 +134,15 @@ where
                         .streaming_worker_slot_mapping_version
             }
             Info::ServingWorkerSlotMappings(_) => true,
-            Info::ServingTableVnodeMappings(_) => true,
-            Info::TableCacheRefillPolicies(_) => true,
+            Info::ServingTableVnodeMappings(_) | Info::TableCacheRefillPolicies(_) => false,
+            Info::TableRefillRuntimeConfig(_) => {
+                notification.version
+                    > info
+                        .table_refill_runtime_config
+                        .as_ref()
+                        .map(|config| config.version)
+                        .unwrap_or_default()
+            }
         });
 
         self.observer_states
@@ -261,7 +268,7 @@ mod tests {
     use risingwave_pb::meta::subscribe_response::Info;
     use risingwave_pb::meta::{
         MetaSnapshot, ServingTableVnodeMappings, SubscribeResponse, SubscribeType,
-        TableCacheRefillPolicies,
+        TableCacheRefillPolicies, TableRefillRuntimeConfig,
     };
 
     use super::*;
@@ -308,11 +315,8 @@ mod tests {
 
         fn handle_notification(&mut self, resp: SubscribeResponse) {
             match resp.info.unwrap() {
-                Info::ServingTableVnodeMappings(_) => {
-                    self.notifications.push("serving_table_vnode_mappings")
-                }
-                Info::TableCacheRefillPolicies(_) => {
-                    self.notifications.push("table_cache_refill_policies")
+                Info::TableRefillRuntimeConfig(_) => {
+                    self.notifications.push("table_refill_runtime_config")
                 }
                 Info::Database(_) => self.notifications.push("database"),
                 info => panic!("unexpected notification: {info:?}"),
@@ -325,15 +329,16 @@ mod tests {
         }
     }
 
-    fn notification(info: Info) -> SubscribeResponse {
+    fn notification(version: u64, info: Info) -> SubscribeResponse {
         SubscribeResponse {
             info: Some(info),
+            version,
             ..Default::default()
         }
     }
 
     #[tokio::test]
-    async fn test_preserve_unversioned_hummock_notifications_before_snapshot() {
+    async fn test_filter_stale_table_refill_runtime_config_before_snapshot() {
         let snapshot = SubscribeResponse {
             info: Some(Info::Snapshot(MetaSnapshot {
                 version: Some(SnapshotVersion {
@@ -341,19 +346,39 @@ mod tests {
                     worker_node_version: 1,
                     streaming_worker_slot_mapping_version: 1,
                 }),
+                table_refill_runtime_config: Some(TableRefillRuntimeConfig {
+                    version: 10,
+                    ..Default::default()
+                }),
                 ..Default::default()
             })),
             ..Default::default()
         };
         let rx = TestChannel {
             messages: VecDeque::from([
-                notification(Info::ServingTableVnodeMappings(
-                    ServingTableVnodeMappings::default(),
-                )),
-                notification(Info::TableCacheRefillPolicies(
-                    TableCacheRefillPolicies::default(),
-                )),
-                notification(Info::Database(Default::default())),
+                notification(
+                    9,
+                    Info::TableRefillRuntimeConfig(TableRefillRuntimeConfig {
+                        version: 9,
+                        ..Default::default()
+                    }),
+                ),
+                notification(
+                    11,
+                    Info::TableRefillRuntimeConfig(TableRefillRuntimeConfig {
+                        version: 11,
+                        ..Default::default()
+                    }),
+                ),
+                notification(1, Info::Database(Default::default())),
+                notification(
+                    0,
+                    Info::TableCacheRefillPolicies(TableCacheRefillPolicies::default()),
+                ),
+                notification(
+                    0,
+                    Info::ServingTableVnodeMappings(ServingTableVnodeMappings::default()),
+                ),
                 snapshot,
             ]),
         };
@@ -368,10 +393,7 @@ mod tests {
         assert!(observer_manager.observer_states.initialized);
         assert_eq!(
             observer_manager.observer_states.notifications,
-            vec![
-                "serving_table_vnode_mappings",
-                "table_cache_refill_policies"
-            ]
+            vec!["table_refill_runtime_config"]
         );
     }
 }

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -134,7 +134,6 @@ where
                         .streaming_worker_slot_mapping_version
             }
             Info::ServingWorkerSlotMappings(_) => true,
-            Info::TableCacheRefillPolicies(_) => true,
             Info::ServingTableVnodeMappings(_) => {
                 notification.version
                     > info
@@ -143,6 +142,7 @@ where
                         .unwrap()
                         .streaming_worker_slot_mapping_version
             }
+            Info::TableCacheRefillPolicies(_) => true,
         });
 
         self.observer_states

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -134,7 +134,6 @@ where
                         .streaming_worker_slot_mapping_version
             }
             Info::ServingWorkerSlotMappings(_) => true,
-            Info::ServingTableVnodeMappings(_) | Info::TableCacheRefillPolicies(_) => false,
             Info::TableRefillRuntimeConfig(_) => {
                 notification.version
                     > info
@@ -267,8 +266,7 @@ mod tests {
     use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
     use risingwave_pb::meta::subscribe_response::Info;
     use risingwave_pb::meta::{
-        MetaSnapshot, ServingTableVnodeMappings, SubscribeResponse, SubscribeType,
-        TableCacheRefillPolicies, TableRefillRuntimeConfig,
+        MetaSnapshot, SubscribeResponse, SubscribeType, TableRefillRuntimeConfig,
     };
 
     use super::*;
@@ -371,14 +369,6 @@ mod tests {
                     }),
                 ),
                 notification(1, Info::Database(Default::default())),
-                notification(
-                    0,
-                    Info::TableCacheRefillPolicies(TableCacheRefillPolicies::default()),
-                ),
-                notification(
-                    0,
-                    Info::ServingTableVnodeMappings(ServingTableVnodeMappings::default()),
-                ),
                 snapshot,
             ]),
         };

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -134,14 +134,7 @@ where
                         .streaming_worker_slot_mapping_version
             }
             Info::ServingWorkerSlotMappings(_) => true,
-            Info::ServingTableVnodeMappings(_) => {
-                notification.version
-                    > info
-                        .version
-                        .as_ref()
-                        .unwrap()
-                        .streaming_worker_slot_mapping_version
-            }
+            Info::ServingTableVnodeMappings(_) => true,
             Info::TableCacheRefillPolicies(_) => true,
         });
 
@@ -257,5 +250,128 @@ impl NotificationClient for RpcNotificationClient {
             .subscribe(subscribe_type)
             .await
             .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
+    use risingwave_pb::meta::subscribe_response::Info;
+    use risingwave_pb::meta::{
+        MetaSnapshot, ServingTableVnodeMappings, SubscribeResponse, SubscribeType,
+        TableCacheRefillPolicies,
+    };
+
+    use super::*;
+
+    struct TestChannel {
+        messages: VecDeque<SubscribeResponse>,
+    }
+
+    #[async_trait::async_trait]
+    impl Channel for TestChannel {
+        type Item = SubscribeResponse;
+
+        async fn message(&mut self) -> std::result::Result<Option<Self::Item>, Status> {
+            Ok(self.messages.pop_front())
+        }
+    }
+
+    struct TestClient;
+
+    #[async_trait::async_trait]
+    impl NotificationClient for TestClient {
+        type Channel = TestChannel;
+
+        async fn subscribe(
+            &self,
+            _subscribe_type: SubscribeType,
+        ) -> Result<Self::Channel, ObserverError> {
+            Ok(TestChannel {
+                messages: VecDeque::new(),
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct TestObserverState {
+        initialized: bool,
+        notifications: Vec<&'static str>,
+    }
+
+    impl ObserverState for TestObserverState {
+        fn subscribe_type() -> SubscribeType {
+            SubscribeType::Hummock
+        }
+
+        fn handle_notification(&mut self, resp: SubscribeResponse) {
+            match resp.info.unwrap() {
+                Info::ServingTableVnodeMappings(_) => {
+                    self.notifications.push("serving_table_vnode_mappings")
+                }
+                Info::TableCacheRefillPolicies(_) => {
+                    self.notifications.push("table_cache_refill_policies")
+                }
+                Info::Database(_) => self.notifications.push("database"),
+                info => panic!("unexpected notification: {info:?}"),
+            }
+        }
+
+        fn handle_initialization_notification(&mut self, resp: SubscribeResponse) {
+            assert!(matches!(resp.info, Some(Info::Snapshot(_))));
+            self.initialized = true;
+        }
+    }
+
+    fn notification(info: Info) -> SubscribeResponse {
+        SubscribeResponse {
+            info: Some(info),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_preserve_unversioned_hummock_notifications_before_snapshot() {
+        let snapshot = SubscribeResponse {
+            info: Some(Info::Snapshot(MetaSnapshot {
+                version: Some(SnapshotVersion {
+                    catalog_version: 1,
+                    worker_node_version: 1,
+                    streaming_worker_slot_mapping_version: 1,
+                }),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let rx = TestChannel {
+            messages: VecDeque::from([
+                notification(Info::ServingTableVnodeMappings(
+                    ServingTableVnodeMappings::default(),
+                )),
+                notification(Info::TableCacheRefillPolicies(
+                    TableCacheRefillPolicies::default(),
+                )),
+                notification(Info::Database(Default::default())),
+                snapshot,
+            ]),
+        };
+        let mut observer_manager = ObserverManager {
+            rx,
+            client: TestClient,
+            observer_states: TestObserverState::default(),
+        };
+
+        observer_manager.wait_init_notification().await.unwrap();
+
+        assert!(observer_manager.observer_states.initialized);
+        assert_eq!(
+            observer_manager.observer_states.notifications,
+            vec![
+                "serving_table_vnode_mappings",
+                "table_cache_refill_policies"
+            ]
+        );
     }
 }

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -527,8 +527,8 @@ impl From<&TableCacheRefillContext> for TableCacheRefillStats {
             })
             .collect();
 
-        let serving_table_vnode_mapping = context.serving_table_vnode_mapping.read();
-        let internal_serving = serving_table_vnode_mapping
+        let internal_serving = context
+            .serving_table_vnode_mapping
             .iter()
             .map(|(table_id, bitmap)| (table_id.as_raw_id(), bitmap_to_vnodes(bitmap)))
             .collect();

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -117,11 +117,11 @@ impl ObserverState for FrontendObserverNode {
             Info::ClusterResource(resource) => {
                 LicenseManager::get().update_cluster_resource(resource);
             }
-            Info::TableCacheRefillPolicies(_) => {
-                panic!("frontend node should not receive TableCacheRefillPolicies");
-            }
             Info::ServingTableVnodeMappings(_) => {
                 panic!("frontend node should not receive ServingTableVnodeMappings");
+            }
+            Info::TableCacheRefillPolicies(_) => {
+                panic!("frontend node should not receive TableCacheRefillPolicies");
             }
         }
     }
@@ -158,6 +158,8 @@ impl ObserverState for FrontendObserverNode {
             secrets,
             cluster_resource,
             object_dependencies,
+            table_cache_refill_policies: _,
+            serving_table_vnode_mappings: _,
         } = snapshot;
 
         for db in databases {

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -117,12 +117,6 @@ impl ObserverState for FrontendObserverNode {
             Info::ClusterResource(resource) => {
                 LicenseManager::get().update_cluster_resource(resource);
             }
-            Info::ServingTableVnodeMappings(_) => {
-                panic!("frontend node should not receive ServingTableVnodeMappings");
-            }
-            Info::TableCacheRefillPolicies(_) => {
-                panic!("frontend node should not receive TableCacheRefillPolicies");
-            }
             Info::TableRefillRuntimeConfig(_) => {
                 panic!("frontend node should not receive TableRefillRuntimeConfig");
             }

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -123,6 +123,9 @@ impl ObserverState for FrontendObserverNode {
             Info::TableCacheRefillPolicies(_) => {
                 panic!("frontend node should not receive TableCacheRefillPolicies");
             }
+            Info::TableRefillRuntimeConfig(_) => {
+                panic!("frontend node should not receive TableRefillRuntimeConfig");
+            }
         }
     }
 
@@ -158,8 +161,7 @@ impl ObserverState for FrontendObserverNode {
             secrets,
             cluster_resource,
             object_dependencies,
-            table_cache_refill_policies: _,
-            serving_table_vnode_mappings: _,
+            table_refill_runtime_config: _,
         } = snapshot;
 
         for db in databases {

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -26,8 +26,8 @@ use risingwave_pb::hummock::WriteLimits;
 use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
 use risingwave_pb::meta::notification_service_server::NotificationService;
 use risingwave_pb::meta::{
-    FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, PbServingTableVnodeMappings,
-    PbTableRefillRuntimeConfig, SubscribeRequest, SubscribeType,
+    FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, SubscribeRequest,
+    SubscribeType,
 };
 use risingwave_pb::user::UserInfo;
 use tokio::sync::mpsc;
@@ -37,9 +37,8 @@ use tonic::{Request, Response, Status};
 use crate::backup_restore::BackupManagerRef;
 use crate::hummock::HummockManagerRef;
 use crate::manager::{MetaSrvEnv, Notification, NotificationVersion, WorkerKey};
-use crate::serving::{
-    ServingVnodeMappingRef, build_worker_table_vnode_mapping, to_pb_serving_table_vnode_mappings,
-};
+use crate::serving::ServingVnodeMappingRef;
+use crate::table_refill::build_hummock_table_refill_runtime_config;
 
 pub struct NotificationServiceImpl {
     env: MetaSrvEnv,
@@ -176,63 +175,6 @@ impl NotificationServiceImpl {
                 mapping: Some(mapping.to_protobuf()),
             })
             .collect()
-    }
-
-    async fn get_hummock_serving_table_vnode_mappings(
-        &self,
-        worker_key: &WorkerKey,
-    ) -> MetaResult<PbServingTableVnodeMappings> {
-        let active_serving_workers = self
-            .metadata_manager
-            .cluster_controller
-            .list_active_serving_workers()
-            .await?;
-        let Some(worker_id) = active_serving_workers
-            .iter()
-            .find(|worker| worker.host.as_ref() == Some(&worker_key.0))
-            .map(|worker| worker.id)
-        else {
-            return Ok(PbServingTableVnodeMappings::default());
-        };
-
-        let streaming_parallelisms = self
-            .metadata_manager
-            .catalog_controller
-            .running_fragment_parallelisms(None)?;
-        let serving_vnode_mappings = self.serving_vnode_mapping.all();
-        let worker_table_vnode_mapping = build_worker_table_vnode_mapping(
-            &active_serving_workers,
-            &serving_vnode_mappings,
-            &streaming_parallelisms,
-        );
-
-        let mappings = worker_table_vnode_mapping
-            .get(&worker_id)
-            .map(to_pb_serving_table_vnode_mappings)
-            .unwrap_or_default();
-
-        Ok(mappings)
-    }
-
-    async fn get_hummock_table_refill_runtime_config(
-        &self,
-        worker_key: &WorkerKey,
-    ) -> MetaResult<PbTableRefillRuntimeConfig> {
-        let version = self.env.notification_manager().current_version().await;
-        let table_cache_refill_policies = self
-            .metadata_manager
-            .catalog_controller
-            .table_cache_refill_policies_snapshot()
-            .await?;
-        let serving_table_vnode_mappings = self
-            .get_hummock_serving_table_vnode_mappings(worker_key)
-            .await?;
-
-        Ok(PbTableRefillRuntimeConfig {
-            table_cache_refill_policies: Some(table_cache_refill_policies),
-            serving_table_vnode_mappings: Some(serving_table_vnode_mappings),
-            version,
-        })
     }
 
     async fn get_worker_node_snapshot(&self) -> MetaResult<(Vec<WorkerNode>, NotificationVersion)> {
@@ -390,9 +332,13 @@ impl NotificationServiceImpl {
         let hummock_write_limits = self.hummock_manager.write_limits().await;
         let meta_backup_manifest_id = self.backup_manager.manifest().await.manifest_id;
         let cluster_resource = self.get_cluster_resource().await;
-        let table_refill_runtime_config = self
-            .get_hummock_table_refill_runtime_config(worker_key)
-            .await?;
+        let table_refill_runtime_config = build_hummock_table_refill_runtime_config(
+            &self.metadata_manager,
+            &self.serving_vnode_mapping,
+            worker_key,
+            self.env.notification_manager().current_version().await,
+        )
+        .await?;
 
         Ok(MetaSnapshot {
             tables,

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -25,7 +25,6 @@ use risingwave_pb::common::{ClusterResource, WorkerNode, WorkerType};
 use risingwave_pb::hummock::WriteLimits;
 use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
 use risingwave_pb::meta::notification_service_server::NotificationService;
-use risingwave_pb::meta::serving_table_vnode_mappings::PbServingTableVnodeMapping;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, PbServingTableVnodeMappings,
     SubscribeRequest, SubscribeType,
@@ -38,7 +37,9 @@ use tonic::{Request, Response, Status};
 use crate::backup_restore::BackupManagerRef;
 use crate::hummock::HummockManagerRef;
 use crate::manager::{MetaSrvEnv, Notification, NotificationVersion, WorkerKey};
-use crate::serving::{ServingVnodeMappingRef, build_worker_table_vnode_mapping};
+use crate::serving::{
+    ServingVnodeMappingRef, build_worker_table_vnode_mapping, to_pb_serving_table_vnode_mappings,
+};
 
 pub struct NotificationServiceImpl {
     env: MetaSrvEnv,
@@ -207,18 +208,10 @@ impl NotificationServiceImpl {
 
         let mappings = worker_table_vnode_mapping
             .get(&worker_id)
-            .map(|table_vnode_mapping| {
-                table_vnode_mapping
-                    .iter()
-                    .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
-                        table_id: table_id.as_raw_id(),
-                        bitmap: Some(bitmap.to_protobuf()),
-                    })
-                    .collect()
-            })
+            .map(to_pb_serving_table_vnode_mappings)
             .unwrap_or_default();
 
-        Ok(PbServingTableVnodeMappings { mappings })
+        Ok(mappings)
     }
 
     async fn get_worker_node_snapshot(&self) -> MetaResult<(Vec<WorkerNode>, NotificationVersion)> {

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -27,7 +27,7 @@ use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
 use risingwave_pb::meta::notification_service_server::NotificationService;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, PbServingTableVnodeMappings,
-    SubscribeRequest, SubscribeType,
+    PbTableRefillRuntimeConfig, SubscribeRequest, SubscribeType,
 };
 use risingwave_pb::user::UserInfo;
 use tokio::sync::mpsc;
@@ -214,6 +214,27 @@ impl NotificationServiceImpl {
         Ok(mappings)
     }
 
+    async fn get_hummock_table_refill_runtime_config(
+        &self,
+        worker_key: &WorkerKey,
+    ) -> MetaResult<PbTableRefillRuntimeConfig> {
+        let version = self.env.notification_manager().current_version().await;
+        let table_cache_refill_policies = self
+            .metadata_manager
+            .catalog_controller
+            .table_cache_refill_policies_snapshot()
+            .await?;
+        let serving_table_vnode_mappings = self
+            .get_hummock_serving_table_vnode_mappings(worker_key)
+            .await?;
+
+        Ok(PbTableRefillRuntimeConfig {
+            table_cache_refill_policies: Some(table_cache_refill_policies),
+            serving_table_vnode_mappings: Some(serving_table_vnode_mappings),
+            version,
+        })
+    }
+
     async fn get_worker_node_snapshot(&self) -> MetaResult<(Vec<WorkerNode>, NotificationVersion)> {
         let cluster_guard = self
             .metadata_manager
@@ -369,13 +390,8 @@ impl NotificationServiceImpl {
         let hummock_write_limits = self.hummock_manager.write_limits().await;
         let meta_backup_manifest_id = self.backup_manager.manifest().await.manifest_id;
         let cluster_resource = self.get_cluster_resource().await;
-        let table_cache_refill_policies = self
-            .metadata_manager
-            .catalog_controller
-            .table_cache_refill_policies_snapshot()
-            .await?;
-        let serving_table_vnode_mappings = self
-            .get_hummock_serving_table_vnode_mappings(worker_key)
+        let table_refill_runtime_config = self
+            .get_hummock_table_refill_runtime_config(worker_key)
             .await?;
 
         Ok(MetaSnapshot {
@@ -392,8 +408,7 @@ impl NotificationServiceImpl {
                 write_limits: hummock_write_limits,
             }),
             cluster_resource: Some(cluster_resource),
-            table_cache_refill_policies: Some(table_cache_refill_policies),
-            serving_table_vnode_mappings: Some(serving_table_vnode_mappings),
+            table_refill_runtime_config: Some(table_refill_runtime_config),
             ..Default::default()
         })
     }

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
-
 use anyhow::{Context, anyhow};
-use risingwave_common::bitmap::Bitmap;
 use risingwave_common::secret::{LocalSecretManager, SecretEncryption};
 use risingwave_hummock_sdk::FrontendHummockVersion;
 use risingwave_meta::MetaResult;
 use risingwave_meta::controller::catalog::Catalog;
 use risingwave_meta::manager::MetadataManager;
-use risingwave_meta_model::{TableId, WorkerId};
 use risingwave_pb::backup_service::MetaBackupManifestId;
 use risingwave_pb::catalog::{Secret, Table};
 use risingwave_pb::common::worker_node::State::Running;
@@ -42,26 +38,7 @@ use tonic::{Request, Response, Status};
 use crate::backup_restore::BackupManagerRef;
 use crate::hummock::HummockManagerRef;
 use crate::manager::{MetaSrvEnv, Notification, NotificationVersion, WorkerKey};
-use crate::serving::ServingVnodeMappingRef;
-
-fn append_worker_table_vnode_mapping(
-    table_vnode_mapping: &mut HashMap<TableId, Bitmap>,
-    worker_id: WorkerId,
-    state_table_ids: &HashSet<TableId>,
-    worker_vnode_mapping: &HashMap<risingwave_common::hash::WorkerSlotId, Bitmap>,
-) {
-    for (worker_slot_id, bitmap) in worker_vnode_mapping {
-        if worker_slot_id.worker_id() != worker_id {
-            continue;
-        }
-        for table_id in state_table_ids {
-            table_vnode_mapping
-                .entry(*table_id)
-                .and_modify(|b| *b |= bitmap.clone())
-                .or_insert_with(|| bitmap.clone());
-        }
-    }
-}
+use crate::serving::{ServingVnodeMappingRef, build_worker_table_vnode_mapping};
 
 pub struct NotificationServiceImpl {
     env: MetaSrvEnv,
@@ -221,28 +198,27 @@ impl NotificationServiceImpl {
             .metadata_manager
             .catalog_controller
             .running_fragment_parallelisms(None)?;
-        let mut table_vnode_mapping: HashMap<TableId, Bitmap> = HashMap::new();
-        for (fragment_id, mapping) in self.serving_vnode_mapping.all() {
-            let Some(parallelism) = streaming_parallelisms.get(&fragment_id) else {
-                continue;
-            };
-            append_worker_table_vnode_mapping(
-                &mut table_vnode_mapping,
-                worker_id,
-                &parallelism.state_table_ids,
-                &mapping.to_bitmaps(),
-            );
-        }
+        let serving_vnode_mappings = self.serving_vnode_mapping.all();
+        let worker_table_vnode_mapping = build_worker_table_vnode_mapping(
+            &active_serving_workers,
+            &serving_vnode_mappings,
+            &streaming_parallelisms,
+        );
 
-        Ok(PbServingTableVnodeMappings {
-            mappings: table_vnode_mapping
-                .into_iter()
-                .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
-                    table_id: table_id.as_raw_id(),
-                    bitmap: Some(bitmap.to_protobuf()),
-                })
-                .collect(),
-        })
+        let mappings = worker_table_vnode_mapping
+            .get(&worker_id)
+            .map(|table_vnode_mapping| {
+                table_vnode_mapping
+                    .iter()
+                    .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
+                        table_id: table_id.as_raw_id(),
+                        bitmap: Some(bitmap.to_protobuf()),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(PbServingTableVnodeMappings { mappings })
     }
 
     async fn get_worker_node_snapshot(&self) -> MetaResult<(Vec<WorkerNode>, NotificationVersion)> {

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{HashMap, HashSet};
+
 use anyhow::{Context, anyhow};
+use risingwave_common::bitmap::Bitmap;
 use risingwave_common::secret::{LocalSecretManager, SecretEncryption};
 use risingwave_hummock_sdk::FrontendHummockVersion;
 use risingwave_meta::MetaResult;
 use risingwave_meta::controller::catalog::Catalog;
 use risingwave_meta::manager::MetadataManager;
+use risingwave_meta_model::{TableId, WorkerId};
 use risingwave_pb::backup_service::MetaBackupManifestId;
 use risingwave_pb::catalog::{Secret, Table};
 use risingwave_pb::common::worker_node::State::Running;
@@ -25,9 +29,10 @@ use risingwave_pb::common::{ClusterResource, WorkerNode, WorkerType};
 use risingwave_pb::hummock::WriteLimits;
 use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
 use risingwave_pb::meta::notification_service_server::NotificationService;
+use risingwave_pb::meta::serving_table_vnode_mappings::PbServingTableVnodeMapping;
 use risingwave_pb::meta::{
-    FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, SubscribeRequest,
-    SubscribeType,
+    FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, PbServingTableVnodeMappings,
+    SubscribeRequest, SubscribeType,
 };
 use risingwave_pb::user::UserInfo;
 use tokio::sync::mpsc;
@@ -38,6 +43,25 @@ use crate::backup_restore::BackupManagerRef;
 use crate::hummock::HummockManagerRef;
 use crate::manager::{MetaSrvEnv, Notification, NotificationVersion, WorkerKey};
 use crate::serving::ServingVnodeMappingRef;
+
+fn append_worker_table_vnode_mapping(
+    table_vnode_mapping: &mut HashMap<TableId, Bitmap>,
+    worker_id: WorkerId,
+    state_table_ids: &HashSet<TableId>,
+    worker_vnode_mapping: &HashMap<risingwave_common::hash::WorkerSlotId, Bitmap>,
+) {
+    for (worker_slot_id, bitmap) in worker_vnode_mapping {
+        if worker_slot_id.worker_id() != worker_id {
+            continue;
+        }
+        for table_id in state_table_ids {
+            table_vnode_mapping
+                .entry(*table_id)
+                .and_modify(|b| *b |= bitmap.clone())
+                .or_insert_with(|| bitmap.clone());
+        }
+    }
+}
 
 pub struct NotificationServiceImpl {
     env: MetaSrvEnv,
@@ -174,6 +198,51 @@ impl NotificationServiceImpl {
                 mapping: Some(mapping.to_protobuf()),
             })
             .collect()
+    }
+
+    async fn get_hummock_serving_table_vnode_mappings(
+        &self,
+        worker_key: &WorkerKey,
+    ) -> MetaResult<PbServingTableVnodeMappings> {
+        let active_serving_workers = self
+            .metadata_manager
+            .cluster_controller
+            .list_active_serving_workers()
+            .await?;
+        let Some(worker_id) = active_serving_workers
+            .iter()
+            .find(|worker| worker.host.as_ref() == Some(&worker_key.0))
+            .map(|worker| worker.id)
+        else {
+            return Ok(PbServingTableVnodeMappings::default());
+        };
+
+        let streaming_parallelisms = self
+            .metadata_manager
+            .catalog_controller
+            .running_fragment_parallelisms(None)?;
+        let mut table_vnode_mapping: HashMap<TableId, Bitmap> = HashMap::new();
+        for (fragment_id, mapping) in self.serving_vnode_mapping.all() {
+            let Some(parallelism) = streaming_parallelisms.get(&fragment_id) else {
+                continue;
+            };
+            append_worker_table_vnode_mapping(
+                &mut table_vnode_mapping,
+                worker_id,
+                &parallelism.state_table_ids,
+                &mapping.to_bitmaps(),
+            );
+        }
+
+        Ok(PbServingTableVnodeMappings {
+            mappings: table_vnode_mapping
+                .into_iter()
+                .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
+                    table_id: table_id.as_raw_id(),
+                    bitmap: Some(bitmap.to_protobuf()),
+                })
+                .collect(),
+        })
     }
 
     async fn get_worker_node_snapshot(&self) -> MetaResult<(Vec<WorkerNode>, NotificationVersion)> {
@@ -322,7 +391,7 @@ impl NotificationServiceImpl {
         })
     }
 
-    async fn hummock_subscribe(&self) -> MetaResult<MetaSnapshot> {
+    async fn hummock_subscribe(&self, worker_key: &WorkerKey) -> MetaResult<MetaSnapshot> {
         let (tables, catalog_version) = self.get_tables_snapshot().await?;
         let hummock_version = self
             .hummock_manager
@@ -331,6 +400,14 @@ impl NotificationServiceImpl {
         let hummock_write_limits = self.hummock_manager.write_limits().await;
         let meta_backup_manifest_id = self.backup_manager.manifest().await.manifest_id;
         let cluster_resource = self.get_cluster_resource().await;
+        let table_cache_refill_policies = self
+            .metadata_manager
+            .catalog_controller
+            .table_cache_refill_policies_snapshot()
+            .await?;
+        let serving_table_vnode_mappings = self
+            .get_hummock_serving_table_vnode_mappings(worker_key)
+            .await?;
 
         Ok(MetaSnapshot {
             tables,
@@ -346,6 +423,8 @@ impl NotificationServiceImpl {
                 write_limits: hummock_write_limits,
             }),
             cluster_resource: Some(cluster_resource),
+            table_cache_refill_policies: Some(table_cache_refill_policies),
+            serving_table_vnode_mappings: Some(serving_table_vnode_mappings),
             ..Default::default()
         })
     }
@@ -392,7 +471,7 @@ impl NotificationService for NotificationServiceImpl {
                 self.hummock_manager
                     .pin_version(req.get_worker_id())
                     .await?;
-                self.hummock_subscribe().await?
+                self.hummock_subscribe(&worker_key).await?
             }
             SubscribeType::Compute => self.compute_subscribe().await?,
             SubscribeType::Unspecified => unreachable!(),

--- a/src/meta/service/src/notification_service.rs
+++ b/src/meta/service/src/notification_service.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, anyhow};
 use risingwave_common::secret::{LocalSecretManager, SecretEncryption};
 use risingwave_hummock_sdk::FrontendHummockVersion;
 use risingwave_meta::MetaResult;
 use risingwave_meta::controller::catalog::Catalog;
+use risingwave_meta::controller::fragment::FragmentParallelismInfo;
 use risingwave_meta::manager::MetadataManager;
+use risingwave_meta_model::{FragmentId, WorkerId};
 use risingwave_pb::backup_service::MetaBackupManifestId;
 use risingwave_pb::catalog::{Secret, Table};
 use risingwave_pb::common::worker_node::State::Running;
@@ -26,8 +30,8 @@ use risingwave_pb::hummock::WriteLimits;
 use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
 use risingwave_pb::meta::notification_service_server::NotificationService;
 use risingwave_pb::meta::{
-    FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, SubscribeRequest,
-    SubscribeType,
+    FragmentWorkerSlotMapping, GetSessionParamsResponse, MetaSnapshot, PbTableCacheRefillPolicies,
+    SubscribeRequest, SubscribeType,
 };
 use risingwave_pb::user::UserInfo;
 use tokio::sync::mpsc;
@@ -209,6 +213,36 @@ impl NotificationServiceImpl {
         Ok((tables, notification_version))
     }
 
+    async fn get_hummock_catalog_snapshot(
+        &self,
+    ) -> MetaResult<(
+        Vec<Table>,
+        PbTableCacheRefillPolicies,
+        HashMap<FragmentId, FragmentParallelismInfo>,
+        NotificationVersion,
+    )> {
+        let catalog_guard = self
+            .metadata_manager
+            .catalog_controller
+            .get_inner_read_guard()
+            .await;
+        let mut tables = catalog_guard.list_all_state_tables().await?;
+        tables.extend(catalog_guard.dropped_tables.values().cloned());
+        let table_cache_refill_policies =
+            catalog_guard.table_cache_refill_policies_snapshot().await?;
+        let streaming_parallelisms = self
+            .metadata_manager
+            .catalog_controller
+            .running_fragment_parallelisms(None)?;
+        let notification_version = self.env.notification_manager().current_version().await;
+        Ok((
+            tables,
+            table_cache_refill_policies,
+            streaming_parallelisms,
+            notification_version,
+        ))
+    }
+
     /// Get the total resource of the cluster.
     async fn get_cluster_resource(&self) -> ClusterResource {
         self.metadata_manager
@@ -323,8 +357,9 @@ impl NotificationServiceImpl {
         })
     }
 
-    async fn hummock_subscribe(&self, worker_key: &WorkerKey) -> MetaResult<MetaSnapshot> {
-        let (tables, catalog_version) = self.get_tables_snapshot().await?;
+    async fn hummock_subscribe(&self, worker_id: WorkerId) -> MetaResult<MetaSnapshot> {
+        let (tables, table_cache_refill_policies, streaming_parallelisms, catalog_version) =
+            self.get_hummock_catalog_snapshot().await?;
         let hummock_version = self
             .hummock_manager
             .on_current_version(|version| version.into())
@@ -333,12 +368,12 @@ impl NotificationServiceImpl {
         let meta_backup_manifest_id = self.backup_manager.manifest().await.manifest_id;
         let cluster_resource = self.get_cluster_resource().await;
         let table_refill_runtime_config = build_hummock_table_refill_runtime_config(
-            &self.metadata_manager,
             &self.serving_vnode_mapping,
-            worker_key,
-            self.env.notification_manager().current_version().await,
-        )
-        .await?;
+            worker_id,
+            table_cache_refill_policies,
+            &streaming_parallelisms,
+            catalog_version,
+        );
 
         Ok(MetaSnapshot {
             tables,
@@ -401,7 +436,7 @@ impl NotificationService for NotificationServiceImpl {
                 self.hummock_manager
                     .pin_version(req.get_worker_id())
                     .await?;
-                self.hummock_subscribe(&worker_key).await?
+                self.hummock_subscribe(req.get_worker_id()).await?
             }
             SubscribeType::Compute => self.compute_subscribe().await?,
             SubscribeType::Unspecified => unreachable!(),

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -23,6 +23,7 @@ use risingwave_meta_model::streaming_job::BackfillOrders;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::SourceId;
+use risingwave_pb::meta::PbTableCacheRefillPolicies;
 use risingwave_pb::stream_service::barrier_complete_response::{
     PbListFinishedSource, PbLoadFinishedSource,
 };
@@ -77,6 +78,13 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
         if is_global {
             self.set_status(BarrierManagerStatus::Running);
         }
+    }
+
+    async fn table_cache_refill_policies_snapshot(&self) -> MetaResult<PbTableCacheRefillPolicies> {
+        self.metadata_manager
+            .catalog_controller
+            .table_cache_refill_policies_snapshot()
+            .await
     }
 
     #[await_tree::instrument("post_collect_command({command})")]

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -23,6 +23,7 @@ use risingwave_common::catalog::DatabaseId;
 use risingwave_common::id::JobId;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
+use risingwave_pb::meta::PbTableCacheRefillPolicies;
 use risingwave_pb::stream_service::barrier_complete_response::{
     PbListFinishedSource, PbLoadFinishedSource,
 };
@@ -76,6 +77,10 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
         recovery_reason: RecoveryReason,
     );
     fn mark_ready(&self, options: MarkReadyOptions);
+
+    async fn table_cache_refill_policies_snapshot(&self) -> MetaResult<PbTableCacheRefillPolicies> {
+        Ok(PbTableCacheRefillPolicies::default())
+    }
 
     fn post_collect_command(
         &self,

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -28,8 +28,8 @@ use risingwave_common::system_param::reader::SystemParamsRead;
 use risingwave_common::system_param::{AdaptiveParallelismStrategy, PAUSE_ON_NEXT_BOOTSTRAP_KEY};
 use risingwave_meta_model::WorkerId;
 use risingwave_pb::common::WorkerNode;
-use risingwave_pb::meta::Recovery;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
+use risingwave_pb::meta::{PbTableRefillRuntimeConfig, Recovery};
 use thiserror_ext::AsReport;
 use tokio::select;
 use tokio::sync::mpsc;
@@ -977,10 +977,17 @@ use crate::barrier::partial_graph::{
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
     async fn notify_table_cache_refill_policies_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
         match context.table_cache_refill_policies_snapshot().await {
-            Ok(policies) => env.notification_manager().notify_hummock_without_version(
-                Operation::Update,
-                Info::TableCacheRefillPolicies(policies),
-            ),
+            Ok(policies) => {
+                env.notification_manager()
+                    .notify_hummock(
+                        Operation::Update,
+                        Info::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                            table_cache_refill_policies: Some(policies),
+                            ..Default::default()
+                        }),
+                    )
+                    .await;
+            }
             Err(err) => {
                 warn!(
                     error = %err.as_report(),

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -613,6 +613,10 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                                         // mark ready to unblock subsequent request
                                         self.context.mark_ready(MarkReadyOptions::Database(database_id));
                                         entering_initializing.remove();
+                                        Self::notify_table_cache_refill_policies_after_recovery(
+                                            self.context.clone(),
+                                            self.env.clone(),
+                                        ).await;
                                     }
                                     Err(e) => {
                                         entering_initializing.fail_reload_runtime_info(e);
@@ -622,6 +626,10 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
                             CheckpointControlEvent::EnteringRunning(entering_running) => {
                                 self.context.mark_ready(MarkReadyOptions::Database(entering_running.database_id()));
                                 entering_running.enter();
+                                Self::notify_table_cache_refill_policies_after_recovery(
+                                    self.context.clone(),
+                                    self.env.clone(),
+                                ).await;
                             }
                         }
                     };
@@ -967,6 +975,21 @@ use crate::barrier::partial_graph::{
 };
 
 impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
+    async fn notify_table_cache_refill_policies_after_recovery(context: Arc<C>, env: MetaSrvEnv) {
+        match context.table_cache_refill_policies_snapshot().await {
+            Ok(policies) => env.notification_manager().notify_hummock_without_version(
+                Operation::Update,
+                Info::TableCacheRefillPolicies(policies),
+            ),
+            Err(err) => {
+                warn!(
+                    error = %err.as_report(),
+                    "failed to notify table cache refill policies after recovery"
+                );
+            }
+        }
+    }
+
     /// Recovery the whole cluster from the latest epoch.
     ///
     /// If `paused_reason` is `Some`, all data sources (including connectors and DMLs) will be
@@ -1325,21 +1348,11 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             ),
         )]);
 
-        match self.context.table_cache_refill_policies_snapshot().await {
-            Ok(policies) => self
-                .env
-                .notification_manager()
-                .notify_hummock_without_version(
-                    Operation::Update,
-                    Info::TableCacheRefillPolicies(policies),
-                ),
-            Err(err) => {
-                warn!(
-                    error = %err.as_report(),
-                    "failed to notify table cache refill policies after recovery"
-                );
-            }
-        }
+        Self::notify_table_cache_refill_policies_after_recovery(
+            self.context.clone(),
+            self.env.clone(),
+        )
+        .await;
 
         self.env
             .notification_manager()

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -1325,6 +1325,22 @@ impl<C: GlobalBarrierWorkerContext> GlobalBarrierWorker<C> {
             ),
         )]);
 
+        match self.context.table_cache_refill_policies_snapshot().await {
+            Ok(policies) => self
+                .env
+                .notification_manager()
+                .notify_hummock_without_version(
+                    Operation::Update,
+                    Info::TableCacheRefillPolicies(policies),
+                ),
+            Err(err) => {
+                warn!(
+                    error = %err.as_report(),
+                    "failed to notify table cache refill policies after recovery"
+                );
+            }
+        }
+
         self.env
             .notification_manager()
             .notify_frontend_without_version(Operation::Update, Info::Recovery(Recovery {}));

--- a/src/meta/src/controller/catalog/alter_op.rs
+++ b/src/meta/src/controller/catalog/alter_op.rs
@@ -20,8 +20,6 @@ use risingwave_common::config::{StreamingConfig, merge_streaming_config_section}
 use risingwave_common::id::JobId;
 use risingwave_common::system_param::{OverrideValidate, Validate};
 use risingwave_meta_model::refresh_job::{self, RefreshState};
-use risingwave_pb::meta::PbTableCacheRefillPolicies;
-use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
 use sea_orm::ActiveValue::{NotSet, Set};
 use sea_orm::prelude::DateTime;
 use sea_orm::sea_query::Expr;
@@ -1150,26 +1148,19 @@ impl CatalogController {
         let updated_config_override = table.to_string();
 
         // Validate the config override by trying to merge it to the default config.
-        // And extract fields for other use.
-        let cache_refill_policy = {
-            let merged = merge_streaming_config_section(
-                &StreamingConfig::default(),
-                &updated_config_override,
-            )
-            .context("invalid streaming job config override")?;
+        let merged =
+            merge_streaming_config_section(&StreamingConfig::default(), &updated_config_override)
+                .context("invalid streaming job config override")?;
 
-            // Reject unrecognized entries.
-            // Note: If these unrecognized entries are pre-existing, we also reject them here.
-            // Users are able to fix them by issuing a `RESET` first.
-            if let Some(merged) = &merged {
-                let unrecognized_keys = merged.unrecognized_keys().collect_vec();
-                if !unrecognized_keys.is_empty() {
-                    bail_invalid_parameter!("unrecognized configs: {:?}", unrecognized_keys);
-                }
+        // Reject unrecognized entries.
+        // Note: If these unrecognized entries are pre-existing, we also reject them here.
+        // Users are able to fix them by issuing a `RESET` first.
+        if let Some(merged) = &merged {
+            let unrecognized_keys = merged.unrecognized_keys().collect_vec();
+            if !unrecognized_keys.is_empty() {
+                bail_invalid_parameter!("unrecognized configs: {:?}", unrecognized_keys);
             }
-
-            merged.map(|config| config.developer.cache_refill_policy)
-        };
+        }
 
         StreamingJob::update(streaming_job::ActiveModel {
             job_id: Set(job_id),
@@ -1180,42 +1171,6 @@ impl CatalogController {
         .await?;
 
         txn.commit().await?;
-
-        let internal_tables: Vec<TableId> = Table::find()
-            .select_only()
-            .column(table::Column::TableId)
-            .filter(table::Column::BelongsToJobId.eq(job_id))
-            .into_tuple()
-            .all(&inner.db)
-            .await?;
-
-        tracing::debug!(
-            ?cache_refill_policy,
-            ?job_id,
-            ?internal_tables,
-            "notify cache refill policy for tables"
-        );
-
-        let table_refill_policies = PbTableCacheRefillPolicies {
-            policies: internal_tables
-                .into_iter()
-                .map(|table_id| {
-                    let mut p = PbTableCacheRefillPolicy::default();
-                    if let Some(policy) = cache_refill_policy {
-                        p.set_policy(policy.to_protobuf());
-                    }
-                    p.table_id = table_id.as_raw_id();
-                    p
-                })
-                .collect(),
-        };
-
-        self.env
-            .notification_manager()
-            .notify_hummock_without_version(
-                Operation::Update,
-                Info::TableCacheRefillPolicies(table_refill_policies),
-            );
 
         Ok(IGNORED_NOTIFICATION_VERSION)
     }

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -152,25 +152,22 @@ impl CatalogController {
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {
-        fn has_explicit_cache_refill_policy(config_override: &str) -> MetaResult<bool> {
+        fn explicit_cache_refill_policy(
+            config_override: &str,
+        ) -> MetaResult<Option<CacheRefillPolicy>> {
             if config_override.trim().is_empty() {
-                return Ok(false);
+                return Ok(None);
             }
 
             let table: toml::Table =
                 toml::from_str(config_override).context("invalid streaming job config override")?;
-            Ok(table
+            let has_explicit_policy = table
                 .get("streaming")
                 .and_then(toml::Value::as_table)
                 .and_then(|table| table.get("developer"))
                 .and_then(toml::Value::as_table)
-                .is_some_and(|table| table.contains_key("cache_refill_policy")))
-        }
-
-        fn explicit_cache_refill_policy(
-            config_override: &str,
-        ) -> MetaResult<Option<CacheRefillPolicy>> {
-            if !has_explicit_cache_refill_policy(config_override)? {
+                .is_some_and(|table| table.contains_key("cache_refill_policy"));
+            if !has_explicit_policy {
                 return Ok(None);
             }
 

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -25,11 +25,13 @@ use std::iter;
 use std::mem::take;
 use std::sync::Arc;
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use itertools::Itertools;
 use risingwave_common::catalog::{
     DEFAULT_SCHEMA_NAME, FragmentTypeFlag, FragmentTypeMask, SYSTEM_SCHEMAS, TableOption,
 };
+use risingwave_common::config::streaming::CacheRefillPolicy;
+use risingwave_common::config::{StreamingConfig, merge_streaming_config_section};
 use risingwave_common::current_cluster_version;
 use risingwave_common::id::JobId;
 use risingwave_common::secret::LocalSecretManager;
@@ -59,7 +61,8 @@ use risingwave_pb::meta::object::PbObjectInfo;
 use risingwave_pb::meta::subscribe_response::{
     Info as NotificationInfo, Info, Operation as NotificationOperation, Operation,
 };
-use risingwave_pb::meta::{PbObject, PbObjectGroup};
+use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
+use risingwave_pb::meta::{PbObject, PbObjectGroup, PbTableCacheRefillPolicies};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::telemetry::PbTelemetryEventStage;
 use risingwave_pb::user::PbUserInfo;
@@ -146,6 +149,82 @@ pub struct ReleaseContext {
 }
 
 impl CatalogController {
+    pub async fn table_cache_refill_policies_snapshot(
+        &self,
+    ) -> MetaResult<PbTableCacheRefillPolicies> {
+        fn has_explicit_cache_refill_policy(config_override: &str) -> MetaResult<bool> {
+            if config_override.trim().is_empty() {
+                return Ok(false);
+            }
+
+            let table: toml::Table =
+                toml::from_str(config_override).context("invalid streaming job config override")?;
+            Ok(table
+                .get("streaming")
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get("developer"))
+                .and_then(toml::Value::as_table)
+                .is_some_and(|table| table.contains_key("cache_refill_policy")))
+        }
+
+        fn explicit_cache_refill_policy(
+            config_override: &str,
+        ) -> MetaResult<Option<CacheRefillPolicy>> {
+            if !has_explicit_cache_refill_policy(config_override)? {
+                return Ok(None);
+            }
+
+            let merged =
+                merge_streaming_config_section(&StreamingConfig::default(), config_override)
+                    .context("invalid streaming job config override")?
+                    .context("empty streaming job config override")?;
+            Ok(Some(merged.developer.cache_refill_policy))
+        }
+
+        let inner = self.inner.read().await;
+        let job_configs = StreamingJob::find()
+            .select_only()
+            .column(streaming_job::Column::JobId)
+            .column(streaming_job::Column::ConfigOverride)
+            .into_tuple::<(JobId, Option<String>)>()
+            .all(&inner.db)
+            .await?;
+        let mut policies_by_job = HashMap::new();
+        for (job_id, config_override) in job_configs {
+            if let Some(policy) =
+                explicit_cache_refill_policy(&config_override.unwrap_or_default())?
+            {
+                policies_by_job.insert(job_id, policy);
+            }
+        }
+
+        if policies_by_job.is_empty() {
+            return Ok(PbTableCacheRefillPolicies::default());
+        }
+
+        let internal_tables: Vec<(TableId, Option<JobId>)> = Table::find()
+            .select_only()
+            .column(table::Column::TableId)
+            .column(table::Column::BelongsToJobId)
+            .filter(table::Column::BelongsToJobId.is_in(policies_by_job.keys().copied()))
+            .into_tuple()
+            .all(&inner.db)
+            .await?;
+
+        let policies = internal_tables
+            .into_iter()
+            .filter_map(|(table_id, job_id)| {
+                let policy = policies_by_job.get(&job_id?)?;
+                Some(PbTableCacheRefillPolicy {
+                    table_id: table_id.as_raw_id(),
+                    policy: policy.to_protobuf() as i32,
+                })
+            })
+            .collect();
+
+        Ok(PbTableCacheRefillPolicies { policies })
+    }
+
     pub async fn new(env: MetaSrvEnv) -> MetaResult<Self> {
         let meta_store = env.meta_store();
         let catalog_controller = Self {

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -148,43 +148,39 @@ pub struct ReleaseContext {
     pub(crate) removed_iceberg_table_sinks: Vec<PbSink>,
 }
 
-impl CatalogController {
+fn explicit_cache_refill_policy(config_override: &str) -> MetaResult<Option<CacheRefillPolicy>> {
+    if config_override.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let table: toml::Table =
+        toml::from_str(config_override).context("invalid streaming job config override")?;
+    let has_explicit_policy = table
+        .get("streaming")
+        .and_then(toml::Value::as_table)
+        .and_then(|table| table.get("developer"))
+        .and_then(toml::Value::as_table)
+        .is_some_and(|table| table.contains_key("cache_refill_policy"));
+    if !has_explicit_policy {
+        return Ok(None);
+    }
+
+    let merged = merge_streaming_config_section(&StreamingConfig::default(), config_override)
+        .context("invalid streaming job config override")?
+        .context("empty streaming job config override")?;
+    Ok(Some(merged.developer.cache_refill_policy))
+}
+
+impl CatalogControllerInner {
     pub async fn table_cache_refill_policies_snapshot(
         &self,
     ) -> MetaResult<PbTableCacheRefillPolicies> {
-        fn explicit_cache_refill_policy(
-            config_override: &str,
-        ) -> MetaResult<Option<CacheRefillPolicy>> {
-            if config_override.trim().is_empty() {
-                return Ok(None);
-            }
-
-            let table: toml::Table =
-                toml::from_str(config_override).context("invalid streaming job config override")?;
-            let has_explicit_policy = table
-                .get("streaming")
-                .and_then(toml::Value::as_table)
-                .and_then(|table| table.get("developer"))
-                .and_then(toml::Value::as_table)
-                .is_some_and(|table| table.contains_key("cache_refill_policy"));
-            if !has_explicit_policy {
-                return Ok(None);
-            }
-
-            let merged =
-                merge_streaming_config_section(&StreamingConfig::default(), config_override)
-                    .context("invalid streaming job config override")?
-                    .context("empty streaming job config override")?;
-            Ok(Some(merged.developer.cache_refill_policy))
-        }
-
-        let inner = self.inner.read().await;
         let job_configs = StreamingJob::find()
             .select_only()
             .column(streaming_job::Column::JobId)
             .column(streaming_job::Column::ConfigOverride)
             .into_tuple::<(JobId, Option<String>)>()
-            .all(&inner.db)
+            .all(&self.db)
             .await?;
         let mut policies_by_job = HashMap::new();
         for (job_id, config_override) in job_configs {
@@ -205,7 +201,7 @@ impl CatalogController {
             .column(table::Column::BelongsToJobId)
             .filter(table::Column::BelongsToJobId.is_in(policies_by_job.keys().copied()))
             .into_tuple()
-            .all(&inner.db)
+            .all(&self.db)
             .await?;
 
         let policies = internal_tables
@@ -220,6 +216,15 @@ impl CatalogController {
             .collect();
 
         Ok(PbTableCacheRefillPolicies { policies })
+    }
+}
+
+impl CatalogController {
+    pub async fn table_cache_refill_policies_snapshot(
+        &self,
+    ) -> MetaResult<PbTableCacheRefillPolicies> {
+        let inner = self.inner.read().await;
+        inner.table_cache_refill_policies_snapshot().await
     }
 
     pub async fn new(env: MetaSrvEnv) -> MetaResult<Self> {

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -42,6 +42,7 @@ pub mod model;
 pub mod rpc;
 pub mod serving;
 pub mod stream;
+pub mod table_refill;
 pub mod telemetry;
 
 pub use error::{MetaError, MetaResult};

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -127,9 +127,12 @@ impl NotificationManager {
         &self,
         target: Target,
         operation: Operation,
-        info: Info,
+        mut info: Info,
         version: Option<NotificationVersion>,
     ) {
+        if let (Some(version), Info::TableRefillRuntimeConfig(config)) = (version, &mut info) {
+            config.version = version;
+        }
         let task = Task {
             target,
             operation,
@@ -214,6 +217,23 @@ impl NotificationManager {
             .await
     }
 
+    pub async fn notify_hummock_with_worker_key(
+        &self,
+        worker_key: Option<WorkerKey>,
+        operation: Operation,
+        info: Info,
+    ) -> NotificationVersion {
+        self.notify_with_version(
+            Target {
+                subscribe_type: SubscribeType::Hummock,
+                worker_key,
+            },
+            operation,
+            info,
+        )
+        .await
+    }
+
     pub async fn notify_compactor(&self, operation: Operation, info: Info) -> NotificationVersion {
         self.notify_with_version(SubscribeType::Compactor.into(), operation, info)
             .await
@@ -229,22 +249,6 @@ impl NotificationManager {
 
     pub fn notify_hummock_without_version(&self, operation: Operation, info: Info) {
         self.notify_without_version(SubscribeType::Hummock.into(), operation, info)
-    }
-
-    pub fn notify_hummock_with_worker_key_without_version(
-        &self,
-        worker_key: Option<WorkerKey>,
-        operation: Operation,
-        info: Info,
-    ) {
-        self.notify_without_version(
-            Target {
-                subscribe_type: SubscribeType::Hummock,
-                worker_key,
-            },
-            operation,
-            info,
-        )
     }
 
     pub fn notify_compactor_without_version(&self, operation: Operation, info: Info) {
@@ -440,6 +444,34 @@ mod tests {
         assert!(rx1.try_recv().is_err());
         assert!(rx2.recv().await.is_some());
         assert!(rx3.recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_versioned_table_refill_runtime_config_carries_version() {
+        let mgr = NotificationManager::new(SqlMetaStore::for_test().await).await;
+        let worker_key = WorkerKey(HostAddress {
+            host: "a".to_owned(),
+            port: 1,
+        });
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        mgr.insert_sender(SubscribeType::Hummock, worker_key.clone(), tx);
+
+        let version = mgr
+            .notify_hummock_with_worker_key(
+                Some(worker_key),
+                Operation::Update,
+                Info::TableRefillRuntimeConfig(Default::default()),
+            )
+            .await;
+
+        let notification = rx.recv().await.unwrap().unwrap();
+        assert_eq!(notification.version, version);
+        match notification.info.unwrap() {
+            Info::TableRefillRuntimeConfig(config) => {
+                assert_eq!(config.version, version);
+            }
+            info => panic!("unexpected notification: {info:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -127,12 +127,9 @@ impl NotificationManager {
         &self,
         target: Target,
         operation: Operation,
-        mut info: Info,
+        info: Info,
         version: Option<NotificationVersion>,
     ) {
-        if let (Some(version), Info::TableRefillRuntimeConfig(config)) = (version, &mut info) {
-            config.version = version;
-        }
         let task = Task {
             target,
             operation,
@@ -215,23 +212,6 @@ impl NotificationManager {
     pub async fn notify_hummock(&self, operation: Operation, info: Info) -> NotificationVersion {
         self.notify_with_version(SubscribeType::Hummock.into(), operation, info)
             .await
-    }
-
-    pub async fn notify_hummock_with_worker_key(
-        &self,
-        worker_key: Option<WorkerKey>,
-        operation: Operation,
-        info: Info,
-    ) -> NotificationVersion {
-        self.notify_with_version(
-            Target {
-                subscribe_type: SubscribeType::Hummock,
-                worker_key,
-            },
-            operation,
-            info,
-        )
-        .await
     }
 
     pub async fn notify_compactor(&self, operation: Operation, info: Info) -> NotificationVersion {
@@ -444,34 +424,6 @@ mod tests {
         assert!(rx1.try_recv().is_err());
         assert!(rx2.recv().await.is_some());
         assert!(rx3.recv().await.is_some());
-    }
-
-    #[tokio::test]
-    async fn test_versioned_table_refill_runtime_config_carries_version() {
-        let mgr = NotificationManager::new(SqlMetaStore::for_test().await).await;
-        let worker_key = WorkerKey(HostAddress {
-            host: "a".to_owned(),
-            port: 1,
-        });
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        mgr.insert_sender(SubscribeType::Hummock, worker_key.clone(), tx);
-
-        let version = mgr
-            .notify_hummock_with_worker_key(
-                Some(worker_key),
-                Operation::Update,
-                Info::TableRefillRuntimeConfig(Default::default()),
-            )
-            .await;
-
-        let notification = rx.recv().await.unwrap().unwrap();
-        assert_eq!(notification.version, version);
-        match notification.info.unwrap() {
-            Info::TableRefillRuntimeConfig(config) => {
-                assert_eq!(config.version, version);
-            }
-            info => panic!("unexpected notification: {info:?}"),
-        }
     }
 
     #[tokio::test]

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -364,16 +364,31 @@ pub fn build_worker_table_vnode_mapping(
 ) -> HashMap<WorkerId, HashMap<TableId, Bitmap>> {
     let mut worker_table_vnode_mapping = init_worker_table_vnode_mapping(active_serving_workers);
     for (fragment_id, mapping) in fragment_worker_slot_mappings {
-        let Some(parallelism) = streaming_parallelisms.get(fragment_id) else {
-            continue;
-        };
+        let state_table_ids = &streaming_parallelisms
+            .get(fragment_id)
+            .expect("streaming parallelism must exist")
+            .state_table_ids;
         append_worker_table_vnode_mapping(
             &mut worker_table_vnode_mapping,
-            &parallelism.state_table_ids,
+            state_table_ids,
             mapping,
         );
     }
     worker_table_vnode_mapping
+}
+
+pub fn to_pb_serving_table_vnode_mappings(
+    table_vnode_mapping: &HashMap<TableId, Bitmap>,
+) -> PbServingTableVnodeMappings {
+    PbServingTableVnodeMappings {
+        mappings: table_vnode_mapping
+            .iter()
+            .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
+                table_id: table_id.as_raw_id(),
+                bitmap: Some(bitmap.to_protobuf()),
+            })
+            .collect(),
+    }
 }
 
 async fn notify_hummock_serving_table_vnode_mapping(
@@ -388,12 +403,6 @@ async fn notify_hummock_serving_table_vnode_mapping(
         .list_active_serving_workers()
         .await
         .expect("fail to list serving compute nodes");
-    for fragment_id in fragment_worker_slot_mappings.keys() {
-        assert!(
-            streaming_parallelisms.contains_key(fragment_id),
-            "streaming parallelism must exist"
-        );
-    }
     let worker_table_vnode_mapping = build_worker_table_vnode_mapping(
         &active_serving_workers,
         fragment_worker_slot_mappings,
@@ -408,15 +417,9 @@ async fn notify_hummock_serving_table_vnode_mapping(
                     port: worker.host.as_ref().unwrap().port,
                 })),
                 operation,
-                Info::ServingTableVnodeMappings(PbServingTableVnodeMappings {
-                    mappings: table_vnode_mapping
-                        .iter()
-                        .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
-                            table_id: table_id.as_raw_id(),
-                            bitmap: Some(bitmap.to_protobuf()),
-                        })
-                        .collect(),
-                }),
+                Info::ServingTableVnodeMappings(to_pb_serving_table_vnode_mappings(
+                    table_vnode_mapping,
+                )),
             );
         }
     }
@@ -458,15 +461,9 @@ async fn notify_hummock_delete_serving_table_vnode_mapping(
                     port: worker.host.as_ref().unwrap().port,
                 })),
                 operation,
-                Info::ServingTableVnodeMappings(PbServingTableVnodeMappings {
-                    mappings: table_vnode_mapping
-                        .iter()
-                        .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
-                            table_id: table_id.as_raw_id(),
-                            bitmap: Some(bitmap.to_protobuf()),
-                        })
-                        .collect(),
-                }),
+                Info::ServingTableVnodeMappings(to_pb_serving_table_vnode_mappings(
+                    table_vnode_mapping,
+                )),
             );
         }
     }

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -26,6 +26,7 @@ use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, FragmentWorkerSlotMappings, PbServingTableVnodeMappings,
+    PbTableRefillRuntimeConfig,
 };
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
@@ -411,16 +412,21 @@ async fn notify_hummock_serving_table_vnode_mapping(
 
     for worker in active_serving_workers {
         if let Some(table_vnode_mapping) = worker_table_vnode_mapping.get(&worker.id) {
-            notification_manager.notify_hummock_with_worker_key_without_version(
-                Some(WorkerKey(PbHostAddress {
-                    host: worker.host.as_ref().unwrap().host.clone(),
-                    port: worker.host.as_ref().unwrap().port,
-                })),
-                operation,
-                Info::ServingTableVnodeMappings(to_pb_serving_table_vnode_mappings(
-                    table_vnode_mapping,
-                )),
-            );
+            notification_manager
+                .notify_hummock_with_worker_key(
+                    Some(WorkerKey(PbHostAddress {
+                        host: worker.host.as_ref().unwrap().host.clone(),
+                        port: worker.host.as_ref().unwrap().port,
+                    })),
+                    operation,
+                    Info::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                        serving_table_vnode_mappings: Some(to_pb_serving_table_vnode_mappings(
+                            table_vnode_mapping,
+                        )),
+                        ..Default::default()
+                    }),
+                )
+                .await;
         }
     }
 }
@@ -455,16 +461,21 @@ async fn notify_hummock_delete_serving_table_vnode_mapping(
 
     for worker in active_serving_workers {
         if let Some(table_vnode_mapping) = worker_table_vnode_mapping.get(&worker.id) {
-            notification_manager.notify_hummock_with_worker_key_without_version(
-                Some(WorkerKey(PbHostAddress {
-                    host: worker.host.as_ref().unwrap().host.clone(),
-                    port: worker.host.as_ref().unwrap().port,
-                })),
-                operation,
-                Info::ServingTableVnodeMappings(to_pb_serving_table_vnode_mappings(
-                    table_vnode_mapping,
-                )),
-            );
+            notification_manager
+                .notify_hummock_with_worker_key(
+                    Some(WorkerKey(PbHostAddress {
+                        host: worker.host.as_ref().unwrap().host.clone(),
+                        port: worker.host.as_ref().unwrap().port,
+                    })),
+                    operation,
+                    Info::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
+                        serving_table_vnode_mappings: Some(to_pb_serving_table_vnode_mappings(
+                            table_vnode_mapping,
+                        )),
+                        ..Default::default()
+                    }),
+                )
+                .await;
         }
     }
 }

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -20,20 +20,19 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_common::hash::WorkerSlotMapping;
 use risingwave_common::vnode_mapping::vnode_placement::place_vnode;
 use risingwave_meta_model::{TableId, WorkerId};
-use risingwave_pb::common::{PbHostAddress, PbWorkerNode, WorkerNode, WorkerType};
+use risingwave_pb::common::{WorkerNode, WorkerType};
 use risingwave_pb::meta::serving_table_vnode_mappings::PbServingTableVnodeMapping;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
 use risingwave_pb::meta::{
     FragmentWorkerSlotMapping, FragmentWorkerSlotMappings, PbServingTableVnodeMappings,
-    PbTableRefillRuntimeConfig,
 };
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
 use crate::controller::fragment::FragmentParallelismInfo;
 use crate::controller::session_params::SessionParamsControllerRef;
-use crate::manager::{LocalNotification, MetadataManager, NotificationManagerRef, WorkerKey};
+use crate::manager::{LocalNotification, MetadataManager, NotificationManagerRef};
 use crate::model::FragmentId;
 
 pub type ServingVnodeMappingRef = Arc<ServingVnodeMapping>;
@@ -147,15 +146,6 @@ pub async fn on_meta_start(
             mappings: to_fragment_worker_slot_mapping(&mappings),
         }),
     );
-
-    notify_hummock_serving_table_vnode_mapping(
-        Operation::Snapshot,
-        metadata_manager,
-        &notification_manager,
-        &mappings,
-        &streaming_parallelisms,
-    )
-    .await;
 }
 
 async fn fetch_serving_infos(
@@ -221,14 +211,6 @@ pub fn start_serving_vnode_mapping_worker(
                     mappings: to_fragment_worker_slot_mapping(&mappings),
                 }),
             );
-            notify_hummock_serving_table_vnode_mapping(
-                Operation::Snapshot,
-                &metadata_manager,
-                &notification_manager,
-                &mappings,
-                &streaming_parallelisms,
-            )
-            .await;
         };
         loop {
             tokio::select! {
@@ -268,23 +250,10 @@ pub fn start_serving_vnode_mapping_worker(
                                     if !upserted.is_empty() {
                                         tracing::debug!("Update serving vnode mapping for fragments {:?}.", upserted.keys());
                                         notification_manager.notify_frontend_without_version(Operation::Update, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_fragment_worker_slot_mapping(&upserted) }));
-                                        notify_hummock_serving_table_vnode_mapping(
-                                            Operation::Update,
-                                            &metadata_manager,
-                                            &notification_manager,
-                                            &upserted,
-                                            &filtered_streaming_parallelisms,
-                                        ).await;
                                     }
                                     if !failed.is_empty() {
                                         tracing::warn!("Fail to update serving vnode mapping for fragments {:?}.", failed);
                                         notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(failed.keys().cloned())}));
-                                        notify_hummock_delete_serving_table_vnode_mapping(
-                                            Operation::Delete,
-                                            &metadata_manager,
-                                            &notification_manager,
-                                            &failed,
-                                        ).await;
                                     }
                                 }
                                 LocalNotification::FragmentMappingsDelete(fragment_ids) => {
@@ -294,23 +263,8 @@ pub fn start_serving_vnode_mapping_worker(
 
                                     tracing::debug!("Delete serving vnode mapping for fragments {:?}.", fragment_ids);
 
-                                    // TODO(MrCroxx): Are streaming parallelisms already needed here?
-                                    let (_, streaming_parallelisms) = fetch_serving_infos(&metadata_manager).await;
-                                    let mut deleted : HashMap<FragmentId, FragmentParallelismInfo> = HashMap::new();
-                                    for fragment_id in &fragment_ids {
-                                        if let Some(info) = streaming_parallelisms.get(fragment_id) {
-                                            deleted.insert(*fragment_id, info.clone());
-                                        }
-                                    }
-
                                     serving_vnode_mapping.remove(&fragment_ids);
                                     notification_manager.notify_frontend_without_version(Operation::Delete, Info::ServingWorkerSlotMappings(FragmentWorkerSlotMappings{ mappings: to_deleted_fragment_worker_slot_mapping(fragment_ids.iter().cloned()) }));
-                                    notify_hummock_delete_serving_table_vnode_mapping(
-                                        Operation::Delete,
-                                        &metadata_manager,
-                                        &notification_manager,
-                                        &deleted,
-                                    ).await;
                                 }
                                 _ => {}
                             }
@@ -329,53 +283,44 @@ pub fn start_serving_vnode_mapping_worker(
     (join_handle, shutdown_tx)
 }
 
-/// Initialize an empty worker to table id to vnode bitmap mapping.
-fn init_worker_table_vnode_mapping(
-    active_serving_workers: &[PbWorkerNode],
-) -> HashMap<WorkerId, HashMap<TableId, Bitmap>> {
-    active_serving_workers
-        .iter()
-        .map(|worker| (worker.id, HashMap::new()))
-        .collect()
-}
-
-/// Append vnode bitmap mapping to each worker for each state table id.
-fn append_worker_table_vnode_mapping(
-    mapping: &mut HashMap<WorkerId, HashMap<TableId, Bitmap>>,
+fn append_table_vnode_mapping_for_worker(
+    table_vnode_mapping: &mut HashMap<TableId, Bitmap>,
+    worker_id: WorkerId,
     state_table_ids: &HashSet<TableId>,
     worker_slot_vnode_mapping: &WorkerSlotMapping,
 ) {
     for (worker_slot_id, bitmap) in &worker_slot_vnode_mapping.to_bitmaps() {
-        let worker_id = worker_slot_id.worker_id();
-        if let Some(worker_mapping) = mapping.get_mut(&worker_id) {
-            for table_id in state_table_ids {
-                worker_mapping
-                    .entry(*table_id)
-                    .and_modify(|b| *b |= bitmap.clone())
-                    .or_insert_with(|| bitmap.clone());
-            }
+        if worker_slot_id.worker_id() != worker_id {
+            continue;
+        }
+        for table_id in state_table_ids {
+            table_vnode_mapping
+                .entry(*table_id)
+                .and_modify(|b| *b |= bitmap.clone())
+                .or_insert_with(|| bitmap.clone());
         }
     }
 }
 
-pub fn build_worker_table_vnode_mapping(
-    active_serving_workers: &[PbWorkerNode],
+pub fn build_table_vnode_mapping_for_worker(
+    worker_id: WorkerId,
     fragment_worker_slot_mappings: &HashMap<FragmentId, WorkerSlotMapping>,
     streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
-) -> HashMap<WorkerId, HashMap<TableId, Bitmap>> {
-    let mut worker_table_vnode_mapping = init_worker_table_vnode_mapping(active_serving_workers);
+) -> HashMap<TableId, Bitmap> {
+    let mut table_vnode_mapping = HashMap::new();
     for (fragment_id, mapping) in fragment_worker_slot_mappings {
-        let state_table_ids = &streaming_parallelisms
-            .get(fragment_id)
-            .expect("streaming parallelism must exist")
-            .state_table_ids;
-        append_worker_table_vnode_mapping(
-            &mut worker_table_vnode_mapping,
-            state_table_ids,
+        let Some(info) = streaming_parallelisms.get(fragment_id) else {
+            tracing::warn!(%fragment_id, "streaming parallelism not found");
+            continue;
+        };
+        append_table_vnode_mapping_for_worker(
+            &mut table_vnode_mapping,
+            worker_id,
+            &info.state_table_ids,
             mapping,
         );
     }
-    worker_table_vnode_mapping
+    table_vnode_mapping
 }
 
 pub fn to_pb_serving_table_vnode_mappings(
@@ -389,93 +334,5 @@ pub fn to_pb_serving_table_vnode_mappings(
                 bitmap: Some(bitmap.to_protobuf()),
             })
             .collect(),
-    }
-}
-
-async fn notify_hummock_serving_table_vnode_mapping(
-    operation: Operation,
-    metadata_manager: &MetadataManager,
-    notification_manager: &NotificationManagerRef,
-    fragment_worker_slot_mappings: &HashMap<FragmentId, WorkerSlotMapping>,
-    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
-) {
-    let active_serving_workers = metadata_manager
-        .cluster_controller
-        .list_active_serving_workers()
-        .await
-        .expect("fail to list serving compute nodes");
-    let worker_table_vnode_mapping = build_worker_table_vnode_mapping(
-        &active_serving_workers,
-        fragment_worker_slot_mappings,
-        streaming_parallelisms,
-    );
-
-    for worker in active_serving_workers {
-        if let Some(table_vnode_mapping) = worker_table_vnode_mapping.get(&worker.id) {
-            notification_manager
-                .notify_hummock_with_worker_key(
-                    Some(WorkerKey(PbHostAddress {
-                        host: worker.host.as_ref().unwrap().host.clone(),
-                        port: worker.host.as_ref().unwrap().port,
-                    })),
-                    operation,
-                    Info::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
-                        serving_table_vnode_mappings: Some(to_pb_serving_table_vnode_mappings(
-                            table_vnode_mapping,
-                        )),
-                        ..Default::default()
-                    }),
-                )
-                .await;
-        }
-    }
-}
-
-/// delete vnode bitmap mapping to each worker for each state table id.
-fn delete_worker_table_vnode_mapping(
-    mapping: &mut HashMap<WorkerId, HashMap<TableId, Bitmap>>,
-    state_table_ids: &HashSet<TableId>,
-) {
-    for table_id in state_table_ids {
-        for worker_mapping in mapping.values_mut() {
-            worker_mapping.insert(*table_id, Bitmap::zeros(0));
-        }
-    }
-}
-
-async fn notify_hummock_delete_serving_table_vnode_mapping(
-    operation: Operation,
-    metadata_manager: &MetadataManager,
-    notification_manager: &NotificationManagerRef,
-    fragment_infos: &HashMap<FragmentId, FragmentParallelismInfo>,
-) {
-    let active_serving_workers = metadata_manager
-        .cluster_controller
-        .list_active_serving_workers()
-        .await
-        .expect("fail to list serving compute nodes");
-    let mut worker_table_vnode_mapping = init_worker_table_vnode_mapping(&active_serving_workers);
-    for info in fragment_infos.values() {
-        delete_worker_table_vnode_mapping(&mut worker_table_vnode_mapping, &info.state_table_ids);
-    }
-
-    for worker in active_serving_workers {
-        if let Some(table_vnode_mapping) = worker_table_vnode_mapping.get(&worker.id) {
-            notification_manager
-                .notify_hummock_with_worker_key(
-                    Some(WorkerKey(PbHostAddress {
-                        host: worker.host.as_ref().unwrap().host.clone(),
-                        port: worker.host.as_ref().unwrap().port,
-                    })),
-                    operation,
-                    Info::TableRefillRuntimeConfig(PbTableRefillRuntimeConfig {
-                        serving_table_vnode_mappings: Some(to_pb_serving_table_vnode_mappings(
-                            table_vnode_mapping,
-                        )),
-                        ..Default::default()
-                    }),
-                )
-                .await;
-        }
     }
 }

--- a/src/meta/src/serving/mod.rs
+++ b/src/meta/src/serving/mod.rs
@@ -357,6 +357,25 @@ fn append_worker_table_vnode_mapping(
     }
 }
 
+pub fn build_worker_table_vnode_mapping(
+    active_serving_workers: &[PbWorkerNode],
+    fragment_worker_slot_mappings: &HashMap<FragmentId, WorkerSlotMapping>,
+    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
+) -> HashMap<WorkerId, HashMap<TableId, Bitmap>> {
+    let mut worker_table_vnode_mapping = init_worker_table_vnode_mapping(active_serving_workers);
+    for (fragment_id, mapping) in fragment_worker_slot_mappings {
+        let Some(parallelism) = streaming_parallelisms.get(fragment_id) else {
+            continue;
+        };
+        append_worker_table_vnode_mapping(
+            &mut worker_table_vnode_mapping,
+            &parallelism.state_table_ids,
+            mapping,
+        );
+    }
+    worker_table_vnode_mapping
+}
+
 async fn notify_hummock_serving_table_vnode_mapping(
     operation: Operation,
     metadata_manager: &MetadataManager,
@@ -369,18 +388,17 @@ async fn notify_hummock_serving_table_vnode_mapping(
         .list_active_serving_workers()
         .await
         .expect("fail to list serving compute nodes");
-    let mut worker_table_vnode_mapping = init_worker_table_vnode_mapping(&active_serving_workers);
-    for (fragment_id, mapping) in fragment_worker_slot_mappings {
-        let state_table_ids = &streaming_parallelisms
-            .get(fragment_id)
-            .expect("streaming parallelism must exist")
-            .state_table_ids;
-        append_worker_table_vnode_mapping(
-            &mut worker_table_vnode_mapping,
-            state_table_ids,
-            mapping,
+    for fragment_id in fragment_worker_slot_mappings.keys() {
+        assert!(
+            streaming_parallelisms.contains_key(fragment_id),
+            "streaming parallelism must exist"
         );
     }
+    let worker_table_vnode_mapping = build_worker_table_vnode_mapping(
+        &active_serving_workers,
+        fragment_worker_slot_mappings,
+        streaming_parallelisms,
+    );
 
     for worker in active_serving_workers {
         if let Some(table_vnode_mapping) = worker_table_vnode_mapping.get(&worker.id) {

--- a/src/meta/src/table_refill.rs
+++ b/src/meta/src/table_refill.rs
@@ -1,0 +1,76 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::meta::{PbServingTableVnodeMappings, PbTableRefillRuntimeConfig};
+
+use crate::MetaResult;
+use crate::manager::{MetadataManager, NotificationVersion, WorkerKey};
+use crate::serving::{
+    ServingVnodeMappingRef, build_table_vnode_mapping_for_worker,
+    to_pb_serving_table_vnode_mappings,
+};
+
+async fn build_hummock_serving_table_vnode_mappings(
+    metadata_manager: &MetadataManager,
+    serving_vnode_mapping: &ServingVnodeMappingRef,
+    worker_key: &WorkerKey,
+) -> MetaResult<PbServingTableVnodeMappings> {
+    let active_serving_workers = metadata_manager
+        .cluster_controller
+        .list_active_serving_workers()
+        .await?;
+    let Some(worker_id) = active_serving_workers
+        .iter()
+        .find(|worker| worker.host.as_ref() == Some(&worker_key.0))
+        .map(|worker| worker.id)
+    else {
+        return Ok(PbServingTableVnodeMappings::default());
+    };
+
+    let streaming_parallelisms = metadata_manager
+        .catalog_controller
+        .running_fragment_parallelisms(None)?;
+    let serving_vnode_mappings = serving_vnode_mapping.all();
+    let table_vnode_mapping = build_table_vnode_mapping_for_worker(
+        worker_id,
+        &serving_vnode_mappings,
+        &streaming_parallelisms,
+    );
+
+    Ok(to_pb_serving_table_vnode_mappings(&table_vnode_mapping))
+}
+
+pub async fn build_hummock_table_refill_runtime_config(
+    metadata_manager: &MetadataManager,
+    serving_vnode_mapping: &ServingVnodeMappingRef,
+    worker_key: &WorkerKey,
+    version: NotificationVersion,
+) -> MetaResult<PbTableRefillRuntimeConfig> {
+    let table_cache_refill_policies = metadata_manager
+        .catalog_controller
+        .table_cache_refill_policies_snapshot()
+        .await?;
+    let serving_table_vnode_mappings = build_hummock_serving_table_vnode_mappings(
+        metadata_manager,
+        serving_vnode_mapping,
+        worker_key,
+    )
+    .await?;
+
+    Ok(PbTableRefillRuntimeConfig {
+        table_cache_refill_policies: Some(table_cache_refill_policies),
+        serving_table_vnode_mappings: Some(serving_table_vnode_mappings),
+        version,
+    })
+}

--- a/src/meta/src/table_refill.rs
+++ b/src/meta/src/table_refill.rs
@@ -12,65 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_pb::meta::{PbServingTableVnodeMappings, PbTableRefillRuntimeConfig};
+use std::collections::HashMap;
 
-use crate::MetaResult;
-use crate::manager::{MetadataManager, NotificationVersion, WorkerKey};
+use risingwave_meta_model::{FragmentId, WorkerId};
+use risingwave_pb::meta::{
+    PbServingTableVnodeMappings, PbTableCacheRefillPolicies, PbTableRefillRuntimeConfig,
+};
+
+use crate::controller::fragment::FragmentParallelismInfo;
+use crate::manager::NotificationVersion;
 use crate::serving::{
     ServingVnodeMappingRef, build_table_vnode_mapping_for_worker,
     to_pb_serving_table_vnode_mappings,
 };
 
-async fn build_hummock_serving_table_vnode_mappings(
-    metadata_manager: &MetadataManager,
+fn build_hummock_serving_table_vnode_mappings(
     serving_vnode_mapping: &ServingVnodeMappingRef,
-    worker_key: &WorkerKey,
-) -> MetaResult<PbServingTableVnodeMappings> {
-    let active_serving_workers = metadata_manager
-        .cluster_controller
-        .list_active_serving_workers()
-        .await?;
-    let Some(worker_id) = active_serving_workers
-        .iter()
-        .find(|worker| worker.host.as_ref() == Some(&worker_key.0))
-        .map(|worker| worker.id)
-    else {
-        return Ok(PbServingTableVnodeMappings::default());
-    };
-
-    let streaming_parallelisms = metadata_manager
-        .catalog_controller
-        .running_fragment_parallelisms(None)?;
+    worker_id: WorkerId,
+    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
+) -> PbServingTableVnodeMappings {
     let serving_vnode_mappings = serving_vnode_mapping.all();
     let table_vnode_mapping = build_table_vnode_mapping_for_worker(
         worker_id,
         &serving_vnode_mappings,
-        &streaming_parallelisms,
+        streaming_parallelisms,
     );
 
-    Ok(to_pb_serving_table_vnode_mappings(&table_vnode_mapping))
+    to_pb_serving_table_vnode_mappings(&table_vnode_mapping)
 }
 
-pub async fn build_hummock_table_refill_runtime_config(
-    metadata_manager: &MetadataManager,
+pub fn build_hummock_table_refill_runtime_config(
     serving_vnode_mapping: &ServingVnodeMappingRef,
-    worker_key: &WorkerKey,
+    worker_id: WorkerId,
+    table_cache_refill_policies: PbTableCacheRefillPolicies,
+    streaming_parallelisms: &HashMap<FragmentId, FragmentParallelismInfo>,
     version: NotificationVersion,
-) -> MetaResult<PbTableRefillRuntimeConfig> {
-    let table_cache_refill_policies = metadata_manager
-        .catalog_controller
-        .table_cache_refill_policies_snapshot()
-        .await?;
+) -> PbTableRefillRuntimeConfig {
     let serving_table_vnode_mappings = build_hummock_serving_table_vnode_mappings(
-        metadata_manager,
         serving_vnode_mapping,
-        worker_key,
-    )
-    .await?;
+        worker_id,
+        streaming_parallelisms,
+    );
 
-    Ok(PbTableRefillRuntimeConfig {
+    PbTableRefillRuntimeConfig {
         table_cache_refill_policies: Some(table_cache_refill_policies),
         serving_table_vnode_mappings: Some(serving_table_vnode_mappings),
         version,
-    })
+    }
 }

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -42,7 +42,7 @@ use risingwave_storage::compaction_catalog_manager::{
 use risingwave_storage::error::StorageResult;
 use risingwave_storage::hummock::HummockStorage;
 use risingwave_storage::hummock::backup_reader::BackupReader;
-use risingwave_storage::hummock::event_handler::HummockVersionUpdate;
+use risingwave_storage::hummock::event_handler::{HummockObserverEvent, HummockVersionUpdate};
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::local_version::pinned_version::PinnedVersion;
 use risingwave_storage::hummock::observer_manager::HummockObserverNode;
@@ -61,11 +61,10 @@ pub async fn prepare_first_valid_version(
     worker_id: WorkerId,
 ) -> (
     PinnedVersion,
-    UnboundedSender<HummockVersionUpdate>,
-    UnboundedReceiver<HummockVersionUpdate>,
+    UnboundedSender<HummockObserverEvent>,
+    UnboundedReceiver<HummockObserverEvent>,
 ) {
-    let (version_update_tx, mut version_update_rx) = unbounded_channel();
-    let (table_refill_runtime_config_tx, _table_refill_runtime_config_rx) = unbounded_channel();
+    let (observer_event_tx, mut observer_event_rx) = unbounded_channel();
 
     let notification_client = get_notification_client_for_test(
         env,
@@ -81,22 +80,23 @@ pub async fn prepare_first_valid_version(
         HummockObserverNode::new(
             Arc::new(CompactionCatalogManager::default()),
             backup_manager,
-            version_update_tx.clone(),
-            table_refill_runtime_config_tx,
+            observer_event_tx.clone(),
             write_limiter,
         ),
     )
     .await;
     observer_manager.start().await;
-    let hummock_version = match version_update_rx.recv().await {
-        Some(HummockVersionUpdate::PinnedVersion(version)) => version,
+    let hummock_version = match observer_event_rx.recv().await {
+        Some(HummockObserverEvent::VersionUpdate(HummockVersionUpdate::PinnedVersion(version))) => {
+            version
+        }
         _ => unreachable!("should be full version"),
     };
 
     (
         PinnedVersion::new(*hummock_version, unbounded_channel().0),
-        version_update_tx,
-        version_update_rx,
+        observer_event_tx,
+        observer_event_rx,
     )
 }
 

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -65,7 +65,7 @@ pub async fn prepare_first_valid_version(
     UnboundedReceiver<HummockVersionUpdate>,
 ) {
     let (version_update_tx, mut version_update_rx) = unbounded_channel();
-    let (serving_table_vnode_mapping_tx, _serving_table_vnode_mapping_rx) = unbounded_channel();
+    let (table_refill_runtime_config_tx, _table_refill_runtime_config_rx) = unbounded_channel();
 
     let notification_client = get_notification_client_for_test(
         env,
@@ -76,15 +76,13 @@ pub async fn prepare_first_valid_version(
     .await;
     let backup_manager = BackupReader::unused().await;
     let write_limiter = WriteLimiter::unused();
-    let (cache_refill_policy_tx, _cache_refill_policy_rx) = unbounded_channel();
     let observer_manager = ObserverManager::new(
         notification_client,
         HummockObserverNode::new(
             Arc::new(CompactionCatalogManager::default()),
             backup_manager,
             version_update_tx.clone(),
-            cache_refill_policy_tx,
-            serving_table_vnode_mapping_tx,
+            table_refill_runtime_config_tx,
             write_limiter,
         ),
     )

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -65,7 +65,6 @@ pub async fn prepare_first_valid_version(
     UnboundedReceiver<HummockVersionUpdate>,
 ) {
     let (version_update_tx, mut version_update_rx) = unbounded_channel();
-    let (cache_refill_policy_tx, _cache_refill_policy_rx) = unbounded_channel();
     let (serving_table_vnode_mapping_tx, _serving_table_vnode_mapping_rx) = unbounded_channel();
 
     let notification_client = get_notification_client_for_test(
@@ -77,6 +76,7 @@ pub async fn prepare_first_valid_version(
     .await;
     let backup_manager = BackupReader::unused().await;
     let write_limiter = WriteLimiter::unused();
+    let (cache_refill_policy_tx, _cache_refill_policy_rx) = unbounded_channel();
     let observer_manager = ObserverManager::new(
         notification_client,
         HummockObserverNode::new(

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -271,16 +271,18 @@ impl HummockEventHandler {
         operation: Operation,
         config: PbTableRefillRuntimeConfig,
     ) {
+        // Meta only emits non-snapshot table refill runtime config after recovery. Online
+        // runtime updates are not supported for either policies or serving vnode mappings.
         if let Some(policies) = config.table_cache_refill_policies {
             refiller
                 .update_table_cache_refill_policies(table_cache_refill_policies_to_map(policies));
         }
 
-        if let Some(mappings) = config.serving_table_vnode_mappings {
-            refiller.update_serving_table_vnode_mapping(
-                operation,
-                serving_table_vnode_mappings_to_map(mappings),
-            );
+        if operation == Operation::Snapshot
+            && let Some(mappings) = config.serving_table_vnode_mappings
+        {
+            refiller
+                .replace_serving_table_vnode_mapping(serving_table_vnode_mappings_to_map(mappings));
         }
     }
 
@@ -1058,7 +1060,7 @@ mod tests {
     use std::task::Poll;
 
     use futures::FutureExt;
-    use parking_lot::Mutex;
+    use parking_lot::{Mutex, RwLock};
     use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::TableId;
     use risingwave_common::config::Role;
@@ -1164,6 +1166,60 @@ mod tests {
             Some(&CacheRefillPolicy::Serving)
         );
         assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+    }
+
+    #[tokio::test]
+    async fn test_recovery_policy_update_preserves_serving_mapping() {
+        let table_id = TableId::new(233);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
+        let storage_opt = default_opts_for_test();
+        let mut refiller = CacheRefiller::new(
+            Role::Serving,
+            CacheRefillConfig::from_storage_opts(&storage_opt),
+            mock_sstable_store().await,
+            CacheRefiller::default_spawn_refill_task(),
+            read_version_mapping,
+        );
+        let policies = || TableCacheRefillPolicies {
+            policies: vec![PbTableCacheRefillPolicy {
+                table_id: table_id.as_raw_id(),
+                policy: PbCacheRefillPolicy::Serving as i32,
+            }],
+        };
+
+        HummockEventHandler::apply_table_refill_runtime_config(
+            &mut refiller,
+            Operation::Snapshot,
+            table_refill_runtime_config_for_test(
+                policies(),
+                HashMap::from([(table_id, serving_vnodes.clone())]),
+            ),
+        );
+        HummockEventHandler::apply_table_refill_runtime_config(
+            &mut refiller,
+            Operation::Update,
+            PbTableRefillRuntimeConfig {
+                table_cache_refill_policies: Some(TableCacheRefillPolicies {
+                    policies: vec![PbTableCacheRefillPolicy {
+                        table_id: table_id.as_raw_id(),
+                        policy: PbCacheRefillPolicy::Disabled as i32,
+                    }],
+                }),
+                ..Default::default()
+            },
+        );
+
+        let context = refiller.table_cache_refill_context().read();
+        assert_eq!(
+            context.policies.get(&table_id),
+            Some(&CacheRefillPolicy::Disabled)
+        );
+        assert!(!context.serving.contains_key(&table_id));
+        assert_eq!(
+            context.serving_table_vnode_mapping.read().get(&table_id),
+            Some(&serving_vnodes)
+        );
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -197,6 +197,21 @@ struct HummockEventHandlerMetrics {
     event_handler_on_spiller: Histogram,
 }
 
+fn table_cache_refill_policies_to_map(
+    policies: TableCacheRefillPolicies,
+) -> HashMap<TableId, Option<CacheRefillPolicy>> {
+    policies
+        .policies
+        .into_iter()
+        .map(|policy| {
+            (
+                TableId::from(policy.table_id),
+                CacheRefillPolicy::from_protobuf(policy.get_policy().unwrap()),
+            )
+        })
+        .collect()
+}
+
 pub(crate) struct HummockEventHandler {
     hummock_event_tx: HummockEventSender,
     hummock_event_rx: HummockEventReceiver,
@@ -238,6 +253,7 @@ impl HummockEventHandler {
     pub fn new(
         role: Role,
         version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
+        initial_cache_refill_policies: TableCacheRefillPolicies,
         cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
         serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
         pinned_version: PinnedVersion,
@@ -261,6 +277,7 @@ impl HummockEventHandler {
         Self::new_inner(
             role,
             version_update_rx,
+            initial_cache_refill_policies,
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             compactor_context.sstable_store.clone(),
@@ -320,6 +337,7 @@ impl HummockEventHandler {
     fn new_inner(
         role: Role,
         version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
+        initial_cache_refill_policies: TableCacheRefillPolicies,
         cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
         serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
         sstable_store: SstableStoreRef,
@@ -358,13 +376,16 @@ impl HummockEventHandler {
             spawn_upload_task,
             buffer_tracker,
         );
-        let refiller = CacheRefiller::new(
+        let mut refiller = CacheRefiller::new(
             role,
             refill_config,
             sstable_store,
             spawn_refill_task,
             read_version_mapping.clone(),
         );
+        refiller.update_table_cache_refill_policies(table_cache_refill_policies_to_map(
+            initial_cache_refill_policies,
+        ));
 
         Self {
             hummock_event_tx,
@@ -747,8 +768,9 @@ impl HummockEventHandler {
                         warn!("cache refill policy stream ends. event handle shutdown");
                         return;
                     };
-                    let policies = policies.policies.into_iter().map(|policy| (TableId::from(policy.table_id), CacheRefillPolicy::from_protobuf(policy.get_policy().unwrap()))).collect::<HashMap<_, _>>();
-                    self.refiller.update_table_cache_refill_policies(policies);
+                    self.refiller.update_table_cache_refill_policies(
+                        table_cache_refill_policies_to_map(policies),
+                    );
                 }
                 serving_table_vnode_mapping = pin!(self.serving_table_vnode_mapping_rx.recv()) => {
                     let Some((op, mapping)) = serving_table_vnode_mapping else {
@@ -893,9 +915,9 @@ impl HummockEventHandler {
                     .get(&instance_id)
                     .unwrap_or_else(|| panic!("query inexist instance instance_id {instance_id}"))
                     .0;
-                self.refiller.update_table_cache_refill_vnodes(table_id);
                 self.uploader.may_destroy_instance(instance_id);
                 self.destroy_read_version(instance_id);
+                self.refiller.update_table_cache_refill_vnodes(table_id);
             }
             HummockEvent::GetMinUncommittedObjectId { result_tx } => {
                 let _ = result_tx
@@ -1018,6 +1040,7 @@ mod tests {
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_hummock_sdk::version::HummockVersion;
     use risingwave_pb::hummock::{PbHummockVersion, StateTableInfo};
+    use risingwave_pb::meta::TableCacheRefillPolicies;
     use tokio::spawn;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::sync::oneshot;
@@ -1075,6 +1098,7 @@ mod tests {
         let event_handler = HummockEventHandler::new_inner(
             Role::None,
             version_update_rx,
+            TableCacheRefillPolicies::default(),
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             mock_sstable_store().await,
@@ -1257,6 +1281,7 @@ mod tests {
         let event_handler = HummockEventHandler::new_inner(
             Role::None,
             version_update_rx,
+            TableCacheRefillPolicies::default(),
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             mock_sstable_store().await,

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -35,8 +35,8 @@ use risingwave_hummock_sdk::compaction_group::hummock_version_ext::SstDeltaInfo;
 use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::version::{HummockVersionCommon, LocalHummockVersionDelta};
 use risingwave_hummock_sdk::{HummockEpoch, SyncResult};
-use risingwave_pb::meta::TableCacheRefillPolicies;
 use risingwave_pb::meta::subscribe_response::Operation;
+use risingwave_pb::meta::{PbServingTableVnodeMappings, PbTableRefillRuntimeConfig};
 use tokio::spawn;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
@@ -198,7 +198,7 @@ struct HummockEventHandlerMetrics {
 }
 
 fn table_cache_refill_policies_to_map(
-    policies: TableCacheRefillPolicies,
+    policies: risingwave_pb::meta::TableCacheRefillPolicies,
 ) -> HashMap<TableId, CacheRefillPolicy> {
     policies
         .policies
@@ -210,12 +210,30 @@ fn table_cache_refill_policies_to_map(
         .collect()
 }
 
+fn serving_table_vnode_mappings_to_map(
+    mappings: PbServingTableVnodeMappings,
+) -> HashMap<TableId, Bitmap> {
+    mappings
+        .mappings
+        .into_iter()
+        .map(|mapping| {
+            (
+                TableId::from(mapping.table_id),
+                Bitmap::from(
+                    mapping
+                        .bitmap
+                        .expect("serving table vnode bitmap must exist"),
+                ),
+            )
+        })
+        .collect()
+}
+
 pub(crate) struct HummockEventHandler {
     hummock_event_tx: HummockEventSender,
     hummock_event_rx: HummockEventReceiver,
     version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
-    cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
-    serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
+    table_refill_runtime_config_rx: UnboundedReceiver<(Operation, PbTableRefillRuntimeConfig)>,
     read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
     /// A copy of `read_version_mapping` but owned by event handler
     local_read_version_mapping: HashMap<LocalInstanceId, (TableId, HummockReadVersionRef)>,
@@ -248,14 +266,29 @@ async fn flush_imms(
 }
 
 impl HummockEventHandler {
-    #[expect(clippy::too_many_arguments)]
+    fn apply_table_refill_runtime_config(
+        refiller: &mut CacheRefiller,
+        operation: Operation,
+        config: PbTableRefillRuntimeConfig,
+    ) {
+        if let Some(policies) = config.table_cache_refill_policies {
+            refiller
+                .update_table_cache_refill_policies(table_cache_refill_policies_to_map(policies));
+        }
+
+        if let Some(mappings) = config.serving_table_vnode_mappings {
+            refiller.update_serving_table_vnode_mapping(
+                operation,
+                serving_table_vnode_mappings_to_map(mappings),
+            );
+        }
+    }
+
     pub fn new(
         role: Role,
         version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
-        initial_cache_refill_policies: TableCacheRefillPolicies,
-        initial_serving_table_vnode_mapping: (Operation, HashMap<TableId, Bitmap>),
-        cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
-        serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
+        initial_table_refill_runtime_config: (Operation, PbTableRefillRuntimeConfig),
+        table_refill_runtime_config_rx: UnboundedReceiver<(Operation, PbTableRefillRuntimeConfig)>,
         pinned_version: PinnedVersion,
         compactor_context: CompactorContext,
         compaction_catalog_manager_ref: CompactionCatalogManagerRef,
@@ -277,10 +310,8 @@ impl HummockEventHandler {
         Self::new_inner(
             role,
             version_update_rx,
-            initial_cache_refill_policies,
-            initial_serving_table_vnode_mapping,
-            cache_refill_policy_rx,
-            serving_table_vnode_mapping_rx,
+            initial_table_refill_runtime_config,
+            table_refill_runtime_config_rx,
             compactor_context.sstable_store.clone(),
             state_store_metrics,
             CacheRefillConfig::from_storage_opts(&compactor_context.storage_opts),
@@ -338,10 +369,8 @@ impl HummockEventHandler {
     fn new_inner(
         role: Role,
         version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
-        initial_cache_refill_policies: TableCacheRefillPolicies,
-        initial_serving_table_vnode_mapping: (Operation, HashMap<TableId, Bitmap>),
-        cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
-        serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
+        initial_table_refill_runtime_config: (Operation, PbTableRefillRuntimeConfig),
+        table_refill_runtime_config_rx: UnboundedReceiver<(Operation, PbTableRefillRuntimeConfig)>,
         sstable_store: SstableStoreRef,
         state_store_metrics: Arc<HummockStateStoreMetrics>,
         refill_config: CacheRefillConfig,
@@ -385,20 +414,17 @@ impl HummockEventHandler {
             spawn_refill_task,
             read_version_mapping.clone(),
         );
-        refiller.update_table_cache_refill_policies(table_cache_refill_policies_to_map(
-            initial_cache_refill_policies,
-        ));
-        refiller.update_serving_table_vnode_mapping(
-            initial_serving_table_vnode_mapping.0,
-            initial_serving_table_vnode_mapping.1,
+        Self::apply_table_refill_runtime_config(
+            &mut refiller,
+            initial_table_refill_runtime_config.0,
+            initial_table_refill_runtime_config.1,
         );
 
         Self {
             hummock_event_tx,
             hummock_event_rx,
             version_update_rx,
-            cache_refill_policy_rx,
-            serving_table_vnode_mapping_rx,
+            table_refill_runtime_config_rx,
             version_update_notifier_tx,
             recent_versions: Arc::new(ArcSwap::from_pointee(recent_versions)),
             read_version_mapping,
@@ -769,21 +795,16 @@ impl HummockEventHandler {
                     };
                     self.handle_version_update(version_update);
                 }
-                cache_refill_policies = pin!(self.cache_refill_policy_rx.recv()) => {
-                    let Some(policies) = cache_refill_policies else {
-                        warn!("cache refill policy stream ends. event handle shutdown");
+                table_refill_runtime_config = pin!(self.table_refill_runtime_config_rx.recv()) => {
+                    let Some((operation, config)) = table_refill_runtime_config else {
+                        warn!("table refill runtime config stream ends. event handle shutdown");
                         return;
                     };
-                    self.refiller.update_table_cache_refill_policies(
-                        table_cache_refill_policies_to_map(policies),
+                    Self::apply_table_refill_runtime_config(
+                        &mut self.refiller,
+                        operation,
+                        config,
                     );
-                }
-                serving_table_vnode_mapping = pin!(self.serving_table_vnode_mapping_rx.recv()) => {
-                    let Some((op, mapping)) = serving_table_vnode_mapping else {
-                        warn!("serving table vnode mapping stream ends. event handle shutdown");
-                        return;
-                    };
-                    self.refiller.update_serving_table_vnode_mapping(op, mapping);
                 }
             }
         }
@@ -1047,10 +1068,13 @@ mod tests {
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_hummock_sdk::version::HummockVersion;
     use risingwave_pb::hummock::{PbHummockVersion, StateTableInfo};
-    use risingwave_pb::meta::TableCacheRefillPolicies;
+    use risingwave_pb::meta::serving_table_vnode_mappings::PbServingTableVnodeMapping;
     use risingwave_pb::meta::subscribe_response::Operation;
     use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
     use risingwave_pb::meta::table_cache_refill_policies::table_cache_refill_policy::PbCacheRefillPolicy;
+    use risingwave_pb::meta::{
+        PbServingTableVnodeMappings, PbTableRefillRuntimeConfig, TableCacheRefillPolicies,
+    };
     use tokio::spawn;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::sync::oneshot;
@@ -1074,6 +1098,25 @@ mod tests {
     use crate::monitor::HummockStateStoreMetrics;
     use crate::store::SealCurrentEpochOptions;
 
+    fn table_refill_runtime_config_for_test(
+        policies: TableCacheRefillPolicies,
+        serving_vnodes: HashMap<TableId, Bitmap>,
+    ) -> PbTableRefillRuntimeConfig {
+        PbTableRefillRuntimeConfig {
+            table_cache_refill_policies: Some(policies),
+            serving_table_vnode_mappings: Some(PbServingTableVnodeMappings {
+                mappings: serving_vnodes
+                    .into_iter()
+                    .map(|(table_id, bitmap)| PbServingTableVnodeMapping {
+                        table_id: table_id.as_raw_id(),
+                        bitmap: Some(bitmap.to_protobuf()),
+                    })
+                    .collect(),
+            }),
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
     async fn test_initial_cache_refill_serving_mapping_applied() {
         let table_id = TableId::new(233);
@@ -1086,26 +1129,26 @@ mod tests {
             unbounded_channel().0,
         );
         let (_version_update_tx, version_update_rx) = unbounded_channel();
-        let (_cache_refill_policy_tx, cache_refill_policy_rx) = unbounded_channel();
-        let (_serving_table_vnode_mapping_tx, serving_table_vnode_mapping_rx) = unbounded_channel();
+        let (_table_refill_runtime_config_tx, table_refill_runtime_config_rx) = unbounded_channel();
         let storage_opt = default_opts_for_test();
         let metrics = Arc::new(HummockStateStoreMetrics::unused());
 
         let event_handler = HummockEventHandler::new_inner(
             Role::Serving,
             version_update_rx,
-            TableCacheRefillPolicies {
-                policies: vec![PbTableCacheRefillPolicy {
-                    table_id: table_id.as_raw_id(),
-                    policy: PbCacheRefillPolicy::Serving as i32,
-                }],
-            },
             (
                 Operation::Snapshot,
-                HashMap::from([(table_id, serving_vnodes.clone())]),
+                table_refill_runtime_config_for_test(
+                    TableCacheRefillPolicies {
+                        policies: vec![PbTableCacheRefillPolicy {
+                            table_id: table_id.as_raw_id(),
+                            policy: PbCacheRefillPolicy::Serving as i32,
+                        }],
+                    },
+                    HashMap::from([(table_id, serving_vnodes.clone())]),
+                ),
             ),
-            cache_refill_policy_rx,
-            serving_table_vnode_mapping_rx,
+            table_refill_runtime_config_rx,
             mock_sstable_store().await,
             metrics.clone(),
             CacheRefillConfig::from_storage_opts(&storage_opt),
@@ -1143,8 +1186,7 @@ mod tests {
         );
 
         let (_version_update_tx, version_update_rx) = unbounded_channel();
-        let (_cache_refill_policy_tx, cache_refill_policy_rx) = unbounded_channel();
-        let (_serving_table_vnode_mapping_tx, serving_table_vnode_mapping_rx) = unbounded_channel();
+        let (_table_refill_runtime_config_tx, table_refill_runtime_config_rx) = unbounded_channel();
 
         let epoch1 = epoch0.next_epoch();
         let epoch2 = epoch1.next_epoch();
@@ -1157,10 +1199,8 @@ mod tests {
         let event_handler = HummockEventHandler::new_inner(
             Role::None,
             version_update_rx,
-            TableCacheRefillPolicies::default(),
-            (Operation::Snapshot, HashMap::new()),
-            cache_refill_policy_rx,
-            serving_table_vnode_mapping_rx,
+            (Operation::Snapshot, PbTableRefillRuntimeConfig::default()),
+            table_refill_runtime_config_rx,
             mock_sstable_store().await,
             metrics.clone(),
             CacheRefillConfig::from_storage_opts(&storage_opt),
@@ -1312,8 +1352,7 @@ mod tests {
         );
 
         let (_version_update_tx, version_update_rx) = unbounded_channel();
-        let (_cache_refill_policy_tx, cache_refill_policy_rx) = unbounded_channel();
-        let (_serving_table_vnode_mapping_tx, serving_table_vnode_mapping_rx) = unbounded_channel();
+        let (_table_refill_runtime_config_tx, table_refill_runtime_config_rx) = unbounded_channel();
 
         let epoch1 = epoch0.next_epoch();
         let epoch2 = epoch1.next_epoch();
@@ -1341,10 +1380,8 @@ mod tests {
         let event_handler = HummockEventHandler::new_inner(
             Role::None,
             version_update_rx,
-            TableCacheRefillPolicies::default(),
-            (Operation::Snapshot, HashMap::new()),
-            cache_refill_policy_rx,
-            serving_table_vnode_mapping_rx,
+            (Operation::Snapshot, PbTableRefillRuntimeConfig::default()),
+            table_refill_runtime_config_rx,
             mock_sstable_store().await,
             metrics.clone(),
             CacheRefillConfig::from_storage_opts(&storage_opt),

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -275,7 +275,7 @@ impl HummockEventHandler {
         // runtime updates are not supported for either policies or serving vnode mappings.
         if let Some(policies) = config.table_cache_refill_policies {
             refiller
-                .update_table_cache_refill_policies(table_cache_refill_policies_to_map(policies));
+                .replace_table_cache_refill_policies(table_cache_refill_policies_to_map(policies));
         }
 
         if operation == Operation::Snapshot
@@ -363,7 +363,6 @@ impl HummockEventHandler {
         )
     }
 
-    #[expect(clippy::too_many_arguments)]
     fn new_inner(
         role: Role,
         mut observer_event_rx: UnboundedReceiver<HummockObserverEvent>,
@@ -1220,7 +1219,7 @@ mod tests {
         );
         assert!(!context.serving.contains_key(&table_id));
         assert_eq!(
-            context.serving_table_vnode_mapping.read().get(&table_id),
+            context.serving_table_vnode_mapping.get(&table_id),
             Some(&serving_vnodes)
         );
     }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -204,8 +204,20 @@ fn table_cache_refill_policies_to_map(
         .policies
         .into_iter()
         .filter_map(|pb_policy| {
-            let policy = CacheRefillPolicy::from_protobuf(pb_policy.get_policy().unwrap())?;
-            Some((TableId::from(pb_policy.table_id), policy))
+            let table_id = TableId::from(pb_policy.table_id);
+            let pb_policy_enum = match pb_policy.get_policy() {
+                Ok(policy) => policy,
+                Err(_) => {
+                    tracing::warn!(
+                        table_id = pb_policy.table_id,
+                        policy = pb_policy.policy,
+                        "ignore unknown table cache refill policy"
+                    );
+                    return None;
+                }
+            };
+            let policy = CacheRefillPolicy::from_protobuf(pb_policy_enum)?;
+            Some((table_id, policy))
         })
         .collect()
 }
@@ -216,15 +228,15 @@ fn serving_table_vnode_mappings_to_map(
     mappings
         .mappings
         .into_iter()
-        .map(|mapping| {
-            (
-                TableId::from(mapping.table_id),
-                Bitmap::from(
-                    mapping
-                        .bitmap
-                        .expect("serving table vnode bitmap must exist"),
-                ),
-            )
+        .filter_map(|mapping| {
+            let Some(bitmap) = mapping.bitmap else {
+                tracing::warn!(
+                    table_id = mapping.table_id,
+                    "ignore serving table vnode mapping without bitmap"
+                );
+                return None;
+            };
+            Some((TableId::from(mapping.table_id), Bitmap::from(bitmap)))
         })
         .collect()
 }
@@ -411,12 +423,21 @@ impl HummockEventHandler {
         );
         let mut pending_observer_events = VecDeque::new();
         while let Ok(event) = observer_event_rx.try_recv() {
-            match event {
-                HummockObserverEvent::TableRefillRuntimeConfig(operation, config) => {
-                    Self::apply_table_refill_runtime_config(&mut refiller, operation, config);
-                }
-                event => pending_observer_events.push_back(event),
-            }
+            pending_observer_events.push_back(event);
+        }
+        if matches!(
+            pending_observer_events.front(),
+            Some(HummockObserverEvent::TableRefillRuntimeConfig(
+                Operation::Snapshot,
+                _
+            ))
+        ) {
+            let Some(HummockObserverEvent::TableRefillRuntimeConfig(operation, config)) =
+                pending_observer_events.pop_front()
+            else {
+                unreachable!();
+            };
+            Self::apply_table_refill_runtime_config(&mut refiller, operation, config);
         }
 
         Self {
@@ -1102,12 +1123,36 @@ mod tests {
     use crate::monitor::HummockStateStoreMetrics;
     use crate::store::SealCurrentEpochOptions;
 
+    fn pinned_version_for_test(id: u64) -> PinnedVersion {
+        PinnedVersion::new(
+            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+                id: id.into(),
+                ..Default::default()
+            }),
+            unbounded_channel().0,
+        )
+    }
+
+    fn table_cache_refill_policies_for_test(
+        policies: impl IntoIterator<Item = (TableId, CacheRefillPolicy)>,
+    ) -> TableCacheRefillPolicies {
+        TableCacheRefillPolicies {
+            policies: policies
+                .into_iter()
+                .map(|(table_id, policy)| PbTableCacheRefillPolicy {
+                    table_id: table_id.as_raw_id(),
+                    policy: policy.to_protobuf() as i32,
+                })
+                .collect(),
+        }
+    }
+
     fn table_refill_runtime_config_for_test(
-        policies: TableCacheRefillPolicies,
+        policies: impl IntoIterator<Item = (TableId, CacheRefillPolicy)>,
         serving_vnodes: HashMap<TableId, Bitmap>,
     ) -> PbTableRefillRuntimeConfig {
         PbTableRefillRuntimeConfig {
-            table_cache_refill_policies: Some(policies),
+            table_cache_refill_policies: Some(table_cache_refill_policies_for_test(policies)),
             serving_table_vnode_mappings: Some(PbServingTableVnodeMappings {
                 mappings: serving_vnodes
                     .into_iter()
@@ -1121,28 +1166,73 @@ mod tests {
         }
     }
 
+    async fn refiller_for_test(role: Role) -> CacheRefiller {
+        let storage_opt = default_opts_for_test();
+        CacheRefiller::new(
+            role,
+            CacheRefillConfig::from_storage_opts(&storage_opt),
+            mock_sstable_store().await,
+            CacheRefiller::default_spawn_refill_task(),
+            Arc::new(RwLock::new(HashMap::new())),
+        )
+    }
+
+    #[test]
+    fn test_unknown_table_cache_refill_policy_is_ignored() {
+        let table_id = TableId::new(233);
+        let unknown_table_id = TableId::new(234);
+        let policies = super::table_cache_refill_policies_to_map(TableCacheRefillPolicies {
+            policies: vec![
+                PbTableCacheRefillPolicy {
+                    table_id: table_id.as_raw_id(),
+                    policy: PbCacheRefillPolicy::Serving as i32,
+                },
+                PbTableCacheRefillPolicy {
+                    table_id: unknown_table_id.as_raw_id(),
+                    policy: i32::MAX,
+                },
+            ],
+        });
+
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies.get(&table_id), Some(&CacheRefillPolicy::Serving));
+        assert!(!policies.contains_key(&unknown_table_id));
+    }
+
+    #[test]
+    fn test_serving_table_vnode_mapping_without_bitmap_is_ignored() {
+        let table_id = TableId::new(233);
+        let missing_bitmap_table_id = TableId::new(234);
+        let bitmap = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let mappings = super::serving_table_vnode_mappings_to_map(PbServingTableVnodeMappings {
+            mappings: vec![
+                PbServingTableVnodeMapping {
+                    table_id: table_id.as_raw_id(),
+                    bitmap: Some(bitmap.to_protobuf()),
+                },
+                PbServingTableVnodeMapping {
+                    table_id: missing_bitmap_table_id.as_raw_id(),
+                    bitmap: None,
+                },
+            ],
+        });
+
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(mappings.get(&table_id), Some(&bitmap));
+        assert!(!mappings.contains_key(&missing_bitmap_table_id));
+    }
+
     #[tokio::test]
     async fn test_initial_cache_refill_serving_mapping_applied() {
         let table_id = TableId::new(233);
         let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
-        let initial_version = PinnedVersion::new(
-            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
-                id: 1.into(),
-                ..Default::default()
-            }),
-            unbounded_channel().0,
-        );
+        let initial_version = pinned_version_for_test(1);
         let (observer_event_tx, observer_event_rx) = unbounded_channel();
         observer_event_tx
             .send(HummockObserverEvent::TableRefillRuntimeConfig(
                 Operation::Snapshot,
                 table_refill_runtime_config_for_test(
-                    TableCacheRefillPolicies {
-                        policies: vec![PbTableCacheRefillPolicy {
-                            table_id: table_id.as_raw_id(),
-                            policy: PbCacheRefillPolicy::Serving as i32,
-                        }],
-                    },
+                    [(table_id, CacheRefillPolicy::Serving)],
                     HashMap::from([(table_id, serving_vnodes.clone())]),
                 ),
             ))
@@ -1171,30 +1261,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_initial_table_refill_config_keeps_pending_observer_event_order() {
+        let table_id = TableId::new(233);
+        let initial_version = pinned_version_for_test(1);
+        let (observer_event_tx, observer_event_rx) = unbounded_channel();
+        observer_event_tx
+            .send(HummockObserverEvent::TableRefillRuntimeConfig(
+                Operation::Snapshot,
+                table_refill_runtime_config_for_test(
+                    [(table_id, CacheRefillPolicy::Serving)],
+                    HashMap::new(),
+                ),
+            ))
+            .unwrap();
+        observer_event_tx
+            .send(HummockObserverEvent::VersionUpdate(
+                super::HummockVersionUpdate::PinnedVersion(Box::new(
+                    HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+                        id: 2.into(),
+                        ..Default::default()
+                    }),
+                )),
+            ))
+            .unwrap();
+        observer_event_tx
+            .send(HummockObserverEvent::TableRefillRuntimeConfig(
+                Operation::Update,
+                PbTableRefillRuntimeConfig {
+                    table_cache_refill_policies: Some(TableCacheRefillPolicies {
+                        policies: vec![PbTableCacheRefillPolicy {
+                            table_id: table_id.as_raw_id(),
+                            policy: PbCacheRefillPolicy::Disabled as i32,
+                        }],
+                    }),
+                    ..Default::default()
+                },
+            ))
+            .unwrap();
+
+        let storage_opt = default_opts_for_test();
+        let metrics = Arc::new(HummockStateStoreMetrics::unused());
+        let event_handler = HummockEventHandler::new_inner(
+            Role::Serving,
+            observer_event_rx,
+            mock_sstable_store().await,
+            metrics.clone(),
+            CacheRefillConfig::from_storage_opts(&storage_opt),
+            RecentVersions::new(initial_version, 10, metrics.clone()),
+            BufferTracker::from_storage_opts(&storage_opt, &metrics),
+            Arc::new(|_, _| spawn(async { unreachable!("upload task should not be spawned") })),
+            CacheRefiller::default_spawn_refill_task(),
+        );
+
+        let context = event_handler.table_cache_refill_context().read();
+        assert_eq!(
+            context.policies.get(&table_id),
+            Some(&CacheRefillPolicy::Serving)
+        );
+        drop(context);
+        assert!(matches!(
+            event_handler.pending_observer_events.front(),
+            Some(HummockObserverEvent::VersionUpdate(_))
+        ));
+        assert!(matches!(
+            event_handler.pending_observer_events.get(1),
+            Some(HummockObserverEvent::TableRefillRuntimeConfig(
+                Operation::Update,
+                _
+            ))
+        ));
+    }
+
+    #[tokio::test]
     async fn test_recovery_policy_update_preserves_serving_mapping() {
         let table_id = TableId::new(233);
         let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
-        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
-        let storage_opt = default_opts_for_test();
-        let mut refiller = CacheRefiller::new(
-            Role::Serving,
-            CacheRefillConfig::from_storage_opts(&storage_opt),
-            mock_sstable_store().await,
-            CacheRefiller::default_spawn_refill_task(),
-            read_version_mapping,
-        );
-        let policies = || TableCacheRefillPolicies {
-            policies: vec![PbTableCacheRefillPolicy {
-                table_id: table_id.as_raw_id(),
-                policy: PbCacheRefillPolicy::Serving as i32,
-            }],
-        };
+        let ignored_update_vnodes = Bitmap::zeros(VirtualNode::COUNT_FOR_TEST);
+        let mut refiller = refiller_for_test(Role::Serving).await;
 
         HummockEventHandler::apply_table_refill_runtime_config(
             &mut refiller,
             Operation::Snapshot,
             table_refill_runtime_config_for_test(
-                policies(),
+                [(table_id, CacheRefillPolicy::Serving)],
                 HashMap::from([(table_id, serving_vnodes.clone())]),
             ),
         );
@@ -1206,6 +1355,12 @@ mod tests {
                     policies: vec![PbTableCacheRefillPolicy {
                         table_id: table_id.as_raw_id(),
                         policy: PbCacheRefillPolicy::Disabled as i32,
+                    }],
+                }),
+                serving_table_vnode_mappings: Some(PbServingTableVnodeMappings {
+                    mappings: vec![PbServingTableVnodeMapping {
+                        table_id: table_id.as_raw_id(),
+                        bitmap: Some(ignored_update_vnodes.to_protobuf()),
                     }],
                 }),
                 ..Default::default()

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -54,8 +54,8 @@ use crate::hummock::event_handler::uploader::{
     HummockUploader, SpawnUploadTask, SyncedData, UploadTaskOutput,
 };
 use crate::hummock::event_handler::{
-    HummockEvent, HummockReadVersionRef, HummockVersionUpdate, ReadOnlyReadVersionMapping,
-    ReadOnlyRwLockRef,
+    HummockEvent, HummockObserverEvent, HummockReadVersionRef, HummockVersionUpdate,
+    ReadOnlyReadVersionMapping, ReadOnlyRwLockRef,
 };
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::local_version::recent_versions::RecentVersions;
@@ -232,8 +232,8 @@ fn serving_table_vnode_mappings_to_map(
 pub(crate) struct HummockEventHandler {
     hummock_event_tx: HummockEventSender,
     hummock_event_rx: HummockEventReceiver,
-    version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
-    table_refill_runtime_config_rx: UnboundedReceiver<(Operation, PbTableRefillRuntimeConfig)>,
+    observer_event_rx: UnboundedReceiver<HummockObserverEvent>,
+    pending_observer_events: VecDeque<HummockObserverEvent>,
     read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
     /// A copy of `read_version_mapping` but owned by event handler
     local_read_version_mapping: HashMap<LocalInstanceId, (TableId, HummockReadVersionRef)>,
@@ -288,9 +288,7 @@ impl HummockEventHandler {
 
     pub fn new(
         role: Role,
-        version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
-        initial_table_refill_runtime_config: (Operation, PbTableRefillRuntimeConfig),
-        table_refill_runtime_config_rx: UnboundedReceiver<(Operation, PbTableRefillRuntimeConfig)>,
+        observer_event_rx: UnboundedReceiver<HummockObserverEvent>,
         pinned_version: PinnedVersion,
         compactor_context: CompactorContext,
         compaction_catalog_manager_ref: CompactionCatalogManagerRef,
@@ -311,9 +309,7 @@ impl HummockEventHandler {
             BufferTracker::from_storage_opts(&compactor_context.storage_opts, &state_store_metrics);
         Self::new_inner(
             role,
-            version_update_rx,
-            initial_table_refill_runtime_config,
-            table_refill_runtime_config_rx,
+            observer_event_rx,
             compactor_context.sstable_store.clone(),
             state_store_metrics,
             CacheRefillConfig::from_storage_opts(&compactor_context.storage_opts),
@@ -370,9 +366,7 @@ impl HummockEventHandler {
     #[expect(clippy::too_many_arguments)]
     fn new_inner(
         role: Role,
-        version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
-        initial_table_refill_runtime_config: (Operation, PbTableRefillRuntimeConfig),
-        table_refill_runtime_config_rx: UnboundedReceiver<(Operation, PbTableRefillRuntimeConfig)>,
+        mut observer_event_rx: UnboundedReceiver<HummockObserverEvent>,
         sstable_store: SstableStoreRef,
         state_store_metrics: Arc<HummockStateStoreMetrics>,
         refill_config: CacheRefillConfig,
@@ -416,17 +410,21 @@ impl HummockEventHandler {
             spawn_refill_task,
             read_version_mapping.clone(),
         );
-        Self::apply_table_refill_runtime_config(
-            &mut refiller,
-            initial_table_refill_runtime_config.0,
-            initial_table_refill_runtime_config.1,
-        );
+        let mut pending_observer_events = VecDeque::new();
+        while let Ok(event) = observer_event_rx.try_recv() {
+            match event {
+                HummockObserverEvent::TableRefillRuntimeConfig(operation, config) => {
+                    Self::apply_table_refill_runtime_config(&mut refiller, operation, config);
+                }
+                event => pending_observer_events.push_back(event),
+            }
+        }
 
         Self {
             hummock_event_tx,
             hummock_event_rx,
-            version_update_rx,
-            table_refill_runtime_config_rx,
+            observer_event_rx,
+            pending_observer_events,
             version_update_notifier_tx,
             recent_versions: Arc::new(ArcSwap::from_pointee(recent_versions)),
             read_version_mapping,
@@ -615,6 +613,17 @@ impl HummockEventHandler {
         info!("clear finished");
     }
 
+    fn handle_observer_event(&mut self, event: HummockObserverEvent) {
+        match event {
+            HummockObserverEvent::VersionUpdate(version_update) => {
+                self.handle_version_update(version_update);
+            }
+            HummockObserverEvent::TableRefillRuntimeConfig(operation, config) => {
+                Self::apply_table_refill_runtime_config(&mut self.refiller, operation, config);
+            }
+        }
+    }
+
     fn handle_version_update(&mut self, version_payload: HummockVersionUpdate) {
         let _timer = self
             .metrics
@@ -771,6 +780,10 @@ impl HummockEventHandler {
 impl HummockEventHandler {
     pub async fn start_hummock_event_handler_worker(mut self) {
         loop {
+            if let Some(event) = self.pending_observer_events.pop_front() {
+                self.handle_observer_event(event);
+                continue;
+            }
             tokio::select! {
                 ssts = self.uploader.next_uploaded_ssts() => {
                     self.handle_uploaded_ssts(ssts);
@@ -790,23 +803,12 @@ impl HummockEventHandler {
                         }
                     }
                 }
-                version_update = pin!(self.version_update_rx.recv()) => {
-                    let Some(version_update) = version_update else {
-                        warn!("version update stream ends. event handle shutdown");
+                observer_event = pin!(self.observer_event_rx.recv()) => {
+                    let Some(observer_event) = observer_event else {
+                        warn!("observer event stream ends. event handle shutdown");
                         return;
                     };
-                    self.handle_version_update(version_update);
-                }
-                table_refill_runtime_config = pin!(self.table_refill_runtime_config_rx.recv()) => {
-                    let Some((operation, config)) = table_refill_runtime_config else {
-                        warn!("table refill runtime config stream ends. event handle shutdown");
-                        return;
-                    };
-                    Self::apply_table_refill_runtime_config(
-                        &mut self.refiller,
-                        operation,
-                        config,
-                    );
+                    self.handle_observer_event(observer_event);
                 }
             }
         }
@@ -1090,7 +1092,8 @@ mod tests {
         prepare_uploader_order_test_spawn_task_fn,
     };
     use crate::hummock::event_handler::{
-        HummockEvent, HummockEventHandler, HummockReadVersionRef, LocalInstanceGuard,
+        HummockEvent, HummockEventHandler, HummockObserverEvent, HummockReadVersionRef,
+        LocalInstanceGuard,
     };
     use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::local_version::pinned_version::PinnedVersion;
@@ -1130,15 +1133,9 @@ mod tests {
             }),
             unbounded_channel().0,
         );
-        let (_version_update_tx, version_update_rx) = unbounded_channel();
-        let (_table_refill_runtime_config_tx, table_refill_runtime_config_rx) = unbounded_channel();
-        let storage_opt = default_opts_for_test();
-        let metrics = Arc::new(HummockStateStoreMetrics::unused());
-
-        let event_handler = HummockEventHandler::new_inner(
-            Role::Serving,
-            version_update_rx,
-            (
+        let (observer_event_tx, observer_event_rx) = unbounded_channel();
+        observer_event_tx
+            .send(HummockObserverEvent::TableRefillRuntimeConfig(
                 Operation::Snapshot,
                 table_refill_runtime_config_for_test(
                     TableCacheRefillPolicies {
@@ -1149,8 +1146,14 @@ mod tests {
                     },
                     HashMap::from([(table_id, serving_vnodes.clone())]),
                 ),
-            ),
-            table_refill_runtime_config_rx,
+            ))
+            .unwrap();
+        let storage_opt = default_opts_for_test();
+        let metrics = Arc::new(HummockStateStoreMetrics::unused());
+
+        let event_handler = HummockEventHandler::new_inner(
+            Role::Serving,
+            observer_event_rx,
             mock_sstable_store().await,
             metrics.clone(),
             CacheRefillConfig::from_storage_opts(&storage_opt),
@@ -1241,8 +1244,7 @@ mod tests {
             unbounded_channel().0,
         );
 
-        let (_version_update_tx, version_update_rx) = unbounded_channel();
-        let (_table_refill_runtime_config_tx, table_refill_runtime_config_rx) = unbounded_channel();
+        let (_observer_event_tx, observer_event_rx) = unbounded_channel();
 
         let epoch1 = epoch0.next_epoch();
         let epoch2 = epoch1.next_epoch();
@@ -1254,9 +1256,7 @@ mod tests {
 
         let event_handler = HummockEventHandler::new_inner(
             Role::None,
-            version_update_rx,
-            (Operation::Snapshot, PbTableRefillRuntimeConfig::default()),
-            table_refill_runtime_config_rx,
+            observer_event_rx,
             mock_sstable_store().await,
             metrics.clone(),
             CacheRefillConfig::from_storage_opts(&storage_opt),
@@ -1407,8 +1407,7 @@ mod tests {
             unbounded_channel().0,
         );
 
-        let (_version_update_tx, version_update_rx) = unbounded_channel();
-        let (_table_refill_runtime_config_tx, table_refill_runtime_config_rx) = unbounded_channel();
+        let (_observer_event_tx, observer_event_rx) = unbounded_channel();
 
         let epoch1 = epoch0.next_epoch();
         let epoch2 = epoch1.next_epoch();
@@ -1435,9 +1434,7 @@ mod tests {
 
         let event_handler = HummockEventHandler::new_inner(
             Role::None,
-            version_update_rx,
-            (Operation::Snapshot, PbTableRefillRuntimeConfig::default()),
-            table_refill_runtime_config_rx,
+            observer_event_rx,
             mock_sstable_store().await,
             metrics.clone(),
             CacheRefillConfig::from_storage_opts(&storage_opt),

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -199,15 +199,13 @@ struct HummockEventHandlerMetrics {
 
 fn table_cache_refill_policies_to_map(
     policies: TableCacheRefillPolicies,
-) -> HashMap<TableId, Option<CacheRefillPolicy>> {
+) -> HashMap<TableId, CacheRefillPolicy> {
     policies
         .policies
         .into_iter()
-        .map(|policy| {
-            (
-                TableId::from(policy.table_id),
-                CacheRefillPolicy::from_protobuf(policy.get_policy().unwrap()),
-            )
+        .filter_map(|pb_policy| {
+            let policy = CacheRefillPolicy::from_protobuf(pb_policy.get_policy().unwrap())?;
+            Some((TableId::from(pb_policy.table_id), policy))
         })
         .collect()
 }
@@ -250,10 +248,12 @@ async fn flush_imms(
 }
 
 impl HummockEventHandler {
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         role: Role,
         version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
         initial_cache_refill_policies: TableCacheRefillPolicies,
+        initial_serving_table_vnode_mapping: (Operation, HashMap<TableId, Bitmap>),
         cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
         serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
         pinned_version: PinnedVersion,
@@ -278,6 +278,7 @@ impl HummockEventHandler {
             role,
             version_update_rx,
             initial_cache_refill_policies,
+            initial_serving_table_vnode_mapping,
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             compactor_context.sstable_store.clone(),
@@ -338,6 +339,7 @@ impl HummockEventHandler {
         role: Role,
         version_update_rx: UnboundedReceiver<HummockVersionUpdate>,
         initial_cache_refill_policies: TableCacheRefillPolicies,
+        initial_serving_table_vnode_mapping: (Operation, HashMap<TableId, Bitmap>),
         cache_refill_policy_rx: UnboundedReceiver<TableCacheRefillPolicies>,
         serving_table_vnode_mapping_rx: UnboundedReceiver<(Operation, HashMap<TableId, Bitmap>)>,
         sstable_store: SstableStoreRef,
@@ -386,6 +388,10 @@ impl HummockEventHandler {
         refiller.update_table_cache_refill_policies(table_cache_refill_policies_to_map(
             initial_cache_refill_policies,
         ));
+        refiller.update_serving_table_vnode_mapping(
+            initial_serving_table_vnode_mapping.0,
+            initial_serving_table_vnode_mapping.1,
+        );
 
         Self {
             hummock_event_tx,
@@ -1035,12 +1041,16 @@ mod tests {
     use risingwave_common::bitmap::Bitmap;
     use risingwave_common::catalog::TableId;
     use risingwave_common::config::Role;
+    use risingwave_common::config::streaming::CacheRefillPolicy;
     use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::{EpochExt, test_epoch};
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_hummock_sdk::version::HummockVersion;
     use risingwave_pb::hummock::{PbHummockVersion, StateTableInfo};
     use risingwave_pb::meta::TableCacheRefillPolicies;
+    use risingwave_pb::meta::subscribe_response::Operation;
+    use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
+    use risingwave_pb::meta::table_cache_refill_policies::table_cache_refill_policy::PbCacheRefillPolicy;
     use tokio::spawn;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::sync::oneshot;
@@ -1063,6 +1073,55 @@ mod tests {
     use crate::mem_table::ImmutableMemtable;
     use crate::monitor::HummockStateStoreMetrics;
     use crate::store::SealCurrentEpochOptions;
+
+    #[tokio::test]
+    async fn test_initial_cache_refill_serving_mapping_applied() {
+        let table_id = TableId::new(233);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let initial_version = PinnedVersion::new(
+            HummockVersion::from_rpc_protobuf(&PbHummockVersion {
+                id: 1.into(),
+                ..Default::default()
+            }),
+            unbounded_channel().0,
+        );
+        let (_version_update_tx, version_update_rx) = unbounded_channel();
+        let (_cache_refill_policy_tx, cache_refill_policy_rx) = unbounded_channel();
+        let (_serving_table_vnode_mapping_tx, serving_table_vnode_mapping_rx) = unbounded_channel();
+        let storage_opt = default_opts_for_test();
+        let metrics = Arc::new(HummockStateStoreMetrics::unused());
+
+        let event_handler = HummockEventHandler::new_inner(
+            Role::Serving,
+            version_update_rx,
+            TableCacheRefillPolicies {
+                policies: vec![PbTableCacheRefillPolicy {
+                    table_id: table_id.as_raw_id(),
+                    policy: PbCacheRefillPolicy::Serving as i32,
+                }],
+            },
+            (
+                Operation::Snapshot,
+                HashMap::from([(table_id, serving_vnodes.clone())]),
+            ),
+            cache_refill_policy_rx,
+            serving_table_vnode_mapping_rx,
+            mock_sstable_store().await,
+            metrics.clone(),
+            CacheRefillConfig::from_storage_opts(&storage_opt),
+            RecentVersions::new(initial_version, 10, metrics.clone()),
+            BufferTracker::from_storage_opts(&storage_opt, &metrics),
+            Arc::new(|_, _| spawn(async { unreachable!("upload task should not be spawned") })),
+            CacheRefiller::default_spawn_refill_task(),
+        );
+
+        let context = event_handler.table_cache_refill_context().read();
+        assert_eq!(
+            context.policies.get(&table_id),
+            Some(&CacheRefillPolicy::Serving)
+        );
+        assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+    }
 
     #[tokio::test]
     async fn test_old_epoch_sync_fail() {
@@ -1099,6 +1158,7 @@ mod tests {
             Role::None,
             version_update_rx,
             TableCacheRefillPolicies::default(),
+            (Operation::Snapshot, HashMap::new()),
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             mock_sstable_store().await,
@@ -1282,6 +1342,7 @@ mod tests {
             Role::None,
             version_update_rx,
             TableCacheRefillPolicies::default(),
+            (Operation::Snapshot, HashMap::new()),
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             mock_sstable_store().await,

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -35,6 +35,8 @@ pub mod uploader;
 pub(crate) use hummock_event_handler::HummockEventHandler;
 use risingwave_hummock_sdk::vector_index::VectorIndexAdd;
 use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
+use risingwave_pb::meta::PbTableRefillRuntimeConfig;
+use risingwave_pb::meta::subscribe_response::Operation;
 
 use super::store::version::HummockReadVersion;
 use crate::hummock::event_handler::hummock_event_handler::HummockEventSender;
@@ -52,6 +54,12 @@ pub struct BufferWriteRequest {
 pub enum HummockVersionUpdate {
     VersionDeltas(Vec<HummockVersionDelta>),
     PinnedVersion(Box<HummockVersion>),
+}
+
+#[derive(Debug)]
+pub enum HummockObserverEvent {
+    VersionUpdate(HummockVersionUpdate),
+    TableRefillRuntimeConfig(Operation, PbTableRefillRuntimeConfig),
 }
 
 pub enum HummockEvent {

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -413,12 +413,19 @@ impl CacheRefiller {
         policies: HashMap<TableId, Option<CacheRefillPolicy>>,
     ) {
         let mut table_cache_refill_context = self.table_cache_refill_context.write();
+        let table_ids = table_cache_refill_context
+            .policies
+            .keys()
+            .chain(policies.keys())
+            .copied()
+            .collect_vec();
+        table_cache_refill_context.policies.clear();
         for (table_id, policy) in policies {
             if let Some(policy) = policy {
                 table_cache_refill_context.policies.insert(table_id, policy);
-            } else {
-                table_cache_refill_context.policies.remove(&table_id);
             }
+        }
+        for table_id in table_ids {
             self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
         }
     }
@@ -1009,5 +1016,108 @@ impl Ord for SstableUnit {
 impl PartialOrd for SstableUnit {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use parking_lot::RwLock;
+    use risingwave_common::bitmap::Bitmap;
+    use risingwave_common::config::Role;
+    use risingwave_common::config::streaming::CacheRefillPolicy;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_pb::id::TableId;
+    use risingwave_pb::meta::subscribe_response::Operation;
+
+    use super::{CacheRefillConfig, CacheRefiller};
+    use crate::hummock::iterator::test_utils::mock_sstable_store;
+
+    fn test_refill_config(default_policy: CacheRefillPolicy) -> CacheRefillConfig {
+        CacheRefillConfig {
+            timeout: Duration::from_secs(1),
+            data_refill_levels: HashSet::new(),
+            meta_refill_concurrency: 1,
+            concurrency: 1,
+            unit: 1,
+            threshold: 0.0,
+            skip_recent_filter: true,
+            skip_inheritance_filter: true,
+            table_cache_refill_default_policy: default_policy,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_serving_snapshot_restores_table_cache_refill_vnodes() {
+        let table_id = TableId::from(233);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
+        let mut refiller = CacheRefiller::new(
+            Role::Serving,
+            test_refill_config(CacheRefillPolicy::Disabled),
+            mock_sstable_store().await,
+            CacheRefiller::default_spawn_refill_task(),
+            read_version_mapping,
+        );
+
+        refiller.update_table_cache_refill_policies(HashMap::from([(
+            table_id,
+            Some(CacheRefillPolicy::Serving),
+        )]));
+        assert!(
+            refiller
+                .table_cache_refill_context()
+                .read()
+                .serving
+                .is_empty()
+        );
+
+        refiller.update_serving_table_vnode_mapping(
+            Operation::Snapshot,
+            HashMap::from([(table_id, serving_vnodes.clone())]),
+        );
+
+        let context = refiller.table_cache_refill_context().read();
+        assert!(context.streaming.is_empty());
+        assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+    }
+
+    #[tokio::test]
+    async fn test_policy_snapshot_replaces_existing_policies() {
+        let table_id = TableId::from(233);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
+        let mut refiller = CacheRefiller::new(
+            Role::Serving,
+            test_refill_config(CacheRefillPolicy::Disabled),
+            mock_sstable_store().await,
+            CacheRefiller::default_spawn_refill_task(),
+            read_version_mapping,
+        );
+
+        refiller.update_serving_table_vnode_mapping(
+            Operation::Snapshot,
+            HashMap::from([(table_id, serving_vnodes)]),
+        );
+        refiller.update_table_cache_refill_policies(HashMap::from([(
+            table_id,
+            Some(CacheRefillPolicy::Serving),
+        )]));
+        assert!(
+            refiller
+                .table_cache_refill_context()
+                .read()
+                .serving
+                .contains_key(&table_id)
+        );
+
+        refiller.update_table_cache_refill_policies(HashMap::new());
+
+        let context = refiller.table_cache_refill_context().read();
+        assert!(context.policies.is_empty());
+        assert!(context.serving.is_empty());
     }
 }

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -270,7 +270,7 @@ pub struct TableCacheRefillContext {
     pub default_policy: CacheRefillPolicy,
 
     pub read_version_mapping: Arc<RwLock<ReadVersionMappingType>>,
-    pub serving_table_vnode_mapping: Arc<RwLock<HashMap<TableId, Bitmap>>>,
+    pub serving_table_vnode_mapping: HashMap<TableId, Bitmap>,
 }
 
 fn vnode_range_bitmap(num_bits: usize, vnode_range: (usize, usize)) -> Bitmap {
@@ -352,14 +352,13 @@ impl CacheRefiller {
     ) -> Self {
         let config = Arc::new(config);
         let concurrency = Arc::new(Semaphore::new(config.concurrency));
-        let serving_table_vnode_mapping = Arc::new(RwLock::new(HashMap::new()));
         let table_cache_refill_context = Arc::new(RwLock::new(TableCacheRefillContext {
             streaming: HashMap::new(),
             serving: HashMap::new(),
             policies: HashMap::new(),
             default_policy: config.table_cache_refill_default_policy,
             read_version_mapping,
-            serving_table_vnode_mapping,
+            serving_table_vnode_mapping: HashMap::new(),
         }));
         let meta_refill_concurrency = if config.meta_refill_concurrency == 0 {
             None
@@ -413,7 +412,7 @@ impl CacheRefiller {
         self.queue.back().map(|item| &item.event.new_pinned_version)
     }
 
-    pub(crate) fn update_table_cache_refill_policies(
+    pub(crate) fn replace_table_cache_refill_policies(
         &mut self,
         policies: HashMap<TableId, CacheRefillPolicy>,
     ) {
@@ -437,14 +436,11 @@ impl CacheRefiller {
         let mut table_cache_refill_context = self.table_cache_refill_context.write();
         let mut table_ids = table_cache_refill_context
             .serving_table_vnode_mapping
-            .read()
             .keys()
             .chain(mapping.keys())
             .copied()
             .collect::<HashSet<_>>();
-        *table_cache_refill_context
-            .serving_table_vnode_mapping
-            .write() = mapping;
+        table_cache_refill_context.serving_table_vnode_mapping = mapping;
         for table_id in table_ids.drain() {
             self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
         }
@@ -480,15 +476,14 @@ impl CacheRefiller {
             }
         }
 
-        if self.role.for_serving() && policy.for_serving() {
-            let serving_table_vnode_mapping = table_cache_refill_context
+        if self.role.for_serving()
+            && policy.for_serving()
+            && let Some(vnodes) = table_cache_refill_context
                 .serving_table_vnode_mapping
-                .clone();
-            if let Some(vnodes) = serving_table_vnode_mapping.read().get(&table_id) {
-                table_cache_refill_context
-                    .serving
-                    .insert(table_id, vnodes.clone());
-            }
+                .get(&table_id)
+                .cloned()
+        {
+            table_cache_refill_context.serving.insert(table_id, vnodes);
         }
     }
 
@@ -1036,7 +1031,7 @@ mod tests {
             read_version_mapping,
         );
 
-        refiller.update_table_cache_refill_policies(HashMap::from([(
+        refiller.replace_table_cache_refill_policies(HashMap::from([(
             table_id,
             CacheRefillPolicy::Serving,
         )]));
@@ -1072,7 +1067,7 @@ mod tests {
             read_version_mapping,
         );
 
-        refiller.update_table_cache_refill_policies(HashMap::from([
+        refiller.replace_table_cache_refill_policies(HashMap::from([
             (table_id, CacheRefillPolicy::Serving),
             (removed_table_id, CacheRefillPolicy::Serving),
         ]));
@@ -1099,7 +1094,6 @@ mod tests {
         assert!(
             !context
                 .serving_table_vnode_mapping
-                .read()
                 .contains_key(&removed_table_id)
         );
     }
@@ -1118,7 +1112,7 @@ mod tests {
         );
 
         refiller.replace_serving_table_vnode_mapping(HashMap::from([(table_id, serving_vnodes)]));
-        refiller.update_table_cache_refill_policies(HashMap::from([(
+        refiller.replace_table_cache_refill_policies(HashMap::from([(
             table_id,
             CacheRefillPolicy::Serving,
         )]));
@@ -1130,7 +1124,7 @@ mod tests {
                 .contains_key(&table_id)
         );
 
-        refiller.update_table_cache_refill_policies(HashMap::new());
+        refiller.replace_table_cache_refill_policies(HashMap::new());
 
         let context = refiller.table_cache_refill_context().read();
         assert!(context.policies.is_empty());

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -422,7 +422,7 @@ impl CacheRefiller {
             .keys()
             .chain(policies.keys())
             .copied()
-            .collect_vec();
+            .collect::<HashSet<_>>();
         table_cache_refill_context.policies = policies;
         for table_id in table_ids {
             self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -40,7 +40,6 @@ use risingwave_hummock_sdk::compaction_group::hummock_version_ext::SstDeltaInfo;
 use risingwave_hummock_sdk::key::{FullKey, vnode_range};
 use risingwave_hummock_sdk::{HummockSstableObjectId, KeyComparator};
 use risingwave_pb::id::TableId;
-use risingwave_pb::meta::subscribe_response::Operation;
 use thiserror_ext::AsReport;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -274,6 +273,12 @@ pub struct TableCacheRefillContext {
     pub serving_table_vnode_mapping: Arc<RwLock<HashMap<TableId, Bitmap>>>,
 }
 
+fn vnode_range_bitmap(num_bits: usize, vnode_range: (usize, usize)) -> Bitmap {
+    let start = vnode_range.0.min(num_bits);
+    let end = vnode_range.1.min(num_bits);
+    Bitmap::from_range(num_bits, start..end)
+}
+
 impl TableCacheRefillContext {
     /// Check whether the given sstable block should be refilled according to the vnode mapping.
     fn check_table_refill_vnodes(&self, sstable: &Sstable, block_index: usize) -> bool {
@@ -309,7 +314,7 @@ impl TableCacheRefillContext {
         if num_bits == 0 {
             return false;
         }
-        let bitmap = Bitmap::from_range(num_bits, vnode_range.0..vnode_range.1 + 1);
+        let bitmap = vnode_range_bitmap(num_bits, vnode_range);
         if let Some(streaming_bitmap) = streaming_bitmap
             && (&bitmap & streaming_bitmap).any()
         {
@@ -425,56 +430,23 @@ impl CacheRefiller {
         }
     }
 
-    pub(crate) fn update_serving_table_vnode_mapping(
+    pub(crate) fn replace_serving_table_vnode_mapping(
         &mut self,
-        op: Operation,
         mapping: HashMap<TableId, Bitmap>,
     ) {
         let mut table_cache_refill_context = self.table_cache_refill_context.write();
-        match op {
-            Operation::Snapshot => {
-                let mut table_ids = table_cache_refill_context
-                    .serving_table_vnode_mapping
-                    .read()
-                    .keys()
-                    .chain(mapping.keys())
-                    .copied()
-                    .collect::<HashSet<_>>();
-                *table_cache_refill_context
-                    .serving_table_vnode_mapping
-                    .write() = mapping;
-                for table_id in table_ids.drain() {
-                    self.update_table_cache_refill_vnodes_inner(
-                        &mut table_cache_refill_context,
-                        table_id,
-                    );
-                }
-            }
-            Operation::Update => {
-                for (table_id, bitmap) in mapping {
-                    table_cache_refill_context
-                        .serving_table_vnode_mapping
-                        .write()
-                        .insert(table_id, bitmap);
-                    self.update_table_cache_refill_vnodes_inner(
-                        &mut table_cache_refill_context,
-                        table_id,
-                    );
-                }
-            }
-            Operation::Delete => {
-                for table_id in mapping.keys() {
-                    table_cache_refill_context
-                        .serving_table_vnode_mapping
-                        .write()
-                        .remove(table_id);
-                    self.update_table_cache_refill_vnodes_inner(
-                        &mut table_cache_refill_context,
-                        *table_id,
-                    );
-                }
-            }
-            _ => unreachable!(),
+        let mut table_ids = table_cache_refill_context
+            .serving_table_vnode_mapping
+            .read()
+            .keys()
+            .chain(mapping.keys())
+            .copied()
+            .collect::<HashSet<_>>();
+        *table_cache_refill_context
+            .serving_table_vnode_mapping
+            .write() = mapping;
+        for table_id in table_ids.drain() {
+            self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
         }
     }
 
@@ -1033,9 +1005,8 @@ mod tests {
     use risingwave_common::config::streaming::CacheRefillPolicy;
     use risingwave_common::hash::VirtualNode;
     use risingwave_pb::id::TableId;
-    use risingwave_pb::meta::subscribe_response::Operation;
 
-    use super::{CacheRefillConfig, CacheRefiller};
+    use super::{CacheRefillConfig, CacheRefiller, vnode_range_bitmap};
     use crate::hummock::iterator::test_utils::mock_sstable_store;
 
     fn test_refill_config(default_policy: CacheRefillPolicy) -> CacheRefillConfig {
@@ -1077,10 +1048,10 @@ mod tests {
                 .is_empty()
         );
 
-        refiller.update_serving_table_vnode_mapping(
-            Operation::Snapshot,
-            HashMap::from([(table_id, serving_vnodes.clone())]),
-        );
+        refiller.replace_serving_table_vnode_mapping(HashMap::from([(
+            table_id,
+            serving_vnodes.clone(),
+        )]));
 
         let context = refiller.table_cache_refill_context().read();
         assert!(context.streaming.is_empty());
@@ -1105,13 +1076,10 @@ mod tests {
             (table_id, CacheRefillPolicy::Serving),
             (removed_table_id, CacheRefillPolicy::Serving),
         ]));
-        refiller.update_serving_table_vnode_mapping(
-            Operation::Snapshot,
-            HashMap::from([
-                (table_id, serving_vnodes.clone()),
-                (removed_table_id, serving_vnodes.clone()),
-            ]),
-        );
+        refiller.replace_serving_table_vnode_mapping(HashMap::from([
+            (table_id, serving_vnodes.clone()),
+            (removed_table_id, serving_vnodes.clone()),
+        ]));
         assert!(
             refiller
                 .table_cache_refill_context()
@@ -1120,10 +1088,10 @@ mod tests {
                 .contains_key(&removed_table_id)
         );
 
-        refiller.update_serving_table_vnode_mapping(
-            Operation::Snapshot,
-            HashMap::from([(table_id, serving_vnodes.clone())]),
-        );
+        refiller.replace_serving_table_vnode_mapping(HashMap::from([(
+            table_id,
+            serving_vnodes.clone(),
+        )]));
 
         let context = refiller.table_cache_refill_context().read();
         assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
@@ -1149,10 +1117,7 @@ mod tests {
             read_version_mapping,
         );
 
-        refiller.update_serving_table_vnode_mapping(
-            Operation::Snapshot,
-            HashMap::from([(table_id, serving_vnodes)]),
-        );
+        refiller.replace_serving_table_vnode_mapping(HashMap::from([(table_id, serving_vnodes)]));
         refiller.update_table_cache_refill_policies(HashMap::from([(
             table_id,
             CacheRefillPolicy::Serving,
@@ -1170,5 +1135,21 @@ mod tests {
         let context = refiller.table_cache_refill_context().read();
         assert!(context.policies.is_empty());
         assert!(context.serving.is_empty());
+    }
+
+    #[test]
+    fn test_vnode_range_bitmap_uses_right_exclusive_end() {
+        let bitmap = vnode_range_bitmap(VirtualNode::COUNT_FOR_TEST, (10, 12));
+        assert_eq!(bitmap.count_ones(), 2);
+        assert!(bitmap.is_set(10));
+        assert!(bitmap.is_set(11));
+        assert!(!bitmap.is_set(12));
+
+        let last = vnode_range_bitmap(
+            VirtualNode::COUNT_FOR_TEST,
+            (VirtualNode::COUNT_FOR_TEST - 1, VirtualNode::COUNT_FOR_TEST),
+        );
+        assert_eq!(last.count_ones(), 1);
+        assert!(last.is_set(VirtualNode::COUNT_FOR_TEST - 1));
     }
 }

--- a/src/storage/src/hummock/event_handler/refiller.rs
+++ b/src/storage/src/hummock/event_handler/refiller.rs
@@ -410,7 +410,7 @@ impl CacheRefiller {
 
     pub(crate) fn update_table_cache_refill_policies(
         &mut self,
-        policies: HashMap<TableId, Option<CacheRefillPolicy>>,
+        policies: HashMap<TableId, CacheRefillPolicy>,
     ) {
         let mut table_cache_refill_context = self.table_cache_refill_context.write();
         let table_ids = table_cache_refill_context
@@ -419,12 +419,7 @@ impl CacheRefiller {
             .chain(policies.keys())
             .copied()
             .collect_vec();
-        table_cache_refill_context.policies.clear();
-        for (table_id, policy) in policies {
-            if let Some(policy) = policy {
-                table_cache_refill_context.policies.insert(table_id, policy);
-            }
-        }
+        table_cache_refill_context.policies = policies;
         for table_id in table_ids {
             self.update_table_cache_refill_vnodes_inner(&mut table_cache_refill_context, table_id);
         }
@@ -438,13 +433,20 @@ impl CacheRefiller {
         let mut table_cache_refill_context = self.table_cache_refill_context.write();
         match op {
             Operation::Snapshot => {
+                let mut table_ids = table_cache_refill_context
+                    .serving_table_vnode_mapping
+                    .read()
+                    .keys()
+                    .chain(mapping.keys())
+                    .copied()
+                    .collect::<HashSet<_>>();
                 *table_cache_refill_context
                     .serving_table_vnode_mapping
-                    .write() = mapping.clone();
-                for table_id in mapping.keys() {
+                    .write() = mapping;
+                for table_id in table_ids.drain() {
                     self.update_table_cache_refill_vnodes_inner(
                         &mut table_cache_refill_context,
-                        *table_id,
+                        table_id,
                     );
                 }
             }
@@ -1065,7 +1067,7 @@ mod tests {
 
         refiller.update_table_cache_refill_policies(HashMap::from([(
             table_id,
-            Some(CacheRefillPolicy::Serving),
+            CacheRefillPolicy::Serving,
         )]));
         assert!(
             refiller
@@ -1083,6 +1085,55 @@ mod tests {
         let context = refiller.table_cache_refill_context().read();
         assert!(context.streaming.is_empty());
         assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+    }
+
+    #[tokio::test]
+    async fn test_serving_snapshot_replaces_existing_vnodes() {
+        let table_id = TableId::from(233);
+        let removed_table_id = TableId::from(234);
+        let serving_vnodes = Bitmap::ones(VirtualNode::COUNT_FOR_TEST);
+        let read_version_mapping = Arc::new(RwLock::new(HashMap::new()));
+        let mut refiller = CacheRefiller::new(
+            Role::Serving,
+            test_refill_config(CacheRefillPolicy::Disabled),
+            mock_sstable_store().await,
+            CacheRefiller::default_spawn_refill_task(),
+            read_version_mapping,
+        );
+
+        refiller.update_table_cache_refill_policies(HashMap::from([
+            (table_id, CacheRefillPolicy::Serving),
+            (removed_table_id, CacheRefillPolicy::Serving),
+        ]));
+        refiller.update_serving_table_vnode_mapping(
+            Operation::Snapshot,
+            HashMap::from([
+                (table_id, serving_vnodes.clone()),
+                (removed_table_id, serving_vnodes.clone()),
+            ]),
+        );
+        assert!(
+            refiller
+                .table_cache_refill_context()
+                .read()
+                .serving
+                .contains_key(&removed_table_id)
+        );
+
+        refiller.update_serving_table_vnode_mapping(
+            Operation::Snapshot,
+            HashMap::from([(table_id, serving_vnodes.clone())]),
+        );
+
+        let context = refiller.table_cache_refill_context().read();
+        assert_eq!(context.serving.get(&table_id), Some(&serving_vnodes));
+        assert!(!context.serving.contains_key(&removed_table_id));
+        assert!(
+            !context
+                .serving_table_vnode_mapping
+                .read()
+                .contains_key(&removed_table_id)
+        );
     }
 
     #[tokio::test]
@@ -1104,7 +1155,7 @@ mod tests {
         );
         refiller.update_table_cache_refill_policies(HashMap::from([(
             table_id,
-            Some(CacheRefillPolicy::Serving),
+            CacheRefillPolicy::Serving,
         )]));
         assert!(
             refiller

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -24,15 +24,14 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::compaction_catalog_manager::CompactionCatalogManagerRef;
 use crate::hummock::backup_reader::BackupReaderRef;
-use crate::hummock::event_handler::HummockVersionUpdate;
+use crate::hummock::event_handler::{HummockObserverEvent, HummockVersionUpdate};
 use crate::hummock::write_limiter::WriteLimiterRef;
 
 pub struct HummockObserverNode {
     compaction_catalog_manager: CompactionCatalogManagerRef,
     backup_reader: BackupReaderRef,
     write_limiter: WriteLimiterRef,
-    version_update_sender: UnboundedSender<HummockVersionUpdate>,
-    table_refill_runtime_config_sender: UnboundedSender<(Operation, PbTableRefillRuntimeConfig)>,
+    observer_event_sender: UnboundedSender<HummockObserverEvent>,
     version: u64,
 }
 
@@ -69,13 +68,15 @@ impl ObserverState for HummockObserverNode {
             }
             Info::HummockVersionDeltas(hummock_version_deltas) => {
                 let _ = self
-                    .version_update_sender
-                    .send(HummockVersionUpdate::VersionDeltas(
-                        hummock_version_deltas
-                            .version_deltas
-                            .iter()
-                            .map(HummockVersionDelta::from_rpc_protobuf)
-                            .collect(),
+                    .observer_event_sender
+                    .send(HummockObserverEvent::VersionUpdate(
+                        HummockVersionUpdate::VersionDeltas(
+                            hummock_version_deltas
+                                .version_deltas
+                                .iter()
+                                .map(HummockVersionDelta::from_rpc_protobuf)
+                                .collect(),
+                        ),
                     ))
                     .inspect_err(|e| {
                         tracing::error!(event = ?e.0, "unable to send version delta");
@@ -125,14 +126,14 @@ impl ObserverState for HummockObserverNode {
                 .write_limits,
         );
         let _ = self
-            .version_update_sender
-            .send(HummockVersionUpdate::PinnedVersion(Box::new(
-                HummockVersion::from_rpc_protobuf(
+            .observer_event_sender
+            .send(HummockObserverEvent::VersionUpdate(
+                HummockVersionUpdate::PinnedVersion(Box::new(HummockVersion::from_rpc_protobuf(
                     &snapshot
                         .hummock_version
                         .expect("should get hummock version"),
-                ),
-            )))
+                ))),
+            ))
             .inspect_err(|e| {
                 tracing::error!(event = ?e.0, "unable to send full version");
             });
@@ -151,18 +152,13 @@ impl HummockObserverNode {
     pub fn new(
         compaction_catalog_manager: CompactionCatalogManagerRef,
         backup_reader: BackupReaderRef,
-        version_update_sender: UnboundedSender<HummockVersionUpdate>,
-        table_refill_runtime_config_sender: UnboundedSender<(
-            Operation,
-            PbTableRefillRuntimeConfig,
-        )>,
+        observer_event_sender: UnboundedSender<HummockObserverEvent>,
         write_limiter: WriteLimiterRef,
     ) -> Self {
         Self {
             compaction_catalog_manager,
             backup_reader,
-            version_update_sender,
-            table_refill_runtime_config_sender,
+            observer_event_sender,
             version: 0,
             write_limiter,
         }
@@ -185,12 +181,13 @@ impl HummockObserverNode {
         );
 
         let _ = self
-            .table_refill_runtime_config_sender
-            .send((operation, config))
+            .observer_event_sender
+            .send(HummockObserverEvent::TableRefillRuntimeConfig(
+                operation, config,
+            ))
             .inspect_err(|e| {
                 tracing::error!(
-                    operation = ?e.0.0,
-                    config = ?e.0.1,
+                    event = ?e.0,
                     "unable to send table refill runtime config"
                 );
             });
@@ -232,6 +229,7 @@ mod tests {
     use super::HummockObserverNode;
     use crate::compaction_catalog_manager::CompactionCatalogManager;
     use crate::hummock::backup_reader::BackupReader;
+    use crate::hummock::event_handler::{HummockObserverEvent, HummockVersionUpdate};
     use crate::hummock::write_limiter::WriteLimiter;
 
     fn policy_snapshot(catalog_version: u64, table_id: u32) -> SubscribeResponse {
@@ -264,33 +262,44 @@ mod tests {
 
     #[tokio::test]
     async fn test_resubscribe_snapshot_refreshes_table_cache_refill_policies() {
-        let (version_update_tx, mut version_update_rx) = unbounded_channel();
-        let (table_refill_runtime_config_tx, mut table_refill_runtime_config_rx) =
-            unbounded_channel();
+        let (observer_event_tx, mut observer_event_rx) = unbounded_channel();
         let mut observer = HummockObserverNode::new(
             Arc::new(CompactionCatalogManager::default()),
             BackupReader::unused().await,
-            version_update_tx,
-            table_refill_runtime_config_tx,
+            observer_event_tx,
             WriteLimiter::unused(),
         );
 
         observer.handle_initialization_notification(policy_snapshot(1, 233));
-        let (operation, config) = table_refill_runtime_config_rx.recv().await.unwrap();
+        assert!(matches!(
+            observer_event_rx.recv().await.unwrap(),
+            HummockObserverEvent::VersionUpdate(HummockVersionUpdate::PinnedVersion(_))
+        ));
+        let HummockObserverEvent::TableRefillRuntimeConfig(operation, config) =
+            observer_event_rx.recv().await.unwrap()
+        else {
+            panic!("expect table refill runtime config");
+        };
         assert_eq!(operation, Operation::Snapshot);
         assert_eq!(
             config.table_cache_refill_policies.unwrap().policies[0].table_id,
             233
         );
-        version_update_rx.recv().await.unwrap();
 
         observer.handle_initialization_notification(policy_snapshot(2, 234));
-        let (operation, config) = table_refill_runtime_config_rx.recv().await.unwrap();
+        assert!(matches!(
+            observer_event_rx.recv().await.unwrap(),
+            HummockObserverEvent::VersionUpdate(HummockVersionUpdate::PinnedVersion(_))
+        ));
+        let HummockObserverEvent::TableRefillRuntimeConfig(operation, config) =
+            observer_event_rx.recv().await.unwrap()
+        else {
+            panic!("expect table refill runtime config");
+        };
         assert_eq!(operation, Operation::Snapshot);
         assert_eq!(
             config.table_cache_refill_policies.unwrap().policies[0].table_id,
             234
         );
-        version_update_rx.recv().await.unwrap();
     }
 }

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -12,19 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
-use risingwave_common::bitmap::Bitmap;
 use risingwave_common::license::LicenseManager;
 use risingwave_common_service::ObserverState;
 use risingwave_hummock_sdk::version::{HummockVersion, HummockVersionDelta};
 use risingwave_hummock_trace::TraceSpan;
 use risingwave_pb::catalog::Table;
-use risingwave_pb::id::TableId;
 use risingwave_pb::meta::object::PbObjectInfo;
-use risingwave_pb::meta::serving_table_vnode_mappings::PbServingTableVnodeMapping;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
-use risingwave_pb::meta::{SubscribeResponse, TableCacheRefillPolicies};
+use risingwave_pb::meta::{PbTableRefillRuntimeConfig, SubscribeResponse};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::compaction_catalog_manager::CompactionCatalogManagerRef;
@@ -37,8 +32,7 @@ pub struct HummockObserverNode {
     backup_reader: BackupReaderRef,
     write_limiter: WriteLimiterRef,
     version_update_sender: UnboundedSender<HummockVersionUpdate>,
-    cache_refill_policy_sender: UnboundedSender<TableCacheRefillPolicies>,
-    serving_table_vnode_mapping_sender: UnboundedSender<(Operation, HashMap<TableId, Bitmap>)>,
+    table_refill_runtime_config_sender: UnboundedSender<(Operation, PbTableRefillRuntimeConfig)>,
     version: u64,
 }
 
@@ -101,10 +95,25 @@ impl ObserverState for HummockObserverNode {
                 LicenseManager::get().update_cluster_resource(resource);
             }
             Info::ServingTableVnodeMappings(mappings) => {
-                self.handle_serving_table_vnode_mappings(resp.operation(), mappings.mappings);
+                self.handle_table_refill_runtime_config(
+                    resp.operation(),
+                    PbTableRefillRuntimeConfig {
+                        serving_table_vnode_mappings: Some(mappings),
+                        ..Default::default()
+                    },
+                );
             }
             Info::TableCacheRefillPolicies(policies) => {
-                self.handle_table_cache_refill_policies(policies);
+                self.handle_table_refill_runtime_config(
+                    resp.operation(),
+                    PbTableRefillRuntimeConfig {
+                        table_cache_refill_policies: Some(policies),
+                        ..Default::default()
+                    },
+                );
+            }
+            Info::TableRefillRuntimeConfig(config) => {
+                self.handle_table_refill_runtime_config(resp.operation(), config);
             }
             info => {
                 panic!("invalid notification info: {info}");
@@ -149,16 +158,9 @@ impl ObserverState for HummockObserverNode {
         self.version = snapshot_version.catalog_version;
         LicenseManager::get().update_cluster_resource(snapshot.cluster_resource.unwrap());
 
-        self.handle_table_cache_refill_policies(
-            snapshot.table_cache_refill_policies.unwrap_or_default(),
-        );
-
-        self.handle_serving_table_vnode_mappings(
+        self.handle_table_refill_runtime_config(
             Operation::Snapshot,
-            snapshot
-                .serving_table_vnode_mappings
-                .unwrap_or_default()
-                .mappings,
+            snapshot.table_refill_runtime_config.unwrap_or_default(),
         );
     }
 }
@@ -168,16 +170,17 @@ impl HummockObserverNode {
         compaction_catalog_manager: CompactionCatalogManagerRef,
         backup_reader: BackupReaderRef,
         version_update_sender: UnboundedSender<HummockVersionUpdate>,
-        cache_refill_policy_sender: UnboundedSender<TableCacheRefillPolicies>,
-        serving_table_vnode_mapping_sender: UnboundedSender<(Operation, HashMap<TableId, Bitmap>)>,
+        table_refill_runtime_config_sender: UnboundedSender<(
+            Operation,
+            PbTableRefillRuntimeConfig,
+        )>,
         write_limiter: WriteLimiterRef,
     ) -> Self {
         Self {
             compaction_catalog_manager,
             backup_reader,
             version_update_sender,
-            cache_refill_policy_sender,
-            serving_table_vnode_mapping_sender,
+            table_refill_runtime_config_sender,
             version: 0,
             write_limiter,
         }
@@ -188,53 +191,25 @@ impl HummockObserverNode {
             .sync(tables.into_iter().map(|t| (t.id, t)).collect());
     }
 
-    fn handle_serving_table_vnode_mappings(
+    fn handle_table_refill_runtime_config(
         &self,
-        op: Operation,
-        mappings: Vec<PbServingTableVnodeMapping>,
+        operation: Operation,
+        config: PbTableRefillRuntimeConfig,
     ) {
-        let mappings = mappings
-            .into_iter()
-            .map(|mapping| {
-                (
-                    TableId::from(mapping.table_id),
-                    Bitmap::from(
-                        mapping
-                            .bitmap
-                            .expect("serving table vnode bitmap must exist"),
-                    ),
-                )
-            })
-            .collect();
-
         tracing::debug!(
-            ?op,
-            ?mappings,
-            "receive serving table vnode mappings updates"
+            ?operation,
+            ?config,
+            "receive table refill runtime config updates"
         );
 
         let _ = self
-            .serving_table_vnode_mapping_sender
-            .send((op, mappings))
+            .table_refill_runtime_config_sender
+            .send((operation, config))
             .inspect_err(|e| {
                 tracing::error!(
-                    op = ?e.0.0,
-                    mappings = ?e.0.1,
-                    "unable to send serving table vnode mappings"
-                );
-            });
-    }
-
-    fn handle_table_cache_refill_policies(&self, policies: TableCacheRefillPolicies) {
-        tracing::debug!(?policies, "receive table cache refill policy updates");
-
-        let _ = self
-            .cache_refill_policy_sender
-            .send(policies)
-            .inspect_err(|e| {
-                tracing::error!(
-                    policies = ?e.0,
-                    "unable to send table cache refill policies"
+                    operation = ?e.0.0,
+                    config = ?e.0.1,
+                    "unable to send table refill runtime config"
                 );
             });
     }
@@ -267,7 +242,9 @@ mod tests {
     use risingwave_pb::meta::subscribe_response::{Info, Operation};
     use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
     use risingwave_pb::meta::table_cache_refill_policies::table_cache_refill_policy::PbCacheRefillPolicy;
-    use risingwave_pb::meta::{MetaSnapshot, SubscribeResponse, TableCacheRefillPolicies};
+    use risingwave_pb::meta::{
+        MetaSnapshot, PbTableRefillRuntimeConfig, SubscribeResponse, TableCacheRefillPolicies,
+    };
     use tokio::sync::mpsc::unbounded_channel;
 
     use super::HummockObserverNode;
@@ -288,11 +265,14 @@ mod tests {
                     write_limits: HashMap::new(),
                 }),
                 cluster_resource: Some(Default::default()),
-                table_cache_refill_policies: Some(TableCacheRefillPolicies {
-                    policies: vec![PbTableCacheRefillPolicy {
-                        table_id,
-                        policy: PbCacheRefillPolicy::Serving as i32,
-                    }],
+                table_refill_runtime_config: Some(PbTableRefillRuntimeConfig {
+                    table_cache_refill_policies: Some(TableCacheRefillPolicies {
+                        policies: vec![PbTableCacheRefillPolicy {
+                            table_id,
+                            policy: PbCacheRefillPolicy::Serving as i32,
+                        }],
+                    }),
+                    ..Default::default()
                 }),
                 ..Default::default()
             })),
@@ -303,36 +283,32 @@ mod tests {
     #[tokio::test]
     async fn test_resubscribe_snapshot_refreshes_table_cache_refill_policies() {
         let (version_update_tx, mut version_update_rx) = unbounded_channel();
-        let (cache_refill_policy_tx, mut cache_refill_policy_rx) = unbounded_channel();
-        let (serving_table_vnode_mapping_tx, mut serving_table_vnode_mapping_rx) =
+        let (table_refill_runtime_config_tx, mut table_refill_runtime_config_rx) =
             unbounded_channel();
         let mut observer = HummockObserverNode::new(
             Arc::new(CompactionCatalogManager::default()),
             BackupReader::unused().await,
             version_update_tx,
-            cache_refill_policy_tx,
-            serving_table_vnode_mapping_tx,
+            table_refill_runtime_config_tx,
             WriteLimiter::unused(),
         );
 
         observer.handle_initialization_notification(policy_snapshot(1, 233));
+        let (operation, config) = table_refill_runtime_config_rx.recv().await.unwrap();
+        assert_eq!(operation, Operation::Snapshot);
         assert_eq!(
-            cache_refill_policy_rx.recv().await.unwrap().policies[0].table_id,
+            config.table_cache_refill_policies.unwrap().policies[0].table_id,
             233
         );
-        let (op, mappings) = serving_table_vnode_mapping_rx.recv().await.unwrap();
-        assert_eq!(op, Operation::Snapshot);
-        assert!(mappings.is_empty());
         version_update_rx.recv().await.unwrap();
 
         observer.handle_initialization_notification(policy_snapshot(2, 234));
+        let (operation, config) = table_refill_runtime_config_rx.recv().await.unwrap();
+        assert_eq!(operation, Operation::Snapshot);
         assert_eq!(
-            cache_refill_policy_rx.recv().await.unwrap().policies[0].table_id,
+            config.table_cache_refill_policies.unwrap().policies[0].table_id,
             234
         );
-        let (op, mappings) = serving_table_vnode_mapping_rx.recv().await.unwrap();
-        assert_eq!(op, Operation::Snapshot);
-        assert!(mappings.is_empty());
         version_update_rx.recv().await.unwrap();
     }
 }

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -94,24 +94,6 @@ impl ObserverState for HummockObserverNode {
             Info::ClusterResource(resource) => {
                 LicenseManager::get().update_cluster_resource(resource);
             }
-            Info::ServingTableVnodeMappings(mappings) => {
-                self.handle_table_refill_runtime_config(
-                    resp.operation(),
-                    PbTableRefillRuntimeConfig {
-                        serving_table_vnode_mappings: Some(mappings),
-                        ..Default::default()
-                    },
-                );
-            }
-            Info::TableCacheRefillPolicies(policies) => {
-                self.handle_table_refill_runtime_config(
-                    resp.operation(),
-                    PbTableRefillRuntimeConfig {
-                        table_cache_refill_policies: Some(policies),
-                        ..Default::default()
-                    },
-                );
-            }
             Info::TableRefillRuntimeConfig(config) => {
                 self.handle_table_refill_runtime_config(resp.operation(), config);
             }

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -153,9 +153,13 @@ impl ObserverState for HummockObserverNode {
             snapshot.table_cache_refill_policies.unwrap_or_default(),
         );
 
-        if let Some(mappings) = snapshot.serving_table_vnode_mappings {
-            self.handle_serving_table_vnode_mappings(Operation::Snapshot, mappings.mappings);
-        }
+        self.handle_serving_table_vnode_mappings(
+            Operation::Snapshot,
+            snapshot
+                .serving_table_vnode_mappings
+                .unwrap_or_default()
+                .mappings,
+        );
     }
 }
 
@@ -197,7 +201,7 @@ impl HummockObserverNode {
                     Bitmap::from(
                         mapping
                             .bitmap
-                            .expect("serving table vnode bitmap cannot inexists"),
+                            .expect("serving table vnode bitmap must exist"),
                     ),
                 )
             })
@@ -260,7 +264,7 @@ mod tests {
     use risingwave_pb::backup_service::MetaBackupManifestId;
     use risingwave_pb::hummock::{PbHummockVersion, WriteLimits};
     use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
-    use risingwave_pb::meta::subscribe_response::Info;
+    use risingwave_pb::meta::subscribe_response::{Info, Operation};
     use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
     use risingwave_pb::meta::table_cache_refill_policies::table_cache_refill_policy::PbCacheRefillPolicy;
     use risingwave_pb::meta::{MetaSnapshot, SubscribeResponse, TableCacheRefillPolicies};
@@ -300,7 +304,8 @@ mod tests {
     async fn test_resubscribe_snapshot_refreshes_table_cache_refill_policies() {
         let (version_update_tx, mut version_update_rx) = unbounded_channel();
         let (cache_refill_policy_tx, mut cache_refill_policy_rx) = unbounded_channel();
-        let (serving_table_vnode_mapping_tx, _serving_table_vnode_mapping_rx) = unbounded_channel();
+        let (serving_table_vnode_mapping_tx, mut serving_table_vnode_mapping_rx) =
+            unbounded_channel();
         let mut observer = HummockObserverNode::new(
             Arc::new(CompactionCatalogManager::default()),
             BackupReader::unused().await,
@@ -315,6 +320,9 @@ mod tests {
             cache_refill_policy_rx.recv().await.unwrap().policies[0].table_id,
             233
         );
+        let (op, mappings) = serving_table_vnode_mapping_rx.recv().await.unwrap();
+        assert_eq!(op, Operation::Snapshot);
+        assert!(mappings.is_empty());
         version_update_rx.recv().await.unwrap();
 
         observer.handle_initialization_notification(policy_snapshot(2, 234));
@@ -322,6 +330,9 @@ mod tests {
             cache_refill_policy_rx.recv().await.unwrap().policies[0].table_id,
             234
         );
+        let (op, mappings) = serving_table_vnode_mapping_rx.recv().await.unwrap();
+        assert_eq!(op, Operation::Snapshot);
+        assert!(mappings.is_empty());
         version_update_rx.recv().await.unwrap();
     }
 }

--- a/src/storage/src/hummock/observer_manager.rs
+++ b/src/storage/src/hummock/observer_manager.rs
@@ -22,6 +22,7 @@ use risingwave_hummock_trace::TraceSpan;
 use risingwave_pb::catalog::Table;
 use risingwave_pb::id::TableId;
 use risingwave_pb::meta::object::PbObjectInfo;
+use risingwave_pb::meta::serving_table_vnode_mappings::PbServingTableVnodeMapping;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::{SubscribeResponse, TableCacheRefillPolicies};
 use tokio::sync::mpsc::UnboundedSender;
@@ -99,51 +100,11 @@ impl ObserverState for HummockObserverNode {
             Info::ClusterResource(resource) => {
                 LicenseManager::get().update_cluster_resource(resource);
             }
-            Info::TableCacheRefillPolicies(policies) => {
-                tracing::info!(?policies, "receive table cache refill policies updates");
-                let _ = self
-                    .cache_refill_policy_sender
-                    .send(policies)
-                    .inspect_err(|e| {
-                        tracing::error!(
-                            policies = ?e.0,
-                            "unable to send table cache refill policies"
-                        );
-                    });
-            }
             Info::ServingTableVnodeMappings(mappings) => {
-                let mappings = mappings
-                    .mappings
-                    .into_iter()
-                    .map(|mapping| {
-                        (
-                            TableId::from(mapping.table_id),
-                            Bitmap::from(
-                                mapping
-                                    .bitmap
-                                    .expect("serving table vnode bitmap cannot inexists"),
-                            ),
-                        )
-                    })
-                    .collect();
-
-                let op = resp.operation();
-                tracing::debug!(
-                    ?op,
-                    ?mappings,
-                    "receive serving table vnode mappings updates"
-                );
-
-                let _ = self
-                    .serving_table_vnode_mapping_sender
-                    .send((op, mappings))
-                    .inspect_err(|e| {
-                        tracing::error!(
-                            op = ?e.0.0,
-                            mappings = ?e.0.1,
-                            "unable to send serving table vnode mappings"
-                        );
-                    });
+                self.handle_serving_table_vnode_mappings(resp.operation(), mappings.mappings);
+            }
+            Info::TableCacheRefillPolicies(policies) => {
+                self.handle_table_cache_refill_policies(policies);
             }
             info => {
                 panic!("invalid notification info: {info}");
@@ -187,6 +148,14 @@ impl ObserverState for HummockObserverNode {
         let snapshot_version = snapshot.version.unwrap();
         self.version = snapshot_version.catalog_version;
         LicenseManager::get().update_cluster_resource(snapshot.cluster_resource.unwrap());
+
+        self.handle_table_cache_refill_policies(
+            snapshot.table_cache_refill_policies.unwrap_or_default(),
+        );
+
+        if let Some(mappings) = snapshot.serving_table_vnode_mappings {
+            self.handle_serving_table_vnode_mappings(Operation::Snapshot, mappings.mappings);
+        }
     }
 }
 
@@ -215,6 +184,57 @@ impl HummockObserverNode {
             .sync(tables.into_iter().map(|t| (t.id, t)).collect());
     }
 
+    fn handle_serving_table_vnode_mappings(
+        &self,
+        op: Operation,
+        mappings: Vec<PbServingTableVnodeMapping>,
+    ) {
+        let mappings = mappings
+            .into_iter()
+            .map(|mapping| {
+                (
+                    TableId::from(mapping.table_id),
+                    Bitmap::from(
+                        mapping
+                            .bitmap
+                            .expect("serving table vnode bitmap cannot inexists"),
+                    ),
+                )
+            })
+            .collect();
+
+        tracing::debug!(
+            ?op,
+            ?mappings,
+            "receive serving table vnode mappings updates"
+        );
+
+        let _ = self
+            .serving_table_vnode_mapping_sender
+            .send((op, mappings))
+            .inspect_err(|e| {
+                tracing::error!(
+                    op = ?e.0.0,
+                    mappings = ?e.0.1,
+                    "unable to send serving table vnode mappings"
+                );
+            });
+    }
+
+    fn handle_table_cache_refill_policies(&self, policies: TableCacheRefillPolicies) {
+        tracing::debug!(?policies, "receive table cache refill policy updates");
+
+        let _ = self
+            .cache_refill_policy_sender
+            .send(policies)
+            .inspect_err(|e| {
+                tracing::error!(
+                    policies = ?e.0,
+                    "unable to send table cache refill policies"
+                );
+            });
+    }
+
     fn handle_catalog_notification(&mut self, operation: Operation, table_catalog: Table) {
         match operation {
             Operation::Add | Operation::Update => {
@@ -228,5 +248,80 @@ impl HummockObserverNode {
 
             _ => panic!("receive an unsupported notify {:?}", operation),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use risingwave_common_service::ObserverState;
+    use risingwave_pb::backup_service::MetaBackupManifestId;
+    use risingwave_pb::hummock::{PbHummockVersion, WriteLimits};
+    use risingwave_pb::meta::meta_snapshot::SnapshotVersion;
+    use risingwave_pb::meta::subscribe_response::Info;
+    use risingwave_pb::meta::table_cache_refill_policies::PbTableCacheRefillPolicy;
+    use risingwave_pb::meta::table_cache_refill_policies::table_cache_refill_policy::PbCacheRefillPolicy;
+    use risingwave_pb::meta::{MetaSnapshot, SubscribeResponse, TableCacheRefillPolicies};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::HummockObserverNode;
+    use crate::compaction_catalog_manager::CompactionCatalogManager;
+    use crate::hummock::backup_reader::BackupReader;
+    use crate::hummock::write_limiter::WriteLimiter;
+
+    fn policy_snapshot(catalog_version: u64, table_id: u32) -> SubscribeResponse {
+        SubscribeResponse {
+            info: Some(Info::Snapshot(MetaSnapshot {
+                hummock_version: Some(PbHummockVersion::default()),
+                version: Some(SnapshotVersion {
+                    catalog_version,
+                    ..Default::default()
+                }),
+                meta_backup_manifest_id: Some(MetaBackupManifestId { id: 0 }),
+                hummock_write_limits: Some(WriteLimits {
+                    write_limits: HashMap::new(),
+                }),
+                cluster_resource: Some(Default::default()),
+                table_cache_refill_policies: Some(TableCacheRefillPolicies {
+                    policies: vec![PbTableCacheRefillPolicy {
+                        table_id,
+                        policy: PbCacheRefillPolicy::Serving as i32,
+                    }],
+                }),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resubscribe_snapshot_refreshes_table_cache_refill_policies() {
+        let (version_update_tx, mut version_update_rx) = unbounded_channel();
+        let (cache_refill_policy_tx, mut cache_refill_policy_rx) = unbounded_channel();
+        let (serving_table_vnode_mapping_tx, _serving_table_vnode_mapping_rx) = unbounded_channel();
+        let mut observer = HummockObserverNode::new(
+            Arc::new(CompactionCatalogManager::default()),
+            BackupReader::unused().await,
+            version_update_tx,
+            cache_refill_policy_tx,
+            serving_table_vnode_mapping_tx,
+            WriteLimiter::unused(),
+        );
+
+        observer.handle_initialization_notification(policy_snapshot(1, 233));
+        assert_eq!(
+            cache_refill_policy_rx.recv().await.unwrap().policies[0].table_id,
+            233
+        );
+        version_update_rx.recv().await.unwrap();
+
+        observer.handle_initialization_notification(policy_snapshot(2, 234));
+        assert_eq!(
+            cache_refill_policy_rx.recv().await.unwrap().policies[0].table_id,
+            234
+        );
+        version_update_rx.recv().await.unwrap();
     }
 }

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -34,7 +34,6 @@ use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_watermark::TableWatermarksIndex;
 use risingwave_hummock_sdk::version::{HummockVersion, LocalHummockVersion};
 use risingwave_hummock_sdk::{HummockRawObjectId, HummockReadEpoch, SyncResult};
-use risingwave_pb::meta::subscribe_response::Operation;
 use risingwave_rpc_client::HummockMetaClient;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -53,7 +52,8 @@ use crate::hummock::compactor::{
 use crate::hummock::event_handler::hummock_event_handler::{BufferTracker, HummockEventSender};
 use crate::hummock::event_handler::refiller::TableCacheRefillContext;
 use crate::hummock::event_handler::{
-    HummockEvent, HummockEventHandler, HummockVersionUpdate, ReadOnlyReadVersionMapping,
+    HummockEvent, HummockEventHandler, HummockObserverEvent, HummockVersionUpdate,
+    ReadOnlyReadVersionMapping,
 };
 use crate::hummock::iterator::change_log::ChangeLogIterator;
 use crate::hummock::local_version::pinned_version::{PinnedVersion, start_pinned_version_worker};
@@ -94,7 +94,7 @@ impl Drop for HummockStorageShutdownGuard {
 pub struct HummockStorage {
     hummock_event_sender: HummockEventSender,
     // only used in test for setting hummock version in uploader
-    _version_update_sender: UnboundedSender<HummockVersionUpdate>,
+    _observer_event_sender: UnboundedSender<HummockObserverEvent>,
 
     context: CompactorContext,
 
@@ -177,34 +177,27 @@ impl HummockStorage {
         .await
         .map_err(HummockError::read_backup_error)?;
         let write_limiter = Arc::new(WriteLimiter::default());
-        let (version_update_tx, mut version_update_rx) = unbounded_channel();
-        let (table_refill_runtime_config_tx, mut table_refill_runtime_config_rx) =
-            unbounded_channel();
-
+        let (observer_event_tx, mut observer_event_rx) = unbounded_channel();
         let observer_manager = ObserverManager::new(
             notification_client,
             HummockObserverNode::new(
                 compaction_catalog_manager_ref.clone(),
                 backup_reader.clone(),
-                version_update_tx.clone(),
-                table_refill_runtime_config_tx,
+                observer_event_tx.clone(),
                 write_limiter.clone(),
             ),
         )
         .await;
         observer_manager.start().await;
 
-        let hummock_version = match version_update_rx.recv().await {
-            Some(HummockVersionUpdate::PinnedVersion(version)) => *version,
+        let hummock_version = match observer_event_rx.recv().await {
+            Some(HummockObserverEvent::VersionUpdate(HummockVersionUpdate::PinnedVersion(
+                version,
+            ))) => *version,
             _ => unreachable!(
                 "the hummock observer manager is the first one to take the event tx. Should be full hummock version"
             ),
         };
-        let initial_table_refill_runtime_config = table_refill_runtime_config_rx
-            .recv()
-            .await
-            .unwrap_or((Operation::Snapshot, Default::default()));
-
         let (pin_version_tx, pin_version_rx) = unbounded_channel();
         let pinned_version = PinnedVersion::new(hummock_version, pin_version_tx);
         tokio::spawn(start_pinned_version_worker(
@@ -224,9 +217,7 @@ impl HummockStorage {
 
         let hummock_event_handler = HummockEventHandler::new(
             role,
-            version_update_rx,
-            initial_table_refill_runtime_config,
-            table_refill_runtime_config_rx,
+            observer_event_rx,
             pinned_version,
             compactor_context.clone(),
             compaction_catalog_manager_ref.clone(),
@@ -243,7 +234,7 @@ impl HummockStorage {
             buffer_tracker: hummock_event_handler.buffer_tracker().clone(),
             version_update_notifier_tx: hummock_event_handler.version_update_notifier_tx(),
             hummock_event_sender: event_tx.clone(),
-            _version_update_sender: version_update_tx,
+            _observer_event_sender: observer_event_tx,
             recent_versions: hummock_event_handler.recent_versions(),
             hummock_version_reader: HummockVersionReader::new(
                 sstable_store,
@@ -968,8 +959,10 @@ impl HummockStorage {
     pub async fn update_version_and_wait(&self, version: HummockVersion) {
         use tokio::task::yield_now;
         let version_id = version.id;
-        self._version_update_sender
-            .send(HummockVersionUpdate::PinnedVersion(Box::new(version)))
+        self._observer_event_sender
+            .send(HummockObserverEvent::VersionUpdate(
+                HummockVersionUpdate::PinnedVersion(Box::new(version)),
+            ))
             .unwrap();
         loop {
             if self.recent_versions.load().latest_version().id() >= version_id {

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -177,7 +177,7 @@ impl HummockStorage {
         .map_err(HummockError::read_backup_error)?;
         let write_limiter = Arc::new(WriteLimiter::default());
         let (version_update_tx, mut version_update_rx) = unbounded_channel();
-        let (cache_refill_policy_tx, cache_refill_policy_rx) = unbounded_channel();
+        let (cache_refill_policy_tx, mut cache_refill_policy_rx) = unbounded_channel();
         let (serving_table_vnode_mapping_tx, serving_table_vnode_mapping_rx) = unbounded_channel();
 
         let observer_manager = ObserverManager::new(
@@ -200,6 +200,7 @@ impl HummockStorage {
                 "the hummock observer manager is the first one to take the event tx. Should be full hummock version"
             ),
         };
+        let initial_cache_refill_policies = cache_refill_policy_rx.recv().await.unwrap_or_default();
 
         let (pin_version_tx, pin_version_rx) = unbounded_channel();
         let pinned_version = PinnedVersion::new(hummock_version, pin_version_tx);
@@ -221,6 +222,7 @@ impl HummockStorage {
         let hummock_event_handler = HummockEventHandler::new(
             role,
             version_update_rx,
+            initial_cache_refill_policies,
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             pinned_version,

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -178,8 +178,7 @@ impl HummockStorage {
         .map_err(HummockError::read_backup_error)?;
         let write_limiter = Arc::new(WriteLimiter::default());
         let (version_update_tx, mut version_update_rx) = unbounded_channel();
-        let (cache_refill_policy_tx, mut cache_refill_policy_rx) = unbounded_channel();
-        let (serving_table_vnode_mapping_tx, mut serving_table_vnode_mapping_rx) =
+        let (table_refill_runtime_config_tx, mut table_refill_runtime_config_rx) =
             unbounded_channel();
 
         let observer_manager = ObserverManager::new(
@@ -188,8 +187,7 @@ impl HummockStorage {
                 compaction_catalog_manager_ref.clone(),
                 backup_reader.clone(),
                 version_update_tx.clone(),
-                cache_refill_policy_tx,
-                serving_table_vnode_mapping_tx,
+                table_refill_runtime_config_tx,
                 write_limiter.clone(),
             ),
         )
@@ -202,8 +200,7 @@ impl HummockStorage {
                 "the hummock observer manager is the first one to take the event tx. Should be full hummock version"
             ),
         };
-        let initial_cache_refill_policies = cache_refill_policy_rx.recv().await.unwrap_or_default();
-        let initial_serving_table_vnode_mapping = serving_table_vnode_mapping_rx
+        let initial_table_refill_runtime_config = table_refill_runtime_config_rx
             .recv()
             .await
             .unwrap_or((Operation::Snapshot, Default::default()));
@@ -228,10 +225,8 @@ impl HummockStorage {
         let hummock_event_handler = HummockEventHandler::new(
             role,
             version_update_rx,
-            initial_cache_refill_policies,
-            initial_serving_table_vnode_mapping,
-            cache_refill_policy_rx,
-            serving_table_vnode_mapping_rx,
+            initial_table_refill_runtime_config,
+            table_refill_runtime_config_rx,
             pinned_version,
             compactor_context.clone(),
             compaction_catalog_manager_ref.clone(),

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -93,7 +93,7 @@ impl Drop for HummockStorageShutdownGuard {
 #[derive(Clone)]
 pub struct HummockStorage {
     hummock_event_sender: HummockEventSender,
-    // only used in test for setting hummock version in uploader
+    // Only used in tests to inject observer events such as version updates.
     _observer_event_sender: UnboundedSender<HummockObserverEvent>,
 
     context: CompactorContext,

--- a/src/storage/src/hummock/store/hummock_storage.rs
+++ b/src/storage/src/hummock/store/hummock_storage.rs
@@ -34,6 +34,7 @@ use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_hummock_sdk::table_watermark::TableWatermarksIndex;
 use risingwave_hummock_sdk::version::{HummockVersion, LocalHummockVersion};
 use risingwave_hummock_sdk::{HummockRawObjectId, HummockReadEpoch, SyncResult};
+use risingwave_pb::meta::subscribe_response::Operation;
 use risingwave_rpc_client::HummockMetaClient;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -178,7 +179,8 @@ impl HummockStorage {
         let write_limiter = Arc::new(WriteLimiter::default());
         let (version_update_tx, mut version_update_rx) = unbounded_channel();
         let (cache_refill_policy_tx, mut cache_refill_policy_rx) = unbounded_channel();
-        let (serving_table_vnode_mapping_tx, serving_table_vnode_mapping_rx) = unbounded_channel();
+        let (serving_table_vnode_mapping_tx, mut serving_table_vnode_mapping_rx) =
+            unbounded_channel();
 
         let observer_manager = ObserverManager::new(
             notification_client,
@@ -201,6 +203,10 @@ impl HummockStorage {
             ),
         };
         let initial_cache_refill_policies = cache_refill_policy_rx.recv().await.unwrap_or_default();
+        let initial_serving_table_vnode_mapping = serving_table_vnode_mapping_rx
+            .recv()
+            .await
+            .unwrap_or((Operation::Snapshot, Default::default()));
 
         let (pin_version_tx, pin_version_rx) = unbounded_channel();
         let pinned_version = PinnedVersion::new(hummock_version, pin_version_tx);
@@ -223,6 +229,7 @@ impl HummockStorage {
             role,
             version_update_rx,
             initial_cache_refill_policies,
+            initial_serving_table_vnode_mapping,
             cache_refill_policy_rx,
             serving_table_vnode_mapping_rx,
             pinned_version,

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -50,6 +50,7 @@ tempfile = "3"
 tikv-jemallocator = { workspace = true }
 tokio = { version = "0.2", package = "madsim-tokio" }
 tokio-postgres = "0.7"
+tonic = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = "*"

--- a/src/tests/simulation/tests/integration_tests/scale/isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/isolation.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
+use risingwave_common::monitor::EndpointExt;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::monitor_service::GetTableCacheRefillStatsRequest;
 use risingwave_pb::monitor_service::monitor_service_client::MonitorServiceClient;
@@ -490,7 +491,10 @@ async fn table_cache_refill_policies_on_compute(
 
     cluster
         .run_on_client(async move {
-            let channel = Endpoint::from_shared(endpoint)?.connect().await?;
+            let channel = Endpoint::from_shared(endpoint)?
+                .connect_timeout(Duration::from_secs(5))
+                .monitored_connect("grpc-table-cache-refill-stats-client", Default::default())
+                .await?;
             let mut client = MonitorServiceClient::new(channel);
             let response = client
                 .get_table_cache_refill_stats(GetTableCacheRefillStatsRequest {})
@@ -527,9 +531,10 @@ async fn wait_refill_policy_on_compute(
 ) -> Result<()> {
     tokio::time::timeout(Duration::from_secs(100), async {
         loop {
-            let policies = table_cache_refill_policies_on_compute(cluster, worker_host).await?;
-            if refill_policy_matches(&policies, table_ids, expected_policy) {
-                return Ok(());
+            if let Ok(policies) = table_cache_refill_policies_on_compute(cluster, worker_host).await
+                && refill_policy_matches(&policies, table_ids, expected_policy)
+            {
+                return Ok::<(), anyhow::Error>(());
             }
             sleep(Duration::from_secs(1)).await;
         }

--- a/src/tests/simulation/tests/integration_tests/scale/isolation.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/isolation.rs
@@ -16,13 +16,19 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
+use risingwave_pb::common::WorkerType;
+use risingwave_pb::monitor_service::GetTableCacheRefillStatsRequest;
+use risingwave_pb::monitor_service::monitor_service_client::MonitorServiceClient;
 use risingwave_simulation::cluster::{Cluster, Configuration, Session};
+use serde_json::Value;
 use tokio::time::sleep;
+use tonic::transport::Endpoint;
 
 const DATABASE_RECOVERY_START: &str = "DATABASE_RECOVERY_START";
 const DATABASE_RECOVERY_SUCCESS: &str = "DATABASE_RECOVERY_SUCCESS";
+const COMPUTE_2_HOST: &str = "192.168.3.2";
 
 async fn assert_no_expected_global_recovery(session: &mut Session) -> Result<()> {
     let global_recovery_events = global_recovery_events(session).await?;
@@ -90,6 +96,70 @@ async fn test_isolation_simple_two_databases() -> Result<()> {
         ])
     );
 
+    assert_no_expected_global_recovery(&mut session).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_table_cache_refill_policy_after_database_recovery() -> Result<()> {
+    let (cluster, mut session) = prepare_refill_policy_db_recovery_env().await?;
+
+    let database_mapping = database_id_mapping(&mut session).await?;
+    let group1_database_id = database_mapping["group1"];
+    let group2_database_id = database_mapping["group2"];
+
+    session.run("use group1").await?;
+    session.run("create table t1(v1 int, v2 int);").await?;
+    session.run("create table t2(v1 int, v3 int);").await?;
+    session
+        .run("create table t3(v1 int primary key, v2 int, v3 int);")
+        .await?;
+    session
+        .run("create sink s3 into t3 as select t1.v1, t1.v2, t2.v3 from t1 join t2 on t1.v1 = t2.v1;")
+        .await?;
+    session
+        .run("alter sink s3 set config(streaming.developer.cache_refill_policy = 'both');")
+        .await?;
+
+    let internal_table_ids = internal_table_ids_for_job(&mut session, "s3").await?;
+    assert!(
+        !internal_table_ids.is_empty(),
+        "sink should have internal state tables"
+    );
+
+    wait_refill_policy_on_compute(&cluster, COMPUTE_2_HOST, &internal_table_ids, None).await?;
+
+    session
+        .run("insert into t2 select * from generate_series(1, 10);")
+        .await?;
+
+    cluster.simple_kill_nodes(["compute-1"]).await;
+    wait_until(
+        &mut session,
+        "select count(*) from rw_catalog.rw_worker_nodes where host = '192.168.3.1';",
+        "0",
+    )
+    .await?;
+
+    wait_until_run_ok(
+        &mut session,
+        "insert into t1 select generate_series, generate_series from generate_series(1, 10);",
+    )
+    .await?;
+
+    wait_refill_policy_on_compute(&cluster, COMPUTE_2_HOST, &internal_table_ids, Some("both"))
+        .await?;
+
+    let mut database_recovery_events = database_recovery_events(&mut session).await?;
+    assert!(!database_recovery_events.contains_key(&group2_database_id));
+    assert_eq!(
+        database_recovery_events.remove(&group1_database_id),
+        Some(vec![
+            DATABASE_RECOVERY_START.to_owned(),
+            DATABASE_RECOVERY_SUCCESS.to_owned()
+        ])
+    );
     assert_no_expected_global_recovery(&mut session).await?;
 
     Ok(())
@@ -367,6 +437,114 @@ async fn wait_until(session: &mut Session, sql: &str, target: &str) -> Result<()
     Ok(())
 }
 
+async fn wait_until_run_ok(session: &mut Session, sql: &str) -> Result<()> {
+    tokio::time::timeout(Duration::from_secs(100), async {
+        loop {
+            if session.run(sql).await.is_ok() {
+                return;
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await?;
+
+    Ok(())
+}
+
+async fn internal_table_ids_for_job(session: &mut Session, job_name: &str) -> Result<Vec<u32>> {
+    let table_ids = session
+        .run(format!(
+            "select id from rw_catalog.rw_internal_table_info \
+             where job_id = (select id from rw_catalog.rw_sinks where name = '{job_name}') \
+             order by id;"
+        ))
+        .await?;
+
+    table_ids
+        .lines()
+        .map(|line| {
+            line.trim()
+                .parse::<u32>()
+                .with_context(|| format!("failed to parse internal table id from {line:?}"))
+        })
+        .collect()
+}
+
+async fn table_cache_refill_policies_on_compute(
+    cluster: &Cluster,
+    worker_host: &str,
+) -> Result<serde_json::Map<String, Value>> {
+    let worker_nodes = cluster.get_cluster_info().await?.worker_nodes;
+    let worker = worker_nodes
+        .into_iter()
+        .find(|worker| {
+            worker.r#type() == WorkerType::ComputeNode
+                && worker
+                    .host
+                    .as_ref()
+                    .is_some_and(|host| host.host == worker_host)
+        })
+        .context("target compute node is missing")?;
+    let host = worker.host.context("compute node host is missing")?;
+    let endpoint = format!("http://{}:{}", host.host, host.port);
+
+    cluster
+        .run_on_client(async move {
+            let channel = Endpoint::from_shared(endpoint)?.connect().await?;
+            let mut client = MonitorServiceClient::new(channel);
+            let response = client
+                .get_table_cache_refill_stats(GetTableCacheRefillStatsRequest {})
+                .await?
+                .into_inner();
+            let stats: Value = serde_json::from_str(&response.stats)
+                .context("failed to parse table cache refill stats")?;
+
+            stats
+                .get("policies")
+                .and_then(Value::as_object)
+                .cloned()
+                .context("table cache refill stats missing policies")
+        })
+        .await
+}
+
+fn refill_policy_matches(
+    policies: &serde_json::Map<String, Value>,
+    table_ids: &[u32],
+    expected_policy: Option<&str>,
+) -> bool {
+    table_ids.iter().all(|table_id| {
+        let actual_policy = policies.get(&table_id.to_string()).and_then(Value::as_str);
+        actual_policy == expected_policy
+    })
+}
+
+async fn wait_refill_policy_on_compute(
+    cluster: &Cluster,
+    worker_host: &str,
+    table_ids: &[u32],
+    expected_policy: Option<&str>,
+) -> Result<()> {
+    tokio::time::timeout(Duration::from_secs(100), async {
+        loop {
+            let policies = table_cache_refill_policies_on_compute(cluster, worker_host).await?;
+            if refill_policy_matches(&policies, table_ids, expected_policy) {
+                return Ok(());
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "timed out waiting for table cache refill policy {:?} on {} for {:?}",
+            expected_policy,
+            worker_host,
+            table_ids
+        )
+    })?
+}
+
 async fn prepare_isolation_env() -> Result<(Cluster, Session)> {
     let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
 
@@ -391,6 +569,31 @@ async fn prepare_isolation_env() -> Result<(Cluster, Session)> {
         .run("create database group3 with resource_group='group3'")
         .await?;
 
+    session.run("set rw_implicit_flush = true;").await?;
+
+    Ok((cluster, session))
+}
+
+async fn prepare_refill_policy_db_recovery_env() -> Result<(Cluster, Session)> {
+    let mut config = Configuration::for_auto_parallelism(MAX_HEARTBEAT_INTERVAL_SEC, true);
+
+    config.compute_nodes = 3;
+    config.compute_node_cores = 2;
+    config.compute_resource_groups = HashMap::from([
+        (1, "group1".to_owned()),
+        (2, "group1".to_owned()),
+        (3, "group2".to_owned()),
+    ]);
+
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run("create database group1 with resource_group='group1'")
+        .await?;
+    session
+        .run("create database group2 with resource_group='group2'")
+        .await?;
     session.run("set rw_implicit_flush = true;").await?;
 
     Ok((cluster, session))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR moves table cache refill runtime state to Hummock `TableRefillRuntimeConfig` and limits runtime refresh to recovery/subscribe boundaries, not online updates.

- Keep `ALTER SET CONFIG` as persistence and validation only; it does not refresh CN runtime state online.
- Restore table cache refill policies after recovery with a full policy snapshot, and include both policies and per-worker serving table vnode mappings in Hummock subscribe snapshots.
- Do not support online runtime updates for either table cache refill policies or serving table vnode mappings in this PR.
- Add regression coverage for stale runtime config filtering, recovery/snapshot refresh, initial serving snapshot apply, and ignoring non-snapshot serving mapping payloads.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not user-facing.

</details>
