### PR TITLE
doc(connector): update Lakehouse Iceberg REST notes

### DIFF
--- a/src/connector/src/connector_common/iceberg/mod.rs
+++ b/src/connector/src/connector_common/iceberg/mod.rs
@@ -158,16 +158,20 @@ pub struct IcebergCommon {
     )]
     pub hosted_catalog: Option<bool>,
 
-    /// The http header to be used in the catalog requests.
+    /// The HTTP header to be used in catalog requests.
     /// Example:
     /// `catalog.header = "key1=value1;key2=value2;key3=value3"`
-    /// explain the format of the header:
+    /// For Google Cloud Lakehouse Iceberg REST catalogs, set
+    /// `catalog.header = "x-goog-user-project=PROJECT_ID"` to specify the billing project.
+    /// Explain the format of the header:
     /// - Each header is a key-value pair, separated by an '='.
     /// - Multiple headers can be specified, separated by a ';'.
     #[serde(rename = "catalog.header")]
     pub catalog_header: Option<String>,
 
-    /// Enable vended credentials for iceberg REST catalog.
+    /// Enable vended credentials for Iceberg REST catalog.
+    /// For Google Cloud Lakehouse Iceberg REST catalogs, this sends
+    /// `X-Iceberg-Access-Delegation: vended-credentials`.
     #[serde(default, deserialize_with = "deserialize_optional_bool_from_string")]
     pub vended_credentials: Option<bool>,
 
@@ -191,6 +195,8 @@ pub struct IcebergCommon {
     /// - `org.apache.iceberg.aws.s3.S3FileIO` for Amazon S3 (default)
     /// - `org.apache.iceberg.gcp.gcs.GCSFileIO` for Google Cloud Storage
     /// - `org.apache.iceberg.azure.adlsv2.ADLSFileIO` for Azure Data Lake Storage Gen2
+    /// Google Cloud Lakehouse Iceberg REST catalogs with credential vending require
+    /// `org.apache.iceberg.gcp.gcs.GCSFileIO`.
     #[serde(rename = "catalog.io_impl")]
     pub catalog_io_impl: Option<String>,
 }
@@ -420,7 +426,7 @@ impl IcebergCommon {
                 Some(warehouse_path) => {
                     let (bucket, _) = {
                         let is_s3_tables = warehouse_path.starts_with("arn:aws:s3tables");
-                        // BigLake catalog federation uses bq:// prefix for BigQuery-managed Iceberg tables
+                        // Lakehouse Iceberg REST catalog federation uses bq:// prefix for BigQuery-managed Iceberg tables.
                         let is_bq_catalog_federation = warehouse_path.starts_with("bq://");
                         let url = Url::parse(warehouse_path);
                         if (url.is_err() || is_s3_tables || is_bq_catalog_federation)
@@ -429,7 +435,7 @@ impl IcebergCommon {
                             // If the warehouse path is not a valid URL, it could be:
                             // - A warehouse name in REST catalog
                             // - An S3 Tables path (arn:aws:s3tables:...)
-                            // - A BigLake path (bq://projects/...) for Google Cloud BigQuery integration
+                            // - A Lakehouse path (bq://projects/...) for Google Cloud BigQuery integration
                             // We allow these to pass through for REST catalogs.
                             (None, None)
                         } else {

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -123,7 +123,7 @@ pub(super) async fn create_table_if_not_exists_impl(
             match &config.common.warehouse_path {
                 Some(warehouse_path) => {
                     let is_s3_tables = warehouse_path.starts_with("arn:aws:s3tables");
-                    // BigLake catalog federation uses bq:// prefix for BigQuery-managed Iceberg tables
+                    // Lakehouse Iceberg REST catalog federation uses bq:// prefix for BigQuery-managed Iceberg tables.
                     let is_bq_catalog_federation = warehouse_path.starts_with("bq://");
                     let url = Url::parse(warehouse_path);
                     if url.is_err() || is_s3_tables || is_bq_catalog_federation {

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -455,14 +455,14 @@ async fn test_hive_catalog() {
     test_create_catalog(values).await;
 }
 
-/// Test parsing Google/BigLake authentication configuration.
+/// Test parsing Google Lakehouse Iceberg REST authentication configuration.
 #[test]
 fn test_parse_google_auth_config() {
     let values: BTreeMap<String, String> = [
             ("connector", "iceberg"),
             ("type", "append-only"),
             ("force_append_only", "true"),
-            ("catalog.name", "biglake-catalog"),
+            ("catalog.name", "lakehouse-catalog"),
             ("catalog.type", "rest"),
             ("catalog.uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog"),
             ("warehouse.path", "bq://projects/my-gcp-project"),

--- a/src/connector/with_options_connection.yaml
+++ b/src/connector/with_options_connection.yaml
@@ -137,16 +137,21 @@ IcebergConnection:
   - name: catalog.header
     field_type: String
     comments: |-
-      The http header to be used in the catalog requests.
+      The HTTP header to be used in catalog requests.
       Example:
       `catalog.header = "key1=value1;key2=value2;key3=value3"`
-      explain the format of the header:
+      For Google Cloud Lakehouse Iceberg REST catalogs, set
+      `catalog.header = "x-goog-user-project=PROJECT_ID"` to specify the billing project.
+      Explain the format of the header:
       - Each header is a key-value pair, separated by an '='.
       - Multiple headers can be specified, separated by a ';'.
     required: false
   - name: vended_credentials
     field_type: bool
-    comments: Enable vended credentials for iceberg REST catalog.
+    comments: |-
+      Enable vended credentials for Iceberg REST catalog.
+      For Google Cloud Lakehouse Iceberg REST catalogs, this sends
+      `X-Iceberg-Access-Delegation: vended-credentials`.
     required: false
     default: Default::default
   - name: catalog.security
@@ -174,6 +179,8 @@ IcebergConnection:
       - `org.apache.iceberg.aws.s3.S3FileIO` for Amazon S3 (default)
       - `org.apache.iceberg.gcp.gcs.GCSFileIO` for Google Cloud Storage
       - `org.apache.iceberg.azure.adlsv2.ADLSFileIO` for Azure Data Lake Storage Gen2
+      Google Cloud Lakehouse Iceberg REST catalogs with credential vending require
+      `org.apache.iceberg.gcp.gcs.GCSFileIO`.
     required: false
   - name: catalog.jdbc.user
     field_type: String

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -586,16 +586,21 @@ IcebergConfig:
   - name: catalog.header
     field_type: String
     comments: |-
-      The http header to be used in the catalog requests.
+      The HTTP header to be used in catalog requests.
       Example:
       `catalog.header = "key1=value1;key2=value2;key3=value3"`
-      explain the format of the header:
+      For Google Cloud Lakehouse Iceberg REST catalogs, set
+      `catalog.header = "x-goog-user-project=PROJECT_ID"` to specify the billing project.
+      Explain the format of the header:
       - Each header is a key-value pair, separated by an '='.
       - Multiple headers can be specified, separated by a ';'.
     required: false
   - name: vended_credentials
     field_type: bool
-    comments: Enable vended credentials for iceberg REST catalog.
+    comments: |-
+      Enable vended credentials for Iceberg REST catalog.
+      For Google Cloud Lakehouse Iceberg REST catalogs, this sends
+      `X-Iceberg-Access-Delegation: vended-credentials`.
     required: false
     default: Default::default
   - name: catalog.security
@@ -623,6 +628,8 @@ IcebergConfig:
       - `org.apache.iceberg.aws.s3.S3FileIO` for Amazon S3 (default)
       - `org.apache.iceberg.gcp.gcs.GCSFileIO` for Google Cloud Storage
       - `org.apache.iceberg.azure.adlsv2.ADLSFileIO` for Azure Data Lake Storage Gen2
+      Google Cloud Lakehouse Iceberg REST catalogs with credential vending require
+      `org.apache.iceberg.gcp.gcs.GCSFileIO`.
     required: false
   - name: database.name
     field_type: String

--- a/src/connector/with_options_source.yaml
+++ b/src/connector/with_options_source.yaml
@@ -308,16 +308,21 @@ IcebergProperties:
   - name: catalog.header
     field_type: String
     comments: |-
-      The http header to be used in the catalog requests.
+      The HTTP header to be used in catalog requests.
       Example:
       `catalog.header = "key1=value1;key2=value2;key3=value3"`
-      explain the format of the header:
+      For Google Cloud Lakehouse Iceberg REST catalogs, set
+      `catalog.header = "x-goog-user-project=PROJECT_ID"` to specify the billing project.
+      Explain the format of the header:
       - Each header is a key-value pair, separated by an '='.
       - Multiple headers can be specified, separated by a ';'.
     required: false
   - name: vended_credentials
     field_type: bool
-    comments: Enable vended credentials for iceberg REST catalog.
+    comments: |-
+      Enable vended credentials for Iceberg REST catalog.
+      For Google Cloud Lakehouse Iceberg REST catalogs, this sends
+      `X-Iceberg-Access-Delegation: vended-credentials`.
     required: false
     default: Default::default
   - name: catalog.security
@@ -345,6 +350,8 @@ IcebergProperties:
       - `org.apache.iceberg.aws.s3.S3FileIO` for Amazon S3 (default)
       - `org.apache.iceberg.gcp.gcs.GCSFileIO` for Google Cloud Storage
       - `org.apache.iceberg.azure.adlsv2.ADLSFileIO` for Azure Data Lake Storage Gen2
+      Google Cloud Lakehouse Iceberg REST catalogs with credential vending require
+      `org.apache.iceberg.gcp.gcs.GCSFileIO`.
     required: false
   - name: database.name
     field_type: String


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR updates Iceberg connector option descriptions and comments for Google Cloud's renamed Lakehouse Iceberg REST catalog documentation.

- Clarify that `catalog.header` can be used to set `x-goog-user-project=PROJECT_ID` for Google Cloud Lakehouse Iceberg REST catalogs.
- Clarify that `vended_credentials` sends `X-Iceberg-Access-Delegation: vended-credentials`.
- Clarify that credential vending with Google Cloud Lakehouse Iceberg REST catalogs requires `catalog.io_impl='org.apache.iceberg.gcp.gcs.GCSFileIO'`.
- Rename stale BigLake-only comments/test descriptions to Lakehouse Iceberg REST while keeping the `biglake.googleapis.com` REST endpoint unchanged, since Google still uses that API endpoint.

No runtime behavior is changed.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. No extra CI labels were added because this is a docs/comment-only update.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Updated Iceberg connector option descriptions to align with Google Cloud Lakehouse Iceberg REST catalog documentation. There is no behavior change.

</details>

## Verification

- `git diff --check`
- `cargo fmt --check`
- `cargo test -p risingwave_connector sink::iceberg::test::test_parse_google_auth_config`
