### PR TITLE
fix(frontend): disable unused prefix bloom hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12682,6 +12682,8 @@ version = "3.1.0-alpha"
 dependencies = [
  "easy-ext",
  "madsim-tokio",
+ "prost 0.14.3",
+ "risingwave_pb",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12688,6 +12688,7 @@ dependencies = [
  "sea-orm-migration",
  "serde",
  "serde_json",
+ "thiserror-ext",
  "uuid",
 ]
 

--- a/src/frontend/planner_test/tests/testdata/output/ch_benchmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/ch_benchmark.yaml
@@ -2001,7 +2001,7 @@
     StreamStatelessSimpleAgg { aggs: [sum(stock.s_order_cnt)] }
     └── StreamExchange NoShuffle from 2
 
-    Table 0 { columns: [ stock_s_i_id, sum(stock_s_order_cnt), $expr2, _rw_timestamp ], primary key: [ $2 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ stock_s_i_id, sum(stock_s_order_cnt), $expr2, _rw_timestamp ], primary key: [ $2 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr3, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -2034,7 +2034,7 @@
     ├── primary key: [ $2 ASC, $0 ASC ]
     ├── value indices: [ 0, 1, 2 ]
     ├── distribution key: [ 0 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
@@ -1987,7 +1987,7 @@
     ├── primary key: [ $2 ASC, $0 ASC, $1 ASC ]
     ├── value indices: [ 0, 1, 2 ]
     ├── distribution key: [ 0 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source_kafka.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source_kafka.yaml
@@ -2010,7 +2010,7 @@
     StreamNoOp
     └── StreamExchange NoShuffle from 3
 
-    Table 0 { columns: [ id, item_name, count(auction), _rw_timestamp ], primary key: [ $2 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ id, item_name, count(auction), _rw_timestamp ], primary key: [ $2 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_temporal_filter.yaml
@@ -97,7 +97,7 @@
     ├── primary key: [ $4 ASC, $5 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4, 5 ]
     ├── distribution key: [ 5 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 1 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -142,7 +142,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '00:05:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 3 ] }
 
-    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -287,7 +287,7 @@
     ├── primary key: [ $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
     ├── distribution key: [ 4 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 9 { columns: [ $expr6, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -416,7 +416,7 @@
     ├── primary key: [ $4 ASC, $5 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4, 5 ]
     ├── distribution key: [ 5 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 6 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -557,7 +557,7 @@
 
     Table 6 { columns: [ partition_id, offset_info, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
 
-    Table 7 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 1 }
+    Table 7 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 0 }
 
     Table 8 { columns: [ $expr6, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -673,7 +673,7 @@
     ├── primary key: [ $4 ASC, $5 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4, 5 ]
     ├── distribution key: [ 5 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 5 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -912,7 +912,7 @@
 
     Table 5 { columns: [ partition_id, offset_info, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
 
-    Table 6 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 1 }
+    Table 6 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 0 }
 
     Table 7 { columns: [ $expr11, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1020,7 +1020,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '00:05:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 3 ] }
 
-    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1079,7 +1079,7 @@
     ├── distribution key: [ 0, 1 ]
     └── read pk prefix len hint: 2
 
-    Table 1 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 1 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 2 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1136,7 +1136,7 @@
     ├── distribution key: [ 0, 1 ]
     └── read pk prefix len hint: 2
 
-    Table 1 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 1 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 2 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1196,7 +1196,7 @@
 
     Table 1 { columns: [ $expr3, $expr4, $expr5, $expr6, $expr7, $expr8, $expr9, $expr1, _row_id, _rw_timestamp ], primary key: [ $0 ASC, $2 DESC, $8 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
-    Table 2 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 2 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 3 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1283,7 +1283,7 @@
 
     Table 3 { columns: [ $expr9, _row_id, _degree, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
-    Table 4 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 1 }
+    Table 4 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 0 }
 
     Table 5 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1342,7 +1342,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '00:05:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 3 ] }
 
-    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1390,7 +1390,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '00:05:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 3 ] }
 
-    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ event_type, person, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 5 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1504,7 +1504,7 @@
 
     Table 6 { columns: [ $expr5, max($expr6), count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
-    Table 7 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 1 }
+    Table 7 { columns: [ event_type, auction, bid, $expr1, _row_id, _rw_timestamp ], primary key: [ $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 4 ], read pk prefix len hint: 0 }
 
     Table 8 { columns: [ $expr4, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1643,7 +1643,7 @@
     ├── primary key: [ $2 ASC, $0 ASC, $1 ASC ]
     ├── value indices: [ 0, 1, 2 ]
     ├── distribution key: [ 0 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 1 { columns: [ $expr6, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1669,7 +1669,7 @@
     ├── primary key: [ $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
     ├── distribution key: [ 4 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 9 { columns: [ $expr4, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1796,7 +1796,7 @@
     ├── primary key: [ $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
     ├── distribution key: [ 4 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 7 { columns: [ $expr4, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -1919,7 +1919,7 @@
     ├── primary key: [ $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
     ├── distribution key: [ 4 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 7 { columns: [ $expr4, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -2051,7 +2051,7 @@
     ├── primary key: [ $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
     ├── distribution key: [ 4 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 9 { columns: [ $expr4, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -2243,7 +2243,7 @@
     ├── primary key: [ $3 ASC, $4 ASC ]
     ├── value indices: [ 0, 1, 2, 3, 4 ]
     ├── distribution key: [ 4 ]
-    └── read pk prefix len hint: 1
+    └── read pk prefix len hint: 0
 
     Table 12 { columns: [ $expr5, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -2074,7 +2074,7 @@
     StreamNoOp
     └── StreamExchange NoShuffle from 4
 
-    Table 0 { columns: [ $expr2, $expr3, count($expr4), _rw_timestamp ], primary key: [ $2 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ $expr2, $expr3, count($expr4), _rw_timestamp ], primary key: [ $2 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr5, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
@@ -61,7 +61,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '00:15:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [[$expr1]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 3 ] }
 
-    Table 0 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -169,7 +169,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '00:15:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [[$expr1]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 3 ] }
 
-    Table 0 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -221,11 +221,11 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '02:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [[$expr2]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 6 ] }
 
-    Table 0 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr2, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
-    Table 2 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 2 { columns: [ t1_ts, t1__row_id, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 0 }
 
     Table 3 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -560,7 +560,7 @@
     StreamProject { exprs: [SubtractWithTimeZone(now, '02:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [[$expr1]], noop_update_hint: true }
     └── StreamNow { output: [now] } { tables: [ Now: 5 ] }
 
-    Table 0 { columns: [ t_a, t_ta, t__row_id, _rw_timestamp ], primary key: [ $1 ASC, $2 ASC ], value indices: [ 0, 1, 2 ], distribution key: [], read pk prefix len hint: 1 }
+    Table 0 { columns: [ t_a, t_ta, t__row_id, _rw_timestamp ], primary key: [ $1 ASC, $2 ASC ], value indices: [ 0, 1, 2 ], distribution key: [], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -669,7 +669,7 @@
     └── StreamFilter { predicate: IsNull(t1.ta) }
         └── StreamExchange NoShuffle from 3
 
-    Table 0 { columns: [ t1_a, t1_ta, t2_b, t2_tb, t1__row_id, t2__row_id, _rw_timestamp ], primary key: [ $1 ASC, $4 ASC, $5 ASC, $3 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 1, 3, 4, 5 ], read pk prefix len hint: 1 }
+    Table 0 { columns: [ t1_a, t1_ta, t2_b, t2_tb, t1__row_id, t2__row_id, _rw_timestamp ], primary key: [ $1 ASC, $4 ASC, $5 ASC, $3 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 1, 3, 4, 5 ], read pk prefix len hint: 0 }
 
     Table 1 { columns: [ $expr1, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/output/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch.yaml
@@ -2468,7 +2468,7 @@
 
     Table 1 { columns: [ partsupp_ps_partkey, sum($expr1), _vnode, _rw_timestamp ], primary key: [ $2 ASC, $1 DESC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 2 }
 
-    Table 2 { columns: [ partsupp_ps_partkey, sum($expr1), _rw_timestamp ], primary key: [ $1 ASC, $0 ASC ], value indices: [ 0, 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+    Table 2 { columns: [ partsupp_ps_partkey, sum($expr1), _rw_timestamp ], primary key: [ $1 ASC, $0 ASC ], value indices: [ 0, 1 ], distribution key: [ 0 ], read pk prefix len hint: 0 }
 
     Table 3 { columns: [ $expr3, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -137,7 +137,10 @@ pub fn infer_left_internal_table_catalog(
 
     // The pk of dynamic filter internal table should be left_key + input_pk.
     let mut pk_indices = vec![left_key_index];
-    let read_prefix_len_hint = pk_indices.len();
+    // The executor replays changes by scanning left-key ranges with `iter_with_vnode`
+    // when the dynamic predicate changes, so there is no fixed prefix lookup for
+    // prefix bloom filters to prune.
+    let read_prefix_len_hint = 0;
 
     for i in me.stream_key().unwrap() {
         if *i != left_key_index {

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -438,7 +438,7 @@ impl StreamMaterialize {
             definition,
             conflict_behavior,
             version_column_indices,
-            read_prefix_len_hint,
+            read_prefix_len_hint: _,
             version,
             watermark_columns: _,
             dist_key_in_pk,
@@ -507,7 +507,10 @@ impl StreamMaterialize {
             definition,
             conflict_behavior,
             version_column_indices,
-            read_prefix_len_hint,
+            // Refresh staging tables are consumed by the refresh merge path with
+            // `iter_keyed_row_with_vnode` range scans. They are not read by
+            // fixed-prefix lookups, so prefix bloom filters would only add write cost.
+            read_prefix_len_hint: 0,
             version,
             created_at_epoch,
             initialized_at_epoch,

--- a/src/frontend/src/optimizer/plan_node/stream_vector_index_write.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_vector_index_write.rs
@@ -150,7 +150,9 @@ impl StreamVectorIndexWrite {
         let (table_pk, stream_key) = derive_pk(input, user_distributed_by, user_order_by, &columns);
         // assert: `stream_key` is a subset of `table_pk`
 
-        let read_prefix_len_hint = table_pk.len();
+        // Vector index writes go through vector writer APIs instead of StateTable
+        // get/prefix-iter reads, so prefix bloom filters are not consumed.
+        let read_prefix_len_hint = 0;
         // We don't need to fill in table id for table in frontend. The id will be generated on
         // meta catalog service.
         Ok(TableCatalog {

--- a/src/meta/model/migration/Cargo.toml
+++ b/src/meta/model/migration/Cargo.toml
@@ -15,5 +15,6 @@ sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
+thiserror-ext = { workspace = true }
 tokio = { workspace = true }
 uuid = { version = "1", features = ["v4"] }

--- a/src/meta/model/migration/Cargo.toml
+++ b/src/meta/model/migration/Cargo.toml
@@ -9,6 +9,8 @@ repository = { workspace = true }
 
 [dependencies]
 easy-ext = "1"
+prost = { workspace = true }
+risingwave_pb = { workspace = true }
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 serde = { workspace = true }

--- a/src/meta/model/migration/src/lib.rs
+++ b/src/meta/model/migration/src/lib.rs
@@ -70,6 +70,7 @@ mod m20260119_153927_streaming_job_is_serverless_backfill;
 mod m20260120_120000_streaming_job_backfill_orders;
 mod m20260311_000000_legacy_streaming_parallelism_session_params;
 mod m20260312_000000_streaming_job_backfill_parallelism_strategy;
+mod m20260518_000000_disable_unused_read_prefix_hints;
 mod utils;
 
 pub struct Migrator;
@@ -178,6 +179,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260120_120000_streaming_job_backfill_orders::Migration),
             Box::new(m20260311_000000_legacy_streaming_parallelism_session_params::Migration),
             Box::new(m20260312_000000_streaming_job_backfill_parallelism_strategy::Migration),
+            Box::new(m20260518_000000_disable_unused_read_prefix_hints::Migration),
         ]
     }
 }

--- a/src/meta/model/migration/src/m20260518_000000_disable_unused_read_prefix_hints.rs
+++ b/src/meta/model/migration/src/m20260518_000000_disable_unused_read_prefix_hints.rs
@@ -1,0 +1,283 @@
+use std::collections::BTreeSet;
+
+use prost::Message;
+use risingwave_pb::catalog::Table as PbTable;
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::{SinkLogStoreType, StreamNode};
+use sea_orm::{FromQueryResult, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let connection = manager.get_connection();
+        let database_backend = connection.get_database_backend();
+
+        let (sql, values) = Query::select()
+            .columns([Fragment::FragmentId, Fragment::StreamNode])
+            .from(Fragment::Table)
+            .build_any(&*database_backend.get_query_builder());
+
+        let fragments = connection
+            .query_all(Statement::from_sql_and_values(
+                database_backend,
+                sql,
+                values,
+            ))
+            .await?;
+
+        let mut table_ids = BTreeSet::new();
+
+        for row in fragments {
+            let fragment = FragmentEntity::from_query_result(&row, "")?;
+            let mut stream_node = StreamNode::decode(fragment.stream_node.as_slice())
+                .map_err(|err| DbErr::Custom(format!("failed to decode stream node: {err}")))?;
+
+            if disable_unused_read_prefix_hints(&mut stream_node, &mut table_ids) {
+                manager
+                    .exec_stmt(
+                        Query::update()
+                            .table(Fragment::Table)
+                            .value(Fragment::StreamNode, stream_node.encode_to_vec())
+                            .and_where(Expr::col(Fragment::FragmentId).eq(fragment.fragment_id))
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        if !table_ids.is_empty() {
+            let table_ids = table_ids.into_iter().collect::<Vec<_>>();
+            manager
+                .exec_stmt(
+                    Query::update()
+                        .table(Table::Table)
+                        .value(Table::ReadPrefixLenHint, 0)
+                        .and_where(Expr::col(Table::TableId).is_in(table_ids))
+                        .and_where(Expr::col(Table::ReadPrefixLenHint).ne(0))
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom(
+            "cannot rollback unused read prefix hint migration".to_owned(),
+        ))
+    }
+}
+
+fn disable_unused_read_prefix_hints(
+    stream_node: &mut StreamNode,
+    table_ids: &mut BTreeSet<i32>,
+) -> bool {
+    let mut changed = false;
+
+    if let Some(node_body) = stream_node.node_body.as_mut() {
+        changed |= match node_body {
+            NodeBody::DynamicFilter(node) => {
+                disable_table_hint(node.left_table.as_mut(), table_ids)
+            }
+            NodeBody::Materialize(node) => {
+                disable_table_hint(node.staging_table.as_mut(), table_ids)
+            }
+            NodeBody::VectorIndexWrite(node) => disable_table_hint(node.table.as_mut(), table_ids),
+            NodeBody::Sink(node) if node.log_store_type == SinkLogStoreType::KvLogStore as i32 => {
+                disable_table_hint(node.table.as_mut(), table_ids)
+            }
+            NodeBody::SyncLogStore(node) => {
+                disable_table_hint(node.log_store_table.as_mut(), table_ids)
+            }
+            _ => false,
+        };
+    }
+
+    for input in &mut stream_node.input {
+        changed |= disable_unused_read_prefix_hints(input, table_ids);
+    }
+
+    changed
+}
+
+fn disable_table_hint(table: Option<&mut PbTable>, table_ids: &mut BTreeSet<i32>) -> bool {
+    let Some(table) = table else {
+        return false;
+    };
+
+    table_ids.insert(table.id.as_raw_id() as i32);
+    if table.read_prefix_len_hint == 0 {
+        return false;
+    }
+
+    table.read_prefix_len_hint = 0;
+    true
+}
+
+#[derive(Debug, FromQueryResult)]
+#[sea_orm(entity = "Fragment")]
+struct FragmentEntity {
+    fragment_id: i32,
+    stream_node: Vec<u8>,
+}
+
+#[derive(DeriveIden)]
+enum Fragment {
+    Table,
+    FragmentId,
+    StreamNode,
+}
+
+#[derive(DeriveIden)]
+enum Table {
+    Table,
+    TableId,
+    ReadPrefixLenHint,
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::id::TableId;
+    use risingwave_pb::stream_plan::{
+        DynamicFilterNode, MaterializeNode, SinkNode, SyncLogStoreNode, VectorIndexWriteNode,
+    };
+
+    use super::*;
+
+    fn table(id: u32, read_prefix_len_hint: u32) -> PbTable {
+        PbTable {
+            id: TableId::new(id),
+            read_prefix_len_hint,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn disable_only_targeted_table_hints() {
+        let mut stream_node = StreamNode {
+            node_body: Some(NodeBody::DynamicFilter(Box::new(DynamicFilterNode {
+                left_table: Some(table(1, 3)),
+                right_table: Some(table(2, 1)),
+                ..Default::default()
+            }))),
+            input: vec![
+                StreamNode {
+                    node_body: Some(NodeBody::Materialize(Box::new(MaterializeNode {
+                        staging_table: Some(table(3, 2)),
+                        refresh_progress_table: Some(table(4, 1)),
+                        ..Default::default()
+                    }))),
+                    ..Default::default()
+                },
+                StreamNode {
+                    node_body: Some(NodeBody::Sink(Box::new(SinkNode {
+                        table: Some(table(5, 3)),
+                        log_store_type: SinkLogStoreType::KvLogStore as i32,
+                        ..Default::default()
+                    }))),
+                    ..Default::default()
+                },
+                StreamNode {
+                    node_body: Some(NodeBody::Sink(Box::new(SinkNode {
+                        table: Some(table(6, 3)),
+                        log_store_type: SinkLogStoreType::InMemoryLogStore as i32,
+                        ..Default::default()
+                    }))),
+                    ..Default::default()
+                },
+                StreamNode {
+                    node_body: Some(NodeBody::SyncLogStore(Box::new(SyncLogStoreNode {
+                        log_store_table: Some(table(7, 3)),
+                        ..Default::default()
+                    }))),
+                    ..Default::default()
+                },
+                StreamNode {
+                    node_body: Some(NodeBody::VectorIndexWrite(Box::new(VectorIndexWriteNode {
+                        table: Some(table(8, 3)),
+                    }))),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut table_ids = BTreeSet::new();
+        assert!(disable_unused_read_prefix_hints(
+            &mut stream_node,
+            &mut table_ids
+        ));
+        assert_eq!(table_ids, BTreeSet::from([1, 3, 5, 7, 8]));
+
+        let Some(NodeBody::DynamicFilter(dynamic_filter)) = &stream_node.node_body else {
+            unreachable!()
+        };
+        assert_eq!(
+            dynamic_filter
+                .left_table
+                .as_ref()
+                .unwrap()
+                .read_prefix_len_hint,
+            0
+        );
+        assert_eq!(
+            dynamic_filter
+                .right_table
+                .as_ref()
+                .unwrap()
+                .read_prefix_len_hint,
+            1
+        );
+
+        let Some(NodeBody::Materialize(materialize)) = &stream_node.input[0].node_body else {
+            unreachable!()
+        };
+        assert_eq!(
+            materialize
+                .staging_table
+                .as_ref()
+                .unwrap()
+                .read_prefix_len_hint,
+            0
+        );
+        assert_eq!(
+            materialize
+                .refresh_progress_table
+                .as_ref()
+                .unwrap()
+                .read_prefix_len_hint,
+            1
+        );
+
+        let Some(NodeBody::Sink(in_memory_sink)) = &stream_node.input[2].node_body else {
+            unreachable!()
+        };
+        assert_eq!(
+            in_memory_sink.table.as_ref().unwrap().read_prefix_len_hint,
+            3
+        );
+    }
+
+    #[test]
+    fn collect_zero_hint_table_without_rewriting_fragment() {
+        let mut stream_node = StreamNode {
+            node_body: Some(NodeBody::SyncLogStore(Box::new(SyncLogStoreNode {
+                log_store_table: Some(table(42, 0)),
+                ..Default::default()
+            }))),
+            ..Default::default()
+        };
+
+        let mut table_ids = BTreeSet::new();
+        assert!(!disable_unused_read_prefix_hints(
+            &mut stream_node,
+            &mut table_ids
+        ));
+        assert_eq!(table_ids, BTreeSet::from([42]));
+    }
+}

--- a/src/meta/model/migration/src/m20260518_000000_disable_unused_read_prefix_hints.rs
+++ b/src/meta/model/migration/src/m20260518_000000_disable_unused_read_prefix_hints.rs
@@ -2,10 +2,12 @@ use std::collections::BTreeSet;
 
 use prost::Message;
 use risingwave_pb::catalog::Table as PbTable;
+use risingwave_pb::id::{FragmentId, TableId};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{SinkLogStoreType, StreamNode};
 use sea_orm::{FromQueryResult, Statement};
 use sea_orm_migration::prelude::*;
+use thiserror_ext::AsReport;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -33,8 +35,10 @@ impl MigrationTrait for Migration {
 
         for row in fragments {
             let fragment = FragmentEntity::from_query_result(&row, "")?;
-            let mut stream_node = StreamNode::decode(fragment.stream_node.as_slice())
-                .map_err(|err| DbErr::Custom(format!("failed to decode stream node: {err}")))?;
+            let mut stream_node =
+                StreamNode::decode(fragment.stream_node.as_slice()).map_err(|err| {
+                    DbErr::Custom(format!("failed to decode stream node: {}", err.as_report()))
+                })?;
 
             if disable_unused_read_prefix_hints(&mut stream_node, &mut table_ids) {
                 manager
@@ -75,7 +79,7 @@ impl MigrationTrait for Migration {
 
 fn disable_unused_read_prefix_hints(
     stream_node: &mut StreamNode,
-    table_ids: &mut BTreeSet<i32>,
+    table_ids: &mut BTreeSet<TableId>,
 ) -> bool {
     let mut changed = false;
 
@@ -105,12 +109,12 @@ fn disable_unused_read_prefix_hints(
     changed
 }
 
-fn disable_table_hint(table: Option<&mut PbTable>, table_ids: &mut BTreeSet<i32>) -> bool {
+fn disable_table_hint(table: Option<&mut PbTable>, table_ids: &mut BTreeSet<TableId>) -> bool {
     let Some(table) = table else {
         return false;
     };
 
-    table_ids.insert(table.id.as_raw_id() as i32);
+    table_ids.insert(table.id);
     if table.read_prefix_len_hint == 0 {
         return false;
     }
@@ -122,7 +126,7 @@ fn disable_table_hint(table: Option<&mut PbTable>, table_ids: &mut BTreeSet<i32>
 #[derive(Debug, FromQueryResult)]
 #[sea_orm(entity = "Fragment")]
 struct FragmentEntity {
-    fragment_id: i32,
+    fragment_id: FragmentId,
     stream_node: Vec<u8>,
 }
 
@@ -142,7 +146,6 @@ enum Table {
 
 #[cfg(test)]
 mod tests {
-    use risingwave_pb::id::TableId;
     use risingwave_pb::stream_plan::{
         DynamicFilterNode, MaterializeNode, SinkNode, SyncLogStoreNode, VectorIndexWriteNode,
     };
@@ -212,7 +215,16 @@ mod tests {
             &mut stream_node,
             &mut table_ids
         ));
-        assert_eq!(table_ids, BTreeSet::from([1, 3, 5, 7, 8]));
+        assert_eq!(
+            table_ids,
+            BTreeSet::from([
+                TableId::new(1),
+                TableId::new(3),
+                TableId::new(5),
+                TableId::new(7),
+                TableId::new(8),
+            ])
+        );
 
         let Some(NodeBody::DynamicFilter(dynamic_filter)) = &stream_node.node_body else {
             unreachable!()
@@ -278,6 +290,6 @@ mod tests {
             &mut stream_node,
             &mut table_ids
         ));
-        assert_eq!(table_ids, BTreeSet::from([42]));
+        assert_eq!(table_ids, BTreeSet::from([TableId::new(42)]));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR disables read-prefix bloom/filter hints for internal tables whose runtime read patterns do not use fixed-prefix lookups.

Frontend catalog hint changes:

- Dynamic filter left internal table: sets `read_prefix_len_hint` to `0`. The executor replays predicate changes by scanning left-key ranges with `iter_with_vnode`, not by fixed-prefix lookups.
- Refresh materialize staging table: sets staging `read_prefix_len_hint` to `0`. Refresh merge consumes staging rows with keyed range scans, while the main materialize table and refresh progress table keep their existing hints.
- Vector index table: sets `read_prefix_len_hint` to `0`. Vector index writes go through vector writer APIs rather than `StateTable` get/prefix-iter reads.

Meta migration:

- Adds a migration to update existing persisted fragment stream-node table catalogs and corresponding rows in the meta store `table` table.
- The migration only targets dynamic-filter left tables, refresh staging tables, vector-index write tables, kv log store sink tables, and synced kv log store tables.
- It intentionally does not update dynamic-filter right tables, refresh progress tables, source tables, locality-provider tables, or unrelated internal tables.

CI labeler:

- The existing `.github/labeler.yml` rule already applies `ci/run-backwards-compat-tests` to migration files under `src/meta/model/migration/`, so no duplicate labeler rule is needed.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwave-labs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing behavior change.

</details>

## Verification

- `cargo test -p risingwave_meta_model_migration disable_unused_read_prefix_hints --lib`
- `./risedev run-planner-test temporal_filter`
- `cargo clippy --all-targets --all-features`
- `git diff --check`
