### PR TITLE
fix(storage): skip empty xor filters

### DIFF
--- a/src/storage/src/compaction_catalog_manager.rs
+++ b/src/storage/src/compaction_catalog_manager.rs
@@ -503,6 +503,27 @@ impl CompactionCatalogAgent {
         self.filter_key_extractor_manager.extract(user_key)
     }
 
+    /// Returns true when this compaction task only contains one table and the table never emits
+    /// filter keys.
+    pub fn is_single_table_no_filter(&self) -> bool {
+        let mut table_ids = self.table_ids();
+        let Some(table_id) = table_ids.next() else {
+            return false;
+        };
+        if table_ids.next().is_some() {
+            return false;
+        }
+
+        match &self.filter_key_extractor_manager {
+            FilterKeyExtractorImpl::Dummy(_) => true,
+            FilterKeyExtractorImpl::Multi(filter) => filter
+                .id_to_filter_key_extractor
+                .get(&table_id)
+                .is_some_and(|extractor| matches!(extractor, FilterKeyExtractorImpl::Dummy(_))),
+            _ => false,
+        }
+    }
+
     pub fn vnode_count(&self, table_id: StateTableId) -> usize {
         *self.table_id_to_vnode.get(&table_id).unwrap_or_else(|| {
             panic!(

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -505,10 +505,20 @@ async fn check_result<
     Ok(true)
 }
 
-pub fn optimize_by_copy_block(compact_task: &CompactTask, context: &CompactorContext) -> bool {
+pub fn optimize_by_copy_block(
+    compact_task: &CompactTask,
+    context: &CompactorContext,
+    compaction_catalog_agent_ref: &CompactionCatalogAgentRef,
+) -> bool {
     let input_ssts = compact_task.read_input_ssts().collect_vec();
     let compaction_size = input_ssts_size(&input_ssts);
-    optimize_by_copy_block_with_input(compact_task, context, &input_ssts, compaction_size)
+    optimize_by_copy_block_with_input(
+        compact_task,
+        context,
+        &input_ssts,
+        compaction_size,
+        compaction_catalog_agent_ref.is_single_table_no_filter(),
+    )
 }
 
 fn optimize_by_copy_block_with_input(
@@ -516,10 +526,12 @@ fn optimize_by_copy_block_with_input(
     context: &CompactorContext,
     input_ssts: &[&SstableInfo],
     compaction_size: u64,
+    allow_sstable_no_filter: bool,
 ) -> bool {
-    let all_ssts_are_blocked_filter = input_ssts
-        .iter()
-        .all(|table_info| table_info.bloom_filter_kind == BloomFilterType::Blocked);
+    let all_ssts_have_copyable_filter = input_ssts.iter().all(|table_info| {
+        table_info.bloom_filter_kind == BloomFilterType::Blocked
+            || (allow_sstable_no_filter && table_info.bloom_filter_kind == BloomFilterType::Sstable)
+    });
 
     let delete_key_count = input_ssts
         .iter()
@@ -532,7 +544,7 @@ fn optimize_by_copy_block_with_input(
 
     let single_table = compact_task.get_table_ids_from_input_ssts().count() == 1;
     context.storage_opts.enable_fast_compaction
-        && all_ssts_are_blocked_filter
+        && all_ssts_have_copyable_filter
         && !compact_task.contains_range_tombstone()
         && !compact_task.contains_ttl()
         && !compact_task.contains_split_sst()
@@ -626,8 +638,15 @@ fn read_sstable_size_and_count<'a>(
 pub fn calculate_task_parallelism(compact_task: &CompactTask, context: &CompactorContext) -> usize {
     let input_ssts = compact_task.read_input_ssts().collect_vec();
     let compaction_size = input_ssts_size(&input_ssts);
-    let optimize_by_copy_block =
-        optimize_by_copy_block_with_input(compact_task, context, &input_ssts, compaction_size);
+    let optimize_by_copy_block = optimize_by_copy_block_with_input(
+        compact_task,
+        context,
+        &input_ssts,
+        compaction_size,
+        // Parallelism is estimated before acquiring table catalogs, so keep the fast-compaction
+        // eligibility conservative. The execution path may relax this with catalog information.
+        false,
+    );
 
     if optimize_by_copy_block {
         return 1;

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -341,7 +341,8 @@ pub async fn compact_with_agent(
 
     let multi_filter = build_multi_compaction_filter(&compact_task);
     let mut task_status = TaskStatus::Success;
-    let optimize_by_copy_block = optimize_by_copy_block(&compact_task, &context);
+    let optimize_by_copy_block =
+        optimize_by_copy_block(&compact_task, &context, &compaction_catalog_agent_ref);
 
     if let Err(e) =
         generate_splits_for_task(&mut compact_task, &context, optimize_by_copy_block).await

--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -145,10 +145,13 @@ impl BlockStreamIterator {
             match ret {
                 Ok(Some((data, _))) => {
                     let meta = self.sstable.meta.block_metas[self.next_block_index].clone();
-                    let filter_block = self
-                        .sstable
-                        .filter_reader
-                        .get_block_raw_filter(self.next_block_index);
+                    let filter_block = if self.sstable.filter_reader.is_block_based_filter() {
+                        self.sstable
+                            .filter_reader
+                            .get_block_raw_filter(self.next_block_index)
+                    } else {
+                        vec![]
+                    };
                     self.next_block_index += 1;
                     return Ok(Some((data, filter_block, meta)));
                 }
@@ -381,6 +384,7 @@ impl<C: CompactionFilter> CompactorRunner<C> {
 
         let key_range = KeyRange::inf();
         let read_table_ids = HashSet::from_iter(task.get_table_ids_from_input_ssts());
+        let discard_raw_filter = compaction_catalog_agent_ref.is_single_table_no_filter();
 
         let task_config = TaskConfig {
             key_range,
@@ -431,11 +435,11 @@ impl<C: CompactionFilter> CompactorRunner<C> {
             .cloned()
             .collect_vec();
         assert!(
-            left_ssts
-                .iter()
-                .chain(right_ssts.iter())
-                .all(|sst| sst.bloom_filter_kind == BloomFilterType::Blocked),
-            "fast compaction requires blocked-filter SSTs: {}",
+            left_ssts.iter().chain(right_ssts.iter()).all(|sst| {
+                sst.bloom_filter_kind == BloomFilterType::Blocked
+                    || (discard_raw_filter && sst.bloom_filter_kind == BloomFilterType::Sstable)
+            }),
+            "fast compaction requires blocked-filter SSTs or no-filter SSTs in single-table no-filter tasks: {}",
             compact_task_to_string(&task)
         );
         let left = Box::new(ConcatSstableIterator::new(
@@ -474,6 +478,7 @@ impl<C: CompactionFilter> CompactorRunner<C> {
                 value_skip_watermark_state,
                 compaction_filter,
                 read_table_ids,
+                discard_raw_filter,
             ),
             left,
             right,
@@ -525,6 +530,7 @@ impl<C: CompactionFilter> CompactorRunner<C> {
                         .download_next_block()
                         .await?
                         .unwrap();
+                    let filter_data = self.executor.filter_data_for_raw_copy(filter_data);
                     let algorithm = Block::get_algorithm(&block)?;
                     if algorithm == CompressionAlgorithm::None
                         && algorithm != self.compression_algorithm
@@ -594,6 +600,7 @@ impl<C: CompactionFilter> CompactorRunner<C> {
                 let smallest_key = FullKey::decode(sstable_iter.next_block_smallest()).to_vec();
                 let (block, filter_data, block_meta) =
                     sstable_iter.download_next_block().await?.unwrap();
+                let filter_data = self.executor.filter_data_for_raw_copy(filter_data);
                 // If the last key is tombstone and it was deleted, the first key of this block must be deleted. So we can not move this block directly.
                 let need_deleted = self.executor.last_key.user_key.eq(&smallest_key.user_key)
                     && self.executor.last_key_is_delete;
@@ -675,6 +682,7 @@ pub struct CompactTaskExecutor<F: TableBuilderFactory, C: CompactionFilter> {
     value_skip_watermark_state: ValueSkipWatermarkState,
     compaction_filter: C,
     read_table_ids: HashSet<TableId>,
+    discard_raw_filter: bool,
 }
 
 impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
@@ -687,6 +695,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
         value_skip_watermark_state: ValueSkipWatermarkState,
         compaction_filter: C,
         read_table_ids: HashSet<TableId>,
+        discard_raw_filter: bool,
     ) -> Self {
         Self {
             builder,
@@ -703,6 +712,7 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
             value_skip_watermark_state,
             compaction_filter,
             read_table_ids,
+            discard_raw_filter,
         }
     }
 
@@ -720,6 +730,14 @@ impl<F: TableBuilderFactory, C: CompactionFilter> CompactTaskExecutor<F, C> {
             self.last_key = FullKey::default();
         }
         self.last_key_is_delete = false;
+    }
+
+    fn filter_data_for_raw_copy(&self, filter_data: Vec<u8>) -> Vec<u8> {
+        if self.discard_raw_filter {
+            vec![]
+        } else {
+            filter_data
+        }
     }
 
     fn reset_watermark(&mut self) {
@@ -887,31 +905,335 @@ mod tests {
     use risingwave_common::catalog::TableId;
     use risingwave_common::hash::VirtualNode;
     use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::LocalSstableInfo;
     use risingwave_hummock_sdk::compact_task::CompactTask;
     use risingwave_hummock_sdk::key::FullKey;
+    use risingwave_hummock_sdk::key_range::KeyRange;
     use risingwave_hummock_sdk::level::InputLevel;
+    use risingwave_hummock_sdk::sstable_info::SstableInfo;
     use risingwave_pb::hummock::compact_task::TaskType;
     use risingwave_pb::hummock::{BloomFilterType, LevelType};
 
     use super::CompactorRunner;
-    use crate::compaction_catalog_manager::CompactionCatalogAgent;
+    use crate::compaction_catalog_manager::{
+        CompactionCatalogAgent, CompactionCatalogAgentRef, DummyFilterKeyExtractor,
+        FilterKeyExtractorImpl, MultiFilterKeyExtractor,
+    };
     use crate::hummock::compactor::compaction_utils::optimize_by_copy_block;
+    use crate::hummock::compactor::compactor_runner::CompactorRunner as NormalCompactorRunner;
     use crate::hummock::compactor::task_progress::TaskProgress;
     use crate::hummock::compactor::{CompactorContext, MultiCompactionFilter};
+    use crate::hummock::iterator::HummockIterator;
     use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::test_utils::{
         default_builder_opt_for_test, default_opts_for_test, gen_test_sstable_impl, test_value_of,
     };
     use crate::hummock::value::HummockValue;
     use crate::hummock::{
-        BlockedXor16FilterBuilder, CachePolicy, SharedComapctorObjectIdManager, Xor16FilterBuilder,
+        BlockedXor16FilterBuilder, CachePolicy, SharedComapctorObjectIdManager, SstableBuilder,
+        SstableIterator, SstableIteratorReadOptions, SstableStoreRef, SstableWriterOptions,
+        Xor16FilterBuilder,
     };
-    use crate::monitor::CompactorMetrics;
+    use crate::monitor::{CompactorMetrics, StoreLocalStatistic};
 
     fn test_key(table_id: u32, idx: usize) -> FullKey<Vec<u8>> {
         let mut table_key = VirtualNode::ZERO.to_be_bytes().to_vec();
         table_key.extend_from_slice(format!("key_test_{idx:05}").as_bytes());
         FullKey::for_test(TableId::new(table_id), table_key, test_epoch(1))
+    }
+
+    fn test_kv(table_id: TableId, idx: usize) -> (FullKey<Vec<u8>>, HummockValue<Vec<u8>>) {
+        (
+            test_key(table_id.as_raw_id(), idx),
+            HummockValue::put(test_value_of(idx)),
+        )
+    }
+
+    #[derive(Clone, Copy)]
+    enum FastCompactInputFilter {
+        Blocked,
+        NoFilter,
+    }
+
+    async fn gen_pruned_mixed_blocked_sst_for_fast_compact_test(
+        sstable_store: SstableStoreRef,
+        object_id: u64,
+        live_table_id: TableId,
+        live_key_indexes: Vec<usize>,
+    ) -> SstableInfo {
+        let dropped_table_id = TableId::new(1);
+        assert_ne!(dropped_table_id, live_table_id);
+        let mut sst = gen_test_sstable_impl::<_, BlockedXor16FilterBuilder>(
+            default_builder_opt_for_test(),
+            object_id,
+            (0..2).map(|idx| test_kv(dropped_table_id, idx)).chain(
+                live_key_indexes
+                    .into_iter()
+                    .map(|idx| test_kv(live_table_id, idx)),
+            ),
+            sstable_store,
+            CachePolicy::NotFill,
+            HashMap::from([
+                (dropped_table_id.as_raw_id(), VirtualNode::COUNT_FOR_TEST),
+                (live_table_id.as_raw_id(), VirtualNode::COUNT_FOR_TEST),
+            ]),
+            HashMap::from([
+                (dropped_table_id.as_raw_id(), None),
+                (live_table_id.as_raw_id(), None),
+            ]),
+        )
+        .await;
+        assert_eq!(sst.table_ids, vec![dropped_table_id, live_table_id]);
+
+        let mut inner = sst.get_inner();
+        inner.table_ids = vec![live_table_id];
+        sst.set_inner(inner);
+        sst
+    }
+
+    async fn gen_sst_for_fast_compact_test(
+        sstable_store: SstableStoreRef,
+        object_id: u64,
+        table_id: TableId,
+        key_indexes: Vec<usize>,
+        input_filter: FastCompactInputFilter,
+    ) -> SstableInfo {
+        match input_filter {
+            FastCompactInputFilter::Blocked => {
+                let raw_table_id = table_id.as_raw_id();
+                gen_test_sstable_impl::<_, BlockedXor16FilterBuilder>(
+                    default_builder_opt_for_test(),
+                    object_id,
+                    key_indexes.into_iter().map(|idx| test_kv(table_id, idx)),
+                    sstable_store,
+                    CachePolicy::NotFill,
+                    HashMap::from([(raw_table_id, VirtualNode::COUNT_FOR_TEST)]),
+                    HashMap::from([(raw_table_id, None)]),
+                )
+                .await
+            }
+            FastCompactInputFilter::NoFilter => {
+                let writer = sstable_store
+                    .clone()
+                    .create_sst_writer(object_id, SstableWriterOptions::default());
+                let mut builder = SstableBuilder::new(
+                    object_id,
+                    writer,
+                    BlockedXor16FilterBuilder::new(1024),
+                    default_builder_opt_for_test(),
+                    no_filter_catalog_agent(table_id),
+                    None,
+                );
+                for idx in key_indexes {
+                    let (key, value) = test_kv(table_id, idx);
+                    builder.add(key.to_ref(), value.as_slice()).await.unwrap();
+                }
+                let output = builder.finish().await.unwrap();
+                output.writer_output.await.unwrap().unwrap();
+                output.sst_info.sst_info
+            }
+        }
+    }
+
+    fn fast_compact_context(sstable_store: SstableStoreRef) -> CompactorContext {
+        let mut storage_opts = default_opts_for_test();
+        storage_opts.enable_fast_compaction = true;
+        storage_opts.compactor_fast_max_compact_task_size = u64::MAX;
+        storage_opts.compactor_fast_max_compact_delete_ratio = 100;
+        CompactorContext::new_local_compact_context(
+            Arc::new(storage_opts),
+            sstable_store,
+            Arc::new(CompactorMetrics::unused()),
+            None,
+        )
+    }
+
+    fn no_filter_catalog_agent(table_id: TableId) -> CompactionCatalogAgentRef {
+        let mut multi_filter_key_extractor = MultiFilterKeyExtractor::default();
+        multi_filter_key_extractor.register(
+            table_id,
+            FilterKeyExtractorImpl::Dummy(DummyFilterKeyExtractor),
+        );
+        Arc::new(CompactionCatalogAgent::new(
+            FilterKeyExtractorImpl::Multi(multi_filter_key_extractor),
+            HashMap::from([(table_id, VirtualNode::COUNT_FOR_TEST)]),
+            HashMap::from([(table_id, None)]),
+            HashMap::default(),
+        ))
+    }
+
+    async fn run_single_table_no_filter_fast_compact(
+        left_key_indexes: Vec<usize>,
+        right_key_indexes: Vec<usize>,
+        task_id: u64,
+        input_filter: FastCompactInputFilter,
+    ) -> (SstableStoreRef, Vec<LocalSstableInfo>) {
+        let sstable_store = mock_sstable_store().await;
+        let table_id = TableId::new(1);
+        let left_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            1,
+            table_id,
+            left_key_indexes,
+            input_filter,
+        )
+        .await;
+        let right_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            2,
+            table_id,
+            right_key_indexes,
+            input_filter,
+        )
+        .await;
+        let expected_filter_kind = match input_filter {
+            FastCompactInputFilter::Blocked => BloomFilterType::Blocked,
+            FastCompactInputFilter::NoFilter => BloomFilterType::Sstable,
+        };
+        assert_eq!(left_sst.bloom_filter_kind, expected_filter_kind);
+        assert_eq!(right_sst.bloom_filter_kind, expected_filter_kind);
+
+        let context = fast_compact_context(sstable_store.clone());
+        let task = single_table_no_filter_compact_task(left_sst, right_sst, table_id, task_id);
+        let compaction_catalog_agent_ref = no_filter_catalog_agent(table_id);
+        assert!(optimize_by_copy_block(
+            &task,
+            &context,
+            &compaction_catalog_agent_ref
+        ));
+
+        let runner = CompactorRunner::new(
+            context,
+            task,
+            compaction_catalog_agent_ref,
+            SharedComapctorObjectIdManager::for_test(VecDeque::from([100])),
+            Arc::new(TaskProgress::default()),
+            MultiCompactionFilter::default(),
+        );
+        let (ssts, _) = runner.run().await.unwrap();
+        (sstable_store, ssts)
+    }
+
+    fn single_table_no_filter_compact_task(
+        left_sst: SstableInfo,
+        right_sst: SstableInfo,
+        table_id: TableId,
+        task_id: u64,
+    ) -> CompactTask {
+        CompactTask {
+            input_ssts: vec![
+                InputLevel {
+                    level_idx: 1,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: vec![left_sst],
+                },
+                InputLevel {
+                    level_idx: 2,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: vec![right_sst],
+                },
+            ],
+            task_id,
+            splits: vec![KeyRange::inf()],
+            target_level: 2,
+            existing_table_ids: vec![table_id],
+            target_file_size: 1 << 20,
+            task_type: TaskType::Dynamic,
+            max_kv_count_for_xor16: Some(0),
+            ..Default::default()
+        }
+    }
+
+    async fn run_single_table_no_filter_normal_compact(
+        left_key_indexes: Vec<usize>,
+        right_key_indexes: Vec<usize>,
+        task_id: u64,
+    ) -> (SstableStoreRef, Vec<LocalSstableInfo>) {
+        let sstable_store = mock_sstable_store().await;
+        let table_id = TableId::new(1);
+        let left_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            1,
+            table_id,
+            left_key_indexes,
+            FastCompactInputFilter::Blocked,
+        )
+        .await;
+        let right_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            2,
+            table_id,
+            right_key_indexes,
+            FastCompactInputFilter::Blocked,
+        )
+        .await;
+        assert_eq!(left_sst.bloom_filter_kind, BloomFilterType::Blocked);
+        assert_eq!(right_sst.bloom_filter_kind, BloomFilterType::Blocked);
+
+        let context = fast_compact_context(sstable_store.clone());
+        let task = single_table_no_filter_compact_task(left_sst, right_sst, table_id, task_id);
+        let runner = NormalCompactorRunner::new(
+            0,
+            context,
+            task,
+            SharedComapctorObjectIdManager::for_test(VecDeque::from([100])),
+        );
+        let (_, ssts, _) = runner
+            .run(
+                MultiCompactionFilter::default(),
+                no_filter_catalog_agent(table_id),
+                Arc::new(TaskProgress::default()),
+            )
+            .await
+            .unwrap();
+        (sstable_store, ssts)
+    }
+
+    async fn assert_single_output_has_no_filter(
+        sstable_store: &SstableStoreRef,
+        ssts: &[LocalSstableInfo],
+    ) {
+        assert_eq!(ssts.len(), 1);
+        let sst_info = &ssts[0].sst_info;
+        assert_eq!(sst_info.bloom_filter_kind, BloomFilterType::Sstable);
+
+        let table = sstable_store
+            .sstable(sst_info, &mut StoreLocalStatistic::default())
+            .await
+            .unwrap();
+        assert!(!table.has_bloom_filter());
+        assert!(!table.filter_reader.is_block_based_filter());
+    }
+
+    async fn assert_single_output_data(
+        sstable_store: &SstableStoreRef,
+        ssts: &[LocalSstableInfo],
+        table_id: TableId,
+        key_indexes: &[usize],
+    ) {
+        assert_eq!(ssts.len(), 1);
+        let sst_info = &ssts[0].sst_info;
+        let table = sstable_store
+            .sstable(sst_info, &mut StoreLocalStatistic::default())
+            .await
+            .unwrap();
+        let mut iter = SstableIterator::new(
+            table,
+            sstable_store.clone(),
+            Arc::new(SstableIteratorReadOptions::default()),
+            sst_info,
+        );
+        iter.rewind().await.unwrap();
+        for idx in key_indexes {
+            assert!(iter.is_valid());
+            assert_eq!(iter.key(), test_key(table_id.as_raw_id(), *idx).to_ref());
+            assert_eq!(
+                iter.value(),
+                HummockValue::put(test_value_of(*idx)).as_slice()
+            );
+            iter.next().await.unwrap();
+        }
+        assert!(!iter.is_valid());
     }
 
     #[tokio::test]
@@ -992,16 +1314,141 @@ mod tests {
         };
 
         assert_eq!(task.input_ssts[0].read_sstable_infos().count(), 1);
-        assert!(optimize_by_copy_block(&task, &context));
+        let compaction_catalog_agent_ref = CompactionCatalogAgent::for_test(vec![1, 2]);
+        assert!(optimize_by_copy_block(
+            &task,
+            &context,
+            &compaction_catalog_agent_ref
+        ));
 
         let runner = CompactorRunner::new(
             context,
             task,
-            CompactionCatalogAgent::for_test(vec![1, 2]),
+            compaction_catalog_agent_ref,
             SharedComapctorObjectIdManager::for_test(VecDeque::from([100])),
             Arc::new(TaskProgress::default()),
             MultiCompactionFilter::default(),
         );
         runner.run().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_fast_compact_single_table_no_filter_drops_raw_filter() {
+        let (sstable_store, ssts) = run_single_table_no_filter_fast_compact(
+            vec![0, 1],
+            vec![2, 3],
+            43,
+            FastCompactInputFilter::Blocked,
+        )
+        .await;
+        assert_single_output_has_no_filter(&sstable_store, &ssts).await;
+        assert_single_output_data(&sstable_store, &ssts, TableId::new(1), &[0, 1, 2, 3]).await;
+    }
+
+    #[tokio::test]
+    async fn test_fast_compact_single_table_no_filter_copies_no_filter_blocks() {
+        let (sstable_store, ssts) = run_single_table_no_filter_fast_compact(
+            vec![0, 1],
+            vec![2, 3],
+            46,
+            FastCompactInputFilter::NoFilter,
+        )
+        .await;
+        assert_single_output_has_no_filter(&sstable_store, &ssts).await;
+        assert_single_output_data(&sstable_store, &ssts, TableId::new(1), &[0, 1, 2, 3]).await;
+    }
+
+    #[tokio::test]
+    async fn test_fast_compact_single_table_no_filter_skips_pruned_mixed_table_blocks() {
+        let sstable_store = mock_sstable_store().await;
+        let table_id = TableId::new(2);
+        let left_sst = gen_pruned_mixed_blocked_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            1,
+            table_id,
+            vec![0, 1],
+        )
+        .await;
+        let right_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            2,
+            table_id,
+            vec![2, 3],
+            FastCompactInputFilter::Blocked,
+        )
+        .await;
+        assert_eq!(left_sst.table_ids, vec![table_id]);
+        assert_eq!(left_sst.bloom_filter_kind, BloomFilterType::Blocked);
+
+        let context = fast_compact_context(sstable_store.clone());
+        let task = single_table_no_filter_compact_task(left_sst, right_sst, table_id, 48);
+        let compaction_catalog_agent_ref = no_filter_catalog_agent(table_id);
+        assert!(optimize_by_copy_block(
+            &task,
+            &context,
+            &compaction_catalog_agent_ref
+        ));
+
+        let runner = CompactorRunner::new(
+            context,
+            task,
+            compaction_catalog_agent_ref,
+            SharedComapctorObjectIdManager::for_test(VecDeque::from([100])),
+            Arc::new(TaskProgress::default()),
+            MultiCompactionFilter::default(),
+        );
+        let (ssts, _) = runner.run().await.unwrap();
+        assert_single_output_has_no_filter(&sstable_store, &ssts).await;
+        assert_single_output_data(&sstable_store, &ssts, table_id, &[0, 1, 2, 3]).await;
+    }
+
+    #[tokio::test]
+    async fn test_fast_compact_single_table_no_filter_rejects_sstable_filter_without_no_filter_agent()
+     {
+        let sstable_store = mock_sstable_store().await;
+        let table_id = TableId::new(1);
+        let left_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            1,
+            table_id,
+            vec![0, 1],
+            FastCompactInputFilter::NoFilter,
+        )
+        .await;
+        let right_sst = gen_sst_for_fast_compact_test(
+            sstable_store.clone(),
+            2,
+            table_id,
+            vec![2, 3],
+            FastCompactInputFilter::NoFilter,
+        )
+        .await;
+        let context = fast_compact_context(sstable_store);
+        let task = single_table_no_filter_compact_task(left_sst, right_sst, table_id, 47);
+        assert!(!optimize_by_copy_block(
+            &task,
+            &context,
+            &CompactionCatalogAgent::for_test(vec![table_id])
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fast_compact_single_table_no_filter_decoded_path() {
+        let (sstable_store, ssts) = run_single_table_no_filter_fast_compact(
+            vec![0, 2],
+            vec![1, 3],
+            44,
+            FastCompactInputFilter::NoFilter,
+        )
+        .await;
+        assert_single_output_has_no_filter(&sstable_store, &ssts).await;
+        assert_single_output_data(&sstable_store, &ssts, TableId::new(1), &[0, 1, 2, 3]).await;
+    }
+
+    #[tokio::test]
+    async fn test_normal_compact_single_table_no_filter() {
+        let (sstable_store, ssts) =
+            run_single_table_no_filter_normal_compact(vec![0, 2], vec![1, 3], 45).await;
+        assert_single_output_has_no_filter(&sstable_store, &ssts).await;
     }
 }

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -116,6 +116,7 @@ pub struct SstableBuilder<W: SstableWriter, F: FilterBuilder> {
     block_builder: BlockBuilder,
 
     compaction_catalog_agent_ref: CompactionCatalogAgentRef,
+    is_single_table_no_filter: bool,
     /// Block metadata vec.
     block_metas: Vec<BlockMeta>,
 
@@ -188,6 +189,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         memory_limiter: Option<Arc<MemoryLimiter>>,
     ) -> Self {
         let sst_object_id = sst_object_id.into();
+        let is_single_table_no_filter = compaction_catalog_agent_ref.is_single_table_no_filter();
         Self {
             vnode_range_collector: VnodeUserKeyRangeCollector::with_limit(
                 options.max_vnode_key_range_bytes,
@@ -208,6 +210,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             last_full_key: vec![],
             sst_object_id,
             compaction_catalog_agent_ref,
+            is_single_table_no_filter,
             table_stats: Default::default(),
             last_table_stats: Default::default(),
             epoch_set: BTreeSet::default(),
@@ -284,7 +287,14 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         );
         meta.offset = self.writer.data_len() as u32;
         self.block_metas.push(meta);
-        self.filter_builder.add_raw_data(filter_data);
+        if self.is_single_table_no_filter {
+            assert!(
+                filter_data.is_empty(),
+                "single-table no-filter compaction should not copy raw filter data"
+            );
+        } else {
+            self.filter_builder.add_raw_data(filter_data);
+        }
         let block_meta = self.block_metas.last_mut().unwrap();
         self.writer.write_block_bytes(buf, block_meta).await?;
 
@@ -469,12 +479,23 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         let right_exclusive = false;
         let meta_offset = self.writer.data_len() as u64;
 
-        let bloom_filter_kind = if self.filter_builder.support_blocked_raw_data() {
+        let should_skip_filter = self.is_single_table_no_filter;
+        assert!(
+            !should_skip_filter || self.table_ids.len() <= 1,
+            "single-table no-filter compaction should not output multiple tables"
+        );
+        assert!(
+            !should_skip_filter || self.filter_builder.approximate_len() == 0,
+            "single-table no-filter compaction should not build filter data"
+        );
+        let bloom_filter_kind = if should_skip_filter {
+            BloomFilterType::Sstable
+        } else if self.filter_builder.support_blocked_raw_data() {
             BloomFilterType::Blocked
         } else {
             BloomFilterType::Sstable
         };
-        let bloom_filter = if self.options.bloom_false_positive > 0.0 {
+        let bloom_filter = if self.options.bloom_false_positive > 0.0 && !should_skip_filter {
             self.filter_builder.finish(self.memory_limiter.clone())
         } else {
             vec![]
@@ -687,8 +708,10 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         let block = self.block_builder.build();
         self.writer.write_block(block, block_meta).await?;
         self.block_size_vec.push(block.len());
-        self.filter_builder
-            .switch_block(self.memory_limiter.clone());
+        if !self.is_single_table_no_filter {
+            self.filter_builder
+                .switch_block(self.memory_limiter.clone());
+        }
         let data_len = utils::checked_into_u32(self.writer.data_len()).unwrap_or_else(|_| {
             panic!(
                 "WARN overflow can't convert writer_data_len {} into u32 table {:?}",
@@ -1364,5 +1387,63 @@ pub(super) mod tests {
                 table.may_match_hash(&(Bound::Included(key_ref), Bound::Included(key_ref)), hash)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_single_table_without_filter_key_writes_no_xor_filter() {
+        let opts = SstableBuilderOptions::default();
+        let sstable_store = mock_sstable_store().await;
+        let object_id = 1;
+        let writer = sstable_store
+            .clone()
+            .create_sst_writer(object_id, SstableWriterOptions::default());
+
+        let mut filter = MultiFilterKeyExtractor::default();
+        filter.register(
+            1.into(),
+            FilterKeyExtractorImpl::Dummy(DummyFilterKeyExtractor),
+        );
+        let compaction_catalog_agent_ref = Arc::new(CompactionCatalogAgent::new(
+            FilterKeyExtractorImpl::Multi(filter),
+            HashMap::from_iter([(1.into(), VirtualNode::COUNT_FOR_TEST)]),
+            HashMap::from_iter([(1.into(), None)]),
+            HashMap::default(),
+        ));
+
+        let mut builder = SstableBuilder::new(
+            object_id,
+            writer,
+            BlockedXor16FilterBuilder::new(1024),
+            opts,
+            compaction_catalog_agent_ref,
+            None,
+        );
+
+        let key_count: usize = 10000;
+        let mut table_key = VirtualNode::ZERO.to_be_bytes().to_vec();
+        for idx in 0..key_count {
+            table_key.resize(VirtualNode::SIZE, 0);
+            table_key.extend_from_slice(format!("key_test_{idx:05}").as_bytes());
+            let k = UserKey::for_test(TableId::new(1), table_key.as_ref());
+            builder
+                .add(
+                    FullKey::from_user_key(k, test_epoch(1)),
+                    HummockValue::put(test_value_of(idx).as_ref()),
+                )
+                .await
+                .unwrap();
+        }
+
+        let ret = builder.finish().await.unwrap();
+        let sst_info = ret.sst_info.sst_info.clone();
+        ret.writer_output.await.unwrap().unwrap();
+
+        let table = sstable_store
+            .sstable(&sst_info, &mut StoreLocalStatistic::default())
+            .await
+            .unwrap();
+        assert_eq!(sst_info.bloom_filter_kind, BloomFilterType::Sstable);
+        assert!(!table.has_bloom_filter());
+        assert!(!table.filter_reader.is_block_based_filter());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Skip writing xor filter bytes for single-table no-filter SSTs, such as tables with `read_prefix_len_hint = 0`.
- Allow fast compaction to copy data blocks for confirmed single-table no-filter tasks while discarding raw filter data.
- Keep mixed-table SSTs on the existing filter path unless their metadata has already been pruned to a single live no-filter table.

- Closes N/A

## Checklist

- [x] I have written necessary rustdoc comments. (N/A: no new public API.)
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) --> (N/A: default PR CI is enough.)
- [x] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 --> (N/A.)
- [x] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future --> (N/A: no breaking changes.)
- [x] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). --> (N/A: covered by focused tests.)
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) --> (Backport can be decided separately for the target bugfix release.)


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users --> (N/A: no user-facing behavior change.)

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

No user-facing behavior change.

</details>

## Verification

- Format and diff checks passed.
- Storage clippy passed with warnings denied.
- Focused storage unit tests passed.
