### PR TITLE
fix(frontend): handle avg over empty window frame

### DIFF
--- a/e2e_test/over_window/generated/batch/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/generated/batch/odd_frames/mod.slt.part
@@ -3,7 +3,7 @@
 # Test weird window frames.
 
 statement ok
-create table t (a int, b int, c int);
+create table t (a int, b int, c decimal);
 
 statement ok
 create view v as
@@ -11,7 +11,9 @@ select
     count(*) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as c1,
     count(*) over (partition by 1::int order by b rows between 10 following and 1 following) as c2,
     count(*) over (partition by 1::int order by b range between 2 preceding and 10 preceding) as c3,
-    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4
+    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4,
+    avg(c) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as a1,
+    avg(c) over (partition by 1::int order by b rows between 10 following and 1 following) as a2
 from t;
 
 statement ok
@@ -21,12 +23,12 @@ insert into t values
    ,(1, 4, 9)
 ;
 
-query IIII
+query IIIIRR
 select * from v;
 ----
-0 0 0 0
-0 0 0 0
-0 0 0 0
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
 
 statement ok
 drop view v;

--- a/e2e_test/over_window/generated/streaming/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/generated/streaming/odd_frames/mod.slt.part
@@ -3,7 +3,7 @@
 # Test weird window frames.
 
 statement ok
-create table t (a int, b int, c int);
+create table t (a int, b int, c decimal);
 
 statement ok
 create materialized view v as
@@ -11,7 +11,9 @@ select
     count(*) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as c1,
     count(*) over (partition by 1::int order by b rows between 10 following and 1 following) as c2,
     count(*) over (partition by 1::int order by b range between 2 preceding and 10 preceding) as c3,
-    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4
+    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4,
+    avg(c) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as a1,
+    avg(c) over (partition by 1::int order by b rows between 10 following and 1 following) as a2
 from t;
 
 statement ok
@@ -21,12 +23,12 @@ insert into t values
    ,(1, 4, 9)
 ;
 
-query IIII
+query IIIIRR
 select * from v;
 ----
-0 0 0 0
-0 0 0 0
-0 0 0 0
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
 
 statement ok
 drop materialized view v;

--- a/e2e_test/over_window/templates/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/templates/odd_frames/mod.slt.part
@@ -1,7 +1,7 @@
 # Test weird window frames.
 
 statement ok
-create table t (a int, b int, c int);
+create table t (a int, b int, c decimal);
 
 statement ok
 create $view_type v as
@@ -9,7 +9,9 @@ select
     count(*) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as c1,
     count(*) over (partition by 1::int order by b rows between 10 following and 1 following) as c2,
     count(*) over (partition by 1::int order by b range between 2 preceding and 10 preceding) as c3,
-    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4
+    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4,
+    avg(c) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as a1,
+    avg(c) over (partition by 1::int order by b rows between 10 following and 1 following) as a2
 from t;
 
 statement ok
@@ -19,12 +21,12 @@ insert into t values
    ,(1, 4, 9)
 ;
 
-query IIII
+query IIIIRR
 select * from v;
 ----
-0 0 0 0
-0 0 0 0
-0 0 0 0
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
 
 statement ok
 drop $view_type v;

--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -176,6 +176,14 @@
     - stream_plan
     - optimized_logical_plan_for_batch
     - batch_plan
+- id: avg aggregate over preceding-only frame
+  sql: |
+    create table t(id int, grp int, val double precision);
+    select id, avg(val) over(PARTITION BY grp ORDER BY id ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+    - batch_plan
 
 # RowNumber/Rank/...
 - id: row_number with empty over clause

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -364,20 +364,20 @@
   logical_plan: |-
     LogicalProject { exprs: [t.x, t.y, t.z, $expr4] }
     └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ($expr4 <= 3.0:Decimal) }
-      └─LogicalProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4] }
+      └─LogicalProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4] }
         └─LogicalOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
           └─LogicalProject { exprs: [t.x, t.y, t.z, t.w, t._row_id, t._rw_timestamp, (t.z * t.z) as $expr1, (t.y + 1:Int32) as $expr2, Abs(t.w) as $expr3] }
             └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t.w, t._row_id, t._rw_timestamp] }
   optimized_logical_plan_for_batch: |-
-    LogicalProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4] }
-    └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ((sum::Decimal / count::Decimal) <= 3.0:Decimal) }
+    LogicalProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4] }
+    └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) <= 3.0:Decimal) }
       └─LogicalOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─LogicalProject { exprs: [t.x, t.y, t.z, (t.z * t.z) as $expr1, (t.y + 1:Int32) as $expr2, Abs(t.w) as $expr3] }
           └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t.w] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4] }
-      └─BatchFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ((sum::Decimal / count::Decimal) <= 3.0:Decimal) }
+    └─BatchProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4] }
+      └─BatchFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) <= 3.0:Decimal) }
         └─BatchOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
           └─BatchExchange { order: [$expr2 ASC, $expr3 ASC], dist: HashShard($expr2) }
             └─BatchSort { order: [$expr2 ASC, $expr3 ASC] }
@@ -385,12 +385,34 @@
                 └─BatchScan { table: t, columns: [t.x, t.y, t.z, t.w], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [x, y, z, res, t._row_id(hidden), $expr2(hidden)], stream_key: [t._row_id, $expr2], pk_columns: [t._row_id, $expr2], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4, t._row_id, $expr2] }
-      └─StreamFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ((sum::Decimal / count::Decimal) <= 3.0:Decimal) }
+    └─StreamProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4, t._row_id, $expr2] }
+      └─StreamFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) <= 3.0:Decimal) }
         └─StreamOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
           └─StreamExchange { dist: HashShard($expr2) }
             └─StreamProject { exprs: [t.x, t.y, t.z, (t.z * t.z) as $expr1, (t.y + 1:Int32) as $expr2, Abs(t.w) as $expr3, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.x, t.y, t.z, t.w, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: avg aggregate over preceding-only frame
+  sql: |
+    create table t(id int, grp int, val double precision);
+    select id, avg(val) over(PARTITION BY grp ORDER BY id ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [t.id, Case((count = 0:Int32), null:Float64, (sum / count::Float64)) as $expr1] }
+    └─LogicalOverWindow { window_functions: [sum(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING), count(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING)] }
+      └─LogicalProject { exprs: [t.id, t.grp, t.val, t._row_id, t._rw_timestamp] }
+        └─LogicalScan { table: t, columns: [t.id, t.grp, t.val, t._row_id, t._rw_timestamp] }
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [t.id, Case((count = 0:Int32), null:Float64, (sum / count::Float64)) as $expr1] }
+      └─BatchOverWindow { window_functions: [sum(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING), count(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING)] }
+        └─BatchExchange { order: [t.grp ASC, t.id ASC], dist: HashShard(t.grp) }
+          └─BatchSort { order: [t.grp ASC, t.id ASC] }
+            └─BatchScan { table: t, columns: [t.id, t.grp, t.val], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [id, avg, t._row_id(hidden), t.grp(hidden)], stream_key: [t._row_id, t.grp], pk_columns: [t._row_id, t.grp], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.id, Case((count = 0:Int32), null:Float64, (sum / count::Float64)) as $expr1, t._row_id, t.grp] }
+      └─StreamOverWindow { window_functions: [sum(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING), count(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING)] }
+        └─StreamExchange { dist: HashShard(t.grp) }
+          └─StreamTableScan { table: t, columns: [t.id, t.grp, t.val, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - id: row_number with empty over clause
   sql: |
     create table t(x int);

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -624,6 +624,7 @@ impl LogicalAggBuilder {
             // Rewrite avg to cast(sum as avg_return_type) / count.
             AggType::Builtin(PbAggKind::Avg) => {
                 assert_eq!(agg_call.args.len(), 1);
+                let return_type = agg_call.return_type();
 
                 let sum = ExprImpl::from(push_agg_call(AggCall::new(
                     PbAggKind::Sum.into(),
@@ -644,7 +645,18 @@ impl LogicalAggBuilder {
                     agg_call.direct_args,
                 )?)?);
 
-                Ok(FunctionCall::new(ExprType::Divide, Vec::from([sum, count]))?.into())
+                let target = ExprImpl::from(FunctionCall::new(
+                    ExprType::Divide,
+                    Vec::from([sum, count.clone()]),
+                )?);
+                let null = ExprImpl::from(Literal::new(None, return_type));
+                let zero = ExprImpl::literal_int(0);
+                let case_cond =
+                    ExprImpl::from(FunctionCall::new(ExprType::Equal, vec![count, zero])?);
+                Ok(ExprImpl::from(FunctionCall::new(
+                    ExprType::Case,
+                    vec![case_cond, null, target],
+                )?))
             }
             // We compute `var_samp` as
             // (sum(sq) - sum * sum / count) / (count - 1)


### PR DESCRIPTION
## What

- Guard AVG rewrite with `CASE count = 0 THEN NULL` to avoid evaluating `sum / count` for empty window frames.
- Add planner coverage for preceding-only AVG frames.
- Add batch/streaming over-window e2e coverage for AVG(decimal) over empty frames.

## Verification

- `./risedev slt ./e2e_test/streaming/over_window/main.slt`
- `./risedev slt ./e2e_test/batch/over_window/main.slt.part`
- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 ./risedev run-planner-test over_window_function`
- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 cargo fmt --check`
- `git diff --check`