### PR TITLE
fix(frontend): handle avg over empty window frame

### DIFF
--- a/e2e_test/batch/aggregate/avg.slt.part
+++ b/e2e_test/batch/aggregate/avg.slt.part
@@ -13,5 +13,11 @@ select round(avg(v1), 1), round(avg(v2), 1), round(avg(v3), 1), round(avg(v4), 1
 ----
 1.5 1.5 1.5 1.5 1.5 1.5
 
+query IR
+select v2, avg(v1) filter (where false) from t group by v2 order by v2
+----
+1 NULL
+2 NULL
+
 statement ok
 drop table t

--- a/e2e_test/batch/describe_fragments.slt
+++ b/e2e_test/batch/describe_fragments.slt
@@ -109,12 +109,10 @@ psql_validate.py --db $__DATABASE__ --sql "DESCRIBE FRAGMENTS describe_plan_test
 StreamMaterialize { columns: [name, count, avg_age, all_data], stream_key: [name], pk_columns: [name], pk_conflict: NoCheck }
 ├── output: [ tbl.name, count, $expr1, jsonb_agg(tbl.data) ]
 ├── stream key: [ tbl.name ]
-└── StreamProject { exprs: [tbl.name, count, (sum(tbl.age)::Decimal / count(tbl.age)::Decimal) as $expr1, jsonb_agg(tbl.data)] }
+└── StreamProject { exprs: [tbl.name, count, Case((count(tbl.age) = 0:Int32), null:Decimal, (sum(tbl.age)::Decimal / count(tbl.age)::Decimal)) as $expr1, jsonb_agg(tbl.data)] }
     ├── output: [ tbl.name, count, $expr1, jsonb_agg(tbl.data) ]
     ├── stream key: [ tbl.name ]
-    └── StreamFilter { predicate: (count > 1:Int32) }
-        ├── output: [ tbl.name, count, sum(tbl.age), count(tbl.age), jsonb_agg(tbl.data) ]
-        ├── stream key: [ tbl.name ]
+    └── StreamFilter { predicate: (count > 1:Int32) } { output: [ tbl.name, count, sum(tbl.age), count(tbl.age), jsonb_agg(tbl.data) ], stream key: [ tbl.name ] }
         └── StreamHashAgg { group_key: [tbl.name], aggs: [count, sum(tbl.age), count(tbl.age), jsonb_agg(tbl.data)] }
             ├── output: [ tbl.name, count, sum(tbl.age), count(tbl.age), jsonb_agg(tbl.data) ]
             ├── stream key: [ tbl.name ]
@@ -122,9 +120,7 @@ StreamMaterialize { columns: [name, count, avg_age, all_data], stream_key: [name
 (empty)
 Fragment % (Actor %)
 StreamFilter { predicate: (tbl.age > 18:Int32) } { output: [ tbl.name, tbl.age, tbl.data, tbl.id ], stream key: [ tbl.id ] }
-└── StreamTableScan { table: tbl, columns: [name, age, data, id] }
-    ├── output: [ tbl.name, tbl.age, tbl.data, tbl.id ]
-    ├── stream key: [ tbl.id ]
+└── StreamTableScan { table: tbl, columns: [name, age, data, id] } { output: [ tbl.name, tbl.age, tbl.data, tbl.id ], stream key: [ tbl.id ] }
     ├── Upstream { output: [ name, age, data, id ], stream key: [] }
     └── BatchPlanNode { output: [ name, age, data, id ], stream key: [] }'
 

--- a/e2e_test/over_window/generated/batch/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/generated/batch/odd_frames/mod.slt.part
@@ -3,7 +3,7 @@
 # Test weird window frames.
 
 statement ok
-create table t (a int, b int, c int);
+create table t (a int, b int, c double precision);
 
 statement ok
 create view v as
@@ -11,7 +11,9 @@ select
     count(*) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as c1,
     count(*) over (partition by 1::int order by b rows between 10 following and 1 following) as c2,
     count(*) over (partition by 1::int order by b range between 2 preceding and 10 preceding) as c3,
-    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4
+    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4,
+    avg(c) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as a1,
+    avg(c) over (partition by 1::int order by b rows between 1 following and 1 following) as a2
 from t;
 
 statement ok
@@ -21,12 +23,12 @@ insert into t values
    ,(1, 4, 9)
 ;
 
-query IIII
+query IIIIRR
 select * from v;
 ----
-0 0 0 0
-0 0 0 0
-0 0 0 0
+0 0 0 0 NULL 3
+0 0 0 0 NULL 9
+0 0 0 0 NULL NULL
 
 statement ok
 drop view v;

--- a/e2e_test/over_window/generated/batch/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/generated/batch/odd_frames/mod.slt.part
@@ -24,7 +24,7 @@ insert into t values
 ;
 
 query IIIIRR
-select * from v;
+select * from v order by a2 nulls last;
 ----
 0 0 0 0 NULL 3
 0 0 0 0 NULL 9

--- a/e2e_test/over_window/generated/streaming/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/generated/streaming/odd_frames/mod.slt.part
@@ -3,7 +3,7 @@
 # Test weird window frames.
 
 statement ok
-create table t (a int, b int, c int);
+create table t (a int, b int, c double precision);
 
 statement ok
 create materialized view v as
@@ -11,7 +11,9 @@ select
     count(*) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as c1,
     count(*) over (partition by 1::int order by b rows between 10 following and 1 following) as c2,
     count(*) over (partition by 1::int order by b range between 2 preceding and 10 preceding) as c3,
-    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4
+    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4,
+    avg(c) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as a1,
+    avg(c) over (partition by 1::int order by b rows between 1 following and 1 following) as a2
 from t;
 
 statement ok
@@ -21,12 +23,12 @@ insert into t values
    ,(1, 4, 9)
 ;
 
-query IIII
+query IIIIRR
 select * from v;
 ----
-0 0 0 0
-0 0 0 0
-0 0 0 0
+0 0 0 0 NULL 3
+0 0 0 0 NULL 9
+0 0 0 0 NULL NULL
 
 statement ok
 drop materialized view v;

--- a/e2e_test/over_window/generated/streaming/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/generated/streaming/odd_frames/mod.slt.part
@@ -24,7 +24,7 @@ insert into t values
 ;
 
 query IIIIRR
-select * from v;
+select * from v order by a2 nulls last;
 ----
 0 0 0 0 NULL 3
 0 0 0 0 NULL 9

--- a/e2e_test/over_window/templates/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/templates/odd_frames/mod.slt.part
@@ -22,7 +22,7 @@ insert into t values
 ;
 
 query IIIIRR
-select * from v;
+select * from v order by a2 nulls last;
 ----
 0 0 0 0 NULL 3
 0 0 0 0 NULL 9

--- a/e2e_test/over_window/templates/odd_frames/mod.slt.part
+++ b/e2e_test/over_window/templates/odd_frames/mod.slt.part
@@ -1,7 +1,7 @@
 # Test weird window frames.
 
 statement ok
-create table t (a int, b int, c int);
+create table t (a int, b int, c double precision);
 
 statement ok
 create $view_type v as
@@ -9,7 +9,9 @@ select
     count(*) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as c1,
     count(*) over (partition by 1::int order by b rows between 10 following and 1 following) as c2,
     count(*) over (partition by 1::int order by b range between 2 preceding and 10 preceding) as c3,
-    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4
+    count(*) over (partition by 1::int order by b range between 10 following and 2 following) as c4,
+    avg(c) over (partition by 1::int order by b rows between 1 preceding and 10 preceding) as a1,
+    avg(c) over (partition by 1::int order by b rows between 1 following and 1 following) as a2
 from t;
 
 statement ok
@@ -19,12 +21,12 @@ insert into t values
    ,(1, 4, 9)
 ;
 
-query IIII
+query IIIIRR
 select * from v;
 ----
-0 0 0 0
-0 0 0 0
-0 0 0 0
+0 0 0 0 NULL 3
+0 0 0 0 NULL 9
+0 0 0 0 NULL NULL
 
 statement ok
 drop $view_type v;

--- a/e2e_test/streaming/basic.slt
+++ b/e2e_test/streaming/basic.slt
@@ -46,6 +46,9 @@ create materialized view mv3 as select v3, sum(v1) as sum_v1, min(v1) as min_v1,
 statement ok
 create materialized view mv4 as select count(*) as count, d from t5 group by d;
 
+statement ok
+create materialized view mv5 as select v2, avg(v1) filter (where false) as avg_v1 from t1 group by v2;
+
 query III rowsort
 select v1, v2, v3 from mv1;
 ----
@@ -90,6 +93,12 @@ select * from mv4
 1	Infinity
 1	NaN
 
+query IR rowsort
+select v2, avg_v1 from mv5
+----
+3 NULL
+4 NULL
+
 statement ok
 drop materialized view mv1
 
@@ -101,6 +110,9 @@ drop materialized view mv3
 
 statement ok
 drop materialized view mv4
+
+statement ok
+drop materialized view mv5
 
 statement ok
 drop table t1
@@ -155,4 +167,3 @@ CREATE MATERIALIZED VIEW mv AS SELECT random();
 
 statement ok
 drop materialized view mv
-

--- a/src/frontend/planner_test/tests/testdata/input/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/agg.yaml
@@ -412,6 +412,13 @@
   - optimized_logical_plan_for_batch
   - logical_plan
   - stream_plan
+- name: avg filter clause with empty input group
+  sql: |
+    create table t(a int, b int);
+    select avg(a) FILTER (WHERE false) AS avga from t group by b;
+  expected_outputs:
+  - logical_plan
+  - stream_plan
 - name: count filter clause
   sql: |
     create table t(a int, b int);

--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -176,6 +176,14 @@
     - stream_plan
     - optimized_logical_plan_for_batch
     - batch_plan
+- id: avg aggregate over preceding-only frame
+  sql: |
+    create table t(id int, grp int, val double precision);
+    select id, avg(val) over(PARTITION BY grp ORDER BY id ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+    - batch_plan
 
 # RowNumber/Rank/...
 - id: row_number with empty over clause

--- a/src/frontend/planner_test/tests/testdata/output/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/agg.yaml
@@ -90,20 +90,20 @@
     select v3, min(v1) * avg(v1+v2) as agg from t group by v3;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.v3, (min(t.v1)::Decimal * (sum($expr1)::Decimal / count($expr1)::Decimal)) as $expr2] }
+    └─BatchProject { exprs: [t.v3, (min(t.v1)::Decimal * Case((count($expr1) = 0:Int32), null:Decimal, (sum($expr1)::Decimal / count($expr1)::Decimal))) as $expr2] }
       └─BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum($expr1), count($expr1)] }
         └─BatchExchange { order: [], dist: HashShard(t.v3) }
           └─BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2) as $expr1] }
             └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |-
-    BatchProject { exprs: [t.v3, (min(t.v1)::Decimal * (sum($expr1)::Decimal / count($expr1)::Decimal)) as $expr2] }
+    BatchProject { exprs: [t.v3, (min(t.v1)::Decimal * Case((count($expr1) = 0:Int32), null:Decimal, (sum($expr1)::Decimal / count($expr1)::Decimal))) as $expr2] }
     └─BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum($expr1), count($expr1)] }
       └─BatchExchange { order: [], dist: Single }
         └─BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2) as $expr1] }
           └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [v3, agg], stream_key: [v3], pk_columns: [v3], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.v3, (min(t.v1)::Decimal * (sum($expr1)::Decimal / count($expr1)::Decimal)) as $expr2] }
+    └─StreamProject { exprs: [t.v3, (min(t.v1)::Decimal * Case((count($expr1) = 0:Int32), null:Decimal, (sum($expr1)::Decimal / count($expr1)::Decimal))) as $expr2] }
       └─StreamHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum($expr1), count($expr1), count] }
         └─StreamExchange { dist: HashShard(t.v3) }
           └─StreamProject { exprs: [t.v3, t.v1, (t.v1 + t.v2) as $expr1, t._row_id] }
@@ -739,18 +739,33 @@
     create table t(a int, b int);
     select avg(a) FILTER (WHERE a > b) AS avga from t group by b ;
   logical_plan: |-
-    LogicalProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))::Decimal) as $expr1] }
+    LogicalProject { exprs: [Case((count(t.a) filter((t.a > t.b)) = 0:Int32), null:Decimal, (sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))::Decimal)) as $expr1] }
     └─LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
       └─LogicalProject { exprs: [t.b, t.a] }
         └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id, t._rw_timestamp] }
   optimized_logical_plan_for_batch: |-
-    LogicalProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))::Decimal) as $expr1] }
+    LogicalProject { exprs: [Case((count(t.a) filter((t.a > t.b)) = 0:Int32), null:Decimal, (sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))::Decimal)) as $expr1] }
     └─LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
       └─LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |-
     StreamMaterialize { columns: [avga, t.b(hidden)], stream_key: [t.b], pk_columns: [t.b], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))::Decimal) as $expr1, t.b] }
+    └─StreamProject { exprs: [Case((count(t.a) filter((t.a > t.b)) = 0:Int32), null:Decimal, (sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))::Decimal)) as $expr1, t.b] }
       └─StreamHashAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b)), count] }
+        └─StreamExchange { dist: HashShard(t.b) }
+          └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: avg filter clause with empty input group
+  sql: |
+    create table t(a int, b int);
+    select avg(a) FILTER (WHERE false) AS avga from t group by b;
+  logical_plan: |-
+    LogicalProject { exprs: [Case((count(t.a) filter(false:Boolean) = 0:Int32), null:Decimal, (sum(t.a) filter(false:Boolean)::Decimal / count(t.a) filter(false:Boolean)::Decimal)) as $expr1] }
+    └─LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter(false:Boolean), count(t.a) filter(false:Boolean)] }
+      └─LogicalProject { exprs: [t.b, t.a] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id, t._rw_timestamp] }
+  stream_plan: |-
+    StreamMaterialize { columns: [avga, t.b(hidden)], stream_key: [t.b], pk_columns: [t.b], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [Case((count(t.a) filter(false:Boolean) = 0:Int32), null:Decimal, (sum(t.a) filter(false:Boolean)::Decimal / count(t.a) filter(false:Boolean)::Decimal)) as $expr1, t.b] }
+      └─StreamHashAgg { group_key: [t.b], aggs: [sum(t.a) filter(false:Boolean), count(t.a) filter(false:Boolean), count] }
         └─StreamExchange { dist: HashShard(t.b) }
           └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - name: count filter clause
@@ -1894,7 +1909,7 @@
       └─BatchOverWindow { window_functions: [sum(sum(t.c)) OVER(PARTITION BY t.a, $expr1 ORDER BY max(t.e) ASC, t.b ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─BatchExchange { order: [t.a ASC, $expr1 ASC, max(t.e) ASC, t.b ASC], dist: HashShard(t.a, $expr1) }
           └─BatchSort { order: [t.a ASC, $expr1 ASC, max(t.e) ASC, t.b ASC] }
-            └─BatchProject { exprs: [t.a, t.b, sum(t.c), max(t.e), (sum(t.d)::Decimal / count(t.d)::Decimal) as $expr1] }
+            └─BatchProject { exprs: [t.a, t.b, sum(t.c), max(t.e), Case((count(t.d) = 0:Int32), null:Decimal, (sum(t.d)::Decimal / count(t.d)::Decimal)) as $expr1] }
               └─BatchHashAgg { group_key: [t.a, t.b], aggs: [sum(t.c), sum(t.d), count(t.d), max(t.e)] }
                 └─BatchExchange { order: [], dist: HashShard(t.a, t.b) }
                   └─BatchScan { table: t, columns: [t.a, t.b, t.c, t.d, t.e], distribution: SomeShard }
@@ -1903,7 +1918,7 @@
     └─StreamProject { exprs: [t.a, t.b, sum, $expr1] }
       └─StreamOverWindow { window_functions: [sum(sum(t.c)) OVER(PARTITION BY t.a, $expr1 ORDER BY max(t.e) ASC, t.b ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(t.a, $expr1) }
-          └─StreamProject { exprs: [t.a, t.b, sum(t.c), max(t.e), (sum(t.d)::Decimal / count(t.d)::Decimal) as $expr1] }
+          └─StreamProject { exprs: [t.a, t.b, sum(t.c), max(t.e), Case((count(t.d) = 0:Int32), null:Decimal, (sum(t.d)::Decimal / count(t.d)::Decimal)) as $expr1] }
             └─StreamHashAgg { group_key: [t.a, t.b], aggs: [sum(t.c), sum(t.d), count(t.d), max(t.e), count] }
               └─StreamExchange { dist: HashShard(t.a, t.b) }
                 └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t.d, t.e, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -2299,7 +2314,7 @@
       └─LogicalShare { id: 7 }
         └─LogicalProject { exprs: [true:Boolean, -2147483600:Float32, -10773:Int16] }
           └─LogicalShare { id: 5 }
-            └─LogicalProject { exprs: ['2025-05-05 16:18:55':Timestamp, (sum(813:Int32)::Decimal / count(813:Int32)::Decimal) as $expr1, (371:Int64 / -2147483648:Int32) as $expr2, 460:Int16] }
+            └─LogicalProject { exprs: ['2025-05-05 16:18:55':Timestamp, Case((count(813:Int32) = 0:Int32), null:Decimal, (sum(813:Int32)::Decimal / count(813:Int32)::Decimal)) as $expr1, (371:Int64 / -2147483648:Int32) as $expr2, 460:Int16] }
               └─LogicalAgg { aggs: [sum(813:Int32), count(813:Int32)] }
                 └─LogicalProject { exprs: [813:Int32] }
                   └─LogicalFilter { predicate: true }

--- a/src/frontend/planner_test/tests/testdata/output/ch_benchmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/ch_benchmark.yaml
@@ -6,18 +6,18 @@
   - create_tables
   sql: "select   ol_number,\n sum(ol_quantity) as sum_qty,\n sum(ol_amount) as sum_amount,\n avg(ol_quantity) as avg_qty,\n avg(ol_amount) as avg_amount,\n count(*) as count_order\nfrom\t order_line\nwhere\t ol_delivery_d > '2007-01-02 00:00:00.000000'\ngroup by ol_number order by ol_number;\n"
   logical_plan: |-
-    LogicalProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr1, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal) as $expr2, count] }
+    LogicalProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr1, Case((count(order_line.ol_amount) = 0:Int32), null:Decimal, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal)) as $expr2, count] }
     └─LogicalAgg { group_key: [order_line.ol_number], aggs: [sum(order_line.ol_quantity), sum(order_line.ol_amount), count(order_line.ol_quantity), count(order_line.ol_amount), count] }
       └─LogicalProject { exprs: [order_line.ol_number, order_line.ol_quantity, order_line.ol_amount] }
         └─LogicalFilter { predicate: (order_line.ol_delivery_d > '2007-01-02 00:00:00':Timestamp) }
           └─LogicalScan { table: order_line, columns: [order_line.ol_o_id, order_line.ol_d_id, order_line.ol_w_id, order_line.ol_number, order_line.ol_i_id, order_line.ol_supply_w_id, order_line.ol_delivery_d, order_line.ol_quantity, order_line.ol_amount, order_line.ol_dist_info, order_line._rw_timestamp] }
   optimized_logical_plan_for_batch: |-
-    LogicalProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr1, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal) as $expr2, count] }
+    LogicalProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr1, Case((count(order_line.ol_amount) = 0:Int32), null:Decimal, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal)) as $expr2, count] }
     └─LogicalAgg { group_key: [order_line.ol_number], aggs: [sum(order_line.ol_quantity), sum(order_line.ol_amount), count(order_line.ol_quantity), count(order_line.ol_amount), count] }
       └─LogicalScan { table: order_line, output_columns: [order_line.ol_number, order_line.ol_quantity, order_line.ol_amount], required_columns: [order_line.ol_number, order_line.ol_quantity, order_line.ol_amount, order_line.ol_delivery_d], predicate: (order_line.ol_delivery_d > '2007-01-02 00:00:00':Timestamp) }
   batch_plan: |-
     BatchExchange { order: [order_line.ol_number ASC], dist: Single }
-    └─BatchProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr1, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal) as $expr2, count] }
+    └─BatchProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr1, Case((count(order_line.ol_amount) = 0:Int32), null:Decimal, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal)) as $expr2, count] }
       └─BatchSort { order: [order_line.ol_number ASC] }
         └─BatchHashAgg { group_key: [order_line.ol_number], aggs: [sum(order_line.ol_quantity), sum(order_line.ol_amount), count(order_line.ol_quantity), count(order_line.ol_amount), count] }
           └─BatchExchange { order: [], dist: HashShard(order_line.ol_number) }
@@ -26,7 +26,7 @@
                 └─BatchScan { table: order_line, columns: [order_line.ol_number, order_line.ol_quantity, order_line.ol_amount, order_line.ol_delivery_d], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [ol_number, sum_qty, sum_amount, avg_qty, avg_amount, count_order], stream_key: [ol_number], pk_columns: [ol_number], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr1, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal) as $expr2, count] }
+    └─StreamProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr1, Case((count(order_line.ol_amount) = 0:Int32), null:Decimal, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal)) as $expr2, count] }
       └─StreamHashAgg { group_key: [order_line.ol_number], aggs: [sum(order_line.ol_quantity), sum(order_line.ol_amount), count(order_line.ol_quantity), count(order_line.ol_amount), count] }
         └─StreamExchange { dist: HashShard(order_line.ol_number) }
           └─StreamProject { exprs: [order_line.ol_number, order_line.ol_quantity, order_line.ol_amount, order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id] }
@@ -35,7 +35,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [ol_number, sum_qty, sum_amount, avg_qty, avg_amount, count_order], stream_key: [ol_number], pk_columns: [ol_number], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr1, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal) as $expr2, count] }
+    └── StreamProject { exprs: [order_line.ol_number, sum(order_line.ol_quantity), sum(order_line.ol_amount), Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr1, Case((count(order_line.ol_amount) = 0:Int32), null:Decimal, (sum(order_line.ol_amount) / count(order_line.ol_amount)::Decimal)) as $expr2, count] }
         └── StreamHashAgg { group_key: [order_line.ol_number], aggs: [sum(order_line.ol_quantity), sum(order_line.ol_amount), count(order_line.ol_quantity), count(order_line.ol_amount), count] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([0]) from 1
 
@@ -2586,7 +2586,7 @@
         └─LogicalFilter { predicate: (order_line.ol_i_id = item.i_id) AND (order_line.ol_quantity::Decimal < $expr1) }
           └─LogicalJoin { type: Inner, on: true, output: all }
             ├─LogicalScan { table: order_line, columns: [order_line.ol_o_id, order_line.ol_d_id, order_line.ol_w_id, order_line.ol_number, order_line.ol_i_id, order_line.ol_supply_w_id, order_line.ol_delivery_d, order_line.ol_quantity, order_line.ol_amount, order_line.ol_dist_info, order_line._rw_timestamp] }
-            └─LogicalProject { exprs: [item.i_id, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr1] }
+            └─LogicalProject { exprs: [item.i_id, Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr1] }
               └─LogicalAgg { group_key: [item.i_id], aggs: [sum(order_line.ol_quantity), count(order_line.ol_quantity)] }
                 └─LogicalProject { exprs: [item.i_id, order_line.ol_quantity] }
                   └─LogicalFilter { predicate: Like(item.i_data, '%b':Varchar) AND (order_line.ol_i_id = item.i_id) }
@@ -2599,7 +2599,7 @@
       └─LogicalJoin { type: Inner, on: (order_line.ol_i_id = item.i_id) AND ($expr1 < $expr2), output: [order_line.ol_amount] }
         ├─LogicalProject { exprs: [order_line.ol_i_id, order_line.ol_amount, order_line.ol_quantity::Decimal as $expr1] }
         │ └─LogicalScan { table: order_line, columns: [order_line.ol_i_id, order_line.ol_quantity, order_line.ol_amount] }
-        └─LogicalProject { exprs: [item.i_id, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr2] }
+        └─LogicalProject { exprs: [item.i_id, Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr2] }
           └─LogicalAgg { group_key: [item.i_id], aggs: [sum(order_line.ol_quantity), count(order_line.ol_quantity)] }
             └─LogicalJoin { type: Inner, on: (order_line.ol_i_id = item.i_id), output: [item.i_id, order_line.ol_quantity] }
               ├─LogicalScan { table: item, output_columns: [item.i_id], required_columns: [item.i_id, item.i_data], predicate: Like(item.i_data, '%b':Varchar) }
@@ -2613,7 +2613,7 @@
             ├─BatchExchange { order: [], dist: HashShard(order_line.ol_i_id) }
             │ └─BatchProject { exprs: [order_line.ol_i_id, order_line.ol_amount, order_line.ol_quantity::Decimal as $expr1] }
             │   └─BatchScan { table: order_line, columns: [order_line.ol_i_id, order_line.ol_quantity, order_line.ol_amount], distribution: SomeShard }
-            └─BatchProject { exprs: [item.i_id, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr2] }
+            └─BatchProject { exprs: [item.i_id, Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr2] }
               └─BatchHashAgg { group_key: [item.i_id], aggs: [sum(order_line.ol_quantity), count(order_line.ol_quantity)] }
                 └─BatchHashJoin { type: Inner, predicate: item.i_id = order_line.ol_i_id, output: [item.i_id, order_line.ol_quantity] }
                   ├─BatchExchange { order: [], dist: HashShard(item.i_id) }
@@ -2634,7 +2634,7 @@
                   ├─StreamExchange { dist: HashShard(order_line.ol_i_id) }
                   │ └─StreamProject { exprs: [order_line.ol_i_id, order_line.ol_amount, order_line.ol_quantity::Decimal as $expr1, order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id, order_line.ol_number] }
                   │   └─StreamTableScan { table: order_line, columns: [order_line.ol_i_id, order_line.ol_quantity, order_line.ol_amount, order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id, order_line.ol_number], stream_scan_type: SnapshotBackfill, stream_key: [order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id, order_line.ol_number], pk: [ol_w_id, ol_d_id, ol_o_id, ol_number], dist: UpstreamHashShard(order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id, order_line.ol_number) }
-                  └─StreamProject { exprs: [item.i_id, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr2] }
+                  └─StreamProject { exprs: [item.i_id, Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr2] }
                     └─StreamHashAgg { group_key: [item.i_id], aggs: [sum(order_line.ol_quantity), count(order_line.ol_quantity), count] }
                       └─StreamHashJoin { type: Inner, predicate: item.i_id = order_line.ol_i_id, output: [item.i_id, order_line.ol_quantity, order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id, order_line.ol_number] }
                         ├─StreamExchange { dist: HashShard(item.i_id) }
@@ -2657,7 +2657,7 @@
         └── StreamFilter { predicate: ($expr1 < $expr2) }
             └── StreamHashJoin { type: Inner, predicate: order_line.ol_i_id = item.i_id, output: all } { tables: [ HashJoinLeft: 1, HashJoinDegreeLeft: 2, HashJoinRight: 3, HashJoinDegreeRight: 4 ] }
                 ├── StreamExchange Hash([0]) from 2
-                └── StreamProject { exprs: [item.i_id, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal) as $expr2] }
+                └── StreamProject { exprs: [item.i_id, Case((count(order_line.ol_quantity) = 0:Int32), null:Decimal, (sum(order_line.ol_quantity)::Decimal / count(order_line.ol_quantity)::Decimal)) as $expr2] }
                     └── StreamHashAgg { group_key: [item.i_id], aggs: [sum(order_line.ol_quantity), count(order_line.ol_quantity), count] } { tables: [ HashAggState: 6 ] }
                         └── StreamHashJoin { type: Inner, predicate: item.i_id = order_line.ol_i_id, output: [item.i_id, order_line.ol_quantity, order_line.ol_w_id, order_line.ol_d_id, order_line.ol_o_id, order_line.ol_number] }
                             ├── tables: [ HashJoinLeft: 7, HashJoinDegreeLeft: 8, HashJoinRight: 9, HashJoinDegreeRight: 10 ]
@@ -3340,7 +3340,7 @@
             │ └─LogicalProject { exprs: [orders.o_id, orders.o_d_id, orders.o_w_id, orders.o_c_id, orders.o_entry_d, orders.o_carrier_id, orders.o_ol_cnt, orders.o_all_local] }
             │   └─LogicalFilter { predicate: (orders.o_c_id = CorrelatedInputRef { index: 0, correlated_id: 1 }) AND (orders.o_w_id = CorrelatedInputRef { index: 2, correlated_id: 1 }) AND (orders.o_d_id = CorrelatedInputRef { index: 1, correlated_id: 1 }) }
             │     └─LogicalScan { table: orders, columns: [orders.o_id, orders.o_d_id, orders.o_w_id, orders.o_c_id, orders.o_entry_d, orders.o_carrier_id, orders.o_ol_cnt, orders.o_all_local, orders._rw_timestamp] }
-            └─LogicalProject { exprs: [(sum(customer.c_balance) / count(customer.c_balance)::Decimal) as $expr1] }
+            └─LogicalProject { exprs: [Case((count(customer.c_balance) = 0:Int32), null:Decimal, (sum(customer.c_balance) / count(customer.c_balance)::Decimal)) as $expr1] }
               └─LogicalAgg { aggs: [sum(customer.c_balance), count(customer.c_balance)] }
                 └─LogicalProject { exprs: [customer.c_balance] }
                   └─LogicalFilter { predicate: (customer.c_balance > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 1:Int32), '1':Varchar, '2':Varchar, '3':Varchar, '4':Varchar, '5':Varchar, '6':Varchar, '7':Varchar) }
@@ -3353,7 +3353,7 @@
         │ ├─LogicalScan { table: customer, output_columns: [customer.c_id, customer.c_d_id, customer.c_w_id, customer.c_state, customer.c_balance], required_columns: [customer.c_id, customer.c_d_id, customer.c_w_id, customer.c_state, customer.c_balance, customer.c_phone], predicate: In(Substr(customer.c_phone, 1:Int32, 1:Int32), '1':Varchar, '2':Varchar, '3':Varchar, '4':Varchar, '5':Varchar, '6':Varchar, '7':Varchar) }
         │ └─LogicalProject { exprs: [orders.o_c_id, orders.o_w_id, orders.o_d_id] }
         │   └─LogicalScan { table: orders, columns: [orders.o_d_id, orders.o_w_id, orders.o_c_id] }
-        └─LogicalProject { exprs: [(sum(customer.c_balance) / count(customer.c_balance)::Decimal) as $expr1] }
+        └─LogicalProject { exprs: [Case((count(customer.c_balance) = 0:Int32), null:Decimal, (sum(customer.c_balance) / count(customer.c_balance)::Decimal)) as $expr1] }
           └─LogicalAgg { aggs: [sum(customer.c_balance), count(customer.c_balance)] }
             └─LogicalScan { table: customer, output_columns: [customer.c_balance], required_columns: [customer.c_balance, customer.c_phone], predicate: (customer.c_balance > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 1:Int32), '1':Varchar, '2':Varchar, '3':Varchar, '4':Varchar, '5':Varchar, '6':Varchar, '7':Varchar) }
   batch_plan: |-
@@ -3372,7 +3372,7 @@
               │   └─BatchExchange { order: [], dist: HashShard(orders.o_c_id, orders.o_w_id, orders.o_d_id) }
               │     └─BatchProject { exprs: [orders.o_c_id, orders.o_w_id, orders.o_d_id] }
               │       └─BatchScan { table: orders, columns: [orders.o_d_id, orders.o_w_id, orders.o_c_id], distribution: SomeShard }
-              └─BatchProject { exprs: [(sum(sum(customer.c_balance)) / sum0(count(customer.c_balance))::Decimal) as $expr1] }
+              └─BatchProject { exprs: [Case((sum0(count(customer.c_balance)) = 0:Int32), null:Decimal, (sum(sum(customer.c_balance)) / sum0(count(customer.c_balance))::Decimal)) as $expr1] }
                 └─BatchSimpleAgg { aggs: [sum(sum(customer.c_balance)), sum0(count(customer.c_balance))] }
                   └─BatchExchange { order: [], dist: Single }
                     └─BatchSimpleAgg { aggs: [sum(customer.c_balance), count(customer.c_balance)] }
@@ -3394,7 +3394,7 @@
             │   └─StreamProject { exprs: [orders.o_c_id, orders.o_w_id, orders.o_d_id, orders.o_id] }
             │     └─StreamTableScan { table: orders, columns: [orders.o_d_id, orders.o_w_id, orders.o_c_id, orders.o_id], stream_scan_type: SnapshotBackfill, stream_key: [orders.o_w_id, orders.o_d_id, orders.o_id], pk: [o_w_id, o_d_id, o_id], dist: UpstreamHashShard(orders.o_w_id, orders.o_d_id, orders.o_id) }
             └─StreamExchange { dist: Broadcast }
-              └─StreamProject { exprs: [(sum(sum(customer.c_balance)) / sum0(count(customer.c_balance))::Decimal) as $expr1] }
+              └─StreamProject { exprs: [Case((sum0(count(customer.c_balance)) = 0:Int32), null:Decimal, (sum(sum(customer.c_balance)) / sum0(count(customer.c_balance))::Decimal)) as $expr1] }
                 └─StreamSimpleAgg [append_only] { aggs: [sum(sum(customer.c_balance)), sum0(count(customer.c_balance)), count] }
                   └─StreamExchange { dist: Single }
                     └─StreamStatelessSimpleAgg { aggs: [sum(customer.c_balance), count(customer.c_balance)] }

--- a/src/frontend/planner_test/tests/testdata/output/named_window.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/named_window.yaml
@@ -76,13 +76,13 @@
     window w1 as (partition by y order by x),
            w2 as (partition by z order by y);
   logical_plan: |-
-    LogicalProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1] }
+    LogicalProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1] }
     └─LogicalOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), sum(t.y) OVER(PARTITION BY t.z ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.y) OVER(PARTITION BY t.z ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
       └─LogicalProject { exprs: [t.x, t.y, t.z, t._row_id, t._rw_timestamp] }
         └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t._row_id, t._rw_timestamp] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1] }
+    └─BatchProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1] }
       └─BatchOverWindow { window_functions: [sum(t.y) OVER(PARTITION BY t.z ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.y) OVER(PARTITION BY t.z ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─BatchExchange { order: [t.z ASC, t.y ASC], dist: HashShard(t.z) }
           └─BatchSort { order: [t.z ASC, t.y ASC] }
@@ -92,7 +92,7 @@
                   └─BatchScan { table: t, columns: [t.x, t.y, t.z], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [x, y, z, sum, avg, t._row_id(hidden)], stream_key: [t._row_id, y, z], pk_columns: [t._row_id, y, z], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, t._row_id] }
+    └─StreamProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, t._row_id] }
       └─StreamOverWindow { window_functions: [sum(t.y) OVER(PARTITION BY t.z ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.y) OVER(PARTITION BY t.z ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(t.z) }
           └─StreamOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
@@ -177,20 +177,20 @@
     from t
     window w as (partition by y order by z);
   logical_plan: |-
-    LogicalProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, min, max, count] }
+    LogicalProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, min, max, count] }
     └─LogicalOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), min(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), max(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count() OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
       └─LogicalProject { exprs: [t.x, t.y, t.z, t._row_id, t._rw_timestamp] }
         └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t._row_id, t._rw_timestamp] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, min, max, count] }
+    └─BatchProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, min, max, count] }
       └─BatchOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), min(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), max(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count() OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─BatchExchange { order: [t.y ASC, t.z ASC], dist: HashShard(t.y) }
           └─BatchSort { order: [t.y ASC, t.z ASC] }
             └─BatchScan { table: t, columns: [t.x, t.y, t.z], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [x, y, z, sum, avg, min, max, count, t._row_id(hidden)], stream_key: [t._row_id, y], pk_columns: [t._row_id, y], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, min, max, count, t._row_id] }
+    └─StreamProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, min, max, count, t._row_id] }
       └─StreamOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), min(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), max(t.x) OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count() OVER(PARTITION BY t.y ORDER BY t.z ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(t.y) }
           └─StreamTableScan { table: t, columns: [t.x, t.y, t.z, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
@@ -269,13 +269,13 @@
     from t
     window w as (partition by y order by x);
   logical_plan: |-
-    LogicalProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, count] }
+    LogicalProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, count] }
     └─LogicalOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), sum(t.y) OVER(PARTITION BY t.z ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.y) OVER(PARTITION BY t.z ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
       └─LogicalProject { exprs: [t.x, t.y, t.z, t._row_id, t._rw_timestamp] }
         └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t._row_id, t._rw_timestamp] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, count] }
+    └─BatchProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, count] }
       └─BatchOverWindow { window_functions: [sum(t.y) OVER(PARTITION BY t.z ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.y) OVER(PARTITION BY t.z ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─BatchExchange { order: [t.z ASC, t.x ASC], dist: HashShard(t.z) }
           └─BatchSort { order: [t.z ASC, t.x ASC] }
@@ -285,7 +285,7 @@
                   └─BatchScan { table: t, columns: [t.x, t.y, t.z], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [x, y, z, sum, avg, count, t._row_id(hidden)], stream_key: [t._row_id, y, z], pk_columns: [t._row_id, y, z], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.x, t.y, t.z, sum, (sum::Decimal / count::Decimal) as $expr1, count, t._row_id] }
+    └─StreamProject { exprs: [t.x, t.y, t.z, sum, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr1, count, t._row_id] }
       └─StreamOverWindow { window_functions: [sum(t.y) OVER(PARTITION BY t.z ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count(t.y) OVER(PARTITION BY t.z ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(t.z) }
           └─StreamOverWindow { window_functions: [sum(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -237,7 +237,7 @@
     GROUP BY Q.category;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price))::Decimal) as $expr1] }
+    └─BatchProject { exprs: [auction.category, Case((count(max(bid.price)) = 0:Int32), null:Decimal, (sum(max(bid.price)) / count(max(bid.price))::Decimal)) as $expr1] }
       └─BatchHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price))] }
         └─BatchExchange { order: [], dist: HashShard(auction.category) }
           └─BatchHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price)] }
@@ -248,7 +248,7 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price))::Decimal) as $expr1] }
+    └─StreamProject { exprs: [auction.category, Case((count(max(bid.price)) = 0:Int32), null:Decimal, (sum(max(bid.price)) / count(max(bid.price))::Decimal)) as $expr1] }
       └─StreamHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price)), count] }
         └─StreamExchange { dist: HashShard(auction.category) }
           └─StreamProject { exprs: [auction.id, auction.category, max(bid.price)] }
@@ -263,15 +263,13 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price))::Decimal) as $expr1] }
-        └── StreamHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price)), count] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [auction.category, Case((count(max(bid.price)) = 0:Int32), null:Decimal, (sum(max(bid.price)) / count(max(bid.price))::Decimal)) as $expr1] }
+        └── StreamHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price)), count] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([1]) from 1
 
     Fragment 1
     StreamProject { exprs: [auction.id, auction.category, max(bid.price)] }
-    └── StreamHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price), count] }
-        ├── tables: [ HashAggState: 2, HashAggCall0: 1 ]
+    └── StreamHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price), count] } { tables: [ HashAggState: 2, HashAggCall0: 1 ] }
         └── StreamProject { exprs: [auction.id, auction.category, bid.price, bid._row_id] }
             └── StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
                 └── StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
@@ -487,7 +485,7 @@
     WHERE Q.rank <= 1;
   stream_plan: |-
     StreamMaterialize { columns: [seller, avg, auction.id(hidden)], stream_key: [auction.id, seller], pk_columns: [auction.id, seller], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [auction.seller, (sum / count::Decimal) as $expr1, auction.id] }
+    └─StreamProject { exprs: [auction.seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, auction.id] }
       └─StreamOverWindow { window_functions: [sum(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(auction.seller) }
           └─StreamProject { exprs: [auction.seller, bid.price, bid.date_time, auction.id] }
@@ -502,7 +500,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [seller, avg, auction.id(hidden)], stream_key: [auction.id, seller], pk_columns: [auction.id, seller], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [auction.seller, (sum / count::Decimal) as $expr1, auction.id] }
+    └── StreamProject { exprs: [auction.seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, auction.id] }
         └── StreamOverWindow { window_functions: [sum(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
@@ -561,7 +559,7 @@
     WHERE Q.rank <= 1
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [auction.seller, (sum / count::Decimal) as $expr1] }
+    └─BatchProject { exprs: [auction.seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1] }
       └─BatchOverWindow { window_functions: [sum(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─BatchExchange { order: [auction.seller ASC, bid.date_time ASC], dist: HashShard(auction.seller) }
           └─BatchSort { order: [auction.seller ASC, bid.date_time ASC] }
@@ -576,7 +574,7 @@
                         └─BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [seller, avg, auction.id(hidden)], stream_key: [auction.id, seller], pk_columns: [auction.id, seller], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [auction.seller, (sum / count::Decimal) as $expr1, auction.id] }
+    └─StreamProject { exprs: [auction.seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, auction.id] }
       └─StreamOverWindow { window_functions: [sum(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(auction.seller) }
           └─StreamProject { exprs: [auction.seller, bid.price, bid.date_time, auction.id] }
@@ -591,7 +589,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [seller, avg, auction.id(hidden)], stream_key: [auction.id, seller], pk_columns: [auction.id, seller], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [auction.seller, (sum / count::Decimal) as $expr1, auction.id] }
+    └── StreamProject { exprs: [auction.seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, auction.id] }
         └── StreamOverWindow { window_functions: [sum(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(bid.price) OVER(PARTITION BY auction.seller ORDER BY bid.date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
@@ -1441,14 +1439,14 @@
     GROUP BY auction, to_char(date_time, 'YYYY-MM-DD');
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
+    └─BatchProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), Case((count(bid.price) = 0:Int32), null:Decimal, (sum(bid.price) / count(bid.price)::Decimal)) as $expr2, sum(bid.price)] }
       └─BatchHashAgg { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
         └─BatchExchange { order: [], dist: HashShard(bid.auction, $expr1) }
           └─BatchProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, bid.price] }
             └─BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
+    └─StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), Case((count(bid.price) = 0:Int32), null:Decimal, (sum(bid.price) / count(bid.price)::Decimal)) as $expr2, sum(bid.price)] }
       └─StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
         └─StreamExchange { dist: HashShard(bid.auction, $expr1) }
           └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, bid.price, bid._row_id] }
@@ -1456,9 +1454,8 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-        └── StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), Case((count(bid.price) = 0:Int32), null:Decimal, (sum(bid.price) / count(bid.price)::Decimal)) as $expr2, sum(bid.price)] }
+        └── StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([0, 1]) from 1
 
     Fragment 1

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
@@ -249,7 +249,7 @@
     GROUP BY Q.category;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [category, (sum(max(price)) / count(max(price))::Decimal) as $expr1] }
+    └─BatchProject { exprs: [category, Case((count(max(price)) = 0:Int32), null:Decimal, (sum(max(price)) / count(max(price))::Decimal)) as $expr1] }
       └─BatchHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price))] }
         └─BatchExchange { order: [], dist: HashShard(category) }
           └─BatchHashAgg { group_key: [id, category], aggs: [max(price)] }
@@ -260,7 +260,7 @@
                 └─BatchSource { source: bid, columns: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [category, (sum(max(price)) / count(max(price))::Decimal) as $expr1] }
+    └─StreamProject { exprs: [category, Case((count(max(price)) = 0:Int32), null:Decimal, (sum(max(price)) / count(max(price))::Decimal)) as $expr1] }
       └─StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
         └─StreamExchange { dist: HashShard(category) }
           └─StreamProject { exprs: [id, category, max(price)] }
@@ -277,15 +277,13 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [category, (sum(max(price)) / count(max(price))::Decimal) as $expr1] }
-        └── StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [category, Case((count(max(price)) = 0:Int32), null:Decimal, (sum(max(price)) / count(max(price))::Decimal)) as $expr1] }
+        └── StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([1]) from 1
 
     Fragment 1
     StreamProject { exprs: [id, category, max(price)] }
-    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
-        ├── tables: [ HashAggState: 1 ]
+    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] } { tables: [ HashAggState: 1 ] }
         └── StreamProject { exprs: [id, category, price, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                 └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
@@ -550,7 +548,7 @@
     WHERE Q.rank <= 1;
   stream_plan: |-
     StreamMaterialize { columns: [seller, avg, id(hidden)], stream_key: [id, seller], pk_columns: [id, seller], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [seller, (sum / count::Decimal) as $expr1, id] }
+    └─StreamProject { exprs: [seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, id] }
       └─StreamOverWindow { window_functions: [sum(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(seller) }
           └─StreamProject { exprs: [seller, price, date_time, id] }
@@ -567,7 +565,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [seller, avg, id(hidden)], stream_key: [id, seller], pk_columns: [id, seller], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [seller, (sum / count::Decimal) as $expr1, id] }
+    └── StreamProject { exprs: [seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, id] }
         └── StreamOverWindow { window_functions: [sum(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
@@ -1429,14 +1427,14 @@
     GROUP BY auction, to_char(date_time, 'YYYY-MM-DD');
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
+    └─BatchProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), Case((count(price) = 0:Int32), null:Decimal, (sum(price) / count(price)::Decimal)) as $expr2, sum(price)] }
       └─BatchHashAgg { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─BatchExchange { order: [], dist: HashShard(auction, $expr1) }
           └─BatchProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price] }
             └─BatchSource { source: bid, columns: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
+    └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), Case((count(price) = 0:Int32), null:Decimal, (sum(price) / count(price)::Decimal)) as $expr2, sum(price)] }
       └─StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
@@ -1445,9 +1443,8 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), Case((count(price) = 0:Int32), null:Decimal, (sum(price) / count(price)::Decimal)) as $expr2, sum(price)] }
+        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
@@ -1464,12 +1461,7 @@
 
     Table 1 { columns: [ partition_id, offset_info, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
 
-    Table 4294967294
-    ├── columns: [ auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price, _rw_timestamp ]
-    ├── primary key: [ $0 ASC, $1 ASC ]
-    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
-    ├── distribution key: [ 0, 1 ]
-    └── read pk prefix len hint: 2
+    Table 4294967294 { columns: [ auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], distribution key: [ 0, 1 ], read pk prefix len hint: 2 }
 
 - id: nexmark_q18
   before:

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source_kafka.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source_kafka.yaml
@@ -261,7 +261,7 @@
     GROUP BY Q.category;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [category, (sum(max(price)) / count(max(price))::Decimal) as $expr1] }
+    └─BatchProject { exprs: [category, Case((count(max(price)) = 0:Int32), null:Decimal, (sum(max(price)) / count(max(price))::Decimal)) as $expr1] }
       └─BatchHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price))] }
         └─BatchExchange { order: [], dist: HashShard(category) }
           └─BatchHashAgg { group_key: [id, category], aggs: [max(price)] }
@@ -272,7 +272,7 @@
                 └─BatchKafkaScan { source: bid, columns: [auction, bidder, price, channel, url, date_time, extra, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id], filter: (None, None) }
   stream_plan: |-
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [category, (sum(max(price)) / count(max(price))::Decimal) as $expr1] }
+    └─StreamProject { exprs: [category, Case((count(max(price)) = 0:Int32), null:Decimal, (sum(max(price)) / count(max(price))::Decimal)) as $expr1] }
       └─StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
         └─StreamExchange { dist: HashShard(category) }
           └─StreamProject { exprs: [id, category, max(price)] }
@@ -289,15 +289,13 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [category, (sum(max(price)) / count(max(price))::Decimal) as $expr1] }
-        └── StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [category, Case((count(max(price)) = 0:Int32), null:Decimal, (sum(max(price)) / count(max(price))::Decimal)) as $expr1] }
+        └── StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([1]) from 1
 
     Fragment 1
     StreamProject { exprs: [id, category, max(price)] }
-    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
-        ├── tables: [ HashAggState: 1 ]
+    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] } { tables: [ HashAggState: 1 ] }
         └── StreamProject { exprs: [id, category, price, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                 └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
@@ -531,7 +529,7 @@
     WHERE Q.rank <= 1;
   stream_plan: |-
     StreamMaterialize { columns: [seller, avg, id(hidden)], stream_key: [id, seller], pk_columns: [id, seller], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [seller, (sum / count::Decimal) as $expr1, id] }
+    └─StreamProject { exprs: [seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, id] }
       └─StreamOverWindow { window_functions: [sum(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard(seller) }
           └─StreamProject { exprs: [seller, price, date_time, id] }
@@ -548,7 +546,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [seller, avg, id(hidden)], stream_key: [id, seller], pk_columns: [id, seller], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [seller, (sum / count::Decimal) as $expr1, id] }
+    └── StreamProject { exprs: [seller, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr1, id] }
         └── StreamOverWindow { window_functions: [sum(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count(price) OVER(PARTITION BY seller ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
@@ -1437,14 +1435,14 @@
     GROUP BY auction, to_char(date_time, 'YYYY-MM-DD');
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
+    └─BatchProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), Case((count(price) = 0:Int32), null:Decimal, (sum(price) / count(price)::Decimal)) as $expr2, sum(price)] }
       └─BatchHashAgg { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─BatchExchange { order: [], dist: HashShard(auction, $expr1) }
           └─BatchProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price] }
             └─BatchKafkaScan { source: bid, columns: [auction, bidder, price, channel, url, date_time, extra, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id], filter: (None, None) }
   stream_plan: |-
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
+    └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), Case((count(price) = 0:Int32), null:Decimal, (sum(price) / count(price)::Decimal)) as $expr2, sum(price)] }
       └─StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
@@ -1453,9 +1451,8 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), Case((count(price) = 0:Int32), null:Decimal, (sum(price) / count(price)::Decimal)) as $expr2, sum(price)] }
+        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
@@ -1473,12 +1470,7 @@
 
     Table 1 { columns: [ partition_id, backfill_progress, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
 
-    Table 4294967294
-    ├── columns: [ auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price, _rw_timestamp ]
-    ├── primary key: [ $0 ASC, $1 ASC ]
-    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
-    ├── distribution key: [ 0, 1 ]
-    └── read pk prefix len hint: 2
+    Table 4294967294 { columns: [ auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], distribution key: [ 0, 1 ], read pk prefix len hint: 2 }
 
 - id: nexmark_q18
   before:

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_temporal_filter.yaml
@@ -168,7 +168,7 @@
     GROUP BY Q.category;
   stream_plan: |-
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr5, (sum(max($expr8)) / count(max($expr8))::Decimal) as $expr10] }
+    └─StreamProject { exprs: [$expr5, Case((count(max($expr8)) = 0:Int32), null:Decimal, (sum(max($expr8)) / count(max($expr8))::Decimal)) as $expr10] }
       └─StreamHashAgg { group_key: [$expr5], aggs: [sum(max($expr8)), count(max($expr8)), count] }
         └─StreamExchange { dist: HashShard($expr5) }
           └─StreamProject { exprs: [$expr2, $expr5, max($expr8)] }
@@ -201,15 +201,13 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr5, (sum(max($expr8)) / count(max($expr8))::Decimal) as $expr10] }
-        └── StreamHashAgg { group_key: [$expr5], aggs: [sum(max($expr8)), count(max($expr8)), count] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [$expr5, Case((count(max($expr8)) = 0:Int32), null:Decimal, (sum(max($expr8)) / count(max($expr8))::Decimal)) as $expr10] }
+        └── StreamHashAgg { group_key: [$expr5], aggs: [sum(max($expr8)), count(max($expr8)), count] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([1]) from 1
 
     Fragment 1
     StreamProject { exprs: [$expr2, $expr5, max($expr8)] }
-    └── StreamHashAgg { group_key: [$expr2, $expr5], aggs: [max($expr8), count] }
-        ├── tables: [ HashAggState: 2, HashAggCall0: 1 ]
+    └── StreamHashAgg { group_key: [$expr2, $expr5], aggs: [max($expr8), count] } { tables: [ HashAggState: 2, HashAggCall0: 1 ] }
         └── StreamProject { exprs: [$expr2, $expr5, $expr8, _row_id, _row_id] }
             └── StreamFilter { predicate: ($expr9 >= $expr3) AND ($expr9 <= $expr4) }
                 └── StreamHashJoin { type: Inner, predicate: $expr2 = $expr7, output: all }
@@ -473,7 +471,7 @@
     WHERE Q.rank <= 1;
   stream_plan: |-
     StreamMaterialize { columns: [seller, avg, $expr2(hidden)], stream_key: [$expr2, seller], pk_columns: [$expr2, seller], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr5, (sum / count::Decimal) as $expr10, $expr2] }
+    └─StreamProject { exprs: [$expr5, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr10, $expr2] }
       └─StreamOverWindow { window_functions: [sum($expr8) OVER(PARTITION BY $expr5 ORDER BY $expr9 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr8) OVER(PARTITION BY $expr5 ORDER BY $expr9 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard($expr5) }
           └─StreamProject { exprs: [$expr5, $expr8, $expr9, $expr2] }
@@ -506,7 +504,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [seller, avg, $expr2(hidden)], stream_key: [$expr2, seller], pk_columns: [$expr2, seller], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr5, (sum / count::Decimal) as $expr10, $expr2] }
+    └── StreamProject { exprs: [$expr5, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr10, $expr2] }
         └── StreamOverWindow { window_functions: [sum($expr8) OVER(PARTITION BY $expr5 ORDER BY $expr9 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr8) OVER(PARTITION BY $expr5 ORDER BY $expr9 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -215,7 +215,7 @@
     GROUP BY Q.category;
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [$expr4, (sum(max($expr7)) / count(max($expr7))::Decimal) as $expr8] }
+    └─BatchProject { exprs: [$expr4, Case((count(max($expr7)) = 0:Int32), null:Decimal, (sum(max($expr7)) / count(max($expr7))::Decimal)) as $expr8] }
       └─BatchHashAgg { group_key: [$expr4], aggs: [sum(max($expr7)), count(max($expr7))] }
         └─BatchExchange { order: [], dist: HashShard($expr4) }
           └─BatchHashAgg { group_key: [$expr2, $expr4], aggs: [max($expr7)] }
@@ -232,7 +232,7 @@
                       └─BatchSource { source: nexmark, columns: [event_type, person, auction, bid, _row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr4, (sum(max($expr6)) / count(max($expr6))::Decimal) as $expr7] }
+    └─StreamProject { exprs: [$expr4, Case((count(max($expr6)) = 0:Int32), null:Decimal, (sum(max($expr6)) / count(max($expr6))::Decimal)) as $expr7] }
       └─StreamHashAgg { group_key: [$expr4], aggs: [sum(max($expr6)), count(max($expr6)), count] }
         └─StreamExchange { dist: HashShard($expr4) }
           └─StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
@@ -261,9 +261,8 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [category, avg], stream_key: [category], pk_columns: [category], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr4, (sum(max($expr6)) / count(max($expr6))::Decimal) as $expr7] }
-        └── StreamHashAgg { group_key: [$expr4], aggs: [sum(max($expr6)), count(max($expr6)), count] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [$expr4, Case((count(max($expr6)) = 0:Int32), null:Decimal, (sum(max($expr6)) / count(max($expr6))::Decimal)) as $expr7] }
+        └── StreamHashAgg { group_key: [$expr4], aggs: [sum(max($expr6)), count(max($expr6)), count] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([1]) from 1
 
     Fragment 1
@@ -534,7 +533,7 @@
     WHERE Q.rank <= 1;
   stream_plan: |-
     StreamMaterialize { columns: [seller, avg, $expr2(hidden)], stream_key: [$expr2, seller], pk_columns: [$expr2, seller], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr4, (sum / count::Decimal) as $expr7, $expr2] }
+    └─StreamProject { exprs: [$expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr7, $expr2] }
       └─StreamOverWindow { window_functions: [sum($expr6) OVER(PARTITION BY $expr4 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr6) OVER(PARTITION BY $expr4 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard($expr4) }
           └─StreamProject { exprs: [$expr4, $expr6, $expr1, $expr2] }
@@ -563,7 +562,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [seller, avg, $expr2(hidden)], stream_key: [$expr2, seller], pk_columns: [$expr2, seller], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr4, (sum / count::Decimal) as $expr7, $expr2] }
+    └── StreamProject { exprs: [$expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr7, $expr2] }
         └── StreamOverWindow { window_functions: [sum($expr6) OVER(PARTITION BY $expr4 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr6) OVER(PARTITION BY $expr4 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
@@ -1378,7 +1377,7 @@
     GROUP BY auction, to_char(date_time, 'YYYY-MM-DD');
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
+    └─BatchProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), Case((count($expr4) = 0:Int32), null:Decimal, (sum($expr4) / count($expr4)::Decimal)) as $expr5, sum($expr4)] }
       └─BatchHashAgg { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
         └─BatchExchange { order: [], dist: HashShard($expr2, $expr3) }
           └─BatchProject { exprs: [Field(bid, 0:Int32) as $expr2, ToChar($expr1, 'YYYY-MM-DD':Varchar) as $expr3, Field(bid, 2:Int32) as $expr4] }
@@ -1387,7 +1386,7 @@
                 └─BatchSource { source: nexmark, columns: [event_type, person, auction, bid, _row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
+    └─StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), Case((count($expr4) = 0:Int32), null:Decimal, (sum($expr4) / count($expr4)::Decimal)) as $expr5, sum($expr4)] }
       └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
         └─StreamExchange { dist: HashShard($expr2, $expr3) }
           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, ToChar($expr1, 'YYYY-MM-DD':Varchar) as $expr3, Field(bid, 2:Int32) as $expr4, _row_id] }
@@ -1399,9 +1398,8 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
-            ├── tables: [ HashAggState: 0 ]
+    └── StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), Case((count($expr4) = 0:Int32), null:Decimal, (sum($expr4) / count($expr4)::Decimal)) as $expr5, sum($expr4)] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] } { tables: [ HashAggState: 0 ] }
             └── StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
@@ -1423,12 +1421,7 @@
 
     Table 2 { columns: [ partition_id, offset_info, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
 
-    Table 4294967294
-    ├── columns: [ auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price, _rw_timestamp ]
-    ├── primary key: [ $0 ASC, $1 ASC ]
-    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
-    ├── distribution key: [ 0, 1 ]
-    └── read pk prefix len hint: 2
+    Table 4294967294 { columns: [ auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], distribution key: [ 0, 1 ], read pk prefix len hint: 2 }
 
   eowc_stream_error: |-
     Not supported: Emit-On-Window-Close mode requires a watermark column in GROUP BY.
@@ -2599,7 +2592,7 @@
     WHERE
         auction % 100 = 0;
   logical_plan: |-
-    LogicalProject { exprs: [$expr1, $expr2, date_time, $expr3, (sum / count::Decimal) as $expr7, max] }
+    LogicalProject { exprs: [$expr1, $expr2, date_time, $expr3, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr7, max] }
     └─LogicalOverWindow { window_functions: [sum($expr3) OVER(PARTITION BY $expr1 ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr3) OVER(PARTITION BY $expr1 ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr3) OVER(PARTITION BY $expr1 ORDER BY date_time ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
       └─LogicalProject { exprs: [$expr1, $expr2, $expr3, $expr4, $expr5, date_time, $expr6] }
         └─LogicalFilter { predicate: (($expr1 % 100:Int32) = 0:Int32) }
@@ -2609,7 +2602,7 @@
                 └─LogicalSource { source: nexmark, is_shared: false, columns: [event_type, person, auction, bid, date_time, _row_id] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [$expr2, $expr3, $expr1, $expr4, (sum / count::Decimal) as $expr5, max] }
+    └─BatchProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max] }
       └─BatchOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─BatchExchange { order: [$expr2 ASC, $expr1 ASC], dist: HashShard($expr2) }
           └─BatchSort { order: [$expr2 ASC, $expr1 ASC] }
@@ -2619,7 +2612,7 @@
                   └─BatchSource { source: nexmark, columns: [event_type, person, auction, bid, _row_id] }
   stream_plan: |-
     StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, (sum / count::Decimal) as $expr5, max, _row_id] }
+    └─StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id] }
       └─StreamOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamExchange { dist: HashShard($expr2) }
           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, $expr1, _row_id], output_watermarks: [[$expr1]] }
@@ -2631,7 +2624,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, (sum / count::Decimal) as $expr5, max, _row_id] }
+    └── StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id] }
         └── StreamOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
@@ -2654,7 +2647,7 @@
 
   eowc_stream_plan: |-
     StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, (sum / count::Decimal) as $expr5, max, _row_id] }
+    └─StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id] }
       └─StreamEowcOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
         └─StreamEowcSort { sort_column: $expr1 }
           └─StreamExchange { dist: HashShard($expr2) }

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -364,20 +364,20 @@
   logical_plan: |-
     LogicalProject { exprs: [t.x, t.y, t.z, $expr4] }
     └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ($expr4 <= 3.0:Decimal) }
-      └─LogicalProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4] }
+      └─LogicalProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4] }
         └─LogicalOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
           └─LogicalProject { exprs: [t.x, t.y, t.z, t.w, t._row_id, t._rw_timestamp, (t.z * t.z) as $expr1, (t.y + 1:Int32) as $expr2, Abs(t.w) as $expr3] }
             └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t.w, t._row_id, t._rw_timestamp] }
   optimized_logical_plan_for_batch: |-
-    LogicalProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4] }
-    └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ((sum::Decimal / count::Decimal) <= 3.0:Decimal) }
+    LogicalProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4] }
+    └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) <= 3.0:Decimal) }
       └─LogicalOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
         └─LogicalProject { exprs: [t.x, t.y, t.z, (t.z * t.z) as $expr1, (t.y + 1:Int32) as $expr2, Abs(t.w) as $expr3] }
           └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t.w] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4] }
-      └─BatchFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ((sum::Decimal / count::Decimal) <= 3.0:Decimal) }
+    └─BatchProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4] }
+      └─BatchFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) <= 3.0:Decimal) }
         └─BatchOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
           └─BatchExchange { order: [$expr2 ASC, $expr3 ASC], dist: HashShard($expr2) }
             └─BatchSort { order: [$expr2 ASC, $expr3 ASC] }
@@ -385,12 +385,34 @@
                 └─BatchScan { table: t, columns: [t.x, t.y, t.z, t.w], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [x, y, z, res, t._row_id(hidden), $expr2(hidden)], stream_key: [t._row_id, $expr2], pk_columns: [t._row_id, $expr2], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.x, t.y, t.z, (sum::Decimal / count::Decimal) as $expr4, t._row_id, $expr2] }
-      └─StreamFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND ((sum::Decimal / count::Decimal) <= 3.0:Decimal) }
+    └─StreamProject { exprs: [t.x, t.y, t.z, Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) as $expr4, t._row_id, $expr2] }
+      └─StreamFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (Case((count = 0:Int32), null:Decimal, (sum::Decimal / count::Decimal)) <= 3.0:Decimal) }
         └─StreamOverWindow { window_functions: [sum($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), count($expr1) OVER(PARTITION BY $expr2 ORDER BY $expr3 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
           └─StreamExchange { dist: HashShard($expr2) }
             └─StreamProject { exprs: [t.x, t.y, t.z, (t.z * t.z) as $expr1, (t.y + 1:Int32) as $expr2, Abs(t.w) as $expr3, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.x, t.y, t.z, t.w, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: avg aggregate over preceding-only frame
+  sql: |
+    create table t(id int, grp int, val double precision);
+    select id, avg(val) over(PARTITION BY grp ORDER BY id ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [t.id, Case((count = 0:Int32), null:Float64, (sum / count::Float64)) as $expr1] }
+    └─LogicalOverWindow { window_functions: [sum(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING), count(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING)] }
+      └─LogicalProject { exprs: [t.id, t.grp, t.val, t._row_id, t._rw_timestamp] }
+        └─LogicalScan { table: t, columns: [t.id, t.grp, t.val, t._row_id, t._rw_timestamp] }
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [t.id, Case((count = 0:Int32), null:Float64, (sum / count::Float64)) as $expr1] }
+      └─BatchOverWindow { window_functions: [sum(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING), count(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING)] }
+        └─BatchExchange { order: [t.grp ASC, t.id ASC], dist: HashShard(t.grp) }
+          └─BatchSort { order: [t.grp ASC, t.id ASC] }
+            └─BatchScan { table: t, columns: [t.id, t.grp, t.val], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [id, avg, t._row_id(hidden), t.grp(hidden)], stream_key: [t._row_id, t.grp], pk_columns: [t._row_id, t.grp], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.id, Case((count = 0:Int32), null:Float64, (sum / count::Float64)) as $expr1, t._row_id, t.grp] }
+      └─StreamOverWindow { window_functions: [sum(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING), count(t.val) OVER(PARTITION BY t.grp ORDER BY t.id ASC ROWS BETWEEN 3 PRECEDING AND 1 PRECEDING)] }
+        └─StreamExchange { dist: HashShard(t.grp) }
+          └─StreamTableScan { table: t, columns: [t.id, t.grp, t.val, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
 - id: row_number with empty over clause
   sql: |
     create table t(x int);

--- a/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery_expr_correlated.yaml
@@ -1147,40 +1147,11 @@
     WHERE T.A > (SELECT avg(c) FROM T2 WHERE B = D);
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchHashJoin { type: Inner, predicate: t.b = t2.d AND ($expr1 > $expr2), output: [t.a, t.b] }
-      ├─BatchExchange { order: [], dist: HashShard(t.b) }
-      │ └─BatchProject { exprs: [t.a, t.b, t.a::Decimal as $expr1] }
-      │   └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
-      └─BatchProject { exprs: [(sum(t2.c)::Decimal / count(t2.c)::Decimal) as $expr2, t2.d] }
-        └─BatchHashAgg { group_key: [t2.d], aggs: [sum(t2.c), count(t2.c)] }
-          └─BatchExchange { order: [], dist: HashShard(t2.d) }
-            └─BatchScan { table: t2, columns: [t2.c, t2.d], distribution: SomeShard }
-  stream_plan: |-
-    StreamMaterialize { columns: [a, b, t._row_id(hidden), t2.d(hidden)], stream_key: [t._row_id, b], pk_columns: [t._row_id, b], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.a, t.b, t._row_id, t2.d] }
-      └─StreamFilter { predicate: ($expr1 > $expr2) }
-        └─StreamHashJoin { type: Inner, predicate: t.b = t2.d, output: all }
-          ├─StreamExchange { dist: HashShard(t.b) }
-          │ └─StreamProject { exprs: [t.a, t.b, t.a::Decimal as $expr1, t._row_id] }
-          │   └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-          └─StreamProject { exprs: [(sum(t2.c)::Decimal / count(t2.c)::Decimal) as $expr2, t2.d] }
-            └─StreamHashAgg { group_key: [t2.d], aggs: [sum(t2.c), count(t2.c), count] }
-              └─StreamExchange { dist: HashShard(t2.d) }
-                └─StreamTableScan { table: t2, columns: [t2.c, t2.d, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
-- name: a case can't be optimized by PullUpCorrelatedPredicateAggRule
-  sql: |
-    CREATE TABLE T (A INT, B INT);
-    CREATE TABLE T2 (C INT, D INT);
-    SELECT * FROM T
-    -- Coalesce is not null-propagating
-    WHERE T.A > (SELECT coalesce(avg(c), 114514) FROM T2 WHERE B = D);
-  batch_plan: |-
-    BatchExchange { order: [], dist: Single }
     └─BatchHashJoin { type: Inner, predicate: t.b IS NOT DISTINCT FROM t.b AND ($expr1 > $expr2), output: [t.a, t.b] }
       ├─BatchExchange { order: [], dist: HashShard(t.b) }
       │ └─BatchProject { exprs: [t.a, t.b, t.a::Decimal as $expr1] }
       │   └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
-      └─BatchProject { exprs: [t.b, Coalesce((sum(t2.c)::Decimal / count(t2.c)::Decimal), 114514:Decimal) as $expr2] }
+      └─BatchProject { exprs: [t.b, Case((count(t2.c) = 0:Int32), null:Decimal, (sum(t2.c)::Decimal / count(t2.c)::Decimal)) as $expr2] }
         └─BatchHashAgg { group_key: [t.b], aggs: [sum(t2.c), count(t2.c)] }
           └─BatchHashJoin { type: LeftOuter, predicate: t.b IS NOT DISTINCT FROM t2.d, output: [t.b, t2.c] }
             ├─BatchHashAgg { group_key: [t.b], aggs: [] }
@@ -1198,7 +1169,49 @@
           ├─StreamExchange { dist: HashShard(t.b) }
           │ └─StreamProject { exprs: [t.a, t.b, t.a::Decimal as $expr1, t._row_id] }
           │   └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-          └─StreamProject { exprs: [t.b, Coalesce((sum(t2.c)::Decimal / count(t2.c)::Decimal), 114514:Decimal) as $expr2] }
+          └─StreamProject { exprs: [t.b, Case((count(t2.c) = 0:Int32), null:Decimal, (sum(t2.c)::Decimal / count(t2.c)::Decimal)) as $expr2] }
+            └─StreamHashAgg { group_key: [t.b], aggs: [sum(t2.c), count(t2.c), count] }
+              └─StreamHashJoin { type: LeftOuter, predicate: t.b IS NOT DISTINCT FROM t2.d, output: [t.b, t2.c, t2._row_id] }
+                ├─StreamProject { exprs: [t.b], noop_update_hint: true }
+                │ └─StreamHashAgg { group_key: [t.b], aggs: [count] }
+                │   └─StreamExchange { dist: HashShard(t.b) }
+                │     └─StreamTableScan { table: t, columns: [t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+                └─StreamExchange { dist: HashShard(t2.d) }
+                  └─StreamProject { exprs: [t2.d, t2.c, t2._row_id] }
+                    └─StreamFilter { predicate: IsNotNull(t2.d) }
+                      └─StreamTableScan { table: t2, columns: [t2.c, t2.d, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }
+- name: a case can't be optimized by PullUpCorrelatedPredicateAggRule
+  sql: |
+    CREATE TABLE T (A INT, B INT);
+    CREATE TABLE T2 (C INT, D INT);
+    SELECT * FROM T
+    -- Coalesce is not null-propagating
+    WHERE T.A > (SELECT coalesce(avg(c), 114514) FROM T2 WHERE B = D);
+  batch_plan: |-
+    BatchExchange { order: [], dist: Single }
+    └─BatchHashJoin { type: Inner, predicate: t.b IS NOT DISTINCT FROM t.b AND ($expr1 > $expr2), output: [t.a, t.b] }
+      ├─BatchExchange { order: [], dist: HashShard(t.b) }
+      │ └─BatchProject { exprs: [t.a, t.b, t.a::Decimal as $expr1] }
+      │   └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
+      └─BatchProject { exprs: [t.b, Coalesce(Case((count(t2.c) = 0:Int32), null:Decimal, (sum(t2.c)::Decimal / count(t2.c)::Decimal)), 114514:Decimal) as $expr2] }
+        └─BatchHashAgg { group_key: [t.b], aggs: [sum(t2.c), count(t2.c)] }
+          └─BatchHashJoin { type: LeftOuter, predicate: t.b IS NOT DISTINCT FROM t2.d, output: [t.b, t2.c] }
+            ├─BatchHashAgg { group_key: [t.b], aggs: [] }
+            │ └─BatchExchange { order: [], dist: HashShard(t.b) }
+            │   └─BatchScan { table: t, columns: [t.b], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: HashShard(t2.d) }
+              └─BatchProject { exprs: [t2.d, t2.c] }
+                └─BatchFilter { predicate: IsNotNull(t2.d) }
+                  └─BatchScan { table: t2, columns: [t2.c, t2.d], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, t._row_id(hidden), t.b(hidden)], stream_key: [t._row_id, b], pk_columns: [t._row_id, b], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.a, t.b, t._row_id, t.b] }
+      └─StreamFilter { predicate: ($expr1 > $expr2) }
+        └─StreamHashJoin { type: Inner, predicate: t.b IS NOT DISTINCT FROM t.b, output: all }
+          ├─StreamExchange { dist: HashShard(t.b) }
+          │ └─StreamProject { exprs: [t.a, t.b, t.a::Decimal as $expr1, t._row_id] }
+          │   └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+          └─StreamProject { exprs: [t.b, Coalesce(Case((count(t2.c) = 0:Int32), null:Decimal, (sum(t2.c)::Decimal / count(t2.c)::Decimal)), 114514:Decimal) as $expr2] }
             └─StreamHashAgg { group_key: [t.b], aggs: [sum(t2.c), count(t2.c), count] }
               └─StreamHashJoin { type: LeftOuter, predicate: t.b IS NOT DISTINCT FROM t2.d, output: [t.b, t2.c, t2._row_id] }
                 ├─StreamProject { exprs: [t.b], noop_update_hint: true }
@@ -1223,7 +1236,7 @@
       │ └─BatchProject { exprs: [t.a, t.b, t.a::Decimal as $expr1] }
       │   └─BatchFilter { predicate: null:Boolean }
       │     └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
-      └─BatchProject { exprs: [Coalesce((sum(t2.c)::Decimal / count(t2.c)::Decimal), 114514:Decimal) as $expr2, t2.d] }
+      └─BatchProject { exprs: [Coalesce(Case((count(t2.c) = 0:Int32), null:Decimal, (sum(t2.c)::Decimal / count(t2.c)::Decimal)), 114514:Decimal) as $expr2, t2.d] }
         └─BatchHashAgg { group_key: [t2.d], aggs: [sum(t2.c), count(t2.c)] }
           └─BatchExchange { order: [], dist: HashShard(t2.d) }
             └─BatchFilter { predicate: null:Boolean }
@@ -1237,7 +1250,7 @@
           │ └─StreamProject { exprs: [t.a, t.b, t.a::Decimal as $expr1, t._row_id] }
           │   └─StreamFilter { predicate: null:Boolean }
           │     └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
-          └─StreamProject { exprs: [Coalesce((sum(t2.c)::Decimal / count(t2.c)::Decimal), 114514:Decimal) as $expr2, t2.d] }
+          └─StreamProject { exprs: [Coalesce(Case((count(t2.c) = 0:Int32), null:Decimal, (sum(t2.c)::Decimal / count(t2.c)::Decimal)), 114514:Decimal) as $expr2, t2.d] }
             └─StreamHashAgg { group_key: [t2.d], aggs: [sum(t2.c), count(t2.c), count] }
               └─StreamExchange { dist: HashShard(t2.d) }
                 └─StreamFilter { predicate: null:Boolean }

--- a/src/frontend/planner_test/tests/testdata/output/time_window.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/time_window.yaml
@@ -137,7 +137,7 @@
     create table t (v1 varchar, v2 timestamp, v3 float);
     select v1, window_end, avg(v3) as avg from hop( t, v2, interval '1' minute, interval '10' minute) group by v1, window_end;
   logical_plan: |-
-    LogicalProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3)::Float64) as $expr1] }
+    LogicalProject { exprs: [t.v1, window_end, Case((count(t.v3) = 0:Int32), null:Float64, (sum(t.v3) / count(t.v3)::Float64)) as $expr1] }
     └─LogicalAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
       └─LogicalProject { exprs: [t.v1, window_end, t.v3] }
         └─LogicalHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: all }
@@ -145,7 +145,7 @@
             └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id, t._rw_timestamp] }
   batch_plan: |-
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3)::Float64) as $expr1] }
+    └─BatchProject { exprs: [t.v1, window_end, Case((count(t.v3) = 0:Int32), null:Float64, (sum(t.v3) / count(t.v3)::Float64)) as $expr1] }
       └─BatchHashAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
         └─BatchHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end] }
           └─BatchExchange { order: [], dist: HashShard(t.v1) }
@@ -153,7 +153,7 @@
               └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [v1, window_end, avg], stream_key: [v1, window_end], pk_columns: [v1, window_end], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3)::Float64) as $expr1] }
+    └─StreamProject { exprs: [t.v1, window_end, Case((count(t.v3) = 0:Int32), null:Float64, (sum(t.v3) / count(t.v3)::Float64)) as $expr1] }
       └─StreamHashAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3), count] }
         └─StreamExchange { dist: HashShard(t.v1, window_end) }
           └─StreamHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end, t._row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch.yaml
@@ -121,14 +121,14 @@
     LIMIT 1;
   logical_plan: |-
     LogicalTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
-    └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal) as $expr3, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal) as $expr4, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal) as $expr5, count] }
+    └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr3, Case((count(lineitem.l_extendedprice) = 0:Int32), null:Decimal, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal)) as $expr4, Case((count(lineitem.l_discount) = 0:Int32), null:Decimal, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal)) as $expr5, count] }
       └─LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
         └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32::Decimal - lineitem.l_discount)) as $expr1, ((lineitem.l_extendedprice * (1:Int32::Decimal - lineitem.l_discount)) * (1:Int32::Decimal + lineitem.l_tax)) as $expr2, lineitem.l_discount] }
           └─LogicalFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Date - '71 days':Interval)) }
             └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment, lineitem._rw_timestamp] }
   optimized_logical_plan_for_batch: |-
     LogicalTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
-    └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal) as $expr3, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal) as $expr4, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal) as $expr5, count] }
+    └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr3, Case((count(lineitem.l_extendedprice) = 0:Int32), null:Decimal, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal)) as $expr4, Case((count(lineitem.l_discount) = 0:Int32), null:Decimal, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal)) as $expr5, count] }
       └─LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
         └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, $expr1, ($expr1 * (1:Int32::Decimal + lineitem.l_tax)) as $expr2, lineitem.l_discount] }
           └─LogicalProject { exprs: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, (lineitem.l_extendedprice * (1:Int32::Decimal - lineitem.l_discount)) as $expr1] }
@@ -137,7 +137,7 @@
     BatchTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
     └─BatchExchange { order: [], dist: Single }
       └─BatchTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
-        └─BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal) as $expr3, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal) as $expr4, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal) as $expr5, count] }
+        └─BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr3, Case((count(lineitem.l_extendedprice) = 0:Int32), null:Decimal, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal)) as $expr4, Case((count(lineitem.l_discount) = 0:Int32), null:Decimal, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal)) as $expr5, count] }
           └─BatchHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
             └─BatchExchange { order: [], dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
               └─BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, $expr1, ($expr1 * (1:Decimal + lineitem.l_tax)) as $expr2, lineitem.l_discount] }
@@ -150,7 +150,7 @@
       └─StreamTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0 }
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0, group_key: [_vnode] }
-            └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal) as $expr3, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal) as $expr4, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal) as $expr5, count, Vnode(lineitem.l_returnflag, lineitem.l_linestatus) as _vnode] }
+            └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr3, Case((count(lineitem.l_extendedprice) = 0:Int32), null:Decimal, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal)) as $expr4, Case((count(lineitem.l_discount) = 0:Int32), null:Decimal, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal)) as $expr5, count, Vnode(lineitem.l_returnflag, lineitem.l_linestatus) as _vnode] }
               └─StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
                 └─StreamExchange { dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
                   └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, $expr1, ($expr1 * (1:Decimal + lineitem.l_tax)) as $expr2, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
@@ -166,7 +166,7 @@
 
     Fragment 1
     StreamGroupTopN { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], limit: 1, offset: 0, group_key: [_vnode] } { tables: [ GroupTopN: 1 ] }
-    └── StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal) as $expr3, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal) as $expr4, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal) as $expr5, count, Vnode(lineitem.l_returnflag, lineitem.l_linestatus) as _vnode] }
+    └── StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr3, Case((count(lineitem.l_extendedprice) = 0:Int32), null:Decimal, (sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)::Decimal)) as $expr4, Case((count(lineitem.l_discount) = 0:Int32), null:Decimal, (sum(lineitem.l_discount) / count(lineitem.l_discount)::Decimal)) as $expr5, count, Vnode(lineitem.l_returnflag, lineitem.l_linestatus) as _vnode] }
         └── StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] } { tables: [ HashAggState: 2 ] }
             └── StreamExchange Hash([0, 1]) from 2
 
@@ -174,8 +174,7 @@
     StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, $expr1, ($expr1 * (1:Decimal + lineitem.l_tax)) as $expr2, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
     └── StreamProject { exprs: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, (lineitem.l_extendedprice * (1:Decimal - lineitem.l_discount)) as $expr1, lineitem.l_orderkey, lineitem.l_linenumber] }
         └── StreamFilter { predicate: (lineitem.l_shipdate <= '1998-09-21 00:00:00':Timestamp) }
-            └── StreamTableScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], stream_scan_type: SnapshotBackfill, stream_key: [lineitem.l_orderkey, lineitem.l_linenumber], pk: [l_orderkey, l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                ├── tables: [ StreamScan: 3 ]
+            └── StreamTableScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], stream_scan_type: SnapshotBackfill, stream_key: [lineitem.l_orderkey, lineitem.l_linenumber], pk: [l_orderkey, l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) } { tables: [ StreamScan: 3 ] }
                 ├── Upstream
                 └── BatchPlanNode
 
@@ -3260,7 +3259,7 @@
             ├─LogicalJoin { type: Inner, on: true, output: all }
             │ ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment, lineitem._rw_timestamp] }
             │ └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment, part._rw_timestamp] }
-            └─LogicalProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr1] }
+            └─LogicalProject { exprs: [(0.2:Decimal * Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal))) as $expr1] }
               └─LogicalAgg { aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
                 └─LogicalProject { exprs: [lineitem.l_quantity] }
                   └─LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 17, correlated_id: 1 }) }
@@ -3268,36 +3267,46 @@
   optimized_logical_plan_for_batch: |-
     LogicalProject { exprs: [(sum(lineitem.l_extendedprice) / 7.0:Decimal) as $expr2] }
     └─LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
-      └─LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (lineitem.l_quantity < $expr1), output: [lineitem.l_extendedprice] }
+      └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(part.p_partkey, part.p_partkey) AND (lineitem.l_quantity < $expr1), output: [lineitem.l_extendedprice] }
         ├─LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
         │ ├─LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice] }
         │ └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [part.p_partkey, part.p_brand, part.p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-        └─LogicalProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr1, lineitem.l_partkey] }
-          └─LogicalAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-            └─LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity] }
+        └─LogicalProject { exprs: [part.p_partkey, (0.2:Decimal * Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal))) as $expr1] }
+          └─LogicalAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+            └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(part.p_partkey, lineitem.l_partkey), output: [part.p_partkey, lineitem.l_quantity] }
+              ├─LogicalAgg { group_key: [part.p_partkey], aggs: [] }
+              │ └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [part.p_partkey, part.p_brand, part.p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+              └─LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], predicate: IsNotNull(lineitem.l_partkey) }
   batch_plan: |-
     BatchProject { exprs: [(sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal) as $expr2] }
     └─BatchSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice))] }
       └─BatchExchange { order: [], dist: Single }
         └─BatchSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
-          └─BatchHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey AND (lineitem.l_quantity < $expr1), output: [lineitem.l_extendedprice] }
+          └─BatchHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey AND (lineitem.l_quantity < $expr1), output: [lineitem.l_extendedprice] }
             ├─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
             │ └─BatchLookupJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey AND (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar), output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey], lookup table: part }
             │   └─BatchExchange { order: [], dist: UpstreamHashShard(lineitem.l_partkey) }
             │     └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice], distribution: SomeShard }
-            └─BatchProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr1, lineitem.l_partkey] }
-              └─BatchHashAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-                └─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                  └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
+            └─BatchProject { exprs: [part.p_partkey, (0.2:Decimal * Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal))) as $expr1] }
+              └─BatchHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                └─BatchHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity] }
+                  ├─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                  │ └─BatchSortAgg { group_key: [part.p_partkey], aggs: [] }
+                  │   └─BatchProject { exprs: [part.p_partkey] }
+                  │     └─BatchFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+                  │       └─BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], distribution: UpstreamHashShard(part.p_partkey) }
+                  └─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+                    └─BatchFilter { predicate: IsNotNull(lineitem.l_partkey) }
+                      └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |-
     StreamMaterialize { columns: [avg_yearly], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
     └─StreamProject { exprs: [(sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal) as $expr2] }
       └─StreamSimpleAgg [append_only] { aggs: [sum(sum(lineitem.l_extendedprice)), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
-            └─StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey, lineitem.l_partkey] }
+            └─StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey, part.p_partkey] }
               └─StreamFilter { predicate: (lineitem.l_quantity < $expr1) }
-                └─StreamHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey, output: all }
+                └─StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
                   ├─StreamExchange { dist: HashShard(part.p_partkey) }
                   │ └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
                   │   ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
@@ -3306,10 +3315,18 @@
                   │     └─StreamProject { exprs: [part.p_partkey] }
                   │       └─StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
                   │         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], stream_scan_type: SnapshotBackfill, stream_key: [part.p_partkey], pk: [p_partkey], dist: UpstreamHashShard(part.p_partkey) }
-                  └─StreamProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr1, lineitem.l_partkey] }
-                    └─StreamHashAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity), count] }
-                      └─StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                        └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber], stream_scan_type: SnapshotBackfill, stream_key: [lineitem.l_orderkey, lineitem.l_linenumber], pk: [l_orderkey, l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                  └─StreamProject { exprs: [part.p_partkey, (0.2:Decimal * Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal))) as $expr1] }
+                    └─StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity), count] }
+                      └─StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber] }
+                        ├─StreamExchange { dist: HashShard(part.p_partkey) }
+                        │ └─StreamProject { exprs: [part.p_partkey], noop_update_hint: true }
+                        │   └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count] }
+                        │     └─StreamProject { exprs: [part.p_partkey] }
+                        │       └─StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+                        │         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], stream_scan_type: SnapshotBackfill, stream_key: [part.p_partkey], pk: [p_partkey], dist: UpstreamHashShard(part.p_partkey) }
+                        └─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+                          └─StreamFilter { predicate: IsNotNull(lineitem.l_partkey) }
+                            └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber], stream_scan_type: SnapshotBackfill, stream_key: [lineitem.l_orderkey, lineitem.l_linenumber], pk: [l_orderkey, l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [avg_yearly], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
@@ -3320,15 +3337,16 @@
 
     Fragment 1
     StreamStatelessSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
-    └── StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey, lineitem.l_partkey] }
+    └── StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey, part.p_partkey] }
         └── StreamFilter { predicate: (lineitem.l_quantity < $expr1) }
-            └── StreamHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey, output: all }
-                ├── tables: [ HashJoinLeft: 1, HashJoinDegreeLeft: 2, HashJoinRight: 3, HashJoinDegreeRight: 4 ]
+            └── StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all } { tables: [ HashJoinLeft: 1, HashJoinDegreeLeft: 2, HashJoinRight: 3, HashJoinDegreeRight: 4 ] }
                 ├── StreamExchange Hash([2]) from 2
-                └── StreamProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal)) as $expr1, lineitem.l_partkey] }
-                    └── StreamHashAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity), count] }
-                        ├── tables: [ HashAggState: 11 ]
-                        └── StreamExchange Hash([0]) from 5
+                └── StreamProject { exprs: [part.p_partkey, (0.2:Decimal * Case((count(lineitem.l_quantity) = 0:Int32), null:Decimal, (sum(lineitem.l_quantity) / count(lineitem.l_quantity)::Decimal))) as $expr1] }
+                    └── StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity), count] } { tables: [ HashAggState: 11 ] }
+                        └── StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber] }
+                            ├── tables: [ HashJoinLeft: 12, HashJoinDegreeLeft: 13, HashJoinRight: 14, HashJoinDegreeRight: 15 ]
+                            ├── StreamExchange Hash([0]) from 5
+                            └── StreamExchange Hash([0]) from 6
 
     Fragment 2
     StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
@@ -3350,10 +3368,20 @@
             └── BatchPlanNode
 
     Fragment 5
-    StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber], stream_scan_type: SnapshotBackfill, stream_key: [lineitem.l_orderkey, lineitem.l_linenumber], pk: [l_orderkey, l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-    ├── tables: [ StreamScan: 12 ]
-    ├── Upstream
-    └── BatchPlanNode
+    StreamProject { exprs: [part.p_partkey], noop_update_hint: true }
+    └── StreamHashAgg { group_key: [part.p_partkey], aggs: [count] } { tables: [ HashAggState: 16 ] }
+        └── StreamProject { exprs: [part.p_partkey] }
+            └── StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+                └── StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], stream_scan_type: SnapshotBackfill, stream_key: [part.p_partkey], pk: [p_partkey], dist: UpstreamHashShard(part.p_partkey) } { tables: [ StreamScan: 17 ] }
+                    ├── Upstream
+                    └── BatchPlanNode
+
+    Fragment 6
+    StreamFilter { predicate: IsNotNull(lineitem.l_partkey) }
+    └── StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber], stream_scan_type: SnapshotBackfill, stream_key: [lineitem.l_orderkey, lineitem.l_linenumber], pk: [l_orderkey, l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+        ├── tables: [ StreamScan: 18 ]
+        ├── Upstream
+        └── BatchPlanNode
 
     Table 0 { columns: [ sum(sum(lineitem_l_extendedprice)), count, _rw_timestamp ], primary key: [], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -3361,9 +3389,9 @@
 
     Table 2 { columns: [ part_p_partkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_partkey, _degree, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC, $2 ASC, $3 ASC ], value indices: [ 4 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
-    Table 3 { columns: [ $expr1, lineitem_l_partkey, _rw_timestamp ], primary key: [ $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 3 { columns: [ part_p_partkey, $expr1, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
-    Table 4 { columns: [ lineitem_l_partkey, _degree, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+    Table 4 { columns: [ part_p_partkey, _degree, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
     Table 5 { columns: [ lineitem_l_partkey, lineitem_l_quantity, lineitem_l_extendedprice, lineitem_l_orderkey, lineitem_l_linenumber, _rw_timestamp ], primary key: [ $0 ASC, $3 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -3377,9 +3405,21 @@
 
     Table 10 { columns: [ vnode, epoch, row_count, is_epoch_finished, p_partkey, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3, 4 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
 
-    Table 11 { columns: [ lineitem_l_partkey, sum(lineitem_l_quantity), count(lineitem_l_quantity), count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+    Table 11 { columns: [ part_p_partkey, sum(lineitem_l_quantity), count(lineitem_l_quantity), count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
-    Table 12 { columns: [ vnode, epoch, row_count, is_epoch_finished, l_orderkey, l_linenumber, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3, 4, 5 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+    Table 12 { columns: [ part_p_partkey, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+
+    Table 13 { columns: [ part_p_partkey, _degree, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+
+    Table 14 { columns: [ lineitem_l_partkey, lineitem_l_quantity, lineitem_l_orderkey, lineitem_l_linenumber, _rw_timestamp ], primary key: [ $0 ASC, $2 ASC, $3 ASC ], value indices: [ 0, 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+
+    Table 15 { columns: [ lineitem_l_partkey, lineitem_l_orderkey, lineitem_l_linenumber, _degree, _rw_timestamp ], primary key: [ $0 ASC, $1 ASC, $2 ASC ], value indices: [ 3 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+
+    Table 16 { columns: [ part_p_partkey, count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
+
+    Table 17 { columns: [ vnode, epoch, row_count, is_epoch_finished, p_partkey, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3, 4 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 18 { columns: [ vnode, epoch, row_count, is_epoch_finished, l_orderkey, l_linenumber, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3, 4, 5 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
 
     Table 4294967294 { columns: [ avg_yearly, _rw_timestamp ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -4282,7 +4322,7 @@
                 │ └─LogicalProject { exprs: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
                 │   └─LogicalFilter { predicate: (orders.o_custkey = CorrelatedInputRef { index: 0, correlated_id: 1 }) }
                 │     └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment, orders._rw_timestamp] }
-                └─LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal)::Decimal) as $expr1] }
+                └─LogicalProject { exprs: [Case((count(customer.c_acctbal) = 0:Int32), null:Decimal, (sum(customer.c_acctbal) / count(customer.c_acctbal)::Decimal)) as $expr1] }
                   └─LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
                     └─LogicalProject { exprs: [customer.c_acctbal] }
                       └─LogicalFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
@@ -4295,7 +4335,7 @@
           ├─LogicalJoin { type: LeftAnti, on: (orders.o_custkey = customer.c_custkey), output: [customer.c_phone, customer.c_acctbal] }
           │ ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
           │ └─LogicalScan { table: orders, columns: [orders.o_custkey] }
-          └─LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal)::Decimal) as $expr1] }
+          └─LogicalProject { exprs: [Case((count(customer.c_acctbal) = 0:Int32), null:Decimal, (sum(customer.c_acctbal) / count(customer.c_acctbal)::Decimal)) as $expr1] }
             └─LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
               └─LogicalScan { table: customer, output_columns: [customer.c_acctbal], required_columns: [customer.c_acctbal, customer.c_phone], predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
   batch_plan: |-
@@ -4313,7 +4353,7 @@
                 │   │   └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], distribution: UpstreamHashShard(customer.c_custkey) }
                 │   └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
                 │     └─BatchScan { table: orders, columns: [orders.o_custkey], distribution: SomeShard }
-                └─BatchProject { exprs: [(sum(sum(customer.c_acctbal)) / sum0(count(customer.c_acctbal))::Decimal) as $expr1] }
+                └─BatchProject { exprs: [Case((sum0(count(customer.c_acctbal)) = 0:Int32), null:Decimal, (sum(sum(customer.c_acctbal)) / sum0(count(customer.c_acctbal))::Decimal)) as $expr1] }
                   └─BatchSimpleAgg { aggs: [sum(sum(customer.c_acctbal)), sum0(count(customer.c_acctbal))] }
                     └─BatchExchange { order: [], dist: Single }
                       └─BatchSimpleAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
@@ -4338,7 +4378,7 @@
                       │ └─StreamExchange { dist: HashShard(orders.o_custkey) }
                       │   └─StreamTableScan { table: orders, columns: [orders.o_custkey, orders.o_orderkey], stream_scan_type: SnapshotBackfill, stream_key: [orders.o_orderkey], pk: [o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
                       └─StreamExchange { dist: Broadcast }
-                        └─StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum0(count(customer.c_acctbal))::Decimal) as $expr1] }
+                        └─StreamProject { exprs: [Case((sum0(count(customer.c_acctbal)) = 0:Int32), null:Decimal, (sum(sum(customer.c_acctbal)) / sum0(count(customer.c_acctbal))::Decimal)) as $expr1] }
                           └─StreamSimpleAgg [append_only] { aggs: [sum(sum(customer.c_acctbal)), sum0(count(customer.c_acctbal)), count] }
                             └─StreamExchange { dist: Single }
                               └─StreamStatelessSimpleAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }

--- a/src/frontend/planner_test/tests/testdata/output/tpch_kafka.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch_kafka.yaml
@@ -149,7 +149,7 @@
       └─StreamTopN { order: [l_returnflag ASC, l_linestatus ASC], limit: 1, offset: 0 }
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: [l_returnflag ASC, l_linestatus ASC], limit: 1, offset: 0, group_key: [_vnode] }
-            └─StreamProject { exprs: [l_returnflag, l_linestatus, sum(l_quantity), sum(l_extendedprice), sum($expr1), sum($expr2), (sum(l_quantity) / count(l_quantity)::Decimal) as $expr3, (sum(l_extendedprice) / count(l_extendedprice)::Decimal) as $expr4, (sum(l_discount) / count(l_discount)::Decimal) as $expr5, count, Vnode(l_returnflag, l_linestatus) as _vnode] }
+            └─StreamProject { exprs: [l_returnflag, l_linestatus, sum(l_quantity), sum(l_extendedprice), sum($expr1), sum($expr2), Case((count(l_quantity) = 0:Int32), null:Decimal, (sum(l_quantity) / count(l_quantity)::Decimal)) as $expr3, Case((count(l_extendedprice) = 0:Int32), null:Decimal, (sum(l_extendedprice) / count(l_extendedprice)::Decimal)) as $expr4, Case((count(l_discount) = 0:Int32), null:Decimal, (sum(l_discount) / count(l_discount)::Decimal)) as $expr5, count, Vnode(l_returnflag, l_linestatus) as _vnode] }
               └─StreamHashAgg [append_only] { group_key: [l_returnflag, l_linestatus], aggs: [sum(l_quantity), sum(l_extendedprice), sum($expr1), sum($expr2), count(l_quantity), count(l_extendedprice), sum(l_discount), count(l_discount), count] }
                 └─StreamExchange { dist: HashShard(l_returnflag, l_linestatus) }
                   └─StreamProject { exprs: [l_returnflag, l_linestatus, l_quantity, l_extendedprice, $expr1, ($expr1 * (1:Decimal + l_tax)) as $expr2, l_discount, _row_id] }
@@ -1155,27 +1155,45 @@
       └─StreamSimpleAgg [append_only] { aggs: [sum(sum(l_extendedprice)), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [sum(l_extendedprice)] }
-            └─StreamProject { exprs: [l_extendedprice, _row_id, _row_id, l_partkey, p_partkey, l_partkey] }
+            └─StreamProject { exprs: [l_extendedprice, _row_id, _row_id, l_partkey, p_partkey, p_partkey] }
               └─StreamFilter { predicate: (l_quantity < $expr1) }
-                └─StreamHashJoin { type: Inner, predicate: p_partkey = l_partkey, output: all }
+                └─StreamHashJoin { type: Inner, predicate: p_partkey IS NOT DISTINCT FROM p_partkey, output: all }
                   ├─StreamExchange { dist: HashShard(p_partkey) }
-                  │ └─StreamHashJoin [append_only] { type: Inner, predicate: l_partkey = p_partkey, output: [l_quantity, l_extendedprice, p_partkey, _row_id, l_partkey, _row_id] }
-                  │   ├─StreamExchange { dist: HashShard(l_partkey) }
-                  │   │ └─StreamShare { id: 3 }
-                  │   │   └─StreamProject { exprs: [l_partkey, l_quantity, l_extendedprice, _row_id] }
-                  │   │     └─StreamRowIdGen { row_id_index: 19 }
-                  │   │       └─StreamSourceScan { columns: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
-                  │   └─StreamExchange { dist: HashShard(p_partkey) }
-                  │     └─StreamFilter { predicate: (p_brand = 'Brand#13':Varchar) AND (p_container = 'JUMBO PKG':Varchar) }
-                  │       └─StreamRowIdGen { row_id_index: 12 }
-                  │         └─StreamSourceScan { columns: [p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
-                  └─StreamProject { exprs: [(0.2:Decimal * (sum(l_quantity) / count(l_quantity)::Decimal)) as $expr1, l_partkey] }
-                    └─StreamHashAgg [append_only] { group_key: [l_partkey], aggs: [sum(l_quantity), count(l_quantity), count] }
-                      └─StreamExchange { dist: HashShard(l_partkey) }
-                        └─StreamShare { id: 3 }
-                          └─StreamProject { exprs: [l_partkey, l_quantity, l_extendedprice, _row_id] }
-                            └─StreamRowIdGen { row_id_index: 19 }
-                              └─StreamSourceScan { columns: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+                  │ └─StreamShare { id: 9 }
+                  │   └─StreamHashJoin [append_only] { type: Inner, predicate: l_partkey = p_partkey, output: [l_quantity, l_extendedprice, p_partkey, _row_id, l_partkey, _row_id] }
+                  │     ├─StreamExchange { dist: HashShard(l_partkey) }
+                  │     │ └─StreamShare { id: 3 }
+                  │     │   └─StreamProject { exprs: [l_partkey, l_quantity, l_extendedprice, _row_id] }
+                  │     │     └─StreamRowIdGen { row_id_index: 19 }
+                  │     │       └─StreamSourceScan { columns: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+                  │     └─StreamExchange { dist: HashShard(p_partkey) }
+                  │       └─StreamFilter { predicate: (p_brand = 'Brand#13':Varchar) AND (p_container = 'JUMBO PKG':Varchar) }
+                  │         └─StreamRowIdGen { row_id_index: 12 }
+                  │           └─StreamSourceScan { columns: [p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+                  └─StreamProject { exprs: [p_partkey, (0.2:Decimal * Case((count(l_quantity) = 0:Int32), null:Decimal, (sum(l_quantity) / count(l_quantity)::Decimal))) as $expr1] }
+                    └─StreamHashAgg { group_key: [p_partkey], aggs: [sum(l_quantity), count(l_quantity), count] }
+                      └─StreamHashJoin { type: LeftOuter, predicate: p_partkey IS NOT DISTINCT FROM l_partkey, output: [p_partkey, l_quantity, _row_id] }
+                        ├─StreamProject { exprs: [p_partkey] }
+                        │ └─StreamAppendOnlyDedup { dedup_cols: [p_partkey] }
+                        │   └─StreamExchange { dist: HashShard(p_partkey) }
+                        │     └─StreamShare { id: 9 }
+                        │       └─StreamHashJoin [append_only] { type: Inner, predicate: l_partkey = p_partkey, output: [l_quantity, l_extendedprice, p_partkey, _row_id, l_partkey, _row_id] }
+                        │         ├─StreamExchange { dist: HashShard(l_partkey) }
+                        │         │ └─StreamShare { id: 3 }
+                        │         │   └─StreamProject { exprs: [l_partkey, l_quantity, l_extendedprice, _row_id] }
+                        │         │     └─StreamRowIdGen { row_id_index: 19 }
+                        │         │       └─StreamSourceScan { columns: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+                        │         └─StreamExchange { dist: HashShard(p_partkey) }
+                        │           └─StreamFilter { predicate: (p_brand = 'Brand#13':Varchar) AND (p_container = 'JUMBO PKG':Varchar) }
+                        │             └─StreamRowIdGen { row_id_index: 12 }
+                        │               └─StreamSourceScan { columns: [p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+                        └─StreamExchange { dist: HashShard(l_partkey) }
+                          └─StreamProject { exprs: [l_partkey, l_quantity, _row_id] }
+                            └─StreamFilter { predicate: IsNotNull(l_partkey) }
+                              └─StreamShare { id: 3 }
+                                └─StreamProject { exprs: [l_partkey, l_quantity, l_extendedprice, _row_id] }
+                                  └─StreamRowIdGen { row_id_index: 19 }
+                                    └─StreamSourceScan { columns: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
 - id: tpch_q18
   before:
   - create_tables
@@ -1501,7 +1519,7 @@
                       │     └─StreamRowIdGen { row_id_index: 12 }
                       │       └─StreamSourceScan { columns: [o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
                       └─StreamExchange { dist: Broadcast }
-                        └─StreamProject { exprs: [(sum(sum(c_acctbal)) / sum0(count(c_acctbal))::Decimal) as $expr1] }
+                        └─StreamProject { exprs: [Case((sum0(count(c_acctbal)) = 0:Int32), null:Decimal, (sum(sum(c_acctbal)) / sum0(count(c_acctbal))::Decimal)) as $expr1] }
                           └─StreamSimpleAgg [append_only] { aggs: [sum(sum(c_acctbal)), sum0(count(c_acctbal)), count] }
                             └─StreamExchange { dist: Single }
                               └─StreamStatelessSimpleAgg { aggs: [sum(c_acctbal), count(c_acctbal)] }

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -624,6 +624,7 @@ impl LogicalAggBuilder {
             // Rewrite avg to cast(sum as avg_return_type) / count.
             AggType::Builtin(PbAggKind::Avg) => {
                 assert_eq!(agg_call.args.len(), 1);
+                let return_type = agg_call.return_type();
 
                 let sum = ExprImpl::from(push_agg_call(AggCall::new(
                     PbAggKind::Sum.into(),
@@ -644,7 +645,18 @@ impl LogicalAggBuilder {
                     agg_call.direct_args,
                 )?)?);
 
-                Ok(FunctionCall::new(ExprType::Divide, Vec::from([sum, count]))?.into())
+                let target = ExprImpl::from(FunctionCall::new(
+                    ExprType::Divide,
+                    Vec::from([sum, count.clone()]),
+                )?);
+                let null = ExprImpl::from(Literal::new(None, return_type));
+                let zero = ExprImpl::literal_int(0);
+                let case_cond =
+                    ExprImpl::from(FunctionCall::new(ExprType::Equal, vec![count, zero])?);
+                Ok(ExprImpl::from(FunctionCall::new(
+                    ExprType::Case,
+                    vec![case_cond, null, target],
+                )?))
             }
             // We compute `var_samp` as
             // (sum(sq) - sum * sum / count) / (count - 1)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes `AVG` rewritten as `sum / count` when an over-window frame is empty.

Before this change, the planner rewrote `AVG(x)` into `sum(x) / count(x)` unconditionally. In streaming over-window execution, an empty frame can produce `count = 0`, so the rewritten expression may evaluate `0 / 0` and generate non-finite values, for example `NaN` for floating-point AVG.

This PR changes the rewrite to:

```sql
CASE WHEN count = 0 THEN NULL ELSE sum / count END
```

This matches SQL aggregate semantics: `AVG` over an empty input should return `NULL`.

It also adds coverage in both planner tests and over-window e2e tests:

- planner tests for `AVG` over empty window frames
- batch/streaming over-window e2e coverage for `AVG(double precision)` over empty odd frames

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixes `AVG` over empty streaming over-window frames to return `NULL` instead of potentially producing non-finite values.

</details>

## Verification

- `./risedev slt './e2e_test/streaming/over_window/main.slt'`
- `./risedev slt './e2e_test/batch/over_window/main.slt.part'`
- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 ./risedev run-planner-test over_window_function`
- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 cargo fmt --check`
- `git diff --check`