### PR TITLE
test(interval): cover mid-string +/- separators

### DIFF
--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -1541,6 +1541,18 @@ mod tests {
             interval,
             Interval::from_month(14) + Interval::from_days(3) + Interval::from_minutes(5)
         );
+
+        // Sign separated from its number by whitespace, as accepted by
+        // PostgreSQL: `1 month - 1 day` == `1 month + (-1) day`. See #22018.
+        let interval = "1 month - 1 day".parse::<Interval>().unwrap();
+        assert_eq!(interval, Interval::from_month(1) + Interval::from_days(-1));
+
+        let interval = "1 month + 1 day".parse::<Interval>().unwrap();
+        assert_eq!(interval, Interval::from_month(1) + Interval::from_days(1));
+
+        // No whitespace between the sign and the digit should still work.
+        let interval = "1 month -1 day".parse::<Interval>().unwrap();
+        assert_eq!(interval, Interval::from_month(1) + Interval::from_days(-1));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

`interval '1 month - 1 day'` (a valid PostgreSQL form where the `-` between `month` and `1 day` flips the sign of the next number) parses correctly in current `main`. `parse_interval` already skips a standalone `-` or `+` across whitespace until it picks up the next digit, so the tokens land as `Num(1), Month, Num(-1), Day` as expected.

That behavior wasn't covered by an explicit test though, so it would be easy to regress. Add three small cases under `test_parse`:

- `1 month - 1 day` (spaced sign)
- `1 month + 1 day` (positive sign for symmetry)
- `1 month -1 day` (no space between sign and digit)

- Closes #22018

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.