### PR TITLE
fix(connector): stop cloning NATS JetStream splits per actor

### DIFF
--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -708,10 +708,7 @@ impl ConnectorProperties {
 
     /// For most connectors, this should be false. When enabled, RisingWave should not track any progress.
     pub fn enable_adaptive_splits(&self) -> bool {
-        matches!(
-            self,
-            ConnectorProperties::Nats(_) | ConnectorProperties::GooglePubsub(_)
-        )
+        matches!(self, ConnectorProperties::GooglePubsub(_))
     }
 
     /// Load additional info from `PbSource`. Currently only used by CDC.
@@ -1072,6 +1069,24 @@ mod tests {
         } else {
             panic!("extract kafka config failed");
         }
+    }
+
+    #[test]
+    fn test_nats_connector_does_not_enable_adaptive_splits() {
+        let props = convert_args!(btreemap!(
+            "connector" => "nats",
+            "server_url" => "nats://localhost:4222",
+            "subject" => "quotes.test",
+            "stream" => "quotes-test",
+            "consumer.durable_name" => "quotes-test-durable",
+            "connect_mode" => "plain",
+        ));
+
+        let props =
+            ConnectorProperties::extract(WithOptionsSecResolved::without_secrets(props), true)
+                .unwrap();
+
+        assert!(!props.enable_adaptive_splits());
     }
 
     #[test]

--- a/src/connector/src/source/util.rs
+++ b/src/connector/src/source/util.rs
@@ -18,32 +18,12 @@ use std::sync::Arc;
 use crate::error::{ConnectorError, ConnectorResult};
 use crate::source::SplitImpl;
 use crate::source::google_pubsub::PubsubSplit;
-use crate::source::nats::split::NatsSplit;
 
 pub fn fill_adaptive_split(
     split_template: &SplitImpl,
     actor_count: usize,
 ) -> ConnectorResult<BTreeMap<Arc<str>, SplitImpl>> {
     match split_template {
-        SplitImpl::Nats(split) => {
-            let mut new_splits = BTreeMap::new();
-            for idx in 0..actor_count {
-                let split_id: Arc<str> = idx.to_string().into();
-                new_splits.insert(
-                    split_id.clone(),
-                    SplitImpl::Nats(NatsSplit::new(
-                        split.subject.clone(),
-                        split_id,
-                        split.start_sequence.clone(),
-                    )),
-                );
-            }
-            tracing::debug!(
-                "Filled adaptive splits for Nats source, {} splits in total",
-                new_splits.len()
-            );
-            Ok(new_splits)
-        }
         SplitImpl::GooglePubsub(split) => {
             let mut new_splits = BTreeMap::new();
             for idx in 0..actor_count {
@@ -75,7 +55,7 @@ pub fn fill_adaptive_split(
 mod tests {
     use super::*;
     use crate::source::SplitMetaData;
-    use crate::source::nats::split::NatsOffset;
+    use crate::source::nats::split::{NatsOffset, NatsSplit};
 
     #[test]
     fn test_fill_adaptive_split_pubsub() {
@@ -118,19 +98,15 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_adaptive_split_nats() {
+    fn test_fill_adaptive_split_nats_unsupported() {
         let template = SplitImpl::Nats(NatsSplit::new(
             "test-subject".to_owned(),
             "0".into(),
             NatsOffset::None,
         ));
 
-        let splits = fill_adaptive_split(&template, 4).unwrap();
-        assert_eq!(splits.len(), 4);
-
-        for idx in 0..4 {
-            assert!(splits.contains_key(idx.to_string().as_str()));
-        }
+        let result = fill_adaptive_split(&template, 4);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/meta/src/stream/source_manager/worker.rs
+++ b/src/meta/src/stream/source_manager/worker.rs
@@ -489,3 +489,51 @@ pub enum SourceWorkerCommand {
     /// Update the properties of the source worker.
     UpdateProps(ConnectorProperties),
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use risingwave_connector::source::nats::split::{NatsOffset, NatsSplit};
+    use risingwave_connector::source::{SplitId, SplitImpl};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_nats_discovered_splits_stay_fixed_when_adaptive_disabled() {
+        let split_id: SplitId = "0".into();
+        let mut discovered = BTreeMap::new();
+        discovered.insert(
+            split_id.clone(),
+            SplitImpl::Nats(NatsSplit::new(
+                "quotes.test".to_owned(),
+                split_id,
+                NatsOffset::None,
+            )),
+        );
+
+        let splits = Arc::new(Mutex::new(SharedSplitMap {
+            splits: Some(discovered),
+        }));
+        let (command_tx, _command_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let handle = ConnectorSourceWorkerHandle {
+            handle: tokio::spawn(async {}),
+            command_tx,
+            splits,
+            enable_drop_split: true,
+            enable_adaptive_splits: false,
+        };
+
+        let discovered = handle.discovered_splits(1.into()).await.unwrap().unwrap();
+        match discovered {
+            DiscoveredSplits::Fixed(splits) => {
+                assert_eq!(splits.len(), 1);
+                assert!(matches!(splits.get("0"), Some(SplitImpl::Nats(_))));
+            }
+            DiscoveredSplits::Adaptive(_) => {
+                panic!("NATS splits must remain fixed when adaptive mode is disabled");
+            }
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR fixes duplicate ingestion for NATS JetStream sources caused by a split-model mismatch between meta and the connector.

- Closes #25681
- RisingWave was advertising NATS as an adaptive-split source, so meta expanded one discovered NATS split into one synthetic split per actor.
- The NATS JetStream connector does not maintain independent per-split progress in RisingWave state. Instead, progress is owned by a single broker-side durable consumer cursor used for ACK advancement.
- That meant multiple source actors could contend on the same durable consumer state, preventing `ack_floor` from advancing reliably and causing JetStream to repeatedly redeliver the same earliest unacked messages.
- The fix stops advertising NATS as adaptive, removes the adaptive split expansion path for NATS, and adds regression coverage in both connector and meta layers to keep NATS discoveries fixed instead of cloned per actor.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fixed a NATS JetStream source bug where one logical source could be expanded into per-actor synthetic splits even though ACK progress is tracked by a single durable consumer. Under multi-actor execution this could stall ACK advancement and cause repeated redelivery of already-ingested messages, producing duplicate rows.

</details>
