### PR TITLE
ci: use CI token for bump main PRs

### DIFF
--- a/.github/workflows/bump-main.yml
+++ b/.github/workflows/bump-main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'release-[0-9]*.[0-9]*'
 
+env:
+  GH_TOKEN: ${{ secrets.RISINGWAVE_CI_GITHUB_TOKEN }}
+
 jobs:
   bump-main-branch-version:
     runs-on: ubuntu-latest
@@ -19,8 +22,6 @@ jobs:
 
       - name: Bump main branch version
         id: bump
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ ! "${{ github.ref_name }}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
             echo "Branch ${{ github.ref_name }} does not match strict X.Y format. Exiting."
@@ -78,7 +79,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.bump.outputs.NEW_VERSION }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RISINGWAVE_CI_GITHUB_TOKEN }}
           title: "chore: bump main branch version to ${{ env.NEW_VERSION }}"
           body: "This PR automatically bumps the main branch version after creating ${{ github.ref_name }} branch."
           base: main


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes the main-version bump automation so the PRs it creates can trigger downstream GitHub Actions checks such as `License checker / license-header-check`.

The existing workflow created bump PRs with the default `GITHUB_TOKEN`. GitHub suppresses workflow runs caused by events created with that token, so the automated bump PR for #25678 did not start the license header check until the PR was manually closed and reopened.

This change mirrors the release-branch cherry-pick workflow by using `secrets.RISINGWAVE_CI_GITHUB_TOKEN`:

- Set workflow-level `GH_TOKEN` to `secrets.RISINGWAVE_CI_GITHUB_TOKEN` for GitHub CLI calls.
- Pass `secrets.RISINGWAVE_CI_GITHUB_TOKEN` to `peter-evans/create-pull-request` so generated bump PRs are created with the CI token instead of `GITHUB_TOKEN`.

Related: #25678

## Checklist

- [x] I have written necessary rustdoc comments. (N/A; GitHub Actions workflow only.)
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests. (N/A; workflow token configuration only.)
- [x] <!-- OPTIONAL --> I have added test labels as necessary. (`A-ci`, `type/fix`, and `github_actions`; no extra `ci/run-*` labels are needed for this workflow-only change.)
- [x] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. (N/A.)
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. (No cherry-pick requested; this only affects main-branch automation.)

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

No user-facing release note. This only changes internal GitHub Actions automation for automated version-bump PRs.

</details>

## Validation

- Parsed `.github/workflows/bump-main.yml` with Ruby YAML loader.
- Ran `git diff --check -- .github/workflows/bump-main.yml`.
- Confirmed this PR triggered `License checker / license-header-check`, and the check passed.
