### PR TITLE
fix(connector): allow parameterized BigQuery numeric types

### DIFF
--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -349,7 +349,7 @@ impl BigQuerySink {
                 ))
             })?;
             let data_type_string = Self::get_string_and_check_support_from_datatype(&i.data_type)?;
-            if data_type_string.ne(value) {
+            if !Self::bigquery_data_type_compatible(&data_type_string, value) {
                 return Err(SinkError::BigQuery(anyhow::anyhow!(
                     "Data type mismatch for column `{:?}`. BigQuery side: `{:?}`, RisingWave side: `{:?}`. ",
                     i.name,
@@ -359,6 +359,81 @@ impl BigQuerySink {
             };
         }
         Ok(())
+    }
+
+    fn bigquery_data_type_compatible(rw_data_type: &str, bigquery_data_type: &str) -> bool {
+        Self::normalize_bigquery_data_type(rw_data_type)
+            == Self::normalize_bigquery_data_type(bigquery_data_type)
+    }
+
+    fn normalize_bigquery_data_type(data_type: &str) -> String {
+        fn is_ident_char(byte: u8) -> bool {
+            byte.is_ascii_alphanumeric() || byte == b'_'
+        }
+
+        fn starts_with_keyword(data_type: &str, index: usize, keyword: &str) -> bool {
+            if index > 0 && is_ident_char(data_type.as_bytes()[index - 1]) {
+                return false;
+            }
+            let Some(candidate) = data_type.get(index..index + keyword.len()) else {
+                return false;
+            };
+            if !candidate.eq_ignore_ascii_case(keyword) {
+                return false;
+            }
+            data_type
+                .as_bytes()
+                .get(index + keyword.len())
+                .is_none_or(|byte| !is_ident_char(*byte))
+        }
+
+        fn skip_parameter_list(data_type: &str, index: usize) -> Option<usize> {
+            let bytes = data_type.as_bytes();
+            let mut i = index;
+            while bytes.get(i).is_some_and(|byte| byte.is_ascii_whitespace()) {
+                i += 1;
+            }
+            if bytes.get(i) != Some(&b'(') {
+                return None;
+            }
+            i += 1;
+            let mut depth = 1;
+            while let Some(byte) = bytes.get(i) {
+                match byte {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(i + 1);
+                        }
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            None
+        }
+
+        const DECIMAL_TYPE_NAMES: [&str; 4] = ["BIGNUMERIC", "BIGDECIMAL", "NUMERIC", "DECIMAL"];
+
+        let mut normalized = String::with_capacity(data_type.len());
+        let mut i = 0;
+        while i < data_type.len() {
+            if let Some(keyword) = DECIMAL_TYPE_NAMES
+                .iter()
+                .find(|keyword| starts_with_keyword(data_type, i, keyword))
+            {
+                normalized.push_str("NUMERIC");
+                let keyword_end = i + keyword.len();
+                i = skip_parameter_list(data_type, keyword_end).unwrap_or(keyword_end);
+                continue;
+            }
+
+            let ch = data_type[i..].chars().next().expect("valid char boundary");
+            normalized.extend(ch.to_uppercase());
+            i += ch.len_utf8();
+        }
+        normalized
     }
 
     fn get_string_and_check_support_from_datatype(rw_data_type: &DataType) -> Result<String> {
@@ -1007,6 +1082,25 @@ mod test {
             BigQuerySink::get_string_and_check_support_from_datatype(&rw_datatype).unwrap(),
             big_query_type_string
         );
+    }
+
+    #[tokio::test]
+    async fn test_parameterized_numeric_type_check() {
+        assert!(BigQuerySink::bigquery_data_type_compatible(
+            "NUMERIC",
+            "NUMERIC(31, 2)"
+        ));
+        assert!(BigQuerySink::bigquery_data_type_compatible(
+            "NUMERIC",
+            "BIGNUMERIC(76, 38)"
+        ));
+        assert!(BigQuerySink::bigquery_data_type_compatible(
+            "ARRAY<STRUCT<v1 NUMERIC, v2 ARRAY<NUMERIC>>>",
+            "ARRAY<STRUCT<v1 NUMERIC(31, 2), v2 ARRAY<BIGNUMERIC(76, 38)>>>"
+        ));
+        assert!(!BigQuerySink::bigquery_data_type_compatible(
+            "NUMERIC", "STRING"
+        ));
     }
 
     #[tokio::test]

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -15,6 +15,7 @@
 use core::pin::Pin;
 use core::time::Duration;
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::LazyLock;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
@@ -48,6 +49,7 @@ use prost_types::{
     DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet,
     field_descriptor_proto,
 };
+use regex::Regex;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
@@ -367,26 +369,15 @@ impl BigQuerySink {
     }
 
     fn normalize_bigquery_data_type(data_type: &str) -> String {
-        fn remove_type_parameters(mut data_type: String, type_name: &str) -> String {
-            let pattern = format!("{type_name}(");
-            while let Some(type_start) = data_type.find(&pattern) {
-                let params_start = type_start + type_name.len();
-                let Some(params_end) = data_type[params_start..].find(')') else {
-                    break;
-                };
-                data_type.replace_range(params_start..=params_start + params_end, "");
-            }
-            data_type
-        }
+        static PARAMETERIZED_NUMERIC_TYPE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"\b(?:BIG)?(?:NUMERIC|DECIMAL)\s*\([^)]*\)").unwrap()
+        });
+        static NUMERIC_ALIAS: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"\b(?:BIGNUMERIC|BIGDECIMAL|DECIMAL)\b").unwrap());
 
-        let mut data_type = data_type.to_ascii_uppercase();
-        for type_name in ["BIGNUMERIC", "BIGDECIMAL", "NUMERIC", "DECIMAL"] {
-            data_type = remove_type_parameters(data_type, type_name);
-        }
-        data_type
-            .replace("BIGNUMERIC", "NUMERIC")
-            .replace("BIGDECIMAL", "NUMERIC")
-            .replace("DECIMAL", "NUMERIC")
+        let data_type = data_type.to_ascii_uppercase();
+        let data_type = PARAMETERIZED_NUMERIC_TYPE.replace_all(&data_type, "NUMERIC");
+        NUMERIC_ALIAS.replace_all(&data_type, "NUMERIC").into_owned()
     }
 
     fn get_string_and_check_support_from_datatype(rw_data_type: &DataType) -> Result<String> {
@@ -1051,6 +1042,10 @@ mod test {
             "ARRAY<STRUCT<v1 NUMERIC, v2 ARRAY<NUMERIC>>>",
             "ARRAY<STRUCT<v1 NUMERIC(31, 2), v2 ARRAY<BIGNUMERIC(76, 38)>>>"
         ));
+        assert_eq!(
+            BigQuerySink::normalize_bigquery_data_type("FOO_NUMERIC(31, 2)"),
+            "FOO_NUMERIC(31, 2)"
+        );
         assert!(!BigQuerySink::bigquery_data_type_compatible(
             "NUMERIC", "STRING"
         ));

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -367,73 +367,26 @@ impl BigQuerySink {
     }
 
     fn normalize_bigquery_data_type(data_type: &str) -> String {
-        fn is_ident_char(byte: u8) -> bool {
-            byte.is_ascii_alphanumeric() || byte == b'_'
-        }
-
-        fn starts_with_keyword(data_type: &str, index: usize, keyword: &str) -> bool {
-            if index > 0 && is_ident_char(data_type.as_bytes()[index - 1]) {
-                return false;
-            }
-            let Some(candidate) = data_type.get(index..index + keyword.len()) else {
-                return false;
-            };
-            if !candidate.eq_ignore_ascii_case(keyword) {
-                return false;
+        fn remove_type_parameters(mut data_type: String, type_name: &str) -> String {
+            let pattern = format!("{type_name}(");
+            while let Some(type_start) = data_type.find(&pattern) {
+                let params_start = type_start + type_name.len();
+                let Some(params_end) = data_type[params_start..].find(')') else {
+                    break;
+                };
+                data_type.replace_range(params_start..=params_start + params_end, "");
             }
             data_type
-                .as_bytes()
-                .get(index + keyword.len())
-                .is_none_or(|byte| !is_ident_char(*byte))
         }
 
-        fn skip_parameter_list(data_type: &str, index: usize) -> Option<usize> {
-            let bytes = data_type.as_bytes();
-            let mut i = index;
-            while bytes.get(i).is_some_and(|byte| byte.is_ascii_whitespace()) {
-                i += 1;
-            }
-            if bytes.get(i) != Some(&b'(') {
-                return None;
-            }
-            i += 1;
-            let mut depth = 1;
-            while let Some(byte) = bytes.get(i) {
-                match byte {
-                    b'(' => depth += 1,
-                    b')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            return Some(i + 1);
-                        }
-                    }
-                    _ => {}
-                }
-                i += 1;
-            }
-            None
+        let mut data_type = data_type.to_ascii_uppercase();
+        for type_name in ["BIGNUMERIC", "BIGDECIMAL", "NUMERIC", "DECIMAL"] {
+            data_type = remove_type_parameters(data_type, type_name);
         }
-
-        const DECIMAL_TYPE_NAMES: [&str; 4] = ["BIGNUMERIC", "BIGDECIMAL", "NUMERIC", "DECIMAL"];
-
-        let mut normalized = String::with_capacity(data_type.len());
-        let mut i = 0;
-        while i < data_type.len() {
-            if let Some(keyword) = DECIMAL_TYPE_NAMES
-                .iter()
-                .find(|keyword| starts_with_keyword(data_type, i, keyword))
-            {
-                normalized.push_str("NUMERIC");
-                let keyword_end = i + keyword.len();
-                i = skip_parameter_list(data_type, keyword_end).unwrap_or(keyword_end);
-                continue;
-            }
-
-            let ch = data_type[i..].chars().next().expect("valid char boundary");
-            normalized.extend(ch.to_uppercase());
-            i += ch.len_utf8();
-        }
-        normalized
+        data_type
+            .replace("BIGNUMERIC", "NUMERIC")
+            .replace("BIGDECIMAL", "NUMERIC")
+            .replace("DECIMAL", "NUMERIC")
     }
 
     fn get_string_and_check_support_from_datatype(rw_data_type: &DataType) -> Result<String> {

--- a/src/connector/src/sink/big_query.rs
+++ b/src/connector/src/sink/big_query.rs
@@ -364,18 +364,16 @@ impl BigQuerySink {
     }
 
     fn bigquery_data_type_compatible(rw_data_type: &str, bigquery_data_type: &str) -> bool {
-        Self::normalize_bigquery_data_type(rw_data_type)
-            == Self::normalize_bigquery_data_type(bigquery_data_type)
+        rw_data_type == Self::normalize_bigquery_data_type(bigquery_data_type)
     }
 
     fn normalize_bigquery_data_type(data_type: &str) -> String {
         static PARAMETERIZED_NUMERIC_TYPE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"\b(?:BIG)?(?:NUMERIC|DECIMAL)\s*\([^)]*\)").unwrap()
+            Regex::new(r"(?i)\b(?:BIG)?(?:NUMERIC|DECIMAL)\s*\([^)]*\)").unwrap()
         });
         static NUMERIC_ALIAS: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"\b(?:BIGNUMERIC|BIGDECIMAL|DECIMAL)\b").unwrap());
+            LazyLock::new(|| Regex::new(r"(?i)\b(?:BIG)?(?:NUMERIC|DECIMAL)\b").unwrap());
 
-        let data_type = data_type.to_ascii_uppercase();
         let data_type = PARAMETERIZED_NUMERIC_TYPE.replace_all(&data_type, "NUMERIC");
         NUMERIC_ALIAS.replace_all(&data_type, "NUMERIC").into_owned()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Normalize BigQuery schema type strings before comparing them with RisingWave sink column types.
- Treat parameterized BigQuery `NUMERIC(...)`, `DECIMAL(...)`, `BIGNUMERIC(...)`, and `BIGDECIMAL(...)` as compatible with RisingWave `NUMERIC`, including inside nested ARRAY/STRUCT type strings.
- Keep non-numeric mismatches rejected by the existing schema validation path.

- Closes #25404

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

BigQuery sinks now accept existing BigQuery columns declared with parameterized NUMERIC/BIGNUMERIC types during schema validation.

</details>