### PR TITLE
ci: add autoupdate rebase workflow

### DIFF
--- a/.github/workflows/pr-auto-update-with-rebase.yml
+++ b/.github/workflows/pr-auto-update-with-rebase.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: autoupdate
         name: autoupdate
@@ -33,3 +34,12 @@ jobs:
           UPDATE_METHOD: "rebase"
         # https://github.com/pascalgn/automerge-action/issues/191
         continue-on-error: true
+      - name: Report autoupdate failure
+        if: steps.autoupdate.outcome == 'failure'
+        run: |
+          echo "::warning::autoupdate failed. Check the autoupdate step logs for details."
+          {
+            echo "### Autoupdate failed"
+            echo
+            echo "The autoupdate action failed. Check the autoupdate step logs for details."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-auto-update-with-rebase.yml
+++ b/.github/workflows/pr-auto-update-with-rebase.yml
@@ -1,0 +1,35 @@
+name: auto update branch with rebase
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+      - auto_merge_enabled
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - id: autoupdate
+        name: autoupdate
+        uses: pascalgn/automerge-action@v0.16.4
+        env:
+          # https://github.com/pascalgn/automerge-action#limitations
+          GITHUB_TOKEN: "${{ secrets.RISINGWAVE_CI_GITHUB_TOKEN }}"
+          MERGE_LABELS: "non-existent-label"
+          UPDATE_LABELS: "autoupdate_rebase,!autoupdate_merge"
+          UPDATE_METHOD: "rebase"
+        # https://github.com/pascalgn/automerge-action/issues/191
+        continue-on-error: true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds an `autoupdate_rebase` workflow for RisingWave PRs, following the existing pattern in `risingwave-cloud`.

When a PR targeting `main` has the `autoupdate_rebase` label, the workflow asks `pascalgn/automerge-action` to update the PR branch with `UPDATE_METHOD=rebase`. This lets developers opt in to automatic branch updates without clicking GitHub's "Update branch" button each time `main` moves.

The workflow intentionally disables automatic merging by setting `MERGE_LABELS` to a non-existent label. It only updates branches matching `UPDATE_LABELS=autoupdate_rebase,!autoupdate_merge`.

To address review feedback, this also:

- Skips fork PRs for `pull_request` events, where repository secrets such as `RISINGWAVE_CI_GITHUB_TOKEN` are unavailable.
- Keeps the existing `continue-on-error` workaround used for `pascalgn/automerge-action`, but emits an explicit warning and job summary if the autoupdate step fails.

The repository label `autoupdate_rebase` has also been created in GitHub with the same color used in `risingwave-cloud`.

## Checklist

- [x] I have written necessary rustdoc comments. (N/A; GitHub Actions workflow only.)
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests. (N/A; workflow configuration only.)
- [x] <!-- OPTIONAL --> I have added test labels as necessary. (`A-ci`, `github_actions`, and `type/enhancement`; no extra `ci/run-*` labels are needed for this workflow-only change.)
- [x] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. (N/A.)
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. (No cherry-pick requested; this only affects main-branch PR automation.)

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

No user-facing release note. This only changes internal GitHub Actions automation for PR branch updates.

</details>

## Validation

- Parsed `.github/workflows/pr-auto-update-with-rebase.yml` with Ruby YAML loader.
- Ran `git diff --check -- .github/workflows/pr-auto-update-with-rebase.yml` after addressing review feedback.
- Verified the `autoupdate_rebase` label exists in `risingwavelabs/risingwave`.
- Confirmed this PR triggered `auto update branch with rebase / autoupdate`, and the check passed on the latest commit.
- Confirmed this PR triggered `License checker / license-header-check`, and the check passed on the latest commit.
