### PR TITLE
fix(frontend): avoid comparing order subqueries

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/subquery.yaml
@@ -192,6 +192,17 @@
   expected_outputs:
   - optimized_logical_plan_for_batch
   - logical_plan
+- name: order by repeated scalar subquery expression
+  sql: |
+    create table t (a int);
+    with q as (select 1 as v)
+    select a, a + (select v from q) as distance
+    from t
+    order by a + (select v from q)
+    limit 5;
+  expected_outputs:
+  - logical_plan
+  - optimized_logical_plan_for_batch
 - name: test subquery on sources
   sql: |
     create source a (a1 int, a2 int)  with ( connector ='datagen' );

--- a/src/frontend/planner_test/tests/testdata/output/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery.yaml
@@ -418,6 +418,37 @@
             ├─LogicalAgg { group_key: [t1.b], aggs: [] }
             │ └─LogicalScan { table: t1, columns: [t1.b] }
             └─LogicalScan { table: t1, columns: [t1.a] }
+- name: order by repeated scalar subquery expression
+  sql: |
+    create table t (a int);
+    with q as (select 1 as v)
+    select a, a + (select v from q) as distance
+    from t
+    order by a + (select v from q)
+    limit 5;
+  logical_plan: |-
+    LogicalProject { exprs: [t.a, $expr1] }
+    └─LogicalTopN { order: [$expr2 ASC], limit: 5, offset: 0 }
+      └─LogicalProject { exprs: [t.a, (t.a + 1:Int32) as $expr1, (t.a + 1:Int32) as $expr2] }
+        └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+          ├─LogicalScan { table: t, columns: [t.a, t._row_id, t._rw_timestamp] }
+          └─LogicalJoin { type: FullOuter, on: true, output: all }
+            ├─LogicalProject { exprs: [1:Int32] }
+            │ └─LogicalShare { id: 2 }
+            │   └─LogicalProject { exprs: [1:Int32] }
+            │     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+            └─LogicalProject { exprs: [1:Int32] }
+              └─LogicalShare { id: 2 }
+                └─LogicalProject { exprs: [1:Int32] }
+                  └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  optimized_logical_plan_for_batch: |-
+    LogicalTopN { order: [$expr2 ASC], limit: 5, offset: 0 }
+    └─LogicalProject { exprs: [t.a, (t.a + 1:Int32) as $expr1, (t.a + 1:Int32) as $expr2] }
+      └─LogicalJoin { type: LeftOuter, on: true, output: all }
+        ├─LogicalScan { table: t, columns: [t.a] }
+        └─LogicalJoin { type: FullOuter, on: true, output: all }
+          ├─LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [1:Int32:Int32] } }
+          └─LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [1:Int32:Int32] } }
 - name: test subquery on sources
   sql: |
     create source a (a1 int, a2 int)  with ( connector ='datagen' );

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -349,7 +349,10 @@ impl Binder {
             expr => {
                 let bound_expr = self.bind_expr(expr)?;
 
+                // Subqueries are unnested later, and comparing expressions that still contain
+                // subqueries is intentionally unsupported.
                 if bound_expr.is_pure()
+                    && !bound_expr.has_subquery()
                     && let Some(select_items) = select_items_for_match
                     && let Some(existing_idx) = select_items.iter().position(|e| e == &bound_expr)
                 {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Fix a binder panic when an `ORDER BY` expression containing a scalar subquery is structurally compared with existing `SELECT` items before planner subquery unnesting.

The binder now skips SELECT-item reuse by equality when the bound `ORDER BY` expression still has a subquery, so the expression is kept as a hidden order column and handled by the existing subquery unnesting path.

Added a planner regression for a non-vector query with the same pattern:

```sql
WITH q AS (SELECT 1 AS v)
SELECT a, a + (SELECT v FROM q) AS distance
FROM t
ORDER BY a + (SELECT v FROM q)
LIMIT 5;
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

## Tests

- `cargo fmt --check --package risingwave_frontend`
- `./risedev do-apply-planner-test`
- `./risedev run-planner-test subquery`

<details>
<summary><b>Release note</b></summary>

Fixed an internal panic for valid queries that repeat a scalar subquery expression in both the `SELECT` list and `ORDER BY`.

</details>