### PR TITLE
feat(iceberg): default snapshot gate for compaction

### DIFF
--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
 use iceberg::arrow::schema_to_arrow_schema;
-use iceberg::spec::{DataFile, Operation, SerializedDataFile};
+use iceberg::spec::{DataFile, Operation, SerializedDataFile, TableMetadata};
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
 use iceberg::{Catalog, TableIdent};
@@ -810,39 +810,43 @@ impl IcebergSinkCommitter {
         Ok(())
     }
 
-    /// Check if the number of snapshots since the last rewrite/overwrite operation exceeds the limit
-    /// Returns the number of snapshots since the last rewrite/overwrite
-    fn count_snapshots_since_rewrite(&self) -> usize {
-        let mut snapshots: Vec<_> = self.table.metadata().snapshots().collect();
-        snapshots.sort_by_key(|b| std::cmp::Reverse(b.timestamp_ms()));
-
-        // Iterate through snapshots in reverse order (newest first) to find the last rewrite/overwrite
+    /// Check the number of snapshots on the given branch lineage since the last rewrite operation.
+    /// Returns the number of snapshots since the last rewrite.
+    fn count_snapshots_since_rewrite_in_metadata(metadata: &TableMetadata, branch: &str) -> usize {
+        // Start from the latest snapshot of the commit branch.
+        let mut snapshot_id = metadata
+            .snapshot_for_ref(branch)
+            .map(|snapshot| snapshot.snapshot_id());
         let mut count = 0;
-        for snapshot in snapshots {
-            // Check if this snapshot represents a rewrite or overwrite operation
-            let summary = snapshot.summary();
-            match &summary.operation {
-                Operation::Replace => {
-                    // Found a rewrite/overwrite operation, stop counting
-                    break;
-                }
 
-                _ => {
-                    // Increment count for each snapshot that is not a rewrite/overwrite
-                    count += 1;
-                }
+        // Iterate through snapshots by parent lineage to find the last rewrite.
+        while let Some(current_snapshot_id) = snapshot_id {
+            let Some(snapshot) = metadata.snapshot_by_id(current_snapshot_id) else {
+                break;
+            };
+
+            // Check if this snapshot represents a rewrite operation.
+            if snapshot.summary().operation == Operation::Replace {
+                // Found a rewrite operation, stop counting.
+                break;
             }
+
+            // Increment count for each snapshot that is not a rewrite.
+            count += 1;
+            snapshot_id = snapshot.parent_snapshot_id();
         }
 
         count
     }
 
+    /// Returns the number of snapshots in the current commit branch since the last rewrite.
+    fn count_snapshots_since_rewrite(&self) -> usize {
+        let branch = commit_branch(self.config.r#type.as_str(), self.config.write_mode);
+        Self::count_snapshots_since_rewrite_in_metadata(self.table.metadata(), branch.as_str())
+    }
+
     /// Wait until snapshot count since last rewrite is below the limit
     async fn wait_for_snapshot_limit(&mut self) -> Result<()> {
-        if !self.config.enable_compaction {
-            return Ok(());
-        }
-
         if let Some(max_snapshots) = self.config.max_snapshots_num_before_compaction {
             loop {
                 let current_count = self.count_snapshots_since_rewrite();
@@ -890,4 +894,88 @@ fn serialize_metadata(metadata: Vec<Vec<u8>>) -> Vec<u8> {
 
 fn deserialize_metadata(bytes: Vec<u8>) -> Vec<Vec<u8>> {
     serde_json::from_slice(&bytes).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use iceberg::spec::{
+        FormatVersion, MAIN_BRANCH, NestedField, PrimitiveType, Schema, Snapshot,
+        SnapshotReference, SnapshotRetention, SortOrder, Summary, TableMetadataBuilder, Type,
+        UnboundPartitionSpec,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_count_snapshots_since_rewrite_in_metadata_ignores_other_branches() {
+        let mut builder = TableMetadataBuilder::new(
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::new(1, "id", Type::Primitive(PrimitiveType::Long), false).into(),
+                ])
+                .build()
+                .unwrap(),
+            UnboundPartitionSpec::builder().build(),
+            SortOrder::unsorted_order(),
+            "s3://warehouse/db/table".to_owned(),
+            FormatVersion::V2,
+            HashMap::new(),
+        )
+        .unwrap();
+
+        for (snapshot_id, parent_snapshot_id, operation) in [
+            (1, None, Operation::Append),
+            (2, Some(1), Operation::Append),
+            (3, Some(2), Operation::Replace),
+            (4, Some(3), Operation::Append),
+            // Simulate the COW publish snapshot on main. It should not affect
+            // the ingestion branch backlog count.
+            (5, None, Operation::Overwrite),
+        ] {
+            builder = builder
+                .add_snapshot(snapshot(snapshot_id, parent_snapshot_id, operation))
+                .unwrap();
+        }
+
+        let metadata = builder
+            .set_ref(super::super::ICEBERG_COW_BRANCH, snapshot_ref(4))
+            .unwrap()
+            .set_ref(MAIN_BRANCH, snapshot_ref(5))
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+
+        let count = IcebergSinkCommitter::count_snapshots_since_rewrite_in_metadata(
+            &metadata,
+            super::super::ICEBERG_COW_BRANCH,
+        );
+
+        assert_eq!(count, 1);
+    }
+
+    fn snapshot(
+        snapshot_id: i64,
+        parent_snapshot_id: Option<i64>,
+        operation: Operation,
+    ) -> Snapshot {
+        Snapshot::builder()
+            .with_snapshot_id(snapshot_id)
+            .with_parent_snapshot_id(parent_snapshot_id)
+            .with_sequence_number(snapshot_id)
+            .with_timestamp_ms(snapshot_id)
+            .with_manifest_list(format!("/snap-{snapshot_id}.avro"))
+            .with_summary(Summary {
+                operation,
+                additional_properties: HashMap::new(),
+            })
+            .with_schema_id(0)
+            .build()
+    }
+
+    fn snapshot_ref(snapshot_id: i64) -> SnapshotReference {
+        SnapshotReference::new(snapshot_id, SnapshotRetention::branch(None, None, None))
+    }
 }

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -126,6 +126,7 @@ pub const COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS: &str =
 pub const COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES: &str =
     "compaction.write_parquet_max_row_group_bytes";
 pub const ORDER_KEY: &str = "order_key";
+pub const DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM: usize = 1000;
 pub const ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES: usize = 128 * 1024 * 1024;
 pub const ENABLE_PK_INDEX: &str = "enable_pk_index";
 
@@ -398,6 +399,7 @@ pub struct IcebergConfig {
 
     /// The maximum number of snapshots allowed since the last rewrite operation
     /// If set, sink will check snapshot count and wait if exceeded
+    /// If unset, defaults to 1000 only when compaction is enabled
     #[serde(rename = "compaction.max_snapshots_num", default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
@@ -528,6 +530,10 @@ impl IcebergConfig {
             serde_json::from_value::<IcebergConfig>(serde_json::to_value(&values).unwrap())
                 .map_err(|e| SinkError::Config(anyhow!(e)))?;
 
+        if config.enable_compaction && !values.contains_key(COMPACTION_MAX_SNAPSHOTS_NUM) {
+            config.max_snapshots_num_before_compaction = Some(DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM);
+        }
+
         if config.r#type != SINK_TYPE_APPEND_ONLY && config.r#type != SINK_TYPE_UPSERT {
             return Err(SinkError::Config(anyhow!(
                 "`{}` must be {}, or {}",
@@ -579,6 +585,12 @@ impl IcebergConfig {
         if config.trigger_snapshot_count == Some(0) {
             return Err(SinkError::Config(anyhow!(
                 "`compaction.trigger_snapshot_count` must be greater than 0"
+            )));
+        }
+
+        if config.max_snapshots_num_before_compaction == Some(0) {
+            return Err(SinkError::Config(anyhow!(
+                "`compaction.max_snapshots_num` must be greater than 0"
             )));
         }
 

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -246,7 +246,7 @@ impl Sink for IcebergSink {
             && max_snapshots < 1
         {
             bail!(
-                "`compaction.max-snapshots-num` must be greater than 0, got: {}",
+                "`compaction.max_snapshots_num` must be greater than 0, got: {}",
                 max_snapshots
             );
         }

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -26,9 +26,10 @@ use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
 use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
 use crate::sink::iceberg::{
     COMPACTION_INTERVAL_SEC, COMPACTION_MAX_SNAPSHOTS_NUM,
-    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, CompactionType, ENABLE_COMPACTION,
-    ENABLE_SNAPSHOT_EXPIRATION, ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, IcebergConfig,
-    IcebergOrderKeyField, IcebergWriteMode, ORDER_KEY, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES,
+    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, CompactionType,
+    DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM, ENABLE_COMPACTION, ENABLE_SNAPSHOT_EXPIRATION,
+    ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, IcebergConfig, IcebergOrderKeyField,
+    IcebergWriteMode, ORDER_KEY, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES,
     SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA, SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS,
     SNAPSHOT_EXPIRATION_RETAIN_LAST, WRITE_MODE, parse_order_key_exprs, validate_order_key_columns,
 };
@@ -324,7 +325,7 @@ fn test_parse_iceberg_config() {
             snapshot_expiration_retain_last: None,
             snapshot_expiration_clear_expired_files: true,
             snapshot_expiration_clear_expired_meta_data: true,
-            max_snapshots_num_before_compaction: None,
+            max_snapshots_num_before_compaction: Some(DEFAULT_COMPACTION_MAX_SNAPSHOTS_NUM),
             small_files_threshold_mb: None,
             delete_files_count_threshold: None,
             trigger_snapshot_count: None,
@@ -712,9 +713,11 @@ fn test_parse_compaction_config() {
     .collect();
 
     let config = IcebergConfig::from_btreemap(values).unwrap();
+    assert!(!config.enable_compaction);
     assert!(config.enable_snapshot_expiration);
     assert_eq!(config.snapshot_expiration_max_age_millis, None);
     assert_eq!(config.snapshot_expiration_retain_last, None);
+    assert_eq!(config.max_snapshots_num_before_compaction, None);
     assert_eq!(config.target_file_size_mb(), 1024); // Default
     assert_eq!(config.write_parquet_compression(), "zstd"); // Default
     assert_eq!(config.write_parquet_max_row_group_rows(), None); // Default
@@ -722,6 +725,25 @@ fn test_parse_compaction_config() {
         config.write_parquet_max_row_group_bytes(),
         Some(ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES)
     );
+
+    let values: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.name", "test-catalog"),
+        ("catalog.type", "storage"),
+        ("warehouse.path", "s3://my-bucket/warehouse"),
+        ("database.name", "test_db"),
+        ("table.name", "test_table"),
+        ("compaction.max_snapshots_num", "1000"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+
+    let config = IcebergConfig::from_btreemap(values).unwrap();
+    assert!(!config.enable_compaction);
+    assert_eq!(config.max_snapshots_num_before_compaction, Some(1000));
 }
 
 #[test]
@@ -745,6 +767,30 @@ fn test_reject_zero_trigger_snapshot_count() {
     assert!(
         err.to_string()
             .contains("`compaction.trigger_snapshot_count` must be greater than 0")
+    );
+}
+
+#[test]
+fn test_reject_zero_max_snapshots_num() {
+    let values: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.name", "test-catalog"),
+        ("catalog.type", "storage"),
+        ("warehouse.path", "s3://my-bucket/warehouse"),
+        ("database.name", "test_db"),
+        ("table.name", "test_table"),
+        ("compaction.max_snapshots_num", "0"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+
+    let err = IcebergConfig::from_btreemap(values).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("`compaction.max_snapshots_num` must be greater than 0")
     );
 }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -731,6 +731,7 @@ IcebergConfig:
     comments: |-
       The maximum number of snapshots allowed since the last rewrite operation
       If set, sink will check snapshot count and wait if exceeded
+      If unset, defaults to 1000 only when compaction is enabled
     required: false
     default: Default::default
     allow_alter_on_fly: true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Add an Iceberg sink write-stop snapshot gate controlled by `compaction.max_snapshots_num`.
- Keep write-stop disabled by default when `enable_compaction = false` and `compaction.max_snapshots_num` is not explicitly configured.
- If `compaction.max_snapshots_num` is explicitly configured, enable the write-stop gate with that value.
- If `enable_compaction = true` and `compaction.max_snapshots_num` is not configured, default the write-stop gate to `1000`.
- Reject `compaction.max_snapshots_num = 0` during config parsing to avoid an unsatisfiable write-stop threshold.
- Keep `enable_snapshot_expiration` enabled by default, preserving the existing Iceberg sink behavior requested in review.
- Count snapshots along the current commit branch lineage for the max-snapshots gate, so COW sinks count `ingestion` snapshots and ignore `main` publish overwrites.
- Regenerate `src/connector/with_options_sink.yaml` and update connector unit tests.

- Closes N/A

## Local verification

- `./risedev generate-with-options`
- `cargo test -p risingwave_connector test_parse_compaction_config --lib`
- `cargo test -p risingwave_connector test_reject_zero_max_snapshots_num --lib`
- `cargo test -p risingwave_connector test_parse_iceberg_config --lib`
- `cargo test -p risingwave_connector test_count_snapshots_since_rewrite_in_metadata_ignores_other_branches --lib`
- `cargo fmt --check`
- `cargo clippy -p risingwave_connector --lib --tests -- -D warnings`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Iceberg sinks now support a write-stop snapshot gate through `compaction.max_snapshots_num`. The gate is disabled by default unless compaction is enabled; with `enable_compaction = true`, it defaults to `1000` when unset. Explicit positive `compaction.max_snapshots_num` values enable the gate with the configured threshold. Snapshot expiration remains enabled by default.

</details>
