### PR TITLE
fix(meta): skip recovered pending sink epochs

### DIFF
--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -246,14 +246,6 @@ impl TwoPhaseCommitHandler {
         );
     }
 
-    fn latest_durable_epoch(&self) -> Option<u64> {
-        self.last_committed_epoch
-            .into_iter()
-            .chain(self.pending_epochs.iter().map(|(epoch, _, _)| *epoch))
-            .chain(self.prepared_epochs.iter().map(|(epoch, _, _)| *epoch))
-            .max()
-    }
-
     fn is_empty(&self) -> bool {
         self.pending_epochs.is_empty() && self.prepared_epochs.is_empty()
     }
@@ -512,7 +504,12 @@ enum CoordinatorWorkerState {
 
 pub struct CoordinatorWorker {
     handle_manager: CoordinationHandleManager,
-    prev_committed_epoch: Option<u64>,
+    /// Last epoch whose commit has been acknowledged to sink writers.
+    ///
+    /// On recovery, pending sink states are treated as already acknowledged to writers, so this is
+    /// initialized to the latest pending epoch if any. Otherwise, it starts from the latest
+    /// committed epoch persisted in `pending_sink_state`.
+    last_writer_acked_epoch: Option<u64>,
     curr_state: CoordinatorWorkerState,
 }
 
@@ -573,7 +570,7 @@ impl CoordinatorWorker {
                 next_handle_id: 0,
                 request_rx,
             },
-            prev_committed_epoch: None,
+            last_writer_acked_epoch: None,
             curr_state: CoordinatorWorkerState::Running,
         };
 
@@ -597,11 +594,8 @@ impl CoordinatorWorker {
             // Delay handling init requests until all pending epochs are flushed.
             self.curr_state = CoordinatorWorkerState::WaitingForFlushed(pending_handle_ids.clone());
         } else {
-            self.handle_init_requests_impl(
-                pending_handle_ids.clone(),
-                two_phase_handler.latest_durable_epoch(),
-            )
-            .await?;
+            self.handle_init_requests_impl(pending_handle_ids.clone())
+                .await?;
         }
         Ok(())
     }
@@ -609,8 +603,8 @@ impl CoordinatorWorker {
     async fn handle_init_requests_impl(
         &mut self,
         pending_handle_ids: impl IntoIterator<Item = HandleId>,
-        log_store_rewind_start_epoch: Option<u64>,
     ) -> anyhow::Result<()> {
+        let log_store_rewind_start_epoch = self.last_writer_acked_epoch;
         self.handle_manager
             .start(log_store_rewind_start_epoch, pending_handle_ids)?;
         if log_store_rewind_start_epoch.is_none() {
@@ -649,11 +643,7 @@ impl CoordinatorWorker {
             && two_phase_handler.is_empty()
         {
             let pending_handle_ids = pending_handle_ids.clone();
-            self.handle_init_requests_impl(
-                pending_handle_ids,
-                two_phase_handler.latest_durable_epoch(),
-            )
-            .await?;
+            self.handle_init_requests_impl(pending_handle_ids).await?;
             self.curr_state = CoordinatorWorkerState::Running;
         }
 
@@ -784,7 +774,6 @@ impl CoordinatorWorker {
                     match commit_res {
                         Ok(_) => {
                             two_phase_handler.ack_committed(epoch).await?;
-                            self.prev_committed_epoch = Some(epoch);
                         }
                         Err(e) => {
                             two_phase_handler.failed_committed(epoch, e);
@@ -858,8 +847,6 @@ impl CoordinatorWorker {
                             )
                             .await?;
                             two_phase_handler.push_new_item(epoch, None, first_schema_change);
-                        } else {
-                            self.prev_committed_epoch = Some(epoch);
                         }
                     }
                     SinkCommitCoordinator::TwoPhase(coordinator) => {
@@ -885,15 +872,13 @@ impl CoordinatorWorker {
                                 commit_metadata,
                                 first_schema_change,
                             );
-                        } else {
-                            // No data to commit and no schema change.
-                            self.prev_committed_epoch = Some(epoch);
                         }
                     }
                 }
 
                 self.handle_manager
                     .ack_commit(epoch, commit_requests.handle_ids)?;
+                self.last_writer_acked_epoch = Some(epoch);
             }
         }
     }
@@ -912,12 +897,15 @@ impl CoordinatorWorker {
         let last_committed_epoch = metadata_iter
             .next_if(|(_, state, _, _)| matches!(state, SinkState::Committed))
             .map(|(epoch, _, _, _)| epoch);
-        self.prev_committed_epoch = last_committed_epoch;
 
         let pending_items = metadata_iter
             .peeking_take_while(|(_, state, _, _)| matches!(state, SinkState::Pending))
             .map(|(epoch, _, metadata, schema_change)| (epoch, metadata, schema_change))
             .collect_vec();
+        self.last_writer_acked_epoch = pending_items
+            .last()
+            .map(|(epoch, _, _)| *epoch)
+            .or(last_committed_epoch);
 
         let mut aborted_epochs = vec![];
 

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -246,6 +246,14 @@ impl TwoPhaseCommitHandler {
         );
     }
 
+    fn latest_durable_epoch(&self) -> Option<u64> {
+        self.last_committed_epoch
+            .into_iter()
+            .chain(self.pending_epochs.iter().map(|(epoch, _, _)| *epoch))
+            .chain(self.prepared_epochs.iter().map(|(epoch, _, _)| *epoch))
+            .max()
+    }
+
     fn is_empty(&self) -> bool {
         self.pending_epochs.is_empty() && self.prepared_epochs.is_empty()
     }
@@ -589,8 +597,11 @@ impl CoordinatorWorker {
             // Delay handling init requests until all pending epochs are flushed.
             self.curr_state = CoordinatorWorkerState::WaitingForFlushed(pending_handle_ids.clone());
         } else {
-            self.handle_init_requests_impl(pending_handle_ids.clone())
-                .await?;
+            self.handle_init_requests_impl(
+                pending_handle_ids.clone(),
+                two_phase_handler.latest_durable_epoch(),
+            )
+            .await?;
         }
         Ok(())
     }
@@ -598,8 +609,8 @@ impl CoordinatorWorker {
     async fn handle_init_requests_impl(
         &mut self,
         pending_handle_ids: impl IntoIterator<Item = HandleId>,
+        log_store_rewind_start_epoch: Option<u64>,
     ) -> anyhow::Result<()> {
-        let log_store_rewind_start_epoch = self.prev_committed_epoch;
         self.handle_manager
             .start(log_store_rewind_start_epoch, pending_handle_ids)?;
         if log_store_rewind_start_epoch.is_none() {
@@ -638,7 +649,11 @@ impl CoordinatorWorker {
             && two_phase_handler.is_empty()
         {
             let pending_handle_ids = pending_handle_ids.clone();
-            self.handle_init_requests_impl(pending_handle_ids).await?;
+            self.handle_init_requests_impl(
+                pending_handle_ids,
+                two_phase_handler.latest_durable_epoch(),
+            )
+            .await?;
             self.curr_state = CoordinatorWorkerState::Running;
         }
 

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -1586,6 +1586,145 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_init_response_skips_recovered_pending_epoch() {
+        let db = prepare_db_backend().await;
+
+        let param = SinkParam {
+            sink_id: SinkId::from(1),
+            sink_name: "test".into(),
+            properties: Default::default(),
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let epoch1 = 233;
+        let metadata = vec![1u8, 2u8];
+
+        let sql = format!(
+            "INSERT INTO pending_sink_state (sink_id, epoch, sink_state, metadata) VALUES ({}, {}, 'PENDING', x'0102')",
+            param.sink_id, epoch1
+        );
+        db.execute(sea_orm::Statement::from_string(
+            db.get_database_backend(),
+            sql,
+        ))
+        .await
+        .unwrap();
+
+        let all_vnode = (0..VirtualNode::COUNT_FOR_TEST).collect_vec();
+        let build_bitmap = |indexes: &[usize]| {
+            let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+            for i in indexes {
+                builder.set(*i, true);
+            }
+            builder.finish()
+        };
+        let vnode = build_bitmap(&all_vnode);
+
+        let sender = Arc::new(tokio::sync::Mutex::new(None));
+        let mock_subscriber: SinkCommittedEpochSubscriber = {
+            let captured_sender = sender.clone();
+            Arc::new(move |_sink_id: SinkId| {
+                let (epoch_sender, receiver) = unbounded_channel();
+                let captured_sender = captured_sender.clone();
+                async move {
+                    let mut guard = captured_sender.lock().await;
+                    *guard = Some(epoch_sender);
+                    Ok((epoch1, receiver))
+                }
+                .boxed()
+            })
+        };
+
+        let pre_commit_attempt = Arc::new(AtomicI32::new(0));
+        let commit_attempt = Arc::new(AtomicI32::new(0));
+        let (manager, (_join_handle, _stop_tx)) =
+            SinkCoordinatorManager::start_worker_with_spawn_worker({
+                let expected_param = param.clone();
+                let db = db.clone();
+                let metadata = metadata.clone();
+                let pre_commit_attempt = pre_commit_attempt.clone();
+                let commit_attempt = commit_attempt.clone();
+                move |param, new_writer_rx| {
+                    let expected_param = expected_param.clone();
+                    let db = db.clone();
+                    let metadata = metadata.clone();
+                    let pre_commit_attempt = pre_commit_attempt.clone();
+                    let commit_attempt = commit_attempt.clone();
+                    tokio::spawn({
+                        let subscriber = mock_subscriber.clone();
+                        async move {
+                            assert_eq!(param, expected_param);
+                            CoordinatorWorker::execute_coordinator(
+                                db,
+                                param.clone(),
+                                new_writer_rx,
+                                MockTwoPhaseCoordinator::new_coordinator(
+                                    move |_epoch, _metadata_list, _schema_change| {
+                                        pre_commit_attempt.fetch_add(
+                                            1,
+                                            std::sync::atomic::Ordering::SeqCst,
+                                        );
+                                        Err(SinkError::Coordinator(anyhow!(
+                                            "pre_commit should not be called for a known pending epoch"
+                                        )))
+                                    },
+                                    move |epoch, commit_metadata| {
+                                        assert_eq!(epoch, epoch1);
+                                        assert_eq!(commit_metadata, metadata);
+                                        commit_attempt
+                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                                        Ok(())
+                                    },
+                                    move |_epoch, _schema_change| unreachable!(),
+                                ),
+                                subscriber.clone(),
+                            )
+                            .await;
+                        }
+                    })
+                }
+            });
+
+        let (_client, log_store_rewind_start_epoch) =
+            CoordinatorStreamHandle::new_with_init_stream(param.to_proto(), vnode, |rx| async {
+                Ok(tonic::Response::new(
+                    manager
+                        .handle_new_request(ReceiverStream::new(rx).map(Ok).boxed())
+                        .await
+                        .unwrap()
+                        .boxed(),
+                ))
+            })
+            .await
+            .unwrap();
+        assert_eq!(log_store_rewind_start_epoch, Some(epoch1));
+
+        for _ in 0..50 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            let rows = list_rows(&db).await;
+            if rows[0].2 == "COMMITTED" {
+                break;
+            }
+        }
+
+        assert_eq!(
+            pre_commit_attempt.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(commit_attempt.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let rows = list_rows(&db).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].1, epoch1 as i64);
+        assert_eq!(rows[0].2, "COMMITTED");
+    }
+
+    #[tokio::test]
     async fn test_pre_commit_failed() {
         let db = prepare_db_backend().await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix the exactly-once sink coordinator error observed after meta restart:

```
"message":"Error inserting into exactly once system table: Execution Error: error returned from database: duplicate key value violates unique constraint \"pending_sink_state_pkey\""},"target":"risingwave_meta::manager::sink_coordination::exactly_once_util"
```

The root issue is that a writer may miss the commit ACK for epoch `E`, reconnect after meta restarts, and replay `E`. If meta has already recovered `E` as a `PENDING` row in `pending_sink_state`, replaying `E` tries to insert the same `(sink_id, epoch)` again.

This PR makes the sink coordinator track `last_writer_acked_epoch`, the latest epoch whose commit has been acknowledged to writers. On recovery, existing `PENDING` rows are treated as already acknowledged to writers, because they must have been persisted before the previous coordinator sent the commit response. Therefore, `last_writer_acked_epoch` is initialized from the latest recovered pending epoch if one exists, otherwise from the latest committed epoch.

Writer init responses now use `last_writer_acked_epoch` as the log-store rewind start epoch. Recovered pending epochs remain in the coordinator retry queue and continue toward commit, while reconnected writers start after those epochs and do not replay already persisted pre-commit metadata.

- Closes N/A

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Bug fix: exactly-once sink writers avoid replaying epochs whose pre-commit metadata was already persisted before a meta restart.

</details>
