### PR TITLE
fix(cdc): reject CDC table creation when Debezium column filter drops PK column

### DIFF
--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -38,7 +38,7 @@ use risingwave_common::{bail, bail_not_implemented};
 use risingwave_connector::sink::decouple_checkpoint_log_sink::COMMIT_CHECKPOINT_INTERVAL;
 use risingwave_connector::source::cdc::external::{
     DATABASE_NAME_KEY, ExternalCdcTableType, ExternalTableConfig, ExternalTableImpl,
-    SCHEMA_NAME_KEY, TABLE_NAME_KEY,
+    SCHEMA_NAME_KEY, SchemaTableName, TABLE_NAME_KEY,
 };
 use risingwave_connector::source::cdc::{
     build_cdc_table_id, normalize_simple_postgres_quoted_table_name,
@@ -1193,6 +1193,50 @@ fn parse_postgres_cdc_external_table_name(external_table_name: &str) -> Result<(
     }
 }
 
+/// Reject `CREATE TABLE` when a primary-key column is excluded from Debezium change-event
+/// values via `debezium.column.exclude.list`.
+///
+/// Debezium's `column.exclude.list` only filters the change-event **value** payload.
+/// Message keys are always built from the upstream PRIMARY KEY and are not affected.
+/// If a PK column is dropped from the value, RisingWave reads NULL for that PK column
+/// from the payload, causing silent data corruption: UPDATE turns into a fresh INSERT
+/// (PK mismatch with the original row) and DELETE silently no-ops.
+///
+/// Debezium pattern format is `<namespace>.<table>.<column>`, where namespace is
+/// `schema` for Postgres / SQL Server and `database` for MySQL. We strip the current
+/// table's `<namespace>.<table>.` prefix to recover the column name; entries that
+/// target other tables are skipped.
+fn reject_pk_excluded_by_debezium_filter(
+    pk_names: &[String],
+    cdc_with_options: &WithOptionsSecResolved,
+) -> Result<()> {
+    const EXCLUDE_KEY: &str = "debezium.column.exclude.list";
+
+    let Some(exclude_list) = cdc_with_options.get(EXCLUDE_KEY) else {
+        return Ok(());
+    };
+
+    let st = SchemaTableName::from_properties(cdc_with_options.as_plaintext());
+    let prefix = format!("{}.{}.", st.schema_name, st.table_name);
+
+    for entry in exclude_list.split(',') {
+        let Some(col) = entry.trim().strip_prefix(prefix.as_str()) else {
+            continue;
+        };
+        if pk_names.iter().any(|pk| pk == col) {
+            return Err(ErrorCode::InvalidInputSyntax(format!(
+                "primary key column `{col}` is excluded by `{EXCLUDE_KEY}`. \
+                 Excluding a PK column causes silent data corruption: Debezium keeps \
+                 the PK in the message key but drops it from the payload, so RisingWave \
+                 cannot match UPDATE/DELETE events against the original row."
+            ))
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_create_table_plan(
     handler_args: HandlerArgs,
@@ -1346,6 +1390,13 @@ pub(super) async fn handle_create_table_plan(
                     (columns, pk_names)
                 }
             };
+
+            // CDC-table branch only: if `debezium.column.exclude.list` covers a PK
+            // column, Debezium drops it from the change-event value while keeping it
+            // in the message key. RisingWave would read NULL for that PK from the
+            // payload, silently corrupting downstream (UPDATE turns into a fresh
+            // INSERT, DELETE no-ops). Plain (non-CDC) tables don't hit this check.
+            reject_pk_excluded_by_debezium_filter(&pk_names, &cdc_with_options)?;
 
             let context: OptimizerContextRef =
                 OptimizerContext::new(handler_args, explain_options).into();
@@ -2721,6 +2772,10 @@ pub async fn generate_stream_graph_for_replace_table(
                 )?;
 
             let (column_catalogs, pk_names) = bind_cdc_table_schema(&columns, &constraints, true)?;
+
+            // CDC-table branch only: see the comment at the symmetric call site in
+            // `handle_create_table_plan`. Plain (non-CDC) tables don't hit this check.
+            reject_pk_excluded_by_debezium_filter(&pk_names, &cdc_with_options)?;
 
             let context: OptimizerContextRef =
                 OptimizerContext::new(handler_args, ExplainOptions::default()).into();

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use clap::ValueEnum;
 use either::Either;
+use fancy_regex::Regex;
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 use percent_encoding::percent_decode_str;
@@ -1193,48 +1194,116 @@ fn parse_postgres_cdc_external_table_name(external_table_name: &str) -> Result<(
     }
 }
 
-/// Reject `CREATE TABLE` when a primary-key column is excluded from Debezium change-event
-/// values via `debezium.column.exclude.list`.
+/// Reject `CREATE TABLE` when a primary-key column is filtered out of Debezium change-event
+/// values via `debezium.column.exclude.list` or `debezium.column.include.list`.
 ///
-/// Debezium's `column.exclude.list` only filters the change-event **value** payload.
-/// Message keys are always built from the upstream PRIMARY KEY and are not affected.
-/// If a PK column is dropped from the value, RisingWave reads NULL for that PK column
-/// from the payload, causing silent data corruption: UPDATE turns into a fresh INSERT
-/// (PK mismatch with the original row) and DELETE silently no-ops.
+/// Debezium's column filters only apply to the change-event **value** payload. Message keys are
+/// always built from the upstream PRIMARY KEY and are not affected. If a PK column is filtered out
+/// of the value, RisingWave reads NULL for that PK column from the payload, causing silent data
+/// corruption: UPDATE turns into a fresh INSERT (PK mismatch with the original row) and DELETE
+/// silently no-ops.
 ///
-/// Debezium pattern format is `<namespace>.<table>.<column>`, where namespace is
-/// `schema` for Postgres / SQL Server and `database` for MySQL. We strip the current
-/// table's `<namespace>.<table>.` prefix to recover the column name; entries that
-/// target other tables are skipped.
-fn reject_pk_excluded_by_debezium_filter(
+/// Debezium entries are regex patterns matched against the fully qualified column name
+/// `<namespace>.<table>.<column>`, where namespace is `schema` for Postgres / SQL Server and
+/// `database` for MySQL.
+fn reject_pk_filtered_by_debezium_column_filter(
     pk_names: &[String],
     cdc_with_options: &WithOptionsSecResolved,
 ) -> Result<()> {
     const EXCLUDE_KEY: &str = "debezium.column.exclude.list";
-
-    let Some(exclude_list) = cdc_with_options.get(EXCLUDE_KEY) else {
-        return Ok(());
-    };
+    const INCLUDE_KEY: &str = "debezium.column.include.list";
 
     let st = SchemaTableName::from_properties(cdc_with_options.as_plaintext());
-    let prefix = format!("{}.{}.", st.schema_name, st.table_name);
+    reject_pk_filtered_by_debezium_column_filter_inner(
+        pk_names,
+        &st,
+        cdc_with_options.get(EXCLUDE_KEY).map(String::as_str),
+        cdc_with_options.get(INCLUDE_KEY).map(String::as_str),
+    )
+}
 
-    for entry in exclude_list.split(',') {
-        let Some(col) = entry.trim().strip_prefix(prefix.as_str()) else {
-            continue;
-        };
-        if pk_names.iter().any(|pk| pk == col) {
-            return Err(ErrorCode::InvalidInputSyntax(format!(
-                "primary key column `{col}` is excluded by `{EXCLUDE_KEY}`. \
-                 Excluding a PK column causes silent data corruption: Debezium keeps \
-                 the PK in the message key but drops it from the payload, so RisingWave \
-                 cannot match UPDATE/DELETE events against the original row."
-            ))
-            .into());
+fn reject_pk_filtered_by_debezium_column_filter_inner(
+    pk_names: &[String],
+    st: &SchemaTableName,
+    exclude_list: Option<&str>,
+    include_list: Option<&str>,
+) -> Result<()> {
+    const EXCLUDE_KEY: &str = "debezium.column.exclude.list";
+    const INCLUDE_KEY: &str = "debezium.column.include.list";
+
+    let pk_full_names = pk_names
+        .iter()
+        .map(|pk| (pk, format!("{}.{}.{}", st.schema_name, st.table_name, pk)))
+        .collect_vec();
+
+    if let Some(exclude_list) = exclude_list {
+        let patterns = compile_debezium_column_filter_patterns(EXCLUDE_KEY, exclude_list)?;
+        for (pk, pk_full_name) in &pk_full_names {
+            for (pattern, regex) in &patterns {
+                if regex.is_match(pk_full_name).map_err(|err| {
+                    ErrorCode::InvalidInputSyntax(format!(
+                        "failed to evaluate Debezium column filter pattern `{pattern}` in `{EXCLUDE_KEY}`: {err}"
+                    ))
+                })? {
+                    return Err(ErrorCode::InvalidInputSyntax(format!(
+                        "primary key column `{pk}` is excluded by `{EXCLUDE_KEY}` pattern \
+                         `{pattern}`. Excluding a PK column causes silent data corruption: \
+                         Debezium keeps the PK in the message key but drops it from the payload, \
+                         so RisingWave cannot match UPDATE/DELETE events against the original row."
+                    ))
+                    .into());
+                }
+            }
+        }
+    }
+
+    if let Some(include_list) = include_list {
+        let patterns = compile_debezium_column_filter_patterns(INCLUDE_KEY, include_list)?;
+        for (pk, pk_full_name) in &pk_full_names {
+            let mut included = false;
+            for (_, regex) in &patterns {
+                if regex.is_match(pk_full_name).map_err(|err| {
+                    ErrorCode::InvalidInputSyntax(format!(
+                        "failed to evaluate Debezium column filter pattern in `{INCLUDE_KEY}`: {err}"
+                    ))
+                })? {
+                    included = true;
+                    break;
+                }
+            }
+            if !included {
+                return Err(ErrorCode::InvalidInputSyntax(format!(
+                    "primary key column `{pk}` is not included by `{INCLUDE_KEY}`. Omitting a PK \
+                     column causes silent data corruption: Debezium keeps the PK in the message key \
+                     but drops it from the payload, so RisingWave cannot match UPDATE/DELETE events \
+                     against the original row."
+                ))
+                .into());
+            }
         }
     }
 
     Ok(())
+}
+
+fn compile_debezium_column_filter_patterns(
+    key: &str,
+    filter_list: &str,
+) -> Result<Vec<(String, Regex)>> {
+    filter_list
+        .split(',')
+        .map(str::trim)
+        .filter(|pattern| !pattern.is_empty())
+        .map(|pattern| {
+            let anchored_pattern = format!("(?i:^(?:{pattern})$)");
+            let regex = Regex::new(&anchored_pattern).map_err(|err| {
+                ErrorCode::InvalidInputSyntax(format!(
+                    "invalid Debezium column filter pattern `{pattern}` in `{key}`: {err}"
+                ))
+            })?;
+            Ok((pattern.to_owned(), regex))
+        })
+        .collect()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1391,12 +1460,11 @@ pub(super) async fn handle_create_table_plan(
                 }
             };
 
-            // CDC-table branch only: if `debezium.column.exclude.list` covers a PK
-            // column, Debezium drops it from the change-event value while keeping it
-            // in the message key. RisingWave would read NULL for that PK from the
-            // payload, silently corrupting downstream (UPDATE turns into a fresh
-            // INSERT, DELETE no-ops). Plain (non-CDC) tables don't hit this check.
-            reject_pk_excluded_by_debezium_filter(&pk_names, &cdc_with_options)?;
+            // CDC-table branch only: if Debezium column filters remove a PK column from the
+            // change-event value, RisingWave reads NULL for that PK from the payload and silently
+            // corrupts downstream (UPDATE turns into a fresh INSERT, DELETE no-ops). Plain
+            // (non-CDC) tables don't hit this check.
+            reject_pk_filtered_by_debezium_column_filter(&pk_names, &cdc_with_options)?;
 
             let context: OptimizerContextRef =
                 OptimizerContext::new(handler_args, explain_options).into();
@@ -2775,7 +2843,7 @@ pub async fn generate_stream_graph_for_replace_table(
 
             // CDC-table branch only: see the comment at the symmetric call site in
             // `handle_create_table_plan`. Plain (non-CDC) tables don't hit this check.
-            reject_pk_excluded_by_debezium_filter(&pk_names, &cdc_with_options)?;
+            reject_pk_filtered_by_debezium_column_filter(&pk_names, &cdc_with_options)?;
 
             let context: OptimizerContextRef =
                 OptimizerContext::new(handler_args, ExplainOptions::default()).into();
@@ -2978,6 +3046,104 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{LocalFrontend, PROTO_FILE_DATA, create_proto_file};
+
+    fn test_schema_table_name() -> SchemaTableName {
+        SchemaTableName {
+            schema_name: "public".to_owned(),
+            table_name: "orders".to_owned(),
+        }
+    }
+
+    fn pk_names() -> Vec<String> {
+        vec!["plan_id".to_owned(), "site_id".to_owned()]
+    }
+
+    #[test]
+    fn test_debezium_filter_rejects_literal_excluded_pk() {
+        let err = reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            Some("public.orders.site_id"),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(err.to_report_string().contains("site_id"));
+        assert!(
+            err.to_report_string()
+                .contains("debezium.column.exclude.list")
+        );
+    }
+
+    #[test]
+    fn test_debezium_filter_rejects_include_list_missing_pk() {
+        let err = reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            None,
+            Some("public.orders.plan_id,public.orders.payload"),
+        )
+        .unwrap_err();
+
+        assert!(err.to_report_string().contains("site_id"));
+        assert!(
+            err.to_report_string()
+                .contains("debezium.column.include.list")
+        );
+    }
+
+    #[test]
+    fn test_debezium_filter_accepts_include_list_covering_all_pks() {
+        reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            None,
+            Some("public.orders.plan_id,public.orders.site_id,public.orders.payload"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_debezium_filter_matches_regex_patterns() {
+        reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            None,
+            Some(r"public[.]orders[.](plan_id|site_id),public[.]orders[.]payload"),
+        )
+        .unwrap();
+
+        let err = reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            Some(r".*[.]orders[.]site_id"),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(err.to_report_string().contains("site_id"));
+    }
+
+    #[test]
+    fn test_debezium_filter_matches_patterns_case_insensitively() {
+        let err = reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            Some("PUBLIC.ORDERS.SITE_ID"),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(err.to_report_string().contains("site_id"));
+
+        reject_pk_filtered_by_debezium_column_filter_inner(
+            &pk_names(),
+            &test_schema_table_name(),
+            None,
+            Some("Public.Orders.Plan_ID,Public.Orders.Site_ID"),
+        )
+        .unwrap();
+    }
 
     #[tokio::test]
     async fn test_create_table_handler() {

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -1242,7 +1242,8 @@ fn reject_pk_filtered_by_debezium_column_filter_inner(
             for (pattern, regex) in &patterns {
                 if regex.is_match(pk_full_name).map_err(|err| {
                     ErrorCode::InvalidInputSyntax(format!(
-                        "failed to evaluate Debezium column filter pattern `{pattern}` in `{EXCLUDE_KEY}`: {err}"
+                        "failed to evaluate Debezium column filter pattern `{pattern}` in `{EXCLUDE_KEY}`: {}",
+                        err.as_report()
                     ))
                 })? {
                     return Err(ErrorCode::InvalidInputSyntax(format!(
@@ -1264,7 +1265,8 @@ fn reject_pk_filtered_by_debezium_column_filter_inner(
             for (_, regex) in &patterns {
                 if regex.is_match(pk_full_name).map_err(|err| {
                     ErrorCode::InvalidInputSyntax(format!(
-                        "failed to evaluate Debezium column filter pattern in `{INCLUDE_KEY}`: {err}"
+                        "failed to evaluate Debezium column filter pattern in `{INCLUDE_KEY}`: {}",
+                        err.as_report()
                     ))
                 })? {
                     included = true;
@@ -1298,7 +1300,8 @@ fn compile_debezium_column_filter_patterns(
             let anchored_pattern = format!("(?i:^(?:{pattern})$)");
             let regex = Regex::new(&anchored_pattern).map_err(|err| {
                 ErrorCode::InvalidInputSyntax(format!(
-                    "invalid Debezium column filter pattern `{pattern}` in `{key}`: {err}"
+                    "invalid Debezium column filter pattern `{pattern}` in `{key}`: {}",
+                    err.as_report()
                 ))
             })?;
             Ok((pattern.to_owned(), regex))


### PR DESCRIPTION
## Summary

When a CDC table is created on a source whose `debezium.column.exclude.list` (or `debezium.column.include.list`) drops a primary-key column from the change-event **value** payload, RisingWave currently lands the table without complaint and then quietly corrupts data downstream.

Debezium's column filters only apply to the value payload. Message keys are always built from the upstream `PRIMARY KEY` and are not affected by these filters. If a PK column is filtered out of the value, RisingWave's CDC parser reads `NULL` for that PK column from the payload, producing:

- **INSERT** → row lands with `NULL` in the PK column.
- **UPDATE** → cannot locate the original row (PK mismatch with the row written by backfill / earlier INSERT), so it behaves like a fresh INSERT and leaves the old row stale.
- **DELETE** → cannot locate the original row, silently no-ops.

The bug is reproducible locally with `postgres-cdc`. A minimal repro:

```sql
CREATE TABLE pk_exclude_test (
    plan_id  int,
    site_id  int,
    payload  text,
    PRIMARY KEY (plan_id, site_id)
);

CREATE SOURCE pg_src WITH (
    connector = 'postgres-cdc',
    ...,
    debezium.column.exclude.list = 'public.pk_exclude_test.site_id'
);

CREATE TABLE pk_exclude_test (*) FROM pg_src TABLE 'public.pk_exclude_test';
```

After a few realtime INSERT / UPDATE / DELETE operations upstream, the downstream table contains rows with `NULL` in `site_id` and the original rows that should have been UPDATE'd or DELETE'd are still around — every row in conflict appears twice.

## Why ban instead of fixing the parser to read PK from message key

Reading PK from the message key (the protocol-correct fix) would require non-trivial parser changes across all CDC connectors and additional handling for `UPDATE`-on-PK-change semantics. In practice this misconfiguration is rare — most users do not configure `debezium.column.exclude.list` on direct CDC at all, and those who do typically don't include PK columns in the filter. Banning the misconfiguration at DDL time is a small, defensive change that converts a silent data-corruption path into a clear, fail-fast error, with very low blast radius.

## Scope

This change only covers **direct CDC** (`postgres-cdc` / `mysql-cdc` / `sqlserver-cdc`). Pipelines that route Debezium events through Kafka are not affected by this fix because RisingWave never sees the standalone Debezium configuration in that path — that's a separate problem to be addressed in the source parser layer.

The single insertion is in the shared `(None, Some(cdc_table))` branch of `handle_create_table_plan`, so PG / MySQL / SQL Server share the same validation path. The symmetric `generate_stream_graph_for_replace_table` codepath is updated too, to keep `ALTER TABLE ... DROP/ADD COLUMN` consistent.

MongoDB CDC is not affected — it uses a different filter (`field.exclude.list`) and a different key shape.

## Implementation

A new private function `reject_pk_excluded_by_debezium_filter` in `create_table.rs`:

- Reads `debezium.column.exclude.list` / `debezium.column.include.list` from the merged CDC options.
- Computes the current table's `<namespace>.<table>.` prefix from `SchemaTableName::from_properties` (`schema` for PG / SQL Server, `database` for MySQL).
- Strips that prefix from each comma-separated entry to recover the column names targeting this table.
- For `exclude.list`: rejects if any PK column appears in the resulting set.
- For `include.list`: rejects if any PK column is missing from the resulting set.

Entries targeting other tables are ignored, so there are no false positives across tables that happen to share PK column names. Patterns using regex meta-characters against PK columns are out of scope — users relying on regex wildcards over PK columns should not be relying on it for correctness.

## Test plan

- [x] Local repro script (`pk_excluded_from_value_test.sh`) before the fix: silent corruption (rows with NULL PK columns, dangling rows after DELETE).
- [x] Same script after the fix: `CREATE TABLE` fails fast with a clear `InvalidInputSyntax` error message instructing the user to remove the PK column from the filter.
- [x] `cargo fmt --all` clean.
- [x] `./risedev c` clean (workspace-wide clippy + typos + trailing whitespace + machete).
- [ ] Add a SLT regression test under `e2e_test/source_legacy/cdc_inline/` covering at least PG and MySQL (follow-up).