### PR TITLE
test(source): regression test for parquet file source with non-parquet objects

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -34,6 +34,7 @@ risedev ci-start ci-1cn-1fe-with-recovery
 
 echo "--- Run generic source tests"
 risedev slt './e2e_test/source_inline/fs/posix_fs.slt'
+risedev slt './e2e_test/source_inline/fs/parquet_dirty_object.slt'
 risedev slt './e2e_test/source_inline/refresh/refresh_table.slt'
 risedev slt './e2e_test/source_inline/vault/vault_secret_ddl.slt'
 

--- a/e2e_test/source_inline/fs/parquet_dirty_object.slt
+++ b/e2e_test/source_inline/fs/parquet_dirty_object.slt
@@ -1,0 +1,69 @@
+# Regression test for https://github.com/risingwavelabs/risingwave/issues/25430
+#
+# In v2.8.2, a Parquet file source that listed an object the Parquet reader
+# could not decode (e.g. a non-Parquet binary that happened to land in the same
+# bucket/directory because the source had no `match_pattern`) would crash the
+# compute node with an `attempt to subtract with overflow` panic in
+# `src/stream/src/executor/source/fs_fetch_executor.rs`:
+#
+#     thread 'rw-streaming' panicked at .../fs_fetch_executor.rs:440:
+#     attempt to subtract with overflow
+#
+# Root cause: the fetch executor's error branch reset `splits_on_fetch` to 0
+# without removing the bad split from the in-flight chained stream. A later
+# legitimate end-of-file `None` event then tried to decrement the counter from
+# 0, hitting the underflow `debug_assert` and panicking the streaming actor.
+#
+# This was fixed on main by #24718 (refactor(source): skip bad file splits
+# after retry in fs_fetch executor), which:
+#   - binds a split id to each per-file sub-stream via `SetReadingFileOnPoll`,
+#   - retries a bad split up to `MAX_RETRIES_PER_SPLIT` times with backoff,
+#   - then marks it dirty, drops the chained merged stream, and rebuilds the
+#     reader from the state table so `splits_on_fetch` stays consistent.
+#
+# This test exercises the exact mixed-content scenario (one valid Parquet plus
+# one undecodable file in the same `posix_fs.root`) and asserts the source
+# converges to the rows from the valid file instead of panicking the streaming
+# actor. Without the #24718 fix, this query would never converge because the
+# compute node panics before the table can be fully ingested.
+
+system ok
+bash -euo pipefail -c '
+  rm -rf /tmp/rw_parquet_dirty_object
+  mkdir -p /tmp/rw_parquet_dirty_object
+  # Inline minimal Parquet file with two rows: (v1=1, v2=10), (v1=2, v2=20).
+  # The leading "PAR1" magic and the row count are visible in the base64.
+  printf "%s" "UEFSMRUAFRQVGCwVAhUAFQYVBgAACiQCAAAAAgEBAAAAFQAVFBUYLBUCFQAVBhUGAAAKJAIAAAACAQoAAAAVABUUFRgsFQIVABUGFQYAAAokAgAAAAIBAgAAABUAFRQVGCwVAhUAFQYVBgAACiQCAAAAAgEUAAAAFQIZPDUAGA1kdWNrZGJfc2NoZW1hFQQAFQIlAhgCdjElIgAVAiUCGAJ2MiUiABYEGSwZLCYAHBUCGRUAGRgCdjEVAhYCFjYWOiYIPBgEAQAAABgEAQAAABYAKAQBAAAAGAQBAAAAAAAAJgAcFQIZFQAZGAJ2MhUCFgIWNhY6JkI8GAQKAAAAGAQKAAAAFgAoBAoAAAAYBAoAAAAAAAAWgIgCFgImCAAZLCYAHBUCGRUAGRgCdjEVAhYCFjYWOiZ8PBgEAgAAABgEAgAAABYAKAQCAAAAGAQCAAAAAAAAJgAcFQIZFQAZGAJ2MhUCFgIWNhY6JrYBPBgEFAAAABgEFAAAABYAKAQUAAAAGAQUAAAAAAAAFoCIAhYCJnwAKAZEdWNrREIAJgEAAFBBUjE=" \
+    | base64 -d > /tmp/rw_parquet_dirty_object/10_good.parquet
+  # Non-Parquet object that the Parquet reader will fail to decode. This is the
+  # in-tree stand-in for the "Hummock SST that landed in the same bucket"
+  # scenario from issue #25430.
+  printf "not a parquet file\n" > /tmp/rw_parquet_dirty_object/bad_14.bin
+'
+
+statement ok
+CREATE TABLE parquet_dirty_object (
+    v1 int,
+    v2 int
+) WITH (
+    connector = 'posix_fs',
+    posix_fs.root = '/tmp/rw_parquet_dirty_object'
+) FORMAT PLAIN ENCODE PARQUET;
+
+# Allow the fetch executor enough time to:
+#   1. discover both files via the list executor,
+#   2. successfully read the good Parquet file,
+#   3. retry the bad file MAX_RETRIES_PER_SPLIT times with backoff,
+#   4. mark the bad file as dirty and converge.
+# Pre-fix (v2.8.2): the compute node panics before this query can succeed.
+# Post-fix (main):  this query converges to (2, 30).
+query II retry 20 backoff 1s
+SELECT count(*), sum(v2) FROM parquet_dirty_object;
+----
+2 30
+
+statement ok
+DROP TABLE parquet_dirty_object;
+
+system ok
+rm -rf /tmp/rw_parquet_dirty_object


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR adds an `e2e_test/source_inline/fs/parquet_dirty_object.slt` regression test for issue #25430, and wires it into the CI generic source-test stage. **No production code is changed.**

### Background — the bug

In v2.8.2, a Parquet `posix_fs` / `s3` file source whose listing root contained a non-Parquet object would crash the compute node with:

```text
thread 'rw-streaming' panicked at src/stream/src/executor/source/fs_fetch_executor.rs:440:
attempt to subtract with overflow
```

This happens in the real-world setup from #25430: the user created an S3 Parquet source on a bucket that was *also* the Hummock storage bucket and did not set `match_pattern`, so the file enumerator recursively listed the bucket and handed Hummock SST objects to the Parquet reader. The first such object failed in the Parquet reader, the executor's error branch reset `splits_on_fetch` to `0` without removing the bad split from the chained per-file stream, then a later legitimate end-of-file `None` event decremented `splits_on_fetch` from `0` — `usize` underflow, debug-assert panic, streaming actor dies.

### Root cause and existing fix

The underlying fetch-executor bug was already fixed on `main` by #24718 (*refactor(source): skip bad file splits after retry in fs_fetch executor*). After #24718, `fs_fetch_executor.rs`:

- binds the current split id per sub-stream via `SetReadingFileOnPoll`, so errors that occur **before the first chunk** can be attributed to the right split;
- retries a failing split up to `MAX_RETRIES_PER_SPLIT` times with exponential backoff;
- after retries are exhausted, marks the split dirty, resets `splits_on_fetch`, **drops the chained merged stream and rebuilds the reader** from the state table (filtering out dirty splits), so the counter and the in-flight stream stay consistent;
- exposes `file_source_dirty_split_count` / `file_source_failed_split_count` metrics for observability.

That fix made the panic disappear in practice, but the failure mode was never covered by an e2e test, so a future refactor could silently regress it.

### What this PR adds

A focused e2e regression test that reproduces the exact mixed-content scenario locally with `posix_fs` (the in-tree stand-in for the original S3 + Hummock-bucket setup — the panic happens in `fs_fetch_executor.rs`, which is the shared OpenDAL-backed code path across `posix_fs` / `s3` / `gcs` / `azblob`):

1. Generates a temporary `posix_fs.root` containing
   - `10_good.parquet` — a minimal valid Parquet file with two rows (`(v1=1, v2=10)`, `(v1=2, v2=20)`), and
   - `bad_14.bin` — a non-Parquet binary that the Parquet reader fails to decode (the in-tree stand-in for the Hummock SST that landed in the same bucket in #25430).
2. Creates a `posix_fs` + `ENCODE PARQUET` table over that directory **without** `match_pattern`, mirroring the user's setup.
3. Asserts the table converges to `(count=2, sum(v2)=30)` with a bounded retry/backoff window, which is only possible if the fetch executor survives the bad object instead of panicking the streaming actor.

Before #24718 (verified locally against a v2.8.2 worktree with debug assertions on), this test reproduces the panic:

```text
thread 'rw-streaming' panicked at src/stream/src/executor/source/fs_fetch_executor.rs:440:37:
attempt to subtract with overflow
```

After #24718 (current `main`), the same test passes (`sqllogictest ... [OK]` ~6s on an M-class laptop).

The CI hook in `ci/scripts/e2e-source-test.sh` runs the new SLT immediately after `posix_fs.slt` in the existing *generic source test* stage, so it runs on every PR without adding a new pipeline.

### Why no production-code change in this PR

The user-visible panic is already fixed by #24718. A `saturating_sub` / `debug_assert` belt-and-suspenders around the remaining `splits_on_fetch -= 1` site, and DDL-level UX hardening (e.g. requiring an explicit `match_pattern` / prefix for `ENCODE PARQUET` so users cannot accidentally scan an entire bucket — including their own Hummock storage bucket — by omission), are reasonable follow-ups but are deliberately out of scope here to keep this PR minimal and the regression coverage isolated.

- Closes #25430

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

None — test-only change. The underlying compute-node panic (issue #25430) was already fixed in `main` by #24718; this PR only adds an e2e regression test so the bug cannot silently come back.

</details>