### PR TITLE
test(source): cover dirty parquet object in file source

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -34,6 +34,7 @@ risedev ci-start ci-1cn-1fe-with-recovery
 
 echo "--- Run generic source tests"
 risedev slt './e2e_test/source_inline/fs/posix_fs.slt'
+risedev slt './e2e_test/source_inline/fs/parquet_dirty_object.slt'
 risedev slt './e2e_test/source_inline/refresh/refresh_table.slt'
 risedev slt './e2e_test/source_inline/vault/vault_secret_ddl.slt'
 

--- a/e2e_test/source_inline/fs/parquet_dirty_object.slt
+++ b/e2e_test/source_inline/fs/parquet_dirty_object.slt
@@ -1,0 +1,22 @@
+system ok
+bash -c 'set -euo pipefail; rm -rf /tmp/rw_parquet_dirty_object; mkdir -p /tmp/rw_parquet_dirty_object; printf "%s" "UEFSMRUAFRQVGCwVAhUAFQYVBgAACiQCAAAAAgEBAAAAFQAVFBUYLBUCFQAVBhUGAAAKJAIAAAACAQoAAAAVABUUFRgsFQIVABUGFQYAAAokAgAAAAIBAgAAABUAFRQVGCwVAhUAFQYVBgAACiQCAAAAAgEUAAAAFQIZPDUAGA1kdWNrZGJfc2NoZW1hFQQAFQIlAhgCdjElIgAVAiUCGAJ2MiUiABYEGSwZLCYAHBUCGRUAGRgCdjEVAhYCFjYWOiYIPBgEAQAAABgEAQAAABYAKAQBAAAAGAQBAAAAAAAAJgAcFQIZFQAZGAJ2MhUCFgIWNhY6JkI8GAQKAAAAGAQKAAAAFgAoBAoAAAAYBAoAAAAAAAAWgIgCFgImCAAZLCYAHBUCGRUAGRgCdjEVAhYCFjYWOiZ8PBgEAgAAABgEAgAAABYAKAQCAAAAGAQCAAAAAAAAJgAcFQIZFQAZGAJ2MhUCFgIWNhY6JrYBPBgEFAAAABgEFAAAABYAKAQUAAAAGAQUAAAAAAAAFoCIAhYCJnwAKAZEdWNrREIAJgEAAFBBUjE=" | base64 -d > /tmp/rw_parquet_dirty_object/10_good.parquet; printf "not a parquet file\n" > /tmp/rw_parquet_dirty_object/bad_14.bin'
+
+statement ok
+CREATE TABLE parquet_dirty_object (
+    v1 int,
+    v2 int
+) WITH (
+    connector = 'posix_fs',
+    posix_fs.root = '/tmp/rw_parquet_dirty_object'
+) FORMAT PLAIN ENCODE PARQUET;
+
+query II retry 20 backoff 1s
+SELECT count(*), sum(v2) FROM parquet_dirty_object;
+----
+2 30
+
+statement ok
+DROP TABLE parquet_dirty_object;
+
+system ok
+rm -rf /tmp/rw_parquet_dirty_object


### PR DESCRIPTION
## What

- Add an SLT regression test for a `posix_fs` Parquet source that scans a directory without `match_pattern` and encounters both a valid Parquet object and a non-Parquet object.
- Wire the new filesystem source test into `ci/scripts/e2e-source-test.sh`.

## Why

Issue #25430 reported a compute-node panic when a file source without `match_pattern` picked up an invalid object. Current main has dirty-split retry/skip handling in `FsFetchExecutor`; this test locks in that behavior by verifying the source continues to read the valid Parquet rows while the dirty object is skipped instead of panicking.

Closes #25430.

## Tests

- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 ./risedev ci-start ci-1cn-1fe-with-recovery`
- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 ./risedev slt ./e2e_test/source_inline/fs/parquet_dirty_object.slt`