### PR TITLE
ci: fix main-cron sink and opendal failures

### DIFF
--- a/ci/scripts/e2e-doris-sink-test.sh
+++ b/ci/scripts/e2e-doris-sink-test.sh
@@ -23,15 +23,34 @@ shift $((OPTIND -1))
 
 sink_test_env_setup "$profile" --sleep-duration 0
 
-echo "--- create doris table"
-sleep 10 # Wait for doris to start. TODO: shall we use `service_healthy` condition in docker-compose.yml?
-mysql -uroot -P 9030 -h doris-server -e "CREATE database demo;use demo;
-CREATE table demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 datev2,v8 datetime,v9 boolean,v10 json) UNIQUE KEY(\`v1\`)
+create_doris_table() {
+  local ddl
+
+  ddl="CREATE DATABASE IF NOT EXISTS demo;
+USE demo;
+DROP TABLE IF EXISTS demo_bhv_table;
+CREATE TABLE demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 datev2,v8 datetime,v9 boolean,v10 json) UNIQUE KEY(\`v1\`)
 DISTRIBUTED BY HASH(\`v1\`) BUCKETS 1
 PROPERTIES (
     \"replication_allocation\" = \"tag.location.default: 1\"
-);
-CREATE USER 'users'@'%' IDENTIFIED BY '123456';
+);"
+
+  echo "--- create doris table"
+  for _ in $(seq 1 60); do
+    if mysql -uroot -P 9030 -h doris-server -e "$ddl"; then
+      return
+    fi
+    mysql -uroot -P 9030 -h doris-server -e "SHOW BACKENDS;" || true
+    sleep 2
+  done
+
+  echo "Doris backend did not become ready for table creation in time"
+  mysql -uroot -P 9030 -h doris-server -e "SHOW BACKENDS;" || true
+  exit 1
+}
+
+create_doris_table
+mysql -uroot -P 9030 -h doris-server -e "CREATE USER 'users'@'%' IDENTIFIED BY '123456';
 GRANT ALL ON *.* TO 'users'@'%';"
 sleep 2
 

--- a/ci/scripts/e2e-starrocks-sink-test.sh
+++ b/ci/scripts/e2e-starrocks-sink-test.sh
@@ -21,21 +21,41 @@ while getopts 'p:' opt; do
 done
 shift $((OPTIND -1))
 
-sink_test_env_setup "$profile"
+sink_test_env_setup "$profile" --sleep-duration 0
 
+create_starrocks_tables() {
+  local ddl
 
-echo "--- create starrocks table"
-sleep 2
-mysql -uroot -P 9030 -h starrocks-fe-server -e "CREATE database demo;use demo;
-CREATE table demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 date,v8 datetime,v9 boolean,v10 json,v11 decimal(10,5)) ENGINE=OLAP
+  ddl="CREATE DATABASE IF NOT EXISTS demo;
+USE demo;
+DROP TABLE IF EXISTS demo_bhv_table;
+CREATE TABLE demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 date,v8 datetime,v9 boolean,v10 json,v11 decimal(10,5)) ENGINE=OLAP
 PRIMARY KEY(\`v1\`)
 DISTRIBUTED BY HASH(\`v1\`) properties(\"replication_num\" = \"1\");
-CREATE table demo_agg_table(id int, value string REPLACE_IF_NOT_NULL) ENGINE=OLAP
+DROP TABLE IF EXISTS demo_agg_table;
+CREATE TABLE demo_agg_table(id int, value string REPLACE_IF_NOT_NULL) ENGINE=OLAP
 AGGREGATE KEY(\`id\`)
 DISTRIBUTED BY HASH(\`id\`) properties(\"replication_num\" = \"1\");
+DROP TABLE IF EXISTS demo_reserved_words;
 CREATE TABLE demo_reserved_words(id int, \`order\` string, \`from\` string) ENGINE=OLAP
-PRIMARY KEY(id) DISTRIBUTED BY HASH (id) properties(\"replication_num\" = \"1\");
-CREATE USER 'users'@'%' IDENTIFIED BY '123456';
+PRIMARY KEY(id) DISTRIBUTED BY HASH (id) properties(\"replication_num\" = \"1\");"
+
+  echo "--- create starrocks table"
+  for _ in $(seq 1 60); do
+    if mysql -uroot -P 9030 -h starrocks-fe-server -e "$ddl"; then
+      return
+    fi
+    mysql -uroot -P 9030 -h starrocks-fe-server -e "SHOW FRONTENDS; SHOW BACKENDS;" || true
+    sleep 2
+  done
+
+  echo "StarRocks backend did not become ready for table creation in time"
+  mysql -uroot -P 9030 -h starrocks-fe-server -e "SHOW FRONTENDS; SHOW BACKENDS;" || true
+  exit 1
+}
+
+create_starrocks_tables
+mysql -uroot -P 9030 -h starrocks-fe-server -e "CREATE USER 'users'@'%' IDENTIFIED BY '123456';
 GRANT ALL ON *.* TO 'users'@'%';"
 sleep 2
 

--- a/ci/scripts/e2e-test-parallel-for-opendal.sh
+++ b/ci/scripts/e2e-test-parallel-for-opendal.sh
@@ -34,7 +34,7 @@ python3 -m pip install --break-system-packages psycopg2-binary
 
 host_args=(-h localhost -p 4565 -h localhost -p 4566 -h localhost -p 4567)
 
-export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::common::table::state_table=warn,risingwave_storage::hummock::compactor=error,risingwave_hummock_sdk::compaction_group::hummock_version_ext=error,risingwave_storage::hummock::event_handler::hummock_event_handler=error"
+export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::common::table::state_table=warn,risingwave_storage::hummock::compactor=error,risingwave_hummock_sdk::compaction_group::hummock_version_ext=error,risingwave_storage::hummock::event_handler::hummock_event_handler=error,await_tree::future=error"
 
 echo "--- e2e, ci-3cn-3fe-opendal-fs-backend, streaming"
 risedev ci-start ci-3cn-3fe-opendal-fs-backend

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -904,6 +904,7 @@ steps:
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-release"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-opendal-tests"
       || build.pull_request.labels includes "ci/run-e2e-tests-for-opendal"
       || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?-for-opendal(,|$$)/
     depends_on:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -210,7 +210,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 30
+    timeout_in_minutes: 45
     retry: *auto-retry
 
   - label: "end-to-end source test"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -210,7 +210,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 14
+    timeout_in_minutes: 30
     retry: *auto-retry
 
   - label: "end-to-end source test"

--- a/e2e_test/streaming/temporal_join/append_only/temporal_join_watermark.slt
+++ b/e2e_test/streaming/temporal_join/append_only/temporal_join_watermark.slt
@@ -2,6 +2,9 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
+SET streaming_parallelism = 1;
+
+statement ok
 create table stream(id1 int, a1 int, b1 int, v1 timestamp with time zone, watermark for v1 as v1 - INTERVAL '10' SECOND) APPEND ONLY;
 
 # FIXME. If we don't insert at first, it would cause a panic when create eowc_mv.
@@ -63,3 +66,6 @@ drop table stream cascade;
 
 statement ok
 drop table version cascade;
+
+statement ok
+SET streaming_parallelism = 0;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::assert_matches::assert_matches;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::mem;
 
 use anyhow::anyhow;
@@ -818,7 +818,14 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             log_reader.init().await?;
                         },
                         RebuildSinkMessage::UpdateConfig(config) => {
-                            if F::ALLOW_REWIND {
+                            if !sink_config_has_changes(&sink_param.properties, &config) {
+                                info!(
+                                    executor_id = %sink_writer_param.executor_id,
+                                    sink_id = %sink_param.sink_id,
+                                    "skip alter sink config because properties are unchanged"
+                                );
+                                Ok(())
+                            } else if F::ALLOW_REWIND {
                                 match log_reader.rewind().await {
                                     Ok(()) => {
                                         sink_param.properties.extend(config.into_iter());
@@ -857,6 +864,15 @@ enum RebuildSinkMessage {
     UpdateConfig(HashMap<String, String>),
 }
 
+fn sink_config_has_changes(
+    current: &BTreeMap<String, String>,
+    incoming: &HashMap<String, String>,
+) -> bool {
+    incoming
+        .iter()
+        .any(|(key, value)| current.get(key) != Some(value))
+}
+
 impl<F: LogStoreFactory> Execute for SinkExecutor<F> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner()
@@ -872,6 +888,27 @@ mod test {
     use super::*;
     use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
     use crate::executor::test_utils::*;
+
+    #[test]
+    fn test_sink_config_has_changes() {
+        let current = BTreeMap::from([
+            ("connector".to_owned(), "blackhole".to_owned()),
+            ("commit_checkpoint_interval".to_owned(), "1".to_owned()),
+        ]);
+
+        assert!(!sink_config_has_changes(
+            &current,
+            &HashMap::from([("commit_checkpoint_interval".to_owned(), "1".to_owned())])
+        ));
+        assert!(sink_config_has_changes(
+            &current,
+            &HashMap::from([("commit_checkpoint_interval".to_owned(), "2".to_owned())])
+        ));
+        assert!(sink_config_has_changes(
+            &current,
+            &HashMap::from([("force_append_only".to_owned(), "true".to_owned())])
+        ));
+    }
 
     #[tokio::test]
     async fn test_force_append_only_sink() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

Fix the main-cron failures seen in https://buildkite.com/risingwavelabs/main-cron/builds/9301, the follow-up triggered build https://buildkite.com/risingwavelabs/main-cron/builds/9312, and the PR OpenDAL timeout in https://buildkite.com/risingwavelabs/pull-request/builds/96166.

- Retry the actual Doris table DDL instead of relying on a fixed sleep or an `Alive` backend check. Doris can report the backend as alive before the disk report is registered, and table creation can still fail with "Failed to find enough backend".
- Skip runtime sink config rebuilds when `ALTER SINK ... CONNECTOR WITH` does not change any effective property. This keeps the StarRocks/ClickHouse `commit_checkpoint_interval = '1'` coverage without forcing recovery for a no-op alter under the default CI profile.
- Suppress the duplicate `await_tree::future` warning in the OpenDAL parallel e2e job by demoting that target to `error`, matching the existing log-filtering approach used by other e2e scripts.
- Increase the PR OpenDAL parallel e2e timeout from 14 to 45 minutes. The failed PR job was killed by Buildkite timeout while tests were still running, not by an SLT mismatch.
- Let the main-cron OpenDAL step also honor the existing `ci/run-opendal-tests` label, since `ci/run-e2e-tests-for-opendal` is referenced by workflow YAML but does not exist as a GitHub label.

This should be cherry-picked to `release-3.0` after it lands on `main`.

## Checklist

- [x] I have written necessary rustdoc comments. (N/A; no public API changes.)
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

No release note.

</details>

## Validation

- `bash -n ci/scripts/e2e-doris-sink-test.sh ci/scripts/e2e-starrocks-sink-test.sh ci/scripts/e2e-clickhouse-sink-test.sh ci/scripts/e2e-test-parallel-for-opendal.sh`
- `ruby -e 'require "yaml"; YAML.load_file("ci/workflows/pull-request.yml"); YAML.load_file("ci/workflows/main-cron.yml"); puts "ok"'`
- `cargo fmt --all --check`
- `cargo test -p risingwave_stream test_sink_config_has_changes --lib`
- `git diff --check`
- `shellcheck` is not available locally.
