### PR TITLE
feat(iceberg): default snapshot expiration

### DIFF
--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -126,6 +126,8 @@ pub const COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS: &str =
 pub const COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES: &str =
     "compaction.write_parquet_max_row_group_bytes";
 pub const ORDER_KEY: &str = "order_key";
+pub const DEFAULT_SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS: i64 = 3_600_000;
+pub const DEFAULT_SNAPSHOT_EXPIRATION_RETAIN_LAST: i32 = 12;
 pub const ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES: usize = 128 * 1024 * 1024;
 pub const ENABLE_PK_INDEX: &str = "enable_pk_index";
 
@@ -150,6 +152,14 @@ fn default_true() -> bool {
 
 fn default_some_true() -> Option<bool> {
     Some(true)
+}
+
+fn default_snapshot_expiration_max_age_millis() -> Option<i64> {
+    Some(DEFAULT_SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS)
+}
+
+fn default_snapshot_expiration_retain_last() -> Option<i32> {
+    Some(DEFAULT_SNAPSHOT_EXPIRATION_RETAIN_LAST)
 }
 
 fn parse_format_version_str(value: &str) -> std::result::Result<FormatVersion, String> {
@@ -349,7 +359,7 @@ pub struct IcebergConfig {
     /// Whether to enable iceberg expired snapshots.
     #[serde(
         rename = "enable_snapshot_expiration",
-        default,
+        default = "default_true",
         deserialize_with = "deserialize_bool_from_string"
     )]
     #[with_option(allow_alter_on_fly)]
@@ -369,13 +379,19 @@ pub struct IcebergConfig {
 
     /// The maximum age (in milliseconds) for snapshots before they expire
     /// For example, if set to 3600000, snapshots older than 1 hour will be expired
-    #[serde(rename = "snapshot_expiration_max_age_millis", default)]
+    #[serde(
+        rename = "snapshot_expiration_max_age_millis",
+        default = "default_snapshot_expiration_max_age_millis"
+    )]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
     pub snapshot_expiration_max_age_millis: Option<i64>,
 
     /// The number of snapshots to retain
-    #[serde(rename = "snapshot_expiration_retain_last", default)]
+    #[serde(
+        rename = "snapshot_expiration_retain_last",
+        default = "default_snapshot_expiration_retain_last"
+    )]
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[with_option(allow_alter_on_fly)]
     pub snapshot_expiration_retain_last: Option<i32>,

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -26,9 +26,11 @@ use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
 use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
 use crate::sink::iceberg::{
     COMPACTION_INTERVAL_SEC, COMPACTION_MAX_SNAPSHOTS_NUM,
-    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, CompactionType, ENABLE_COMPACTION,
-    ENABLE_SNAPSHOT_EXPIRATION, ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, IcebergConfig,
-    IcebergOrderKeyField, IcebergWriteMode, ORDER_KEY, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES,
+    COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, CompactionType,
+    DEFAULT_SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS, DEFAULT_SNAPSHOT_EXPIRATION_RETAIN_LAST,
+    ENABLE_COMPACTION, ENABLE_SNAPSHOT_EXPIRATION,
+    ICEBERG_DEFAULT_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, IcebergConfig, IcebergOrderKeyField,
+    IcebergWriteMode, ORDER_KEY, SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_FILES,
     SNAPSHOT_EXPIRATION_CLEAR_EXPIRED_META_DATA, SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS,
     SNAPSHOT_EXPIRATION_RETAIN_LAST, WRITE_MODE, parse_order_key_exprs, validate_order_key_columns,
 };
@@ -320,8 +322,8 @@ fn test_parse_iceberg_config() {
             enable_snapshot_expiration: true,
             write_mode: IcebergWriteMode::MergeOnRead,
             format_version: FormatVersion::V2,
-            snapshot_expiration_max_age_millis: None,
-            snapshot_expiration_retain_last: None,
+            snapshot_expiration_max_age_millis: Some(DEFAULT_SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS),
+            snapshot_expiration_retain_last: Some(DEFAULT_SNAPSHOT_EXPIRATION_RETAIN_LAST),
             snapshot_expiration_clear_expired_files: true,
             snapshot_expiration_clear_expired_meta_data: true,
             max_snapshots_num_before_compaction: None,
@@ -712,6 +714,15 @@ fn test_parse_compaction_config() {
     .collect();
 
     let config = IcebergConfig::from_btreemap(values).unwrap();
+    assert!(config.enable_snapshot_expiration);
+    assert_eq!(
+        config.snapshot_expiration_max_age_millis,
+        Some(DEFAULT_SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS)
+    );
+    assert_eq!(
+        config.snapshot_expiration_retain_last,
+        Some(DEFAULT_SNAPSHOT_EXPIRATION_RETAIN_LAST)
+    );
     assert_eq!(config.target_file_size_mb(), 1024); // Default
     assert_eq!(config.write_parquet_compression(), "zstd"); // Default
     assert_eq!(config.write_parquet_max_row_group_rows(), None); // Default

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -683,7 +683,7 @@ IcebergConfig:
     field_type: bool
     comments: Whether to enable iceberg expired snapshots.
     required: false
-    default: Default::default
+    default: 'true'
     allow_alter_on_fly: true
   - name: write_mode
     field_type: IcebergWriteMode
@@ -701,13 +701,13 @@ IcebergConfig:
       The maximum age (in milliseconds) for snapshots before they expire
       For example, if set to 3600000, snapshots older than 1 hour will be expired
     required: false
-    default: Default::default
+    default: Some (DEFAULT_SNAPSHOT_EXPIRATION_MAX_AGE_MILLIS)
     allow_alter_on_fly: true
   - name: snapshot_expiration_retain_last
     field_type: i32
     comments: The number of snapshots to retain
     required: false
-    default: Default::default
+    default: Some (DEFAULT_SNAPSHOT_EXPIRATION_RETAIN_LAST)
     allow_alter_on_fly: true
   - name: snapshot_expiration_clear_expired_files
     field_type: bool


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Enable Iceberg snapshot expiration by default:
  - `enable_snapshot_expiration = true`
  - `snapshot_expiration_max_age_millis = 3600000`
  - `snapshot_expiration_retain_last = 12`
- Regenerate `src/connector/with_options_sink.yaml` and update connector unit tests.

- Closes N/A

## Local verification

- `./risedev generate-with-options`
- `cargo fmt --check`
- `cargo test -p risingwave_connector sink::iceberg::test::test_parse_iceberg_config -- --exact`
- `cargo test -p risingwave_connector sink::iceberg::test::test_parse_compaction_config -- --exact`
- `cargo clippy -p risingwave_connector --lib --tests -- -D warnings`

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Iceberg sink now enables snapshot expiration by default when the option is not explicitly configured.

</details>
