### PR TITLE
fix(source): default NATS ack policy to explicit

### DIFF
--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -118,8 +118,8 @@ impl EnforceSecret for NatsProperties {
 }
 
 impl NatsProperties {
-    pub fn set_config(&self, c: &mut Config) {
-        self.nats_properties_consumer.set_config(c);
+    pub fn set_config(&self, c: &mut Config) -> ConnectorResult<()> {
+        self.nats_properties_consumer.set_config(c)
     }
 }
 
@@ -220,14 +220,14 @@ pub struct NatsPropertiesConsumer {
 }
 
 impl NatsPropertiesConsumer {
-    pub fn set_config(&self, c: &mut Config) {
+    pub fn set_config(&self, c: &mut Config) -> ConnectorResult<()> {
         if let Some(v) = &self.name {
             c.name = Some(v.clone())
         }
         if let Some(v) = &self.description {
             c.description = Some(v.clone())
         }
-        c.ack_policy = self.effective_ack_policy().unwrap();
+        c.ack_policy = self.effective_ack_policy()?;
         if let Some(v) = &self.ack_wait {
             c.ack_wait = Duration::from_secs(*v)
         }
@@ -241,7 +241,7 @@ impl NatsPropertiesConsumer {
             c.filter_subjects = v.clone()
         }
         if let Some(v) = &self.replay_policy {
-            c.replay_policy = ReplayPolicyWrapper::parse_str(v).unwrap()
+            c.replay_policy = ReplayPolicyWrapper::parse_str(v).map_err(ConnectorError::from)?
         }
         if let Some(v) = &self.rate_limit {
             c.rate_limit = *v
@@ -279,6 +279,7 @@ impl NatsPropertiesConsumer {
         if let Some(v) = &self.backoff {
             c.backoff = v.iter().map(|&x| Duration::from_secs(x)).collect()
         }
+        Ok(())
     }
 
     fn effective_ack_policy(&self) -> ConnectorResult<AckPolicy> {
@@ -311,13 +312,17 @@ impl crate::source::UnknownFields for NatsProperties {
 mod test {
     use std::collections::BTreeMap;
 
+    use async_nats::jetstream::consumer::pull::Config;
     use maplit::btreemap;
 
     use super::*;
 
-    #[test]
-    fn test_parse_config_consumer() {
-        let config: BTreeMap<String, String> = btreemap! {
+    fn parse_props(config: BTreeMap<String, String>) -> NatsProperties {
+        serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap()
+    }
+
+    fn base_config() -> BTreeMap<String, String> {
+        btreemap! {
             "stream".to_owned() => "risingwave".to_owned(),
 
             // NATS common
@@ -330,7 +335,6 @@ mod test {
             "consumer.name".to_owned() => "foobar".to_owned(),
             "consumer.durable_name".to_owned() => "durable_foobar".to_owned(),
             "consumer.description".to_owned() => "A description".to_owned(),
-            "consumer.ack_policy".to_owned() => "all".to_owned(),
             "consumer.ack_wait.sec".to_owned() => "10".to_owned(),
             "consumer.max_deliver".to_owned() => "10".to_owned(),
             "consumer.filter_subject".to_owned() => "subject".to_owned(),
@@ -349,11 +353,15 @@ mod test {
             "consumer.memory_storage".to_owned() => "true".to_owned(),
             "consumer.backoff.sec".to_owned() => "2,10,15".to_owned(),
             "durable_consumer_name".to_owned() => "test_durable_consumer".to_owned(),
+        }
+    }
 
-        };
+    #[test]
+    fn test_parse_config_consumer() {
+        let mut config = base_config();
+        config.insert("consumer.ack_policy".to_owned(), "all".to_owned());
 
-        let props: NatsProperties =
-            serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap();
+        let props = parse_props(config);
 
         assert_eq!(
             props.nats_properties_consumer.name,
@@ -391,6 +399,58 @@ mod test {
         assert_eq!(
             props.nats_properties_consumer.backoff,
             Some(vec![2, 10, 15])
+        );
+    }
+
+    #[test]
+    fn test_default_ack_policy_is_explicit() {
+        let props = parse_props(base_config());
+
+        let mut consumer_config = Config::default();
+        props.set_config(&mut consumer_config).unwrap();
+
+        assert_eq!(
+            props.nats_properties_consumer.get_ack_policy().unwrap(),
+            AckPolicy::Explicit
+        );
+        assert_eq!(consumer_config.ack_policy, AckPolicy::Explicit);
+    }
+
+    #[test]
+    fn test_ack_policy_none_is_preserved() {
+        let mut config = base_config();
+        config.insert("consumer.ack_policy".to_owned(), "none".to_owned());
+        let props = parse_props(config);
+
+        let mut consumer_config = Config::default();
+        props.set_config(&mut consumer_config).unwrap();
+
+        assert_eq!(
+            props.nats_properties_consumer.get_ack_policy().unwrap(),
+            AckPolicy::None
+        );
+        assert_eq!(consumer_config.ack_policy, AckPolicy::None);
+    }
+
+    #[test]
+    fn test_invalid_ack_policy_returns_error() {
+        let mut config = base_config();
+        config.insert("consumer.ack_policy".to_owned(), "invalid".to_owned());
+        let props = parse_props(config);
+
+        let err = props.nats_properties_consumer.get_ack_policy().unwrap_err();
+        let err_message = format!("{err:#}");
+        assert!(
+            err_message.contains("Invalid AckPolicy 'invalid'"),
+            "unexpected error: {err_message}"
+        );
+
+        let mut consumer_config = Config::default();
+        let err = props.set_config(&mut consumer_config).unwrap_err();
+        let err_message = format!("{err:#}");
+        assert!(
+            err_message.contains("Invalid AckPolicy 'invalid'"),
+            "unexpected error: {err_message}"
         );
     }
 }

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -227,9 +227,7 @@ impl NatsPropertiesConsumer {
         if let Some(v) = &self.description {
             c.description = Some(v.clone())
         }
-        if let Some(v) = &self.ack_policy {
-            c.ack_policy = AckPolicyWrapper::parse_str(v).unwrap()
-        }
+        c.ack_policy = self.effective_ack_policy().unwrap();
         if let Some(v) = &self.ack_wait {
             c.ack_wait = Duration::from_secs(*v)
         }
@@ -283,11 +281,15 @@ impl NatsPropertiesConsumer {
         }
     }
 
-    pub fn get_ack_policy(&self) -> ConnectorResult<AckPolicy> {
+    fn effective_ack_policy(&self) -> ConnectorResult<AckPolicy> {
         match &self.ack_policy {
             Some(policy) => Ok(AckPolicyWrapper::parse_str(policy).map_err(ConnectorError::from)?),
-            None => Ok(AckPolicy::None),
+            None => Ok(AckPolicy::Explicit),
         }
+    }
+
+    pub fn get_ack_policy(&self) -> ConnectorResult<AckPolicy> {
+        self.effective_ack_policy()
     }
 }
 

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::time::Duration;
 
+use anyhow::Context;
 use async_nats::jetstream::consumer::pull::Config;
 use async_nats::jetstream::consumer::{AckPolicy, ReplayPolicy};
 use serde::Deserialize;
@@ -241,7 +242,9 @@ impl NatsPropertiesConsumer {
             c.filter_subjects = v.clone()
         }
         if let Some(v) = &self.replay_policy {
-            c.replay_policy = ReplayPolicyWrapper::parse_str(v).map_err(ConnectorError::from)?
+            c.replay_policy = ReplayPolicyWrapper::parse_str(v)
+                .with_context(|| format!("invalid value for `consumer.replay_policy`: {v}"))
+                .map_err(ConnectorError::from)?
         }
         if let Some(v) = &self.rate_limit {
             c.rate_limit = *v
@@ -284,7 +287,9 @@ impl NatsPropertiesConsumer {
 
     fn effective_ack_policy(&self) -> ConnectorResult<AckPolicy> {
         match &self.ack_policy {
-            Some(policy) => Ok(AckPolicyWrapper::parse_str(policy).map_err(ConnectorError::from)?),
+            Some(policy) => Ok(AckPolicyWrapper::parse_str(policy)
+                .with_context(|| format!("invalid value for `consumer.ack_policy`: {policy}"))
+                .map_err(ConnectorError::from)?),
             None => Ok(AckPolicy::Explicit),
         }
     }
@@ -317,7 +322,7 @@ mod test {
 
     use super::*;
 
-    fn parse_props(config: BTreeMap<String, String>) -> NatsProperties {
+    fn parse_nats_properties(config: BTreeMap<String, String>) -> NatsProperties {
         serde_json::from_value(
             serde_json::to_value(config).expect("failed to serialize NATS test config"),
         )
@@ -364,7 +369,7 @@ mod test {
         let mut config = base_config();
         config.insert("consumer.ack_policy".to_owned(), "all".to_owned());
 
-        let props = parse_props(config);
+        let props = parse_nats_properties(config);
 
         assert_eq!(
             props.nats_properties_consumer.name,
@@ -407,7 +412,7 @@ mod test {
 
     #[test]
     fn test_default_ack_policy_is_explicit() {
-        let props = parse_props(base_config());
+        let props = parse_nats_properties(base_config());
 
         let mut consumer_config = Config::default();
         props.set_config(&mut consumer_config).unwrap();
@@ -423,7 +428,7 @@ mod test {
     fn test_ack_policy_none_is_preserved() {
         let mut config = base_config();
         config.insert("consumer.ack_policy".to_owned(), "none".to_owned());
-        let props = parse_props(config);
+        let props = parse_nats_properties(config);
 
         let mut consumer_config = Config::default();
         props.set_config(&mut consumer_config).unwrap();
@@ -439,7 +444,7 @@ mod test {
     fn test_invalid_ack_policy_returns_error() {
         let mut config = base_config();
         config.insert("consumer.ack_policy".to_owned(), "invalid".to_owned());
-        let props = parse_props(config);
+        let props = parse_nats_properties(config);
 
         let err = props.nats_properties_consumer.get_ack_policy().unwrap_err();
         let err_message = format!("{err:#}");

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -318,7 +318,10 @@ mod test {
     use super::*;
 
     fn parse_props(config: BTreeMap<String, String>) -> NatsProperties {
-        serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap()
+        serde_json::from_value(
+            serde_json::to_value(config).expect("failed to serialize NATS test config"),
+        )
+        .expect("failed to deserialize NATS test config into NatsProperties")
     }
 
     fn base_config() -> BTreeMap<String, String> {

--- a/src/connector/src/source/nats/source/reader.rs
+++ b/src/connector/src/source/nats/source/reader.rs
@@ -88,7 +88,7 @@ impl SplitReader for NatsSplitReader {
         let mut config = consumer::pull::Config {
             ..Default::default()
         };
-        properties.set_config(&mut config);
+        properties.set_config(&mut config)?;
 
         let (consumer, client) = properties
             .common


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa82669158300baec4f402ad1fe101a/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

- Closes #25679.
- Default the effective NATS JetStream consumer ACK policy to `explicit` when `consumer.ack_policy` is omitted.
- Use the same effective ACK policy when populating the async-nats consumer config and when deciding whether RisingWave should create the post-checkpoint `AckNatsJetStream` task.

Before this PR, omitting `consumer.ack_policy` left the async-nats pull consumer config at its crate default (`AckPolicy::Explicit`), but RisingWave's checkpoint ACK task selection interpreted the omitted option as `AckPolicy::None`. That meant JetStream could require ACKs while RisingWave created no checkpoint ACK task, causing messages to be redelivered after `AckWait`.

With this PR, omitted `consumer.ack_policy` consistently means `explicit`, matching NATS pull-consumer semantics and allowing RisingWave to ACK messages after checkpoint commit. Explicitly setting `consumer.ack_policy = 'none'` is still preserved.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

Fixed a NATS JetStream source issue where omitting `consumer.ack_policy` could make RisingWave skip post-checkpoint ACKs even though the pull consumer expected explicit ACKs. The omitted option now consistently defaults to explicit ACKs, preventing repeated redelivery caused by the mismatch.

</details>
