### PR TITLE
feat(meta): support iceberg v3 exactly once commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ book/
 
 # Code agent temporary files
 docs/superpowers
+.context/

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -45,26 +45,26 @@ anchors:
         propagate-environment: true
         upload-container-logs: always
 
-other-sql-backend: &other-sql-backend
-  matrix:
-    setup:
-      label: [""]
-      endpoint: [""]
-    adjustments:
-      - with:
-          label: ""
-          endpoint: ""
-        skip: true # hack
-      - with:
-          label: "postgres"
-          # PGPASSWORD=postgres psql -h db -p 5432 -U postgres -d rwmeta
-          endpoint: "postgres://postgres:post\\tgres@db:5432/rwmeta"
-      - with:
-          label: "mysql"
-          # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
-          endpoint: "mysql://root:123456@mysql-meta:3306/rwmeta"
-  env:
-    RISEDEV_SQL_ENDPOINT: "{{matrix.endpoint}}"
+# Shared config for the meta-store-backend (postgres/mysql) e2e steps.
+# The serial e2e suite is meta-store-backend agnostic, so shard it across parallel jobs
+# (sqllogictest auto-partitions by Buildkite parallel job config). Without sharding the
+# un-sharded suite chronically runs ~60min and trips the timeout. `parallelism` and `matrix`
+# can't coexist on a single step, so each backend is its own explicit step instead of a matrix.
+e2e-other-backend: &e2e-other-backend
+  command: "ci/scripts/e2e-test-serial.sh -p ci-dev -m ci-3streaming-2serving-3fe"
+  if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
+  depends_on:
+    - "build"
+  plugins:
+    - docker-compose#v5.5.0:
+        <<: *docker-compose
+        run: ci-standard-env
+        propagate-environment: true
+    - ./ci/plugins/upload-failure-logs
+  # Headroom over the default e2e step's 35min since the SQL meta store is slower per-op.
+  timeout_in_minutes: 45
+  parallelism: 4
+  retry: *auto-retry
 
 
 steps:
@@ -914,20 +914,17 @@ steps:
     parallelism: 4
     retry: *auto-retry
 
-  - label: "end-to-end test ({{matrix.label}} backend)"
-    <<: *other-sql-backend
-    command: "ci/scripts/e2e-test-serial.sh -p ci-dev -m ci-3streaming-2serving-3fe"
-    if: build.pull_request.labels includes "ci/run-e2e-test-other-backends" || build.env("CI_STEPS") =~ /(^|,)e2e-test-other-backends?(,|$$)/
-    depends_on:
-      - "build"
-    plugins:
-      - docker-compose#v5.5.0:
-          <<: *docker-compose
-          run: ci-standard-env
-          propagate-environment: true
-      - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 60
-    retry: *auto-retry
+  - <<: *e2e-other-backend
+    label: "end-to-end test (postgres backend)"
+    env:
+      # PGPASSWORD=postgres psql -h db -p 5432 -U postgres -d rwmeta
+      RISEDEV_SQL_ENDPOINT: "postgres://postgres:post\\tgres@db:5432/rwmeta"
+
+  - <<: *e2e-other-backend
+    label: "end-to-end test (mysql backend)"
+    env:
+      # mysql -h mysql-meta -P 3306 -u root -p123456 -D rwmeta
+      RISEDEV_SQL_ENDPOINT: "mysql://root:123456@mysql-meta:3306/rwmeta"
 
   # FIXME(kwannoel): Let the github PR labeller label it, if sqlsmith source files has changes.
   - label: "fuzz test"

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_lakekeeper.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_lakekeeper.slt
@@ -1,0 +1,72 @@
+statement ok
+set streaming_parallelism=4;
+
+statement ok
+create secret lakekeeper_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+statement ok
+create connection lakekeeper_catalog_conn
+with (
+    type = 'iceberg',
+    catalog.type = 'rest',
+    catalog.uri = 'http://127.0.0.1:8181/catalog/',
+    warehouse.path = 'risingwave-warehouse',
+    s3.access.key = secret lakekeeper_secret,
+    s3.secret.key = secret lakekeeper_secret,
+    s3.path.style.access = 'true',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1'
+);
+
+statement ok
+CREATE TABLE t_v3_no_partition_pk_index (id int, v1 int primary key, v2 bigint, v3 varchar, v4 date);
+
+statement ok
+INSERT INTO t_v3_no_partition_pk_index VALUES
+    (1, 1, 2, '1-2', '2022-03-11');
+
+statement ok
+CREATE SINK s_v3_no_partition_pk_index FROM t_v3_no_partition_pk_index
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    connection = lakekeeper_catalog_conn,
+    database.name = 'public',
+    table.name = 'no_partition_upsert_v3_pk_index_table',
+    create_table_if_not_exists = 'true',
+    primary_key = 'v1',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+CREATE SOURCE iceberg_no_partition_v3_pk_index_source WITH (
+    connector = 'iceberg',
+    database.name = 'public',
+    table.name = 'no_partition_upsert_v3_pk_index_table',
+    connection = lakekeeper_catalog_conn
+);
+
+query ????? rowsort retry 11 backoff 1s
+select * from iceberg_no_partition_v3_pk_index_source;
+----
+1 1 2 1-2 2022-03-11
+
+statement ok
+DROP SOURCE iceberg_no_partition_v3_pk_index_source;
+
+statement ok
+DROP SINK s_v3_no_partition_pk_index;
+
+statement ok
+DROP TABLE t_v3_no_partition_pk_index;
+
+statement ok
+DROP CONNECTION lakekeeper_catalog_conn;
+
+statement ok
+DROP SECRET lakekeeper_secret;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_no_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_no_partition.slt
@@ -1,0 +1,102 @@
+statement ok
+set streaming_parallelism=4;
+
+statement ok
+CREATE TABLE t_v3_no_partition_pk_index (id int, v1 int primary key, v2 bigint, v3 varchar, v4 date);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_v3_no_partition_pk_index AS SELECT * FROM t_v3_no_partition_pk_index;
+
+statement ok
+CREATE SINK s_v3_no_partition_pk_index FROM mv_v3_no_partition_pk_index
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'no_partition_upsert_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    primary_key = 'v1',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+INSERT INTO t_v3_no_partition_pk_index VALUES
+    (1, 1, 2, '1-2', '2022-03-11'),
+    (1, 2, 2, '2-2', '2022-03-12'),
+    (1, 3, 2, '3-2', '2022-03-13'),
+    (1, 5, 2, '5-2', '2022-03-15'),
+    (1, 8, 2, '8-2', '2022-03-18'),
+    (1, 13, 2, '13-2', '2022-03-13'),
+    (1, 21, 2, '21-2', '2022-03-21');
+
+statement ok
+FLUSH;
+
+statement ok
+DELETE FROM t_v3_no_partition_pk_index WHERE v1 IN (2, 8);
+
+statement ok
+INSERT INTO t_v3_no_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-13');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_no_partition_v3_pk_index_source WITH (
+    connector = 'iceberg',
+    database.name = 'public',
+    table.name = 'no_partition_upsert_v3_pk_index_table',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+query ????? rowsort retry 11 backoff 1s
+select * from iceberg_no_partition_v3_pk_index_source;
+----
+1 1 50 1-50 2022-03-11
+1 13 130 13-130 2022-03-13
+1 21 2 21-2 2022-03-21
+1 3 2 3-2 2022-03-13
+1 5 2 5-2 2022-03-15
+
+query T retry 11 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where source_name = 'iceberg_no_partition_v3_pk_index_source'
+  and content = 'PositionDeletes'
+  and file_format = 'puffin';
+----
+t
+
+query T retry 11 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where source_name = 'iceberg_no_partition_v3_pk_index_source'
+  and content = 'EqualityDeletes';
+----
+t
+
+statement ok
+DROP SOURCE iceberg_no_partition_v3_pk_index_source;
+
+statement ok
+DROP SINK s_v3_no_partition_pk_index;
+
+statement ok
+DROP MATERIALIZED VIEW mv_v3_no_partition_pk_index;
+
+statement ok
+DROP TABLE t_v3_no_partition_pk_index;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_range_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_range_partition.slt
@@ -1,0 +1,103 @@
+statement ok
+set streaming_parallelism=4;
+
+statement ok
+CREATE TABLE t_v3_range_partition_pk_index (id int, v1 int primary key, v2 bigint, v3 varchar, v4 date);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_v3_range_partition_pk_index AS SELECT * FROM t_v3_range_partition_pk_index;
+
+statement ok
+CREATE SINK s_v3_range_partition_pk_index FROM mv_v3_range_partition_pk_index
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'range_partition_upsert_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    primary_key = 'v1',
+    partition_by = 'day(v4)',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+INSERT INTO t_v3_range_partition_pk_index VALUES
+    (1, 1, 2, '1-2', '2022-03-11'),
+    (1, 2, 2, '2-2', '2022-03-12'),
+    (1, 3, 2, '3-2', '2022-03-13'),
+    (1, 5, 2, '5-2', '2022-03-15'),
+    (1, 8, 2, '8-2', '2022-03-18'),
+    (1, 13, 2, '13-2', '2022-03-13'),
+    (1, 21, 2, '21-2', '2022-03-21');
+
+statement ok
+FLUSH;
+
+statement ok
+DELETE FROM t_v3_range_partition_pk_index WHERE v1 IN (2, 8);
+
+statement ok
+INSERT INTO t_v3_range_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-23');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_range_partition_v3_pk_index_source WITH (
+    connector = 'iceberg',
+    database.name = 'public',
+    table.name = 'range_partition_upsert_v3_pk_index_table',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+query ????? rowsort retry 11 backoff 1s
+select * from iceberg_range_partition_v3_pk_index_source;
+----
+1 1 50 1-50 2022-03-11
+1 13 130 13-130 2022-03-23
+1 21 2 21-2 2022-03-21
+1 3 2 3-2 2022-03-13
+1 5 2 5-2 2022-03-15
+
+query T retry 11 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where source_name = 'iceberg_range_partition_v3_pk_index_source'
+  and content = 'PositionDeletes'
+  and file_format = 'puffin';
+----
+t
+
+query T retry 11 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where source_name = 'iceberg_range_partition_v3_pk_index_source'
+  and content = 'EqualityDeletes';
+----
+t
+
+statement ok
+DROP SOURCE iceberg_range_partition_v3_pk_index_source;
+
+statement ok
+DROP SINK s_v3_range_partition_pk_index;
+
+statement ok
+DROP MATERIALIZED VIEW mv_v3_range_partition_pk_index;
+
+statement ok
+DROP TABLE t_v3_range_partition_pk_index;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_sparse_partition.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/sink_sparse_partition.slt
@@ -1,0 +1,103 @@
+statement ok
+set streaming_parallelism=4;
+
+statement ok
+CREATE TABLE t_v3_partition_pk_index (id int, v1 int primary key, v2 bigint, v3 varchar, v4 date);
+
+statement ok
+CREATE MATERIALIZED VIEW mv_v3_partition_pk_index AS SELECT * FROM t_v3_partition_pk_index;
+
+statement ok
+CREATE SINK s_v3_partition_pk_index FROM mv_v3_partition_pk_index
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    force_append_only = 'false',
+    catalog.name = 'demo',
+    database.name = 'public',
+    table.name = 'partition_upsert_v3_pk_index_table',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin',
+    create_table_if_not_exists = 'true',
+    primary_key = 'v1',
+    partition_by = 'v1,v2,truncate(2,v3)',
+    write_mode = 'merge-on-read',
+    format_version = '3',
+    enable_pk_index = 'true'
+);
+
+statement ok
+INSERT INTO t_v3_partition_pk_index VALUES
+    (1, 1, 2, '1-2', '2022-03-11'),
+    (1, 2, 2, '2-2', '2022-03-12'),
+    (1, 3, 2, '3-2', '2022-03-13'),
+    (1, 5, 2, '5-2', '2022-03-15'),
+    (1, 8, 2, '8-2', '2022-03-18'),
+    (1, 13, 2, '13-2', '2022-03-13'),
+    (1, 21, 2, '21-2', '2022-03-21');
+
+statement ok
+FLUSH;
+
+statement ok
+DELETE FROM t_v3_partition_pk_index WHERE v1 IN (2, 8);
+
+statement ok
+INSERT INTO t_v3_partition_pk_index VALUES (1, 1, 50, '1-50', '2022-03-11'), (1, 13, 130, '13-130', '2022-03-13');
+
+statement ok
+FLUSH;
+
+statement ok
+CREATE SOURCE iceberg_partition_v3_pk_index_source WITH (
+    connector = 'iceberg',
+    database.name = 'public',
+    table.name = 'partition_upsert_v3_pk_index_table',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3a://hummock001/iceberg_v3',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-east-1',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+
+query ????? rowsort retry 11 backoff 1s
+select * from iceberg_partition_v3_pk_index_source;
+----
+1 1 50 1-50 2022-03-11
+1 13 130 13-130 2022-03-13
+1 21 2 21-2 2022-03-21
+1 3 2 3-2 2022-03-13
+1 5 2 5-2 2022-03-15
+
+query T retry 11 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where source_name = 'iceberg_partition_v3_pk_index_source'
+  and content = 'PositionDeletes'
+  and file_format = 'puffin';
+----
+t
+
+query T retry 11 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where source_name = 'iceberg_partition_v3_pk_index_source'
+  and content = 'EqualityDeletes';
+----
+t
+
+statement ok
+DROP SOURCE iceberg_partition_v3_pk_index_source;
+
+statement ok
+DROP SINK s_v3_partition_pk_index;
+
+statement ok
+DROP MATERIALIZED VIEW mv_v3_partition_pk_index;
+
+statement ok
+DROP TABLE t_v3_partition_pk_index;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/with_pk_index.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/with_pk_index.slt
@@ -1,0 +1,167 @@
+statement ok
+create secret hosted_catalog_secret with (
+  backend = 'meta'
+) as 'hummockadmin';
+
+# Test hosted catalog connection using the warehouse created by risedev
+statement ok
+create connection hosted_catalog_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg_v3_puffin',
+    s3.access.key = secret hosted_catalog_secret,
+    s3.secret.key = secret hosted_catalog_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2',
+    hosted_catalog = true
+);
+
+statement ok
+set iceberg_engine_connection = 'public.hosted_catalog_conn';
+
+statement ok
+create table t_v3(id int primary key, name varchar, v1 int)
+with(
+    commit_checkpoint_interval = 3,
+    format_version = 3,
+    partition_by = 'id',
+    enable_pk_index = 'true'
+) engine = iceberg;
+
+statement ok
+insert into t_v3 values(1, 'alice', 100), (2, 'bob', 200), (3, 'charlie', 300);
+
+statement ok
+flush;
+
+statement ok
+update t_v3 set v1 = 150 where id = 1;
+
+statement ok
+delete from t_v3 where id = 2;
+
+statement ok
+FLUSH;
+
+query ?? retry 6 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and file_format = 'puffin';
+----
+t
+
+query ?? retry 6 backoff 1s
+select count(*) = 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and content = 'EqualityDeletes';
+----
+t
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v3;
+----
+1 alice 150
+3 charlie 300
+
+# generate eq deletes to test the reader of mixed delete files in v3
+statement ok
+delete from t_v3 where id = 1;
+
+statement ok
+FLUSH;
+
+query ?? retry 6 backoff 1s
+select count(*) > 0 from rw_iceberg_files
+where schema_name = 'public'
+  and source_name = '__iceberg_source_t_v3'
+  and content = 'EqualityDeletes';
+----
+f
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v3;
+----
+3 charlie 300
+
+# ---- Compaction havn't been supported for v3 ----
+# # This compaction won't clean up puffin files, but only generate new data files.
+# statement ok
+# VACUUM FULL t_v3;
+
+# # Run again to clean up the puffin files.
+# statement ok
+# VACUUM FULL t_v3;
+
+# query ? retry 3 backoff 1s
+# select count(*) = 0 from rw_iceberg_files
+# where schema_name = 'public'
+#   and source_name = '__iceberg_source_t_v3'
+#   and file_format = 'puffin';
+# ----
+# t
+
+# query ?? retry 3 backoff 1s
+# select count(*) = 0 from rw_iceberg_files
+# where schema_name = 'public'
+#   and source_name = '__iceberg_source_t_v3'
+#   and content in ('EqualityDeletes', 'PositionDeletes');
+# ----
+# t
+
+# query ??? rowsort
+# select * from t_v3;
+# ----
+# 3 charlie 300
+
+statement ok
+DROP TABLE t_v3;
+
+statement ok
+DROP CONNECTION hosted_catalog_conn;
+
+# Test storage catalog connection with format version 3
+statement ok
+create connection storage_catalog_conn
+with (
+    type = 'iceberg',
+    catalog.type = 'storage',
+    warehouse.path = 's3://hummock001/iceberg_v3_puffin',
+    s3.access.key = secret hosted_catalog_secret,
+    s3.secret.key = secret hosted_catalog_secret,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'us-west-2'
+);
+
+statement ok
+set iceberg_engine_connection = 'public.storage_catalog_conn';
+
+statement ok
+create table t_v3_storage(id int primary key, name varchar)
+with(
+    commit_checkpoint_interval = 2,
+    format_version = 3,
+    enable_pk_index = 'true'
+) engine = iceberg;
+
+statement ok
+insert into t_v3_storage values(1, 'alice'), (2, 'bob');
+
+statement ok
+flush;
+
+query ??? rowsort retry 3 backoff 1s
+select * from t_v3_storage;
+----
+1 alice
+2 bob
+
+statement ok
+DROP TABLE t_v3_storage;
+
+statement ok
+DROP CONNECTION storage_catalog_conn;
+
+statement ok
+DROP SECRET hosted_catalog_secret;

--- a/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/without_pk_index.slt
+++ b/e2e_test/iceberg/test_case/pure_slt/iceberg_v3/without_pk_index.slt
@@ -1,5 +1,3 @@
-control substitution on
-
 statement ok
 create secret hosted_catalog_secret with (
   backend = 'meta'

--- a/proto/connector_service.proto
+++ b/proto/connector_service.proto
@@ -272,3 +272,8 @@ message CoordinateResponse {
 service SinkCoordinationService {
   rpc Coordinate(stream CoordinateRequest) returns (stream CoordinateResponse);
 }
+
+message IcebergV3PreCommitState {
+  bytes agg_result = 1;
+  int64 snapshot_id = 2;
+}

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -3,12 +3,19 @@ syntax = "proto3";
 package stream_service;
 
 import "common.proto";
+import "connector_service.proto";
 import "hummock.proto";
 import "plan_common.proto";
 import "stream_plan.proto";
 
 option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
+
+enum PbIcebergV3SinkRole {
+  PB_ICEBERG_V3_SINK_ROLE_UNSPECIFIED = 0;
+  PB_ICEBERG_V3_SINK_ROLE_WRITER = 1;
+  PB_ICEBERG_V3_SINK_ROLE_DV_MERGER = 2;
+}
 
 message InjectBarrierRequest {
   string request_id = 1;
@@ -127,6 +134,14 @@ message BarrierCompleteResponse {
     uint32 source_id = 2;
   }
   repeated CdcSourceOffsetUpdated cdc_source_offset_updated = 17;
+  message IcebergV3SinkMetadata {
+    uint32 reporter_actor_id = 1;
+    uint32 sink_id = 2;
+    uint64 prev_epoch = 3;
+    PbIcebergV3SinkRole role = 4;
+    connector_service.SinkMetadata metadata = 5;
+  }
+  repeated IcebergV3SinkMetadata iceberg_v3_sink_metadata = 18;
 }
 
 message StreamingControlStreamRequest {

--- a/src/connector/src/sink/iceberg/commit.rs
+++ b/src/connector/src/sink/iceberg/commit.rs
@@ -17,11 +17,11 @@ use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use iceberg::Catalog;
 use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::spec::{DataFile, Operation, SerializedDataFile, TableMetadata};
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
-use iceberg::{Catalog, TableIdent};
 use itertools::Itertools;
 use risingwave_common::array::arrow::arrow_schema_iceberg::{
     DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields,
@@ -34,13 +34,13 @@ use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::connector_service::sink_metadata::Metadata::Serialized;
 use risingwave_pb::connector_service::sink_metadata::SerializedMetadata;
 use risingwave_pb::stream_plan::PbSinkSchemaChange;
+use serde::{Deserialize, Serialize};
 use serde_json::from_value;
 use thiserror_ext::AsReport;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio_retry::RetryIf;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tracing::warn;
 
+use super::commit_retry::{self, CommitError};
 use super::{GLOBAL_SINK_METRICS, IcebergConfig, SinkError, commit_branch};
 use crate::connector_common::{IcebergCommittedSnapshot, IcebergSinkCompactionUpdate};
 use crate::sink::catalog::SinkId;
@@ -58,62 +58,17 @@ pub struct IcebergCommitResult {
 }
 
 impl IcebergCommitResult {
-    fn try_from(value: &SinkMetadata) -> Result<Self> {
-        if let Some(Serialized(v)) = &value.metadata {
-            let mut values = if let serde_json::Value::Object(v) =
-                serde_json::from_slice::<serde_json::Value>(&v.metadata)
-                    .context("Can't parse iceberg sink metadata")?
-            {
-                v
-            } else {
-                bail!("iceberg sink metadata should be an object");
-            };
+    pub fn try_from(value: &SinkMetadata) -> Result<Self> {
+        let Some(Serialized(value)) = &value.metadata else {
+            bail!("Can't create iceberg sink write result from empty data!");
+        };
 
-            let schema_id;
-            if let Some(serde_json::Value::Number(value)) = values.remove(SCHEMA_ID) {
-                schema_id = value
-                    .as_u64()
-                    .ok_or_else(|| anyhow!("schema_id should be a u64"))?;
-            } else {
-                bail!("iceberg sink metadata should have schema_id");
-            }
-
-            let partition_spec_id;
-            if let Some(serde_json::Value::Number(value)) = values.remove(PARTITION_SPEC_ID) {
-                partition_spec_id = value
-                    .as_u64()
-                    .ok_or_else(|| anyhow!("partition_spec_id should be a u64"))?;
-            } else {
-                bail!("iceberg sink metadata should have partition_spec_id");
-            }
-
-            let data_files: Vec<SerializedDataFile>;
-            if let serde_json::Value::Array(values) = values
-                .remove(DATA_FILES)
-                .ok_or_else(|| anyhow!("iceberg sink metadata should have data_files object"))?
-            {
-                data_files = values
-                    .into_iter()
-                    .map(from_value::<SerializedDataFile>)
-                    .collect::<std::result::Result<_, _>>()
-                    .unwrap();
-            } else {
-                bail!("iceberg sink metadata should have data_files object");
-            }
-
-            Ok(Self {
-                schema_id: schema_id as i32,
-                partition_spec_id: partition_spec_id as i32,
-                data_files,
-            })
-        } else {
-            bail!("Can't create iceberg sink write result from empty data!")
-        }
+        Self::try_from_serialized_bytes(&value.metadata)
     }
 
-    fn try_from_serialized_bytes(value: Vec<u8>) -> Result<Self> {
+    pub fn try_from_serialized_bytes(value: &[u8]) -> Result<Self> {
         let mut values = if let serde_json::Value::Object(value) =
-            serde_json::from_slice::<serde_json::Value>(&value)
+            serde_json::from_slice::<serde_json::Value>(value)
                 .context("Can't parse iceberg sink metadata")?
         {
             value
@@ -165,42 +120,17 @@ impl<'a> TryFrom<&'a IcebergCommitResult> for SinkMetadata {
     type Error = SinkError;
 
     fn try_from(value: &'a IcebergCommitResult) -> std::result::Result<SinkMetadata, Self::Error> {
-        let json_data_files = serde_json::Value::Array(
-            value
-                .data_files
-                .iter()
-                .map(serde_json::to_value)
-                .collect::<std::result::Result<Vec<serde_json::Value>, _>>()
-                .context("Can't serialize data files to json")?,
-        );
-        let json_value = serde_json::Value::Object(
-            vec![
-                (
-                    SCHEMA_ID.to_owned(),
-                    serde_json::Value::Number(value.schema_id.into()),
-                ),
-                (
-                    PARTITION_SPEC_ID.to_owned(),
-                    serde_json::Value::Number(value.partition_spec_id.into()),
-                ),
-                (DATA_FILES.to_owned(), json_data_files),
-            ]
-            .into_iter()
-            .collect(),
-        );
+        let bytes = <Vec<u8>>::try_from(value)?;
         Ok(SinkMetadata {
-            metadata: Some(Serialized(SerializedMetadata {
-                metadata: serde_json::to_vec(&json_value)
-                    .context("Can't serialize iceberg sink metadata")?,
-            })),
+            metadata: Some(Serialized(SerializedMetadata { metadata: bytes })),
         })
     }
 }
 
-impl TryFrom<IcebergCommitResult> for Vec<u8> {
+impl<'a> TryFrom<&'a IcebergCommitResult> for Vec<u8> {
     type Error = SinkError;
 
-    fn try_from(value: IcebergCommitResult) -> std::result::Result<Vec<u8>, Self::Error> {
+    fn try_from(value: &'a IcebergCommitResult) -> std::result::Result<Vec<u8>, Self::Error> {
         let json_data_files = serde_json::Value::Array(
             value
                 .data_files
@@ -225,6 +155,39 @@ impl TryFrom<IcebergCommitResult> for Vec<u8> {
             .collect(),
         );
         Ok(serde_json::to_vec(&json_value).context("Can't serialize iceberg sink metadata")?)
+    }
+}
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct IcebergDvMergerCommitResult {
+    pub schema_id: i32,
+    pub partition_spec_id: i32,
+    pub delete_files: Vec<SerializedDataFile>,
+    pub overwrite_files: Vec<SerializedDataFile>,
+}
+
+impl<'a> TryFrom<&'a SinkMetadata> for IcebergDvMergerCommitResult {
+    type Error = SinkError;
+
+    fn try_from(value: &'a SinkMetadata) -> Result<Self> {
+        let Some(Serialized(value)) = &value.metadata else {
+            bail!("Can't create iceberg dv merger commit result from empty data!");
+        };
+        let value = serde_json::from_slice(&value.metadata)
+            .context("Can't deserialize iceberg dv merger commit result from metadata")?;
+        Ok(value)
+    }
+}
+
+impl<'a> TryFrom<&'a IcebergDvMergerCommitResult> for SinkMetadata {
+    type Error = SinkError;
+
+    fn try_from(value: &'a IcebergDvMergerCommitResult) -> Result<SinkMetadata> {
+        let bytes = serde_json::to_vec(value)
+            .context("Can't serialize iceberg dv merger commit result to metadata")?;
+        Ok(SinkMetadata {
+            metadata: Some(Serialized(SerializedMetadata { metadata: bytes })),
+        })
     }
 }
 
@@ -334,35 +297,6 @@ impl IcebergSinkCommitter {
             );
         }
     }
-
-    // Reload table and guarantee current schema_id and partition_spec_id matches
-    // given `schema_id` and `partition_spec_id`
-    async fn reload_table(
-        catalog: &dyn Catalog,
-        table_ident: &TableIdent,
-        schema_id: i32,
-        partition_spec_id: i32,
-    ) -> Result<Table> {
-        let table = catalog
-            .load_table(table_ident)
-            .await
-            .map_err(|err| SinkError::Iceberg(anyhow!(err)))?;
-        if table.metadata().current_schema_id() != schema_id {
-            return Err(SinkError::Iceberg(anyhow!(
-                "Schema evolution not supported, expect schema id {}, but got {}",
-                schema_id,
-                table.metadata().current_schema_id()
-            )));
-        }
-        if table.metadata().default_partition_spec_id() != partition_spec_id {
-            return Err(SinkError::Iceberg(anyhow!(
-                "Partition evolution not supported, expect partition spec id {}, but got {}",
-                partition_spec_id,
-                table.metadata().default_partition_spec_id()
-            )));
-        }
-        Ok(table)
-    }
 }
 
 #[async_trait]
@@ -439,8 +373,8 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
 
         let mut write_results_bytes = Vec::new();
         for each_parallelism_write_result in write_results {
-            let each_parallelism_write_result_bytes: Vec<u8> =
-                each_parallelism_write_result.try_into()?;
+            let each_parallelism_write_result_bytes =
+                <Vec<u8>>::try_from(&each_parallelism_write_result)?;
             write_results_bytes.push(each_parallelism_write_result_bytes);
         }
 
@@ -480,7 +414,7 @@ impl TwoPhaseCommitCoordinator for IcebergSinkCommitter {
         // Remaining elements are write_results
         let write_results = payload
             .into_iter()
-            .map(IcebergCommitResult::try_from_serialized_bytes)
+            .map(|p| IcebergCommitResult::try_from_serialized_bytes(&p))
             .collect::<Result<Vec<_>>>()?;
 
         let snapshot_committed = self
@@ -583,13 +517,14 @@ impl IcebergSinkCommitter {
         let expect_partition_spec_id = write_results[0].partition_spec_id;
 
         // Load the latest table to avoid concurrent modification with the best effort.
-        self.table = Self::reload_table(
+        self.table = commit_retry::reload_table(
             self.catalog.as_ref(),
             self.table.identifier(),
             expect_schema_id,
             expect_partition_spec_id,
         )
-        .await?;
+        .await
+        .map_err(SinkError::Iceberg)?;
 
         let Some(schema) = self.table.metadata().schema_by_id(expect_schema_id) else {
             return Err(SinkError::Iceberg(anyhow!(
@@ -622,84 +557,50 @@ impl IcebergSinkCommitter {
                 })
             })
             .collect::<Result<Vec<DataFile>>>()?;
+
         // # TODO:
         // This retry behavior should be revert and do in iceberg-rust when it supports retry(Track in: https://github.com/apache/iceberg-rust/issues/964)
         // because retry logic involved reapply the commit metadata.
         // For now, we just retry the commit operation.
-        let retry_strategy = ExponentialBackoff::from_millis(10)
-            .max_delay(Duration::from_secs(60))
-            .map(jitter)
-            .take(self.commit_retry_num as usize);
         let catalog = self.catalog.clone();
         let table_ident = self.table.identifier().clone();
+        let target_branch = commit_branch(self.config.r#type.as_str(), self.config.write_mode);
 
-        // Custom retry logic that:
-        // 1. Calls reload_table before each commit attempt to get the latest metadata
-        // 2. If reload_table fails (table not exists/schema/partition mismatch), stops retrying immediately
-        // 3. If commit fails, retries with backoff
-        enum CommitError {
-            ReloadTable(SinkError), // Non-retriable: schema/partition mismatch
-            Commit(SinkError),      // Retriable: commit conflicts, network errors
-        }
+        let table = commit_retry::run_with_retry(
+            catalog.clone(),
+            table_ident.clone(),
+            expect_schema_id,
+            expect_partition_spec_id,
+            self.commit_retry_num as usize,
+            |table| {
+                let target_branch = target_branch.clone();
+                let data_files = data_files.clone();
+                let catalog = catalog.clone();
+                async move {
+                    let txn = Transaction::new(&table);
+                    let append_action = txn
+                        .fast_append()
+                        .set_snapshot_id(snapshot_id)
+                        .set_target_branch(target_branch)
+                        .add_data_files(data_files);
 
-        let table = RetryIf::spawn(
-            retry_strategy,
-            || async {
-                // Reload table before each commit attempt to get the latest metadata
-                let table = Self::reload_table(
-                    catalog.as_ref(),
-                    &table_ident,
-                    expect_schema_id,
-                    expect_partition_spec_id,
-                )
-                .await
-                .map_err(|e| {
-                    tracing::error!(error = %e.as_report(), "Failed to reload iceberg table");
-                    CommitError::ReloadTable(e)
-                })?;
+                    let tx = append_action.apply(txn).map_err(|err| {
+                        let err: IcebergError = err.into();
+                        tracing::error!(error = %err.as_report(), "Failed to apply iceberg fast_append action");
+                        CommitError::Commit(anyhow!(err).context("apply iceberg fast_append"))
+                    })?;
 
-                let txn = Transaction::new(&table);
-                let append_action = txn
-                    .fast_append()
-                    .set_snapshot_id(snapshot_id)
-                    .set_target_branch(commit_branch(
-                        self.config.r#type.as_str(),
-                        self.config.write_mode,
-                    ))
-                    .add_data_files(data_files.clone());
-
-                let tx = append_action.apply(txn).map_err(|err| {
-                    let err: IcebergError = err.into();
-                    tracing::error!(error = %err.as_report(), "Failed to apply iceberg table");
-                    CommitError::Commit(SinkError::Iceberg(anyhow!(err)))
-                })?;
-
-                tx.commit(catalog.as_ref()).await.map_err(|err| {
-                    let err: IcebergError = err.into();
-                    tracing::error!(error = %err.as_report(), "Failed to commit iceberg table");
-                    CommitError::Commit(SinkError::Iceberg(anyhow!(err)))
-                })
-            },
-            |err: &CommitError| {
-                // Only retry on commit errors, not on reload_table errors
-                match err {
-                    CommitError::Commit(_) => {
-                        tracing::warn!("Commit failed, will retry");
-                        true
-                    }
-                    CommitError::ReloadTable(_) => {
-                        tracing::error!(
-                            "reload_table failed with non-retriable error, will not retry"
-                        );
-                        false
-                    }
+                    let table = tx.commit(catalog.as_ref()).await.map_err(|err| {
+                        let err: IcebergError = err.into();
+                        tracing::error!(error = %err.as_report(), "Failed to commit iceberg table");
+                        CommitError::Commit(anyhow!(err).context("commit iceberg transaction"))
+                    })?;
+                    Ok(table)
                 }
             },
         )
         .await
-        .map_err(|e| match e {
-            CommitError::ReloadTable(e) | CommitError::Commit(e) => e,
-        })?;
+        .map_err(SinkError::Iceberg)?;
         self.table = table;
 
         let snapshot_num = self.table.metadata().snapshots().count();

--- a/src/connector/src/sink/iceberg/commit_retry.rs
+++ b/src/connector/src/sink/iceberg/commit_retry.rs
@@ -1,0 +1,130 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared iceberg commit-with-retry primitive used by both the V1/V2 sink
+//! committer and the V3 sink coordinator worker. Wraps the standard pattern
+//! of "reload the table, build an action against the freshly-loaded snapshot,
+//! commit, retry on transient errors only".
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use iceberg::table::Table;
+use iceberg::{Catalog, TableIdent};
+use thiserror_ext::AsReport;
+use tokio_retry::RetryIf;
+use tokio_retry::strategy::{ExponentialBackoff, jitter};
+
+/// Distinguishes retriable from non-retriable errors inside [`run_with_retry`].
+pub enum CommitError {
+    /// `reload_table` failed (table not found, schema mismatch, partition
+    /// evolution). Non-retriable — the call site's invariants no longer hold.
+    ReloadTable(anyhow::Error),
+    /// `Transaction::commit` (or its `apply`) failed. Retriable — likely a
+    /// commit conflict or transient network error.
+    Commit(anyhow::Error),
+}
+
+/// Reload the iceberg table from the catalog and assert that its current
+/// `schema_id` and `default_partition_spec_id` still match the values the
+/// caller computed against. Schema or partition evolution mid-commit is
+/// surfaced as a non-retriable error by the call sites.
+pub async fn reload_table(
+    catalog: &dyn Catalog,
+    table_ident: &TableIdent,
+    schema_id: i32,
+    partition_spec_id: i32,
+) -> Result<Table> {
+    let table = catalog
+        .load_table(table_ident)
+        .await
+        .map_err(|e| anyhow!(e).context("reload iceberg table"))?;
+    if table.metadata().current_schema_id() != schema_id {
+        bail!(
+            "iceberg sink: schema evolution not supported; expect schema id {}, got {}",
+            schema_id,
+            table.metadata().current_schema_id(),
+        );
+    }
+    if table.metadata().default_partition_spec_id() != partition_spec_id {
+        bail!(
+            "iceberg sink: partition evolution not supported; expect partition spec id {}, got {}",
+            partition_spec_id,
+            table.metadata().default_partition_spec_id(),
+        );
+    }
+    Ok(table)
+}
+
+/// Run a commit-action against the given iceberg table with retry.
+/// 1. Calls `reload_table` before each commit attempt to get the latest metadata
+/// 2. If `reload_table` fails (table not exists/schema/partition mismatch), stops retrying immediately
+/// 3. If commit fails, retries with backoff up to `retry_num` times.
+///
+/// Strategy: exponential backoff 10ms→60s with jitter, up to `retry_num` retries.
+pub async fn run_with_retry<F, Fut, Out>(
+    catalog: Arc<dyn Catalog>,
+    table_ident: TableIdent,
+    schema_id: i32,
+    partition_spec_id: i32,
+    retry_num: usize,
+    commit_action: F,
+) -> Result<Out>
+where
+    F: Fn(Table) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Out, CommitError>> + Send,
+{
+    let retry_strategy = ExponentialBackoff::from_millis(10)
+        .max_delay(Duration::from_secs(60))
+        .map(jitter)
+        .take(retry_num);
+
+    RetryIf::spawn(
+        retry_strategy,
+        || {
+            let catalog = catalog.clone();
+            let table_ident = table_ident.clone();
+            let commit_action = &commit_action;
+            async move {
+                let table =
+                    reload_table(catalog.as_ref(), &table_ident, schema_id, partition_spec_id)
+                        .await
+                        .map_err(CommitError::ReloadTable)?;
+                commit_action(table).await
+            }
+        },
+        |err: &CommitError| match err {
+            CommitError::Commit(e) => {
+                tracing::warn!(
+                    error = %e.as_report(),
+                    "iceberg commit failed; will retry",
+                );
+                true
+            }
+            CommitError::ReloadTable(e) => {
+                tracing::error!(
+                    error = %e.as_report(),
+                    "iceberg reload_table failed; will not retry",
+                );
+                false
+            }
+        },
+    )
+    .await
+    .map_err(|e| match e {
+        CommitError::ReloadTable(e) | CommitError::Commit(e) => e,
+    })
+}

--- a/src/connector/src/sink/iceberg/mod.rs
+++ b/src/connector/src/sink/iceberg/mod.rs
@@ -16,6 +16,7 @@
 mod test;
 
 mod commit;
+pub mod commit_retry;
 mod config;
 mod create_table;
 mod prometheus;

--- a/src/meta/node/src/server.rs
+++ b/src/meta/node/src/server.rs
@@ -90,6 +90,7 @@ use crate::barrier::BarrierScheduler;
 use crate::controller::SqlMetaStore;
 use crate::controller::system_param::SystemParamsController;
 use crate::hummock::HummockManager;
+use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{IdleManager, MetaOpts, MetaSrvEnv};
 use crate::rpc::election::sql::{MySqlDriver, PostgresDriver, SqlBackendElectionClient};
@@ -464,6 +465,9 @@ pub async fn start_service_as_election_leader(
     // TODO(shutdown): remove this as there's no need to gracefully shutdown some of these sub-tasks.
     let mut sub_tasks = vec![shutdown_handle];
 
+    let iceberg_v3_sink_manager = IcebergV3SinkManager::new(env.meta_store_ref().conn.clone());
+    tracing::info!("IcebergV3SinkManager started");
+
     let iceberg_compactor_manager = Arc::new(IcebergCompactorManager::new());
 
     // TODO: introduce compactor event stream handler to handle iceberg compaction events.
@@ -507,6 +511,7 @@ pub async fn start_service_as_election_leader(
         hummock_manager.clone(),
         source_manager.clone(),
         sink_manager.clone(),
+        iceberg_v3_sink_manager.clone(),
         scale_controller.clone(),
         barrier_scheduler.clone(),
         refresh_manager.clone(),
@@ -550,6 +555,7 @@ pub async fn start_service_as_election_leader(
         meta_metrics.clone(),
         iceberg_compaction_mgr.clone(),
         barrier_scheduler.clone(),
+        iceberg_v3_sink_manager.clone(),
     )
     .await;
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -57,6 +57,7 @@ use tonic::{Request, Response, Status};
 
 use crate::MetaError;
 use crate::barrier::BarrierManagerRef;
+use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, StreamingJob};
 use crate::rpc::ddl_controller::{
@@ -87,6 +88,7 @@ impl DdlServiceImpl {
         meta_metrics: Arc<MetaMetrics>,
         iceberg_compaction_manager: iceberg_compaction::IcebergCompactionManagerRef,
         barrier_scheduler: BarrierScheduler,
+        iceberg_v3_sink_manager: IcebergV3SinkManager,
     ) -> Self {
         let ddl_controller = DdlController::new(
             env.clone(),
@@ -96,6 +98,7 @@ impl DdlServiceImpl {
             barrier_manager,
             sink_manager.clone(),
             iceberg_compaction_manager.clone(),
+            iceberg_v3_sink_manager,
         )
         .await;
         Self {

--- a/src/meta/src/barrier/checkpoint/control.rs
+++ b/src/meta/src/barrier/checkpoint/control.rs
@@ -1105,7 +1105,7 @@ impl DatabaseCheckpointControl {
                 Command::collect_commit_epoch_info(
                     &self.database_info,
                     &info,
-                    &mut task.commit_info,
+                    task,
                     resps_to_commit,
                     self.collect_backfill_pinned_upstream_log_epoch(),
                 );
@@ -1129,12 +1129,7 @@ impl DatabaseCheckpointControl {
         if !independent_jobs_task.is_empty() {
             let task = task.get_or_insert_default();
             for (job_id, epoch, resps, info) in independent_jobs_task {
-                collect_independent_job_commit_epoch_info(
-                    &mut task.commit_info,
-                    epoch,
-                    resps,
-                    &info,
-                );
+                collect_independent_job_commit_epoch_info(task, epoch, resps, &info);
                 task.epoch_infos
                     .try_insert(to_partial_graph_id(self.database_id, Some(job_id)), info)
                     .expect("non duplicate");

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -55,6 +55,7 @@ use tracing::warn;
 
 use super::info::InflightDatabaseInfo;
 use crate::barrier::backfill_order_control::get_nodes_with_backfill_dependencies;
+use crate::barrier::complete_task::CompleteBarrierTask;
 use crate::barrier::edge_builder::FragmentEdgeBuildResult;
 use crate::barrier::info::BarrierInfo;
 use crate::barrier::partial_graph::PartialGraphBarrierInfo;
@@ -63,7 +64,7 @@ use crate::barrier::utils::{collect_new_vector_index_info, collect_resp_info};
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::controller::scale::LoadedFragmentContext;
 use crate::controller::utils::StreamingJobExtraInfo;
-use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
+use crate::hummock::NewTableFragmentInfo;
 use crate::manager::{StreamingJob, StreamingJobType};
 use crate::model::{
     ActorId, ActorUpstreams, DispatcherId, FragmentActorDispatchers, FragmentDownstreamRelation,
@@ -826,7 +827,7 @@ impl Command {
     pub(super) fn collect_commit_epoch_info(
         database_info: &InflightDatabaseInfo,
         barrier_info: &PartialGraphBarrierInfo,
-        info: &mut CommitEpochInfo,
+        task: &mut CompleteBarrierTask,
         resps: Vec<BarrierCompleteResponse>,
         backfill_pinned_log_epoch: HashMap<JobId, (u64, HashSet<TableId>)>,
     ) {
@@ -837,6 +838,7 @@ impl Command {
             old_value_ssts,
             vector_index_adds,
             truncate_tables,
+            iceberg_v3_sink_metadata,
         ) = collect_resp_info(resps);
 
         let new_table_fragment_infos =
@@ -895,6 +897,7 @@ impl Command {
         );
 
         let epoch = barrier_info.barrier_info.prev_epoch();
+        let info = &mut task.commit_info;
         for table_id in &barrier_info.table_ids_to_commit {
             info.tables_to_commit
                 .try_insert(*table_id, epoch)
@@ -926,6 +929,8 @@ impl Command {
                 .expect("non-duplicate");
         }
         info.truncate_tables.extend(truncate_tables);
+        task.iceberg_v3_sink_metadata
+            .extend(iceberg_v3_sink_metadata);
     }
 }
 

--- a/src/meta/src/barrier/complete_task.rs
+++ b/src/meta/src/barrier/complete_task.rs
@@ -25,7 +25,7 @@ use risingwave_common::util::deployment::Deployment;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::{DatabaseId, PartialGraphId};
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbListFinishedSource, PbLoadFinishedSource,
+    PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
 };
 use tokio::task::JoinHandle;
 
@@ -71,6 +71,8 @@ pub(super) struct CompleteBarrierTask {
     pub(super) load_finished_source_ids: Vec<PbLoadFinishedSource>,
     /// Table IDs that have finished materialize refresh and need completion signaling
     pub(super) refresh_finished_table_job_ids: Vec<JobId>,
+    /// Iceberg V3 sink reports collected during this barrier
+    pub(super) iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
 }
 
 impl CompleteBarrierTask {
@@ -103,7 +105,26 @@ impl CompleteBarrierTask {
             let wait_commit_timer = GLOBAL_META_METRICS
                 .barrier_wait_commit_latency
                 .start_timer();
+
+            // Iceberg V3 sink metadata reports are handled in three steps around hummock `commit_epoch`:
+            //   1. pre_commit: persist pending rows under `pending_sink_state` (no iceberg I/O).
+            //   2. commit_epoch: advance hummock.
+            //   3. commit: drive iceberg overwrite_files for queued epochs.
+            let mut iceberg_v3_commit_sink_ids = Vec::new();
+            if !self.iceberg_v3_sink_metadata.is_empty() {
+                let res = context
+                    .pre_commit_iceberg_v3_sink_metadata(self.iceberg_v3_sink_metadata)
+                    .await?;
+                iceberg_v3_commit_sink_ids = res;
+            }
+
             let version_stats = context.commit_epoch(self.commit_info).await?;
+
+            if !iceberg_v3_commit_sink_ids.is_empty() {
+                context
+                    .commit_iceberg_v3_sink_metadata(iceberg_v3_commit_sink_ids)
+                    .await?;
+            }
 
             // Handle list finished source IDs for refreshable batch sources
             // Spawn this asynchronously to avoid deadlock during barrier collection

--- a/src/meta/src/barrier/context/context_impl.rs
+++ b/src/meta/src/barrier/context/context_impl.rs
@@ -16,18 +16,21 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Context;
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use risingwave_common::catalog::{DatabaseId, FragmentTypeFlag, TableId};
-use risingwave_common::id::JobId;
+use risingwave_common::id::{JobId, SinkId};
 use risingwave_meta_model::ActorId;
 use risingwave_meta_model::streaming_job::BackfillOrders;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::id::SourceId;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbListFinishedSource, PbLoadFinishedSource,
+    PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
+use thiserror_ext::AsReport;
 
 use crate::barrier::cdc_progress::CdcTableBackfillTracker;
 use crate::barrier::checkpoint::independent_job::BatchRefreshJobTriggerContext;
@@ -252,6 +255,108 @@ impl GlobalBarrierWorkerContext for GlobalBarrierWorkerContextImpl {
         self.load_batch_refresh_trigger_context_impl(job_id, database_id, last_committed_epoch)
             .await
     }
+
+    #[await_tree::instrument]
+    async fn pre_commit_iceberg_v3_sink_metadata(
+        &self,
+        reports: Vec<PbIcebergV3SinkMetadata>,
+    ) -> MetaResult<Vec<SinkId>> {
+        let grouped = group_v3_reports_by_sink(reports)?;
+        let success_ids: Vec<SinkId> = grouped.keys().cloned().collect();
+        let futs = FuturesUnordered::new();
+        for (sink_id, (prev_epoch, reports)) in grouped {
+            if reports.is_empty() {
+                continue;
+            }
+            let manager = &self.iceberg_v3_sink_manager;
+            futs.push(async move {
+                (
+                    sink_id,
+                    manager
+                        .pre_commit_v3_epoch(sink_id, prev_epoch, reports)
+                        .await,
+                )
+            });
+        }
+
+        // Drain all futures regardless of individual failures, so that no coordinator is left with
+        // state inconsistent vs. the caller's view.
+        let results: Vec<(SinkId, anyhow::Result<()>)> = futs.collect().await;
+        let errs: Vec<(SinkId, anyhow::Error)> = results
+            .into_iter()
+            .filter_map(|(id, r)| r.err().map(|e| (id, e)))
+            .collect();
+        if errs.is_empty() {
+            Ok(success_ids)
+        } else {
+            Err(aggregate_v3_sink_errors("pre-commit", errs).into())
+        }
+    }
+
+    #[await_tree::instrument]
+    async fn commit_iceberg_v3_sink_metadata(&self, sink_ids: Vec<SinkId>) -> MetaResult<()> {
+        let futs = FuturesUnordered::new();
+        for sink_id in sink_ids {
+            let manager = &self.iceberg_v3_sink_manager;
+            futs.push(async move { (sink_id, manager.commit_v3_epoch(sink_id).await) });
+        }
+
+        let results: Vec<(SinkId, anyhow::Result<()>)> = futs.collect().await;
+        let errs: Vec<(SinkId, anyhow::Error)> = results
+            .into_iter()
+            .filter_map(|(id, r)| r.err().map(|e| (id, e)))
+            .collect();
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(aggregate_v3_sink_errors("commit", errs).into())
+        }
+    }
+}
+
+/// Combine per-sink errors from a fan-out into a single `anyhow::Error`. The first failing
+/// sink's error is used as the source so the original chain is preserved; the message lists
+/// every failing `sink_id` and its error stringified.
+fn aggregate_v3_sink_errors(
+    phase: &'static str,
+    mut errs: Vec<(SinkId, anyhow::Error)>,
+) -> anyhow::Error {
+    debug_assert!(!errs.is_empty());
+    let sink_ids: Vec<String> = errs.iter().map(|(id, _)| id.to_string()).collect();
+    let details: Vec<String> = errs
+        .iter()
+        .map(|(id, e)| format!("sink {}: {}", id, e.as_report()))
+        .collect();
+    // Preserve the first error's chain as the cause.
+    let (_, first_err) = errs.remove(0);
+    first_err.context(format!(
+        "iceberg v3 sink {} failed for sink_id(s) [{}]: {}",
+        phase,
+        sink_ids.join(", "),
+        details.join("; ")
+    ))
+}
+
+fn group_v3_reports_by_sink(
+    reports: Vec<PbIcebergV3SinkMetadata>,
+) -> MetaResult<HashMap<SinkId, (u64, Vec<PbIcebergV3SinkMetadata>)>> {
+    let mut grouped: HashMap<SinkId, (u64, Vec<PbIcebergV3SinkMetadata>)> = HashMap::new();
+    for r in reports {
+        let sink_id = r.sink_id;
+        let prev_epoch = r.prev_epoch;
+        let entry = grouped.entry(sink_id).or_insert((prev_epoch, Vec::new()));
+        if entry.0 != prev_epoch {
+            return Err(anyhow::anyhow!(
+                "iceberg v3 sink {} reports disagree on prev_epoch: {} vs {}",
+                sink_id,
+                entry.0,
+                prev_epoch
+            )
+            .into());
+        }
+        entry.1.push(r);
+    }
+    Ok(grouped)
 }
 
 impl GlobalBarrierWorkerContextImpl {

--- a/src/meta/src/barrier/context/mod.rs
+++ b/src/meta/src/barrier/context/mod.rs
@@ -21,10 +21,11 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use risingwave_common::catalog::DatabaseId;
 use risingwave_common::id::JobId;
+use risingwave_meta_model::SinkId;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::HummockVersionStats;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbListFinishedSource, PbLoadFinishedSource,
+    IcebergV3SinkMetadata as PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_pb::stream_service::streaming_control_stream_request::PbInitRequest;
 use risingwave_rpc_client::StreamingControlHandle;
@@ -40,6 +41,7 @@ use crate::barrier::{
     RecoveryReason, Scheduled, SnapshotBackfillInfo,
 };
 use crate::hummock::{CommitEpochInfo, HummockManagerRef};
+use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::stream::source_manager::SplitAssignment;
@@ -141,6 +143,16 @@ pub(super) trait GlobalBarrierWorkerContext: Send + Sync + 'static {
         database_id: DatabaseId,
         last_committed_epoch: u64,
     ) -> impl Future<Output = MetaResult<BatchRefreshJobTriggerContext>> + Send + '_;
+
+    fn pre_commit_iceberg_v3_sink_metadata(
+        &self,
+        reports: Vec<PbIcebergV3SinkMetadata>,
+    ) -> impl Future<Output = MetaResult<Vec<SinkId>>> + Send + '_;
+
+    fn commit_iceberg_v3_sink_metadata(
+        &self,
+        sink_ids: Vec<SinkId>,
+    ) -> impl Future<Output = MetaResult<()>> + Send + '_;
 }
 
 pub(super) struct GlobalBarrierWorkerContextImpl {
@@ -164,9 +176,12 @@ pub(super) struct GlobalBarrierWorkerContextImpl {
     pub(super) refresh_manager: GlobalRefreshManagerRef,
 
     sink_manager: SinkCoordinatorManager,
+
+    pub(super) iceberg_v3_sink_manager: IcebergV3SinkManager,
 }
 
 impl GlobalBarrierWorkerContextImpl {
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         scheduled_barriers: ScheduledBarriers,
         status: Arc<ArcSwap<BarrierManagerStatus>>,
@@ -178,6 +193,7 @@ impl GlobalBarrierWorkerContextImpl {
         barrier_scheduler: BarrierScheduler,
         refresh_manager: GlobalRefreshManagerRef,
         sink_manager: SinkCoordinatorManager,
+        iceberg_v3_sink_manager: IcebergV3SinkManager,
     ) -> Self {
         Self {
             scheduled_barriers,
@@ -190,6 +206,7 @@ impl GlobalBarrierWorkerContextImpl {
             barrier_scheduler,
             refresh_manager,
             sink_manager,
+            iceberg_v3_sink_manager,
         }
     }
 

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -18,6 +18,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicU32;
 
 use anyhow::{Context, anyhow};
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::{DatabaseId, TableId};
@@ -464,9 +466,52 @@ impl GlobalBarrierWorkerContextImpl {
                 .catalog_controller
                 .list_sink_ids(Some(database_id))
                 .await?;
-            self.sink_manager.stop_sink_coordinator(sink_ids).await;
+            self.sink_manager
+                .stop_sink_coordinator(sink_ids.clone())
+                .await;
+            self.iceberg_v3_sink_manager.unregister_v3_sinks(sink_ids);
         } else {
             self.sink_manager.reset().await;
+            self.iceberg_v3_sink_manager.reset();
+        }
+        Ok(())
+    }
+
+    /// Re-register iceberg V3 sink commit coordinators after recovery wipes them.
+    async fn reregister_iceberg_v3_sinks(&self, database_id: Option<DatabaseId>) -> MetaResult<()> {
+        let pb_sinks = self
+            .metadata_manager
+            .catalog_controller
+            .list_sinks()
+            .await?;
+        let mut futs = FuturesUnordered::new();
+        for pb_sink in pb_sinks {
+            if database_id.is_some_and(|db_id| pb_sink.database_id != db_id)
+                || !crate::manager::iceberg_v3_sink::is_iceberg_v3_sink(&pb_sink.properties)
+            {
+                continue;
+            }
+            let config = crate::manager::iceberg_v3_sink::build_iceberg_config(&pb_sink)
+                .with_context(|| {
+                    format!(
+                        "build iceberg config while re-registering v3 sink {}",
+                        pb_sink.id
+                    )
+                })?;
+            let manager = &self.iceberg_v3_sink_manager;
+            futs.push(async move {
+                (
+                    pb_sink.id,
+                    manager.register_v3_sink(pb_sink.id, config).await,
+                )
+            });
+        }
+
+        while let Some((id, res)) = futs.next().await {
+            if let Err(e) = res {
+                let msg = format!("register iceberg v3 sink {} during recovery", id);
+                return Err(e.context(msg).into());
+            }
         }
         Ok(())
     }
@@ -781,6 +826,13 @@ impl GlobalBarrierWorkerContextImpl {
                         .await
                         .context("abort dirty pending sink state")?;
 
+                    // We must abort dirty pending sink state before registering iceberg V3 sinks,
+                    // otherwise recover_pending will take speculative (epoch > committed epoch) pending sink state
+                    // as valid and cause duplicated iceberg commit.
+                    self.reregister_iceberg_v3_sinks(None)
+                        .await
+                        .context("re-register iceberg v3 sinks after recovery")?;
+
                     // Background job progress needs to be recovered.
                     tracing::info!("recovering background job progress");
                     let mut initial_background_jobs = self
@@ -952,6 +1004,9 @@ impl GlobalBarrierWorkerContextImpl {
         self.abort_dirty_pending_sink_state(Some(database_id))
             .await
             .context("abort dirty pending sink state")?;
+        self.reregister_iceberg_v3_sinks(Some(database_id))
+            .await
+            .context("re-register iceberg v3 sinks after recovery")?;
 
         // Background job progress needs to be recovered.
         tracing::info!(

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -703,8 +703,7 @@ impl InflightDatabaseInfo {
             .values()
             .flat_map(|resp| &resp.cdc_source_offset_updated)
         {
-            use risingwave_common::id::SourceId;
-            let source_id = SourceId::new(cdc_offset_updated.source_id);
+            let source_id = cdc_offset_updated.source_id;
             let job_id = source_id.as_share_source_job_id();
             if let Some(job) = self.jobs.get_mut(&job_id) {
                 if let CreateStreamingJobStatus::Creating { tracker, .. } = &mut job.status {

--- a/src/meta/src/barrier/manager.rs
+++ b/src/meta/src/barrier/manager.rs
@@ -39,6 +39,7 @@ use crate::barrier::{
     RecoveryReason, UpdateDatabaseBarrierRequest, schedule,
 };
 use crate::hummock::HummockManagerRef;
+use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{MetaSrvEnv, MetadataManager};
 use crate::stream::{GlobalRefreshManagerRef, ScaleControllerRef, SourceManagerRef};
@@ -199,6 +200,7 @@ impl GlobalBarrierManager {
         hummock_manager: HummockManagerRef,
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
+        iceberg_v3_sink_manager: IcebergV3SinkManager,
         scale_controller: ScaleControllerRef,
         barrier_scheduler: schedule::BarrierScheduler,
         refresh_manager: GlobalRefreshManagerRef,
@@ -213,6 +215,7 @@ impl GlobalBarrierManager {
             hummock_manager,
             source_manager,
             sink_manager,
+            iceberg_v3_sink_manager,
             scale_controller,
             request_rx,
             barrier_scheduler,

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -946,6 +946,22 @@ mod tests {
         {
             unimplemented!()
         }
+
+        async fn pre_commit_iceberg_v3_sink_metadata(
+            &self,
+            _reports: Vec<
+                risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata,
+            >,
+        ) -> MetaResult<Vec<risingwave_meta_model::SinkId>> {
+            unimplemented!()
+        }
+
+        async fn commit_iceberg_v3_sink_metadata(
+            &self,
+            _sink_ids: Vec<risingwave_meta_model::SinkId>,
+        ) -> MetaResult<()> {
+            unimplemented!()
+        }
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
+++ b/src/meta/src/barrier/tests/worker_crash_no_early_commit.rs
@@ -20,7 +20,7 @@ use anyhow::anyhow;
 use futures::StreamExt;
 use risingwave_common::catalog::{DatabaseId, TableId};
 use risingwave_common::hash::VirtualNode;
-use risingwave_common::id::JobId;
+use risingwave_common::id::{JobId, SinkId};
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_meta_model::fragment::DistributionType;
 use risingwave_meta_model::{
@@ -168,6 +168,19 @@ impl GlobalBarrierWorkerContext for MockBarrierWorkerContext {
         _last_committed_epoch: u64,
     ) -> MetaResult<crate::barrier::checkpoint::independent_job::BatchRefreshJobTriggerContext>
     {
+        unimplemented!()
+    }
+
+    async fn pre_commit_iceberg_v3_sink_metadata(
+        &self,
+        _reports: Vec<
+            risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata,
+        >,
+    ) -> MetaResult<Vec<SinkId>> {
+        unimplemented!()
+    }
+
+    async fn commit_iceberg_v3_sink_metadata(&self, _sink_ids: Vec<SinkId>) -> MetaResult<()> {
         unimplemented!()
     }
 }

--- a/src/meta/src/barrier/utils.rs
+++ b/src/meta/src/barrier/utils.rs
@@ -31,11 +31,13 @@ use risingwave_pb::catalog::table::PbTableType;
 use risingwave_pb::hummock::vector_index_delta::PbVectorIndexInit;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_service::BarrierCompleteResponse;
+use risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata;
 
 use crate::barrier::CreateStreamingJobCommandInfo;
 use crate::barrier::command::PostCollectCommand;
+use crate::barrier::complete_task::CompleteBarrierTask;
 use crate::barrier::partial_graph::PartialGraphBarrierInfo;
-use crate::hummock::{CommitEpochInfo, NewTableFragmentInfo};
+use crate::hummock::NewTableFragmentInfo;
 
 #[expect(clippy::type_complexity)]
 pub(super) fn collect_resp_info(
@@ -47,6 +49,7 @@ pub(super) fn collect_resp_info(
     Vec<SstableInfo>,
     HashMap<TableId, Vec<VectorIndexAdd>>,
     HashSet<TableId>,
+    Vec<IcebergV3SinkMetadata>,
 ) {
     let mut sst_to_worker: HashMap<HummockSstableObjectId, _> = HashMap::new();
     let mut synced_ssts: Vec<LocalSstableInfo> = vec![];
@@ -54,6 +57,7 @@ pub(super) fn collect_resp_info(
     let mut old_value_ssts = Vec::with_capacity(resps.len());
     let mut vector_index_adds = HashMap::new();
     let mut truncate_tables: HashSet<TableId> = HashSet::new();
+    let mut iceberg_v3_sink_metadata = Vec::new();
 
     for resp in resps {
         let ssts_iter = resp.synced_sstables.into_iter().map(|local_sst| {
@@ -81,6 +85,7 @@ pub(super) fn collect_resp_info(
                 .expect("non-duplicate");
         }
         truncate_tables.extend(resp.truncate_tables);
+        iceberg_v3_sink_metadata.extend(resp.iceberg_v3_sink_metadata);
     }
 
     (
@@ -102,6 +107,7 @@ pub(super) fn collect_resp_info(
         old_value_ssts,
         vector_index_adds,
         truncate_tables,
+        iceberg_v3_sink_metadata,
     )
 }
 
@@ -128,7 +134,7 @@ pub(super) fn collect_new_vector_index_info(
 }
 
 pub(super) fn collect_independent_job_commit_epoch_info(
-    commit_info: &mut CommitEpochInfo,
+    task: &mut CompleteBarrierTask,
     epoch: u64,
     resps: Vec<BarrierCompleteResponse>,
     barrier_info: &PartialGraphBarrierInfo,
@@ -140,8 +146,10 @@ pub(super) fn collect_independent_job_commit_epoch_info(
         old_value_sst,
         vector_index_adds,
         truncate_tables,
+        iceberg_v3_sink_metadata,
     ) = collect_resp_info(resps);
     assert!(old_value_sst.is_empty());
+    let commit_info = &mut task.commit_info;
     commit_info.sst_to_context.extend(sst_to_context);
     commit_info.sstables.extend(sstables);
     commit_info
@@ -182,6 +190,8 @@ pub(super) fn collect_independent_job_commit_epoch_info(
                 .expect("non-duplicate");
         }
     };
+    task.iceberg_v3_sink_metadata
+        .extend(iceberg_v3_sink_metadata);
 }
 
 pub(super) type NodeToCollect = HashSet<WorkerId>;

--- a/src/meta/src/barrier/worker.rs
+++ b/src/meta/src/barrier/worker.rs
@@ -56,6 +56,7 @@ use crate::barrier::{
 use crate::controller::scale::{materialize_actor_assignments, preview_actor_assignments};
 use crate::error::MetaErrorInner;
 use crate::hummock::HummockManagerRef;
+use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{
     ActiveStreamingWorkerChange, ActiveStreamingWorkerNodes, LocalNotification, MetaSrvEnv,
@@ -299,6 +300,7 @@ fn build_reschedule_from_context(
 
 impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
     /// Create a new [`crate::barrier::worker::GlobalBarrierWorker`].
+    #[expect(clippy::too_many_arguments)]
     pub async fn new(
         scheduled_barriers: schedule::ScheduledBarriers,
         env: MetaSrvEnv,
@@ -306,6 +308,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
         hummock_manager: HummockManagerRef,
         source_manager: SourceManagerRef,
         sink_manager: SinkCoordinatorManager,
+        iceberg_v3_sink_manager: IcebergV3SinkManager,
         scale_controller: ScaleControllerRef,
         request_rx: mpsc::UnboundedReceiver<BarrierManagerRequest>,
         barrier_scheduler: schedule::BarrierScheduler,
@@ -324,6 +327,7 @@ impl GlobalBarrierWorker<GlobalBarrierWorkerContextImpl> {
             barrier_scheduler,
             refresh_manager,
             sink_manager,
+            iceberg_v3_sink_manager,
         ));
 
         Self::new_inner(env, request_rx, context).await

--- a/src/meta/src/controller/catalog/drop_op.rs
+++ b/src/meta/src/controller/catalog/drop_op.rs
@@ -219,6 +219,21 @@ impl CatalogController {
             .map(|(sink, obj)| ObjectModel(sink, obj.unwrap(), None).into())
             .collect();
 
+        // Collect Iceberg V3 sink ids among dropped sinks so the V3 sink manager
+        // can tear down their per-sink commit workers. Unlike the iceberg-table
+        // cleanup above, V3 sinks are user-created with arbitrary names, so we
+        // identify them by inspecting properties rather than by name prefix.
+        let removed_iceberg_v3_sink_ids: Vec<SinkId> = Sink::find()
+            .filter(sink::Column::SinkId.is_in(removed_object_ids.clone()))
+            .all(&txn)
+            .await?
+            .into_iter()
+            .filter_map(|sink| {
+                crate::manager::iceberg_v3_sink::is_iceberg_v3_sink(sink.properties.inner_ref())
+                    .then_some(sink.sink_id)
+            })
+            .collect();
+
         let removed_streaming_job_ids: Vec<JobId> = StreamingJob::find()
             .select_only()
             .column(streaming_job::Column::JobId)
@@ -431,6 +446,7 @@ impl CatalogController {
                 removed_fragments,
                 removed_sink_fragment_by_targets,
                 removed_iceberg_table_sinks,
+                removed_iceberg_v3_sink_ids,
             },
             version,
         ))

--- a/src/meta/src/controller/catalog/mod.rs
+++ b/src/meta/src/controller/catalog/mod.rs
@@ -142,6 +142,11 @@ pub struct ReleaseContext {
 
     /// Dropped iceberg table sinks
     pub(crate) removed_iceberg_table_sinks: Vec<PbSink>,
+
+    /// Dropped Iceberg V3 sink ids. Used to unregister per-sink commit workers
+    /// owned by `IcebergV3SinkManager`. Filtered via `is_iceberg_v3_sink` on
+    /// the sink properties so user-created V3 sinks (any name) are included.
+    pub(crate) removed_iceberg_v3_sink_ids: Vec<SinkId>,
 }
 
 #[derive(Default)]

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(anonymous_lifetime_in_impl_trait)]
 #![feature(duration_millis_float)]
 #![feature(iterator_try_reduce)]
+#![feature(iterator_try_collect)]
 
 pub mod backup_restore;
 pub mod barrier;

--- a/src/meta/src/manager/exactly_once_util.rs
+++ b/src/meta/src/manager/exactly_once_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RisingWave Labs
+// Copyright 2026 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ use sea_orm::{
 };
 use thiserror_ext::AsReport;
 
-// This file contains methods for accessing system tables in the meta store with two-phase commit sink support.
+// Helpers for accessing the `pending_sink_state` system table used by exactly-once sink coordinators
+// (both the generic sink coordinator and the Iceberg V3 sink coordinator).
 
 pub async fn persist_pre_commit_metadata(
     db: &DatabaseConnection,

--- a/src/meta/src/manager/iceberg_v3_sink/backfill.rs
+++ b/src/meta/src/manager/iceberg_v3_sink/backfill.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use iceberg::spec::DataFile;
+
+pub fn backfill_dv_partitions(
+    writer_files: &[DataFile],
+    dv_delete_files: &mut [DataFile],
+) -> Result<()> {
+    if dv_delete_files.is_empty() {
+        return Ok(());
+    }
+    let mut waiting_delete_files = dv_delete_files
+        .iter_mut()
+        .filter(|dv| dv.partition().fields().is_empty())
+        .map(|dv| (dv.referenced_data_file().unwrap(), dv))
+        .collect::<HashMap<_, _>>();
+    if waiting_delete_files.is_empty() {
+        return Ok(());
+    }
+
+    for f in writer_files {
+        if let Some(dv) = waiting_delete_files.remove(f.file_path()) {
+            dv.set_partition(f.partition().clone());
+            if waiting_delete_files.is_empty() {
+                return Ok(());
+            }
+        }
+    }
+
+    if !waiting_delete_files.is_empty() {
+        anyhow::bail!(
+            "backfill iceberg v3 sink delete files failed, missing referenced data files: {:?}",
+            waiting_delete_files.keys().collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use iceberg::spec::{DataContentType, DataFileBuilder, DataFileFormat, Literal, Struct};
+
+    use super::*;
+
+    fn writer_file(path: &str, partition: Struct) -> DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(path.to_owned())
+            .file_format(DataFileFormat::Parquet)
+            .partition(partition)
+            .partition_spec_id(0)
+            .record_count(1)
+            .file_size_in_bytes(1)
+            .build()
+            .expect("writer file build")
+    }
+
+    fn dv_file(path: &str, referenced: &str, partition: Struct) -> DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(path.to_owned())
+            .file_format(DataFileFormat::Puffin)
+            .partition(partition)
+            .partition_spec_id(0)
+            .record_count(1)
+            .file_size_in_bytes(1)
+            .referenced_data_file(Some(referenced.to_owned()))
+            .build()
+            .expect("dv file build")
+    }
+
+    fn struct_with_int(value: i32) -> Struct {
+        Struct::from_iter([Some(Literal::int(value))])
+    }
+
+    #[test]
+    fn empty_inputs_noop() -> Result<()> {
+        let mut dvs: Vec<DataFile> = vec![];
+        backfill_dv_partitions(&[], &mut dvs)?;
+        assert!(dvs.is_empty());
+
+        let writers = [writer_file("data/a.parquet", struct_with_int(7))];
+        let mut dvs: Vec<DataFile> = vec![];
+        backfill_dv_partitions(&writers, &mut dvs)?;
+
+        assert!(dvs.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn dv_referencing_same_epoch_writer_gets_partition() -> Result<()> {
+        let writers = [writer_file("data/a.parquet", struct_with_int(42))];
+        let mut dvs = vec![dv_file("dv/a.puff", "data/a.parquet", Struct::empty())];
+
+        backfill_dv_partitions(&writers, &mut dvs)?;
+
+        assert_eq!(dvs[0].partition(), &struct_with_int(42));
+        Ok(())
+    }
+
+    #[test]
+    fn dv_referencing_older_snapshot_left_alone() -> Result<()> {
+        // DV references a data file NOT in the uncommitted writer set — its
+        // partition was correctly populated by DvMerger from the older
+        // snapshot and must not be overwritten.
+        let writers = [writer_file("data/a.parquet", struct_with_int(1))];
+        let dv_partition = struct_with_int(99);
+        let mut dvs = vec![dv_file(
+            "dv/old.puff",
+            "data/somewhere_old.parquet",
+            dv_partition.clone(),
+        )];
+
+        backfill_dv_partitions(&writers, &mut dvs)?;
+
+        assert_eq!(dvs[0].partition(), &dv_partition, "must not overwrite");
+        Ok(())
+    }
+
+    #[test]
+    fn mixed_set_partial_backfill() -> Result<()> {
+        let writers = [
+            writer_file("data/a.parquet", struct_with_int(1)),
+            writer_file("data/b.parquet", struct_with_int(2)),
+        ];
+        let mut dvs = vec![
+            dv_file("dv/a.puff", "data/a.parquet", Struct::empty()),
+            dv_file("dv/old.puff", "data/c.parquet", struct_with_int(99)),
+            dv_file("dv/b.puff", "data/b.parquet", Struct::empty()),
+        ];
+
+        backfill_dv_partitions(&writers, &mut dvs)?;
+
+        assert_eq!(dvs[0].partition(), &struct_with_int(1));
+        assert_eq!(
+            dvs[1].partition(),
+            &struct_with_int(99),
+            "older snapshot DV untouched"
+        );
+        assert_eq!(dvs[2].partition(), &struct_with_int(2));
+        Ok(())
+    }
+}

--- a/src/meta/src/manager/iceberg_v3_sink/coordinator.rs
+++ b/src/meta/src/manager/iceberg_v3_sink/coordinator.rs
@@ -1,0 +1,518 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-sink Iceberg V3 commit coordinator. This is a plain struct (no background task / mpsc): the
+//! [`crate::manager::iceberg_v3_sink::IcebergV3SinkManager`] holds one per registered sink behind a
+//! per-sink async mutex and calls [`IcebergV3Coordinator::pre_commit`] / [`IcebergV3Coordinator::commit`]
+//! directly from the barrier-completion path. The barrier path already serializes pre-commit/commit per
+//! epoch, so the coordinator never needs its own request queue.
+//!
+//! [`IcebergV3Coordinator::init`] is synchronous with respect to registration: it loads the iceberg
+//! catalog/table, reads `pending_sink_state`, and drains any recovered pending epoch via an iceberg
+//! `overwrite_files` transaction BEFORE returning a ready coordinator. Only once init completes does the
+//! sink start accepting live pre-commit/commit calls.
+//!
+//! The two phases dispatched from `complete_barrier`:
+//!
+//! 1. `pre_commit` — aggregate the reports, generate a `snapshot_id`, persist the merged file list under
+//!    `pending_sink_state`, return. No iceberg I/O.
+//! 2. `commit` — run an iceberg `overwrite_files` transaction (keyed on the pre-generated `snapshot_id`
+//!    for idempotency), then mark the row Committed and prune the prior epoch's row.
+//!
+//! On retry-exhausted commit failure the error propagates to the caller; the barrier then fails and the
+//! meta-recovery path drops the coordinator, re-registers it (re-running `init`), and retries from the
+//! persisted `pending_sink_state` rows.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use iceberg::Catalog;
+use iceberg::spec::{DataFile, FormatVersion, SerializedDataFile};
+use iceberg::table::Table;
+use iceberg::transaction::{ApplyTransactionAction, FastAppendAction, Transaction};
+use prost::Message;
+use risingwave_connector::sink::catalog::SinkId;
+use risingwave_connector::sink::iceberg::commit_retry::{self, CommitError};
+use risingwave_connector::sink::iceberg::{
+    IcebergCommitResult, IcebergConfig, IcebergDvMergerCommitResult, commit_branch,
+};
+use risingwave_meta_model::pending_sink_state::SinkState;
+use risingwave_pb::connector_service::PbIcebergV3PreCommitState;
+use risingwave_pb::stream_service::PbIcebergV3SinkRole;
+use risingwave_pb::stream_service::barrier_complete_response::PbIcebergV3SinkMetadata;
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use thiserror_ext::AsReport;
+use tokio::time::timeout;
+
+use super::backfill::backfill_dv_partitions;
+use crate::manager::exactly_once_util::{
+    clean_aborted_records, commit_and_prune_epoch, list_sink_states_ordered_by_epoch,
+    persist_pre_commit_metadata,
+};
+
+/// Bound the init phase so a register call can't hang forever if the iceberg endpoint is unreachable;
+/// on timeout `init` returns an error and registration fails (the caller surfaces it / retries).
+const INIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// One epoch's worth of pre-committed state queued inside the coordinator. Holds the decoded merged file
+/// list and the pre-generated `snapshot_id`. The blob form ([`PbIcebergV3PreCommitState`]) is only
+/// materialized when persisting to `pending_sink_state`; in-memory we keep the structured form.
+#[derive(Clone)]
+struct EpochCommit {
+    epoch: u64,
+    merged: Arc<IcebergV3AggResult>,
+    snapshot_id: i64,
+}
+
+/// Per-sink Iceberg V3 commit coordinator. Owns the loaded iceberg catalog/table (reused across commits)
+/// and the meta SQL connection (used for `pending_sink_state` exactly-once persistence).
+pub struct IcebergV3Coordinator {
+    sink_id: SinkId,
+    db: DatabaseConnection,
+    catalog: Arc<dyn Catalog>,
+    table: Table,
+    target_branch: String,
+    retry_num: usize,
+    /// The epoch pre-committed but not yet committed, carried from `pre_commit` to the next `commit`.
+    waiting_commit: Option<EpochCommit>,
+    prev_committed_epoch: Option<u64>,
+}
+
+impl IcebergV3Coordinator {
+    /// Build a ready-to-serve coordinator: load the iceberg catalog/table, recover any persisted pending
+    /// state, and drain recovered pending epochs to iceberg. Returns only once recovery is complete, so a
+    /// successful return means the sink is ready to accept live pre-commit/commit calls.
+    pub async fn init(
+        sink_id: SinkId,
+        iceberg_config: IcebergConfig,
+        db: DatabaseConnection,
+    ) -> Result<Self> {
+        let (catalog, table) = timeout(INIT_TIMEOUT, load_catalog_and_table(&iceberg_config))
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "iceberg v3 coordinator for sink {} timed out after {}s loading iceberg catalog/table",
+                    sink_id,
+                    INIT_TIMEOUT.as_secs()
+                )
+            })?
+            .with_context(|| format!("init iceberg v3 coordinator for sink {}", sink_id))?;
+
+        let (prev_committed_epoch, recovered) = recovery(&db, sink_id)
+            .await
+            .with_context(|| format!("recover pending state for iceberg v3 sink {}", sink_id))?;
+
+        let target_branch =
+            commit_branch(iceberg_config.r#type.as_str(), iceberg_config.write_mode);
+
+        let mut coordinator = Self {
+            sink_id,
+            db,
+            catalog,
+            table,
+            target_branch,
+            retry_num: iceberg_config.commit_retry_num as usize,
+            waiting_commit: None,
+            prev_committed_epoch,
+        };
+
+        for commit in recovered {
+            coordinator.waiting_commit = Some(commit);
+            coordinator
+                .commit()
+                .await
+                .with_context(|| format!("drain recovered pending epoch for sink {}", sink_id))?;
+        }
+
+        Ok(coordinator)
+    }
+
+    pub async fn pre_commit(
+        &mut self,
+        prev_epoch: u64,
+        reports: Vec<PbIcebergV3SinkMetadata>,
+    ) -> Result<()> {
+        if reports.iter().all(|r| r.metadata.is_none()) {
+            return Ok(());
+        }
+
+        let merged = aggregate_reports(&reports)?;
+        if merged.data_files.is_empty() && merged.delete_files.is_empty() {
+            bail!("v3 sink epoch {} has no data files to commit", prev_epoch);
+        }
+        let merged = Arc::new(self.backfill_dv_partitions(merged)?);
+
+        let snapshot_id = FastAppendAction::generate_snapshot_id(&self.table);
+        let blob = encode_pre_commit_state(&merged, snapshot_id)?;
+        persist_pre_commit_metadata(&self.db, self.sink_id, prev_epoch, Some(blob), None).await?;
+
+        self.waiting_commit = Some(EpochCommit {
+            epoch: prev_epoch,
+            merged,
+            snapshot_id,
+        });
+        Ok(())
+    }
+
+    pub async fn commit(&mut self) -> Result<()> {
+        let Some(commit) = self.waiting_commit.take() else {
+            return Ok(());
+        };
+
+        let refreshed_table = commit_one_epoch(
+            self.catalog.clone(),
+            self.table.identifier().clone(),
+            self.target_branch.clone(),
+            &commit,
+            self.retry_num,
+        )
+        .await
+        .map_err(|err| {
+            let err_report = match err {
+                CommitError::Commit(e) | CommitError::ReloadTable(e) => e,
+            };
+            anyhow!(err_report).context(format!(
+                "iceberg v3 commit failed for sink {} epoch {}",
+                self.sink_id, commit.epoch
+            ))
+        })?;
+        self.table = refreshed_table;
+
+        commit_and_prune_epoch(
+            &self.db,
+            self.sink_id,
+            commit.epoch,
+            self.prev_committed_epoch,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "iceberg v3 mark_committed failed for sink {} epoch {}",
+                self.sink_id, commit.epoch
+            )
+        })?;
+
+        self.prev_committed_epoch = Some(commit.epoch);
+        Ok(())
+    }
+
+    fn backfill_dv_partitions(&self, merged: IcebergV3AggResult) -> Result<IcebergV3AggResult> {
+        let partition_spec = self
+            .table
+            .metadata()
+            .partition_spec_by_id(merged.partition_spec_id)
+            .context("find partition spec for v3 commit")?;
+        if partition_spec.is_unpartitioned() {
+            return Ok(merged);
+        }
+
+        let schema = self.table.metadata().current_schema();
+        let partition_type = partition_spec.partition_type(schema)?;
+        let data_files = merged
+            .data_files
+            .clone()
+            .into_iter()
+            .map(|f| f.try_into(merged.partition_spec_id, &partition_type, schema))
+            .try_collect::<Vec<_>>()?;
+        let mut delete_files = merged
+            .delete_files
+            .into_iter()
+            .map(|f| f.try_into(merged.partition_spec_id, &partition_type, schema))
+            .try_collect::<Vec<_>>()?;
+        backfill_dv_partitions(&data_files, &mut delete_files)?;
+        let delete_files = delete_files
+            .into_iter()
+            .map(|f| SerializedDataFile::try_from(f, &partition_type, FormatVersion::V3))
+            .try_collect()?;
+
+        Ok(IcebergV3AggResult {
+            schema_id: merged.schema_id,
+            partition_spec_id: merged.partition_spec_id,
+            data_files: merged.data_files,
+            delete_files,
+            overwrite_files: merged.overwrite_files,
+        })
+    }
+}
+
+async fn load_catalog_and_table(
+    iceberg_config: &IcebergConfig,
+) -> Result<(Arc<dyn Catalog>, Table)> {
+    let catalog = iceberg_config
+        .create_catalog()
+        .await
+        .map_err(|e| anyhow!(e).context("create iceberg catalog for v3 sink"))?;
+    let table = iceberg_config
+        .load_table()
+        .await
+        .map_err(|e| anyhow!(e).context("load iceberg table for v3 sink"))?;
+    Ok((catalog, table))
+}
+
+/// Read every persisted row for this sink, recovering `prev_committed_epoch` and pending commits.
+async fn recovery(
+    db: &DatabaseConnection,
+    sink_id: SinkId,
+) -> Result<(Option<u64>, Vec<EpochCommit>)> {
+    let rows = list_sink_states_ordered_by_epoch(db, sink_id)
+        .await
+        .context("list pending sink states for v3 recovery")?;
+
+    let mut prev_committed_epoch = None;
+    let mut pending = Vec::new();
+    let mut aborted_epochs = Vec::new();
+    for (epoch, state, metadata, _schema_change) in rows {
+        match state {
+            SinkState::Committed => {
+                prev_committed_epoch = Some(epoch);
+            }
+            SinkState::Pending => {
+                let blob = metadata.ok_or_else(|| {
+                    anyhow!("v3 pending row at epoch {} missing metadata blob", epoch)
+                })?;
+                let (merged, snapshot_id) = decode_pre_commit_state(&blob)
+                    .with_context(|| format!("decode v3 pre-commit state at epoch {}", epoch))?;
+                pending.push(EpochCommit {
+                    epoch,
+                    merged,
+                    snapshot_id,
+                });
+            }
+            SinkState::Aborted => {
+                // V3 doesn't produce Aborted rows; tolerate them defensively and drop them so they don't
+                // accumulate across restarts.
+                tracing::warn!(
+                    sink_id = %sink_id,
+                    epoch,
+                    "unexpected Aborted state in v3 recovery; cleaning up",
+                );
+                aborted_epochs.push(epoch);
+            }
+        }
+    }
+    if !aborted_epochs.is_empty()
+        && let Err(e) = clean_aborted_records(db, sink_id, aborted_epochs).await
+    {
+        // Best-effort cleanup; defer to next recovery if the DB rejects.
+        tracing::warn!(
+            error = %e.as_report(),
+            sink_id = %sink_id,
+            "failed to clean unexpected Aborted rows during v3 recovery",
+        );
+    }
+    Ok((prev_committed_epoch, pending))
+}
+
+async fn commit_one_epoch(
+    catalog: Arc<dyn Catalog>,
+    table_ident: iceberg::TableIdent,
+    target_branch: String,
+    commit: &EpochCommit,
+    retry_num: usize,
+) -> Result<Table, CommitError> {
+    let merged = commit.merged.clone();
+    let snapshot_id = commit.snapshot_id;
+
+    commit_retry::run_with_retry(
+        catalog.clone(),
+        table_ident,
+        merged.schema_id,
+        merged.partition_spec_id,
+        retry_num,
+        |table| {
+            let merged = merged.clone();
+            let catalog = catalog.clone();
+            let target_branch = target_branch.clone();
+            async move {
+                // Idempotency: if iceberg already saw this `snapshot_id`, skip the overwrite_files transaction.
+                if table
+                    .metadata()
+                    .snapshots()
+                    .any(|s| s.snapshot_id() == snapshot_id)
+                {
+                    return Ok(table);
+                }
+
+                let schema = table.metadata().current_schema();
+                let partition_spec = table
+                    .metadata()
+                    .partition_spec_by_id(merged.partition_spec_id)
+                    .ok_or_else(|| CommitError::Commit(anyhow!("partition spec not found")))?;
+                let partition_type = partition_spec
+                    .partition_type(schema)
+                    .map_err(|e| CommitError::Commit(anyhow!(e)))?;
+
+                let mut add_files: Vec<DataFile> = Vec::new();
+                let mut overwrite_files: Vec<DataFile> = Vec::new();
+                for serialized in merged.data_files.iter().chain(merged.delete_files.iter()) {
+                    let f = serialized
+                        .clone()
+                        .try_into(merged.partition_spec_id, &partition_type, schema)
+                        .map_err(|err| {
+                            CommitError::Commit(
+                                anyhow!(err).context("materialize v3 SerializedDataFile"),
+                            )
+                        })?;
+                    add_files.push(f);
+                }
+                for serialized in &merged.overwrite_files {
+                    let f = serialized
+                        .clone()
+                        .try_into(merged.partition_spec_id, &partition_type, schema)
+                        .map_err(|err| {
+                            CommitError::Commit(
+                                anyhow!(err).context("materialize v3 SerializedDataFile"),
+                            )
+                        })?;
+                    overwrite_files.push(f);
+                }
+
+                let txn = Transaction::new(&table);
+                let action = txn
+                    .overwrite_files()
+                    .set_snapshot_id(snapshot_id)
+                    .set_target_branch(target_branch)
+                    .add_data_files(add_files)
+                    .delete_files(overwrite_files);
+                let txn = action.apply(txn).map_err(|err| {
+                    CommitError::Commit(
+                        anyhow!(err).context("apply iceberg v3 overwrite_files action"),
+                    )
+                })?;
+                let table = txn.commit(catalog.as_ref()).await.map_err(|err| {
+                    CommitError::Commit(anyhow!(err).context("commit iceberg v3 transaction"))
+                })?;
+                Ok(table)
+            }
+        },
+    )
+    .await
+    .map_err(CommitError::Commit)
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct IcebergV3AggResult {
+    schema_id: i32,
+    partition_spec_id: i32,
+    data_files: Vec<SerializedDataFile>,
+    delete_files: Vec<SerializedDataFile>,
+    overwrite_files: Vec<SerializedDataFile>,
+}
+
+fn aggregate_reports(reports: &[PbIcebergV3SinkMetadata]) -> Result<IcebergV3AggResult> {
+    let mut shared_schema_id: Option<i32> = None;
+    let mut shared_partition_spec_id: Option<i32> = None;
+
+    let mut data_files: Vec<SerializedDataFile> = Vec::new();
+    let mut delete_files: Vec<SerializedDataFile> = Vec::new();
+    let mut overwrite_files: Vec<SerializedDataFile> = Vec::new();
+
+    if reports.is_empty() {
+        bail!("no reports to aggregate for iceberg v3 coordinator");
+    }
+
+    for r in reports {
+        let Some(meta) = &r.metadata else {
+            bail!("iceberg v3 sink report missing metadata in aggregate_reports");
+        };
+
+        // Validate role: explicitly-Unspecified is a wire-format bug.
+        let role = PbIcebergV3SinkRole::try_from(r.role)
+            .ok()
+            .filter(|r| !matches!(r, PbIcebergV3SinkRole::Unspecified))
+            .ok_or_else(|| anyhow!("iceberg v3 sink report has invalid role: {}", r.role))?;
+
+        match role {
+            PbIcebergV3SinkRole::Writer => {
+                let commit_result = IcebergCommitResult::try_from(meta)?;
+                align_report_id(
+                    commit_result.schema_id,
+                    commit_result.partition_spec_id,
+                    &mut shared_schema_id,
+                    &mut shared_partition_spec_id,
+                )?;
+                data_files.extend(commit_result.data_files);
+            }
+            PbIcebergV3SinkRole::DvMerger => {
+                let commit_result = IcebergDvMergerCommitResult::try_from(meta)
+                    .map_err(|e| anyhow!(e).context("decode v3 dv merger metadata"))?;
+                align_report_id(
+                    commit_result.schema_id,
+                    commit_result.partition_spec_id,
+                    &mut shared_schema_id,
+                    &mut shared_partition_spec_id,
+                )?;
+                delete_files.extend(commit_result.delete_files);
+                overwrite_files.extend(commit_result.overwrite_files);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(IcebergV3AggResult {
+        schema_id: shared_schema_id.unwrap(),
+        partition_spec_id: shared_partition_spec_id.unwrap(),
+        data_files,
+        delete_files,
+        overwrite_files,
+    })
+}
+
+fn align_report_id(
+    schema_id: i32,
+    partition_spec_id: i32,
+    shared_schema_id: &mut Option<i32>,
+    shared_partition_spec_id: &mut Option<i32>,
+) -> Result<()> {
+    match shared_schema_id {
+        Some(prev) if *prev != schema_id => {
+            bail!(
+                "iceberg v3 sink reports disagree on schema_id: {} vs {}",
+                prev,
+                schema_id
+            );
+        }
+        None => *shared_schema_id = Some(schema_id),
+        _ => {}
+    }
+    match shared_partition_spec_id {
+        Some(prev) if *prev != partition_spec_id => {
+            bail!(
+                "iceberg v3 sink reports disagree on partition_spec_id: {} vs {}",
+                prev,
+                partition_spec_id
+            );
+        }
+        None => *shared_partition_spec_id = Some(partition_spec_id),
+        _ => {}
+    }
+    Ok(())
+}
+
+fn encode_pre_commit_state(agg_result: &IcebergV3AggResult, snapshot_id: i64) -> Result<Vec<u8>> {
+    let agg_result = serde_json::to_vec(agg_result)?;
+    Ok(PbIcebergV3PreCommitState {
+        agg_result,
+        snapshot_id,
+    }
+    .encode_to_vec())
+}
+
+fn decode_pre_commit_state(blob: &[u8]) -> Result<(Arc<IcebergV3AggResult>, i64)> {
+    let state = PbIcebergV3PreCommitState::decode(blob)?;
+    let agg_result = Arc::new(serde_json::from_slice(&state.agg_result)?);
+    Ok((agg_result, state.snapshot_id))
+}

--- a/src/meta/src/manager/iceberg_v3_sink/manager.rs
+++ b/src/meta/src/manager/iceberg_v3_sink/manager.rs
@@ -1,0 +1,130 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use parking_lot::RwLock;
+use risingwave_connector::sink::catalog::SinkId;
+use risingwave_connector::sink::iceberg::IcebergConfig;
+use risingwave_pb::stream_service::barrier_complete_response::IcebergV3SinkMetadata as PbIcebergV3SinkMetadata;
+use sea_orm::DatabaseConnection;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use super::coordinator::IcebergV3Coordinator;
+
+type CoordinatorRef = Arc<Mutex<IcebergV3Coordinator>>;
+
+/// Manager for the Iceberg V3 sink path, cheap to clone.
+#[derive(Clone)]
+pub struct IcebergV3SinkManager {
+    inner: Arc<ManagerInner>,
+}
+
+struct ManagerInner {
+    db: DatabaseConnection,
+    /// Read on every pre-commit/commit (only to clone out the `CoordinatorRef`, never held across an await);
+    /// written only by register/unregister/reset, which are rare control-plane events.
+    coordinators: RwLock<HashMap<SinkId, CoordinatorRef>>,
+}
+
+impl IcebergV3SinkManager {
+    pub fn new(db: DatabaseConnection) -> Self {
+        IcebergV3SinkManager {
+            inner: Arc::new(ManagerInner {
+                db,
+                coordinators: RwLock::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Register an Iceberg V3 sink so its commit coordinator is ready to receive epoch reports. Builds and
+    /// fully initializes the coordinator (loading the iceberg table and draining any recovered pending
+    /// commits) BEFORE inserting it, so a successful return means the sink is ready to serve. Idempotent:
+    /// registering the same `sink_id` replaces the existing coordinator.
+    pub async fn register_v3_sink(
+        &self,
+        sink_id: SinkId,
+        iceberg_config: IcebergConfig,
+    ) -> anyhow::Result<()> {
+        // Initialize (load + recover + drain) outside the map lock; this is the slow, fallible part.
+        let coordinator =
+            IcebergV3Coordinator::init(sink_id, iceberg_config, self.inner.db.clone()).await?;
+
+        let prev = self
+            .inner
+            .coordinators
+            .write()
+            .insert(sink_id, Arc::new(Mutex::new(coordinator)));
+        if prev.is_some() {
+            // Replacing an existing coordinator. Any in-flight commit on the old one keeps it alive via its
+            // own `Arc` until it finishes; the snapshot_id idempotency check guards against double-commit.
+            warn!(%sink_id, "iceberg v3 coordinator re-registered; replacing previous instance");
+        }
+        Ok(())
+    }
+
+    /// Pre-commit phase for one epoch: persist the merged report under `pending_sink_state` (no iceberg IO).
+    /// The barrier-complete path awaits this BEFORE issuing hummock `commit_epoch`.
+    pub async fn pre_commit_v3_epoch(
+        &self,
+        sink_id: SinkId,
+        prev_epoch: u64,
+        reports: Vec<PbIcebergV3SinkMetadata>,
+    ) -> anyhow::Result<()> {
+        let coordinator = self.coordinator(sink_id)?;
+        coordinator
+            .lock()
+            .await
+            .pre_commit(prev_epoch, reports)
+            .await
+    }
+
+    /// Commit phase for one epoch: run an iceberg `overwrite_files` transaction and mark its pending row
+    /// committed. The barrier-complete path awaits this AFTER hummock `commit_epoch`.
+    pub async fn commit_v3_epoch(&self, sink_id: SinkId) -> anyhow::Result<()> {
+        let coordinator = self.coordinator(sink_id)?;
+        coordinator.lock().await.commit().await
+    }
+
+    /// Unregister the given `sink_id`(s)' coordinator(s) (e.g. at DROP SINK time). Unregistering an unknown
+    /// `sink_id` is a no-op.
+    pub fn unregister_v3_sinks(&self, sink_ids: Vec<SinkId>) {
+        let mut coordinators = self.inner.coordinators.write();
+        for sink_id in sink_ids {
+            coordinators.remove(&sink_id);
+        }
+    }
+
+    /// Drop every coordinator. Used at recovery time.
+    pub fn reset(&self) {
+        self.inner.coordinators.write().clear();
+    }
+
+    fn coordinator(&self, sink_id: SinkId) -> anyhow::Result<CoordinatorRef> {
+        self.inner
+            .coordinators
+            .read()
+            .get(&sink_id)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!(
+                    "iceberg v3 coordinator for sink {} is not registered",
+                    sink_id
+                )
+            })
+    }
+}

--- a/src/meta/src/manager/iceberg_v3_sink/mod.rs
+++ b/src/meta/src/manager/iceberg_v3_sink/mod.rs
@@ -1,0 +1,61 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Manager for the Iceberg V3 sink path. Owns per-sink commit coordinators that
+//! drive iceberg `commit_epoch` ahead of hummock `commit_epoch` and persist
+//! exactly-once state via `pending_sink_state`.
+//!
+//! This is intentionally separate from [`crate::manager::sink_coordination`]
+//! (which serves V1/V2 sinks via gRPC). Future V3 responsibilities such as
+//! per-sink compaction will live alongside the per-sink commit coordinator here.
+
+pub mod backfill;
+mod coordinator;
+mod manager;
+
+use std::collections::BTreeMap;
+
+use anyhow::anyhow;
+pub use manager::IcebergV3SinkManager;
+use risingwave_common::secret::LocalSecretManager;
+use risingwave_connector::sink::iceberg::{ENABLE_PK_INDEX, IcebergConfig};
+use risingwave_connector::source::UPSTREAM_SOURCE_KEY;
+use risingwave_pb::catalog::PbSink;
+
+/// Returns true if the given sink properties identify a Iceberg V3 sink
+/// (i.e. an iceberg sink with `enable_pk_index = 'true'`).
+pub fn is_iceberg_v3_sink(properties: &BTreeMap<String, String>) -> bool {
+    let connector_match = properties
+        .get(UPSTREAM_SOURCE_KEY)
+        .map(|v| v.eq_ignore_ascii_case("iceberg"))
+        .unwrap_or(false);
+    let pk_index_enabled = properties
+        .get(ENABLE_PK_INDEX)
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    connector_match && pk_index_enabled
+}
+
+/// Build an [`IcebergConfig`] from a [`PbSink`], filling secret refs along the
+/// way. Used at CREATE SINK time and during recovery to (re-)register the V3
+/// commit coordinator.
+pub fn build_iceberg_config(pb_sink: &PbSink) -> anyhow::Result<IcebergConfig> {
+    let properties: BTreeMap<String, String> = pb_sink.properties.clone().into_iter().collect();
+    let secret_refs: BTreeMap<_, _> = pb_sink.secret_refs.clone().into_iter().collect();
+    let with_secrets = LocalSecretManager::global()
+        .fill_secrets(properties, secret_refs)
+        .map_err(|e| anyhow!(e).context("fill secrets for iceberg"))?;
+    IcebergConfig::from_btreemap(with_secrets)
+        .map_err(|e| anyhow!(e).context("parse iceberg config"))
+}

--- a/src/meta/src/manager/mod.rs
+++ b/src/meta/src/manager/mod.rs
@@ -15,7 +15,9 @@
 pub mod diagnose;
 mod env;
 pub mod event_log;
+mod exactly_once_util;
 pub mod iceberg_compaction;
+pub mod iceberg_v3_sink;
 mod idle;
 mod license;
 mod metadata;

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -44,7 +44,7 @@ use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tonic::Status;
 use tracing::{error, warn};
 
-use crate::manager::sink_coordination::exactly_once_util::{
+use crate::manager::exactly_once_util::{
     clean_aborted_records, commit_and_prune_epoch, list_sink_states_ordered_by_epoch,
     persist_pre_commit_metadata,
 };

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -74,7 +74,6 @@ enum ManagerRequest {
 pub struct SinkCoordinatorManager {
     request_tx: mpsc::Sender<ManagerRequest>,
 }
-
 fn new_committed_epoch_subscriber(
     hummock_manager: HummockManagerRef,
     metadata_manager: MetadataManager,

--- a/src/meta/src/manager/sink_coordination/mod.rs
+++ b/src/meta/src/manager/sink_coordination/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 mod coordinator_worker;
-mod exactly_once_util;
 mod handle;
 mod manager;
 

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -76,6 +76,7 @@ use crate::controller::streaming_job::{FinishAutoRefreshSchemaSinkContext, SinkI
 use crate::controller::utils::build_select_node_list;
 use crate::error::{MetaErrorInner, bail_invalid_parameter};
 use crate::manager::iceberg_compaction::IcebergCompactionManagerRef;
+use crate::manager::iceberg_v3_sink::IcebergV3SinkManager;
 use crate::manager::sink_coordination::SinkCoordinatorManager;
 use crate::manager::{
     IGNORED_NOTIFICATION_VERSION, LocalNotification, MetaSrvEnv, MetadataManager,
@@ -284,6 +285,7 @@ pub struct DdlController {
     barrier_manager: BarrierManagerRef,
     sink_manager: SinkCoordinatorManager,
     iceberg_compaction_manager: IcebergCompactionManagerRef,
+    iceberg_v3_sink_manager: IcebergV3SinkManager,
 
     // The semaphore is used to limit the number of concurrent streaming job creation.
     pub(crate) creating_streaming_job_permits: Arc<CreatingStreamingJobPermit>,
@@ -389,6 +391,7 @@ impl DdlController {
         barrier_manager: BarrierManagerRef,
         sink_manager: SinkCoordinatorManager,
         iceberg_compaction_manager: IcebergCompactionManagerRef,
+        iceberg_v3_sink_manager: IcebergV3SinkManager,
     ) -> Self {
         let creating_streaming_job_permits = Arc::new(CreatingStreamingJobPermit::new(&env).await);
         Self {
@@ -399,6 +402,7 @@ impl DdlController {
             barrier_manager,
             sink_manager,
             iceberg_compaction_manager,
+            iceberg_v3_sink_manager,
             creating_streaming_job_permits,
             seq: Arc::new(AtomicU64::new(0)),
         }
@@ -1275,6 +1279,18 @@ impl DdlController {
                 }
                 // Validate the sink on the connector node.
                 validate_sink(sink).await?;
+                // For Iceberg V3 sinks, spawn the per-sink commit worker now
+                // so it's ready to receive epoch reports from the very first
+                // barrier instead of relying on lazy registration on every
+                // commit.
+                if crate::manager::iceberg_v3_sink::is_iceberg_v3_sink(&sink.properties) {
+                    let iceberg_config =
+                        crate::manager::iceberg_v3_sink::build_iceberg_config(sink)?;
+                    self.iceberg_v3_sink_manager
+                        .register_v3_sink(sink.id, iceberg_config)
+                        .await
+                        .map_err(|e| anyhow!(e).context("register v3 sink worker"))?;
+                }
                 let connector_name = sink.get_properties().get(UPSTREAM_SOURCE_KEY).cloned();
                 let attr = sink.format_desc.as_ref().map(|sink_info| {
                     jsonbb::json!({
@@ -1363,6 +1379,7 @@ impl DdlController {
             removed_fragments,
             removed_sink_fragment_by_targets,
             removed_iceberg_table_sinks,
+            removed_iceberg_v3_sink_ids,
         } = release_ctx;
 
         // Notify serving module about deleted fragments so it can clean up serving vnode mappings.
@@ -1446,6 +1463,14 @@ impl DdlController {
                 self.iceberg_compaction_manager
                     .clear_iceberg_maintenance_by_sink_id(sink_id);
             }
+        }
+
+        // Unregister per-sink commit coordinators for any dropped V3 iceberg sink,
+        // including user-created sinks with arbitrary names (not just the
+        // `__iceberg_sink_%` auto-created ones above).
+        if !removed_iceberg_v3_sink_ids.is_empty() {
+            self.iceberg_v3_sink_manager
+                .unregister_v3_sinks(removed_iceberg_v3_sink_ids);
         }
 
         // remove secrets.

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -913,6 +913,10 @@ for_all_wrapped_id_fields! (
             load_finished_source_ids: SourceId,
             partial_graph_id: PartialGraphId,
         }
+        BarrierCompleteResponse.CdcSourceOffsetUpdated {
+            reporter_actor_id: ActorId,
+            source_id: SourceId,
+        }
         BarrierCompleteResponse.CdcTableBackfillProgress {
             fragment_id: FragmentId,
             actor_id: ActorId,
@@ -920,6 +924,10 @@ for_all_wrapped_id_fields! (
         BarrierCompleteResponse.CreateMviewProgress {
             backfill_actor_id: ActorId,
             fragment_id: FragmentId,
+        }
+        BarrierCompleteResponse.IcebergV3SinkMetadata {
+            reporter_actor_id: ActorId,
+            sink_id: SinkId,
         }
         BarrierCompleteResponse.ListFinishedSource {
             reporter_actor_id: ActorId,

--- a/src/stream/src/executor/iceberg_with_pk_index/dv_handler_impl.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/dv_handler_impl.rs
@@ -16,18 +16,21 @@ use std::collections::{HashMap as StdHashMap, HashSet};
 
 use anyhow::Context;
 use hashbrown::HashMap;
+use hashbrown::hash_map::Entry;
 use iceberg::delete_vector::DeleteVector;
 use iceberg::io::FileIO;
 use iceberg::puffin::{CompressionCodec, PuffinReader, PuffinWriter};
 use iceberg::spec::{
-    DataContentType, DataFile, DataFileBuilder, DataFileFormat, ManifestContentType, PartitionKey,
-    SerializedDataFile,
+    DataContentType, DataFile, DataFileBuilder, DataFileFormat, ManifestContentType, ManifestList,
+    PartitionKey, SerializedDataFile,
 };
 use iceberg::table::Table;
 use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator, FileNameGenerator, LocationGenerator,
 };
-use risingwave_connector::sink::iceberg::{IcebergCommitResult, IcebergConfig, truncate_datafile};
+use risingwave_connector::sink::iceberg::{
+    IcebergConfig, IcebergDvMergerCommitResult, truncate_datafile,
+};
 use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::id::{ActorId, SinkId};
 use uuid::Uuid;
@@ -44,6 +47,7 @@ const DELETION_VECTOR_PROPERTY_REFERENCED_DATA_FILE: &str = "referenced-data-fil
 struct LoadedDeleteVectorEntry {
     delete_vector: Option<DeleteVector>,
     partition_key: Option<PartitionKey>,
+    overwrite_file: Option<DataFile>,
 }
 
 /// Real implementation of [`DvHandler`] using the iceberg-rust crate.
@@ -81,6 +85,88 @@ impl DvHandlerImpl {
             sink_id,
         })
     }
+
+    /// Merges `delete_vector` with any existing DV from `loaded`, writes the result
+    /// as a Puffin blob, and returns the resulting [`DataFile`] metadata.
+    async fn write_dv_puffin_file(
+        &mut self,
+        table: &Table,
+        data_file_path: String,
+        mut delete_vector: DeleteVector,
+        loaded: LoadedDeleteVectorEntry,
+    ) -> StreamExecutorResult<DataFile> {
+        let LoadedDeleteVectorEntry {
+            delete_vector: existing_delete_vector,
+            partition_key,
+            ..
+        } = loaded;
+
+        if let Some(existing) = existing_delete_vector {
+            delete_vector |= existing;
+        }
+
+        let file_name = self.file_name_generator.generate_file_name();
+        let location = self
+            .location_generator
+            .generate_location(partition_key.as_ref(), &file_name);
+        let output_file = table
+            .file_io()
+            .new_output(&location)
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+        let mut writer = PuffinWriter::new(&output_file, StdHashMap::new(), false)
+            .await
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+
+        let cardinality = delete_vector.len();
+        let properties = StdHashMap::from([
+            (
+                DELETION_VECTOR_PROPERTY_CARDINALITY.to_owned(),
+                cardinality.to_string(),
+            ),
+            (
+                DELETION_VECTOR_PROPERTY_REFERENCED_DATA_FILE.to_owned(),
+                data_file_path.clone(),
+            ),
+        ]);
+        let blob = delete_vector
+            .to_puffin_blob(properties)
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+        writer
+            .add(blob, CompressionCodec::None)
+            .await
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+
+        let result = writer
+            .close_with_metadata()
+            .await
+            .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
+        let blob_metadata = result
+            .blobs_metadata
+            .first()
+            .context("blob metadata should be present")?;
+
+        let mut builder = DataFileBuilder::default();
+        builder
+            .content(DataContentType::PositionDeletes)
+            .file_path(location)
+            .file_format(DataFileFormat::Puffin)
+            .record_count(cardinality)
+            .file_size_in_bytes(result.file_size_in_bytes)
+            .referenced_data_file(Some(data_file_path))
+            .content_offset(Some(blob_metadata.offset() as i64))
+            .content_size_in_bytes(Some(blob_metadata.length() as i64));
+        if let Some(partition_key) = partition_key {
+            builder
+                .partition(partition_key.data().clone())
+                .partition_spec_id(partition_key.spec().spec_id());
+        }
+        builder.build().map_err(|err| {
+            StreamExecutorError::sink_error(
+                anyhow::anyhow!(err).context("Failed to build deletion vector file metadata"),
+                self.sink_id,
+            )
+        })
+    }
 }
 
 #[async_trait::async_trait]
@@ -108,126 +194,122 @@ impl DvHandler for DvHandlerImpl {
         )
         .await?;
 
-        let mut data_files = Vec::with_capacity(self.delete_vectors.len());
-        for (data_file_path, mut delete_vector) in self.delete_vectors.drain() {
-            let LoadedDeleteVectorEntry {
-                delete_vector: existing_delete_vector,
-                partition_key,
-            } = loaded_delete_vectors
+        let overwrite_files = loaded_delete_vectors
+            .values()
+            .filter_map(|entry| entry.overwrite_file.clone())
+            .collect::<Vec<_>>();
+
+        let pending = std::mem::take(&mut self.delete_vectors);
+        let mut delete_files = Vec::with_capacity(pending.len());
+        for (data_file_path, delete_vector) in pending {
+            let loaded = loaded_delete_vectors
                 .remove(&data_file_path)
                 .unwrap_or_default();
-
-            if let Some(existing) = existing_delete_vector {
-                delete_vector |= existing;
-            }
-
-            let file_name = self.file_name_generator.generate_file_name();
-            let location = self
-                .location_generator
-                .generate_location(partition_key.as_ref(), &file_name);
-            let output_file = table
-                .file_io()
-                .new_output(&location)
-                .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
-            let mut writer = PuffinWriter::new(&output_file, StdHashMap::new(), false)
-                .await
-                .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
-
-            let cardinality = delete_vector.len();
-            let properties = StdHashMap::from([
-                (
-                    DELETION_VECTOR_PROPERTY_CARDINALITY.to_owned(),
-                    cardinality.to_string(),
-                ),
-                (
-                    DELETION_VECTOR_PROPERTY_REFERENCED_DATA_FILE.to_owned(),
-                    data_file_path.clone(),
-                ),
-            ]);
-            let blob = delete_vector
-                .to_puffin_blob(properties)
-                .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
-            writer
-                .add(blob, CompressionCodec::None)
-                .await
-                .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
-
-            let result = writer
-                .close_with_metadata()
-                .await
-                .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
-            let blob_metadata = result
-                .blobs_metadata
-                .first()
-                .context("blob metadata should be present")?;
-
-            let mut builder = DataFileBuilder::default();
-            builder
-                .content(DataContentType::PositionDeletes)
-                .file_path(location)
-                .file_format(DataFileFormat::Puffin)
-                .record_count(cardinality)
-                .file_size_in_bytes(result.file_size_in_bytes)
-                .referenced_data_file(Some(data_file_path))
-                .content_offset(Some(blob_metadata.offset() as i64))
-                .content_size_in_bytes(Some(blob_metadata.length() as i64));
-            if let Some(partition_key) = partition_key {
-                builder
-                    .partition(partition_key.data().clone())
-                    .partition_spec_id(partition_key.spec().spec_id());
-            }
-            let data_file = builder.build().map_err(|err| {
-                StreamExecutorError::sink_error(
-                    anyhow::anyhow!(err).context("Failed to build deletion vector file metadata"),
-                    self.sink_id,
-                )
-            })?;
-
-            data_files.push(data_file);
+            let file = self
+                .write_dv_puffin_file(&table, data_file_path, delete_vector, loaded)
+                .await?;
+            delete_files.push(file);
         }
 
-        if data_files.is_empty() {
+        if delete_files.is_empty() {
             return Ok(None);
         }
 
-        let format_version = table.metadata().format_version();
-        let partition_type = table.metadata().default_partition_type();
-        let data_files = data_files
-            .into_iter()
-            .map(|f| {
-                // Truncate large column statistics BEFORE serialization
-                let truncated = truncate_datafile(f);
-                SerializedDataFile::try_from(truncated, partition_type, format_version)
-                    .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))
-            })
-            .collect::<StreamExecutorResult<Vec<_>>>()?;
-        let sink_metadata = SinkMetadata::try_from(&IcebergCommitResult {
-            data_files,
+        let delete_files = serialize_delete_files(&table, self.sink_id, delete_files)?;
+        let overwrite_files = serialize_overwrite_files(&table, self.sink_id, overwrite_files)?;
+
+        let sink_metadata = SinkMetadata::try_from(&IcebergDvMergerCommitResult {
             schema_id: table.metadata().current_schema_id(),
             partition_spec_id: table.metadata().default_partition_spec_id(),
+            delete_files,
+            overwrite_files,
         })
         .map_err(|e| StreamExecutorError::sink_error(e, self.sink_id))?;
         Ok(Some(sink_metadata))
     }
 }
 
+/// Serializes newly written deletion vector files against the current default
+/// partition spec, after truncating oversized column statistics.
+fn serialize_delete_files(
+    table: &Table,
+    sink_id: SinkId,
+    delete_files: Vec<DataFile>,
+) -> StreamExecutorResult<Vec<SerializedDataFile>> {
+    let format_version = table.metadata().format_version();
+    let partition_type = table.metadata().default_partition_type();
+    delete_files
+        .into_iter()
+        .map(|f| {
+            // Truncate large column statistics BEFORE serialization
+            let truncated = truncate_datafile(f);
+            SerializedDataFile::try_from(truncated, partition_type, format_version)
+                .map_err(|e| StreamExecutorError::sink_error(e, sink_id))
+        })
+        .collect()
+}
+
+/// Serializes the original DV puffin files that are being overwritten. Each
+/// existing DV puffin file was written under its own partition spec (potentially
+/// older than the current default), so we resolve its partition type via the
+/// file's `partition_spec_id` so the serialized form round-trips correctly,
+/// instead of forcing the current default partition type.
+fn serialize_overwrite_files(
+    table: &Table,
+    sink_id: SinkId,
+    overwrite_files: Vec<DataFile>,
+) -> StreamExecutorResult<Vec<SerializedDataFile>> {
+    let format_version = table.metadata().format_version();
+    let schema = table.metadata().current_schema();
+    let mut partition_type_cache: HashMap<i32, iceberg::spec::StructType> = HashMap::new();
+    overwrite_files
+        .into_iter()
+        .map(|f| {
+            let spec_id = f.partition_spec_id();
+            let pt = match partition_type_cache.entry(spec_id) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    let spec = table
+                        .metadata()
+                        .partition_spec_by_id(spec_id)
+                        .with_context(|| {
+                            format!(
+                                "failed to find partition spec {} for file {}",
+                                spec_id,
+                                f.file_path()
+                            )
+                        })
+                        .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
+                    let pt = spec.partition_type(schema).map_err(|e| {
+                        StreamExecutorError::sink_error(anyhow::anyhow!(e), sink_id)
+                    })?;
+                    entry.insert(pt)
+                }
+            };
+
+            SerializedDataFile::try_from(f, pt, format_version)
+                .map_err(|e| StreamExecutorError::sink_error(e, sink_id))
+        })
+        .collect()
+}
+
 /// Loads existing delete vectors for the given data file paths by scanning the
 /// table's current snapshot. Returns a map from data file path to the loaded
-/// delete vector and partition key (if partitioned).
+/// delete vector, partition key (if partitioned), and original data file (for overwrite).
 ///
 /// The lookup proceeds in two passes:
 /// 1. Scan delete manifests for entries matching the given data file paths. If found,
-///    load the DV (and partition key, when partitioned) from the delete entry. This
-///    reflects the latest DV state for the data file as of the current snapshot.
-/// 2. For partitioned tables, scan data manifests for any data files still missing a
-///    partition key after pass 1 (data files that have not yet accumulated any DV).
+///    load the DV, partition key (when partitioned), and the existing DV file (as the
+///    overwrite target) from the delete entry. This reflects the latest DV state for
+///    the data file as of the current snapshot.
+/// 2. For partitioned tables, scan data manifests for any data files still missing an
+///    entry after pass 1 (data files that have not yet accumulated any DV). Records
+///    the data file as the overwrite target and its partition key.
 async fn load_delete_vectors(
     table: &Table,
     sink_id: SinkId,
     mut paths: HashSet<String>,
 ) -> StreamExecutorResult<HashMap<String, LoadedDeleteVectorEntry>> {
-    let mut result: HashMap<String, LoadedDeleteVectorEntry> = HashMap::with_capacity(paths.len());
-
     let Some(snapshot) = table.metadata().current_snapshot() else {
         return Ok(HashMap::new());
     };
@@ -239,7 +321,39 @@ async fn load_delete_vectors(
         .await
         .map_err(|e| StreamExecutorError::sink_error(e, sink_id))?;
 
-    'deletes_outer: for manifest_file in manifest_list.entries() {
+    let mut result: HashMap<String, LoadedDeleteVectorEntry> = HashMap::with_capacity(paths.len());
+
+    scan_existing_dvs(
+        table,
+        sink_id,
+        partitioned,
+        &manifest_list,
+        &mut paths,
+        &mut result,
+    )
+    .await?;
+
+    if !paths.is_empty() && partitioned {
+        scan_data_files_for_partition_keys(table, sink_id, &manifest_list, &mut paths, &mut result)
+            .await?;
+    }
+
+    Ok(result)
+}
+
+/// Pass 1: scan delete manifests for DV puffin files referencing any path in
+/// `paths`. On hit, removes the path from `paths`, loads the DV, captures the
+/// partition key (for partitioned tables), and records the existing DV file as
+/// the overwrite target.
+async fn scan_existing_dvs(
+    table: &Table,
+    sink_id: SinkId,
+    partitioned: bool,
+    manifest_list: &ManifestList,
+    paths: &mut HashSet<String>,
+    result: &mut HashMap<String, LoadedDeleteVectorEntry>,
+) -> StreamExecutorResult<()> {
+    for manifest_file in manifest_list.entries() {
         if manifest_file.content != ManifestContentType::Deletes {
             continue;
         }
@@ -279,20 +393,30 @@ async fn load_delete_vectors(
                 LoadedDeleteVectorEntry {
                     delete_vector: Some(delete_vector),
                     partition_key,
+                    overwrite_file: Some(data_file.clone()),
                 },
             );
 
             if paths.is_empty() {
-                break 'deletes_outer;
+                return Ok(());
             }
         }
     }
+    Ok(())
+}
 
-    if paths.is_empty() || !partitioned {
-        return Ok(result);
-    }
-
-    'data_outer: for manifest_file in manifest_list.entries() {
+/// Pass 2 (partitioned tables only): scan data manifests for data files whose
+/// path is still in `paths` (i.e. no existing DV was found in pass 1). Records
+/// the data file as the overwrite target along with its partition key, with no
+/// pre-existing delete vector.
+async fn scan_data_files_for_partition_keys(
+    table: &Table,
+    sink_id: SinkId,
+    manifest_list: &ManifestList,
+    paths: &mut HashSet<String>,
+    result: &mut HashMap<String, LoadedDeleteVectorEntry>,
+) -> StreamExecutorResult<()> {
+    for manifest_file in manifest_list.entries() {
         if manifest_file.content != ManifestContentType::Data {
             continue;
         }
@@ -318,16 +442,16 @@ async fn load_delete_vectors(
                 LoadedDeleteVectorEntry {
                     delete_vector: None,
                     partition_key: Some(partition_key),
+                    overwrite_file: None,
                 },
             );
 
             if paths.is_empty() {
-                break 'data_outer;
+                return Ok(());
             }
         }
     }
-
-    Ok(result)
+    Ok(())
 }
 
 async fn read_dv_positions_from_data_file(

--- a/src/stream/src/executor/iceberg_with_pk_index/dv_merger.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/dv_merger.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use anyhow::Context;
+use risingwave_common::id::SinkId;
 use risingwave_pb::connector_service::SinkMetadata;
+use risingwave_pb::stream_service::PbIcebergV3SinkRole;
 
 use crate::executor::prelude::*;
+use crate::task::LocalBarrierManager;
 
 /// Trait abstracting DV (Deletion Vector) file operations for testability.
 ///
@@ -38,12 +41,14 @@ pub trait DvHandler: Send + 'static {
 /// positions for the files assigned to its shard.
 ///
 /// Input schema: [`file_path`: Varchar, `position`: int64]
-/// Output: Only barriers (terminal executor in the stream graph).
+/// Output: Barriers and watermarks only; no data chunks (terminal executor in the stream graph).
 pub struct DvMergerExecutor<H>
 where
     H: DvHandler,
 {
-    _ctx: ActorContextRef,
+    actor_id: ActorId,
+    sink_id: SinkId,
+    local_barrier_manager: LocalBarrierManager,
     input: Option<Executor>,
     handler: H,
 }
@@ -52,9 +57,17 @@ impl<H> DvMergerExecutor<H>
 where
     H: DvHandler,
 {
-    pub fn new(ctx: ActorContextRef, input: Executor, handler: H) -> Self {
+    pub fn new(
+        actor_id: ActorId,
+        sink_id: SinkId,
+        local_barrier_manager: LocalBarrierManager,
+        input: Executor,
+        handler: H,
+    ) -> Self {
         Self {
-            _ctx: ctx,
+            actor_id,
+            sink_id,
+            local_barrier_manager,
             input: Some(input),
             handler,
         }
@@ -86,8 +99,22 @@ where
                     }
                 }
                 Message::Barrier(barrier) => {
-                    let _metadata = self.handler.flush().await?.unwrap_or_default();
-                    // TODO: commit the DV metadata
+                    let mut metadata = None;
+                    if barrier.is_checkpoint() {
+                        metadata = self.handler.flush().await?;
+                    }
+
+                    if let Some(metadata) = metadata
+                        && metadata.metadata.is_some()
+                    {
+                        self.local_barrier_manager.report_iceberg_v3_sink_metadata(
+                            barrier.epoch,
+                            self.sink_id,
+                            self.actor_id,
+                            PbIcebergV3SinkRole::DvMerger,
+                            Some(metadata),
+                        );
+                    }
 
                     yield Message::Barrier(barrier);
                 }
@@ -116,11 +143,13 @@ mod tests {
     use hashbrown::HashMap;
     use risingwave_common::array::{Array, ArrayBuilder, I64ArrayBuilder, Op, Utf8ArrayBuilder};
     use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::id::SinkId;
     use risingwave_common::types::DataType;
     use risingwave_common::util::epoch::test_epoch;
 
     use super::*;
     use crate::executor::test_utils::MockSource;
+    use crate::task::LocalBarrierManager;
 
     fn build_delete_position_chunk(positions: &[(&str, i64)]) -> StreamChunk {
         let len = positions.len();
@@ -198,6 +227,11 @@ mod tests {
                 existing_dvs.insert(file_path.clone(), merged.clone());
                 written_dvs.insert(file_path, merged);
             }
+            // The mock asserts on side effects (`written_dvs`) rather than emitted
+            // metadata, so we still return Ok(None). The report-on-barrier path
+            // is exercised by the SLT integration tests.
+            // TODO: add unit test for report-on-barrier path once test infra is
+            // available to capture `LocalBarrierEvent`s on the receiver side.
             Ok(None)
         }
     }
@@ -217,7 +251,8 @@ mod tests {
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
-        let mut executor = DvMergerExecutor::new(ActorContext::for_test(123), source, handler)
+        let lbm = LocalBarrierManager::for_test();
+        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
             .boxed()
             .execute();
 
@@ -247,7 +282,8 @@ mod tests {
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
-        let mut executor = DvMergerExecutor::new(ActorContext::for_test(123), source, handler)
+        let lbm = LocalBarrierManager::for_test();
+        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
             .boxed()
             .execute();
 
@@ -278,7 +314,8 @@ mod tests {
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
-        let mut executor = DvMergerExecutor::new(ActorContext::for_test(123), source, handler)
+        let lbm = LocalBarrierManager::for_test();
+        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
             .boxed()
             .execute();
 
@@ -299,7 +336,8 @@ mod tests {
         let (mut tx, source) = MockSource::channel();
         let source = source.into_executor(input_schema(), vec![]);
 
-        let mut executor = DvMergerExecutor::new(ActorContext::for_test(123), source, handler)
+        let lbm = LocalBarrierManager::for_test();
+        let mut executor = DvMergerExecutor::new(123.into(), SinkId::new(0), lbm, source, handler)
             .boxed()
             .execute();
 

--- a/src/stream/src/executor/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/writer.rs
@@ -16,17 +16,19 @@ use anyhow::Context;
 use iceberg::writer::PositionDeleteInput;
 use risingwave_common::array::DataChunk;
 use risingwave_common::array::stream_record::Record;
+use risingwave_common::id::SinkId;
 use risingwave_common::row::{Project, RowExt};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_pb::connector_service::SinkMetadata;
+use risingwave_pb::stream_service::PbIcebergV3SinkRole;
 use risingwave_storage::StateStore;
 
 use crate::common::change_buffer::output_kind;
 use crate::common::compact_chunk::{InconsistencyBehavior, compact_chunk_inline};
 use crate::executor::prelude::*;
+use crate::task::LocalBarrierManager;
 
-pub type IcebergWriterFlushOutput = SinkMetadata;
 type PkRow<'a> = Project<'a, RowRef<'a>>;
 
 fn new_chunk_builder(chunk_size: usize) -> DataChunkBuilder {
@@ -52,9 +54,9 @@ pub trait IcebergWriter: Send + 'static {
         chunk: DataChunk,
     ) -> StreamExecutorResult<Vec<PositionDeleteInput>>;
 
-    /// Flush current data files on barrier. Returns the written data files
-    /// and each file's partition information (if partitioned).
-    async fn flush(&mut self) -> StreamExecutorResult<Option<IcebergWriterFlushOutput>>;
+    /// Flush current data files on barrier. Returns serialized commit metadata,
+    /// or `None` if no data was written since the last flush.
+    async fn flush(&mut self) -> StreamExecutorResult<Option<SinkMetadata>>;
 }
 
 /// Writer Executor for Iceberg V3 Sink with PK index
@@ -88,6 +90,8 @@ where
     delete_position_buffer: Option<DataChunkBuilder>,
     chunk_size: usize,
     pk_matched: bool,
+    sink_id: SinkId,
+    local_barrier_manager: LocalBarrierManager,
 }
 
 impl<S, W> WriterExecutor<S, W>
@@ -104,6 +108,8 @@ where
         writer: W,
         chunk_size: usize,
         pk_matched: bool,
+        sink_id: SinkId,
+        local_barrier_manager: LocalBarrierManager,
     ) -> Self {
         Self {
             ctx,
@@ -114,6 +120,8 @@ where
             delete_position_buffer: None,
             chunk_size,
             pk_matched,
+            sink_id,
+            local_barrier_manager,
         }
     }
 
@@ -156,10 +164,9 @@ where
     // chunk in the same checkpoint observes earlier writes/deletes via the state table.
     #[try_stream(ok = DataChunk, error = StreamExecutorError)]
     async fn process_chunk(&mut self, chunk: StreamChunk) {
-        // PK uniqueness within a chunk is not guaranteed by upstream (this executor sits in front
-        // of `SinkExecutor` and does not inherit its compaction). Run it ourselves so the loop
-        // below can stay linear. `Warn` matches `SinkExecutor`'s policy: tolerate inconsistent
-        // upstream PK rather than panic.
+        // PK uniqueness within a chunk is not guaranteed by upstream. Run compaction ourselves so
+        // the loop below can stay linear. `Warn` tolerates inconsistent upstream PK rather than
+        // panic.
         let chunk = compact_chunk_inline::<{ output_kind::RETRACT }>(
             chunk,
             &self.pk_indices,
@@ -246,6 +253,7 @@ where
         // Consume the first barrier.
         let barrier = expect_first_barrier(&mut input).await?;
         let first_epoch = barrier.epoch;
+
         yield Message::Barrier(barrier);
         self.pk_index_state_table.init_epoch(first_epoch).await?;
 
@@ -260,20 +268,33 @@ where
                     }
                 }
                 Message::Barrier(barrier) => {
-                    if let Some(chunk) = self
-                        .delete_position_buffer
-                        .take()
-                        .and_then(|mut b| b.consume_all())
-                    {
-                        yield Message::Chunk(chunk.into());
+                    let mut metadata = None;
+                    if barrier.is_checkpoint() {
+                        if let Some(chunk) = self
+                            .delete_position_buffer
+                            .take()
+                            .and_then(|mut b| b.consume_all())
+                        {
+                            yield Message::Chunk(chunk.into());
+                        }
+                        metadata = self.writer.flush().await?;
                     }
 
-                    let _metadata = self.writer.flush().await?.unwrap_or_default();
                     let epoch = barrier.epoch;
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
                     let post_commit = self.pk_index_state_table.commit(epoch).await?;
 
-                    // TODO: commit the writer metadata
+                    if let Some(metadata) = metadata
+                        && metadata.metadata.is_some()
+                    {
+                        self.local_barrier_manager.report_iceberg_v3_sink_metadata(
+                            epoch,
+                            self.sink_id,
+                            self.ctx.id,
+                            PbIcebergV3SinkRole::Writer,
+                            Some(metadata),
+                        );
+                    }
 
                     yield Message::Barrier(barrier);
 
@@ -304,6 +325,7 @@ mod tests {
     use iceberg::writer::PositionDeleteInput;
     use risingwave_common::array::Op;
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
+    use risingwave_common::id::SinkId;
     use risingwave_common::test_prelude::StreamChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_common::util::epoch::test_epoch;
@@ -313,6 +335,7 @@ mod tests {
     use super::*;
     use crate::common::table::test_utils::gen_pbtable;
     use crate::executor::test_utils::{MessageSender, MockSource, StreamExecutorTestExt};
+    use crate::task::LocalBarrierManager;
 
     const CHUNK_SIZE: usize = 1024;
     const TEST_FILE_PATH: &str = "file1.parquet";
@@ -356,7 +379,7 @@ mod tests {
             Ok(positions)
         }
 
-        async fn flush(&mut self) -> StreamExecutorResult<Option<IcebergWriterFlushOutput>> {
+        async fn flush(&mut self) -> StreamExecutorResult<Option<SinkMetadata>> {
             Ok(None)
         }
     }
@@ -419,6 +442,7 @@ mod tests {
 
             let (tx, source) = MockSource::channel();
             let source = source.into_executor(input_schema(), vec![0]);
+            let lbm = LocalBarrierManager::for_test();
             let executor = WriterExecutor::new(
                 ActorContext::for_test(123),
                 source,
@@ -427,6 +451,8 @@ mod tests {
                 writer,
                 CHUNK_SIZE,
                 true,
+                SinkId::new(0),
+                lbm,
             )
             .boxed()
             .execute();

--- a/src/stream/src/executor/iceberg_with_pk_index/writer_impl.rs
+++ b/src/stream/src/executor/iceberg_with_pk_index/writer_impl.rs
@@ -17,9 +17,10 @@ use iceberg::writer::PositionDeleteInput;
 use risingwave_common::array::DataChunk;
 use risingwave_connector::sink::SinkWriterParam;
 use risingwave_connector::sink::iceberg::{IcebergConfig, IcebergSinkWriterInner};
+use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::id::SinkId;
 
-use super::writer::{IcebergWriter, IcebergWriterFlushOutput};
+use super::writer::IcebergWriter;
 use crate::executor::{StreamExecutorError, StreamExecutorResult};
 
 pub struct IcebergWriterImpl {
@@ -55,7 +56,7 @@ impl IcebergWriter for IcebergWriterImpl {
         Ok(positions)
     }
 
-    async fn flush(&mut self) -> StreamExecutorResult<Option<IcebergWriterFlushOutput>> {
+    async fn flush(&mut self) -> StreamExecutorResult<Option<SinkMetadata>> {
         let Some(data_files) = self
             .inner
             .close()
@@ -64,6 +65,10 @@ impl IcebergWriter for IcebergWriterImpl {
         else {
             return Ok(None);
         };
+        if data_files.is_empty() {
+            return Ok(None);
+        }
+
         let metadata = self
             .inner
             .generate_commit_metadata(data_files)

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -90,7 +90,7 @@ mod filter;
 mod gap_fill;
 pub mod hash_join;
 mod hop_window;
-mod iceberg_with_pk_index;
+pub(crate) mod iceberg_with_pk_index;
 mod join;
 pub mod locality_provider;
 mod lookup;

--- a/src/stream/src/from_proto/iceberg_with_pk_index/dv_merger.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/dv_merger.rs
@@ -48,7 +48,13 @@ impl ExecutorBuilder for IcebergWithPkIndexDvMergerExecutorBuilder {
             .map_err(|err| StreamExecutorError::from((err, sink_id)))?;
         let handler = DvHandlerImpl::new(config, params.actor_context.id, sink_id).await?;
 
-        let exec = DvMergerExecutor::new(params.actor_context, input, handler);
+        let exec = DvMergerExecutor::new(
+            params.actor_context.id,
+            sink_id,
+            params.local_barrier_manager.clone(),
+            input,
+            handler,
+        );
         Ok((params.info, exec).into())
     }
 }

--- a/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
+++ b/src/stream/src/from_proto/iceberg_with_pk_index/writer.rs
@@ -114,6 +114,8 @@ impl ExecutorBuilder for IcebergWithPkIndexWriterExecutorBuilder {
             writer,
             params.config.developer.chunk_size,
             pk_matched,
+            sink_id,
+            params.local_barrier_manager.clone(),
         );
         Ok((params.info, exec).into())
     }

--- a/src/stream/src/task/barrier_manager/mod.rs
+++ b/src/stream/src/task/barrier_manager/mod.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 pub use progress::CreateMviewProgressReporter;
 use risingwave_common::id::{SourceId, TableId};
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_pb::id::{FragmentId, PartialGraphId};
+use risingwave_pb::connector_service::SinkMetadata;
+use risingwave_pb::id::{FragmentId, PartialGraphId, SinkId};
+use risingwave_pb::stream_service::PbIcebergV3SinkRole;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
@@ -83,6 +85,13 @@ pub(super) enum LocalBarrierEvent {
         epoch: EpochPair,
         actor_id: ActorId,
         source_id: SourceId,
+    },
+    ReportIcebergV3SinkMetadata {
+        epoch: EpochPair,
+        sink_id: SinkId,
+        actor_id: ActorId,
+        role: PbIcebergV3SinkRole,
+        metadata: Option<SinkMetadata>,
     },
 }
 
@@ -239,6 +248,23 @@ impl LocalBarrierManager {
             epoch,
             actor_id,
             source_id,
+        });
+    }
+
+    pub fn report_iceberg_v3_sink_metadata(
+        &self,
+        epoch: EpochPair,
+        sink_id: risingwave_common::id::SinkId,
+        actor_id: ActorId,
+        role: PbIcebergV3SinkRole,
+        metadata: Option<SinkMetadata>,
+    ) {
+        self.send_event(LocalBarrierEvent::ReportIcebergV3SinkMetadata {
+            epoch,
+            sink_id,
+            actor_id,
+            role,
+            metadata,
         });
     }
 }

--- a/src/stream/src/task/barrier_worker/managed_state.rs
+++ b/src/stream/src/task/barrier_worker/managed_state.rs
@@ -26,12 +26,13 @@ use futures::stream::{FuturesOrdered, FuturesUnordered};
 use futures::{FutureExt, StreamExt};
 use prometheus::HistogramTimer;
 use risingwave_common::catalog::TableId;
-use risingwave_common::id::SourceId;
+use risingwave_common::id::{SinkId, SourceId};
 use risingwave_common::util::epoch::EpochPair;
+use risingwave_pb::connector_service::SinkMetadata;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_service::barrier_complete_response::{
-    PbCdcSourceOffsetUpdated, PbCdcTableBackfillProgress, PbCreateMviewProgress,
-    PbListFinishedSource, PbLoadFinishedSource,
+    IcebergV3SinkMetadata as PbIcebergV3SinkMetadata, PbCdcSourceOffsetUpdated,
+    PbCdcTableBackfillProgress, PbCreateMviewProgress, PbListFinishedSource, PbLoadFinishedSource,
 };
 use risingwave_storage::StateStoreImpl;
 use tokio::sync::mpsc;
@@ -75,6 +76,7 @@ enum ManagedBarrierStateInner {
         load_finished_source_ids: Vec<PbLoadFinishedSource>,
         cdc_table_backfill_progress: Vec<PbCdcTableBackfillProgress>,
         cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
+        iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
         truncate_tables: Vec<TableId>,
         refresh_finished_tables: Vec<TableId>,
     },
@@ -90,7 +92,7 @@ struct BarrierState {
 
 use risingwave_common::must_match;
 use risingwave_pb::id::FragmentId;
-use risingwave_pb::stream_service::InjectBarrierRequest;
+use risingwave_pb::stream_service::{InjectBarrierRequest, PbIcebergV3SinkRole};
 
 use crate::executor::exchange::permit;
 use crate::task::barrier_worker::await_epoch_completed_future::AwaitEpochCompletedFuture;
@@ -320,6 +322,9 @@ pub(crate) struct PartialGraphManagedBarrierState {
     /// Used to track when CDC sources have updated their offset at least once.
     pub(crate) cdc_source_offset_updated: HashMap<u64, Vec<PbCdcSourceOffsetUpdated>>,
 
+    /// Record Iceberg V3 sink metadata reports per epoch for concurrent checkpoints.
+    pub(crate) iceberg_v3_sink_metadata: HashMap<u64, Vec<PbIcebergV3SinkMetadata>>,
+
     /// Record the tables to truncate for each epoch of concurrent checkpoints.
     pub(crate) truncate_tables: HashMap<u64, HashSet<TableId>>,
     /// Record the tables that have finished refresh for each epoch of concurrent checkpoints.
@@ -348,6 +353,7 @@ impl PartialGraphManagedBarrierState {
             load_finished_source_ids: Default::default(),
             cdc_table_backfill_progress: Default::default(),
             cdc_source_offset_updated: Default::default(),
+            iceberg_v3_sink_metadata: Default::default(),
             truncate_tables: Default::default(),
             refresh_finished_tables: Default::default(),
             state_store,
@@ -951,6 +957,15 @@ impl PartialGraphState {
                 } => {
                     self.report_cdc_source_offset_updated(epoch, actor_id, source_id);
                 }
+                LocalBarrierEvent::ReportIcebergV3SinkMetadata {
+                    epoch,
+                    sink_id,
+                    actor_id,
+                    role,
+                    metadata,
+                } => {
+                    self.report_iceberg_v3_sink_metadata(epoch, sink_id, actor_id, role, metadata);
+                }
             }
         }
 
@@ -1085,13 +1100,47 @@ impl PartialGraphState {
                 .entry(epoch.curr)
                 .or_default()
                 .push(PbCdcSourceOffsetUpdated {
-                    reporter_actor_id: actor_id.as_raw_id(),
-                    source_id: source_id.as_raw_id(),
+                    reporter_actor_id: actor_id,
+                    source_id,
                 });
         } else {
             warn!(
                 ?epoch,
                 %actor_id, %source_id, "ignore cdc source offset updated"
+            );
+        }
+    }
+
+    /// Record a Iceberg V3 sink metadata report.
+    pub(super) fn report_iceberg_v3_sink_metadata(
+        &mut self,
+        epoch: EpochPair,
+        sink_id: SinkId,
+        actor_id: ActorId,
+        role: PbIcebergV3SinkRole,
+        metadata: Option<SinkMetadata>,
+    ) {
+        if let Some(actor_state) = self.actor_states.get(&actor_id)
+            && actor_state.inflight_barriers.contains(&epoch.prev)
+        {
+            self.graph_state
+                .iceberg_v3_sink_metadata
+                .entry(epoch.curr)
+                .or_default()
+                .push(PbIcebergV3SinkMetadata {
+                    sink_id,
+                    reporter_actor_id: actor_id,
+                    prev_epoch: epoch.prev,
+                    role: role as i32,
+                    metadata,
+                });
+        } else {
+            tracing::warn!(
+                ?epoch,
+                %actor_id,
+                %sink_id,
+                ?role,
+                "ignore iceberg v3 sink metadata report from non-inflight actor"
             );
         }
     }
@@ -1136,9 +1185,8 @@ impl PartialGraphState {
 }
 
 impl PartialGraphManagedBarrierState {
-    /// This method is called when barrier state is modified in either `Issued` or `Stashed`
-    /// to transform the state to `AllCollected` and start state store `sync` when the barrier
-    /// has been collected from all actors for an `Issued` barrier.
+    /// Check whether any `Issued` barrier has been collected by all actors and, if so,
+    /// transition it to `AllCollected`.
     fn may_have_collected_all(&mut self) -> Option<Barrier> {
         for barrier_state in self.epoch_barrier_state_map.values_mut() {
             match &barrier_state.inner {
@@ -1186,6 +1234,11 @@ impl PartialGraphManagedBarrierState {
                 .remove(&barrier_state.barrier.epoch.curr)
                 .unwrap_or_default();
 
+            let iceberg_v3_sink_metadata = self
+                .iceberg_v3_sink_metadata
+                .remove(&barrier_state.barrier.epoch.curr)
+                .unwrap_or_default();
+
             let truncate_tables = self
                 .truncate_tables
                 .remove(&barrier_state.barrier.epoch.curr)
@@ -1209,6 +1262,7 @@ impl PartialGraphManagedBarrierState {
                     refresh_finished_tables,
                     cdc_table_backfill_progress,
                     cdc_source_offset_updated,
+                    iceberg_v3_sink_metadata,
                 },
             );
 
@@ -1238,6 +1292,7 @@ impl PartialGraphManagedBarrierState {
             load_finished_source_ids,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
+            iceberg_v3_sink_metadata,
             truncate_tables,
             refresh_finished_tables,
         ) = must_match!(barrier_state.inner, ManagedBarrierStateInner::AllCollected {
@@ -1248,8 +1303,9 @@ impl PartialGraphManagedBarrierState {
             refresh_finished_tables,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
+            iceberg_v3_sink_metadata,
         } => {
-            (create_mview_progress, list_finished_source_ids, load_finished_source_ids, cdc_table_backfill_progress, cdc_source_offset_updated, truncate_tables, refresh_finished_tables)
+            (create_mview_progress, list_finished_source_ids, load_finished_source_ids, cdc_table_backfill_progress, cdc_source_offset_updated, iceberg_v3_sink_metadata, truncate_tables, refresh_finished_tables)
         });
         BarrierToComplete {
             barrier: barrier_state.barrier,
@@ -1261,6 +1317,7 @@ impl PartialGraphManagedBarrierState {
             refresh_finished_tables,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
+            iceberg_v3_sink_metadata,
         }
     }
 }
@@ -1275,6 +1332,7 @@ pub(crate) struct BarrierToComplete {
     pub refresh_finished_tables: Vec<TableId>,
     pub cdc_table_backfill_progress: Vec<PbCdcTableBackfillProgress>,
     pub cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
+    pub iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
 }
 
 impl PartialGraphManagedBarrierState {

--- a/src/stream/src/task/barrier_worker/mod.rs
+++ b/src/stream/src/task/barrier_worker/mod.rs
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use risingwave_pb::stream_plan::barrier::BarrierKind;
 use risingwave_pb::stream_service::barrier_complete_response::{
     PbCdcSourceOffsetUpdated, PbCdcTableBackfillProgress, PbCreateMviewProgress,
-    PbListFinishedSource, PbLoadFinishedSource, PbLocalSstableInfo,
+    PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource, PbLocalSstableInfo,
 };
 use risingwave_rpc_client::error::{ToTonicStatus, TonicStatusWrapper};
 use risingwave_storage::store_impl::AsHummock;
@@ -97,6 +97,9 @@ pub struct BarrierCompleteResult {
 
     /// CDC sources that have updated their offset at least once.
     pub cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
+
+    /// Iceberg V3 sink metadata reports collected during this barrier.
+    pub iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
 
     /// The table IDs that should be truncated.
     pub truncate_tables: Vec<TableId>,
@@ -637,7 +640,7 @@ mod await_epoch_completed_future {
     use risingwave_hummock_sdk::SyncResult;
     use risingwave_pb::stream_service::barrier_complete_response::{
         PbCdcSourceOffsetUpdated, PbCdcTableBackfillProgress, PbCreateMviewProgress,
-        PbListFinishedSource, PbLoadFinishedSource,
+        PbIcebergV3SinkMetadata, PbListFinishedSource, PbLoadFinishedSource,
     };
 
     use crate::error::StreamResult;
@@ -658,6 +661,7 @@ mod await_epoch_completed_future {
         load_finished_source_ids: Vec<PbLoadFinishedSource>,
         cdc_table_backfill_progress: Vec<PbCdcTableBackfillProgress>,
         cdc_source_offset_updated: Vec<PbCdcSourceOffsetUpdated>,
+        iceberg_v3_sink_metadata: Vec<PbIcebergV3SinkMetadata>,
         truncate_tables: Vec<TableId>,
         refresh_finished_tables: Vec<TableId>,
     ) -> AwaitEpochCompletedFuture {
@@ -680,6 +684,7 @@ mod await_epoch_completed_future {
                     load_finished_source_ids,
                     cdc_table_backfill_progress,
                     cdc_source_offset_updated,
+                    iceberg_v3_sink_metadata,
                     truncate_tables,
                     refresh_finished_tables,
                 }),
@@ -756,6 +761,7 @@ impl LocalBarrierWorker {
                 load_finished_source_ids,
                 cdc_table_backfill_progress,
                 cdc_source_offset_updated,
+                iceberg_v3_sink_metadata,
                 truncate_tables,
                 refresh_finished_tables,
             } = graph_state.pop_barrier_to_complete(prev_epoch);
@@ -792,6 +798,7 @@ impl LocalBarrierWorker {
                         load_finished_source_ids,
                         cdc_table_backfill_progress,
                         cdc_source_offset_updated,
+                        iceberg_v3_sink_metadata,
                         truncate_tables,
                         refresh_finished_tables,
                     )
@@ -812,6 +819,7 @@ impl LocalBarrierWorker {
             load_finished_source_ids,
             cdc_table_backfill_progress,
             cdc_source_offset_updated,
+            iceberg_v3_sink_metadata,
             truncate_tables,
             refresh_finished_tables,
         } = result;
@@ -876,6 +884,7 @@ impl LocalBarrierWorker {
                         cdc_table_backfill_progress,
                         truncate_tables,
                         refresh_finished_tables,
+                        iceberg_v3_sink_metadata,
                     },
                 )
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR adds the meta-side exactly-once commit coordinator for Iceberg V3 sinks. The executor already maintains the PK index and produces deletion-vector data; this PR provides the barrier-driven commit path that turns those per-actor outputs into a single atomic Iceberg snapshot.

### Meta: per-sink V3 coordinator (src/meta/src/manager/iceberg_v3_sink/)

  - `IcebergV3SinkManager` (cheap, cloneable handle) dispatches to a per-sink `CoordinatorWorker` over a bounded mpsc. Re-registering a sink_id drops the prior worker and synchronously awaits its exit to avoid double-committing the pending row. 
  - The worker loads the Iceberg catalog/table once on init (60s timeout), then recovers state from the `pending_sink_state` table — at most one Pending epoch per sink.
  - Two-phase commit per epoch: 
    a. **PreCommit**: aggregate reports from `Writer` + `DvMerger` fragments, validate schema_id/partition_spec_id consistency, backfill DV partition values from writer data files, pre-generate a snapshot_id (idempotency token), encode as `PbIcebergV3PreCommitState`, persist as Pending.
    b. **Commit** (after Hummock is durable): run overwrite_files with the pre-generated snapshot id, mark Committed, prune the prior epoch.
  - `backfill.rs` solves the same-epoch DV/data-file partition gap: `DvMerger` writes DVs with empty partition fields; the coordinator fills them from the writer's data files before commit.

### Barrier plumbing (meta)
  - `complete_task` collects `iceberg_v3_sink_metadata` from barrier responses and fans out `PreCommit → Hummock commit → Commit` through new `pre_commit_iceberg_v3_sink_metadata` / `commit_iceberg_v3_sink_metadata` hooks on `GlobalBarrierWorkerContext` (`context_impl.rs`).
  - Per-sink errors are aggregated (aggregate_v3_sink_errors) so one failing sink doesn't mask others.
  - `recovery.rs` calls reset() / unregister_v3_sinks() then reregister_iceberg_v3_sinks() so workers reload `pending_sink_state` and retry.

### DDL / catalog
  - ddl_controller.rs: register the worker at `CREATE SINK` for V3 sinks (iceberg + enable_pk_index=true); unregister on `DROP SINK`.
  - catalog/drop_op.rs: `ReleaseContext.removed_iceberg_v3_sink_ids` so dropped sinks reach the DDL controller.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
