### PR TITLE
chore: update actions/checkout from v4 to v5 (#25579)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-create-doc-issue-by-issue.yml
+++ b/.github/workflows/auto-create-doc-issue-by-issue.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check if issue is done and labeled 'user-facing-changes'
         uses: dacbd/create-issue-action@main
         if: ${{ github.event.action == 'closed' && contains(github.event.issue.labels.*.name, 'user-facing-changes') }}

--- a/.github/workflows/auto-update-helm-and-operator-version-by-release.yml
+++ b/.github/workflows/auto-update-helm-and-operator-version-by-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Helm Charts Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'risingwavelabs/helm-charts'
           token: ${{ secrets.PR_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Risingwave Operator Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'risingwavelabs/risingwave-operator'
           token: ${{ secrets.PR_TOKEN }}

--- a/.github/workflows/build-docker-image-on-demand-ec2.yml
+++ b/.github/workflows/build-docker-image-on-demand-ec2.yml
@@ -23,7 +23,7 @@ jobs:
   build_image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Generate image tag'
         id: get_release_branch
         run: |

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,7 +23,7 @@ jobs:
   build_image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Generate image tag'
         id: get_release_branch
         run: |

--- a/.github/workflows/bump-main.yml
+++ b/.github/workflows/bump-main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Bump main branch version
         id: bump

--- a/.github/workflows/cherry-pick-since-release-branch.yml
+++ b/.github/workflows/cherry-pick-since-release-branch.yml
@@ -34,7 +34,7 @@ jobs:
       pr_sha: ${{ steps.filter-release-branches.outputs.pr_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Ensures all branches are fetched
 
@@ -107,7 +107,7 @@ jobs:
         branch: ${{ fromJson(needs.get-target-release-branches.outputs.branches) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create PR to branch
         uses: risingwavelabs/github-action-cherry-pick@master

--- a/.github/workflows/connector-node-integration.yml
+++ b/.github/workflows/connector-node-integration.yml
@@ -16,7 +16,7 @@ jobs:
         java: [ '17', '21' ]
     name: Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: risingwave-copilot-agent-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         run: rustup show

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -11,7 +11,7 @@ jobs:
   dashboard-ui-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: risingwave-large # this runner comes with more disk space, necessary for workflows that build RW
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Rust toolchain
         run: rustup show
       - name: Install dependencies for compiling RisingWave

--- a/.github/workflows/grafana-generate-check.yml
+++ b/.github/workflows/grafana-generate-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Set up Python

--- a/.github/workflows/grafana-generate-prod.yml
+++ b/.github/workflows/grafana-generate-prod.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: Set up Python

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: license-header-check
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         # For pull_request, `GITHUB_SHA` contains a implicit merge commit we want to avoid

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     runs-on: risingwave-large # this runner comes with more disk space, necessary for workflows that build RW
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ github.event_name == 'schedule' }}
         with:
           # For daily scheduled run, we use a fixed branch, so that we can apply patches to fix compile errors earlier.
           # We can also ensure the regression is due to new rust instead of new RisingWave code.
           ref: xxchan/latest-nightly-rust
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !(github.event_name == 'schedule') }}
       - name: Setup Rust toolchain
         run: |

--- a/.github/workflows/package_version_check.yml
+++ b/.github/workflows/package_version_check.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/protobuf-breaking.yml
+++ b/.github/workflows/protobuf-breaking.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check breaking changes in Protobuf files
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/run-main-cron.yml
+++ b/.github/workflows/run-main-cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Label PR
         run: |
           pr_number="${{ github.event.pull_request.number }}"

--- a/.github/workflows/run-perf-test.yml
+++ b/.github/workflows/run-perf-test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Environment
         run: |
           echo "Running perf test"

--- a/.github/workflows/slt-coverage-check.yml
+++ b/.github/workflows/slt-coverage-check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/typo.yml
+++ b/.github/workflows/typo.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Check spelling of the entire repository
       uses: crate-ci/typos@v1.38.1


### PR DESCRIPTION
Cherry picking #25579 onto branch release-2.8,

This PR/issue cannot be created by cherry-pick action from commit 7e6500eb024ef620aeba817df4040fa529167e03:
https://github.com/risingwavelabs/risingwave/actions/runs/26090921672/job/76716158840
```
git cherry-pick succeeded. We will create a pull request for it.
git push -u origin auto-release-2.8-7e6500eb024ef620aeba817df4040fa529167e03-1779185880 
To https://github.com/risingwavelabs/risingwave
 ! [remote rejected]       auto-release-2.8-7e6500eb024ef620aeba817df4040fa529167e03-1779185880 -> auto-release-2.8-7e6500eb024ef620aeba817df4040fa529167e03-1779185880 (refusing to allow a GitHub App to create or update workflow `.github/workflows/bump-main.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/risingwavelabs/risingwave'
```