### PR TITLE
feat(cdc): allow alter `debezium.heartbeat.interval.ms` for Postgres CDC

### DIFF
--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -121,6 +121,7 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
             "cdc.source.wait.streaming.start.timeout".to_owned(),
             "debezium.max.queue.size".to_owned(),
             "debezium.queue.memory.ratio".to_owned(),
+            "debezium.heartbeat.interval.ms".to_owned(),
             "password".to_owned(),
         ].into_iter().collect(),
     ).unwrap();

--- a/src/connector/src/with_options_test.rs
+++ b/src/connector/src/with_options_test.rs
@@ -639,6 +639,7 @@ pub static SOURCE_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<St
             "cdc.source.wait.streaming.start.timeout".to_owned(),
             "debezium.max.queue.size".to_owned(),
             "debezium.queue.memory.ratio".to_owned(),
+            "debezium.heartbeat.interval.ms".to_owned(),
             "password".to_owned(),
         ].into_iter().collect(),
     ).unwrap();

--- a/src/frontend/src/handler/alter_source_props.rs
+++ b/src/frontend/src/handler/alter_source_props.rs
@@ -115,6 +115,17 @@ async fn handle_alter_source_props_inner(
         .into());
     }
 
+    // Validate debezium.heartbeat.interval.ms if present: must be a valid integer and not 0
+    if let Some(interval_value) = changed_props.get("debezium.heartbeat.interval.ms")
+        && !interval_value.parse::<i64>().is_ok_and(|v| v != 0)
+    {
+        return Err(ErrorCode::InvalidConfigValue {
+            config_entry: "debezium.heartbeat.interval.ms".to_owned(),
+            config_value: interval_value.to_owned(),
+        }
+        .into());
+    }
+
     meta_client
         .alter_source_connector_props(
             source_id,

--- a/src/frontend/src/handler/create_source/validate.rs
+++ b/src/frontend/src/handler/create_source/validate.rs
@@ -271,5 +271,17 @@ pub fn validate_compatibility(
         .into());
     }
 
+    // Validate debezium.heartbeat.interval.ms for Postgres CDC: must be a valid integer and not 0
+    if connector == POSTGRES_CDC_CONNECTOR
+        && let Some(interval_value) = props.get("debezium.heartbeat.interval.ms")
+        && !interval_value.parse::<i64>().is_ok_and(|v| v != 0)
+    {
+        return Err(ErrorCode::InvalidConfigValue {
+            config_entry: "debezium.heartbeat.interval.ms".to_owned(),
+            config_value: interval_value.to_owned(),
+        }
+        .into());
+    }
+
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Similar to #23886, this PR allows `debezium.heartbeat.interval.ms` to be altered on the fly for Postgres CDC sources. The heartbeat interval controls how often Debezium emits low-LSN heartbeat events when upstream traffic is idle, which advances the replication slot and prevents WAL retention growth.

```sql
ALTER SOURCE s CONNECTOR WITH (debezium.heartbeat.interval.ms = '60000');
```

Scope is intentionally limited to Postgres CDC for now; other CDC connectors can be enabled in follow-ups if needed.

Also adds Rust-side validation for both CREATE and ALTER paths (must parse as integer and be non-zero), matching the semantics of the existing Java `validateHeartbeatInterval`.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>