### PR TITLE
chore: cherry-pick main-cron CI fixes to release-2.8

### DIFF
--- a/ci/scripts/e2e-doris-sink-test.sh
+++ b/ci/scripts/e2e-doris-sink-test.sh
@@ -26,15 +26,34 @@ download_and_prepare_rw "$profile" source
 echo "--- starting risingwave cluster"
 risedev ci-start ci-sink-test
 
-echo "--- create doris table"
-sleep 10 # Wait for doris to start. TODO: shall we use `service_healthy` condition in docker-compose.yml?
-mysql -uroot -P 9030 -h doris-server -e "CREATE database demo;use demo;
-CREATE table demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 datev2,v8 datetime,v9 boolean,v10 json) UNIQUE KEY(\`v1\`)
+create_doris_table() {
+  local ddl
+
+  ddl="CREATE DATABASE IF NOT EXISTS demo;
+USE demo;
+DROP TABLE IF EXISTS demo_bhv_table;
+CREATE TABLE demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 datev2,v8 datetime,v9 boolean,v10 json) UNIQUE KEY(\`v1\`)
 DISTRIBUTED BY HASH(\`v1\`) BUCKETS 1
 PROPERTIES (
     \"replication_allocation\" = \"tag.location.default: 1\"
-);
-CREATE USER 'users'@'%' IDENTIFIED BY '123456';
+);"
+
+  echo "--- create doris table"
+  for _ in $(seq 1 60); do
+    if mysql -uroot -P 9030 -h doris-server -e "$ddl"; then
+      return
+    fi
+    mysql -uroot -P 9030 -h doris-server -e "SHOW BACKENDS;" || true
+    sleep 2
+  done
+
+  echo "Doris backend did not become ready for table creation in time"
+  mysql -uroot -P 9030 -h doris-server -e "SHOW BACKENDS;" || true
+  exit 1
+}
+
+create_doris_table
+mysql -uroot -P 9030 -h doris-server -e "CREATE USER 'users'@'%' IDENTIFIED BY '123456';
 GRANT ALL ON *.* TO 'users'@'%';"
 sleep 2
 

--- a/ci/scripts/e2e-starrocks-sink-test.sh
+++ b/ci/scripts/e2e-starrocks-sink-test.sh
@@ -27,19 +27,39 @@ echo "--- starting risingwave cluster"
 risedev ci-start ci-sink-test
 sleep 1
 
+create_starrocks_tables() {
+  local ddl
 
-echo "--- create starrocks table"
-sleep 2
-mysql -uroot -P 9030 -h starrocks-fe-server -e "CREATE database demo;use demo;
-CREATE table demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 date,v8 datetime,v9 boolean,v10 json,v11 decimal(10,5)) ENGINE=OLAP
+  ddl="CREATE DATABASE IF NOT EXISTS demo;
+USE demo;
+DROP TABLE IF EXISTS demo_bhv_table;
+CREATE TABLE demo_bhv_table(v1 int,v2 smallint,v3 bigint,v4 float,v5 double,v6 string,v7 date,v8 datetime,v9 boolean,v10 json,v11 decimal(10,5)) ENGINE=OLAP
 PRIMARY KEY(\`v1\`)
 DISTRIBUTED BY HASH(\`v1\`) properties(\"replication_num\" = \"1\");
-CREATE table demo_agg_table(id int, value string REPLACE_IF_NOT_NULL) ENGINE=OLAP
+DROP TABLE IF EXISTS demo_agg_table;
+CREATE TABLE demo_agg_table(id int, value string REPLACE_IF_NOT_NULL) ENGINE=OLAP
 AGGREGATE KEY(\`id\`)
 DISTRIBUTED BY HASH(\`id\`) properties(\"replication_num\" = \"1\");
+DROP TABLE IF EXISTS demo_reserved_words;
 CREATE TABLE demo_reserved_words(id int, \`order\` string, \`from\` string) ENGINE=OLAP
-PRIMARY KEY(id) DISTRIBUTED BY HASH (id) properties(\"replication_num\" = \"1\");
-CREATE USER 'users'@'%' IDENTIFIED BY '123456';
+PRIMARY KEY(id) DISTRIBUTED BY HASH (id) properties(\"replication_num\" = \"1\");"
+
+  echo "--- create starrocks table"
+  for _ in $(seq 1 60); do
+    if mysql -uroot -P 9030 -h starrocks-fe-server -e "$ddl"; then
+      return
+    fi
+    mysql -uroot -P 9030 -h starrocks-fe-server -e "SHOW FRONTENDS; SHOW BACKENDS;" || true
+    sleep 2
+  done
+
+  echo "StarRocks backend did not become ready for table creation in time"
+  mysql -uroot -P 9030 -h starrocks-fe-server -e "SHOW FRONTENDS; SHOW BACKENDS;" || true
+  exit 1
+}
+
+create_starrocks_tables
+mysql -uroot -P 9030 -h starrocks-fe-server -e "CREATE USER 'users'@'%' IDENTIFIED BY '123456';
 GRANT ALL ON *.* TO 'users'@'%';"
 sleep 2
 

--- a/ci/scripts/e2e-test-parallel-for-opendal.sh
+++ b/ci/scripts/e2e-test-parallel-for-opendal.sh
@@ -34,7 +34,7 @@ python3 -m pip install --break-system-packages psycopg2-binary
 
 host_args=(-h localhost -p 4565 -h localhost -p 4566 -h localhost -p 4567)
 
-export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::common::table::state_table=warn,risingwave_storage::hummock::compactor=error,risingwave_hummock_sdk::compaction_group::hummock_version_ext=error,risingwave_storage::hummock::event_handler::hummock_event_handler=error"
+export RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info,risingwave_stream::common::table::state_table=warn,risingwave_storage::hummock::compactor=error,risingwave_hummock_sdk::compaction_group::hummock_version_ext=error,risingwave_storage::hummock::event_handler::hummock_event_handler=error,await_tree::future=error"
 
 echo "--- e2e, ci-3cn-3fe-opendal-fs-backend, streaming"
 risedev ci-start ci-3cn-3fe-opendal-fs-backend

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -723,6 +723,7 @@ steps:
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-release"
     if: |
       !(build.pull_request.labels includes "ci/main-cron/run-selected") && build.env("CI_STEPS") == null
+      || build.pull_request.labels includes "ci/run-opendal-tests"
       || build.pull_request.labels includes "ci/run-e2e-tests-for-opendal"
       || build.env("CI_STEPS") =~ /(^|,)e2e-parallel-tests?-for-opendal(,|$$)/
     depends_on:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -210,7 +210,7 @@ steps:
     plugins:
       - docker-compose#v5.5.0: *docker-compose
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 14
+    timeout_in_minutes: 45
     retry: *auto-retry
 
   - label: "end-to-end source test"

--- a/e2e_test/streaming/temporal_join/append_only/temporal_join_watermark.slt
+++ b/e2e_test/streaming/temporal_join/append_only/temporal_join_watermark.slt
@@ -2,6 +2,9 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
+SET streaming_parallelism = 1;
+
+statement ok
 create table stream(id1 int, a1 int, b1 int, v1 timestamp with time zone, watermark for v1 as v1 - INTERVAL '10' SECOND) APPEND ONLY;
 
 # FIXME. If we don't insert at first, it would cause a panic when create eowc_mv.
@@ -63,3 +66,6 @@ drop table stream cascade;
 
 statement ok
 drop table version cascade;
+
+statement ok
+SET streaming_parallelism = 0;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::assert_matches::assert_matches;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::mem;
 
 use anyhow::anyhow;
@@ -819,7 +819,14 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                             log_reader.init().await?;
                         },
                         RebuildSinkMessage::UpdateConfig(config) => {
-                            if F::ALLOW_REWIND {
+                            if !sink_config_has_changes(&sink_param.properties, &config) {
+                                info!(
+                                    executor_id = %sink_writer_param.executor_id,
+                                    sink_id = %sink_param.sink_id,
+                                    "skip alter sink config because properties are unchanged"
+                                );
+                                Ok(())
+                            } else if F::ALLOW_REWIND {
                                 match log_reader.rewind().await {
                                     Ok(()) => {
                                         sink_param.properties.extend(config.into_iter());
@@ -858,6 +865,15 @@ enum RebuildSinkMessage {
     UpdateConfig(HashMap<String, String>),
 }
 
+fn sink_config_has_changes(
+    current: &BTreeMap<String, String>,
+    incoming: &HashMap<String, String>,
+) -> bool {
+    incoming
+        .iter()
+        .any(|(key, value)| current.get(key) != Some(value))
+}
+
 impl<F: LogStoreFactory> Execute for SinkExecutor<F> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner()
@@ -873,6 +889,27 @@ mod test {
     use super::*;
     use crate::common::log_store_impl::in_mem::BoundedInMemLogStoreFactory;
     use crate::executor::test_utils::*;
+
+    #[test]
+    fn test_sink_config_has_changes() {
+        let current = BTreeMap::from([
+            ("connector".to_owned(), "blackhole".to_owned()),
+            ("commit_checkpoint_interval".to_owned(), "1".to_owned()),
+        ]);
+
+        assert!(!sink_config_has_changes(
+            &current,
+            &HashMap::from([("commit_checkpoint_interval".to_owned(), "1".to_owned())])
+        ));
+        assert!(sink_config_has_changes(
+            &current,
+            &HashMap::from([("commit_checkpoint_interval".to_owned(), "2".to_owned())])
+        ));
+        assert!(sink_config_has_changes(
+            &current,
+            &HashMap::from([("force_append_only".to_owned(), "true".to_owned())])
+        ));
+    }
 
     #[tokio::test]
     async fn test_force_append_only_sink() {


### PR DESCRIPTION
## What

Cherry-pick PR #25707 / commit `2ef3f47e7f39a31950c1132219e1b664708ce038` to `release-2.8`.

This brings the main-cron CI fixes for:

- Doris sink table creation waiting for backend readiness.
- StarRocks sink table creation waiting for frontend/backend readiness.
- OpenDAL e2e log filtering for noisy `await_tree::future` warnings.
- Sink executor config update behavior.
- Related workflow/test adjustments from the original cherry-pick.

## Why

`main-cron#9333` failed on `release-3.0` with Doris/StarRocks/OpenDAL/sink failures that are covered by #25707. We need the same fix available on `release-2.8`.

## Notes

The cherry-pick had one conflict in `ci/scripts/e2e-starrocks-sink-test.sh`. I resolved it by preserving the `release-2.8` setup path (`download_and_prepare_rw` + `risedev ci-start ci-sink-test`) and applying the StarRocks ready-retry logic from #25707.

## Validation

- `bash -n ci/scripts/e2e-doris-sink-test.sh ci/scripts/e2e-starrocks-sink-test.sh ci/scripts/e2e-test-parallel-for-opendal.sh`
