### PR TITLE
ci: wait for elasticsearch health in sink test

### DIFF
--- a/ci/scripts/e2e-elasticsearch-sink-test.sh
+++ b/ci/scripts/e2e-elasticsearch-sink-test.sh
@@ -3,8 +3,26 @@
 # Exits as soon as any line fails.
 set -euo pipefail
 
-echo "--- check elasticsearch"
-curl -u elastic:risingwave http://elasticsearch:9200
+ES_HEALTH_RESPONSE=$(mktemp)
+trap 'rm -f "$ES_HEALTH_RESPONSE"' EXIT
+
+echo "--- wait for elasticsearch"
+curl -fsS \
+  --connect-timeout 2 \
+  --max-time 5 \
+  --retry 60 \
+  --retry-delay 2 \
+  --retry-connrefused \
+  -u elastic:risingwave \
+  "http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=1s" \
+  > "$ES_HEALTH_RESPONSE" || {
+    echo "Elasticsearch did not become ready in time"
+    curl -fsS -u elastic:risingwave http://elasticsearch:9200/ || true
+    exit 1
+  }
+echo "Elasticsearch is ready:"
+cat "$ES_HEALTH_RESPONSE"
+echo
 
 echo "--- testing elasticsearch sink"
 sqllogictest -p 4566 -d dev './e2e_test/sink/elasticsearch/elasticsearch_sink.slt'
@@ -12,9 +30,9 @@ sqllogictest -p 4566 -d dev './e2e_test/sink/elasticsearch/elasticsearch_sink.sl
 sleep 5
 
 echo "--- checking elasticsearch sink result"
-curl -XGET -u elastic:risingwave "http://elasticsearch:9200/test/_search" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}}' > ./e2e_test/sink/elasticsearch/elasticsearch_sink.tmp.result
-curl -XGET -u elastic:risingwave "http://elasticsearch:9200/test1/_search" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}}' > ./e2e_test/sink/elasticsearch/elasticsearch_with_pk_sink.tmp.result
-curl -XGET -u elastic:risingwave "http://elasticsearch:9200/test_route/_search" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}}' > ./e2e_test/sink/elasticsearch/elasticsearch_with_route.tmp.result
+curl -fsS -XGET -u elastic:risingwave "http://elasticsearch:9200/test/_search" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}}' > ./e2e_test/sink/elasticsearch/elasticsearch_sink.tmp.result
+curl -fsS -XGET -u elastic:risingwave "http://elasticsearch:9200/test1/_search" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}}' > ./e2e_test/sink/elasticsearch/elasticsearch_with_pk_sink.tmp.result
+curl -fsS -XGET -u elastic:risingwave "http://elasticsearch:9200/test_route/_search" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}}' > ./e2e_test/sink/elasticsearch/elasticsearch_with_route.tmp.result
 python3 e2e_test/sink/elasticsearch/elasticsearch.py e2e_test/sink/elasticsearch/elasticsearch_sink.result e2e_test/sink/elasticsearch/elasticsearch_sink.tmp.result
 python3 e2e_test/sink/elasticsearch/elasticsearch.py e2e_test/sink/elasticsearch/elasticsearch_with_pk_sink.result e2e_test/sink/elasticsearch/elasticsearch_with_pk_sink.tmp.result
 python3 e2e_test/sink/elasticsearch/elasticsearch.py e2e_test/sink/elasticsearch/elasticsearch_with_route.result e2e_test/sink/elasticsearch/elasticsearch_with_route.tmp.result


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

This PR strengthens the Elasticsearch sink CI test used by main-cron.

The recent main-cron failure in Buildkite showed the Elasticsearch sink job failing before any SQLLogicTest ran because the script checked Elasticsearch with a single immediate `curl`:

- Failed build: https://buildkite.com/risingwavelabs/main-cron/builds/9335#019e42af-d3a0-4435-b291-16a5cd74a1ac
- Error: `curl: (7) Failed to connect to elasticsearch port 9200 after 0 ms: Couldn't connect to server`

This is likely a sidecar readiness race: Docker Compose starts the `elasticsearch` container for `sink-elasticsearch-test-env`, but `depends_on` does not guarantee the Elasticsearch HTTP API is ready. The RisingWave prepare/startup flow waits for the RisingWave cluster, not for the Elasticsearch sidecar.

Changes:

- Replace the one-shot Elasticsearch check with `curl`'s built-in retry support instead of adding a custom wait helper.
- Use `/_cluster/health?wait_for_status=yellow&timeout=1s` so the test starts only after Elasticsearch is query-ready.
- Bound each curl attempt with `--connect-timeout` and `--max-time`.
- Retry connection-refused/startup failures for up to 60 attempts with 2 seconds between attempts.
- Store the health response in a `mktemp` file and clean it up with a trap.
- Avoid verbose curl diagnostics so the Authorization header is not echoed into CI logs.
- Use `curl -fsS` for the result-fetching requests so HTTP errors fail clearly instead of silently writing error responses into temporary result files.

This keeps the change scoped to the Elasticsearch sink test script and is intended to reduce main-cron flakiness without changing sink behavior.

- Closes N/A

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Local verification

- `bash -n ci/scripts/e2e-elasticsearch-sink-test.sh`

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes. This only stabilizes the Elasticsearch sink CI test readiness check.

</details>
