### PR TITLE
feat: support resource_group for source sink index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12909,6 +12909,7 @@ dependencies = [
  "madsim",
  "madsim-rdkafka",
  "madsim-tokio",
+ "madsim-tonic",
  "maplit",
  "paste",
  "pin-project",

--- a/e2e_test/source_inline/kafka/resource_group_source_sink.slt.serial
+++ b/e2e_test/source_inline/kafka/resource_group_source_sink.slt.serial
@@ -1,0 +1,200 @@
+# Verify create-time resource_group on shared Kafka source, Kafka sink, and index.
+control substitution on
+
+statement ok
+SET rw_implicit_flush = true;
+
+statement ok
+SET sink_decouple = false;
+
+statement ok
+SET streaming_use_arrangement_backfill = true;
+
+statement ok
+DROP SOURCE IF EXISTS rg_sink_readback;
+
+statement ok
+DROP SINK IF EXISTS rg_sink;
+
+statement ok
+DROP INDEX IF EXISTS rg_idx;
+
+statement ok
+DROP MATERIALIZED VIEW IF EXISTS rg_mv;
+
+statement ok
+DROP SOURCE IF EXISTS rg_src;
+
+system ok
+rpk topic delete rw_rg_source_input || true
+
+system ok
+rpk topic delete rw_rg_sink_output || true
+
+system ok
+rpk topic create rw_rg_source_input -p 1
+
+system ok
+rpk topic create rw_rg_sink_output -p 1
+
+system ok
+cat <<EOF2 | rpk topic produce rw_rg_source_input -f "%v\n"
+{"id":1,"v":"a"}
+{"id":2,"v":"b"}
+{"id":3,"v":"c"}
+EOF2
+
+statement ok
+SET streaming_use_shared_source = true;
+
+statement ok
+CREATE SOURCE rg_src (
+  id int,
+  v varchar
+) WITH (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'rw_rg_source_input',
+  scan.startup.mode = 'earliest',
+  resource_group = 'default'
+) FORMAT PLAIN ENCODE JSON;
+
+query T
+SELECT resource_group FROM rw_catalog.rw_streaming_jobs WHERE name = 'rg_src';
+----
+default
+
+statement ok
+CREATE MATERIALIZED VIEW rg_mv AS SELECT id, v FROM rg_src;
+
+query I retry 30 backoff 1s
+SELECT count(*) FROM rg_mv;
+----
+3
+
+statement ok
+CREATE INDEX rg_idx ON rg_mv(id) WITH (resource_group = 'default');
+
+query T
+SELECT resource_group FROM rw_catalog.rw_streaming_jobs WHERE name = 'rg_idx';
+----
+default
+
+query T
+SELECT status FROM rw_catalog.rw_streaming_jobs WHERE name = 'rg_idx';
+----
+CREATED
+
+statement ok
+SET streaming_use_arrangement_backfill = false;
+
+statement ok
+CREATE INDEX IF NOT EXISTS rg_idx ON rg_mv(id) WITH (resource_group = 'default');
+
+statement ok
+SET streaming_use_arrangement_backfill = true;
+
+statement ok
+CREATE SINK rg_sink FROM rg_mv WITH (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'rw_rg_sink_output',
+  resource_group = 'default'
+) FORMAT PLAIN ENCODE JSON (
+  force_append_only = 'true'
+);
+
+statement ok
+FLUSH;
+
+query T
+SELECT resource_group FROM rw_catalog.rw_streaming_jobs WHERE name = 'rg_sink';
+----
+default
+
+statement ok
+CREATE SOURCE rg_sink_readback (
+  id int,
+  v varchar
+) WITH (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'rw_rg_sink_output',
+  scan.startup.mode = 'earliest'
+) FORMAT PLAIN ENCODE JSON;
+
+query IT rowsort retry 30 backoff 1s
+SELECT id, v FROM rg_sink_readback;
+----
+1 a
+2 b
+3 c
+
+statement ok
+SET streaming_use_shared_source = false;
+
+statement error resource_group can only be specified for shared sources
+CREATE SOURCE rg_non_shared_src (
+  id int,
+  v varchar
+) WITH (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'rw_rg_source_input',
+  scan.startup.mode = 'earliest',
+  resource_group = 'default'
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+SET streaming_use_shared_source = true;
+
+statement error resource_group can only be specified for shared sources
+CREATE TEMPORARY SOURCE rg_temp_src (
+  id int,
+  v varchar
+) WITH (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'rw_rg_source_input',
+  scan.startup.mode = 'earliest',
+  resource_group = 'default'
+) FORMAT PLAIN ENCODE JSON;
+
+statement error cloud.serverless_backfill_enabled is not a CREATE SOURCE option
+CREATE SOURCE rg_serverless_src (
+  id int,
+  v varchar
+) WITH (
+  ${RISEDEV_KAFKA_WITH_OPTIONS_COMMON},
+  topic = 'rw_rg_source_input',
+  scan.startup.mode = 'earliest',
+  cloud.serverless_backfill_enabled = true
+) FORMAT PLAIN ENCODE JSON;
+
+statement ok
+DROP SOURCE rg_sink_readback;
+
+statement ok
+DROP SINK rg_sink;
+
+statement ok
+DROP INDEX rg_idx;
+
+statement ok
+DROP MATERIALIZED VIEW rg_mv;
+
+statement ok
+DROP SOURCE rg_src;
+
+statement ok
+SET streaming_use_shared_source TO DEFAULT;
+
+statement ok
+SET streaming_use_arrangement_backfill TO DEFAULT;
+
+statement ok
+SET sink_decouple TO DEFAULT;
+
+statement ok
+SET rw_implicit_flush TO DEFAULT;
+
+system ok
+rpk topic delete rw_rg_source_input || true
+
+system ok
+rpk topic delete rw_rg_sink_output || true

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -57,6 +57,7 @@ message CreateSourceRequest {
   catalog.Source source = 1;
   stream_plan.StreamFragmentGraph fragment_graph = 2;
   bool if_not_exists = 3;
+  StreamingJobResourceType resource_type = 4;
 }
 
 message CreateSourceResponse {
@@ -103,6 +104,7 @@ message CreateSinkRequest {
   // The list of object IDs that this sink depends on.
   repeated uint32 dependencies = 4;
   bool if_not_exists = 5;
+  StreamingJobResourceType resource_type = 6;
 }
 
 message CreateSinkResponse {
@@ -164,6 +166,7 @@ message CreateMaterializedViewRequest {
 
   bool if_not_exists = 6;
   optional uint64 refresh_interval_sec = 7;
+  string serverless_backfill_resource_group = 8;
 }
 
 message CreateMaterializedViewResponse {
@@ -454,6 +457,7 @@ message CreateIndexRequest {
   catalog.Table index_table = 2;
   stream_plan.StreamFragmentGraph fragment_graph = 3;
   bool if_not_exists = 4;
+  StreamingJobResourceType resource_type = 5;
 }
 
 message CreateIndexResponse {

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -97,6 +97,7 @@ pub trait CatalogWriter: Send + Sync {
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
         refresh_interval_sec: Option<u64>,
+        serverless_backfill_resource_group: Option<String>,
     ) -> Result<()>;
 
     async fn replace_materialized_view(
@@ -130,6 +131,7 @@ pub trait CatalogWriter: Send + Sync {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -137,6 +139,7 @@ pub trait CatalogWriter: Send + Sync {
         &self,
         source: PbSource,
         graph: Option<StreamFragmentGraph>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -145,6 +148,7 @@ pub trait CatalogWriter: Send + Sync {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()>;
 
@@ -349,6 +353,7 @@ impl CatalogWriter for CatalogWriterImpl {
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
         refresh_interval_sec: Option<u64>,
+        serverless_backfill_resource_group: Option<String>,
     ) -> Result<()> {
         let create_type = table.get_create_type().unwrap_or(PbCreateType::Foreground);
         let version = self
@@ -360,6 +365,7 @@ impl CatalogWriter for CatalogWriterImpl {
                 resource_type,
                 if_not_exists,
                 refresh_interval_sec,
+                serverless_backfill_resource_group,
             )
             .await?;
         if matches!(create_type, PbCreateType::Foreground) {
@@ -398,11 +404,12 @@ impl CatalogWriter for CatalogWriterImpl {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_index(index, table, graph, if_not_exists)
+            .create_index(index, table, graph, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }
@@ -461,11 +468,12 @@ impl CatalogWriter for CatalogWriterImpl {
         &self,
         source: PbSource,
         graph: Option<StreamFragmentGraph>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_source(source, graph, if_not_exists)
+            .create_source(source, graph, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }
@@ -475,11 +483,12 @@ impl CatalogWriter for CatalogWriterImpl {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<()> {
         let version = self
             .meta_client
-            .create_sink(sink, graph, dependencies, if_not_exists)
+            .create_sink(sink, graph, dependencies, resource_type, if_not_exists)
             .await?;
         self.wait_version(version).await
     }

--- a/src/frontend/src/handler/alter_mv.rs
+++ b/src/frontend/src/handler/alter_mv.rs
@@ -146,7 +146,14 @@ async fn handle_alter_mv_bound(
 
     // TODO(alter-mv): use `ColumnIdGenerator` to generate IDs for MV columns, in order to
     // support schema changes.
-    let (mut table, graph, _dependencies, _resource_group, refresh_interval_sec) = {
+    let (
+        mut table,
+        graph,
+        _dependencies,
+        _resource_group,
+        _serverless_backfill_resource_group,
+        refresh_interval_sec,
+    ) = {
         create_mv::gen_create_mv_graph(
             handler_args,
             name,

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -34,6 +34,10 @@ use risingwave_sqlparser::ast::{Ident, ObjectName, OrderByExpr};
 use thiserror_ext::AsReport;
 
 use super::RwPgResponse;
+use super::create_mv::{
+    check_resource_group_arrangement_backfill, check_resource_group_available,
+    reject_cloud_serverless_backfill_enabled, remove_streaming_job_resource_group_option,
+};
 use crate::TableCatalog;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
@@ -640,7 +644,7 @@ fn assemble_materialize(
 }
 
 pub async fn handle_create_index(
-    handler_args: HandlerArgs,
+    mut handler_args: HandlerArgs,
     if_not_exists: bool,
     index_name: ObjectName,
     table_name: ObjectName,
@@ -651,9 +655,29 @@ pub async fn handle_create_index(
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
 
-    let (graph, index_table, index) = {
+    let (graph, index_table, index, resource_type) = {
         let (schema_name, table, index_table_name) =
             resolve_index_schema(&session, index_name, table_name)?;
+        let search_path = session.config().search_path();
+        let user_name = session.user_name();
+        let database = session.database();
+        let schema_path = SchemaPath::new(Some(&schema_name), &search_path, &user_name);
+        if let Ok((index, _)) = session
+            .env()
+            .catalog_reader()
+            .read_guard()
+            .get_any_index_by_name(&database, schema_path, &index_table_name)
+            && if_not_exists
+            && index.is_created()
+        {
+            return Ok(PgResponse::builder(StatementType::CREATE_INDEX)
+                .notice(format!(
+                    "relation \"{}\" already exists, skipping",
+                    index_table_name
+                ))
+                .into());
+        }
+
         let qualified_index_name = ObjectName(vec![
             Ident::from_real_value(&schema_name),
             Ident::from_real_value(&index_table_name),
@@ -665,6 +689,13 @@ pub async fn handle_create_index(
         )? {
             return Ok(resp);
         }
+
+        let resource_group_option =
+            remove_streaming_job_resource_group_option(&mut handler_args.with_options);
+        reject_cloud_serverless_backfill_enabled(&mut handler_args.with_options, "CREATE INDEX")?;
+        check_resource_group_available(&resource_group_option.resource_type)?;
+        check_resource_group_arrangement_backfill(&session, &resource_group_option.resource_type)?;
+        let resource_type = resource_group_option.resource_type;
 
         let context = OptimizerContext::from_handler_args(handler_args);
         let (plan, index_table, index) = gen_create_index_plan(
@@ -680,7 +711,7 @@ pub async fn handle_create_index(
         )?;
         let graph = build_graph(plan, Some(GraphJobType::Index))?;
 
-        (graph, index_table, index)
+        (graph, index_table, index, resource_type)
     };
 
     tracing::trace!(
@@ -702,7 +733,13 @@ pub async fn handle_create_index(
 
     let catalog_writer = session.catalog_writer()?;
     catalog_writer
-        .create_index(index, index_table.to_prost(), graph, if_not_exists)
+        .create_index(
+            index,
+            index_table.to_prost(),
+            graph,
+            resource_type,
+            if_not_exists,
+        )
         .await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_INDEX))

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -52,6 +52,68 @@ use crate::{TableCatalog, WithOptions};
 pub const RESOURCE_GROUP_KEY: &str = "resource_group";
 pub const CLOUD_SERVERLESS_BACKFILL_ENABLED: &str = "cloud.serverless_backfill_enabled";
 
+pub(super) struct StreamingJobResourceGroupOption {
+    pub present: bool,
+    pub resource_type: streaming_job_resource_type::ResourceType,
+}
+
+pub(super) fn remove_streaming_job_resource_group_option(
+    with_options: &mut WithOptions,
+) -> StreamingJobResourceGroupOption {
+    let Some(group) = with_options.remove(RESOURCE_GROUP_KEY) else {
+        return StreamingJobResourceGroupOption {
+            present: false,
+            resource_type: streaming_job_resource_type::ResourceType::Regular(true),
+        };
+    };
+
+    StreamingJobResourceGroupOption {
+        present: true,
+        resource_type: streaming_job_resource_type::ResourceType::SpecificResourceGroup(group),
+    }
+}
+
+pub(super) fn check_resource_group_available(
+    resource_type: &streaming_job_resource_type::ResourceType,
+) -> Result<()> {
+    if let streaming_job_resource_type::ResourceType::SpecificResourceGroup(_) = resource_type {
+        risingwave_common::license::Feature::ResourceGroup.check_available()?;
+    }
+    Ok(())
+}
+
+pub(super) fn check_resource_group_arrangement_backfill(
+    session: &crate::session::SessionImpl,
+    resource_type: &streaming_job_resource_type::ResourceType,
+) -> Result<()> {
+    if matches!(
+        resource_type,
+        streaming_job_resource_type::ResourceType::SpecificResourceGroup(_)
+    ) && !session.config().streaming_use_arrangement_backfill()
+    {
+        return Err(RwError::from(ProtocolError(
+            "The session config arrangement backfill must be enabled to use the resource_group option"
+                .to_owned(),
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn reject_cloud_serverless_backfill_enabled(
+    with_options: &mut WithOptions,
+    statement: &str,
+) -> Result<()> {
+    if with_options
+        .remove(CLOUD_SERVERLESS_BACKFILL_ENABLED)
+        .is_some()
+    {
+        return Err(RwError::from(InvalidInputSyntax(format!(
+            "{CLOUD_SERVERLESS_BACKFILL_ENABLED} is not a {statement} option; serverless backfill is controlled by system/session configuration"
+        ))));
+    }
+    Ok(())
+}
+
 pub(super) fn parse_column_names(columns: &[Ident]) -> Option<Vec<String>> {
     if columns.is_empty() {
         None
@@ -262,7 +324,14 @@ pub async fn handle_create_mv_bound(
         "CREATE MATERIALIZED VIEW",
     )?;
 
-    let (table, graph, dependencies, resource_type, refresh_interval_sec) = {
+    let (
+        table,
+        graph,
+        dependencies,
+        resource_type,
+        serverless_backfill_resource_group,
+        refresh_interval_sec,
+    ) = {
         gen_create_mv_graph(
             handler_args,
             name,
@@ -297,6 +366,7 @@ pub async fn handle_create_mv_bound(
             resource_type,
             if_not_exists,
             refresh_interval_sec,
+            serverless_backfill_resource_group,
         ),
         &session,
         "CREATE MATERIALIZED VIEW",
@@ -323,6 +393,7 @@ pub(crate) async fn gen_create_mv_graph(
     PbStreamFragmentGraph,
     HashSet<ObjectId>,
     streaming_job_resource_type::ResourceType,
+    Option<String>,
     Option<u64>,
 )> {
     let mut with_options = get_with_options(handler_args.clone());
@@ -337,22 +408,8 @@ pub(crate) async fn gen_create_mv_graph(
     let serverless_backfill_from_with = with_options
         .remove(&CLOUD_SERVERLESS_BACKFILL_ENABLED.to_owned())
         .map(|value| value.parse::<bool>().unwrap_or(false));
-    let is_serverless_backfill = match serverless_backfill_from_with {
-        Some(value) => value,
-        None => {
-            if resource_group.is_some() {
-                false
-            } else {
-                handler_args.session.config().enable_serverless_backfill()
-            }
-        }
-    };
-
-    if resource_group.is_some() && is_serverless_backfill {
-        return Err(RwError::from(InvalidInputSyntax(
-            "Please do not specify serverless backfilling and resource group together".to_owned(),
-        )));
-    }
+    let is_serverless_backfill = serverless_backfill_from_with
+        .unwrap_or_else(|| handler_args.session.config().enable_serverless_backfill());
 
     if !with_options.is_empty() {
         // get other useful fields by `remove`, the logic here is to reject unknown options.
@@ -374,8 +431,7 @@ pub(crate) async fn gen_create_mv_graph(
         )));
     }
 
-    let resource_type = if is_serverless_backfill {
-        assert_eq!(resource_group, None);
+    let serverless_backfill_resource_group = if is_serverless_backfill {
         match provision_resource_group(sbc_addr).await {
             Err(e) => {
                 return Err(RwError::from(ProtocolError(format!(
@@ -388,11 +444,20 @@ pub(crate) async fn gen_create_mv_graph(
                     resource_group = group,
                     "provisioning serverless backfill resource group"
                 );
-                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group)
+                Some(group)
             }
         }
-    } else if let Some(group) = resource_group {
+    } else {
+        None
+    };
+
+    let resource_type = if let Some(group) = resource_group {
         streaming_job_resource_type::ResourceType::SpecificResourceGroup(group)
+    } else if let Some(group) = &serverless_backfill_resource_group {
+        // Preserve the legacy MV serverless-backfill wire representation when there is no
+        // steady-state SQL resource-group override. New meta nodes also read the split request
+        // field below; older meta nodes ignore that field but still understand this oneof arm.
+        streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(group.clone())
     } else {
         streaming_job_resource_type::ResourceType::Regular(true)
     };
@@ -404,14 +469,7 @@ It only indicates the physical clustering of the data, which may improve the per
 "#.to_owned());
     }
 
-    if resource_type.resource_group().is_some()
-        && !context
-            .session_ctx()
-            .config()
-            .streaming_use_arrangement_backfill()
-    {
-        return Err(RwError::from(ProtocolError("The session config arrangement backfill must be enabled to use the resource_group option".to_owned())));
-    }
+    check_resource_group_arrangement_backfill(context.session_ctx(), &resource_type)?;
 
     let context: OptimizerContextRef = context.into();
     let session = context.session_ctx().as_ref();
@@ -456,6 +514,7 @@ It only indicates the physical clustering of the data, which may improve the per
         graph,
         dependencies,
         resource_type,
+        serverless_backfill_resource_group,
         refresh_interval_sec,
     ))
 }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -114,6 +114,21 @@ pub(super) fn reject_cloud_serverless_backfill_enabled(
     Ok(())
 }
 
+fn remove_cloud_serverless_backfill_enabled(
+    with_options: &mut WithOptions,
+) -> Result<Option<bool>> {
+    with_options
+        .remove(CLOUD_SERVERLESS_BACKFILL_ENABLED)
+        .map(|value| {
+            value.parse::<bool>().map_err(|_| {
+                RwError::from(InvalidInputSyntax(format!(
+                    "{CLOUD_SERVERLESS_BACKFILL_ENABLED} expects a boolean value, got {value:?}"
+                )))
+            })
+        })
+        .transpose()
+}
+
 pub(super) fn parse_column_names(columns: &[Ident]) -> Option<Vec<String>> {
     if columns.is_empty() {
         None
@@ -405,9 +420,8 @@ pub(crate) async fn gen_create_mv_graph(
         risingwave_common::license::Feature::ResourceGroup.check_available()?;
     }
 
-    let serverless_backfill_from_with = with_options
-        .remove(&CLOUD_SERVERLESS_BACKFILL_ENABLED.to_owned())
-        .map(|value| value.parse::<bool>().unwrap_or(false));
+    let serverless_backfill_from_with =
+        remove_cloud_serverless_backfill_enabled(&mut with_options)?;
     let is_serverless_backfill = serverless_backfill_from_with
         .unwrap_or_else(|| handler_args.session.config().enable_serverless_backfill());
 
@@ -521,7 +535,7 @@ It only indicates the physical clustering of the data, which may improve the per
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use pgwire::pg_response::StatementType::CREATE_MATERIALIZED_VIEW;
     use risingwave_common::catalog::{
@@ -529,8 +543,33 @@ pub mod tests {
     };
     use risingwave_common::types::{DataType, StructType};
 
+    use super::{CLOUD_SERVERLESS_BACKFILL_ENABLED, remove_cloud_serverless_backfill_enabled};
+    use crate::WithOptions;
     use crate::catalog::root_catalog::SchemaPath;
     use crate::test_utils::{LocalFrontend, PROTO_FILE_DATA, create_proto_file};
+
+    #[test]
+    fn test_cloud_serverless_backfill_enabled_requires_boolean() {
+        let mut with_options = WithOptions::new_with_options(BTreeMap::from([(
+            CLOUD_SERVERLESS_BACKFILL_ENABLED.to_owned(),
+            "true".to_owned(),
+        )]));
+        assert_eq!(
+            remove_cloud_serverless_backfill_enabled(&mut with_options).unwrap(),
+            Some(true)
+        );
+        assert!(with_options.is_empty());
+
+        let mut with_options = WithOptions::new_with_options(BTreeMap::from([(
+            CLOUD_SERVERLESS_BACKFILL_ENABLED.to_owned(),
+            "definitely".to_owned(),
+        )]));
+        let err = remove_cloud_serverless_backfill_enabled(&mut with_options).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            r#"Invalid input syntax: cloud.serverless_backfill_enabled expects a boolean value, got "definitely""#
+        );
+    }
 
     #[tokio::test]
     async fn test_create_mv_handler() {

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -56,7 +56,10 @@ use risingwave_sqlparser::ast::{
 use risingwave_sqlparser::parser::Parser;
 
 use super::RwPgResponse;
-use super::create_mv::get_column_names;
+use super::create_mv::{
+    check_resource_group_arrangement_backfill, check_resource_group_available, get_column_names,
+    reject_cloud_serverless_backfill_enabled, remove_streaming_job_resource_group_option,
+};
 use super::create_source::UPSTREAM_SOURCE_KEY;
 use super::util::gen_query_from_table_name;
 use crate::binder::{Binder, Relation};
@@ -109,6 +112,7 @@ pub struct SinkPlanContext {
     pub sink_catalog: SinkCatalog,
     pub target_table_catalog: Option<Arc<TableCatalog>>,
     pub dependencies: HashSet<ObjectId>,
+    pub resource_type: risingwave_pb::ddl_service::streaming_job_resource_type::ResourceType,
 }
 
 pub async fn gen_sink_plan(
@@ -125,6 +129,10 @@ pub async fn gen_sink_plan(
         Binder::resolve_schema_qualified_name(db_name, &stmt.sink_name)?;
 
     let mut with_options = handler_args.with_options.clone();
+    let resource_group_option = remove_streaming_job_resource_group_option(&mut with_options);
+    reject_cloud_serverless_backfill_enabled(&mut with_options, "CREATE SINK")?;
+    check_resource_group_available(&resource_group_option.resource_type)?;
+    check_resource_group_arrangement_backfill(session, &resource_group_option.resource_type)?;
 
     if session
         .env()
@@ -512,6 +520,7 @@ pub async fn gen_sink_plan(
         sink_catalog,
         target_table_catalog,
         dependencies,
+        resource_type: resource_group_option.resource_type,
     })
 }
 
@@ -628,7 +637,7 @@ pub async fn handle_create_sink(
         ))));
     }
 
-    let (mut sink, graph, target_table_catalog, dependencies) = {
+    let (mut sink, graph, target_table_catalog, dependencies, resource_type) = {
         let backfill_order_strategy = handle_args.with_options.backfill_order_strategy();
 
         let SinkPlanContext {
@@ -637,6 +646,7 @@ pub async fn handle_create_sink(
             sink_catalog: sink,
             target_table_catalog,
             dependencies,
+            resource_type,
         } = gen_sink_plan(handle_args, stmt, None, is_iceberg_engine_internal).await?;
 
         let has_order_by = !query.order_by.is_empty();
@@ -653,7 +663,13 @@ pub async fn handle_create_sink(
         let graph =
             build_graph_with_strategy(plan, Some(GraphJobType::Sink), Some(backfill_order))?;
 
-        (sink, graph, target_table_catalog, dependencies)
+        (
+            sink,
+            graph,
+            target_table_catalog,
+            dependencies,
+            resource_type,
+        )
     };
 
     if let Some(table_catalog) = target_table_catalog {
@@ -673,7 +689,13 @@ pub async fn handle_create_sink(
 
     let catalog_writer = session.catalog_writer()?;
     execute_with_long_running_notification(
-        catalog_writer.create_sink(sink.to_proto(), graph, dependencies, if_not_exists),
+        catalog_writer.create_sink(
+            sink.to_proto(),
+            graph,
+            dependencies,
+            resource_type,
+            if_not_exists,
+        ),
         &session,
         "CREATE SINK",
         LongRunningNotificationAction::MonitorBackfillJob,

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -85,6 +85,10 @@ use risingwave_sqlparser::parser::{IncludeOption, IncludeOptionItem};
 use thiserror_ext::AsReport;
 
 use super::RwPgResponse;
+use super::create_mv::{
+    check_resource_group_arrangement_backfill, check_resource_group_available,
+    reject_cloud_serverless_backfill_enabled, remove_streaming_job_resource_group_option,
+};
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
 use crate::catalog::source_catalog::SourceCatalog;
@@ -1147,11 +1151,26 @@ pub async fn handle_create_source(
         )));
     }
 
+    let resource_group_option =
+        remove_streaming_job_resource_group_option(&mut handler_args.with_options);
+    reject_cloud_serverless_backfill_enabled(&mut handler_args.with_options, "CREATE SOURCE")?;
+
     let format_encode = stmt.format_encode.into_v2_with_warning();
     let (with_properties, refresh_mode) =
         bind_connector_props(&handler_args, &format_encode, true)?;
 
     let create_source_type = CreateSourceType::for_newly_created(&session, &*with_properties);
+    if resource_group_option.present && (stmt.temporary || !create_source_type.is_shared()) {
+        return Err(RwError::from(InvalidInputSyntax(
+            "resource_group can only be specified for shared sources".to_owned(),
+        )));
+    }
+
+    if create_source_type.is_shared() {
+        check_resource_group_available(&resource_group_option.resource_type)?;
+        check_resource_group_arrangement_backfill(&session, &resource_group_option.resource_type)?;
+    }
+
     let (columns_from_resolve_source, source_info) = bind_columns_from_source(
         &session,
         &format_encode,
@@ -1207,12 +1226,22 @@ pub async fn handle_create_source(
     if create_source_type.is_shared() {
         let graph = generate_stream_graph_for_source(handler_args, source_catalog)?;
         catalog_writer
-            .create_source(source, Some(graph), stmt.if_not_exists)
+            .create_source(
+                source,
+                Some(graph),
+                resource_group_option.resource_type,
+                stmt.if_not_exists,
+            )
             .await?;
     } else {
         // For other sources we don't create a streaming job
         catalog_writer
-            .create_source(source, None, stmt.if_not_exists)
+            .create_source(
+                source,
+                None,
+                resource_group_option.resource_type,
+                stmt.if_not_exists,
+            )
             .await?;
     }
 

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -309,6 +309,7 @@ impl CatalogWriter for MockCatalogWriter {
         _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
         _refresh_interval_sec: Option<u64>,
+        _serverless_backfill_resource_group: Option<String>,
     ) -> Result<()> {
         table.id = self.gen_id();
         table.stream_job_status = PbStreamJobStatus::Created as _;
@@ -359,6 +360,7 @@ impl CatalogWriter for MockCatalogWriter {
             streaming_job_resource_type::ResourceType::Regular(true),
             if_not_exists,
             None,
+            None,
         )
         .await?;
         Ok(())
@@ -386,6 +388,7 @@ impl CatalogWriter for MockCatalogWriter {
         &self,
         source: PbSource,
         _graph: Option<StreamFragmentGraph>,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         self.create_source_inner(source).map(|_| ())
@@ -396,6 +399,7 @@ impl CatalogWriter for MockCatalogWriter {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         let sink_id = self.create_sink_inner(sink, graph)?;
@@ -412,6 +416,7 @@ impl CatalogWriter for MockCatalogWriter {
         mut index: PbIndex,
         mut index_table: PbTable,
         _graph: StreamFragmentGraph,
+        _resource_type: streaming_job_resource_type::ResourceType,
         _if_not_exists: bool,
     ) -> Result<()> {
         index_table.id = self.gen_id();

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -143,6 +143,29 @@ impl DdlServiceImpl {
         streaming_job_resource_type::ResourceType::Regular(true)
     }
 
+    fn request_streaming_job_resource_type(
+        resource_type: Option<StreamingJobResourceType>,
+    ) -> streaming_job_resource_type::ResourceType {
+        resource_type
+            .and_then(|resource_type| resource_type.resource_type)
+            .unwrap_or_else(Self::default_streaming_job_resource_type)
+    }
+
+    fn reject_serverless_backfill_resource_type(
+        resource_type: &streaming_job_resource_type::ResourceType,
+        object_type: &str,
+    ) -> Result<(), Status> {
+        if matches!(
+            resource_type,
+            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
+        ) {
+            return Err(Status::invalid_argument(format!(
+                "ServerlessBackfillResourceGroup is not supported for CREATE {object_type}"
+            )));
+        }
+        Ok(())
+    }
+
     pub fn start_migrate_table_fragments(&self) -> (JoinHandle<()>, Sender<()>) {
         tracing::info!("start migrate legacy table fragments task");
         let env = self.env.clone();
@@ -363,9 +386,19 @@ impl DdlService for DdlServiceImpl {
     ) -> Result<Response<CreateSourceResponse>, Status> {
         let req = request.into_inner();
         let source = req.get_source()?.clone();
+        let resource_type = Self::request_streaming_job_resource_type(req.resource_type);
+        Self::reject_serverless_backfill_resource_type(&resource_type, "SOURCE")?;
 
         match req.fragment_graph {
             None => {
+                if !matches!(
+                    resource_type,
+                    streaming_job_resource_type::ResourceType::Regular(_)
+                ) {
+                    return Err(Status::invalid_argument(
+                        "resource_group can only be specified for shared sources",
+                    ));
+                }
                 let version = self
                     .ddl_controller
                     .run_command(DdlCommand::CreateNonSharedSource(source))
@@ -384,7 +417,8 @@ impl DdlService for DdlServiceImpl {
                         stream_job,
                         fragment_graph,
                         dependencies: HashSet::new(),
-                        resource_type: Self::default_streaming_job_resource_type(),
+                        resource_type,
+                        serverless_backfill_resource_group: None,
                         if_not_exists: req.if_not_exists,
                         refresh_interval_sec: None,
                     })
@@ -450,6 +484,8 @@ impl DdlService for DdlServiceImpl {
         let sink = req.get_sink()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
         let dependencies = req.get_dependencies().iter().copied().collect();
+        let resource_type = Self::request_streaming_job_resource_type(req.resource_type);
+        Self::reject_serverless_backfill_resource_type(&resource_type, "SINK")?;
 
         let stream_job = StreamingJob::Sink(sink);
 
@@ -457,7 +493,8 @@ impl DdlService for DdlServiceImpl {
             stream_job,
             fragment_graph,
             dependencies,
-            resource_type: Self::default_streaming_job_resource_type(),
+            resource_type,
+            serverless_backfill_resource_group: None,
             if_not_exists: req.if_not_exists,
             refresh_interval_sec: None,
         };
@@ -544,7 +581,7 @@ impl DdlService for DdlServiceImpl {
         let mview = req.get_materialized_view()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
         let dependencies = req.get_dependencies().iter().copied().collect();
-        let resource_type = req.resource_type.unwrap().resource_type.unwrap();
+        let resource_type = Self::request_streaming_job_resource_type(req.resource_type);
 
         let stream_job = StreamingJob::MaterializedView(mview);
         let version = self
@@ -554,6 +591,10 @@ impl DdlService for DdlServiceImpl {
                 fragment_graph,
                 dependencies,
                 resource_type,
+                serverless_backfill_resource_group: (!req
+                    .serverless_backfill_resource_group
+                    .is_empty())
+                .then_some(req.serverless_backfill_resource_group),
                 if_not_exists: req.if_not_exists,
                 refresh_interval_sec: req.refresh_interval_sec,
             })
@@ -599,6 +640,8 @@ impl DdlService for DdlServiceImpl {
         let index = req.get_index()?.clone();
         let index_table = req.get_index_table()?.clone();
         let fragment_graph = req.get_fragment_graph()?.clone();
+        let resource_type = Self::request_streaming_job_resource_type(req.resource_type);
+        Self::reject_serverless_backfill_resource_type(&resource_type, "INDEX")?;
 
         let stream_job = StreamingJob::Index(index, index_table);
         let version = self
@@ -607,7 +650,8 @@ impl DdlService for DdlServiceImpl {
                 stream_job,
                 fragment_graph,
                 dependencies: HashSet::new(),
-                resource_type: Self::default_streaming_job_resource_type(),
+                resource_type,
+                serverless_backfill_resource_group: None,
                 if_not_exists: req.if_not_exists,
                 refresh_interval_sec: None,
             })
@@ -699,6 +743,7 @@ impl DdlService for DdlServiceImpl {
                 fragment_graph,
                 dependencies,
                 resource_type: Self::default_streaming_job_resource_type(),
+                serverless_backfill_resource_group: None,
                 if_not_exists: request.if_not_exists,
                 refresh_interval_sec: None,
             })
@@ -1678,6 +1723,7 @@ impl DdlService for DdlServiceImpl {
                 fragment_graph,
                 dependencies: HashSet::new(),
                 resource_type: Self::default_streaming_job_resource_type(),
+                serverless_backfill_resource_group: None,
                 if_not_exists,
                 refresh_interval_sec: None,
             })
@@ -1763,6 +1809,7 @@ impl DdlService for DdlServiceImpl {
                 fragment_graph,
                 dependencies,
                 resource_type: Self::default_streaming_job_resource_type(),
+                serverless_backfill_resource_group: None,
                 if_not_exists,
                 refresh_interval_sec: None,
             })

--- a/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
+++ b/src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs
@@ -59,7 +59,7 @@ use crate::barrier::{
 use crate::controller::fragment::InflightFragmentInfo;
 use crate::controller::scale::{
     ComponentFragmentAligner, EnsembleActorTemplate, LoadedFragment, NoShuffleEnsemble,
-    build_no_shuffle_fragment_graph_edges, find_no_shuffle_graphs,
+    ResourceGroupRenderPolicy, build_no_shuffle_fragment_graph_edges, find_no_shuffle_graphs,
 };
 use crate::model::{
     FragmentDownstreamRelation, StreamActor, StreamJobActorsToCreate, StreamingJobModelContextExt,
@@ -174,6 +174,7 @@ impl BatchRefreshJobCheckpointControl {
         worker_nodes: &HashMap<WorkerId, WorkerNode>,
         database_resource_group: &str,
         streaming_job_model: &streaming_job::Model,
+        resource_group_policy: ResourceGroupRenderPolicy,
         // Edge building context:
         partial_graph_id: PartialGraphId,
     ) -> MetaResult<BatchRefreshRenderResult> {
@@ -222,6 +223,7 @@ impl BatchRefreshJobCheckpointControl {
                 worker_nodes,
                 entry_fragment_parallelism,
                 database_resource_group.to_owned(),
+                resource_group_policy,
                 distribution_type,
                 vnode_count,
             )?;
@@ -448,6 +450,7 @@ impl BatchRefreshJobCheckpointControl {
             worker_nodes,
             &create_info.info.database_resource_group,
             &create_info.info.streaming_job_model,
+            ResourceGroupRenderPolicy::for_create(create_info.info.is_serverless),
             partial_graph_id,
         )?;
         let initial_partial_graph_mutation =

--- a/src/meta/src/barrier/checkpoint/state.rs
+++ b/src/meta/src/barrier/checkpoint/state.rs
@@ -58,7 +58,7 @@ use crate::barrier::{BarrierKind, Command, CreateStreamingJobType, TracedEpoch};
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::controller::scale::{
     ComponentFragmentAligner, EnsembleActorTemplate, LoadedFragment, NoShuffleEnsemble,
-    build_no_shuffle_fragment_graph_edges, find_no_shuffle_graphs,
+    ResourceGroupRenderPolicy, build_no_shuffle_fragment_graph_edges, find_no_shuffle_graphs,
 };
 use crate::model::{
     ActorId, ActorNewNoShuffle, FragmentDownstreamRelation, FragmentId, StreamActor, StreamContext,
@@ -270,6 +270,7 @@ pub(super) fn render_actors(
     worker_map: &HashMap<WorkerId, WorkerNode>,
     ensembles: &[NoShuffleEnsemble],
     database_resource_group: &str,
+    resource_group_policy: ResourceGroupRenderPolicy,
 ) -> MetaResult<RenderResult> {
     // Step 2: Render actors for each ensemble.
     // For each new fragment, produce a simple assignment: actor_id -> (worker_id, vnode_bitmap).
@@ -331,6 +332,7 @@ pub(super) fn render_actors(
                 worker_map,
                 None,
                 database_resource_group.to_owned(),
+                resource_group_policy,
                 distribution_type,
                 vnode_count,
             )?
@@ -511,6 +513,7 @@ impl DatabaseCheckpointControl {
                     worker_nodes,
                     &ensembles,
                     &info.database_resource_group,
+                    ResourceGroupRenderPolicy::for_create(info.is_serverless),
                 )?;
                 {
                     assert!(!self.state.is_paused());
@@ -801,6 +804,7 @@ impl DatabaseCheckpointControl {
                     worker_nodes,
                     &ensembles,
                     &info.database_resource_group,
+                    ResourceGroupRenderPolicy::for_create(info.is_serverless),
                 )?;
                 for fragment in info.stream_job_fragments.inner.fragments.values_mut() {
                     fill_snapshot_backfill_epoch(
@@ -1105,6 +1109,7 @@ impl DatabaseCheckpointControl {
                     worker_nodes,
                     &ensembles,
                     &plan.database_resource_group,
+                    ResourceGroupRenderPolicy::SpecificThenProvided,
                 )?;
 
                 // Render actors for auto_refresh_schema_sinks.

--- a/src/meta/src/barrier/context/recovery.rs
+++ b/src/meta/src/barrier/context/recovery.rs
@@ -43,7 +43,7 @@ use crate::barrier::rpc::to_partial_graph_id;
 use crate::controller::fragment::{InflightActorInfo, InflightFragmentInfo};
 use crate::controller::scale::{
     FragmentRenderMap, LoadedFragment, LoadedFragmentContext, RenderedGraph,
-    render_actor_assignments,
+    ResourceGroupRenderPolicy, render_actor_assignments,
 };
 use crate::controller::utils::StreamingJobExtraInfo;
 use crate::manager::ActiveStreamingWorkerNodes;
@@ -174,6 +174,7 @@ pub fn render_runtime_info(
             worker_nodes.current(),
             &database_model.resource_group,
             streaming_job_model,
+            ResourceGroupRenderPolicy::SpecificThenProvided,
             partial_graph_id,
         )?;
 

--- a/src/meta/src/controller/catalog/get_op.rs
+++ b/src/meta/src/controller/catalog/get_op.rs
@@ -586,6 +586,8 @@ impl CatalogController {
             Option<String>,
             Option<StreamingParallelism>,
             Option<String>,
+            bool,
+            Option<String>,
         )>,
     > {
         let inner = self.inner.read().await;
@@ -597,11 +599,15 @@ impl CatalogController {
                 streaming_job::Column::AdaptiveParallelismStrategy,
                 streaming_job::Column::BackfillParallelism,
                 streaming_job::Column::BackfillAdaptiveParallelismStrategy,
+                streaming_job::Column::IsServerlessBackfill,
+                streaming_job::Column::SpecificResourceGroup,
             ])
             .into_tuple::<(
                 StreamingParallelism,
                 Option<String>,
                 Option<StreamingParallelism>,
+                Option<String>,
+                bool,
                 Option<String>,
             )>()
             .one(&inner.db)
@@ -651,11 +657,21 @@ impl CatalogController {
             .join(JoinType::InnerJoin, object::Relation::Table.def())
             .join(JoinType::InnerJoin, object::Relation::Database2.def())
             .join(JoinType::InnerJoin, object::Relation::Schema2.def())
+            .join(JoinType::LeftJoin, object::Relation::StreamingJob.def())
             .column(object::Column::Oid)
             .column(database::Column::Name)
             .column(schema::Column::Name)
             .column(table::Column::Name)
-            .column(database::Column::ResourceGroup)
+            .column_as(
+                Expr::if_null(
+                    Expr::col((
+                        streaming_job::Entity,
+                        streaming_job::Column::SpecificResourceGroup,
+                    )),
+                    Expr::col((database::Entity, database::Column::ResourceGroup)),
+                ),
+                "resource_group",
+            )
             .column(table::Column::TableType)
             .into_tuple()
             .all(&inner.db)
@@ -672,11 +688,21 @@ impl CatalogController {
             .join(JoinType::InnerJoin, object::Relation::Source.def())
             .join(JoinType::InnerJoin, object::Relation::Database2.def())
             .join(JoinType::InnerJoin, object::Relation::Schema2.def())
+            .join(JoinType::LeftJoin, object::Relation::StreamingJob.def())
             .column(object::Column::Oid)
             .column(database::Column::Name)
             .column(schema::Column::Name)
             .column(source::Column::Name)
-            .column(database::Column::ResourceGroup)
+            .column_as(
+                Expr::if_null(
+                    Expr::col((
+                        streaming_job::Entity,
+                        streaming_job::Column::SpecificResourceGroup,
+                    )),
+                    Expr::col((database::Entity, database::Column::ResourceGroup)),
+                ),
+                "resource_group",
+            )
             .into_tuple()
             .all(&inner.db)
             .await?)
@@ -692,11 +718,21 @@ impl CatalogController {
             .join(JoinType::InnerJoin, object::Relation::Sink.def())
             .join(JoinType::InnerJoin, object::Relation::Database2.def())
             .join(JoinType::InnerJoin, object::Relation::Schema2.def())
+            .join(JoinType::LeftJoin, object::Relation::StreamingJob.def())
             .column(object::Column::Oid)
             .column(database::Column::Name)
             .column(schema::Column::Name)
             .column(sink::Column::Name)
-            .column(database::Column::ResourceGroup)
+            .column_as(
+                Expr::if_null(
+                    Expr::col((
+                        streaming_job::Entity,
+                        streaming_job::Column::SpecificResourceGroup,
+                    )),
+                    Expr::col((database::Entity, database::Column::ResourceGroup)),
+                ),
+                "resource_group",
+            )
             .into_tuple()
             .all(&inner.db)
             .await?)

--- a/src/meta/src/controller/scale.rs
+++ b/src/meta/src/controller/scale.rs
@@ -995,6 +995,7 @@ fn render_actors_with_allocator(
             worker_map,
             entry_fragment_parallelism,
             database_resource_group,
+            ResourceGroupRenderPolicy::SpecificThenProvided,
             distribution_type,
             vnode_count,
         )?;
@@ -1086,6 +1087,26 @@ fn render_actors_with_allocator(
     Ok(all_fragments)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResourceGroupRenderPolicy {
+    /// Prefer the persisted job-level resource group and fall back to the provided group.
+    SpecificThenProvided,
+    /// Use the provided group as the active placement target for this render.
+    Provided,
+}
+
+impl ResourceGroupRenderPolicy {
+    pub(crate) fn for_create(is_serverless_backfill: bool) -> Self {
+        if is_serverless_backfill {
+            // The create path passes the temporary serverless backfill group as the provided
+            // group, while the persisted job-specific group remains the steady-state target.
+            Self::Provided
+        } else {
+            Self::SpecificThenProvided
+        }
+    }
+}
+
 pub(crate) struct EnsembleActorTemplate {
     assignment: BTreeMap<WorkerId, BTreeMap<u32, Option<Bitmap>>>,
     distribution_type: DistributionType,
@@ -1097,7 +1118,8 @@ impl EnsembleActorTemplate {
         job: &streaming_job::Model,
         worker_map: &HashMap<WorkerId, WorkerNode>,
         entry_fragment_parallelism: Option<StreamingParallelism>,
-        database_resource_group: String,
+        provided_resource_group: String,
+        resource_group_policy: ResourceGroupRenderPolicy,
         distribution_type: DistributionType,
         vnode_count: usize,
     ) -> MetaResult<Self> {
@@ -1111,9 +1133,12 @@ impl EnsembleActorTemplate {
             .as_deref()
             .map(|s| parse_strategy(s).expect("strategy should be validated before persisting"));
 
-        let resource_group = match &job.specific_resource_group {
-            None => database_resource_group,
-            Some(resource_group) => resource_group.clone(),
+        let resource_group = match resource_group_policy {
+            ResourceGroupRenderPolicy::SpecificThenProvided => job
+                .specific_resource_group
+                .clone()
+                .unwrap_or(provided_resource_group),
+            ResourceGroupRenderPolicy::Provided => provided_resource_group,
         };
 
         let available_workers: BTreeMap<WorkerId, NonZeroUsize> = worker_map
@@ -1801,6 +1826,80 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn render_new_respects_resource_group_policy() {
+        let worker_map: HashMap<WorkerId, WorkerNode> = HashMap::from([
+            (1.into(), build_worker_node(1, 1, "serverless_rg")),
+            (2.into(), build_worker_node(2, 1, "steady_rg")),
+        ]);
+
+        let mut job = streaming_job::Model {
+            job_id: 106.into(),
+            job_status: JobStatus::Initial,
+            create_type: CreateType::Background,
+            timezone: None,
+            config_override: None,
+            adaptive_parallelism_strategy: None,
+            parallelism: StreamingParallelism::Fixed(1),
+            backfill_parallelism: None,
+            backfill_adaptive_parallelism_strategy: None,
+            backfill_orders: None,
+            max_parallelism: 1,
+            specific_resource_group: Some("steady_rg".to_owned()),
+            is_serverless_backfill: true,
+            refresh_interval_sec: None,
+        };
+
+        let rendered = EnsembleActorTemplate::render_new(
+            &job,
+            &worker_map,
+            None,
+            "serverless_rg".to_owned(),
+            ResourceGroupRenderPolicy::Provided,
+            DistributionType::Single,
+            1,
+        )
+        .expect("active resource group render succeeds");
+        assert_eq!(
+            rendered.assignment.keys().copied().collect_vec(),
+            vec![1],
+            "active create-time rendering should use the provided serverless group"
+        );
+
+        let rendered = EnsembleActorTemplate::render_new(
+            &job,
+            &worker_map,
+            None,
+            "serverless_rg".to_owned(),
+            ResourceGroupRenderPolicy::SpecificThenProvided,
+            DistributionType::Single,
+            1,
+        )
+        .expect("steady-state resource group render succeeds");
+        assert_eq!(
+            rendered.assignment.keys().copied().collect_vec(),
+            vec![2],
+            "steady-state rendering should honor the persisted specific_resource_group"
+        );
+
+        job.specific_resource_group = None;
+        let rendered = EnsembleActorTemplate::render_new(
+            &job,
+            &worker_map,
+            None,
+            "serverless_rg".to_owned(),
+            ResourceGroupRenderPolicy::SpecificThenProvided,
+            DistributionType::Single,
+            1,
+        )
+        .expect("fallback resource group render succeeds");
+        assert_eq!(
+            rendered.assignment.keys().copied().collect_vec(),
+            vec![1],
+            "steady-state rendering should fall back to the provided group"
+        );
     }
 
     #[test]

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -180,17 +180,22 @@ impl CatalogController {
         streaming_parallelism: StreamingParallelism,
         max_parallelism: usize,
         resource_type: streaming_job_resource_type::ResourceType,
+        is_serverless_backfill: bool,
         backfill_parallelism: Option<StreamingParallelism>,
         backfill_adaptive_parallelism_strategy: Option<AdaptiveParallelismStrategy>,
         refresh_interval_sec: Option<u64>,
     ) -> MetaResult<streaming_job::Model> {
         let obj = Self::create_object(txn, obj_type, owner_id, database_id, schema_id).await?;
         let job_id = obj.oid.as_job_id();
-        let specific_resource_group = resource_type.resource_group();
-        let is_serverless_backfill = matches!(
-            &resource_type,
-            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
-        );
+        let specific_resource_group = match &resource_type {
+            streaming_job_resource_type::ResourceType::SpecificResourceGroup(group) => {
+                Some(group.clone())
+            }
+            // Serverless backfill is an active backfill placement policy, not a steady-state
+            // streaming-job resource-group override.
+            streaming_job_resource_type::ResourceType::Regular(_)
+            | streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_) => None,
+        };
         let model = streaming_job::Model {
             job_id,
             job_status: JobStatus::Initial,
@@ -232,6 +237,7 @@ impl CatalogController {
         max_parallelism: usize,
         mut dependencies: HashSet<ObjectId>,
         resource_type: streaming_job_resource_type::ResourceType,
+        is_serverless_backfill: bool,
         backfill_parallelism: &Option<Parallelism>,
         adaptive_parallelism_strategy: Option<AdaptiveParallelismStrategy>,
         backfill_adaptive_parallelism_strategy: Option<AdaptiveParallelismStrategy>,
@@ -328,6 +334,7 @@ impl CatalogController {
                     streaming_parallelism,
                     max_parallelism,
                     resource_type,
+                    is_serverless_backfill,
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     refresh_interval_sec,
@@ -362,6 +369,7 @@ impl CatalogController {
                     streaming_parallelism,
                     max_parallelism,
                     resource_type,
+                    is_serverless_backfill,
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -385,6 +393,7 @@ impl CatalogController {
                     streaming_parallelism,
                     max_parallelism,
                     resource_type,
+                    is_serverless_backfill,
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -450,6 +459,7 @@ impl CatalogController {
                     streaming_parallelism,
                     max_parallelism,
                     resource_type,
+                    is_serverless_backfill,
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -488,6 +498,7 @@ impl CatalogController {
                     streaming_parallelism,
                     max_parallelism,
                     resource_type,
+                    is_serverless_backfill,
                     backfill_parallelism.clone(),
                     backfill_adaptive_parallelism_strategy,
                     None, // refresh_interval_sec: only for MV
@@ -1141,6 +1152,7 @@ impl CatalogController {
             parallelism,
             original_job.max_parallelism as _,
             resource_type,
+            false,
             // `backfill_parallelism` is intentionally NOT inherited from the original job.
             // Replace has no "backfill finish -> restore parallelism" phase, so inheriting it
             // would render actors at the backfill parallelism and never recover to steady-state.

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -165,6 +165,7 @@ pub enum DdlCommand {
         fragment_graph: StreamFragmentGraphProto,
         dependencies: HashSet<ObjectId>,
         resource_type: streaming_job_resource_type::ResourceType,
+        serverless_backfill_resource_group: Option<String>,
         if_not_exists: bool,
         refresh_interval_sec: Option<u64>,
     },
@@ -453,6 +454,7 @@ impl DdlController {
                     fragment_graph,
                     dependencies,
                     resource_type,
+                    serverless_backfill_resource_group,
                     if_not_exists,
                     refresh_interval_sec,
                 } => {
@@ -461,6 +463,7 @@ impl DdlController {
                         fragment_graph,
                         dependencies,
                         resource_type,
+                        serverless_backfill_resource_group,
                         if_not_exists,
                         refresh_interval_sec,
                     )
@@ -1050,6 +1053,7 @@ impl DdlController {
         fragment_graph: StreamFragmentGraphProto,
         dependencies: HashSet<ObjectId>,
         resource_type: streaming_job_resource_type::ResourceType,
+        serverless_backfill_resource_group: Option<String>,
         if_not_exists: bool,
         refresh_interval_sec: Option<u64>,
     ) -> MetaResult<NotificationVersion> {
@@ -1081,6 +1085,13 @@ impl DdlController {
                 fragment_graph.max_parallelism as _,
                 dependencies,
                 resource_type.clone(),
+                serverless_backfill_resource_group.is_some()
+                    || matches!(
+                        &resource_type,
+                        streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(
+                            _
+                        )
+                    ),
                 &fragment_graph.backfill_parallelism,
                 adaptive_parallelism_strategy,
                 backfill_adaptive_parallelism_strategy,
@@ -1140,6 +1151,7 @@ impl DdlController {
                 streaming_job,
                 fragment_graph,
                 resource_type,
+                serverless_backfill_resource_group,
                 streaming_job_model,
             )
             .await
@@ -1193,6 +1205,7 @@ impl DdlController {
         mut streaming_job: StreamingJob,
         fragment_graph: StreamFragmentGraphProto,
         resource_type: streaming_job_resource_type::ResourceType,
+        serverless_backfill_resource_group: Option<String>,
         streaming_job_model: streaming_job::Model,
     ) -> MetaResult<(StreamJobFragmentsToCreate, CreateStreamingJobContext)> {
         let mut fragment_graph =
@@ -1219,6 +1232,7 @@ impl DdlController {
                 streaming_job,
                 fragment_graph,
                 resource_type,
+                serverless_backfill_resource_group,
                 streaming_job_model,
             )
             .await?;
@@ -1766,6 +1780,7 @@ impl DdlController {
         mut stream_job: StreamingJob,
         fragment_graph: StreamFragmentGraph,
         resource_type: streaming_job_resource_type::ResourceType,
+        serverless_backfill_resource_group: Option<String>,
         streaming_job_model: streaming_job::Model,
     ) -> MetaResult<(CreateStreamingJobContext, StreamJobFragmentsToCreate)> {
         let id = stream_job.id();
@@ -1840,17 +1855,37 @@ impl DdlController {
             },
             (&stream_job).into(),
         )?;
-        let resource_group = if let Some(group) = resource_type.resource_group() {
-            group
-        } else {
-            self.metadata_manager
-                .get_database_resource_group(stream_job.database_id())
-                .await?
+        let steady_state_resource_group = match &resource_type {
+            streaming_job_resource_type::ResourceType::Regular(_) => {
+                self.metadata_manager
+                    .get_database_resource_group(stream_job.database_id())
+                    .await?
+            }
+            streaming_job_resource_type::ResourceType::SpecificResourceGroup(group) => {
+                group.clone()
+            }
+            // Backward compatibility for older clients: a legacy serverless-only resource type
+            // does not represent a steady-state SQL resource-group override.
+            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_) => {
+                self.metadata_manager
+                    .get_database_resource_group(stream_job.database_id())
+                    .await?
+            }
         };
-        let is_serverless_backfill = matches!(
-            &resource_type,
-            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
-        );
+        let is_serverless_backfill = serverless_backfill_resource_group.is_some()
+            || matches!(
+                &resource_type,
+                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
+            );
+        let active_resource_group = serverless_backfill_resource_group
+            .clone()
+            .or_else(|| match &resource_type {
+                streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(
+                    group,
+                ) => Some(group.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| steady_state_resource_group.clone());
 
         // 3. Build the actor graph.
         let actor_graph_builder = ActorGraphBuilder::new(complete_graph)?;
@@ -1927,7 +1962,7 @@ impl DdlController {
 
         let ctx = CreateStreamingJobContext {
             upstream_fragment_downstreams,
-            database_resource_group: resource_group,
+            database_resource_group: active_resource_group,
             definition: stream_job.definition(),
             create_type: stream_job.create_type(),
             job_type: (&stream_job).into(),

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1856,17 +1856,13 @@ impl DdlController {
             (&stream_job).into(),
         )?;
         let steady_state_resource_group = match &resource_type {
-            streaming_job_resource_type::ResourceType::Regular(_) => {
-                self.metadata_manager
-                    .get_database_resource_group(stream_job.database_id())
-                    .await?
-            }
             streaming_job_resource_type::ResourceType::SpecificResourceGroup(group) => {
                 group.clone()
             }
             // Backward compatibility for older clients: a legacy serverless-only resource type
             // does not represent a steady-state SQL resource-group override.
-            streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_) => {
+            streaming_job_resource_type::ResourceType::Regular(_)
+            | streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_) => {
                 self.metadata_manager
                     .get_database_resource_group(stream_job.database_id())
                     .await?
@@ -1878,13 +1874,14 @@ impl DdlController {
                 streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(_)
             );
         let active_resource_group = serverless_backfill_resource_group
-            .clone()
+            .as_ref()
             .or_else(|| match &resource_type {
                 streaming_job_resource_type::ResourceType::ServerlessBackfillResourceGroup(
                     group,
-                ) => Some(group.clone()),
+                ) => Some(group),
                 _ => None,
             })
+            .cloned()
             .unwrap_or_else(|| steady_state_resource_group.clone());
 
         // 3. Build the actor graph.

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -1504,15 +1504,16 @@ impl GlobalStreamManager {
         }
     }
 
-    /// Restores a streaming job's parallelism to its target value after backfill completes.
+    /// Restores a streaming job's temporary backfill placement to its steady-state target after
+    /// backfill completes.
     async fn apply_post_backfill_parallelism(&self, job_id: JobId) -> MetaResult<()> {
-        // Fetch both the target parallelism (final desired state) and the backfill parallelism
-        // (temporary parallelism used during backfill phase) from the catalog.
         let Some((
             target,
             target_adaptive_parallelism_strategy,
             backfill_parallelism,
             backfill_adaptive_parallelism_strategy,
+            is_serverless_backfill,
+            steady_state_specific_resource_group,
         )) = self
             .metadata_manager
             .catalog_controller
@@ -1523,60 +1524,67 @@ impl GlobalStreamManager {
             // Treat it as a benign no-op so we don't trigger unnecessary retries.
             tracing::debug!(
                 job_id = %job_id,
-                "streaming job not found when applying post-backfill parallelism, skip"
+                "streaming job not found when applying post-backfill reschedule, skip"
             );
             return Ok(());
         };
 
-        // Determine if we need to reschedule based on the backfill configuration.
-        match backfill_parallelism {
+        let should_restore_parallelism = match &backfill_parallelism {
             Some(backfill_parallelism)
-                if backfill_parallelism == target
+                if *backfill_parallelism == target
                     && backfill_adaptive_parallelism_strategy
                         == target_adaptive_parallelism_strategy =>
             {
-                // Backfill parallelism matches target - no reschedule needed since the job
-                // is already running at the desired parallelism.
                 tracing::debug!(
                     job_id = %job_id,
                     ?backfill_parallelism,
                     ?target,
-                    "backfill parallelism equals job parallelism, skip reschedule"
+                    "backfill parallelism equals job parallelism"
                 );
-                return Ok(());
+                false
             }
-            Some(_) => {
-                // Backfill parallelism differs from target - proceed to restore target parallelism.
-            }
+            Some(_) => true,
             None => {
-                // No backfill parallelism was configured, meaning the job was created without
-                // a special backfill override. No reschedule is necessary.
                 tracing::debug!(
                     job_id = %job_id,
                     ?target,
-                    "no backfill parallelism configured, skip post-backfill reschedule"
+                    "no backfill parallelism configured"
                 );
-                return Ok(());
+                false
             }
+        };
+
+        if !should_restore_parallelism && !is_serverless_backfill {
+            return Ok(());
         }
 
-        // Reschedule the job to restore its target parallelism.
+        let parallelism_policy = ParallelismPolicy {
+            parallelism: target.clone(),
+            adaptive_parallelism_strategy: target_adaptive_parallelism_strategy,
+        };
+        let resource_group_policy = ResourceGroupPolicy {
+            resource_group: steady_state_specific_resource_group,
+        };
+        let policy = match (should_restore_parallelism, is_serverless_backfill) {
+            (true, true) => ReschedulePolicy::Both(parallelism_policy, resource_group_policy),
+            (true, false) => ReschedulePolicy::Parallelism(parallelism_policy),
+            (false, true) => ReschedulePolicy::ResourceGroup(resource_group_policy),
+            (false, false) => unreachable!(),
+        };
+
         tracing::info!(
             job_id = %job_id,
             ?target,
             ?backfill_parallelism,
-            "restoring parallelism after backfill via reschedule"
+            is_serverless_backfill,
+            "restoring streaming job placement after backfill via reschedule"
         );
-        let policy = ReschedulePolicy::Parallelism(ParallelismPolicy {
-            parallelism: target,
-            adaptive_parallelism_strategy: target_adaptive_parallelism_strategy,
-        });
         if let Err(e) = self.reschedule_streaming_job(job_id, policy, false).await {
             tracing::warn!(job_id = %job_id, error = %e.as_report(), "reschedule after backfill failed");
             return Err(e);
         }
 
-        tracing::info!(job_id = %job_id, "parallelism reschedule after backfill submitted");
+        tracing::info!(job_id = %job_id, "post-backfill reschedule submitted");
         Ok(())
     }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -429,6 +429,7 @@ impl MetaClient {
         resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
         refresh_interval_sec: Option<u64>,
+        serverless_backfill_resource_group: Option<String>,
     ) -> Result<WaitVersion> {
         let request = CreateMaterializedViewRequest {
             materialized_view: Some(table),
@@ -439,6 +440,8 @@ impl MetaClient {
             dependencies: dependencies.into_iter().collect(),
             if_not_exists,
             refresh_interval_sec,
+            serverless_backfill_resource_group: serverless_backfill_resource_group
+                .unwrap_or_default(),
         };
         let resp = self.inner.create_materialized_view(request).await?;
         // TODO: handle error in `resp.status` here
@@ -464,12 +467,16 @@ impl MetaClient {
         &self,
         source: PbSource,
         graph: Option<StreamFragmentGraph>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateSourceRequest {
             source: Some(source),
             fragment_graph: graph,
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
 
         let resp = self.inner.create_source(request).await?;
@@ -483,6 +490,7 @@ impl MetaClient {
         sink: PbSink,
         graph: StreamFragmentGraph,
         dependencies: HashSet<ObjectId>,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateSinkRequest {
@@ -490,6 +498,9 @@ impl MetaClient {
             fragment_graph: Some(graph),
             dependencies: dependencies.into_iter().collect(),
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
 
         let resp = self.inner.create_sink(request).await?;
@@ -838,6 +849,7 @@ impl MetaClient {
         index: PbIndex,
         table: PbTable,
         graph: StreamFragmentGraph,
+        resource_type: streaming_job_resource_type::ResourceType,
         if_not_exists: bool,
     ) -> Result<WaitVersion> {
         let request = CreateIndexRequest {
@@ -845,6 +857,9 @@ impl MetaClient {
             index_table: Some(table),
             fragment_graph: Some(graph),
             if_not_exists,
+            resource_type: Some(PbStreamingJobResourceType {
+                resource_type: Some(resource_type),
+            }),
         };
         let resp = self.inner.create_index(request).await?;
         // TODO: handle error in `resp.status` here

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3"
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = "0.7"
+tonic = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = "*"

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -98,6 +98,9 @@ pub struct Configuration {
     /// Roles for compute nodes (1-indexed). If not set, defaults to "both".
     /// Values: "serving", "streaming", "both".
     pub compute_node_roles: HashMap<usize, String>,
+
+    /// Optional serverless backfill controller address passed to frontend nodes.
+    pub serverless_backfill_controller_addr: Option<String>,
 }
 
 impl Default for Configuration {
@@ -127,6 +130,7 @@ metrics_level = "Disabled"
             per_session_queries: vec![].into(),
             compute_resource_groups: Default::default(),
             compute_node_roles: Default::default(),
+            serverless_backfill_controller_addr: None,
         }
     }
 }
@@ -251,6 +255,7 @@ default_parallelism = {default_parallelism}
             per_session_queries: vec![].into(),
             compute_resource_groups: Default::default(),
             compute_node_roles: Default::default(),
+            serverless_backfill_controller_addr: None,
         }
     }
 
@@ -496,19 +501,24 @@ impl Cluster {
 
         // frontend node
         for i in 1..=conf.frontend_nodes {
-            let opts = risingwave_frontend::FrontendOpts::parse_from([
-                "frontend-node",
-                "--config-path",
-                conf.config_path.as_str(),
-                "--listen-addr",
-                "0.0.0.0:4566",
-                "--health-check-listener-addr",
-                "0.0.0.0:6786",
-                "--advertise-addr",
-                &format!("192.168.2.{i}:4566"),
-                "--temp-secret-file-dir",
-                &format!("./secrets/frontend-{i}"),
-            ]);
+            let mut args = vec![
+                "frontend-node".to_owned(),
+                "--config-path".to_owned(),
+                conf.config_path.as_str().to_owned(),
+                "--listen-addr".to_owned(),
+                "0.0.0.0:4566".to_owned(),
+                "--health-check-listener-addr".to_owned(),
+                "0.0.0.0:6786".to_owned(),
+                "--advertise-addr".to_owned(),
+                format!("192.168.2.{i}:4566"),
+                "--temp-secret-file-dir".to_owned(),
+                format!("./secrets/frontend-{i}"),
+            ];
+            if let Some(addr) = &conf.serverless_backfill_controller_addr {
+                args.push("--serverless-backfill-controller-addr".to_owned());
+                args.push(addr.clone());
+            }
+            let opts = risingwave_frontend::FrontendOpts::parse_from(args);
             handle
                 .create_node()
                 .name(format!("frontend-{i}"))

--- a/src/tests/simulation/src/main.rs
+++ b/src/tests/simulation/src/main.rs
@@ -179,6 +179,7 @@ async fn main() {
         },
         compute_resource_groups: Default::default(),
         compute_node_roles: Default::default(),
+        serverless_backfill_controller_addr: None,
     };
     let kill_opts = KillOpts {
         kill_meta: false,

--- a/src/tests/simulation/tests/integration_tests/scale/resource_group.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/resource_group.rs
@@ -15,15 +15,68 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use rdkafka::ClientConfig;
 use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
 use risingwave_common::config::meta::default;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
+#[cfg(madsim)]
+use risingwave_pb::serverless_backfill_controller::node_group_controller_service_server::{
+    NodeGroupControllerService, NodeGroupControllerServiceServer,
+};
+#[cfg(madsim)]
+use risingwave_pb::serverless_backfill_controller::{ProvisionRequest, ProvisionResponse};
 use risingwave_simulation::cluster::{Cluster, Configuration, Session};
 use risingwave_simulation::ctl_ext::predicate::{identity_contains, no_identity_contains};
 use risingwave_simulation::utils::AssertResult;
 use tokio::time::sleep;
+#[cfg(madsim)]
+use tonic::{Request, Response, Status};
+
+#[cfg(madsim)]
+const SERVERLESS_BACKFILL_RESOURCE_GROUP: &str = "serverless_rg";
+#[cfg(madsim)]
+const SERVERLESS_BACKFILL_CONTROLLER_ADDR: &str = "http://192.168.13.1:50051";
+#[cfg(madsim)]
+const SERVERLESS_BACKFILL_CONTROLLER_BIND_ADDR: &str = "0.0.0.0:50051";
+
+#[cfg(madsim)]
+struct FixedServerlessBackfillController;
+
+#[cfg(madsim)]
+#[async_trait::async_trait]
+impl NodeGroupControllerService for FixedServerlessBackfillController {
+    async fn provision(
+        &self,
+        _request: Request<ProvisionRequest>,
+    ) -> std::result::Result<Response<ProvisionResponse>, Status> {
+        Ok(Response::new(ProvisionResponse {
+            resource_group: SERVERLESS_BACKFILL_RESOURCE_GROUP.to_owned(),
+        }))
+    }
+}
+
+#[cfg(madsim)]
+fn start_fixed_serverless_backfill_controller() {
+    madsim::runtime::Handle::current()
+        .create_node()
+        .name("serverless-backfill-controller")
+        .ip([192, 168, 13, 1].into())
+        .init(|| async {
+            tonic::transport::Server::builder()
+                .add_service(NodeGroupControllerServiceServer::new(
+                    FixedServerlessBackfillController,
+                ))
+                .serve(
+                    SERVERLESS_BACKFILL_CONTROLLER_BIND_ADDR
+                        .parse()
+                        .expect("valid serverless backfill controller bind address"),
+                )
+                .await
+                .expect("serverless backfill controller should serve");
+        })
+        .build();
+}
 
 async fn assert_streaming_job_effective_resource_group(
     session: &mut Session,
@@ -40,6 +93,7 @@ async fn assert_streaming_job_effective_resource_group(
     Ok(())
 }
 
+#[derive(Clone, Copy)]
 enum FragmentPlacementFilter {
     All,
     SourceBackfill,
@@ -79,7 +133,7 @@ async fn assert_streaming_job_actor_placement(
         .table_fragments
         .iter()
         .find(|fragments| fragments.table_id.as_raw_id() == job_id)
-        .unwrap_or_else(|| panic!("streaming job fragments not found for {job_name}({job_id})"));
+        .ok_or_else(|| anyhow!("streaming job fragments not found for {job_name}({job_id})"))?;
 
     let mut actor_count = 0;
     for fragment in table_fragments.fragments.values() {
@@ -113,6 +167,34 @@ async fn assert_streaming_job_actor_placement(
     );
 
     Ok(())
+}
+
+#[cfg(madsim)]
+async fn wait_streaming_job_actor_placement(
+    cluster: &Cluster,
+    session: &mut Session,
+    job_name: &str,
+    expected_resource_group: &str,
+    fragment_filter: FragmentPlacementFilter,
+) -> Result<()> {
+    let mut last_error = None;
+    for _ in 0..50 {
+        match assert_streaming_job_actor_placement(
+            cluster,
+            session,
+            job_name,
+            expected_resource_group,
+            fragment_filter,
+        )
+        .await
+        {
+            Ok(()) => return Ok(()),
+            Err(err) => last_error = Some(err),
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow!("timed out waiting for actor placement")))
 }
 
 async fn assert_streaming_job_placement(
@@ -281,6 +363,65 @@ async fn test_resource_group() -> Result<()> {
 
     assert_eq!(union_fragment.inner.actors.len(), 2);
     assert_eq!(mat_fragment.inner.actors.len(), 2);
+
+    Ok(())
+}
+
+#[cfg(madsim)]
+#[tokio::test]
+async fn test_mv_serverless_backfill_uses_active_resource_group_during_create() -> Result<()> {
+    start_fixed_serverless_backfill_controller();
+
+    let mut config = Configuration::for_arrangement_backfill();
+    config.compute_nodes = 3;
+    config.compute_node_cores = 2;
+    config.serverless_backfill_controller_addr =
+        Some(SERVERLESS_BACKFILL_CONTROLLER_ADDR.to_owned());
+    config.compute_resource_groups = HashMap::from([
+        (1, DEFAULT_RESOURCE_GROUP.to_owned()),
+        (2, "mv_rg".to_owned()),
+        (3, SERVERLESS_BACKFILL_RESOURCE_GROUP.to_owned()),
+    ]);
+
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run("set streaming_use_arrangement_backfill = true")
+        .await?;
+    session.run("set background_ddl = true").await?;
+    session.run("set backfill_rate_limit = 1").await?;
+
+    session.run("create table rg_serverless_t(v int)").await?;
+    session
+        .run("insert into rg_serverless_t select * from generate_series(1, 1000)")
+        .await?;
+    session
+        .run(
+            "create materialized view rg_serverless_mv with (
+                resource_group = 'mv_rg',
+                cloud.serverless_backfill_enabled = true
+            ) as select * from rg_serverless_t",
+        )
+        .await?;
+
+    assert_streaming_job_effective_resource_group(&mut session, "rg_serverless_mv", "mv_rg")
+        .await?;
+    wait_streaming_job_actor_placement(
+        &cluster,
+        &mut session,
+        "rg_serverless_mv",
+        SERVERLESS_BACKFILL_RESOURCE_GROUP,
+        FragmentPlacementFilter::All,
+    )
+    .await?;
+
+    let job_id = session
+        .run("select id from rw_streaming_jobs where name = 'rg_serverless_mv'")
+        .await?;
+    session
+        .run(format!("cancel job {};", job_id.trim()))
+        .await?;
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/scale/resource_group.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/resource_group.rs
@@ -16,12 +16,154 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Result;
+use rdkafka::ClientConfig;
+use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
 use risingwave_common::config::meta::default;
 use risingwave_common::util::worker_util::DEFAULT_RESOURCE_GROUP;
-use risingwave_simulation::cluster::{Cluster, Configuration};
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
 use risingwave_simulation::ctl_ext::predicate::{identity_contains, no_identity_contains};
 use risingwave_simulation::utils::AssertResult;
 use tokio::time::sleep;
+
+async fn assert_streaming_job_effective_resource_group(
+    session: &mut Session,
+    job_name: &str,
+    expected_resource_group: &str,
+) -> Result<()> {
+    session
+        .run(format!(
+            "select resource_group from rw_streaming_jobs where name = '{}'",
+            job_name
+        ))
+        .await?
+        .assert_result_eq(expected_resource_group);
+    Ok(())
+}
+
+enum FragmentPlacementFilter {
+    All,
+    SourceBackfill,
+    NonSourceBackfill,
+}
+
+async fn assert_streaming_job_actor_placement(
+    cluster: &Cluster,
+    session: &mut Session,
+    job_name: &str,
+    expected_resource_group: &str,
+    fragment_filter: FragmentPlacementFilter,
+) -> Result<()> {
+    let job_id = session
+        .run(format!(
+            "select id from rw_streaming_jobs where name = '{}'",
+            job_name
+        ))
+        .await?
+        .trim()
+        .parse::<u32>()?;
+    let info = cluster.get_cluster_info().await?;
+    let worker_resource_groups = info
+        .worker_nodes
+        .iter()
+        .map(|worker| {
+            (
+                worker.id,
+                worker
+                    .resource_group()
+                    .unwrap_or_else(|| DEFAULT_RESOURCE_GROUP.to_owned()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let table_fragments = info
+        .table_fragments
+        .iter()
+        .find(|fragments| fragments.table_id.as_raw_id() == job_id)
+        .unwrap_or_else(|| panic!("streaming job fragments not found for {job_name}({job_id})"));
+
+    let mut actor_count = 0;
+    for fragment in table_fragments.fragments.values() {
+        let is_source_backfill = fragment
+            .nodes
+            .as_ref()
+            .and_then(|node| node.find_source_backfill())
+            .is_some();
+        let should_check = match fragment_filter {
+            FragmentPlacementFilter::All => true,
+            FragmentPlacementFilter::SourceBackfill => is_source_backfill,
+            FragmentPlacementFilter::NonSourceBackfill => !is_source_backfill,
+        };
+        if !should_check {
+            continue;
+        }
+
+        for actor in &fragment.actors {
+            actor_count += 1;
+            let worker_id = table_fragments.actor_status[&actor.actor_id].worker_id();
+            assert_eq!(
+                worker_resource_groups[&worker_id], expected_resource_group,
+                "actor {} of job {} is scheduled on worker {} outside resource group {}",
+                actor.actor_id, job_name, worker_id, expected_resource_group
+            );
+        }
+    }
+    assert!(
+        actor_count > 0,
+        "job {job_name} has no actors matching the placement assertion"
+    );
+
+    Ok(())
+}
+
+async fn assert_streaming_job_placement(
+    cluster: &Cluster,
+    session: &mut Session,
+    job_name: &str,
+    expected_resource_group: &str,
+) -> Result<()> {
+    assert_streaming_job_effective_resource_group(session, job_name, expected_resource_group)
+        .await?;
+    assert_streaming_job_actor_placement(
+        cluster,
+        session,
+        job_name,
+        expected_resource_group,
+        FragmentPlacementFilter::All,
+    )
+    .await
+}
+
+async fn assert_non_source_backfill_placement(
+    cluster: &Cluster,
+    session: &mut Session,
+    job_name: &str,
+    expected_resource_group: &str,
+) -> Result<()> {
+    assert_streaming_job_actor_placement(
+        cluster,
+        session,
+        job_name,
+        expected_resource_group,
+        FragmentPlacementFilter::NonSourceBackfill,
+    )
+    .await
+}
+
+async fn assert_source_backfill_placement(
+    cluster: &Cluster,
+    session: &mut Session,
+    mv_name: &str,
+    expected_resource_group: &str,
+) -> Result<()> {
+    assert_streaming_job_actor_placement(
+        cluster,
+        session,
+        mv_name,
+        expected_resource_group,
+        FragmentPlacementFilter::SourceBackfill,
+    )
+    .await
+}
 
 #[tokio::test]
 async fn test_resource_group() -> Result<()> {
@@ -139,6 +281,124 @@ async fn test_resource_group() -> Result<()> {
 
     assert_eq!(union_fragment.inner.actors.len(), 2);
     assert_eq!(mat_fragment.inner.actors.len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_create_streaming_jobs_resource_group_placement() -> Result<()> {
+    let mut config = Configuration::for_arrangement_backfill();
+    config.compute_nodes = 5;
+    config.compute_node_cores = 2;
+    config.compute_resource_groups = HashMap::from([
+        (1, DEFAULT_RESOURCE_GROUP.to_owned()),
+        (2, "source_rg".to_owned()),
+        (3, "mv_rg".to_owned()),
+        (4, "sink_rg".to_owned()),
+        (5, "index_rg".to_owned()),
+    ]);
+
+    let mut cluster = Cluster::start(config).await?;
+    let mut session = cluster.start_session();
+
+    session
+        .run("set streaming_use_arrangement_backfill = true")
+        .await?;
+    session
+        .run("set streaming_use_shared_source = true")
+        .await?;
+
+    cluster.create_kafka_topics(HashMap::from([("rg_source_topic".to_owned(), 2)]));
+
+    session
+        .run(
+            "create source rg_source (id int) with (
+                connector = 'kafka',
+                properties.bootstrap.server = '192.168.11.1:29092',
+                topic = 'rg_source_topic',
+                resource_group = 'source_rg'
+            ) format plain encode json",
+        )
+        .await?;
+    assert_streaming_job_placement(&cluster, &mut session, "rg_source", "source_rg").await?;
+
+    session
+        .run(
+            "create materialized view rg_source_mv with (resource_group = 'mv_rg') as
+             select count(*) as cnt from rg_source",
+        )
+        .await?;
+    assert_streaming_job_effective_resource_group(&mut session, "rg_source_mv", "mv_rg").await?;
+    assert_source_backfill_placement(&cluster, &mut session, "rg_source_mv", "source_rg").await?;
+    assert_non_source_backfill_placement(&cluster, &mut session, "rg_source_mv", "mv_rg").await?;
+
+    cluster
+        .run_on_client(async move {
+            let producer = ClientConfig::new()
+                .set("bootstrap.servers", "192.168.11.1:29092")
+                .create::<BaseProducer>()
+                .await
+                .expect("failed to create kafka producer");
+            for id in 1..=3 {
+                let payload = format!(r#"{{"id":{id}}}"#);
+                producer
+                    .send(
+                        BaseRecord::to("rg_source_topic")
+                            .payload(payload.as_bytes())
+                            .key(""),
+                    )
+                    .expect("failed to send kafka record");
+            }
+            producer
+                .flush(None)
+                .await
+                .expect("failed to flush producer");
+        })
+        .await;
+
+    for _ in 0..30 {
+        if session
+            .run("select cnt >= 3 from rg_source_mv")
+            .await?
+            .trim()
+            == "t"
+        {
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    session
+        .run("select cnt >= 3 from rg_source_mv")
+        .await?
+        .assert_result_eq("t");
+
+    session
+        .run("create table rg_t(id int primary key, v int)")
+        .await?;
+    session
+        .run("insert into rg_t values (1, 10), (2, 20), (3, 30)")
+        .await?;
+    session
+        .run("create materialized view rg_mv as select * from rg_t")
+        .await?;
+
+    session
+        .run("create index rg_idx on rg_mv(id) with (resource_group = 'index_rg')")
+        .await?;
+    assert_streaming_job_placement(&cluster, &mut session, "rg_idx", "index_rg").await?;
+
+    session.run("insert into rg_t values (4, 40)").await?;
+    session.flush().await?;
+    session
+        .run("select v from rg_mv where id = 4")
+        .await?
+        .assert_result_eq("40");
+
+    session
+        .run("create sink rg_sink from rg_mv with (connector = 'blackhole', resource_group = 'sink_rg')")
+        .await?;
+    assert_streaming_job_placement(&cluster, &mut session, "rg_sink", "sink_rg").await?;
+    session.flush().await?;
 
     Ok(())
 }

--- a/src/tests/simulation/tests/integration_tests/scale/resource_group.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/resource_group.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, ensure};
 use rdkafka::ClientConfig;
 use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
 use risingwave_common::config::meta::default;
@@ -154,14 +154,22 @@ async fn assert_streaming_job_actor_placement(
         for actor in &fragment.actors {
             actor_count += 1;
             let worker_id = table_fragments.actor_status[&actor.actor_id].worker_id();
-            assert_eq!(
-                worker_resource_groups[&worker_id], expected_resource_group,
-                "actor {} of job {} is scheduled on worker {} outside resource group {}",
-                actor.actor_id, job_name, worker_id, expected_resource_group
+            let actual_resource_group =
+                worker_resource_groups.get(&worker_id).ok_or_else(|| {
+                    anyhow!("worker {worker_id} not found for actor {}", actor.actor_id)
+                })?;
+            ensure!(
+                actual_resource_group == expected_resource_group,
+                "actor {} of job {} is scheduled on worker {} in resource group {}, expected {}",
+                actor.actor_id,
+                job_name,
+                worker_id,
+                actual_resource_group,
+                expected_resource_group
             );
         }
     }
-    assert!(
+    ensure!(
         actor_count > 0,
         "job {job_name} has no actors matching the placement assertion"
     );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR implements the RFC in `.omx/plans/resource-group-ddl-rfc.md` for create-time resource-group placement on additional streaming jobs.

### User-facing SQL surface

This PR adds `WITH (resource_group = '...')` support for:

| Statement | Support | Reason |
|---|---:|---|
| `CREATE MATERIALIZED VIEW` | yes | creates an MV streaming job |
| shared `CREATE SOURCE` | yes | creates a shared-source streaming job |
| non-shared `CREATE SOURCE` | no | no standalone streaming source job is created at `CREATE SOURCE` time |
| temporary `CREATE SOURCE` | no | no persistent streaming-job placement is created |
| `CREATE SINK` | yes | creates a sink streaming job |
| `CREATE INDEX` | yes | creates an index-maintenance streaming job |

Unsupported/confusing options are rejected explicitly:

- non-shared and temporary sources cannot specify `resource_group` because no standalone streaming source job is created;
- `cloud.serverless_backfill_enabled` is not accepted as a source/sink/index option.

Statement-specific placement behavior:

- `CREATE MATERIALIZED VIEW WITH (resource_group = ...)`: sets the MV's steady-state streaming-job resource group. Shared-source `SourceBackfill` fragments may still be `NoShuffle`-aligned with the upstream source at the fragment level.
- `CREATE INDEX WITH (resource_group = ...)`: sets the index-maintenance streaming job's resource group. Any internal `NoShuffle` fragments follow the common `NoShuffle` rendering rule below.
- `CREATE SINK WITH (resource_group = ...)`: sets the sink streaming job's resource group. Any internal `NoShuffle` fragments follow the common `NoShuffle` rendering rule below.
- shared `CREATE SOURCE WITH (resource_group = ...)`: sets the shared-source streaming job's resource group.
- CDC tables created from a shared CDC source: the `CdcFilter` boundary fragment follows the same upstream `NoShuffle` placement rule as shared-source `SourceBackfill`.
- non-shared / temporary `CREATE SOURCE`: rejects `resource_group` because no standalone persistent source streaming job is created at `CREATE SOURCE` time.

### Conceptual model: object identity vs compute placement

`resource_group` is a **compute-placement option for the streaming job created by the DDL**. It does not change the object's database, schema, owner, namespace, or catalog identity.

The steady-state effective resource group is:

```text
streaming_job.specific_resource_group
OR database.resource_group
OR default
```

Catalog/object observability is updated so table/source/sink object listings report this effective steady-state streaming-job resource group via `COALESCE(streaming_job.specific_resource_group, database.resource_group)`.

### Resource-group rendering priority and NoShuffle placement

Actor rendering distinguishes the streaming job's persisted steady-state resource group from the active resource group used by a specific create command.

For newly rendered actor ensembles, the priority is:

1. If a new fragment is in a `NoShuffle` ensemble with an existing upstream fragment, the new fragment is aligned to the existing ensemble's actor count and worker placement. This keeps shared-source and shared-CDC boundary fragments compatible with their upstream source.
2. Otherwise, a fresh ensemble uses the create command's active resource group. For ordinary jobs this is the same as the steady-state resource group. For MV serverless backfill this is the provisioned serverless resource group during initial backfill.
3. For steady-state reschedule/recovery paths, actor rendering uses `streaming_job.specific_resource_group` first and falls back to the database/default resource group.
4. For an all-new `NoShuffle` ensemble inside the same new job, all fragments in that ensemble are rendered together under the same resolved job placement.

This means `NoShuffle` is a fragment-level co-location constraint, not a catalog/object ownership rule and not a blanket rule that every fragment in a downstream job must use the upstream job's resource group.

For non-serverless shared-source MVs, the MV-owned `SourceBackfill` fragment is connected to the upstream shared-source fragment through `NoShuffle`, so that fragment is placement-compatible with the source while other MV fragments use the MV's own steady-state resource group. For MV serverless backfill, fresh non-upstream ensembles use the provisioned serverless resource group during initial backfill and are restored to the steady-state SQL/database resource group after backfill; existing-upstream `NoShuffle` ensembles still follow upstream placement.

For CDC tables created from a shared CDC source, the `CdcFilter` fragment plays the analogous shared-source boundary role: it is connected to the upstream source fragment with `NoShuffle`, so it follows the upstream source placement. The CDC-specific `CdcFilter` behavior is therefore the same fragment-level `NoShuffle` co-location rule, not a separate whole-job resource-group restriction.

### MV serverless backfill and steady-state resource group

This PR separates MV steady-state placement from temporary serverless-backfill placement:

| SQL `resource_group` | Serverless backfill | Active placement during backfill | Steady-state placement after backfill | Persisted `specific_resource_group` |
|---|---:|---|---|---|
| absent | disabled | database/default RG | database/default RG | `NULL` |
| present | disabled | SQL RG | SQL RG | SQL RG |
| absent | enabled | provisioned serverless RG | database/default RG | `NULL` |
| present | enabled | provisioned serverless RG | SQL RG | SQL RG |

Implementation notes:

- SQL `resource_group` remains the MV's steady-state placement;
- provisioned `ServerlessBackfillResourceGroup` is treated as temporary active backfill placement;
- create-time rendering uses the active serverless resource group only for all-new/fresh ensembles, so existing-upstream `NoShuffle` ensembles still follow upstream placement;
- post-backfill reschedule restores steady-state resource-group placement even when there is no backfill-parallelism override;
- the legacy MV serverless-backfill wire representation is preserved when there is no SQL steady-state `resource_group`, for mixed-version compatibility.

### Testing and review status

The current test coverage verifies:

- SQL acceptance/rejection for shared source, sink, index, and unsupported source forms;
- catalog-visible effective resource group resolution;
- real compute actor placement in simulation, not only catalog metadata;
- shared-source MV behavior where `SourceBackfill` is aligned to the source RG while non-`SourceBackfill` MV fragments use the MV RG;
- MV serverless backfill plus explicit SQL `resource_group`, where the catalog-visible steady-state RG remains the SQL RG but initial actors are rendered in the active serverless RG;
- source/MV/index/sink runtime behavior after placement.

Known follow-up before marking ready: decide whether docs should land in this PR or a linked docs PR.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwave-labs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [x] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

RisingWave now supports specifying a compute resource group when creating shared sources, sinks, and indexes with `WITH (resource_group = '...')`. This allows ingestion, egress, and index maintenance jobs to be placed in dedicated compute pools without moving the database or changing object ownership.

</details>

## Testing

Current update:

- `git diff --check`
- `cargo fmt --check -- src/frontend/src/handler/create_mv.rs src/meta/src/rpc/ddl_controller.rs src/tests/simulation/tests/integration_tests/scale/resource_group.rs`
- `cargo fmt --check -- src/meta/src/barrier/checkpoint/independent_job/batch_refresh_job/mod.rs src/meta/src/barrier/checkpoint/state.rs src/meta/src/barrier/context/recovery.rs src/meta/src/controller/scale.rs src/tests/simulation/src/cluster.rs src/tests/simulation/src/main.rs src/tests/simulation/tests/integration_tests/scale/resource_group.rs`
- `cargo test -p risingwave_frontend test_cloud_serverless_backfill_enabled_requires_boolean -- --nocapture`
- `cargo test -p risingwave_meta render_new_respects_resource_group_policy -- --nocapture`
- `cargo check -p risingwave_meta`
- `cargo check -p risingwave_simulation --test integration_tests`
- `MADSIM_TEST_SEED=1 ./risedev sit-test -E 'test(test_mv_serverless_backfill_uses_active_resource_group_during_create)'`
- `MADSIM_TEST_SEED=1 ./risedev sit-test -E 'test(test_create_streaming_jobs_resource_group_placement)'`

Earlier in this PR:

- `cargo fmt --check`
- `cargo check -p risingwave_frontend -p risingwave_rpc_client -p risingwave_meta -p risingwave_simulation`
- `cargo check -p risingwave_simulation --test integration_tests`
- `MADSIM_TEST_SEED=1 ./risedev sit-test -E 'test(test_create_streaming_jobs_resource_group_placement)'`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH="$JAVA_HOME/bin:$PATH" ./risedev d`
- `RISEDEV_KAFKA_WITH_OPTIONS_COMMON="connector='kafka',properties.bootstrap.server='127.0.0.1:9092'" RPK_BROKERS="127.0.0.1:9092" ./risedev slt-clean './e2e_test/source_inline/kafka/resource_group_source_sink.slt.serial'`
- `RISEDEV_KAFKA_WITH_OPTIONS_COMMON="connector='kafka',properties.bootstrap.server='127.0.0.1:9092'" RPK_BROKERS="127.0.0.1:9092" ./risedev slt './e2e_test/source_inline/kafka/resource_group_source_sink.slt.serial'`




