### PR TITLE
ci: reduce skipped auto-update rebase runs

### DIFF
--- a/.github/workflows/pr-auto-update-with-rebase.yml
+++ b/.github/workflows/pr-auto-update-with-rebase.yml
@@ -8,20 +8,25 @@ on:
     branches:
       - main
     types:
+      # GitHub Actions cannot filter pull_request events by label in `on`.
+      # Keep this list narrow so ordinary PR updates do not create skipped runs.
       - labeled
       - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-      - auto_merge_enabled
+
+concurrency:
+  group: pr-auto-update-with-rebase-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'autoupdate_rebase') &&
+        !contains(github.event.pull_request.labels.*.name, 'autoupdate_merge')
+      )
     steps:
       - id: autoupdate
         name: autoupdate


### PR DESCRIPTION
## Summary

- narrow `pr-auto-update-with-rebase` pull request triggers to label changes only
- add a job-level label guard so the runner only starts for PRs with `autoupdate_rebase` and without `autoupdate_merge`
- add workflow concurrency to cancel stale autoupdate runs for the same PR/ref

## Notes

This keeps the `push` on `main` trigger so already-labeled PRs can still be rebased after main moves, while avoiding skipped runs for ordinary PR opens, edits, synchronizes, and ready-for-review events.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-auto-update-with-rebase.yml"); puts "yaml ok"'`\n- `git diff --check`