### PR TITLE
fix(cdc): use shared source in direct offset injection test

### DIFF
--- a/e2e_test/source_inline/cdc/mysql/cron_only/direct_cdc_inject_offset.slt.serial
+++ b/e2e_test/source_inline/cdc/mysql/cron_only/direct_cdc_inject_offset.slt.serial
@@ -25,16 +25,18 @@ mysql -e "
 "
 
 statement ok
-create table direct_cdc_inject_offset (
-    id INT PRIMARY KEY,
-    payload VARCHAR
-) with (
+create source direct_cdc_inject_offset_source with (
     ${RISEDEV_MYSQL_WITH_OPTIONS_COMMON},
     username = 'non-shared-cdc',
     password = '123456',
-    database.name = 'testdb_direct_cdc_inject_offset',
-    table.name = 't_inject_offset'
+    database.name = 'testdb_direct_cdc_inject_offset'
 );
+
+statement ok
+create table direct_cdc_inject_offset (
+    id INT PRIMARY KEY,
+    payload VARCHAR
+) from direct_cdc_inject_offset_source table 'testdb_direct_cdc_inject_offset.t_inject_offset';
 
 query I retry 20 backoff 1s
 select count(*) from direct_cdc_inject_offset;
@@ -65,7 +67,7 @@ psql -h ${RISEDEV_RW_FRONTEND_LISTEN_ADDRESS} \
     -t -A \
     -c "SELECT id
         FROM rw_sources
-        WHERE associated_table_id = (SELECT id FROM rw_tables WHERE name = 'direct_cdc_inject_offset')
+        WHERE name = 'direct_cdc_inject_offset_source'
         ORDER BY id DESC
         LIMIT 1;" > /tmp/direct_cdc_source_id.txt
 
@@ -74,6 +76,8 @@ python3 e2e_test/source_inline/cdc/mysql/cron_only/extract_direct_cdc_current_of
     --host ${RISEDEV_RW_FRONTEND_LISTEN_ADDRESS} \
     --port ${RISEDEV_RW_FRONTEND_PORT} \
     --database $__DATABASE__ \
+    --job-name direct_cdc_inject_offset_source \
+    --job-type source \
     --source-id-file /tmp/direct_cdc_source_id.txt \
     --output /tmp/direct_cdc_current_offset.txt
 
@@ -101,7 +105,7 @@ python3 e2e_test/source_inline/cdc/mysql/cron_only/wait_direct_cdc_rows.py \
     --expected '1:row-1,2:row-2,3:row-3,4:row-4-before-inject,5:row-5-after-inject'
 
 statement ok
-drop table direct_cdc_inject_offset;
+drop source direct_cdc_inject_offset_source cascade;
 
 system ok
 mysql -e "DROP DATABASE IF EXISTS testdb_direct_cdc_inject_offset;"

--- a/e2e_test/source_inline/cdc/mysql/cron_only/extract_direct_cdc_current_offset.py
+++ b/e2e_test/source_inline/cdc/mysql/cron_only/extract_direct_cdc_current_offset.py
@@ -36,6 +36,7 @@ def main() -> None:
     parser.add_argument('--port', required=True, type=int)
     parser.add_argument('--database', required=True)
     parser.add_argument('--job-name', default='direct_cdc_inject_offset')
+    parser.add_argument('--job-type', default='table')
     parser.add_argument('--source-id-file', required=True, type=Path)
     parser.add_argument('--output', required=True, type=Path)
     parser.add_argument('--timeout-secs', type=int, default=60)
@@ -50,7 +51,7 @@ def main() -> None:
             'SELECT name '
             'FROM rw_catalog.rw_internal_table_info '
             f"WHERE job_name = '{args.job_name}' "
-            "AND job_type = 'table' "
+            f"AND job_type = '{args.job_type}' "
             'ORDER BY job_id DESC '
             'LIMIT 1;'
         ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This PR fixes `e2e_test/source_inline/cdc/mysql/cron_only/direct_cdc_inject_offset.slt.serial` after #25682 banned directly creating CDC tables from upstream databases.

The test now follows the supported shared CDC source flow:

1. `CREATE SOURCE direct_cdc_inject_offset_source ...`
2. `CREATE TABLE direct_cdc_inject_offset ... FROM direct_cdc_inject_offset_source TABLE 'testdb_direct_cdc_inject_offset.t_inject_offset'`
3. Read and inject offsets against the shared source state table instead of looking up an associated source from the CDC table.

This keeps the existing offset-injection coverage while aligning the fixture with the current MySQL CDC DDL contract.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes.

</details>

## Verification

- `python3 -m py_compile e2e_test/source_inline/cdc/mysql/cron_only/extract_direct_cdc_current_offset.py e2e_test/source_inline/cdc/mysql/cron_only/inject_source_offsets_with_retry.py e2e_test/source_inline/cdc/mysql/cron_only/wait_direct_cdc_rows.py`
- `git diff --check`
- Attempted `./risedev slt './e2e_test/source_inline/cdc/mysql/cron_only/direct_cdc_inject_offset.slt.serial'`, but local execution is blocked before RisingWave SQL by missing `mysql` CLI in this environment (`e2e_test/commands/mysql: line 9: mysql: command not found`).
