### PR TITLE
chore: bump iceberg deps for token refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c68b693e6f3f223eb05ae5090e24a39e8b89cea8#c68b693e6f3f223eb05ae5090e24a39e8b89cea8"
 dependencies = [
  "anyhow",
  "apache-avro 0.20.0",
@@ -6617,7 +6617,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c68b693e6f3f223eb05ae5090e24a39e8b89cea8#c68b693e6f3f223eb05ae5090e24a39e8b89cea8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c68b693e6f3f223eb05ae5090e24a39e8b89cea8#c68b693e6f3f223eb05ae5090e24a39e8b89cea8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=68df67448dcad974a4a011691eff4fdea8941891#68df67448dcad974a4a011691eff4fdea8941891"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=b625b4146e03486de3943ac618915d08910897f1#b625b4146e03486de3943ac618915d08910897f1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6684,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c68b693e6f3f223eb05ae5090e24a39e8b89cea8#c68b693e6f3f223eb05ae5090e24a39e8b89cea8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,14 +169,14 @@ hashbrown0_15 = { package = "hashbrown", version = "0.15", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20251111
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c68b693e6f3f223eb05ae5090e24a39e8b89cea8", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c68b693e6f3f223eb05ae5090e24a39e8b89cea8" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c68b693e6f3f223eb05ae5090e24a39e8b89cea8" }
 
 adbc_core = { version = "0.22" }
 adbc_snowflake = { version = "0.22", default-features = false }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,7 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "68df67448dcad974a4a011691eff4fdea8941891" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "b625b4146e03486de3943ac618915d08910897f1" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
## Summary
- bump iceberg / iceberg-catalog-glue / iceberg-catalog-rest to risingwavelabs/iceberg-rust#159
- bump iceberg-compaction-core to nimtable/iceberg-compaction#144
- refresh Cargo.lock without changing RisingWave source code

## Testing
- CARGO_NET_GIT_FETCH_WITH_CLI=true cargo +nightly-2025-10-10 check -p risingwave_connector -p risingwave_batch_executors -p risingwave_storage -p risingwave_meta -p risingwave_frontend -p risingwave_expr_impl -p risingwave_error -p risingwave_batch --features datafusion