### PR TITLE
feat(storage): write binary fuse8 sstable filters

### DIFF
--- a/src/storage/src/hummock/compactor/fast_compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/fast_compactor_runner.rs
@@ -47,7 +47,7 @@ use crate::hummock::multi_builder::{CapacitySplitTableBuilder, TableBuilderFacto
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::value::HummockValue;
 use crate::hummock::{
-    Block, BlockBuilder, BlockHolder, BlockIterator, BlockMeta, BlockedXor16FilterBuilder,
+    Block, BlockBuilder, BlockHolder, BlockIterator, BlockMeta, BlockedBinaryFuse8FilterBuilder,
     CachePolicy, CompressionAlgorithm, GetObjectId, HummockResult, SstableBuilderOptions,
     TableHolder, UnifiedSstableWriterFactory,
 };
@@ -355,7 +355,7 @@ pub struct CompactorRunner<C: CompactionFilter = MultiCompactionFilter> {
     right: Box<ConcatSstableIterator>,
     task_id: u64,
     executor: CompactTaskExecutor<
-        RemoteBuilderFactory<UnifiedSstableWriterFactory, BlockedXor16FilterBuilder>,
+        RemoteBuilderFactory<UnifiedSstableWriterFactory, BlockedBinaryFuse8FilterBuilder>,
         C,
     >,
     compression_algorithm: CompressionAlgorithm,
@@ -394,7 +394,7 @@ impl<C: CompactionFilter> CompactorRunner<C> {
         };
         let factory = UnifiedSstableWriterFactory::new(context.sstable_store.clone());
 
-        let builder_factory = RemoteBuilderFactory::<_, BlockedXor16FilterBuilder> {
+        let builder_factory = RemoteBuilderFactory::<_, BlockedBinaryFuse8FilterBuilder> {
             object_id_getter,
             limiter: context.memory_limiter.clone(),
             options,

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -90,7 +90,7 @@ pub use self::compaction_utils::{
 pub use self::task_progress::TaskProgress;
 use super::multi_builder::CapacitySplitTableBuilder;
 use super::{
-    GetObjectId, HummockResult, ObjectIdManager, SstableBuilderOptions, Xor16FilterBuilder,
+    BinaryFuse8FilterBuilder, GetObjectId, HummockResult, ObjectIdManager, SstableBuilderOptions,
 };
 use crate::compaction_catalog_manager::{
     CompactionCatalogAgentRef, CompactionCatalogManager, CompactionCatalogManagerRef,
@@ -100,8 +100,8 @@ use crate::hummock::compactor::compactor_runner::{compact_and_build_sst, compact
 use crate::hummock::compactor::iceberg_compaction::TaskKey;
 use crate::hummock::iterator::{Forward, HummockIterator};
 use crate::hummock::{
-    BlockedXor16FilterBuilder, FilterBuilder, SharedComapctorObjectIdManager, SstableWriterFactory,
-    UnifiedSstableWriterFactory, validate_ssts,
+    BlockedBinaryFuse8FilterBuilder, FilterBuilder, SharedComapctorObjectIdManager,
+    SstableWriterFactory, UnifiedSstableWriterFactory, validate_ssts,
 };
 use crate::monitor::CompactorMetrics;
 
@@ -213,7 +213,7 @@ impl Compactor {
         let (split_table_outputs, table_stats_map) = {
             let factory = UnifiedSstableWriterFactory::new(self.context.sstable_store.clone());
             if self.task_config.use_block_based_filter {
-                self.compact_key_range_impl::<_, BlockedXor16FilterBuilder>(
+                self.compact_key_range_impl::<_, BlockedBinaryFuse8FilterBuilder>(
                     factory,
                     iter,
                     compaction_filter,
@@ -224,7 +224,7 @@ impl Compactor {
                 .instrument_await("compact".verbose())
                 .await?
             } else {
-                self.compact_key_range_impl::<_, Xor16FilterBuilder>(
+                self.compact_key_range_impl::<_, BinaryFuse8FilterBuilder>(
                     factory,
                     iter,
                     compaction_filter,

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -29,7 +29,8 @@ mod xor_filter;
 pub use bloom::BloomFilterBuilder;
 use serde::{Deserialize, Serialize};
 pub use xor_filter::{
-    BlockedXor16FilterBuilder, Xor8FilterBuilder, Xor16FilterBuilder, XorFilterReader,
+    BinaryFuse8FilterBuilder, BlockedBinaryFuse8FilterBuilder, BlockedXor16FilterBuilder,
+    Xor8FilterBuilder, Xor16FilterBuilder, XorFilterReader,
 };
 pub mod builder;
 pub use builder::*;

--- a/src/storage/src/hummock/sstable/xor_filter.rs
+++ b/src/storage/src/hummock/sstable/xor_filter.rs
@@ -18,9 +18,8 @@ use std::sync::Arc;
 
 use bytes::{Buf, BufMut};
 use itertools::Itertools;
-use risingwave_common::must_match;
 use risingwave_hummock_sdk::key::{FullKey, UserKeyRangeRef};
-use xorf::{Filter, Xor8, Xor16};
+use xorf::{BinaryFuse8, BinaryFuse8Ref, DmaSerializable, Filter, FilterRef, Xor8, Xor16};
 
 use super::{FilterBuilder, Sstable};
 use crate::hummock::{BlockMeta, MemoryLimiter};
@@ -28,12 +27,18 @@ use crate::hummock::{BlockMeta, MemoryLimiter};
 const FOOTER_XOR8: u8 = 254;
 const FOOTER_XOR16: u8 = 255;
 const FOOTER_BLOCKED_XOR16: u8 = 253;
+const FOOTER_BINARY_FUSE8: u8 = 252;
+const FOOTER_BLOCKED_BINARY_FUSE8: u8 = 251;
 
 pub struct Xor16FilterBuilder {
     key_hash_entries: Vec<u64>,
 }
 
 pub struct Xor8FilterBuilder {
+    key_hash_entries: Vec<u64>,
+}
+
+pub struct BinaryFuse8FilterBuilder {
     key_hash_entries: Vec<u64>,
 }
 
@@ -54,6 +59,27 @@ impl Xor8FilterBuilder {
         buf.put_slice(xor_filter.fingerprints.as_ref());
         // Add footer to tell which kind of filter. 254 indicates a xor8 filter.
         buf.put_u8(FOOTER_XOR8);
+        buf
+    }
+}
+
+impl BinaryFuse8FilterBuilder {
+    pub fn new(capacity: usize) -> Self {
+        let key_hash_entries = if capacity > 0 {
+            Vec::with_capacity(capacity)
+        } else {
+            vec![]
+        };
+        Self { key_hash_entries }
+    }
+
+    fn build_from_binary_fuse8(filter: &BinaryFuse8) -> Vec<u8> {
+        let mut buf =
+            Vec::with_capacity(BinaryFuse8::DESCRIPTOR_LEN + filter.dma_fingerprints().len() + 1);
+        buf.resize(BinaryFuse8::DESCRIPTOR_LEN, 0);
+        filter.dma_copy_descriptor_to(&mut buf);
+        buf.put_slice(filter.dma_fingerprints());
+        buf.put_u8(FOOTER_BINARY_FUSE8);
         buf
     }
 }
@@ -151,8 +177,48 @@ impl FilterBuilder for Xor8FilterBuilder {
     }
 }
 
+impl FilterBuilder for BinaryFuse8FilterBuilder {
+    fn add_key(&mut self, key: &[u8], table_id: u32) {
+        self.key_hash_entries
+            .push(Sstable::hash_for_bloom_filter(key, table_id));
+    }
+
+    fn finish(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8> {
+        self.key_hash_entries.sort();
+        self.key_hash_entries.dedup();
+
+        let _memory_tracker = memory_limiter.as_ref().map(|memory_limit| {
+            memory_limit.must_require_memory(self.approximate_building_memory() as u64)
+        });
+
+        let filter = BinaryFuse8::try_from(&self.key_hash_entries)
+            .expect("deduplicated keys should construct a binary fuse filter");
+        self.key_hash_entries.clear();
+        Self::build_from_binary_fuse8(&filter)
+    }
+
+    fn approximate_len(&self) -> usize {
+        self.key_hash_entries.len() * 4
+    }
+
+    fn create(_fpr: f64, capacity: usize) -> Self {
+        BinaryFuse8FilterBuilder::new(capacity)
+    }
+
+    fn approximate_building_memory(&self) -> usize {
+        const BINARY_FUSE_MEMORY_PROPORTION: usize = 64;
+        self.key_hash_entries.len() * BINARY_FUSE_MEMORY_PROPORTION
+    }
+}
+
 pub struct BlockedXor16FilterBuilder {
     current: Xor16FilterBuilder,
+    data: Vec<u8>,
+    block_count: usize,
+}
+
+pub struct BlockedBinaryFuse8FilterBuilder {
+    current: BinaryFuse8FilterBuilder,
     data: Vec<u8>,
     block_count: usize,
 }
@@ -163,6 +229,16 @@ impl BlockedXor16FilterBuilder {
     pub fn new(capacity: usize) -> Self {
         Self {
             current: Xor16FilterBuilder::new(BLOCK_FILTER_CAPACITY),
+            data: Vec::with_capacity(capacity),
+            block_count: 0,
+        }
+    }
+}
+
+impl BlockedBinaryFuse8FilterBuilder {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            current: BinaryFuse8FilterBuilder::new(BLOCK_FILTER_CAPACITY),
             data: Vec::with_capacity(capacity),
             block_count: 0,
         }
@@ -212,8 +288,79 @@ impl FilterBuilder for BlockedXor16FilterBuilder {
     }
 }
 
+impl FilterBuilder for BlockedBinaryFuse8FilterBuilder {
+    fn add_key(&mut self, key: &[u8], table_id: u32) {
+        self.current.add_key(key, table_id)
+    }
+
+    fn finish(&mut self, _memory_limiter: Option<Arc<MemoryLimiter>>) -> Vec<u8> {
+        self.data.put_u32_le(self.block_count as u32);
+        self.data.put_u8(FOOTER_BLOCKED_BINARY_FUSE8);
+        std::mem::take(&mut self.data)
+    }
+
+    fn approximate_len(&self) -> usize {
+        self.current.approximate_len() + self.data.len()
+    }
+
+    fn create(_fpr: f64, capacity: usize) -> Self {
+        BlockedBinaryFuse8FilterBuilder::new(capacity)
+    }
+
+    fn switch_block(&mut self, memory_limiter: Option<Arc<MemoryLimiter>>) {
+        let block = self.current.finish(memory_limiter);
+        self.data.put_u32_le(block.len() as u32);
+        self.data.extend(block);
+        self.block_count += 1;
+    }
+
+    fn approximate_building_memory(&self) -> usize {
+        self.current.approximate_building_memory()
+    }
+
+    fn add_raw_data(&mut self, raw: Vec<u8>) {
+        assert!(self.current.key_hash_entries.is_empty());
+        self.data.put_u32_le(raw.len() as u32);
+        self.data.extend(raw);
+        self.block_count += 1;
+    }
+
+    fn support_blocked_raw_data(&self) -> bool {
+        true
+    }
+}
+
 pub struct BlockBasedXor16Filter {
     filters: Vec<Xor16>,
+}
+
+#[derive(Clone)]
+pub struct BinaryFuse8Bytes {
+    descriptor: Vec<u8>,
+    fingerprints: Vec<u8>,
+}
+
+impl BinaryFuse8Bytes {
+    fn contains(&self, h: &u64) -> bool {
+        BinaryFuse8Ref::from_dma(&self.descriptor, &self.fingerprints).contains(h)
+    }
+
+    fn estimate_size(&self) -> usize {
+        self.descriptor.len() + self.fingerprints.len()
+    }
+
+    fn encode_to_bytes(&self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(self.descriptor.len() + self.fingerprints.len() + 1);
+        data.put_slice(&self.descriptor);
+        data.put_slice(&self.fingerprints);
+        data.put_u8(FOOTER_BINARY_FUSE8);
+        data
+    }
+}
+
+#[derive(Clone)]
+pub struct BlockBasedBinaryFuse8Filter {
+    filters: Vec<BinaryFuse8Bytes>,
 }
 
 impl Clone for BlockBasedXor16Filter {
@@ -230,6 +377,52 @@ impl Clone for BlockBasedXor16Filter {
     }
 }
 
+fn may_exist_in_block_filters(
+    block_metas: &[BlockMeta],
+    filter_count: usize,
+    user_key_range: &UserKeyRangeRef<'_>,
+    mut contains: impl FnMut(usize) -> bool,
+) -> bool {
+    debug_assert_eq!(filter_count, block_metas.len());
+    let mut block_idx = match user_key_range.0 {
+        Bound::Unbounded => 0,
+        Bound::Included(left) | Bound::Excluded(left) => block_metas
+            .partition_point(|block_meta| {
+                let ord = FullKey::decode(&block_meta.smallest_key)
+                    .user_key
+                    .cmp(&left);
+                ord == Ordering::Less || ord == Ordering::Equal
+            })
+            .saturating_sub(1),
+    };
+
+    while block_idx < filter_count {
+        let read_bound = match user_key_range.1 {
+            Bound::Unbounded => false,
+            Bound::Included(right) => {
+                let ord = FullKey::decode(&block_metas[block_idx].smallest_key)
+                    .user_key
+                    .cmp(&right);
+                ord == Ordering::Greater
+            }
+            Bound::Excluded(right) => {
+                let ord = FullKey::decode(&block_metas[block_idx].smallest_key)
+                    .user_key
+                    .cmp(&right);
+                ord != Ordering::Less
+            }
+        };
+        if read_bound {
+            break;
+        }
+        if contains(block_idx) {
+            return true;
+        }
+        block_idx += 1;
+    }
+    false
+}
+
 impl BlockBasedXor16Filter {
     pub fn may_exist(
         &self,
@@ -237,51 +430,37 @@ impl BlockBasedXor16Filter {
         user_key_range: &UserKeyRangeRef<'_>,
         h: u64,
     ) -> bool {
-        debug_assert_eq!(self.filters.len(), block_metas.len());
-        let mut block_idx = match user_key_range.0 {
-            Bound::Unbounded => 0,
-            Bound::Included(left) | Bound::Excluded(left) => block_metas
-                .partition_point(|block_meta| {
-                    let ord = FullKey::decode(&block_meta.smallest_key)
-                        .user_key
-                        .cmp(&left);
-                    ord == Ordering::Less || ord == Ordering::Equal
-                })
-                .saturating_sub(1),
-        };
+        may_exist_in_block_filters(
+            block_metas,
+            self.filters.len(),
+            user_key_range,
+            |block_idx| self.filters[block_idx].contains(&h),
+        )
+    }
+}
 
-        while block_idx < self.filters.len() {
-            let read_bound = match user_key_range.1 {
-                Bound::Unbounded => false,
-                Bound::Included(right) => {
-                    let ord = FullKey::decode(&block_metas[block_idx].smallest_key)
-                        .user_key
-                        .cmp(&right);
-                    ord == Ordering::Greater
-                }
-                Bound::Excluded(right) => {
-                    let ord = FullKey::decode(&block_metas[block_idx].smallest_key)
-                        .user_key
-                        .cmp(&right);
-                    ord != Ordering::Less
-                }
-            };
-            if read_bound {
-                break;
-            }
-            if self.filters[block_idx].contains(&h) {
-                return true;
-            }
-            block_idx += 1;
-        }
-        false
+impl BlockBasedBinaryFuse8Filter {
+    pub fn may_exist(
+        &self,
+        block_metas: &[BlockMeta],
+        user_key_range: &UserKeyRangeRef<'_>,
+        h: u64,
+    ) -> bool {
+        may_exist_in_block_filters(
+            block_metas,
+            self.filters.len(),
+            user_key_range,
+            |block_idx| self.filters[block_idx].contains(&h),
+        )
     }
 }
 
 pub enum XorFilter {
     Xor8(Xor8),
     Xor16(Xor16),
+    BinaryFuse8(BinaryFuse8Bytes),
     BlockXor16(BlockBasedXor16Filter),
+    BlockBinaryFuse8(BlockBasedBinaryFuse8Filter),
 }
 
 pub struct XorFilterReader {
@@ -302,9 +481,15 @@ impl XorFilterReader {
         }
 
         let kind = *data.last().unwrap();
-        let filter = if kind == FOOTER_BLOCKED_XOR16 {
+        let filter = if kind == FOOTER_BLOCKED_BINARY_FUSE8 {
+            let block_filter = Self::to_block_binary_fuse8(data, metas);
+            XorFilter::BlockBinaryFuse8(block_filter)
+        } else if kind == FOOTER_BLOCKED_XOR16 {
             let block_filter = Self::to_block_xor16(data, metas);
             XorFilter::BlockXor16(block_filter)
+        } else if kind == FOOTER_BINARY_FUSE8 {
+            let binary_fuse8 = Self::to_binary_fuse8(data);
+            XorFilter::BinaryFuse8(binary_fuse8)
         } else if kind == FOOTER_XOR16 {
             let xor16 = Self::to_xor16(data);
             XorFilter::Xor16(xor16)
@@ -313,6 +498,18 @@ impl XorFilterReader {
             XorFilter::Xor8(xor8)
         };
         Self { filter }
+    }
+
+    fn to_binary_fuse8(data: &[u8]) -> BinaryFuse8Bytes {
+        let kind = *data.last().unwrap();
+        assert_eq!(kind, FOOTER_BINARY_FUSE8);
+        let payload = &data[..data.len() - 1];
+        assert!(payload.len() >= BinaryFuse8::DESCRIPTOR_LEN);
+        let (descriptor, fingerprints) = payload.split_at(BinaryFuse8::DESCRIPTOR_LEN);
+        BinaryFuse8Bytes {
+            descriptor: descriptor.to_vec(),
+            fingerprints: fingerprints.to_vec(),
+        }
     }
 
     fn to_xor8(mut data: &[u8]) -> Xor8 {
@@ -371,14 +568,36 @@ impl XorFilterReader {
         BlockBasedXor16Filter { filters }
     }
 
+    fn to_block_binary_fuse8(mut data: &[u8], metas: &[BlockMeta]) -> BlockBasedBinaryFuse8Filter {
+        let l = data.len();
+        let reader = &mut &data[(l - 5)..];
+        let block_count = reader.get_u32_le() as usize;
+        assert_eq!(block_count, metas.len());
+        let reader = &mut data;
+        let mut filters = Vec::with_capacity(block_count);
+        for _ in 0..block_count {
+            let len = reader.get_u32_le() as usize;
+            let filter = Self::to_binary_fuse8(&reader[..len]);
+            reader.advance(len);
+            filters.push(filter);
+        }
+        BlockBasedBinaryFuse8Filter { filters }
+    }
+
     pub fn estimate_size(&self) -> usize {
         match &self.filter {
             XorFilter::Xor8(filter) => filter.fingerprints.len(),
             XorFilter::Xor16(filter) => filter.fingerprints.len() * std::mem::size_of::<u16>(),
+            XorFilter::BinaryFuse8(filter) => filter.estimate_size(),
             XorFilter::BlockXor16(reader) => reader
                 .filters
                 .iter()
                 .map(|filter| filter.fingerprints.len() * std::mem::size_of::<u16>())
+                .sum(),
+            XorFilter::BlockBinaryFuse8(reader) => reader
+                .filters
+                .iter()
+                .map(BinaryFuse8Bytes::estimate_size)
                 .sum(),
         }
     }
@@ -387,7 +606,9 @@ impl XorFilterReader {
         match &self.filter {
             XorFilter::Xor8(filter) => filter.block_length == 0,
             XorFilter::Xor16(filter) => filter.block_length == 0,
+            XorFilter::BinaryFuse8(filter) => filter.fingerprints.is_empty(),
             XorFilter::BlockXor16(reader) => reader.filters.is_empty(),
+            XorFilter::BlockBinaryFuse8(reader) => reader.filters.is_empty(),
         }
     }
 
@@ -410,24 +631,37 @@ impl XorFilterReader {
             match &self.filter {
                 XorFilter::Xor8(filter) => filter.contains(&h),
                 XorFilter::Xor16(filter) => filter.contains(&h),
+                XorFilter::BinaryFuse8(filter) => filter.contains(&h),
                 XorFilter::BlockXor16(reader) => reader.may_exist(block_metas, user_key_range, h),
+                XorFilter::BlockBinaryFuse8(reader) => {
+                    reader.may_exist(block_metas, user_key_range, h)
+                }
             }
         }
     }
 
     pub fn get_block_raw_filter(&self, block_index: usize) -> Vec<u8> {
-        let reader = must_match!(&self.filter, XorFilter::BlockXor16(reader) => reader);
-        Xor16FilterBuilder::build_from_xor16(&reader.filters[block_index])
+        match &self.filter {
+            XorFilter::BlockXor16(reader) => {
+                Xor16FilterBuilder::build_from_xor16(&reader.filters[block_index])
+            }
+            XorFilter::BlockBinaryFuse8(reader) => reader.filters[block_index].encode_to_bytes(),
+            _ => unreachable!("raw block filter is only available for block-based filters"),
+        }
     }
 
     pub fn is_block_based_filter(&self) -> bool {
-        matches!(self.filter, XorFilter::BlockXor16(_))
+        matches!(
+            self.filter,
+            XorFilter::BlockXor16(_) | XorFilter::BlockBinaryFuse8(_)
+        )
     }
 
     pub fn encode_to_bytes(&self) -> Vec<u8> {
         match &self.filter {
             XorFilter::Xor8(filter) => Xor8FilterBuilder::build_from_xor8(filter),
             XorFilter::Xor16(filter) => Xor16FilterBuilder::build_from_xor16(filter),
+            XorFilter::BinaryFuse8(filter) => filter.encode_to_bytes(),
             XorFilter::BlockXor16(reader) => {
                 let mut data = Vec::with_capacity(4 + reader.filters.len() * 1024);
                 for filter in &reader.filters {
@@ -438,6 +672,17 @@ impl XorFilterReader {
                 // Add footer to tell which kind of filter. 253 indicates a blocked xor16 filter.
                 data.put_u32_le(reader.filters.len() as u32);
                 data.put_u8(FOOTER_BLOCKED_XOR16);
+                data
+            }
+            XorFilter::BlockBinaryFuse8(reader) => {
+                let mut data = Vec::with_capacity(4 + reader.filters.len() * 1024);
+                for filter in &reader.filters {
+                    let block = filter.encode_to_bytes();
+                    data.put_u32_le(block.len() as u32);
+                    data.extend(block);
+                }
+                data.put_u32_le(reader.filters.len() as u32);
+                data.put_u8(FOOTER_BLOCKED_BINARY_FUSE8);
                 data
             }
         }
@@ -461,8 +706,14 @@ impl Clone for XorFilterReader {
                     fingerprints: filter.fingerprints.clone(),
                 }),
             },
+            XorFilter::BinaryFuse8(filter) => Self {
+                filter: XorFilter::BinaryFuse8(filter.clone()),
+            },
             XorFilter::BlockXor16(reader) => Self {
                 filter: XorFilter::BlockXor16(reader.clone()),
+            },
+            XorFilter::BlockBinaryFuse8(reader) => Self {
+                filter: XorFilter::BlockBinaryFuse8(reader.clone()),
             },
         }
     }
@@ -599,6 +850,24 @@ mod tests {
             "Xor16 builder and reader should produce identical bytes"
         );
 
+        // Test BinaryFuse8 filter
+        let mut binary_fuse8_builder = BinaryFuse8FilterBuilder::new(100);
+        for i in 0..100 {
+            binary_fuse8_builder.add_key(&test_user_key_of(i).encode(), 0);
+        }
+        let binary_fuse8_bytes = binary_fuse8_builder.finish(None);
+        let binary_fuse8_reader = XorFilterReader::new(&binary_fuse8_bytes, &[]);
+        let binary_fuse8_encoded = binary_fuse8_reader.encode_to_bytes();
+        assert_eq!(
+            binary_fuse8_bytes, binary_fuse8_encoded,
+            "BinaryFuse8 builder and reader should produce identical bytes"
+        );
+        for i in 0..100 {
+            let key = test_user_key_of(i).encode();
+            let h = Sstable::hash_for_bloom_filter(&key, 0);
+            assert!(binary_fuse8_reader.may_match(&[], &(Bound::Unbounded, Bound::Unbounded), h));
+        }
+
         // Test BlockedXor16 filter
         let mut blocked_builder = BlockedXor16FilterBuilder::new(1024);
         let mut block_metas = Vec::new();
@@ -635,5 +904,49 @@ mod tests {
             blocked_bytes, blocked_encoded,
             "BlockedXor16 builder and reader should produce identical bytes"
         );
+
+        // Test BlockedBinaryFuse8 filter
+        let mut blocked_builder = BlockedBinaryFuse8FilterBuilder::new(1024);
+        let mut block_metas = Vec::new();
+
+        for block_idx in 0..3 {
+            for i in 0..50 {
+                let key_idx = block_idx * 50 + i;
+                blocked_builder.add_key(&test_user_key_of(key_idx).encode(), 0);
+            }
+
+            let smallest_key = FullKey {
+                user_key: test_user_key_of(block_idx * 50),
+                epoch_with_gap: EpochWithGap::new_from_epoch(test_epoch(1)),
+            };
+
+            block_metas.push(BlockMeta {
+                smallest_key: smallest_key.encode(),
+                len: 0,
+                offset: 0,
+                uncompressed_size: 0,
+                total_key_count: 50,
+                stale_key_count: 0,
+            });
+
+            blocked_builder.switch_block(None);
+        }
+
+        let blocked_bytes = blocked_builder.finish(None);
+        let blocked_reader = XorFilterReader::new(&blocked_bytes, &block_metas);
+        let blocked_encoded = blocked_reader.encode_to_bytes();
+        assert_eq!(
+            blocked_bytes, blocked_encoded,
+            "BlockedBinaryFuse8 builder and reader should produce identical bytes"
+        );
+        for i in 0..150 {
+            let key = test_user_key_of(i).encode();
+            let h = Sstable::hash_for_bloom_filter(&key, 0);
+            assert!(blocked_reader.may_match(
+                &block_metas,
+                &(Bound::Unbounded, Bound::Unbounded),
+                h
+            ));
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

This is a draft experiment for reducing Hummock SST filter memory in meta cache.

This PR changes newly written SST filters to xorf `BinaryFuse8`:

- non-block-based new SST writes use `BinaryFuse8FilterBuilder`.
- block-based new SST writes use `BlockedBinaryFuse8FilterBuilder`.
- fast compaction also writes `BlockedBinaryFuse8` filters.
- old SST filter formats remain readable: `Xor8`, `Xor16`, and `BlockedXor16` reader paths are kept.

The intention is to build an image and validate whether the production meta cache reduction is mostly from lowering fingerprint width. The PR deliberately does not add a config switch yet; it is a single-mode experiment for newly written SSTs.

Compatibility boundary:

- New binary reading old SSTs: supported by keeping the existing reader branches.
- Old binary reading newly written BinaryFuse8 SSTs: not supported, because new footers are introduced for the experiment.
- Existing SSTs are not rewritten until compaction/flush produces new SSTs.

Trade-off summary:

| Implementation | Write/read status in this PR | Serialized shape | Build-time memory estimate | Resident filter memory estimate | FPR |
| --- | --- | --- | --- | --- | --- |
| `Xor16` | old read compatible; no longer selected for new normal compaction writes | `seed + block_length + u16 fingerprints + footer` | current estimator is about `123 B/key` | about `2 * (1.23n + 32)`, roughly `2.46 B/key` for large filters | about `1 / 2^16 = 0.0015%` |
| `BlockedXor16` | old read compatible; no longer selected for new block-based writes | length-prefixed per-block `Xor16` filters plus block count/footer | current estimator is about `123 B/key` for the active block | same fingerprint width as `Xor16`, plus per-block framing; around `2.49 B/key` near 2K keys/block | about `0.0015%` per checked block |
| `BinaryFuse8` | new normal compaction write format | 20-byte descriptor + `u8` fingerprints + footer | new estimator is `64 B/key` | for large filters, roughly `1.13 B/key + 20B descriptor` | documented by xorf as `< 0.4%` |
| `BlockedBinaryFuse8` | new block-based and fast-compaction write format | length-prefixed per-block `BinaryFuse8` filters plus block count/footer | new estimator is `64 B/key` for the active block | due to segment rounding, roughly `1.50 B/key` at 1K keys/block and `1.375 B/key` at 2K-4K keys/block, plus 20B descriptor per block | documented by xorf as `< 0.4%` per checked block |

Notes from the earlier analysis:

- The current `BlockedXor16` FPR is much more precise than common LSM/KV defaults.
- Most filter memory pressure in the investigated cluster is from lower levels, especially L5/L6, so using an 8-bit filter is expected to be a better trade-off than keeping 16-bit fingerprints everywhere.
- `BinaryFuse8` does not always have the same per-key ratio as a large global filter when used per block. Small block filters pay segment-rounding overhead, so the expected block-based reduction is closer to `~45%` than exactly `50%` for 2K-key blocks.
- PR #25706 removes a duplicated block-meta-key copy in memory. This PR targets the remaining fingerprint bytes.

Testing done locally:

- `cargo fmt -- src/storage/src/hummock/sstable/xor_filter.rs src/storage/src/hummock/sstable/mod.rs src/storage/src/hummock/compactor/mod.rs src/storage/src/hummock/compactor/fast_compactor_runner.rs`
- `cargo test -p risingwave_storage hummock::sstable::xor_filter::tests --lib`
- `cargo check -p risingwave_storage --lib`
- `cargo clippy -p risingwave_storage --lib -- -D warnings`

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide) -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing release note for this draft experiment.

</details>
